### PR TITLE
Resolved cannot find module defs issue. 

### DIFF
--- a/cgi-bin/core/doctype/doctype/doctype.py
+++ b/cgi-bin/core/doctype/doctype/doctype.py
@@ -83,7 +83,7 @@ class DocType:
 		import webnotes.defs
 		from webnotes.utils.transfer import in_transfer
 
-		if (not in_transfer) and getattr(defs,'developer_mode', 0):
+		if (not in_transfer) and getattr(webnotes.defs,'developer_mode', 0):
 			self.export_doc()
 		sql("delete from __DocTypeCache")
 		


### PR DESCRIPTION
The module was referred to as defs and not as webnotes.defs, hence the issue.
