### PR TITLE
*bsd compatibility

### DIFF
--- a/wnf.py
+++ b/wnf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2012 Web Notes Technologies Pvt Ltd (http://erpnext.com)
 # 


### PR DESCRIPTION
# !/usr/bin/python > #!/usr/bin/env python for *bsd compatibility

  /usr/bin/python is read-only on NetBSD as Python is not a standard part of this OS.
