### PR TITLE
Email bulk fixing

### DIFF
--- a/webnotes/utils/email_lib/bulk.py
+++ b/webnotes/utils/email_lib/bulk.py
@@ -50,7 +50,7 @@ def send(recipients=None, sender=None, doctype='Profile', email_field='email',
 			
 	if not recipients: recipients = []
 	if not sender or sender == "Administrator":
-		sender = webnotes.conn.get_value('Email Settings', None, 'auto_mail_id')
+		sender = webnotes.conn.get_value('Email Settings', None, 'auto_email_id')
 	check_bulk_limit(len(recipients))
 
 	import HTMLParser


### PR DESCRIPTION
Correction of var getting in bulk emails, the correct var name is "auto_email_id" but the code uses "auto_mail_id" in line 53
