### PR TITLE
Patch 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ six
 termcolor
 werkzeug
 gunicorn
+slugify


### PR DESCRIPTION
use slugify to handle unicode characters because files with utf-8 or iso8859-1 characters were not saved properly and impossible to open
add doc.name to file name saved because every file received is different and we can't use a previous file
delete file form pop3 server only after mail processing in order to avoid losing it if an error happens
