### PR TITLE
Update datatype.js

### DIFF
--- a/public/js/legacy/datatype.js
+++ b/public/js/legacy/datatype.js
@@ -81,9 +81,11 @@ var crop = function(s, len) {
 }
 
 var strip = function(s, chars) {
-	var s= lstrip(s, chars)
-	s = rstrip(s, chars);
-	return s;
+	if (s) {
+		var s= lstrip(s, chars)
+		s = rstrip(s, chars);
+		return s;
+	}
 }
 
 var rstrip = function(s, chars) {


### PR DESCRIPTION
I have an error with IE10 loading the app. Nothing appears because of the cookies. The cookie cart_count is undefined so the strip method returns an error (lstrip).
The solution to this error was to check if the string is empty before trying to strip it.
