### PR TITLE
[fix] Browser's LocalStorage initialisation

### DIFF
--- a/public/js/wn/app.js
+++ b/public/js/wn/app.js
@@ -92,7 +92,7 @@ wn.Application = Class.extend({
 		if(wn.boot.metadata_version != localStorage.metadata_version) {
 			localStorage.clear();
 			console.log("Cleared Cache - New Metadata");
-			localStorage.metadata_version = wn.boot.metadata_version;
+			wn.assets.init_local_storage();
 		}
 	},
 	

--- a/public/js/wn/assets.js
+++ b/public/js/wn/assets.js
@@ -41,8 +41,14 @@ wn.assets = {
 			localStorage.clear();
 			console.log("Cleared localstorage");
 		}
+		
+		wn.assets.init_local_storage();
+	},
+	
+	init_local_storage: function() {
 		localStorage._last_load = new Date();
 		localStorage._version_number = window._version_number;
+		if(wn.boot) localStorage.metadata_version = wn.boot.metadata_version;
 	},
 	
 	// check if the asset exists in


### PR DESCRIPTION
Two functions were clearing LocalStorage. Hence, there needs to be a common init system, which adds required values to LocalStorage after clearing.
