### PR TITLE
Fix TypeError: 'list' object is not callable

### DIFF
--- a/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py
+++ b/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py
@@ -81,7 +81,7 @@ def build_website_sitemap_config(app):
 					if config_type=="pages":
 						pages.append(["Page", app, path, fname, basepath])
 					else:
-						generators(["Generator", app, path, fname, basepath])
+						generators.append(["Generator", app, path, fname, basepath])
 
 	for args in pages:
 		add_website_sitemap_config(*args)


### PR DESCRIPTION
``` python
Traceback (most recent call last):
  File "/root/frappe/bin/frappe", line 9, in <module>
    load_entry_point('frappe==4.0.0-beta', 'console_scripts', 'frappe')()
  File "/root/frappe/bench/frappe/frappe/cli.py", line 44, in main
    run(fn, parsed_args)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 65, in run
    out = globals().get(fn)(*args.get(fn), **args)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 58, in new_fn
    return fn(*args, **new_kwargs)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 250, in install
    install_app("frappe", verbose=verbose)
  File "/root/frappe/bench/frappe/frappe/installer.py", line 106, in install_app
    add_to_installed_apps(name)
  File "/root/frappe/bench/frappe/frappe/installer.py", line 124, in add_to_installed_apps
    rebuild_website_sitemap_config()
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py", line 57, in rebuild_website_sitemap_config
    build_website_sitemap_config(app)
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py", line 84, in build_website_sitemap_config
    generators(["Generator", app, path, fname, basepath])
TypeError: 'list' object is not callable
```
