### PR TITLE
Fix  _mysql_exceptions.ProgrammingError: (1146, "Table 'wnmax.tabNone' d...

### DIFF
--- a/frappe/website/doctype/website_sitemap/website_sitemap.py
+++ b/frappe/website/doctype/website_sitemap/website_sitemap.py
@@ -37,7 +37,7 @@ class DocType(DocTypeNestedSet):
 		if self.doc.old_parent != self.doc.parent_website_sitemap:
 			frappe.conn.sql("""update `tabWebsite Sitemap` set idx=idx-1 
 				where parent_website_sitemap=%s and idx>%s""", (self.doc.old_parent, self.doc.idx))
-			frappe.conn.sql("""update `tab{}` set idx=idx-1 
+			frappe.conn.sql("""update `tab{0}` set idx=idx-1 
 				where parent_website_sitemap=%s and idx>%s""".format(self.doc.ref_doctype), 
 					(self.doc.old_parent, self.doc.idx))
 			self.doc.idx = None


### PR DESCRIPTION
...oesn't exist") ```

``` python
Traceback (most recent call last):
  File "/root/frappe/bin/frappe", line 9, in <module>
    load_entry_point('frappe==4.0.0-beta', 'console_scripts', 'frappe')()
  File "/root/frappe/bench/frappe/frappe/cli.py", line 44, in main
    run(fn, parsed_args)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 67, in run
    out = globals().get(fn)(**args)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 58, in new_fn
    return fn(*args, **new_kwargs)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 262, in reinstall
    install(db_name=frappe.conf.db_name, verbose=verbose, force=True, reinstall=True)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 58, in new_fn
    return fn(*args, **new_kwargs)
  File "/root/frappe/bench/frappe/frappe/cli.py", line 250, in install
    install_app("frappe", verbose=verbose)
  File "/root/frappe/bench/frappe/frappe/installer.py", line 106, in install_app
    add_to_installed_apps(name)
  File "/root/frappe/bench/frappe/frappe/installer.py", line 124, in add_to_installed_apps
    rebuild_website_sitemap_config()
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py", line 57, in rebuild_website_sitemap_config
    build_website_sitemap_config(app)
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py", line 87, in build_website_sitemap_config
    add_website_sitemap_config(*args)
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py", line 127, in add_website_sitemap_config
    frappe.bean(wsc).insert()
  File "/root/frappe/bench/frappe/frappe/model/bean.py", line 265, in insert
    return self.save()
  File "/root/frappe/bench/frappe/frappe/model/bean.py", line 315, in save
    self.run_method("after_insert")
  File "/root/frappe/bench/frappe/frappe/model/bean.py", line 238, in run_method
    frappe.call(getattr(self.controller, method), *args, **kwargs))
  File "/root/frappe/bench/frappe/frappe/__init__.py", line 493, in call
    return fn(*args, **newargs)
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap_config/website_sitemap_config.py", line 29, in after_insert
    add_to_sitemap(opts)
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap/website_sitemap.py", line 131, in add_to_sitemap
    bean.insert(ignore_permissions=True)
  File "/root/frappe/bench/frappe/frappe/model/bean.py", line 265, in insert
    return self.save()
  File "/root/frappe/bench/frappe/frappe/model/bean.py", line 309, in save
    self.run_method('validate')
  File "/root/frappe/bench/frappe/frappe/model/bean.py", line 238, in run_method
    frappe.call(getattr(self.controller, method), *args, **kwargs))
  File "/root/frappe/bench/frappe/frappe/__init__.py", line 493, in call
    return fn(*args, **newargs)
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap/website_sitemap.py", line 33, in validate
    self.renumber_if_moved()
  File "/root/frappe/bench/frappe/frappe/website/doctype/website_sitemap/website_sitemap.py", line 42, in renumber_if_moved
    (self.doc.old_parent, self.doc.idx))
  File "/root/frappe/bench/frappe/frappe/db.py", line 101, in sql
    self._cursor.execute(query, values)
  File "build/bdist.linux-i686/egg/MySQLdb/cursors.py", line 205, in execute
  File "build/bdist.linux-i686/egg/MySQLdb/connections.py", line 36, in defaulterrorhandler
_mysql_exceptions.ProgrammingError: (1146, "Table 'wnmax.tabNone' doesn't exist")
```
