### PR TITLE
Fixed untranslated strings in toolbar

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -208,17 +208,17 @@ frappe.ui.form.Toolbar = Class.extend({
 		this.appframe.clear_primary_action();
 		
 		if(this.can_submit()) {
-			status = "Submit";
+			status = frappe._("Submit");
 		} else if(this.can_save()) {
 			if(!this.frm.save_disabled) {
-				status = "Save";
+				status = frappe._("Save");
 			}
 		} else if(this.can_update()) {
-			status = "Update";
+			status = frappe._("Update");
 		} else if(this.can_cancel()) {
-			status = "Cancel";
+			status = frappe._("Cancel");
 		} else if(this.can_amend()) {
-			status = "Amend";
+			status = frappe._("Amend");
 		}
 		
 		if(status) {
@@ -229,7 +229,7 @@ frappe.ui.form.Toolbar = Class.extend({
 					"Update": function() { me.frm.save('Update', null, this); },
 					"Cancel": function() { me.frm.savecancel(this); },
 					"Amend": function() { me.frm.amend_doc(); }
-				}[status], null, status==="Cancel" ? "btn-default" : "btn-primary");
+				}[status], null, status===frappe._("Cancel") ? "btn-default" : "btn-primary");
 			}
 		} else {
 			this.appframe.set_title_right();

--- a/frappe/public/js/frappe/ui/listing.js
+++ b/frappe/public/js/frappe/ui/listing.js
@@ -170,7 +170,7 @@ frappe.ui.Listing = Class.extend({
 		// new
 		if(this.new_doctype) {
 			if(this.appframe) {
-				this.appframe.set_title_right("<i class='icon-plus'></i> New", function() { 
+				this.appframe.set_title_right("<i class='icon-plus'></i> " + frappe._('New') + ", function() { 
 					(me.custom_new_doc || me.make_new_doc).apply(me, [me.new_doctype]); });
 			}
 			this.add_button(frappe._('New'), function() { 


### PR DESCRIPTION
Here's a quick fix for the untranslated strings in the toolbar. It's a quick fix which assumes frappe._ is idempotent, but it gets the job done. Fell free to reject and replace with a 'cleaner' approach, but let's please have these properly translated in the future ;-)
