### PR TITLE
changed self.delete to self.delete_key in base_document and document

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -83,7 +83,7 @@ class BaseDocument(object):
 		else:
 			self.__dict__[key] = value
 
-	def delete(self, key):
+	def delete_key(self, key):
 		if key in self.__dict__:
 			del self.__dict__[key]
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -128,7 +128,7 @@ class Document(BaseDocument):
 		self.set("__in_insert", True)
 		self.run_before_save_methods()
 		self._validate()
-		self.delete("__in_insert")
+		self.delete_key("__in_insert")
 
 		# run validate, on update etc.
 
@@ -145,7 +145,7 @@ class Document(BaseDocument):
 		self.run_method("after_insert")
 		self.set("__in_insert", True)
 		self.run_post_save_methods()
-		self.delete("__in_insert")
+		self.delete_key("__in_insert")
 
 		return self
 


### PR DESCRIPTION
DocPerm has a field called 'delete'. This clashes with the function name. 
Leads to this error: 

```
self.delete("__in_insert") 
TypeError: 'int' object is not callable
```
