### PR TITLE
Clear notifications where necessary, and not during clear_cache

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -320,6 +320,9 @@ def clear_perms(doctype):
 	db.sql("""delete from tabDocPerm where parent=%s""", doctype)
 
 def reset_perms(doctype):
+	from frappe.core.doctype.notification_count.notification_count import delete_notification_count_for
+	delete_notification_count_for(doctype)
+
 	clear_perms(doctype)
 	reload_doc(db.get_value("DocType", doctype, "module"),
 		"DocType", doctype, force=True)

--- a/frappe/cli.py
+++ b/frappe/cli.py
@@ -407,6 +407,7 @@ def latest(rebuild_website=True, quiet=False):
 	import frappe.model.sync
 	from frappe.utils.fixtures import sync_fixtures
 	import frappe.translate
+	from frappe.core.doctype.notification_count.notification_count import clear_notifications
 
 	verbose = not quiet
 
@@ -419,6 +420,8 @@ def latest(rebuild_website=True, quiet=False):
 		frappe.model.sync.sync_all(verbose=verbose)
 		frappe.translate.clear_cache()
 		sync_fixtures()
+
+		clear_notifications()
 
 		if rebuild_website:
 			build_website()
@@ -533,8 +536,10 @@ def make_custom_server_script(doctype):
 @cmd
 def clear_cache():
 	import frappe.sessions
+	from frappe.core.doctype.notification_count.notification_count import clear_notifications
 	frappe.connect()
 	frappe.clear_cache()
+	clear_notifications()
 	frappe.destroy()
 
 @cmd

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -12,6 +12,7 @@ from frappe.model import no_value_fields
 from frappe.model.document import Document
 from frappe.model.db_schema import type_map
 from frappe.core.doctype.property_setter.property_setter import make_property_setter
+from frappe.core.doctype.notification_count.notification_count import delete_notification_count_for
 
 form_grid_templates = {
 	"fields": "templates/form_grid/fields.html"
@@ -99,6 +100,8 @@ class DocType(Document):
 			module = load_doctype_module(self.name, self.module)
 			if hasattr(module, "on_doctype_update"):
 				module.on_doctype_update()
+
+		delete_notification_count_for(doctype=self.name)
 		frappe.clear_cache(doctype=self.name)
 
 	def before_rename(self, old, new, merge=False):

--- a/frappe/core/doctype/notification_count/notification_count.py
+++ b/frappe/core/doctype/notification_count/notification_count.py
@@ -5,7 +5,6 @@
 
 from __future__ import unicode_literals
 import frappe
-
 from frappe.model.document import Document
 
 class NotificationCount(Document):
@@ -15,6 +14,7 @@ class NotificationCount(Document):
 def get_notifications():
 	if frappe.flags.in_install_app:
 		return
+
 	config = get_notification_config()
 	can_read = frappe.user.get_can_read()
 	open_count_doctype = {}
@@ -52,14 +52,20 @@ def get_notifications():
 		"open_count_module": open_count_module
 	}
 
+def clear_notifications(user=None):
+	if frappe.flags.in_install_app=="frappe":
+		return
+
+	if user:
+		frappe.db.sql("""delete from `tabNotification Count` where owner=%s""", (user,))
+	else:
+		frappe.db.sql("""delete from `tabNotification Count`""")
+
 def delete_notification_count_for(doctype):
 	if frappe.flags.in_import: return
 	frappe.db.sql("""delete from `tabNotification Count` where for_doctype = %s""", (doctype,))
 
-def delete_event_notification_count():
-	delete_notification_count_for("Event")
-
-def clear_doctype_notifications(doc, method=None):
+def clear_doctype_notifications(doc, method=None, *args, **kwargs):
 	if frappe.flags.in_import:
 		return
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.utils import cint, now, get_gravatar
 from frappe import throw, msgprint, _
 from frappe.auth import _update_password
+from frappe.core.doctype.notification_count.notification_count import clear_notifications
 import frappe.permissions
 
 STANDARD_USERS = ("Guest", "Administrator")
@@ -71,6 +72,7 @@ class User(Document):
 		new_password = self.new_password
 		self.db_set("new_password", "")
 
+		clear_notifications(user=self.name)
 		frappe.clear_cache(user=self.name)
 
 		try:

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 import frappe.defaults
 from frappe.modules.import_file import get_file_path, read_doc_from_file
+from frappe.core.doctype.notification_count.notification_count import delete_notification_count_for
 
 @frappe.whitelist()
 def get_roles_and_doctypes():
@@ -69,6 +70,7 @@ def reset(doctype):
 
 def clear_doctype_cache(doctype):
 	frappe.clear_cache(doctype=doctype)
+	delete_notification_count_for(doctype)
 	for user in frappe.db.sql_list("""select distinct tabUserRole.parent from tabUserRole, tabDocPerm
 		where tabDocPerm.parent = %s
 		and tabDocPerm.role = tabUserRole.role""", doctype):

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
+from frappe.core.doctype.notification_count.notification_count import clear_notifications
 
 # Note: DefaultValue records are identified by parenttype
 # __default, __global or 'User Permission'
@@ -161,6 +162,7 @@ def _clear_cache(parent):
 	if parent in common_keys:
 		frappe.clear_cache()
 	else:
+		clear_notifications(user=parent)
 		frappe.clear_cache(user=parent)
 
 def clear_cache(user=None):

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -57,6 +57,7 @@ doc_events = {
 			"frappe.core.doctype.notification_count.notification_count.clear_doctype_notifications",
 			"frappe.core.doctype.email_alert.email_alert.trigger_email_alerts"
 		],
+		"after_rename": "frappe.core.doctype.notification_count.notification_count.clear_doctype_notifications",
 		"on_submit": "frappe.core.doctype.email_alert.email_alert.trigger_email_alerts",
 		"on_cancel": [
 			"frappe.core.doctype.notification_count.notification_count.clear_doctype_notifications",
@@ -76,7 +77,7 @@ scheduler_events = {
 	"all": ["frappe.utils.email_lib.bulk.flush"],
 	"daily": [
 		"frappe.utils.email_lib.bulk.clear_outbox",
-		"frappe.core.doctype.notification_count.notification_count.delete_event_notification_count",
+		"frappe.core.doctype.notification_count.notification_count.clear_notifications",
 		"frappe.core.doctype.event.event.send_event_digest",
 		"frappe.sessions.clear_expired_sessions",
 		"frappe.core.doctype.email_alert.email_alert.trigger_daily_alerts",

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -31,16 +31,8 @@ def clear_cache(user=None):
 		for key in ("bootinfo", "lang", "roles", "user_permissions", "home_page"):
 			cache.delete_value(key + ":" + user)
 
-	def clear_notifications(user=None):
-		if frappe.flags.in_install_app!="frappe":
-			if user:
-				frappe.db.sql("""delete from `tabNotification Count` where owner=%s""", (user,))
-			else:
-				frappe.db.sql("""delete from `tabNotification Count`""")
-
 	if user:
 		delete_user_cache(user)
-		clear_notifications(user)
 
 		if frappe.session:
 			if user==frappe.session.user and frappe.session.sid:
@@ -57,7 +49,6 @@ def clear_cache(user=None):
 			cache.delete_value("session:" + sess.sid)
 
 		delete_user_cache("Guest")
-		clear_notifications()
 		clear_global_cache()
 		frappe.defaults.clear_cache()
 


### PR DESCRIPTION
Fixes frappe/erpnext#1871
