### PR TITLE
Add the /g global flag, so all occourances of the '#' get replaced with ...

### DIFF
--- a/frappe/public/js/frappe/form/attachments.js
+++ b/frappe/public/js/frappe/form/attachments.js
@@ -107,7 +107,7 @@ frappe.ui.form.Attachments = Class.extend({
 			}
 		}
 		// hash is not escaped, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
-		return encodeURI(file_url).replace('#', '%23');
+		return encodeURI(file_url).replace('#/g', '%23');
 	},
 	remove_attachment_by_filename: function(filename, callback) {
 		this.remove_attachment(this.get_attachments()[filename], callback);

--- a/frappe/public/js/frappe/form/attachments.js
+++ b/frappe/public/js/frappe/form/attachments.js
@@ -107,7 +107,7 @@ frappe.ui.form.Attachments = Class.extend({
 			}
 		}
 		// hash is not escaped, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
-		return encodeURI(file_url).replace('#/g', '%23');
+		return encodeURI(file_url).replace(/#/g, '%23');
 	},
 	remove_attachment_by_filename: function(filename, callback) {
 		this.remove_attachment(this.get_attachments()[filename], callback);


### PR DESCRIPTION
...the encoded %23' value. Closes #1961
