### PR TITLE
Typo Error ? frappe.client.submit fail

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -92,7 +92,7 @@ def submit(doclist):
 	doclistobj = frappe.get_doc(doclist)
 	doclistobj.submit()
 
-	return doclist.as_dict()
+	return doclistobj.as_dict()
 
 @frappe.whitelist()
 def cancel(doctype, name):


### PR DESCRIPTION
- Frappe client use this submit function and failed due to doclist is actually a {dict} or a [list]. Both cannot have as_dict() function 
- Seem like just a typo -> change to doclistobj instead.
