### PR TITLE
Update event.py

### DIFF
--- a/frappe/core/doctype/event/event.py
+++ b/frappe/core/doctype/event/event.py
@@ -14,6 +14,9 @@ class Event(Document):
 	def validate(self):
 		if self.starts_on and self.ends_on and self.starts_on > self.ends_on:
 			frappe.msgprint(frappe._("Event end must be after start"), raise_exception=True)
+		if self.starts_on and self.ends_on and int(date_diff(self.ends_on.split(" ")[0], self.starts_on.split(" ")[0])) > 0 \
+			and self.repeat_on == "Every Day":
+			frappe.msgprint(frappe._("Every day events should finish on the same day."), raise_exception=True)
 
 def get_permission_query_conditions(user):
 	if not user: user = frappe.session.user
@@ -72,7 +75,7 @@ def get_events(start, end, user=None, for_reminder=False):
 		user = frappe.session.user
 	roles = frappe.get_roles(user)
 	events = frappe.db.sql("""select name, subject, description,
-		starts_on, ends_on, owner, all_day, event_type, repeat_this_event, repeat_on,
+		starts_on, ends_on, owner, all_day, event_type, repeat_this_event, repeat_on,repeat_till,
 		monday, tuesday, wednesday, thursday, friday, saturday, sunday
 		from tabEvent where ((
 			(date(starts_on) between date('%(start)s') and date('%(end)s'))
@@ -105,14 +108,19 @@ def get_events(start, end, user=None, for_reminder=False):
 
 	def add_event(e, date):
 		new_event = e.copy()
+		enddate = add_days(date,int(date_diff(e.ends_on.split(" ")[0], e.starts_on.split(" ")[0])))
 		new_event.starts_on = date + " " + e.starts_on.split(" ")[1]
 		if e.ends_on:
-			new_event.ends_on = date + " " + e.ends_on.split(" ")[1]
+			new_event.ends_on = enddate + " " + e.ends_on.split(" ")[1]
 		add_events.append(new_event)
 
 	for e in events:
 		if e.repeat_this_event:
 			event_start, time_str = e.starts_on.split(" ")
+			if e.repeat_till == None or "":
+				repeat = "3000-01-01"
+			else:
+				repeat = e.repeat_till
 			if e.repeat_on=="Every Year":
 				start_year = cint(start.split("-")[0])
 				end_year = cint(end.split("-")[0])
@@ -121,7 +129,7 @@ def get_events(start, end, user=None, for_reminder=False):
 				# repeat for all years in period
 				for year in range(start_year, end_year+1):
 					date = str(year) + "-" + event_start
-					if date >= start and date <= end:
+					if date >= start and date <= repeat:
 						add_event(e, date)
 
 				remove_events.append(e)
@@ -138,7 +146,7 @@ def get_events(start, end, user=None, for_reminder=False):
 
 				start_from = date
 				for i in xrange(int(date_diff(end, start) / 30) + 3):
-					if date >= start and date <= end and date >= event_start:
+					if date >= start and date <= repeat and date >= event_start:
 						add_event(e, date)
 					date = add_months(start_from, i+1)
 
@@ -153,7 +161,7 @@ def get_events(start, end, user=None, for_reminder=False):
 				date = add_days(start, weekday - start_weekday)
 
 				for cnt in xrange(int(date_diff(end, start) / 7) + 3):
-					if date >= start and date <= end and date >= event_start:
+					if date >= start and date <= repeat and date >= event_start:
 						add_event(e, date)
 
 					date = add_days(date, 7)
@@ -163,7 +171,7 @@ def get_events(start, end, user=None, for_reminder=False):
 			if e.repeat_on=="Every Day":
 				for cnt in xrange(date_diff(end, start) + 1):
 					date = add_days(start, cnt)
-					if date >= event_start and date <= end \
+					if date >= event_start and date <= repeat \
 						and e[weekdays[getdate(date).weekday()]]:
 						add_event(e, date)
 				remove_events.append(e)


### PR DESCRIPTION
Calendar Bug: When you create an event and repeat it to a certain date, it repeats the event from the start date to the last day of the calendar on the page.

Fix: it gets the repeat_till data from the database and limits the event to the proposed date.
