### PR TITLE
Fix UnknownLocaleError

### DIFF
--- a/frappe/geo/country_info.py
+++ b/frappe/geo/country_info.py
@@ -31,7 +31,7 @@ def get_translated_dict():
 	from babel.dates import get_timezone, get_timezone_name, Locale
 
 	translated_dict = {}
-	locale = Locale(frappe.local.lang)
+	locale = Locale(frappe.local.lang, sep="-")
 
 	# timezones
 	for tz in get_all_timezones():


### PR DESCRIPTION
This change fix the error below, according the _Basic Interface_ from core documentation of Babel
http://babel.pocoo.org/docs/api/core/

``` python
Traceback (innermost last):
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/website/render.py", line 23, in render
    data = render_page(path)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/website/render.py", line 116, in render_page
    return build(path)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/website/render.py", line 125, in build
    return build_method(path)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/website/render.py", line 138, in build_page
    context = get_context(path)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/website/context.py", line 32, in get_context
    context = build_context(context)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/website/context.py", line 68, in build_context
    ret = module.get_context(context)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/templates/pages/desk.py", line 23, in get_context
    boot = frappe.sessions.get()
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/sessions.py", line 91, in get
    bootinfo = get_bootinfo()
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/boot.py", line 47, in get_bootinfo
    add_home_page(bootinfo, doclist)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/boot.py", line 131, in add_home_page
    page = frappe.desk.desk_page.get(home_page)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/desk/desk_page.py", line 15, in get
    page.load_assets()
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/core/doctype/page/page.py", line 92, in load_assets
    self.script += get_lang_js("page", self.name)
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/translate.py", line 161, in get_lang_js
    return "\n\n$.extend(frappe._messages, %s)" % json.dumps(get_dict(fortype, name))
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/translate.py", line 114, in get_dict
    translation_assets[asset_key].update(get_dict_from_hooks(fortype, name))
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/translate.py", line 127, in get_dict_from_hooks
    translated_dict.update(frappe.get_attr(method)())
  File "/home/erpnext/frappe-bench/apps/frappe/frappe/geo/country_info.py", line 34, in get_translated_dict
    locale = Locale(frappe.local.lang)
  File "/home/erpnext/frappe-bench/env/local/lib/python2.7/site-packages/babel/core.py", line 150, in __init__
    raise UnknownLocaleError(identifier)
 UnknownLocaleError: unknown locale 'pt-BR'
```
