### PR TITLE
Updated Greek Translations v5.0

### DIFF
--- a/frappe/translations/el.csv
+++ b/frappe/translations/el.csv
@@ -1,1433 +1,1428 @@
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +209,Press Esc to close,Πατήστε Esc για να κλείσετε
-apps/frappe/frappe/desk/page/messages/messages_main.html +12,Post,θέση
-apps/frappe/frappe/config/setup.py +97,Rename many items by uploading a .csv file.,Μετονομασία πολλά στοιχεία από μεταφόρτωση ενός αρχείου csv . .
-DocType: Workflow State,pause,παύση
-apps/frappe/frappe/templates/pages/desk.py +20,You are not permitted to access this page.,Δεν επιτρέπεται η πρόσβαση σε αυτήν τη σελίδα.
-DocType: User,Facebook Username,Όνομα Χρήστη
-DocType: Workflow State,eye-open,μάτι-άνοιγμα
-apps/frappe/frappe/utils/file_manager.py +28,Please select a file or url,Παρακαλώ επιλέξτε ένα αρχείο ή ένα URL
-DocType: DocField,DocField,DocField
-DocType: Comment,Comment By Fullname,Σχόλιο από Ονοματεπώνυμο
-DocType: DocField,Options,Επιλογές
-apps/frappe/frappe/client.py +42,Cannot edit standard fields,Δεν μπορείτε να επεξεργαστείτε τα τυπικά πεδία
-DocType: Print Format,Print Format Builder,Εκτύπωση Μορφή Builder
-DocType: Report,Report Manager,Διαχείριση αναφορών
-DocType: Workflow,Document States,Έγγραφο μελών
-sites/assets/js/desk.min.js +762,Sorry! I could not find what you were looking for.,Συγγνώμη! Δεν μπόρεσα να βρω αυτό που ψάχνατε.
-DocType: DocPerm,This role update User Permissions for a user,Ο ρόλος Δικαιώματα ενημέρωση του χρήστη για ένα χρήστη
-sites/assets/js/desk.min.js +527,Rename {0},Μετονομασία {0}
-DocType: Workflow State,zoom-out,zoom-out
-apps/frappe/frappe/model/document.py +625,Table {0} cannot be empty,Πίνακας {0} δεν μπορεί να είναι κενή
-DocType: Social Login Keys,GitHub,GitHub
-apps/frappe/frappe/model/document.py +589,Beginning with,αρχίζοντας με
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +51,Data Import Template,Εισαγωγή δεδομένων Πρότυπο
-sites/assets/js/desk.min.js +510,Parent,Μητρική εταιρεία
-sites/assets/js/desk.min.js +779,"<i>document type...</i>, e.g. <b>customer</b>","<i> τύπο εγγράφου ... </ i>, π.χ. <b> πελάτη </ b>"
-apps/frappe/frappe/print/doctype/print_format/print_format.py +26,Syntax error in Jinja template,Συντακτικό σφάλμα στην Τζίντζα ​​πρότυπο
-DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Μέλη της ομάδας&quot; ή &quot;Management&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py +263,Default for 'Check' type of field must be either '0' or '1',Προεπιλογή για «Check« τύπος πεδίου πρέπει να είναι είτε «0» είτε «1»
-DocType: Email Account,Enable Incoming,Ενεργοποίηση εισερχόμενου
-DocType: Workflow State,Danger,Κίνδυνος
-DocType: Workflow State,th-large,ου-μεγάλο
-sites/assets/js/desk.min.js +665,Export not allowed. You need {0} role to export.,Η εξαγωγή δεν επιτρέπεται . Χρειάζεται {0} ρόλο για την εξαγωγή .
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +139,Set the display label for the field,Ρυθμίστε την ετικέτα οθόνης για το πεδίο
-apps/frappe/frappe/model/document.py +616,Incorrect value: {0} must be {1} {2},Λανθασμένη αξία: {0} πρέπει να είναι {1} {2}
-apps/frappe/frappe/config/setup.py +178,"Change field properties (hide, readonly, permission etc.)","Αλλαγή ιδιοτήτων πεδίου ( απόκρυψη , μόνο για ανάγνωση , την άδεια κλπ. )"
-DocType: Workflow State,lock,κλειδαριά
-apps/frappe/frappe/config/website.py +73,Settings for Contact Us Page.,Ρυθμίσεις για την Επικοινωνία Σελίδα.
-DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","Επιλογές επικοινωνίας, όπως &quot;Πωλήσεις Query, Υποστήριξη Query&quot; κλπ. το καθένα σε μια νέα γραμμή ή διαχωρισμένες με κόμμα."
-sites/assets/js/editor.min.js +155,Insert,Εισαγωγή
-sites/assets/js/desk.min.js +487,Select {0},Επιλέξτε {0}
-DocType: Outgoing Email Settings,Email Settings for Outgoing and Incoming Emails.,Ρυθμίσεις email για εξερχόμενες και εισερχόμενες email.
-DocType: Feed,Color,Χρώμα
-DocType: Workflow State,indent-right,παύλα-δεξιά
-sites/assets/js/desk.min.js +710,Web Link,Web Σύνδεσμος
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +33,"Recommended bulk editing records via import, or understanding the import format.","Συνιστάται χύμα επεξεργασία εγγραφών μέσω εισαγωγών, ή την κατανόηση της μορφής εισαγωγής."
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +36,"Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type.","Εκτός από το Διαχειριστή του Συστήματος, με τους ρόλους Ορισμός δικαιωμάτων χρήστη το δικαίωμα να ορίσετε δικαιώματα για άλλους χρήστες για αυτόν τον τύπο εγγράφου."
-DocType: Company History,Company History,Ιστορικό Εταιρίας
-DocType: Workflow State,volume-up,όγκου-up
-apps/frappe/frappe/core/page/data_import_tool/importer.py +42,Only allowed {0} rows in one import,Επιτρέπεται μόνο {0} σειρές σε μία εισαγωγή
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +4,"To import or update records, you must first download the template for importing.","Για τα μητρώα εισαγωγών ή ενημέρωση, θα πρέπει πρώτα να κατεβάσετε το πρότυπο για την εισαγωγή."
-DocType: DocType,Default Print Format,Προεπιλογή έντυπη μορφή
-DocType: Workflow State,Tags,ετικέτες
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +47,Document Types,Τύποι εγγράφων
-DocType: Workflow,Workflow State Field,Workflow Πεδίο κράτος
-DocType: DocType,Title Field,Τίτλος Field
-DocType: Workflow State,eject,βγάλετε
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +16,Help for User Permissions,Βοήθεια για δικαιώματα χρήσης
-DocType: Communication,Visit,Επίσκεψη
-apps/frappe/frappe/desk/page/applications/application_row.html +7,Install,Εγκατάσταση
-DocType: Table of Contents,Table of Contents,Πίνακας Περιεχομένων
-DocType: Website Settings,Twitter Share via,Twitter Μοιραστείτε μέσω
-apps/frappe/frappe/config/website.py +32,Embed image slideshows in website pages.,Ενσωμάτωση slideshows εικόνας σε ιστοσελίδες.
-DocType: Workflow Action,Workflow Action Name,Όνομα Ροής Εργασιών Δράση
-apps/frappe/frappe/core/doctype/doctype/doctype.py +126,DocType can not be merged,DocType δεν μπορούν να συγχωνευθούν
-DocType: Web Form Field,Fieldtype,Fieldtype
-DocType: Style Settings,Page Header Background,Page Header Ιστορικό
-apps/frappe/frappe/desk/form/save.py +43,Did not cancel,Δεν ακύρωση
-DocType: Workflow State,plus,συν
-DocType: Scheduler Log,Scheduler Log,Scheduler Log
-sites/assets/js/desk.min.js +615,You,Εσείς
-DocType: Style Settings,lowercase,πεζά
-DocType: Note,Everyone can read,Ο καθένας μπορεί να διαβάσει
-apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py +25,Please specify user,Παρακαλείστε να προσδιορίσετε τον χρήστη
-DocType: Website Settings,Select an image of approx width 150px with a transparent background for best results.,Επιλέξτε μια εικόνα 150px πλάτους περ. με ένα διαφανές φόντο για καλύτερα αποτελέσματα.
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py +61,"Insert After field '{0}' mentioned in Custom Field '{1}', does not exist","Εισαγωγή Μετά πεδίο ' {0}' που αναφέρονται στο προσαρμοσμένο πεδίο '{1}' , δεν υπάρχει"
-DocType: Workflow State,circle-arrow-up,κύκλο-arrow-up
-sites/assets/js/desk.min.js +722,Uploading...,Μεταφόρτωση ...
-DocType: Workflow State,italic,πλάγια
-apps/frappe/frappe/core/doctype/doctype/doctype.py +377,{0}: Cannot set Import without Create,{0} : Δεν είναι δυνατή η ρύθμιση εισαγωγής χωρίς να δημιουργήσετε
-DocType: Comment,Post Topic,Δημοσίευση Θέμα
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_column_selector.html +2,Widths can be set in px or %.,Πλάτη μπορεί να ρυθμιστεί σε px ή%.
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +6,Permissions get applied on Users based on what Roles they are assigned.,Δικαιώματα πάρει εφαρμόζονται σε χρήστες με βάση τους ρόλους που τους έχουν ανατεθεί .
-sites/assets/js/desk.min.js +838,You are not allowed to send emails related to this document,Δεν επιτρέπεται να στείλετε μηνύματα ηλεκτρονικού ταχυδρομείου που σχετίζονται με αυτό το έγγραφο
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +161,Example,Παράδειγμα
-DocType: Workflow State,gift,δώρο
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +165,Reqd,Reqd
-apps/frappe/frappe/core/doctype/communication/communication.py +82,Unable to find attachment {0},Ανίκανος να βρει συνημμένο {0}
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +153,Assign a permission level to the field.,Αντιστοιχίστε ένα επίπεδο δικαιωμάτων στο πεδίο.
-apps/frappe/frappe/config/setup.py +71,Show / Hide Modules,Εμφάνιση / Απόκρυψη Ενότητες
-apps/frappe/frappe/core/doctype/report/report.js +37,Disable Report,Απενεργοποίηση Έκθεση
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
-DocType: Version,Doclist JSON,Λίστα εγγράφων JSON
-DocType: Workflow State,chevron-up,Chevron-up
-sites/assets/js/desk.min.js +804,Documentation,Τεκμηρίωση
-DocType: Style Settings,Google Web Font (Text),Google Web Font (Κείμενο)
-DocType: DocShare,Internal record of document shares,Εσωτερική ρεκόρ των μετοχών εγγράφου
-DocType: Workflow State,Comment,Σχόλιο
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +17,"You can change Submitted documents by cancelling them and then, amending them.","Μπορείτε να αλλάξετε Υποβλήθηκε έγγραφα ακυρώνοντας τους και στη συνέχεια , για την τροποποίηση τους ."
-DocType: DocField,Display,επίδειξη
-sites/assets/js/desk.min.js +785,<i>e.g. <strong>(55 + 434) / 4</strong> or <strong>=Math.sin(Math.PI/2)</strong>...</i>,<i> π.χ. <strong> (55 + 434) / 4 </ strong> ή = <strong> Math.sin (άβακαςPI / 2) </ strong> ... </ i>
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +25,"If a Role does not have access at Level 0, then higher levels are meaningless.","Εάν ένας ρόλος δεν έχει πρόσβαση στο επίπεδο 0 , στη συνέχεια υψηλότερα επίπεδα είναι χωρίς νόημα ."
-sites/assets/js/desk.min.js +358,Show more details,Δείτε περισσότερες λεπτομέρειες
-DocType: System Settings,Run scheduled jobs only if checked,Εκτελέστε προγραμματισμένες εργασίες μόνο εάν ελέγχεται
-DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Εκτύπωση εύρος του πεδίου, εάν το πεδίο είναι μια στήλη σε έναν πίνακα"
-DocType: Workflow State,headphones,ακουστικά
-DocType: Bulk Email,Bulk Email records.,Μαζική αρχεία ηλεκτρονικού ταχυδρομείου.
-apps/frappe/frappe/config/setup.py +210,Send download link of a recent backup to System Managers,Αποστολή download link από ένα πρόσφατο αντίγραφο ασφαλείας σε Διευθυντές Σύστημα
-DocType: Email Account,e.g. replies@yourcomany.com. All replies will come to this inbox.,π.χ. replies@yourcomany.com. Όλες οι απαντήσεις θα έρθουν σε αυτό το inbox.
-apps/frappe/frappe/templates/includes/login.js +31,Valid email and name required,Έγκυρο e-mail και το όνομα που απαιτούνται
-DocType: DocType,Hide Heading,Απόκρυψη Τομέας
-DocType: Workflow State,remove-circle,αφαίρεση-κύκλο
-apps/frappe/frappe/config/website.py +53,Javascript to append to the head section of the page.,Javascript για να προσθέσετε στο τμήμα της κεφαλής της σελίδας.
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +52,Reset to defaults,Επαναφορά στις προεπιλογές
-DocType: Workflow,Transition Rules,Κανόνες μετάβασης
-apps/frappe/frappe/core/doctype/report/report.js +11,Example:,Παράδειγμα:
-DocType: Workflow,Defines workflow states and rules for a document.,Καθορίζει τα κράτη ροής εργασίας και τους κανόνες για ένα έγγραφο.
-DocType: DocType,Show this field as title,"Δείτε αυτό το πεδίο , όπως τον τίτλο"
-apps/frappe/frappe/model/document.py +339,Error: Document has been modified after you have opened it,Σφάλμα: Το έγγραφο έχει τροποποιηθεί αφού το έχετε ανοίξει
-apps/frappe/frappe/core/doctype/doctype/doctype.py +398,{0}: Cannot set Assign Submit if not Submittable,{0} : Δεν είναι δυνατή η ρύθμιση Εκχώρηση Υποβολή αν δεν Submittable
-DocType: Social Login Keys,Facebook,Facebook
-DocType: Blog Settings,Blog Title,Τίτλος Blog
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_layout.html +12,Edit to set heading,Επεξεργασία για να ορίσετε τίτλο
-DocType: About Us Settings,Team Members,Μέλη της Ομάδας
-sites/assets/js/desk.min.js +721,Please attach a file or set a URL,Παρακαλείστε να επισυνάψετε ένα αρχείο ή να ορίσετε μια διεύθυνση URL
-DocType: DocField,Permissions,Δικαιώματα
-DocType: Style Settings,Auto generated,Παράγεται Αυτόματα
-DocType: Workflow State,plus-sign,συν-υπογράψει
-sites/assets/js/desk.min.js +783,<i>module name...</i>,<i> όνομα της λειτουργικής μονάδας ... </ i>
-DocType: Event,Public,Δημόσιο
-apps/frappe/frappe/email/smtp.py +114,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Δεν λογαριασμό ηλεκτρονικού ταχυδρομείου εγκατάστασης. Παρακαλούμε να δημιουργήσετε ένα νέο λογαριασμό ηλεκτρονικού ταχυδρομείου από το πρόγραμμα Εγκατάστασης> E-mail> λογαριασμό ηλεκτρονικού ταχυδρομείου
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +3,Export Template,Εξαγωγή προτύπου
-DocType: DocType,Module,Ενότητα
-DocType: Email Alert,Send Alert On,Αποστολή ειδοποίησης On
-DocType: Web Form,Website URL,URL ιστοσελίδας
-DocType: Customize Form,"Customize Label, Print Hide, Default etc.","Προσαρμογή Label, Hide εκτύπωσης, κλπ. Προεπιλογή"
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_start.html +16,Create a New Format,Δημιουργήστε μια νέα μορφή
-DocType: Website Settings,Add a banner to the site. (small banners are usually good),Προσθέστε ένα banner στο site. (Μικρά πανό είναι συνήθως καλό)
-DocType: Website Settings,Set Banner from Image,Ορισμός Banner από την εικόνα
-DocType: Email Account,Set Footer,Σετ Φούτερ
-apps/frappe/frappe/utils/data.py +391,thousand,χίλια
-DocType: Style Settings,Verdana,Verdana
-apps/frappe/frappe/core/doctype/user/user.py +199,User {0} cannot be deleted,Χρήστης {0} δεν μπορεί να διαγραφεί
-DocType: Property Setter,Field Name,Όνομα πεδίου
-sites/assets/js/desk.min.js +646,or,ή
-DocType: Custom Field,Fieldname,Fieldname
-DocType: Workflow State,certificate,πιστοποιητικό
-DocType: User,Tile,Πλακάκι
-DocType: User,"Get your globally recognized avatar from <a href=""https://gravatar.com/"">Gravatar.com</a>","Πάρτε παγκοσμίως αναγνωρισμένη avatar σας από <a href=""https://gravatar.com/""> Gravatar.com </ a>"
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +62,First data column must be blank.,Πρώτη στήλη των δεδομένων πρέπει να είναι κενό.
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +285,Add A User Permission,Προσθέστε μια άδεια χρήστη
-DocType: Workflow State,Print,Εκτύπωση
-DocType: User,Restrict IP,Περιορισμός IP
-apps/frappe/frappe/email/smtp.py +152,Unable to send emails at this time,Δεν μπορεί να στείλει e-mail αυτή τη στιγμή
-sites/assets/js/desk.min.js +804,Search or type a command,Αναζήτηση ή πληκτρολογήστε μια εντολή
-DocType: Email Account,e.g. smtp.gmail.com,π.χ. smtp.gmail.com
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +359,Add A New Rule,Προσθέσετε ένα νέο κανόνα
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +52,Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer,Όνομα του τύπου εγγράφου (DocType) θέλετε αυτό το πεδίο να συνδέεται με. π.χ. Πελάτης
-DocType: User,Roles Assigned,Ρόλοι ειδικό
-DocType: Top Bar Item,Parent Label,Ετικέτα γονέων
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +10,Permissions are automatically translated to Standard Reports and Searches.,Τα δικαιώματα μετατρέπονται αυτόματα σε πρότυπο Εκθέσεις και αναζητήσεις .
-DocType: Event,Repeat Till,Επαναλάβετε Till
-DocType: Blogger,Will be used in url (usually first name).,Θα πρέπει να χρησιμοποιείται σε url (συνήθως το πρώτο όνομα).
-apps/frappe/frappe/client.py +53,Can not edit Read Only fields,Δεν μπορείτε να επεξεργαστείτε Διαβάστε Μόνο πεδία
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +427,Edit Heading,Επεξεργασία Τομέας
-DocType: File Data,File URL,URL αρχείου
-apps/frappe/frappe/desk/doctype/event/event.py +64,Upcoming Events for Today,Επερχόμενες εκδηλώσεις για σήμερα
-DocType: Email Alert Recipient,Email By Document Field,Email Με έγγραφο Field
-DocType: File Data,File Data,Αρχείου δεδομένων
-apps/frappe/frappe/utils/nestedset.py +210,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,Η συγχώνευση είναι δυνατή μόνο μεταξύ ομάδας - to- ομάδας ή Leaf κόμβου - to- Leaf κόμβου
-apps/frappe/frappe/utils/file_manager.py +40,Added {0},Προστέθηκε {0}
-DocType: Currency,Fraction Units,Μονάδες κλάσμα
-DocType: Web Page,Parent Web Page,Μητρική Ιστοσελίδα
-DocType: Style Settings,Footer Text,Κείμενο Τελικοί
-apps/frappe/frappe/model/base_document.py +336,{0} must be set first,{0} πρέπει να ορίσετε πρώτα
-apps/frappe/frappe/utils/data.py +407,crore,crore
-DocType: Workflow State,plane,αεροπλάνο
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +64,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","Αν το φόρτωμα νέες εγγραφές, ""Ονομασία σειράς"" καθίσταται υποχρεωτική, εφόσον υπάρχουν."
-apps/frappe/frappe/utils/data.py +404,lakh,λάκκα
-apps/frappe/frappe/core/doctype/doctype/doctype.py +282,Fold can not be at the end of the form,Fold δεν μπορεί να είναι στο τέλος του εντύπου
-apps/frappe/frappe/config/setup.py +13,System and Website Users,Σύστημα και χρήστες της ιστοσελίδας
-DocType: Workflow Document State,Doc Status,Doc Status
-sites/assets/js/desk.min.js +818,"Your download is being built, this may take a few moments...","Η λήψη σας χτίζεται, αυτό μπορεί να διαρκέσει λίγα λεπτά ..."
-sites/assets/js/desk.min.js +781,<i>text</i> <b>in</b> <i>document type</i>,<i> κείμενο </ i> <b> </ b> <i> τύπο εγγράφου </ i>
-DocType: Web Page,Begin this page with a slideshow of images,Ξεκινήστε τη σελίδα με ένα slideshow των εικόνων
-DocType: Version,Docname,Docname
-apps/frappe/frappe/core/doctype/version/version.js +10,Version restored,έκδοση αποκατασταθεί
-DocType: Event Role,Event Role,Ο ρόλος Event
-sites/assets/js/editor.min.js +125,Indent (Tab),Περίπτωση (Tab)
-DocType: Style Settings,Footer Background,Ιστορικό Τελικοί
-DocType: Workflow State,List,κατάλογος
-DocType: Page Role,Page Role,Ο ρόλος Σελίδα
-apps/frappe/frappe/core/doctype/doctype/doctype.py +244,Field {0} in row {1} cannot be hidden and mandatory without default,Το πεδίο {0} στη γραμμή {1} δεν μπορεί να κρυφτεί και υποχρεωτικά χωρίς προεπιλογή
-DocType: System Settings,mm/dd/yyyy,ηη / μμ / εεεε
-apps/frappe/frappe/email/doctype/email_account/email_account.py +183,Re:,Re: 
-DocType: Currency,"Sub-currency. For e.g. ""Cent""",Υπο-νόμισμα. Για παράδειγμα &quot;Cent&quot;
-DocType: Letter Head,Check this to make this the default letter head in all prints,Επιλέξτε το για να κάνουν αυτό το κεφάλι επιστολή προεπιλογή σε όλες τις εκτυπώσεις
-DocType: Print Format,Server,Διακομιστή
-DocType: DocField,Link,Σύνδεσμος
-apps/frappe/frappe/utils/file_manager.py +83,No file attached,Δεν συνημμένο αρχείο
-DocType: Version,Version,εκδοχή
-DocType: User,Fill Screen,Συμπληρώστε Screen
-apps/frappe/frappe/email/bulk.py +36,Bulk email limit {0} crossed,Μαζική email όριο {0} διέσχισε
-apps/frappe/frappe/core/doctype/role/role.js +9,Edit Permissions,Επεξεργασία Δικαιώματα
-DocType: Country,Country Name,Όνομα Χώρα
-DocType: About Us Team Member,About Us Team Member,Μέλος της Ομάδας σχετικά με εμάς 
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +5,"Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions.","Τα δικαιώματα που έχουν οριστεί για Ρόλοι και τύποι εγγράφων (που ονομάζεται doctypes ) με τον καθορισμό των δικαιωμάτων , όπως διαβάζω , γράφω, Δημιουργία, Διαγραφή , Υποβολή , Ακύρωση , τροποποιούνται , έκθεση , εισαγωγή, εξαγωγή , εκτύπωση , e-mail και τα δικαιώματα των χρηστών ."
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +19,"Apart from Role based Permission Rules, you can apply User Permissions based on DocTypes.","Εκτός από το ρόλο που βασίζονται Κανόνες άδεια , μπορείτε να εφαρμόσετε τα δικαιώματα χρήσης με βάση doctypes ."
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +23,"These permissions will apply for all transactions where the permitted record is linked. For example, if Company C is added to User Permissions of user X, user X will only be able to see transactions that has company C as a linked value.",Αυτά τα δικαιώματα θα ισχύουν για όλες τις συναλλαγές όπου το επιτρεπόμενο αρχείο είναι συνδεδεμένο .
-DocType: Property Setter,ID (name) of the entity whose property is to be set,ID (όνομα) της οντότητας της οποίας ιδιοκτησία είναι να καθοριστούν
-apps/frappe/frappe/print/doctype/letter_head/letter_head.js +9,Step 2: Set Letterhead content.,Βήμα 2: Ρύθμιση επιστολόχαρτο περιεχόμενο .
-DocType: Website Settings,Sidebar Items,Sidebar Είδη
-DocType: Workflow State,exclamation-sign,θαυμαστικό-sign
-DocType: About Us Settings,Introduce your company to the website visitor.,Εισαγάγει την εταιρεία σας στην ιστοσελίδα επισκέπτη.
-DocType: Outgoing Email Settings,Mail Password,Mail Κωδικός
-apps/frappe/frappe/print/doctype/print_format/print_format.js +14,Please duplicate this to make changes,Παρακαλούμε διπλούν αυτό για να κάνουν αλλαγές
-DocType: Print Settings,Font Size,Μέγεθος γραμματοσειράς
-sites/assets/js/desk.min.js +804,Unread Messages,Μη αναγνωσμένα μηνύματα
-DocType: Workflow State,facetime-video,FaceTime-video
-apps/frappe/frappe/templates/pages/blog.py +53,1 comment,1 σχόλιο
-apps/frappe/frappe/website/doctype/website_settings/website_settings.js +73,Select a Banner Image first.,Επιλέξτε μια εικόνα banner πρώτα.
-DocType: Workflow State,volume-down,όγκου-down
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +582,Saved,Αποθηκεύτηκε
-apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py +28,Please specify doctype,Παρακαλείστε να προσδιορίσετε τον τύπο εγγράφου
-DocType: Style Settings,Style Settings,Ρυθμίσεις Style
-DocType: Print Format,Format Data,Μορφή δεδομένων
-DocType: Customize Form Field,Customize Form Field,Προσαρμογή πεδίου φόρμας
-apps/frappe/frappe/config/setup.py +46,Check which Documents are readable by a User,Ελέγξτε ποια έγγραφα είναι δυνατόν να αναγνωσθούν από έναν χρήστη
-DocType: User,Reset Password Key,Επαναφορά Password κλειδί
-DocType: Email Account,Enable Auto Reply,Ενεργοποίηση Αυτόματης Απάντησης
-DocType: Outgoing Email Settings,Set Login and Password if authentication is required.,"Ορισμός Login και Password, εάν απαιτείται έλεγχος ταυτότητας."
-DocType: Workflow State,zoom-in,zoom-in
-apps/frappe/frappe/desk/page/activity/activity.js +154,Sep,Σεπτέμβριος
-DocType: DocField,Width,Πλάτος
-DocType: Style Settings,This must be checked if Style Settings are applicable,Αυτό πρέπει να ελεγχθεί εάν Ρυθμίσεις Style ισχύουν
-DocType: DocType,Fields,Πεδία
-apps/frappe/frappe/core/page/data_import_tool/data_import_tool.py +15,Parent Table,Μητρική Πίνακας
-apps/frappe/frappe/website/doctype/website_settings/website_settings.py +36,{0} in row {1} cannot have both URL and child items,{0} στη γραμμή {1} δεν μπορεί να έχει τόσο URL και είδη παιδικής
-apps/frappe/frappe/utils/nestedset.py +194,Root {0} cannot be deleted,Root {0} δεν μπορεί να διαγραφεί
-apps/frappe/frappe/templates/pages/blog.py +51,No comments yet,Δεν υπάρχουν ακόμη σχόλια
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +103,Both DocType and Name required,Τόσο DocType και Όνομα υποχρεωτικό
-apps/frappe/frappe/model/document.py +373,Cannot change docstatus from 1 to 0,Δεν είναι δυνατή η αλλαγή docstatus 1-0
-DocType: Style Settings,Page Background,Ιστορικό Σελίδα
-DocType: Workflow Transition,Defines actions on states and the next step and allowed roles.,Καθορίζει τις δράσεις για τα κράτη και το επόμενο βήμα και επέτρεψε ρόλους.
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +11,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","Ως βέλτιστη πρακτική , δεν αποδίδουν το ίδιο σύνολο κανόνα άδεια για διαφορετικούς ρόλους . Αντ 'αυτού , που πολλούς ρόλους στο ίδιο το χρήστη ."
-DocType: Web Form,Message to be displayed on successful completion,Μήνυμα που θα εμφανίζεται μετά την επιτυχή ολοκλήρωση
-DocType: Website Settings,Footer Items,Τελικοί Είδη
-sites/assets/js/desk.min.js +315,Menu,Μενού
-DocType: DefaultValue,DefaultValue,DefaultValue
-apps/frappe/frappe/config/setup.py +18,User Roles,Ρόλοι Χρηστών
-DocType: Property Setter,Property Setter overrides a standard DocType or Field property,Ακίνητα Σέττερ παρακάμπτει ένα πρότυπο DocType ή περιουσία πεδίο
-apps/frappe/frappe/core/doctype/user/user.py +330,Cannot Update: Incorrect / Expired Link.,Δεν είναι δυνατή η ενημέρωση : Εσφαλμένη / Έληξε σύνδεσης .
-DocType: DocField,Set Only Once,Οριστεί μόνο μία φορά
-apps/frappe/frappe/website/doctype/style_settings/style_settings.py +21,Top Bar text and background is same color. Please change.,Top Bar κείμενο και το φόντο είναι ίδιο χρώμα. Παρακαλούμε αλλάξει.
-apps/frappe/frappe/core/doctype/doctype/doctype.py +404,{0}: Cannot set import as {1} is not importable,"{0} : Δεν είναι δυνατή η ρύθμιση των εισαγωγών, όπως {1} δεν είναι δυνατόν να εισάγονται"
-DocType: Top Bar Item,"target = ""_blank""",target = &quot;_blank&quot;
-DocType: Workflow State,hdd,hdd
-DocType: Style Settings,"Set your background color, font and image (tiled)","Ρυθμίστε το χρώμα του φόντου σας, γραμματοσειρά και εικόνας (πλακάκια)"
-DocType: User,Roles Assigned To User,Αντιστοιχίσει ρόλους χρήστη
-apps/frappe/frappe/desk/query_report.py +18,You don't have access to Report: {0},Δεν έχετε πρόσβαση στην έκθεση του: {0}
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +132,Upload CSV file containing all user permissions in the same format as Download.,Ανεβάστε το αρχείο CSV που περιέχει όλα τα δικαιώματα των χρηστών στην ίδια μορφή όπως Download.
-DocType: Feed,Doc Name,Doc Name
-DocType: DocField,Heading,Επικεφαλίδα
-DocType: Workflow State,resize-vertical,resize-κάθετη
-DocType: Contact Us Settings,Introductory information for the Contact Us Page,Εισαγωγικές πληροφορίες για την επαφή μας σελίδα
-DocType: Workflow State,thumbs-down,thumbs-down
-DocType: Comment,Comment Time,Χρόνος Σχόλιο
-DocType: Workflow State,indent-left,παύλα-αριστερά
-DocType: Currency,Currency Name,Όνομα Νόμισμα
-DocType: Report,Javascript,Javascript
-DocType: File Data,Content Hash,Hash περιεχόμενο
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +316,Did not remove,Δεν αφαιρέσετε
-DocType: Report,Query,Απορία
-DocType: DocType,Sort Order,ταξινόμησης
-apps/frappe/frappe/core/doctype/doctype/doctype.py +252,'In List View' not allowed for type {0} in row {1},«Στην Προβολή λίστας » δεν επιτρέπεται για τον τύπο {0} στη γραμμή {1}
-DocType: Custom Field,Select the label after which you want to insert new field.,Επιλέξτε την ετικέτα μετά την οποία θέλετε να εισαγάγετε νέο πεδίο.
-DocType: Website Settings,Tweet will be shared via your user account (if specified),Tweet θα μοιραστούν μέσω του λογαριασμού χρήστη σας (αν ορίζεται)
-,Document Share Report,Έγγραφο Μοίρασε
-DocType: User,Last Login,Είσοδος
-apps/frappe/frappe/core/doctype/doctype/doctype.py +298,Fieldname is required in row {0},Fieldname απαιτείται στη γραμμή {0}
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_column_selector.html +4,Column,Στήλη
-DocType: Custom Field,Adds a custom field to a DocType,Προσθέτει ένα πεδίο σε μια DocType
-sites/assets/js/editor.min.js +103,Bold (Ctrl/Cmd+B),Bold (Ctrl / Cmd + Β)
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +140,Upload and Sync,Ανεβάστε και Sync
-DocType: DocType,Single Types have only one record no tables associated. Values are stored in tabSingles,Ενιαία τύποι έχουν μόνο μία εγγραφή δεν πινάκων που συσχετίζονται . Οι τιμές που αποθηκεύονται σε tabSingles
-DocType: Bulk Email,Bulk Email,Bulk Email
-DocType: Workflow,Rules defining transition of state in the workflow.,Κανόνες που καθορίζουν τη μετάβαση της κατάστασης στη ροή εργασίας.
-DocType: DocField,Index,Δείκτης
-sites/assets/js/editor.min.js +107,Number list,Λίστα Αριθμός
-apps/frappe/frappe/desk/page/messages/messages_sidebar.html +9,Everyone,Όλοι
-DocType: Workflow State,backward,πίσω
-apps/frappe/frappe/config/setup.py +78,Set numbering series for transactions.,Ορίστε σειρά αρίθμησης για τις συναλλαγές .
-DocType: Email Account,POP3 Server,POP3 διακομιστή
-DocType: Web Page,Description for page header.,Περιγραφή για το header της σελίδας.
-DocType: User,Last IP,Τελευταία IP
-apps/frappe/frappe/core/doctype/communication/communication.js +17,Add To,Προσθήκη στο
-DocType: DocPerm,Filter records based on User Permissions defined for a user,Φιλτράρισμα εγγραφών με βάση τα δικαιώματα χρήσης που ορίζεται για ένα χρήστη
-sites/assets/js/editor.min.js +111,Insert picture (or just drag & drop),Εισαγωγή εικόνας (ή απλά drag & drop)
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py +29,Fieldname not set for Custom Field,Fieldname δεν έχει οριστεί για το Custom Field
-sites/assets/js/desk.min.js +510,Last Updated By,Τελευταία ενημέρωση από
-DocType: Style Settings,Background Color,Χρώμα φόντου
-sites/assets/js/desk.min.js +841,There were errors while sending email. Please try again.,Υπήρξαν σφάλματα κατά την αποστολή ηλεκτρονικού ταχυδρομείου . Παρακαλώ δοκιμάστε ξανά .
-DocType: Web Page,0 is highest,0 είναι η υψηλότερη
-DocType: Email Alert,Value Changed,Αξία Άλλαξε
-apps/frappe/frappe/model/base_document.py +243,Duplicate name {0} {1},Διπλότυπο όνομα {0} {1}
-DocType: Web Form Field,Web Form Field,Web πεδίο φόρμας
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +182,Hide field in Report Builder,Απόκρυψη τομέα στην έκθεση Builder
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_field.html +12,Edit HTML,Επεξεργασία HTML
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +487,Restore Original Permissions,Επαναφορά των αρχικών Δικαιώματα
-DocType: DocField,Button,Κουμπί
-DocType: Email Account,Default Outgoing,Προεπιλογή Εξερχόμενες
-DocType: Workflow State,play,παιχνίδι
-apps/frappe/frappe/templates/emails/new_user.html +5,Click on the link below to complete your registration and set a new password,Κάντε κλικ στον παρακάτω σύνδεσμο για να ολοκληρωθεί η εγγραφή σας και να ορίσετε έναν νέο κωδικό πρόσβασης
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +396,Did not add,Δεν προσθέτουν
-DocType: Contact Us Settings,Contact Us Settings,Επικοινωνήστε μαζί μας Ρυθμίσεις
-DocType: Workflow State,text-width,text-πλάτους
-DocType: Website Settings,Sidebar,Sidebar
-apps/frappe/frappe/core/doctype/report/report.js +5,Report Builder reports are managed directly by the report builder. Nothing to do.,Οι αναφορές του Builder διαχειρίζεται απευθείας από τον κατασκευαστή έκθεση. Δεν έχει τίποτα να κάνει.
-apps/frappe/frappe/website/doctype/web_page/web_page.py +27,Cannot edit templated page,Δεν μπορείτε να επεξεργαστείτε templated σελίδα
-apps/frappe/frappe/model/document.py +588,none of,κανένας από
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +127,Upload User Permissions,Ανεβάστε Δικαιώματα χρήσης
-apps/frappe/frappe/core/page/desktop/all_applications_dialog.html +3,Checked items will be shown on desktop,Ελεγμένο στοιχεία θα εμφανίζονται στην επιφάνεια εργασίας
-apps/frappe/frappe/core/doctype/doctype/doctype.py +394,{0} cannot be set for Single types,{0} δεν μπορεί να ρυθμιστεί για Ενιαία τύπους
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +96,{0} updated,{0} ενημέρωση
-apps/frappe/frappe/core/doctype/doctype/doctype.py +384,Report cannot be set for Single types,Έκθεση δεν μπορεί να ρυθμιστεί για Ενιαίου τύπους
-apps/frappe/frappe/utils/data.py +394,million,εκατομμύριο
-apps/frappe/frappe/desk/page/activity/activity.js +153,Feb,Φεβρουάριος
-DocType: Default Home Page,Role,Ρόλος
-apps/frappe/frappe/utils/data.py +339,Cent,Σεντ
-apps/frappe/frappe/config/setup.py +103,Manage uploaded files.,Διαχειριστείτε τα αρχεία που φορτώνονται .
-apps/frappe/frappe/config/setup.py +119,"States for workflow (e.g. Draft, Approved, Cancelled).","Κράτη μέλη για τη ροή εργασίας ( π.χ. σχέδιο , που εγκρίθηκε , Ακυρώθηκε ) ."
-apps/frappe/frappe/config/setup.py +167,Customized HTML Templates for printing transctions.,Προσαρμοσμένη Πρότυπα HTML για εκτύπωση Συναλλαγών .
-,Data Import Tool,Εργαλείο εισαγωγής δεδομένων
-DocType: Outgoing Email Settings,Auto Email Id,Auto Id Email
-apps/frappe/frappe/core/doctype/user/user.py +369,Registration Details Emailed.,Στοιχεία Εγγραφής εστάλησαν με ηλεκτρονικό ταχυδρομείο.
-DocType: DocType,Is Single,Είναι Single
-DocType: Blogger,User ID of a Blogger,Αναγνωριστικό χρήστη του Blogger
-apps/frappe/frappe/core/doctype/user/user.py +194,There should remain at least one System Manager,Εκεί θα πρέπει να παραμείνει τουλάχιστον ενός διαχειριστή συστήματος
-DocType: Workflow State,circle-arrow-right,κύκλο βέλος δεξιά
-DocType: Style Settings,Georgia,Γεωργία
-DocType: Scheduler Log,Method,Μέθοδος
-DocType: User,Short Bio,Σύντομο Βιογραφικό
-DocType: Report,Script Report,Έκθεση Script
-DocType: About Us Settings,Company Introduction,Εισαγωγή Εταιρεία
-DocType: Style Settings,Top Bar Text,Top Κείμενο Bar
-DocType: DocPerm,Apply User Permissions,Εφαρμογή δικαιωμάτων χρηστών
-DocType: Style Settings,add your own CSS (careful!),προσθέσετε το δικό σας CSS (careful!)
-sites/assets/js/desk.min.js +385,Missing Values Required,Λείπει τιμές Απαραίτητα
-apps/frappe/frappe/permissions.py +148,Not allowed to access {0} with {1} = {2},Δεν επιτρέπεται να έχουν πρόσβαση {0} με το {1} = {2}
-apps/frappe/frappe/templates/emails/print_link.html +2,View this in your browser,Δείτε αυτό στο πρόγραμμα περιήγησής σας
-DocType: DocType,Search Fields,Πεδία αναζήτησης
-sites/assets/js/desk.min.js +840,Email sent to {0},Μηνύματος που αποστέλλεται σε {0}
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +426,Apply User Permissions of these Document Types,Εφαρμόστε Δικαιώματα χρήσης αυτών των τύπων εγγράφων
-DocType: Event,Event,Συμβάν
-sites/assets/js/desk.min.js +848,"On {0}, {1} wrote:","Στις {0}, {1} έγραψε:"
-DocType: Top Bar Item,For top bar,Για την κορυφή μπαρ
-DocType: Print Settings,In points. Default is 9.,Στα σημεία. Η προεπιλογή είναι 9.
-sites/assets/js/editor.min.js +123,Reduce indent (Shift+Tab),Μειώστε περίπτωση (Shift + Tab)
-DocType: Print Settings,"Print with Letterhead, unless unchecked in a particular Document","Εκτύπωση με επιστολόχαρτο, εκτός εάν ανεξέλεγκτη σε ένα συγκεκριμένο έγγραφο"
-DocType: Workflow State,heart,καρδιά
-DocType: Workflow State,minus,πλην
-sites/assets/js/desk.min.js +169,Server Error: Please check your server logs or contact tech support.,Σφάλμα διακομιστή : Παρακαλούμε ελέγξτε τα αρχεία καταγραφής του διακομιστή σας ή επικοινωνήστε με την τεχνική υποστήριξη .
-apps/frappe/frappe/core/doctype/user/user.py +113,Welcome email sent,Καλώς ήρθατε email που αποστέλλονται
-sites/assets/js/desk.min.js +793,Open Source Web Applications for the Web,Open Source Web εφαρμογών για το Web
-apps/frappe/frappe/core/doctype/user/user.py +352,Already Registered,Ήδη Εγγεγραμμένοι
-DocType: System Settings,Float Precision,Float ακριβείας
-apps/frappe/frappe/core/doctype/doctype/doctype.js +24,Property Setter,Setter Ακινήτου
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +209,Select User or DocType to start.,Επιλέξτε το χρήστη ή DocType για να ξεκινήσει .
-apps/frappe/frappe/desk/page/applications/applications.js +24,No Apps Installed,Δεν υπάρχουν εγκατεστημένες εφαρμογές
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +166,Mark the field as Mandatory,Σημειώστε το πεδίο ως Υποχρεωτική
-DocType: User,Google User ID,Google ID χρήστη
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +9,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Το σύστημα παρέχει πολλές προκαθορισμένες ρόλους . Μπορείτε να προσθέσετε νέους ρόλους για να ορίσετε λεπτότερα δικαιώματα .
-DocType: Country,Geo,Geo
-DocType: Blog Category,Blog Category,Κατηγορία Blog
-DocType: User,Roles HTML,Ρόλοι HTML
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +94,All customizations will be removed. Please confirm.,Όλες οι προσαρμογές θα πρέπει να αφαιρεθεί. Παρακαλούμε να επιβεβαιώσετε.
-DocType: Page,Page HTML,Σελίδα HTML
-DocType: Web Page,Header,Header
-sites/assets/js/desk.min.js +510,Unknown Column: {0},Άγνωστος Στήλη : {0}
-DocType: Email Alert Recipient,Optional: Always send to these ids. Each email id on a new row,Προαιρετικά: Πάντα αποστολή σε αυτούς τους ταυτότητες. Κάθε ταυτότητα ηλεκτρονικού ταχυδρομείου σε μια νέα σειρά
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +292,Users with role {0}:,Οι χρήστες με ρόλο {0} :
-DocType: Print Format,Custom Format,Προσαρμοσμένη Μορφή
-DocType: Website Settings,Integrations,Ολοκληρώσεις
-DocType: DocField,Section Break,Διάλειμμα Ενότητα
-DocType: Communication,Sender Full Name,Αποστολέας Ονοματεπώνυμο
-DocType: Website Settings,No Sidebar,Δεν Sidebar
-,Messages,Μηνύματα
-apps/frappe/frappe/desk/query_report.py +75,Must specify a Query to run,Πρέπει να ορίσετε ένα ερώτημα για να τρέξει
-apps/frappe/frappe/config/setup.py +65,"Language, Date and Time settings","Γλώσσα , ρυθμίσεις ημερομηνίας και ώρας"
-DocType: Email Account,Outgoing Mail Settings,Εξερχόμενες Ρυθμίσεις Mail
-DocType: User,Represents a User in the system.,Αντιπροσωπεύει ένα χρήστη στο σύστημα.
-DocType: Print Format,Print Format Type,Εκτύπωση Τύπος Format
-DocType: DocType,Hide Toolbar,Απόκρυψη της γραμμής εργαλείων
-DocType: Email Account,SMTP Settings for outgoing emails,Ρυθμίσεις SMTP για εξερχόμενα μηνύματα ηλεκτρονικού ταχυδρομείου
-apps/frappe/frappe/core/page/data_import_tool/data_import_tool.js +116,Import Failed,Η εισαγωγή απέτυχε
-apps/frappe/frappe/templates/emails/password_update.html +3,Your password has been updated. Here is your new password,Ο κωδικός σας έχει ενημερωθεί. Εδώ είναι το νέο κωδικό σας
-DocType: Email Account,Auto Reply Message,Αυτόματη Απάντηση Μήνυμα
-DocType: Email Alert,Condition,Κατάσταση
-sites/assets/js/desk.min.js +782,Open a module or tool,Ανοίξτε μια λειτουργική μονάδα ή ένα εργαλείο
-DocType: Module Def,App Name,Όνομα App
-DocType: Workflow,"Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)","Πεδίο που αντιπροσωπεύει το Workflow κράτος της συναλλαγής (εάν το πεδίο δεν είναι παρόν, ένα νέο κρυφό προσαρμοσμένου πεδίου θα δημιουργηθεί)"
-apps/frappe/frappe/templates/pages/login.py +158,Email not verified with {1},Email δεν επαληθεύονται με {1}
-DocType: Email Account,e.g. pop.gmail.com,π.χ. pop.gmail.com
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +494,Edit to add content,Επεξεργασία για να προσθέσετε περιεχόμενο
-DocType: Web Form,Advanced,Σύνθετη
-DocType: User,"User Type ""System User"" can access Desktop. ""Website User"" can only be logged into the website and portal pages.","Τύπος χρήστη ""Χρήστης Συστήματος» μπορούν να έχουν πρόσβαση Desktop. ""Ιστοσελίδα χρήστη"" μπορούν να καταγραφούν στην ιστοσελίδα και τις σελίδες της πύλης μόνο."
-DocType: Web Page,Link to other pages in the side bar and next section,Σχέση με άλλες σελίδες στο μπαρ πλευρά και το επόμενο τμήμα
-DocType: File Data,Attached To Name,Συνδέονται με το όνομα
-apps/frappe/frappe/email/receive.py +50,Invalid User Name or Support Password. Please rectify and try again.,Μη έγκυρο όνομα χρήστη ή τον κωδικό υποστήριξης . Παρακαλούμε διορθώσει και δοκιμάστε ξανά .
-DocType: Email Account,Yahoo Mail,Yahoo Mail
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +469,Saved!,Αποθηκεύτηκε!
-apps/frappe/frappe/desk/page/activity/activity_row.html +17,Updated {0}: {1},Ενημέρωση {0}: {1}
-DocType: DocType,Master,Κύριος
-DocType: DocType,User Cannot Create,Ο χρήστης δεν μπορεί να δημιουργήσει
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +27,"These will also be set as default values for those links, if only one such permission record is defined.","Αυτά θα πρέπει επίσης να οριστεί ως προεπιλεγμένες τιμές για αυτούς τους δεσμούς , αν μόνο μια τέτοια εγγραφή άδεια ορίζεται ."
-apps/frappe/frappe/desk/page/activity/activity.js +197,{0} on {1},{0} σε {1}
-DocType: Customize Form,Enter Form Type,Εισάγετε Τύπος Φόρμα
-DocType: DocField,Depends On,Εξαρτάται από
-DocType: DocPerm,Additional Permissions,Πρόσθετα Δικαιώματα
-apps/frappe/frappe/core/page/data_import_tool/data_import_tool.py +13,Start entering data below this line,Ξεκινήστε την εισαγωγή δεδομένων κάτω από αυτή τη γραμμή
-DocType: Workflow State,retweet,retweet
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +40,Update the template and save in CSV (Comma Separate Values) format before attaching.,Ενημερώστε το πρότυπο και να το αποθηκεύσετε σε μορφή CSV (Comma Ξεχωριστή Values) πριν από την τοποθέτηση.
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +148,Specify the value of the field,Καθορίστε την τιμή του πεδίου
-apps/frappe/frappe/desk/page/activity/activity.js +153,May,Μάιος
-apps/frappe/frappe/desk/page/activity/activity.js +153,Jan,Ιαν
-DocType: Style Settings,Lucida Grande,Lucida Grande
-DocType: DocType,DocType Details,DocType Λεπτομέρειες
-DocType: Workflow State,eye-close,μάτι-κλείσιμο
-,Applications,Εφαρμογές
-sites/assets/js/desk.min.js +197,Report this issue,Αναφέρετε αυτό το ζήτημα
-DocType: Custom Script,Adds a custom script (client or server) to a DocType,Προσθέτει μια προσαρμοσμένη δέσμη ενεργειών (client ή server) σε ένα DocType
-DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): <br>
-myfield
-eval:doc.myfield=='My Value'<br>
-eval:doc.age>18","Αυτό το πεδίο θα εμφανιστεί μόνο αν η ΌνομαΠεδίου ορίζεται εδώ έχει αξία ή οι κανόνες είναι αλήθεια (παραδείγματα): <br> 
- 
- myfield eval: doc.myfield == «η αξία μου» <br> 
- eval: doc.age> 18"
-apps/frappe/frappe/email/doctype/email_alert/email_alert.py +20,Cannot set Email Alert on Document Type {0},Δεν είναι δυνατή η ρύθμιση ειδοποίησης e-mail στο Τύπος εγγράφου {0}
-apps/frappe/frappe/config/website.py +48,Setup of fonts and background.,Ρύθμιση των γραμματοσειρών και του φόντου.
-DocType: Workflow Action,Workflow Action Master,Workflow Δράσης Δάσκαλος
-DocType: Custom Field,Field Type,Τύπος πεδίου
-apps/frappe/frappe/utils/data.py +356,only.,μόνο.
-DocType: Feed,Doc Type,Doc Τύπος
-apps/frappe/frappe/email/receive.py +46,Invalid Mail Server. Please rectify and try again.,Άκυρα Mail Server . Παρακαλούμε διορθώσει και δοκιμάστε ξανά .
-DocType: Workflow State,film,ταινία
-apps/frappe/frappe/model/db_query.py +268,No permission to read {0},Δεν έχετε άδεια για να διαβάσετε {0}
-apps/frappe/frappe/utils/nestedset.py +221,Multiple root nodes not allowed.,Πολλαπλούς κόμβους ρίζα δεν επιτρέπονται .
-sites/assets/js/desk.min.js +575,Get,Λήψη
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +55,Options for select. Each option on a new line. e.g.: <br>Option 1<br>Option 2<br>Option 3<br>,Επιλογές για επιλογή. Κάθε επιλογή σε μια νέα γραμμή. π.χ.: <br> Επιλογή 1 <br> Επιλογή 2 Επιλογή 3 <br> <br>
-sites/assets/js/desk.min.js +108,Confirm,Επιβεβαιώνω
-DocType: System Settings,yyyy-mm-dd,εεεε-μμ-ηη
-DocType: Website Slideshow,Website Slideshow,Παρουσίαση Ιστοσελίδας
-DocType: Website Settings,"Link that is the website home page. Standard Links (index, login, products, blog, about, contact)","Συνδέσεων που είναι η αρχική σελίδα του ιστοτόπου . Πρότυπο Links ( δείκτης , login , τα προϊόντα , το blog , περίπου , επικοινωνία )"
-sites/assets/js/editor.min.js +105,Bullet list,Λίστα με κουκκίδες
-DocType: Website Settings,Banner Image,Εικόνα Banner
-apps/frappe/frappe/core/doctype/doctype/doctype.js +22,Custom Field,Προσαρμοσμένο πεδίο
-apps/frappe/frappe/email/doctype/email_alert/email_alert.py +13,Please specify which date field must be checked,Παρακαλείσθε να προσδιορίσετε το πεδίο ημερομηνίας πρέπει να ελέγχεται
-DocType: DocPerm,Set User Permissions,Ορίστε τα δικαιώματα χρήσης
-DocType: Email Account,Email Account Name,Όνομα λογαριασμού ηλεκτρονικού ταχυδρομείου
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +248,Select Document Types,Επιλέξτε τύπους εγγράφων
-DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","π.χ. ""Υποστήριξη "","" Πωλήσεις "","" Jerry Yang """
-DocType: User,Facebook User ID,Facebook ταυτότητα χρήστη
-DocType: Workflow State,fast-forward,fast-forward
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_column_selector.html +1,"Check columns to select, drag to set order.","Ελέγξτε τις στήλες για να επιλέξετε, σύρετε για να αλλάξετε την σειρά."
-DocType: Event,Every Day,Κάθε μέρα
-apps/frappe/frappe/email/smtp.py +74,Please setup default Email Account from Setup > Email > Email Account,Παρακαλούμε προεπιλεγμένο λογαριασμό ρύθμισης email από τις Ρυθμίσεις> E-mail> λογαριασμό ηλεκτρονικού ταχυδρομείου
-,Permission Manager,Άδεια Διευθυντής
-DocType: Workflow State,move,Κίνηση
-DocType: System Settings,Date and Number Format,Ημερομηνία και Μορφή αριθμών
-DocType: User,Personal Info,Προσωπικές Πληροφορίες
-DocType: Email Account,Actions,δράσεις
-DocType: Workflow State,align-justify,ευθυγράμμιση δικαιολογεί
-DocType: User,Middle Name (Optional),Πατρώνυμο (προαιρετικό)
-sites/assets/js/desk.min.js +494,No Results,Δεν υπάρχουν αποτελέσματα
-DocType: System Settings,Security,ασφάλεια
-DocType: Currency,**Currency** Master,** Νομίσματος ** Μάστερ
-DocType: Website Settings,Address and other legal information you may want to put in the footer.,Διεύθυνση και άλλα νομικά στοιχεία που μπορεί να θέλετε να βάλετε στο υποσέλιδο.
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +48,Select Document Type,Επιλογή τύπου εγγράφου
-apps/frappe/frappe/utils/nestedset.py +201,Cannot delete {0} as it has child nodes,"Δεν είναι δυνατή η διαγραφή {0} , όπως έχει κόμβους του παιδιού"
-apps/frappe/frappe/desk/doctype/event/event.py +24,Every day events should finish on the same day.,Κάθε μέρα τα γεγονότα θα πρέπει να ολοκληρωθεί την ίδια ημέρα.
-DocType: Communication,User Tags,Ετικέτες
-DocType: Workflow State,download-alt,download-alt
-DocType: Web Page,Main Section,Το τμήμα Main
-apps/frappe/frappe/core/doctype/doctype/doctype.py +222,{0} not allowed in fieldname {1},{0} δεν επιτρέπεται σε fieldname {1}
-DocType: Page,Icon,εικονίδιο
-DocType: Web Page,Content in markdown format that appears on the main side of your page,Περιεκτικότητα σε μορφή markdown που εμφανίζεται στην κύρια όψη της σελίδας σας
-DocType: System Settings,dd/mm/yyyy,ηη / μμ / εεεε
-DocType: Website Settings,"An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [<a href=""http://favicon-generator.org/"" target=""_blank"">favicon-generator.org</a>]","Ένα αρχείο με το εικονίδιο. Επέκταση ICO. Θα πρέπει να είναι 16 x 16 px. Generated χρησιμοποιώντας μια γεννήτρια favicon. [ <a href=""http://favicon-generator.org/"" target=""_blank"">favicon-generator.org</a> ]"
-DocType: Blog Settings,Blog Settings,Ρυθμίσεις Blog
-apps/frappe/frappe/templates/emails/new_user.html +8,You can also copy-paste this link in your browser,Μπορείτε επίσης copy-paste αυτό το σύνδεσμο στο πρόγραμμα περιήγησής σας
-DocType: Workflow State,bullhorn,bullhorn
-DocType: Social Login Keys,Facebook Client Secret,Facebook Πελάτης Secret
-DocType: Website Settings,Copyright,Πνευματική ιδιοκτησία
-DocType: Social Login Keys,Google Client Secret,Google Πελάτης Secret
-apps/frappe/frappe/core/doctype/report/report.js +16,Write a Python file in the same folder where this is saved and return column and result.,Γράψτε μια Python αρχείο στον ίδιο φάκελο όπου αυτό αποθηκεύεται και στήλη της επιστροφής και το αποτέλεσμα.
-DocType: DocType,Sort Field,Ταξινόμηση πεδίο
-apps/frappe/frappe/templates/pages/404.html +11,"We are very sorry for this, but the page you are looking for is missing (this could be because of a typo in the address) or moved.","Λυπούμαστε πολύ για αυτό, αλλά η σελίδα που ψάχνετε λείπει (αυτό μπορεί να οφείλεται σε λάθος πληκτρολόγησης διεύθυνση) ή να μετακινηθεί."
-apps/frappe/frappe/core/doctype/doctype/doctype.py +231,Field {0} of type {1} cannot be mandatory,Το πεδίο {0} του τύπου {1} δεν μπορεί να είναι υποχρεωτική
-DocType: Style Settings,Open Sans,Open Sans
-,Activity,Δραστηριότητα
-DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Βοήθεια: Για να συνδέσετε με άλλη εγγραφή στο σύστημα, χρησιμοποιήστε &quot;# Μορφή / Note / [Name] Σημείωση&quot;, όπως τη διεύθυνση URL σύνδεσης. (Δεν χρησιμοποιούν &quot;http://&quot;)"
-apps/frappe/frappe/config/setup.py +184,Add fields to forms.,Προσθήκη πεδίων σε φόρμες .
-DocType: Workflow State,leaf,φύλλο
-apps/frappe/frappe/config/desktop.py +59,Installer,Installer
-sites/assets/js/editor.min.js +113,Insert Link,Εισαγωγή συνδέσμου
-DocType: Contact Us Settings,Query Options,Επιλογές Αιτημάτων
-DocType: Patch Log,Patch Log,Σύνδεση Patch
-DocType: Communication,Sent or Received,Αποστέλλονται ή λαμβάνονται
-DocType: DefaultValue,Key,Πλήκτρο
-apps/frappe/frappe/config/setup.py +53,Report of all document shares,Έκθεση του συνόλου των μετοχών του εγγράφου
-sites/assets/js/desk.min.js +510,Starred By,Με αστέρι
-DocType: User,New Password,New Password
-DocType: Communication,Reference DocType,Αναφορά DocType
-DocType: User,System User,Χρήστης Συστήματος
-DocType: Report,Is Standard,Είναι πρότυπο
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +203,Specify a default value,Καθορίστε μια προεπιλεγμένη τιμή
-DocType: Website Settings,FavIcon,Favicon
-DocType: Workflow State,minus-sign,μείον-sign
-sites/assets/js/desk.min.js +168,Not Found,Δεν βρέθηκε
-apps/frappe/frappe/templates/pages/print.py +124,No {0} permission,Όχι {0} άδεια
-DocType: Feed,Login,σύνδεση
-DocType: System Settings,Enable Scheduled Jobs,Ενεργοποίηση προγραμματισμένες εργασίες
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +60,Notes:,Σημειώσεις :
-sites/assets/js/desk.min.js +480,Markdown,Χαμήλωση τιμής
-DocType: DocShare,Document Name,Όνομα εγγράφου
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +289,Add New User Permission,Προσθήκη νέου Άδεια χρήσης
-DocType: Comment,Comment By,Σχόλιο από
-DocType: Customize Form,Customize Form,Προσαρμογή Μορφή
-apps/frappe/frappe/model/db_schema.py +406,"Fieldname {0} cannot contain letters, numbers or spaces","Fieldname {0} δεν μπορεί να περιέχει γράμματα , αριθμούς ή χώρους"
-DocType: Currency,A symbol for this currency. For e.g. $,Ένα σύμβολο για το νόμισμα αυτό. Για παράδειγμα $
-sites/assets/js/desk.min.js +791,Frappe Framework,Πλαίσιο Frappe
-apps/frappe/frappe/model/naming.py +160,Name of {0} cannot be {1},Όνομα του {0} δεν μπορεί να είναι {1}
-apps/frappe/frappe/config/setup.py +73,Show or hide modules globally.,Εμφάνιση ή απόκρυψη μονάδων σε παγκόσμιο επίπεδο .
-DocType: Workflow State,Success,Επιτυχία
-DocType: Website Settings,Sidebar Links for Home Page only,Sidebar Σύνδεσμοι για την αρχική σελίδα μόνο
-apps/frappe/frappe/templates/includes/login.js +119,Invalid Login,Άκυρα Login
-DocType: Communication,Phone No.,Αριθμός τηλεφώνου
-DocType: Workflow State,fire,φωτιά
-DocType: Workflow State,picture,εικόνα
-DocType: Workflow Transition,Next State,Επόμενη κράτος
-sites/assets/js/editor.min.js +119,Align Left (Ctrl/Cmd+L),Στοίχισηαριστερά (Ctrl / Cmd + L)
-apps/frappe/frappe/core/doctype/communication/communication.py +201,"Error generating PDF, attachment sent as HTML","Σφάλμα κατά PDF, συνημμένο που έχει αποσταλεί ως HTML"
-DocType: Style Settings,Custom CSS,Προσαρμοσμένη CSS
-apps/frappe/frappe/config/setup.py +222,Log of error on automated events (scheduler).,Συνδεθείτε σφάλματος στην αυτοματοποιημένη γεγονότα ( scheduler ) .
-apps/frappe/frappe/utils/csvutils.py +73,Not a valid Comma Separated Value (CSV File),Μη έγκυρο διαχωρισμένες με κόμματα ( CSV ​​αρχείου )
-DocType: Email Account,Default Incoming,Προεπιλογή Εισερχόμενη
-DocType: Workflow State,repeat,επαναλαμβάνω
-DocType: Website Settings,Banner,Λάβαρο
-sites/assets/js/desk.min.js +775,Help on Search,Βοήθεια για Αναζήτηση
-DocType: DocType,Hide Copy,Απόκρυψη Αντιγραφή
-apps/frappe/frappe/core/doctype/user/user.js +127,Clear all roles,Καταργήστε όλους τους ρόλους
-apps/frappe/frappe/model/base_document.py +267,{0} must be unique,{0} πρέπει να είναι μοναδικό
-apps/frappe/frappe/permissions.py +151,Row,Σειρά
-DocType: Workflow State,Check,Έλεγχος
-apps/frappe/frappe/desk/page/activity/activity.js +153,Apr,Απρίλιος
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +58,Fieldname which will be the DocType for this link field.,Fieldname η οποία θα είναι η DocType για αυτό το πεδίο σύνδεσμο.
-DocType: User,Email Signature,Υπογραφή Email
-DocType: Website Settings,Google Analytics ID,Google Analytics ID
-sites/assets/js/desk.min.js +480,Edit as {0},Επεξεργασία ως {0}
-sites/assets/js/desk.min.js +777,<b>new</b> <i>type of document</i>,<b> νέα </ b> <i> τύπο του εγγράφου </ i>
-apps/frappe/frappe/email/doctype/email_account/email_account_list.js +10,Default Inbox,Προεπιλογή Εισερχόμενα
-sites/assets/js/desk.min.js +496,Make a new,Κάντε μια νέα
-DocType: Print Settings,PDF Page Size,PDF Μέγεθος σελίδας
-sites/assets/js/desk.min.js +804,About,Σχετικά
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +66,"For updating, you can update only selective columns.","Για ενημέρωση, μπορείτε να ενημερώσετε επιλεκτική μόνο στήλες."
-sites/assets/js/desk.min.js +822,Attach Document Print,Συνδέστε Εκτύπωση εγγράφου
-DocType: Social Login Keys,Google Client ID,Google πελάτη ID
-apps/frappe/frappe/core/doctype/user/user.py +56,Adding System Manager to this User as there must be atleast one System Manager,"Προσθέτοντας Διαχειριστή του Συστήματος για τον χρήστη , όπως πρέπει να υπάρχει atleast Διαχειριστής ενός συστήματος"
-apps/frappe/frappe/desk/doctype/todo/todo.py +14,Assigned to {0},Ανατέθηκε σε {0}
-DocType: Workflow State,list-alt,list-alt
-apps/frappe/frappe/core/doctype/user/user.py +343,Password Updated,Κωδικός ενημέρωση
-apps/frappe/frappe/core/page/modules_setup/modules_setup.js +18,"Select modules to be shown (based on permission). If hidden, they will be hidden for all users.","Επιλέξτε ενότητες που πρέπει να δείξει ( με βάση την άδεια ) . Αν κρύβεται , θα είναι κρυμμένα για όλους τους χρήστες ."
-DocType: Top Bar Item,Link to the page you want to open,Σύνδεσμο προς τη σελίδα που θέλετε να ανοίξετε
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +149,Permissions Updated,Δικαιώματα Ενημερώθηκε
-DocType: Outgoing Email Settings,Outgoing Mail Server,Διακομιστής εξερχόμενης αλληλογραφίας
-apps/frappe/frappe/core/doctype/doctype/doctype.py +236,Options requried for Link or Table type field {0} in row {1},"Επιλογές που απαιτούνται, για Link ή πεδίο τύπου πίνακα {0} στη γραμμή {1}"
-DocType: Report,Query Report,Έκθεση ερωτήματος
-DocType: Communication,On,Επί
-DocType: User,Github User ID,Github ID χρήστη
-DocType: Communication,Chat,Κουβέντα
-apps/frappe/frappe/core/doctype/doctype/doctype.py +227,Fieldname {0} appears multiple times in rows {1},Fieldname {0} εμφανίζεται πολλαπλές φορές σε σειρές {1}
-DocType: Workflow State,arrow-down,βέλος προς τα κάτω
-sites/assets/js/desk.min.js +735,Collapse,κατάρρευση
-apps/frappe/frappe/model/delete_doc.py +127,User not allowed to delete {0}: {1},Ο χρήστης δεν επιτρέπεται να διαγράψετε {0}: {1}
-DocType: Website Settings,Linked In Share,Συνδέεται Σε Share
-sites/assets/js/desk.min.js +510,Last Updated On,Τελευταία ενημέρωση στις
-DocType: Style Settings,Top Bar,Top Bar
-sites/assets/js/desk.min.js +667,Alternative download link,Εναλλακτική σύνδεση λήψης
-sites/assets/js/desk.min.js +443,Please save the document before uploading.,Παρακαλούμε να αποθηκεύσετε το έγγραφο πριν από την αποστολή.
-apps/frappe/frappe/core/doctype/user/user.py +374,Not allowed to reset the password of {0},Δεν επιτρέπεται να επαναφέρετε τον κωδικό πρόσβασης του {0}
-DocType: Workflow State,hand-down,το χέρι προς τα κάτω
-apps/frappe/frappe/core/doctype/doctype/doctype.py +370,{0}: Cannot set Cancel without Submit,{0} : Δεν είναι δυνατή η ρύθμιση Ακύρωση χωρίς Υποβολή
-DocType: DocType,Is Submittable,Είναι Submittable
-apps/frappe/frappe/custom/doctype/property_setter/property_setter.js +7,Value for a check field can be either 0 or 1,Τιμή για ένα πεδίο ελέγχου μπορεί να είναι είτε 0 ή 1
-apps/frappe/frappe/model/document.py +423,Could not find {0},Δεν μπόρεσα να βρω {0}
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +217,Column Labels:,Ετικέτες Στήλη:
-apps/frappe/frappe/model/naming.py +60,Naming Series mandatory,Ονομασία σειράς υποχρεωτική
-DocType: Social Login Keys,Facebook Client ID,Facebook ταυτότητα πελατών
-DocType: Workflow State,Inbox,Εισερχόμενα
-DocType: Workflow State,Tag,Ετικέτα
-DocType: Custom Script,Script,Γραφή
-sites/assets/js/desk.min.js +804,My Settings,Οι ρυθμίσεις μου
-apps/frappe/frappe/website/doctype/web_form/web_form.py +51,Invalid Request,Άκυρη Αίτηση
-sites/assets/js/desk.min.js +351,This form does not have any input,Αυτή η μορφή δεν έχει καμία είσοδο
-apps/frappe/frappe/core/doctype/system_settings/system_settings.py +17,Session Expiry must be in format {0},Συνεδρία λήξης θα πρέπει να είναι σε μορφή {0}
-DocType: Top Bar Item,"Select target = ""_blank"" to open in a new page.","Επιλέξτε target = "" _blank "" για να ανοίξει σε μια νέα σελίδα ."
-sites/assets/js/desk.min.js +526,Permanently delete {0}?,Να διαγράψετε οριστικά {0} ;
-apps/frappe/frappe/core/doctype/file_data/file_data.py +33,Same file has already been attached to the record,Το ίδιο αρχείο έχει ήδη επισυναφθεί στο αρχείο
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +59,Ignore encoding errors.,Αγνοήστε τα σφάλματα κωδικοποίησης.
-DocType: Workflow State,wrench,κλειδί
-apps/frappe/frappe/templates/emails/auto_reply.html +2,"Your query has been received. We will back reply shortly. If you have any additional information, please reply to this mail.","Το ερώτημά σας έχει παραληφθεί. Θα στηρίξουμε την απάντηση σύντομα. Εάν έχετε οποιεσδήποτε πρόσθετες πληροφορίες, παρακαλώ απαντήστε σε αυτό το μήνυμα."
-DocType: Website Settings,Disable Signup,Απενεργοποίηση Εγγραφή
-DocType: Style Settings,Heading Text As,Τομέας κειμένου ως
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +7,Roles can be set for users from their User page.,Οι ρόλοι μπορεί να ρυθμιστεί για τους χρήστες από τη σελίδα χρήστη τους .
-DocType: DocField,Mandatory,Υποχρεωτική
-apps/frappe/frappe/core/doctype/doctype/doctype.py +341,{0}: No basic permissions set,{0} : Δεν βασικά δικαιώματα σετ
-apps/frappe/frappe/utils/backups.py +136,Download link for your backup will be emailed on the following email address: {0},Λήψη σύνδεσμο για backup σας θα σας αποσταλεί στην ακόλουθη διεύθυνση ηλεκτρονικού ταχυδρομείου: {0}
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +14,"Meaning of Submit, Cancel, Amend","Σημασία των Υποβολή, Άκυρο, τροποποιούνται"
-apps/frappe/frappe/desk/doctype/todo/todo_list.js +7,To Do,Για να κάνετε
-DocType: Style Settings,Font (Text),Font (Κείμενο)
-DocType: Outgoing Email Settings,Check this if you want to send emails as this id only (in case of restriction by your email provider).,"Ελέγξτε αυτό, αν θέλετε να στείλετε μηνύματα ηλεκτρονικού ταχυδρομείου, όπως αυτό id μόνο (στην περίπτωση του περιορισμού από τον παροχέα email σας)."
-sites/assets/js/editor.min.js +94,Paragraph,Παράγραφος
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +133,Any existing permission will be deleted / overwritten.,Κάθε υφιστάμενη άδεια θα διαγραφεί / αντικατασταθεί.
-DocType: Style Settings,"If image is selected, color will be ignored (attach first)","Εάν η εικόνα έχει επιλεγεί, το χρώμα θα πρέπει να αγνοηθεί (επισυνάψετε πρώτα)"
-DocType: DocField,Percent,Τοις εκατό
-DocType: Workflow State,book,βιβλίο
-DocType: Website Settings,Landing Page,Landing Page
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +162,No Permissions set for this criteria.,Δεν Δικαιώματα για το εν λόγω κριτήρια.
-DocType: DocField,"For Links, enter the DocType as range
-For Select, enter list of Options separated by comma","Για τις συνδέσεις, εισάγετε το DocType ως εύρος 
- Για Select, μπείτε στη λίστα των επιλογών χωρισμένα με κόμμα"
-apps/frappe/frappe/config/setup.py +140,Setup Email Alert based on various criteria.,Ρύθμιση Email Alert με βάση διάφορα κριτήρια.
-DocType: Email Alert,Send alert if date matches this field's value,Αποστολή ειδοποίησης σε περίπτωση ημερομηνία ταιριάζει με την αξία αυτού του πεδίου
-DocType: Workflow,Transitions,Μεταβάσεις
-DocType: User,Login After,Είσοδος μετά
-DocType: Workflow State,thumbs-up,thumbs-up
-sites/assets/js/desk.min.js +822,Add Reply,Προσθήκη Απάντησης
-DocType: DocPerm,DocPerm,DocPerm
-DocType: Style Settings,Fonts,Γραμματοσειρές
-apps/frappe/frappe/core/doctype/doctype/doctype.py +267,Precision should be between 1 and 6,Ακρίβεια πρέπει να είναι μεταξύ 1 και 6
-DocType: About Us Team Member,Image Link,Σύνδεσμος εικόνας
-DocType: Workflow State,step-backward,βήμα προς τα πίσω
-apps/frappe/frappe/utils/boilerplate.py +223,{app_title},{ app_title }
-apps/frappe/frappe/desk/form/assign_to.py +112,"The task %s, that you assigned to %s, has been closed.","Η αποστολή% s, ώστε να αποδίδεται στο% s, έχει κλείσει."
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +65,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,Μόνο υποχρεωτικά πεδία είναι απαραίτητα για νέες εγγραφές. Μπορείτε να διαγράψετε μη υποχρεωτικές στήλες εάν το επιθυμείτε.
-apps/frappe/frappe/core/doctype/user/user.py +335,Cannot Update: Incorrect Password,Δεν είναι δυνατή η ενημέρωση : Λάθος Κωδικός
-DocType: Workflow State,text-height,text-Ύψος
-DocType: Workflow State,map-marker,χάρτης σήμανσης
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +39,Submit an Issue,Υποβολή προβλήματος
-DocType: Event,Repeat this Event,Επαναλάβετε αυτό το Event
-DocType: DocPerm,Amend,Τροποποιούνται
-DocType: Outgoing Email Settings,Always use above Login Id as sender,Πάντα να χρησιμοποιείτε παραπάνω Είσοδος Id ως αποστολέα
-apps/frappe/frappe/templates/includes/login.js +43,Valid Login id required.,Ισχύει Είσοδος id απαιτείται.
-apps/frappe/frappe/desk/doctype/todo/todo.js +20,Re-open,Re - ανοικτή
-apps/frappe/frappe/core/doctype/docshare/docshare.py +44,{0} un-shared this document with {1},{0} un-κοινόχρηστο αυτό το έγγραφο με {1}
-apps/frappe/frappe/templates/emails/auto_reply.html +4,This is an automatically generated reply,Αυτό έχει δημιουργηθεί αυτόματα απάντηση
-apps/frappe/frappe/model/document.py +329,Record does not exist,Δεν υπάρχει εγγραφή
-apps/frappe/frappe/templates/pages/404.html +4,Page missing or moved,Σελίδα λείπουν ή μετακινηθεί
-DocType: Style Settings,"Add the name of <a href=""http://google.com/webfonts"" target=""_blank"">Google Web Font</a> e.g. ""Open Sans""","Προσθέστε το όνομα της <a href=""http://google.com/webfonts"" target=""_blank"">Google Font Web</a> π.χ. &quot;Open Sans&quot;"
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +47,"Always insert, even if ID is given.","Εισάγετε πάντα, ακόμη και εάν το αναγνωριστικό είναι δεδομένη."
-sites/assets/js/desk.min.js +456,Open Link,Άνοιγμα συνδέσμου
-apps/frappe/frappe/desk/form/load.py +42,Did not load,Δεν φορτώθηκαν
-apps/frappe/frappe/desk/query_report.py +79,Query must be a SELECT,Ερώτημα πρέπει να είναι μια SELECT
-DocType: Website Settings,Facebook Share,Facebook Share
-apps/frappe/frappe/utils/file_manager.py +169,File size exceeded the maximum allowed size of {0} MB,Μέγεθος αρχείου υπερβεί το μέγιστο επιτρεπόμενο μέγεθος του {0} MB
-apps/frappe/frappe/core/doctype/doctype/doctype.py +329,Enter at least one permission row,Εισάγετε τουλάχιστον μία σειρά άδεια
-sites/assets/js/desk.min.js +510,Created On,Δημιουργήθηκε Από
-DocType: Workflow State,align-center,ευθυγράμμιση κέντρο
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +16,"Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit.","Ορισμένα έγγραφα , όπως ένα τιμολόγιο , δεν θα πρέπει να αλλάξει μία φορά τελικό . Η τελική κατάσταση των εν λόγω εγγράφων ονομάζεται Υποβλήθηκε . Μπορείτε να περιορίσετε ποιοι ρόλοι μπορούν Υποβολή ."
-DocType: Communication,Sender,Αποστολέας
-DocType: Outgoing Email Settings,"<a href=""https://en.wikipedia.org/wiki/Transport_Layer_Security"" target=""_blank"">[?]</a>","<a href=""https://en.wikipedia.org/wiki/Transport_Layer_Security"" target=""_blank""> [ ?] < / a>"
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +21,Download Blank Template,Κατεβάστε το κενό πρότυπο
-DocType: DocField,In Filter,Το Φίλτρο
-apps/frappe/frappe/core/page/user_permissions/user_permissions.py +58,Cannot remove permission for DocType: {0} and Name: {1},Δεν μπορεί να αφαιρέσει την άδεια για DocType : {0} και Όνομα : {1}
-sites/assets/js/editor.min.js +115,Remove Link,Κατάργηση συνδέσμου
-apps/frappe/frappe/desk/page/activity/activity_row.html +11,Logged in,Συνδέθηκε
-apps/frappe/frappe/email/doctype/email_account/email_account_list.js +6,Default Sending and Inbox,Προεπιλογή Αποστολή και Εισερχόμενα
-DocType: Print Settings,Letter,Επιστολή
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +95,Reset Permissions for {0}?,Επαναφορά Δικαιώματα για {0} ;
-apps/frappe/frappe/permissions.py +202,{0} {1} not found,{0} {1} δεν βρέθηκε
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +199,Show a description below the field,Δείτε την περιγραφή κάτω από το πεδίο
-DocType: Workflow State,align-left,ευθυγράμμιση αριστερά
-DocType: User,Defaults,Προεπιλογές
-sites/assets/js/desk.min.js +527,Merge with existing,Συγχώνευση με τις υπάρχουσες
-DocType: Email Alert,[Optional] Send the email X days in advance of the specified date. 0 equals same day.,[Προαιρετικό] Στείλτε τα email X ημέρες πριν από την καθορισμένη ημερομηνία. 0 ισούται ίδια ημέρα.
-DocType: User,Birth Date,Ημερομηνία Γέννησης
-DocType: Workflow State,fast-backward,fast-backward
-DocType: DocShare,DocShare,DocShare
-DocType: Report,Add Total Row,Προσθήκη Σύνολο Row
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +19,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Για παράδειγμα, αν έχετε ακυρώσει και να τροποποιήσει INV004 θα γίνει μια νέα INV004-1 έγγραφο. Αυτό σας βοηθά να παρακολουθείτε κάθε τροποποίηση."
-DocType: Workflow Document State,0 - Draft; 1 - Submitted; 2 - Cancelled,0 - Σχέδιο? 1 - Υποβλήθηκε? 2 - Ακυρώθηκε
-apps/frappe/frappe/core/page/modules_setup/modules_setup.js +5,Show or Hide Modules,Εμφάνιση ή Απόκρυψη Ενότητες
-DocType: File Data,Attached To DocType,Που συνδέονται με DOCTYPE
-apps/frappe/frappe/desk/page/activity/activity.js +154,Aug,Αύγουστος
-DocType: DocField,Int,Int
-DocType: Currency,"1 Currency = [?] Fraction
-For e.g. 1 USD = 100 Cent","1 Νόμισμα = [?] Κλάσμα 
- Για παράδειγμα 1 USD = 100 Cent"
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +363,Add New Permission Rule,Προσθέστε νέο κανόνα άδεια
-sites/assets/js/desk.min.js +487,You can use wildcard %,Μπορείτε να χρησιμοποιήσετε το χαρακτήρα μπαλαντέρ%
-apps/frappe/frappe/desk/page/activity/activity.js +153,Mar,Mar
-DocType: DocField,Text Editor,Επεξεργαστής κειμένου
-apps/frappe/frappe/config/website.py +68,Settings for About Us Page.,Ρυθμίσεις για την εταιρεία μας σελίδα.
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +499,Edit Custom HTML,Επεξεργασία προσαρμοσμένου HTML
-DocType: Email Alert,Value Change,Αξία Αλλαγή
-DocType: Standard Reply,Standard Reply,Πρότυπο Απάντηση
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +160,Width of the input box,Το πλάτος του πλαισίου εισόδου
-DocType: UserRole,UserRole,UserRole
-DocType: Print Settings,With Letterhead,Με επιστολόχαρτο
-apps/frappe/frappe/email/smtp.py +148,Invalid Outgoing Mail Server or Port,Άκυρα Outgoing Mail Server ή το λιμάνι
-DocType: DocPerm,Write,Γράφω
-apps/frappe/frappe/core/doctype/report/report.py +29,Only Administrator allowed to create Query / Script Reports,Μόνο διαχειριστή τη δυνατότητα να δημιουργήσουν Query / Script Εκθέσεις
-DocType: Outgoing Email Settings,Outgoing Email Settings,Εξερχόμενες Ρυθμίσεις Email
-sites/assets/js/desk.min.js +822,Select Attachments,Επιλέξτε Συνημμένα
-apps/frappe/frappe/templates/emails/new_user.html +3,A new account has been created for you,Ένας νέος λογαριασμός έχει δημιουργηθεί για εσάς
-apps/frappe/frappe/templates/emails/password_update.html +1,Password Update Notification,Κωδικός Ειδοποίηση ενημέρωσης
-DocType: DocPerm,User Permission DocTypes,Doctypes Άδεια χρήσης
-sites/assets/js/desk.min.js +527,New Name,Νέο Όνομα
-DocType: Custom Field,Default Value,Προεπιλεγμένη τιμή
-DocType: Workflow Document State,Update Field,Ενημέρωση Field
-apps/frappe/frappe/model/base_document.py +332,Options not set for link field {0},Επιλογές δεν έχει οριστεί για το πεδίο link {0}
-DocType: Style Settings,Google Web Font (Heading),Google Web Font (Τομέας)
-DocType: Workflow State,asterisk,αστερίσκος
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +61,Please do not change the template headings.,Παρακαλώ μην αλλάξετε τις επικεφαλίδες πρότυπο.
-DocType: Workflow State,shopping-cart,shopping-cart
-DocType: Social Login Keys,Google,Google
-DocType: Workflow State,Inverse,Αντίστροφος
-DocType: DocField,User permissions should not apply for this Link,Δικαιώματα χρήστη δεν πρέπει να εφαρμόζονται για αυτή την σύνδεση
-apps/frappe/frappe/model/naming.py +88,Invalid naming series (. missing),Μη έγκυρη σειρά ονομασίας (. Που λείπουν)
-DocType: System Settings,Language,Γλώσσα
-DocType: DocPerm,Cancel,Ακύρωση
-DocType: Web Page,Page content,Περιεχόμενο της σελίδας
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +91,Leave blank for new records,Αφήστε κενό για νέες εγγραφές
-sites/assets/js/desk.min.js +804,Logout,Αποσύνδεση
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +26,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,Δικαιώματα σε υψηλότερα επίπεδα είναι τα δικαιώματα τοπικό επίπεδο. Όλα τα πεδία έχουν ένα σύνολο επίπεδο δικαιωμάτων εναντίον τους και τους κανόνες που ορίζονται στο ότι τα δικαιώματα εφαρμόζονται στον τομέα. Αυτό είναι χρήσιμο στην περίπτωση που θέλετε να αποκρύψετε ή να προβεί σε ορισμένες τομέα μόνο για ανάγνωση για ορισμένους ρόλους.
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +38,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Εάν αυτές οι οδηγίες , όπου δεν είναι χρήσιμο , παρακαλούμε να προσθέσετε δικές σας προτάσεις σχετικά GitHub θέματα ."
-DocType: Workflow State,bookmark,σελιδοδείκτη
-DocType: Currency,Symbol,Σύμβολο
-apps/frappe/frappe/model/base_document.py +373,Row #{0}:,Σειρά # {0}:
-apps/frappe/frappe/core/doctype/user/user.py +73,New password emailed,Νέος κωδικός μέσω e-mail
-apps/frappe/frappe/auth.py +195,Login not allowed at this time,Είσοδος Δεν επιτρέπεται αυτή τη στιγμή
-DocType: DocType,Permissions Settings,Δικαιώματα Ρυθμίσεις
+DocType: About Us Settings,"""Company History""","""Ιστορικό εταιρείας"""
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +69,"""Parent"" signifies the parent table in which this row must be added",H λέξη «γονικός» δηλώνει το γονικό πίνακα στον οποίο πρέπει να προστεθεί αυτή η σειρά
+DocType: About Us Settings,"""Team Members"" or ""Management""","""Μέλη ομάδας"" ή ""διαχείριση"""
+DocType: Currency,**Currency** Master,Κύρια εγγραφή ** νομίσματος ** 
+apps/frappe/frappe/core/doctype/report/report.js +10,[Label]:[Field Type]/[Options]:[Width],[Label]:[field type]/[options]:[width]
+DocType: Email Alert,[Optional] Send the email X days in advance of the specified date. 0 equals same day.,[Προαιρετικό] στείλτε τα email x ημέρες πριν από την καθορισμένη ημερομηνία. Το 0 σημαίνει την ίδια ημέρα.
+apps/frappe/frappe/desk/form/save.py +21,{0} {1} already exists,{0} {1} Υπάρχει ήδη
+apps/frappe/frappe/model/base_document.py +377,"{0} {1} cannot be ""{2}"". It should be one of ""{3}""","{0} {1} Δεν μπορεί να είναι ""{2}"". Θα πρέπει να είναι ένα από τα ""{3}"""
+apps/frappe/frappe/utils/nestedset.py +227,{0} {1} cannot be a leaf node as it has children,"{0} {1} Δεν μπορεί να είναι ένας κόμβος φύλλο, δεδομένου ότι έχει θυγατρικούς κόμβους"
+apps/frappe/frappe/model/rename_doc.py +90,"{0} {1} does not exist, select a new target to merge","{0} {1} Δεν υπάρχει, επιλέξτε ένα νέο στόχο για τη συγχώνευση"
+apps/frappe/frappe/permissions.py +202,{0} {1} not found,{0} {1} Δεν βρέθηκε
+apps/frappe/frappe/model/delete_doc.py +131,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Οι υποβεβλημένες εγγραφές δεν μπορούν να διαγραφούν.
+sites/assets/js/desk.min.js +498,{0} added,{0} Προστέθηκε
+apps/frappe/frappe/templates/includes/comments.py +48,{0} by {1},{0} Από {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py +394,{0} cannot be set for Single types,{0} Δεν μπορεί να οριστεί για μοναδιαίους τύπους
+apps/frappe/frappe/templates/pages/blog.py +55,{0} comments,{0} Σχόλια
+apps/frappe/frappe/website/doctype/website_settings/website_settings.py +32,{0} does not exist in row {1},{0} Δεν υπάρχει στη γραμμή {1}
+apps/frappe/frappe/website/doctype/website_settings/website_settings.py +36,{0} in row {1} cannot have both URL and child items,{0} Στη γραμμή {1} δεν μπορεί να έχει και url και θυγατρικά είδη
+apps/frappe/frappe/desk/reportview.py +72,{0} is saved,{0} Είναι αποθηκευμένο
 sites/assets/js/desk.min.js +788,{0} List,{0} Λίστα
-apps/frappe/frappe/desk/form/assign_to.py +40,Already in user's To Do list,Ήδη από το χρήστη να κάνει λίστα
-DocType: Email Account,Enable Outgoing,Ενεργοποίηση Εξερχόμενες
-DocType: DocField,Text,Κείμενο
-apps/frappe/frappe/config/setup.py +145,Standard replies to common queries.,Πρότυπο απαντήσεις σε συχνά ερωτήματα.
-sites/assets/js/desk.min.js +804,Report an Issue,Αναφορά προβλήματος
-apps/frappe/frappe/email/doctype/email_account/email_account_list.js +14,Default Sending,Προεπιλογή Αποστολή
-DocType: Workflow State,volume-off,όγκου-off
-DocType: Custom Field,Properties,Ακίνητα
-DocType: Email Alert,Date Change,Αλλαγή της ημερομηνίας
-DocType: DocField,Dynamic Link,Dynamic Link
-DocType: Property Setter,DocType or Field,DocType ή Field
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +3,Quick Help for Setting Permissions,Γρήγορη βοήθεια για τον καθορισμό των δικαιωμάτων
-DocType: Report,Report Builder,Έκθεση Builder
-DocType: Website Settings,Hide the sidebar,Απόκρυψη του sidebar
-DocType: Workflow,Workflow,Workflow
-DocType: Workflow State,Upload,μεταφόρτωση
-DocType: System Settings,Date Format,Μορφή ημερομηνίας
-apps/frappe/frappe/website/doctype/blog_post/blog_post_list.js +7,Not Published,Δεν έχει δημοσιευθεί
-apps/frappe/frappe/config/setup.py +124,"Actions for workflow (e.g. Approve, Cancel).","Ενέργειες για τη ροή εργασίας ( π.χ. Έγκριση , Ακύρωση ) ."
-DocType: Workflow State,flag,σημαία
-DocType: Web Page,Text Align,Κείμενο Στοίχιση
-DocType: Contact Us Settings,Forward To Email Address,Μπροστά στη διεύθυνση ηλεκτρονικού ταχυδρομείου
-apps/frappe/frappe/core/doctype/doctype/doctype.py +80,Title field must be a valid fieldname,Τίτλος πεδίο πρέπει να είναι ένα έγκυρο όνομα πεδίου
-DocType: Communication,Archived,Αρχείο
-DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Λήξη συνεδρίας σε ώρες, π.χ. 6:00"
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +35,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Αφού έχετε ρυθμίσει αυτό, οι χρήστες θα είναι σε θέση πρόσβαση σε έγγραφα ( π.χ. Blog Post) , όπου υπάρχει ο σύνδεσμος ( π.χ. Blogger ) ."
-apps/frappe/frappe/utils/csvutils.py +32,Unable to open attached file. Please try again.,Ανίκανος να ανοίξει συνημμένο αρχείο . Παρακαλώ δοκιμάστε ξανά .
-DocType: Scheduler Log,Log of Scheduler Errors,Σύνδεση του Scheduler Λάθη
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +158,Custom HTML,Προσαρμοσμένη HTML
-DocType: Comment,Comment Docname,Σχόλιο Docname
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +54,Select Role,Επιλέξτε Ρόλος
-apps/frappe/frappe/model/delete_doc.py +186,Deleted,Διαγράφεται
-DocType: Workflow State,adjust,προσαρμόσει
-DocType: Website Settings,Disable Customer Signup link in Login page,Απενεργοποίηση Πελάτης Εγγραφή συνδέσμου στη σελίδα Login
-apps/frappe/frappe/core/report/todo/ToDo.py +21,Assigned To/Owner,Ανατέθηκε σε / Ιδιοκτήτης
-DocType: Workflow State,arrow-left,βέλος αριστερά
-apps/frappe/frappe/desk/page/applications/application_row.html +5,Installed,εγκατεστημένο
-DocType: Workflow State,fullscreen,fullscreen
-DocType: Event,Ref Name,Όνομα Κωδ
-DocType: Web Page,Center,Κέντρο
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +33,Setup > User Permissions Manager,Ρύθμιση> Τα δικαιώματα χρήστη διαχειριστή
-DocType: Workflow Document State,Represents the states allowed in one document and role assigned to change the state.,Εκπροσωπεί τα κράτη μέλη επιτρέπεται σε ένα έγγραφο και ο ρόλος που ανατίθεται να αλλάξει την κατάσταση.
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +48,Refresh Form,Ανανέωση Έντυπο
-DocType: DocField,Select,Επιλέξτε
-apps/frappe/frappe/utils/csvutils.py +24,File not attached,Το αρχείο δεν συνδέεται
-DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","Αν ορίσετε αυτό, αυτό το στοιχείο θα έρθει σε ένα drop-down κάτω από τον επιλεγμένο γονέα."
-apps/frappe/frappe/model/db_query.py +371,Please select atleast 1 column from {0} to sort,Παρακαλώ επιλέξτε atleast στήλη 1 από {0} για να ταξινομήσετε
-apps/frappe/frappe/templates/pages/print.py +150,No template found at path: {0},Δεν βρέθηκε στην πορεία πρότυπο: {0}
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +53,Submit after importing.,Υποβολή μετά την εισαγωγή.
-DocType: Blogger,Avatar,Avatar
-DocType: Blogger,Posts,Δημοσιεύσεις
-sites/assets/js/desk.min.js +843,Dear,Αγαπητός
-DocType: ToDo,Description and Status,Περιγραφή και Κατάσταση
-DocType: Web Page,HTML for header section. Optional,HTML για ενότητα κεφαλίδας . προαιρετικός
-apps/frappe/frappe/core/doctype/userrole/userrole.py +14,Role exists,υπάρχει ο ρόλος
-sites/assets/js/desk.min.js +822,Select Print Format,Επιλέξτε έντυπη μορφή
-DocType: DocField,Print Hide,Εκτύπωση Απόκρυψη
-sites/assets/js/desk.min.js +148,Enter Value,Εισαγωγή τιμής
-DocType: Workflow State,tint,απόχρωση
-DocType: Outgoing Email Settings,System generated mails will be sent from this email id.,Σύστημα που δημιουργούνται μηνύματα θα αποστέλλονται από αυτό το email id.
-DocType: Workflow State,Style,Στυλ
-apps/frappe/frappe/templates/pages/blog.py +55,{0} comments,{0} σχόλια
-DocType: DocField,Label and Type,Ετικέτα και Τύπος
-DocType: Workflow State,forward,προς τα εμπρός
-DocType: Web Page,Custom Javascript,Προσαρμοσμένη Javascript
-DocType: DocPerm,Submit,Υποβολή
-DocType: Website Settings,Sub-domain provided by erpnext.com,Sub-domain που παρέχεται από erpnext.com
-DocType: System Settings,dd-mm-yyyy,dd-mm-yyyy
-apps/frappe/frappe/desk/query_report.py +69,Must have report permission to access this report.,Πρέπει να έχετε δικαιώματα έκθεση πρόσβαση σε αυτή την έκθεση.
-apps/frappe/frappe/desk/doctype/event/event.py +62,Daily Event Digest is sent for Calendar Events where reminders are set.,Daily Event Digest αποστέλλεται για Ημερολόγιο Εκδηλώσεων όπου υπενθυμίσεις έχουν οριστεί.
-sites/assets/js/desk.min.js +804,View Website,Δείτε την ιστοσελίδα
-DocType: Workflow State,remove,Κατάργηση
-DocType: Outgoing Email Settings,If non standard port (e.g. 587),Αν μη τυπική θύρα (π.χ. 587)
-sites/assets/js/desk.min.js +804,Reload,Ανανέωση
-DocType: Event,Participants,Οι συμμετέχοντες
-DocType: Bulk Email,Reference DocName,Αναφορά DocName
-DocType: Web Form,Success Message,Επιτυχία Μήνυμα
-DocType: DocType,User Cannot Search,Ο χρήστης δεν μπορεί Αναζήτηση
-apps/frappe/frappe/desk/page/activity/activity.js +48,Build Report,Κατασκευάστηκε Έκθεση
-apps/frappe/frappe/model/rename_doc.py +90,"{0} {1} does not exist, select a new target to merge","{0} {1} δεν υπάρχει , επιλέξτε ένα νέο στόχο για τη συγχώνευση"
-apps/frappe/frappe/core/page/user_permissions/user_permissions.py +66,Cannot set permission for DocType: {0} and Name: {1},Δεν είναι δυνατός ο ορισμός άδεια για DocType : {0} και Όνομα : {1}
-DocType: Comment,Comment Doctype,Σχόλιο DOCTYPE
-apps/frappe/frappe/core/page/modules_setup/modules_setup.js +55,There were errors,Υπήρξαν σφάλματα
-apps/frappe/frappe/desk/doctype/todo/todo.js +12,Close,Κοντά
-apps/frappe/frappe/model/document.py +363,Cannot change docstatus from 0 to 2,Δεν είναι δυνατή η αλλαγή docstatus 0-2
-apps/frappe/frappe/core/doctype/doctype/doctype.py +240,Options must be a valid DocType for field {0} in row {1},Επιλογές θα πρέπει να είναι μια έγκυρη DocType για το πεδίο {0} στη γραμμή {1}
-DocType: Patch Log,List of patches executed,Κατάλογος των patches που εκτελέστηκαν
-DocType: Communication,Communication Medium,Μέσο Επικοινωνίας
-DocType: Website Settings,Banner HTML,HTML Διαφήμιση
-apps/frappe/frappe/model/base_document.py +377,"{0} {1} cannot be ""{2}"". It should be one of ""{3}""","{0} {1} δεν μπορεί να είναι ""{2}"". Θα πρέπει να είναι ένα από τα ""{3}"""
-apps/frappe/frappe/core/doctype/user/user.py +154,Password Update,Κωδικός Ενημέρωση
-DocType: Workflow State,trash,σκουπίδια
-apps/frappe/frappe/desk/page/activity/activity.js +154,Dec,Δεκέμβριος
-DocType: Event,Leave blank to repeat always,Αφήστε το κενό για να επαναλάβετε πάντα
-DocType: Event,Ends on,Λήγει στις
-apps/frappe/frappe/utils/nestedset.py +181,Item cannot be added to its own descendents,Το αντικείμενο δεν μπορεί να προστεθεί στις δικές τους απογόνους του
-DocType: Style Settings,Tahoma,Tahoma
-DocType: Style Settings,Page Text,Κείμενο σελίδας
-DocType: Blogger,Short Name,Short Name
-DocType: Workflow State,magnet,μαγνήτης
-apps/frappe/frappe/geo/doctype/currency/currency.js +7,This Currency is disabled. Enable to use in transactions,Αυτό το νόμισμα είναι απενεργοποιημένη . Ενεργοποίηση για να χρησιμοποιήσετε στις συναλλαγές
-DocType: Contact Us Settings,"Default: ""Contact Us""",Προεπιλογή: &quot;Επικοινωνήστε μαζί μας&quot;
-DocType: Email Account,Auto Reply,Αυτόματη Απάντηση
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +371,"Level 0 is for document level permissions, higher levels for field level permissions.","Επίπεδο 0 είναι για δικαιώματα σε επίπεδο εγγράφων, τα υψηλότερα επίπεδα για τα δικαιώματα σε επίπεδο τομέα."
-DocType: Custom Script,Sample,Δείγμα
-DocType: Event,Every Week,Κάθε εβδομάδα
-DocType: Custom Field,Is Mandatory Field,Είναι υποχρεωτικό πεδίο
-DocType: User,Website User,Χρήστης Website
-DocType: Website Script,Script to attach to all web pages.,Script για να επισυνάψετε σε όλες τις ιστοσελίδες.
-DocType: Web Form,Allow Multiple,Επιτρέπουν πολλαπλές
-DocType: Outgoing Email Settings,SMTP Server (e.g. smtp.gmail.com),SMTP Server (π.χ. smtp.gmail.com)
-DocType: Email Alert,Date Changed,Ημερομηνία Άλλαξε
-apps/frappe/frappe/config/setup.py +92,Import / Export Data from .csv files.,Εισαγωγή / Εξαγωγή δεδομένων από . Csv αρχεία .
-DocType: Workflow State,Icon will appear on the button,Θα εμφανιστεί το εικονίδιο στο κουμπί
-DocType: Web Page,Page url name (auto-generated),Όνομα σελίδας url ( δημιουργείται αυτόματα )
-apps/frappe/frappe/core/page/user_permissions/user_permissions.py +105,Please upload using the same template as download.,Παρακαλούμε να αποστείλετε χρησιμοποιώντας το ίδιο πρότυπο όπως μεταφορτώνει.
-apps/frappe/frappe/modules/__init__.py +77,App not found,App δεν βρέθηκε
-DocType: Workflow State,pencil,μολύβι
-apps/frappe/frappe/desk/form/assign_to.py +118,"The task %s, that you assigned to %s, has been closed by %s.","Η αποστολή% s, ώστε να αποδίδεται στο% s, έχει κλείσει από την% s."
-DocType: Workflow State,hand-up,χέρι-up
-DocType: Blog Settings,Writers Introduction,Συγγραφείς Εισαγωγή
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +140,Select Document Type or Role to start.,Επιλογή τύπου εγγράφου ή Ρόλου για να ξεκινήσει.
-sites/assets/js/desk.min.js +744,Page not found,Η σελίδα δεν βρέθηκε
-DocType: DocField,Precision,Ακρίβεια
-DocType: Website Slideshow,Slideshow Items,Παρουσίαση Προϊόντα
-apps/frappe/frappe/model/delete_doc.py +149,Cannot delete or cancel because {0} {1} is linked with {2} {3},Δεν είναι δυνατή η διαγραφή ή ακύρωση επειδή {0} {1} συνδέεται με {2} {3}
-DocType: Website Settings,Twitter Share,Μοιραστείτε το στο Twitter
-DocType: Workflow State,Workflow State,Workflow κράτος
-apps/frappe/frappe/templates/emails/password_reset.html +4,Please click on the following link to set your new password,Παρακαλώ κάντε κλικ στον παρακάτω σύνδεσμο για να ορίσετε νέο κωδικό πρόσβασης
-DocType: Contact Us Settings,Settings for Contact Us Page,Ρυθμίσεις για την Επικοινωνία Σελίδα
-DocType: Custom Script,Script Type,Τύπος Script
-DocType: Email Account,Footer,Υποσέλιδο
-apps/frappe/frappe/core/doctype/doctype/doctype.py +280,Fold must come before a labelled Section Break,Διπλώστε πρέπει να έρθει πριν από ένα επισημασμένο τμήμα Διάλειμμα
-DocType: Property Setter,Property Type,Τύπος ακινήτου
-DocType: Workflow State,screenshot,screenshot
-apps/frappe/frappe/core/doctype/report/report.py +24,Only Administrator can save a standard report. Please rename and save.,Μόνο διαχειριστή να αποθηκεύσετε ένα πρότυπο για την έκθεση. Παρακαλούμε να μετονομάσετε και να αποθηκεύσετε.
-DocType: DocField,Data,Δεδομένα
-sites/assets/js/desk.min.js +510,Document Status,Κατάσταση Εγγράφου
-DocType: Outgoing Email Settings,Login Id,Είσοδος Id
-apps/frappe/frappe/core/page/data_import_tool/importer.py +175,Not allowed to Import,Δεν επιτρέπεται για εισαγωγή
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +22,Permission Levels,Επίπεδα δικαιωμάτων
-DocType: Workflow State,Warning,Προειδοποίηση
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +193,No User Permissions found.,Δεν βρέθηκε δικαιώματα χρήσης .
-DocType: DocType,In Dialog,Στο Dialog
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +127,Help,Βοήθεια
-DocType: User,Login Before,Είσοδος Πριν από
-DocType: Web Page,Insert Style,Εισαγωγή Style
-apps/frappe/frappe/desk/page/applications/applications.js +93,Application Installer,Εγκατάσταση εφαρμογών
-DocType: Workflow State,info-sign,info-sign
-DocType: Currency,"How should this currency be formatted? If not set, will use system defaults","Πώς θα πρέπει αυτό το νόμισμα να διαμορφωθεί; Αν δεν έχει οριστεί, θα χρησιμοποιήσει τις προεπιλογές του συστήματος"
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +249,Show User Permissions,Δικαιώματα Εμφάνιση Χρήστη
-apps/frappe/frappe/utils/response.py +108,You need to be logged in and have System Manager Role to be able to access backups.,Θα πρέπει να είστε συνδεδεμένοι στο σύστημα και έχουν Ρόλος Manager για να είναι σε θέση να έχουν πρόσβαση σε αντίγραφα ασφαλείας .
-sites/assets/js/desk.min.js +497,Added {0} ({1}),Προστέθηκε {0} ({1})
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +247,Fieldtype cannot be changed from {0} to {1} in row {2},Fieldtype δεν μπορεί να αλλάξει από {0} έως {1} στη γραμμή {2}
-apps/frappe/frappe/core/doctype/doctype/doctype.py +292,Search Fields should contain valid fieldnames,Τα πεδία αναζήτησης πρέπει να περιέχουν έγκυρες fieldnames
-apps/frappe/frappe/core/doctype/user/user.js +282,Role Permissions,Δικαιώματα Ρόλος
-DocType: Standard Reply,Response,Απάντηση
-apps/frappe/frappe/email/smtp.py +37,Invalid recipient address,Μη έγκυρη διεύθυνση παραλήπτη
-DocType: Workflow State,step-forward,βήμα προς τα εμπρός
-apps/frappe/frappe/core/doctype/user/user.js +41,Refreshing...,Αναζωογονητικό ...
-apps/frappe/frappe/print/doctype/letter_head/letter_head.js +7,Step 1: Set the name and save.,Βήμα 1 : Ορίστε το όνομα και να σώσει .
-DocType: Event,Starts on,Ξεκινά στις
-DocType: Workflow State,th,ου
-sites/assets/js/desk.min.js +465,Create a new {0},Δημιουργήστε ένα νέο {0}
-sites/assets/js/desk.min.js +788,Open {0},Open {0}
-DocType: Workflow State,ok-sign,ok-sign
-apps/frappe/frappe/email/doctype/email_alert/email_alert.py +16,Please specify which value field must be checked,Παρακαλείσθε να προσδιορίσετε ποια πρέπει να ελέγχεται πεδίο τιμών
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +69,"""Parent"" signifies the parent table in which this row must be added",«Μητρική» δηλώνει η μητρική πίνακα στον οποίο πρέπει να προστεθεί αυτή η σειρά
-DocType: Style Settings,Apply Style,Εφαρμογή στυλ
-apps/frappe/frappe/templates/includes/blog.js +34,Nothing more to show.,Τίποτα περισσότερο για να δείξει.
-,Modules Setup,Modules Ρυθμίσεις
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +220,Type:,Είδος:
-apps/frappe/frappe/desk/moduleview.py +57,Module Not Found,Ενότητα Δεν βρέθηκε
-DocType: User,Location,τοποθεσία
-,Permitted Documents For User,Επιτρεπόμενες Έγγραφα για το χρήστη
-apps/frappe/frappe/core/doctype/docshare/docshare.py +33,"You need to have ""Share"" permission","Θα πρέπει να έχουν ""Share"" άδεια"
-DocType: Email Alert Recipient,Email Alert Recipient,Email Alert Παραλήπτης
-DocType: About Us Settings,Settings for the About Us Page,Ρυθμίσεις για την εταιρεία μας σελίδα
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +5,Select Type of Document to Download,Επιλέξτε Τύπος εγγράφου για να κατεβάσετε
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +170,Use the field to filter records,Χρησιμοποιήστε το πεδίο για να φιλτράρετε τα αρχεία
-DocType: Email Account,Outlook.com,Outlook.com
-DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Προσθέστε το Google Analytics ID: παράδειγμα. UA-89XXX57-1. Παρακαλούμε Ψάξτε στη βοήθεια του Google Analytics για περισσότερες πληροφορίες.
-DocType: Email Alert Recipient,"Expression, Optional","Έκφραση, Προαιρετικά"
-apps/frappe/frappe/templates/includes/blog.js +37,No posts written yet.,Δεν υπάρχουν αναρτήσεις γραπτή ακόμα.
-DocType: Email Account,Check this to pull emails from your mailbox,Επιλέξτε αυτό για να τραβήξει τα μηνύματα από το γραμματοκιβώτιό σας
-apps/frappe/frappe/model/document.py +376,Cannot edit cancelled document,Δεν μπορείτε να επεξεργαστείτε ακυρωθέν έγγραφο
-apps/frappe/frappe/utils/nestedset.py +77,Nested set error. Please contact the Administrator.,Εγκλωβισμένος σφάλμα σύνολο . Παρακαλώ επικοινωνήστε με το Διαχειριστή .
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_layout.html +11,<span class=text-muted data-no-content=1>,<Span class = text-σίγαση δεδομένων χωρίς περιεχόμενο = 1>
-DocType: Workflow State,envelope,φάκελος
-DocType: Style Settings,Top Bar Background,Αρχή Ιστορικό Bar
-apps/frappe/frappe/core/doctype/docshare/docshare.py +37,{0} shared this document with {1},{0} από κοινού αυτό το έγγραφο με {1}
-DocType: Website Settings,Google Plus One,Google Plus One
-apps/frappe/frappe/desk/page/activity/activity.js +154,Jul,Ιούλιος
-DocType: Communication,Additional Info,Πρόσθετες Πληροφορίες
-apps/frappe/frappe/config/website.py +43,"Setup of top navigation bar, footer and logo.","Ρύθμιση της επάνω γραμμή πλοήγησης, footer και το λογότυπο."
-apps/frappe/frappe/core/doctype/doctype/doctype.py +337,For {0} at level {1} in {2} in row {3},Για {0} σε επίπεδο {1} στο {2} στη γραμμή {3}
-DocType: Bulk Email,Recipient,Παραλήπτης
-apps/frappe/frappe/config/setup.py +157,Drag and Drop tool to build and customize Print Formats.,Drag and drop εργαλείο για την οικοδόμηση και να προσαρμόσετε τις μορφές εκτύπωσης.
-sites/assets/js/desk.min.js +735,Expand,Αναπτύξτε
-DocType: Workflow State,align-right,ευθυγράμμιση δεξιά
-DocType: Page,Roles,Ρόλοι
-DocType: System Settings,Session Expiry,Λήξη συνεδρίας
-DocType: Workflow State,ban-circle,ban-κύκλο
-DocType: Event,Desk,Γραφείο
-apps/frappe/frappe/core/doctype/report/report.js +8,Write a SELECT query. Note result is not paged (all data is sent in one go).,Γράψτε ένα ερώτημα επιλογής. Σημείωση αποτέλεσμα δεν σελιδοποιείται (όλα τα δεδομένα που αποστέλλονται σε ένα go).
-DocType: Email Account,Attachment Limit (MB),Όριο Συνημμένο (MB)
-DocType: Style Settings,Helvetica Neue,Helvetica Neue
-DocType: User,User Defaults,Προεπιλογές Προφίλ
-DocType: Workflow State,chevron-down,Chevron-down
-DocType: Workflow State,th-list,ου-list
-DocType: Web Page,Enable Comments,Ενεργοποίηση Σχόλια
-DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Περιορίστε χρήστη από την διεύθυνση αυτή και μόνο. Πολλαπλές διευθύνσεις IP μπορούν να προστεθούν διαχωρίζοντας με κόμμα. Επίσης δέχεται μερική IP διευθύνσεις, όπως (111.111.111)"
-sites/assets/js/desk.min.js +788,Find {0} in {1},Βρείτε {0} {1}
-DocType: Email Account,"Append as communication against this DocType (must have fields, ""Status"", ""Subject"")","Προσάρτηση ως ανακοίνωση κατά αυτού του DocType (πρέπει να έχει πεδία, ""Status"", ""Θέμα"")"
-DocType: DocType,Allow Import via Data Import Tool,Αφήστε εισαγωγής μέσω Εργαλείο εισαγωγής δεδομένων
-apps/frappe/frappe/model/base_document.py +398,Not allowed to change {0} after submission,Δεν επιτρέπεται να αλλάξετε {0} μετά την υποβολή
-DocType: Comment,Comment Type,Σχόλιο Τύπος
-apps/frappe/frappe/config/setup.py +7,Users,Χρήστες
-DocType: Email Account,Signature,Υπογραφή
-apps/frappe/frappe/config/website.py +78,"Enter keys to enable login via Facebook, Google, GitHub.","Εισάγετε τα πλήκτρα για να ενεργοποιήσετε την είσοδο μέσω του Facebook , Google , GitHub ."
-sites/assets/js/desk.min.js +452,Please attach a file first.,Επισυνάψτε ένα αρχείο για πρώτη φορά.
-apps/frappe/frappe/model/naming.py +154,"There were some errors setting the name, please contact the administrator","Υπήρξαν κάποια λάθη ρύθμιση το όνομα, επικοινωνήστε με το διαχειριστή"
-DocType: Website Slideshow Item,Website Slideshow Item,Website Στοιχείο Παρουσίαση
-DocType: Outgoing Email Settings,Server & Credentials,Server & Εντολής
-DocType: DocType,Title Case,Υπόθεση τίτλος
-DocType: Blog Post,Email Sent,Email Sent
-sites/assets/js/desk.min.js +822,Send As Email,Αποστολή ως e-mail
-apps/frappe/frappe/core/doctype/user/user.py +40,User {0} cannot be disabled,Χρήστης {0} δεν μπορεί να απενεργοποιηθεί
-apps/frappe/frappe/desk/form/assign_to.py +126,"A new task, %s, has been assigned to you by %s. %s","Ένα νέο έργο,% s, έχει ανατεθεί σε σας από το% s. % S"
-apps/frappe/frappe/config/setup.py +207,Download Backup,Λήψη αντιγράφων ασφαλείας
-apps/frappe/frappe/desk/page/activity/activity.js +20,Activty,Activty
-sites/assets/js/desk.min.js +487,Dialog box to select a Link Value,Παράθυρο διαλόγου για να επιλέξετε μια τιμή σύνδεσης
-DocType: Contact Us Settings,Send enquiries to this email address,Στείλτε τις απορίες σε αυτή τη διεύθυνση ηλεκτρονικού ταχυδρομείου
-DocType: Letter Head,Letter Head Name,Επιστολή Όνομα Head
-apps/frappe/frappe/config/website.py +22,User editable form on Website.,Χρήστης επεξεργάσιμη μορφή στην ιστοσελίδα.
-DocType: Workflow State,file,αρχείο
-apps/frappe/frappe/model/rename_doc.py +96,You need write permission to rename,Χρειάζεται να γράψετε την άδεια να μετονομάσετε
-DocType: User,Karma,Κάρμα
-DocType: DocField,Table,Τραπέζι
-DocType: File Data,File Size,Μέγεθος Αρχείου
-apps/frappe/frappe/website/doctype/web_form/web_form.py +85,You must login to submit this form,Θα πρέπει να συνδεθείτε για να υποβάλετε το έντυπο αυτό
-DocType: User,Background Image,Εικόνα φόντου
-DocType: DocPerm,Create,Δημιουργία
-DocType: About Us Settings,Org History,org Ιστορία
-DocType: Workflow,Workflow Name,Όνομα Ροής Εργασιών
-DocType: Web Form,Allow Edit,Επιτρέψτε Επεξεργασία
-apps/frappe/frappe/utils/data.py +397,billion,δισεκατομμύριο
-DocType: Website Settings,"Menu items in the Top Bar. For setting the color of the Top Bar, go to <a href=""#Form/Style Settings"">Style Settings</a>","Τα στοιχεία μενού στην πάνω μπάρα. Για τον καθορισμό του χρώματος του Top Bar, πηγαίνετε στο <a href=""#Form/Style Settings"">Settings Style</a>"
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py +64,Cannot change state of Cancelled Document. Transition row {0},Δεν μπορεί να αλλάξει κατάσταση Ακυρώθηκε εγγράφου .
-DocType: Workflow,"Rules for how states are transitions, like next state and which role is allowed to change state etc.","Κανόνες για το πώς τα κράτη είναι μεταβάσεις, όπως και το επόμενο κράτος και της οποίας ο ρόλος έχει τη δυνατότητα να αλλάξει κατάσταση, κλπ."
-apps/frappe/frappe/desk/form/save.py +21,{0} {1} already exists,{0} {1} υπάρχει ήδη
-DocType: User,Github Username,Github Όνομα Χρήστη
-DocType: Web Page,Title / headline of your page,Τίτλος / τίτλος της σελίδας σας
-DocType: DocType,Plugin,plugin
-sites/assets/js/desk.min.js +829,Add Attachments,Προσθήκη Συνημμένων
-DocType: Workflow State,signal,σηματοδοτούν
-DocType: DocType,Show Print First,Εμφάνιση Εκτύπωση Πρώτη
-DocType: Email Account,Incoming Mail Settings,Εισερχόμενη Ρυθμίσεις Mail
-DocType: Print Settings,Monochrome,Μονόχρωμος
-DocType: Workflow,"Different ""States"" this document can exist in. Like ""Open"", ""Pending Approval"" etc.","Different &quot;μέλη&quot; αυτό το έγγραφο μπορεί να υπάρχει μέσα όπως &quot;Άνοιγμα&quot;, &quot;Έγκριση σε εκκρεμότητα&quot;, κλπ."
-DocType: Web Form,Web Form Fields,Πεδία της φόρμας Web
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +334,Remove Section,Αφαιρέστε το τμήμα
-sites/assets/js/desk.min.js +420,Invalid Email: {0},Μη έγκυρο Email : {0}
-apps/frappe/frappe/desk/doctype/event/event.py +16,Event end must be after start,Λήξης συμβάντος πρέπει να είναι μετά την έναρξη
-apps/frappe/frappe/templates/includes/sidebar.html +7,Back,Πίσω
-apps/frappe/frappe/desk/query_report.py +21,You don't have permission to get a report on: {0},Δεν έχετε άδεια για να πάρετε μια έκθεση σχετικά με: {0}
-sites/assets/js/desk.min.js +468,Advanced Search,Σύνθετη Αναζήτηση
-apps/frappe/frappe/core/doctype/user/user.py +381,Password reset instructions have been sent to your email,Οι οδηγίες επαναφοράς κωδικού πρόσβασης έχει αποσταλεί στο e-mail σας
-apps/frappe/frappe/config/setup.py +216,Manage cloud backups on Dropbox,Διαχειριστείτε αντιγράφων ασφαλείας σύννεφο Dropbox
-DocType: Workflow,States,Τα κράτη
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +18,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Όταν τροποποιηθεί ένα έγγραφο μετά Ακύρωση και να το αποθηκεύσετε , θα πάρετε ένα νέο αριθμό που είναι μια έκδοση του παλιού αριθμού ."
-DocType: Style Settings,Solid background color (default light gray),Στερεά χρώμα του φόντου (προεπιλογή ανοιχτό γκρι)
-apps/frappe/frappe/core/doctype/doctype/doctype.py +38,{0} not allowed in name,{0} δεν επιτρέπονται στο όνομα
-DocType: Workflow State,circle-arrow-left,κύκλο βέλος αριστερά
-apps/frappe/frappe/sessions.py +97,Redis cache server not running. Please contact Administrator / Tech support,Ρέντη διακομιστή cache δεν λειτουργεί. Παρακαλώ επικοινωνήστε με το διαχειριστή / Τεχνική υποστήριξη
-sites/assets/js/desk.min.js +776,Make a new record,Κάντε ένα νέο ρεκόρ
-DocType: Currency,Fraction,Κλάσμα
-DocType: Custom Field,Field Description,Πεδίο Περιγραφή
-apps/frappe/frappe/model/naming.py +47,Name not set via Prompt,Το όνομα δεν έχει οριστεί μέσω εντολών
-DocType: Note,Note is a free page where users can share documents / notes,Σημείωση είναι μια δωρεάν σελίδα όπου οι χρήστες μπορούν να μοιράζονται έγγραφα / σημειώσεις
-DocType: DocType,Allow Import,Να επιτρέψουν την εισαγωγή
-apps/frappe/frappe/templates/includes/comments.py +57,New comment on {0} {1},Νέο σχόλιο για {0} {1}
-DocType: Workflow State,glass,ποτήρι
-DocType: Country,Time Zones,Ζώνες ώρας
-DocType: Workflow State,remove-sign,αφαίρεση εισέλθετε
-apps/frappe/frappe/config/setup.py +114,Define workflows for forms.,Ορίστε ροών εργασίας για τις μορφές .
-DocType: Website Settings,Misc,Διάφορα
-DocType: Workflow State,font,γραμματοσειρά
-DocType: Workflow,"If checked, all other workflows become inactive.","Εάν είναι επιλεγμένο, όλες οι άλλες ροές εργασίας καταστεί ανενεργή."
-apps/frappe/frappe/core/doctype/report/report.js +10,[Label]:[Field Type]/[Options]:[Width],[Ετικέτα]: [Type Field] / [Options]: [Width]
-DocType: Workflow State,folder-close,φάκελο-κλείσιμο
-DocType: Email Alert Recipient,Optional: Alert will only be sent if value is a valid email id.,Προαιρετικά: Alert θα αποστέλλονται μόνο αν η αξία είναι μια έγκυρη ταυτότητα ηλεκτρονικού ταχυδρομείου.
-apps/frappe/frappe/model/rename_doc.py +99,{0} not allowed to be renamed,{0} δεν επιτρέπεται να μετονομαστεί
-apps/frappe/frappe/core/doctype/doctype/doctype.js +23,Custom Script,Προσαρμοσμένη Script
-DocType: ToDo,Assigned To,Ανατέθηκε σε
-apps/frappe/frappe/core/doctype/user/user.py +163,Verify Your Account,Επαληθεύσετε το λογαριασμό σας
-DocType: Workflow Transition,Action,Δράση
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +221,Info:,Πληροφορίες:
-DocType: Custom Field,Permission Level,Επίπεδο δικαιωμάτων
-apps/frappe/frappe/core/doctype/doctype/doctype.py +373,"{0}: Cannot set Submit, Cancel, Amend without Write","{0} : Δεν είναι δυνατή η ρύθμιση Υποβολή , Ακύρωση , τροποποιηθεί χωρίς Write"
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +8,Setup > User,Ρύθμιση> User
-apps/frappe/frappe/templates/emails/new_user.html +9,Thank you,Σας ευχαριστώ
-DocType: Print Settings,Print Style Preview,Προεπισκόπηση εκτύπωσης Style
-DocType: User,Default is system timezone,Η προεπιλογή είναι ζώνη ώρας του συστήματος
-DocType: About Us Settings,About Us Settings,Ρυθμίσεις σχετικά με εμάς 
-DocType: DocField,In List View,Στην Λίστα
-DocType: Outgoing Email Settings,Use TLS,Χρήση TLS
-apps/frappe/frappe/email/smtp.py +34,Invalid login or password,Μη έγκυρη είσοδος ή τον κωδικό πρόσβασης
-apps/frappe/frappe/config/setup.py +189,Add custom javascript to forms.,Προσθήκη προσαρμοσμένων javascript για να τις μορφές .
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +4,Role Permissions Manager,Δικαιώματα ρόλο Διευθυντής
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +94,Name of the new Print Format,Όνομα του νέου σχήματος Εκτύπωση
-DocType: Style Settings,Page Links,Σελίδα Links
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +219,Mandatory:,Υποχρεωτικά:
-,User Permissions Manager,Δικαιώματα χρήστης του Διαχειριστή
-DocType: Property Setter,New value to be set,Νέα τιμή που θα καθοριστούν
-DocType: Email Alert,Email Alert,Ειδοποίηση e-mail
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +34,Select Document Types to set which User Permissions are used to limit access.,Επιλέξτε τύπους εγγράφων για να ορίσετε ποια χρήστη δικαιώματα χρησιμοποιούνται για να περιορίσουν την πρόσβαση.
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +234,User Permission,άδεια χρήστη
-DocType: User,Language preference for user interface (only if available).,Γλώσσα προτίμησης για την διεπαφή χρήστη (μόνο εάν είναι διαθέσιμο).
-DocType: Workflow State,hand-right,χέρι-δεξιά
-DocType: Website Settings,Subdomain,Υποκατηγορία
-DocType: Web Form,Allow Delete,Επιτρέψτε Διαγραφή
-DocType: Email Alert,Message Examples,Παραδείγματα μήνυμα
-DocType: Web Form,Login Required,Απαιτείται σύνδεση
-apps/frappe/frappe/config/website.py +58,Write titles and introductions to your blog.,Γράψτε τους τίτλους και τις εισαγωγές στο blog σας.
-apps/frappe/frappe/config/website.py +63,Categorize blog posts.,Κατηγοριοποίηση blog θέσεις.
-DocType: DocField,Attach,Επισυνάψτε
-DocType: DocType,Permission Rules,Κανόνες άδεια
-apps/frappe/frappe/model/base_document.py +301,Value missing for,Αξία λείπει για
-apps/frappe/frappe/model/delete_doc.py +131,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Υποβλήθηκε εγγραφής δεν μπορούν να διαγραφούν.
-DocType: DocPerm,Read,Ανάγνωση
-apps/frappe/frappe/templates/pages/update-password.html +17,Old Password,Παλιά Κωδικός
-apps/frappe/frappe/core/doctype/report/report.js +9,"To format columns, give column labels in the query.","Για να διαμορφώσετε τις στήλες, δίνουν ετικέτες στηλών στο ερώτημα."
-apps/frappe/frappe/core/doctype/doctype/doctype.py +400,{0}: Cannot set Assign Amend if not Submittable,"{0} : Δεν είναι δυνατή η ρύθμιση Εκχώρηση τροποποιηθεί , αν όχι Submittable"
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +14,Edit Role Permissions,Δικαιώματα Επεξεργασία Ρόλος
-DocType: Social Login Keys,Social Login Keys,Social Login Keys
-DocType: Comment,Comment Date,Σχόλιο Ημερομηνία
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +53,Remove all customizations?,Αφαιρέστε όλες τις προσαρμογές ;
-DocType: Website Slideshow,Slideshow Name,Παρουσίαση Name
-DocType: DocType,Allow Rename,Αφήστε Μετονομασία
-DocType: DocType,Child Tables are shown as a Grid in other DocTypes.,Οι πίνακες παιδιών απεικονίζεται ως πλέγμα σε άλλες doctypes.
-DocType: Website Settings,"If checked, the Home page will be the default Item Group for the website.","Εάν επιλεγεί, η σελίδα θα είναι η ομάδα προεπιλεγμένο στοιχείο για την ιστοσελίδα."
-DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Περιγραφή για τη σελίδα σας, σε μορφή απλού κειμένου, μόνο μια-δυο γραμμές. (Max 140 χαρακτήρες)"
-sites/assets/js/desk.min.js +804,Forums,φόρουμ
-DocType: DocType,Name Case,Περίπτωση που το όνομα
-apps/frappe/frappe/model/base_document.py +297,Data missing in table,Στοιχεία που λείπουν στον πίνακα
-DocType: Web Form,Success URL,Επιτυχία URL
-DocType: Email Account,Append To,Επισυνάπτω
-DocType: Workflow Document State,Only Allow Edit For,Μόνο Αφήστε Επεξεργασία για
-DocType: DocType,DocType,DOCTYPE
-apps/frappe/frappe/core/doctype/user/user.py +384,User {0} does not exist,Χρήστης {0} δεν υπάρχει
-DocType: Top Bar Item,Top Bar Item,Κορυφαία Θέση Bar
-apps/frappe/frappe/utils/csvutils.py +49,"Unknown file encoding. Tried utf-8, windows-1250, windows-1252.","Άγνωστη κωδικοποίηση του αρχείου . Προσπάθησε utf - 8 , windows - 1250 , windows- 1252 ."
-apps/frappe/frappe/core/doctype/user/user.py +97,Sorry! Sharing with Website User is prohibited.,Συγγνώμη! Κοινή χρήση με το χρήστη δικτυακό τόπο απαγορεύεται.
-apps/frappe/frappe/core/doctype/user/user.js +117,Add all roles,Προσθέστε όλους τους ρόλους
-apps/frappe/frappe/templates/includes/contact.js +11,"Please enter both your email and message so that we \
-				can get back to you. Thanks!","Παρακαλώ εισάγετε τόσο το email και το μήνυμά σας έτσι ώστε να \
- μπορεί να πάρει πίσω σε σας. Ευχαριστώ!"
-apps/frappe/frappe/email/smtp.py +126,Could not connect to outgoing email server,Δεν ήταν δυνατή η σύνδεση με διακομιστή εξερχόμενων e-mail
-sites/assets/js/desk.min.js +480,Rich Text,Εμπλουτισμένου κειμένου
-DocType: Workflow State,resize-full,resize-πλήρης
-DocType: Workflow State,off,μακριά από
-apps/frappe/frappe/desk/query_report.py +25,Report {0} is disabled,Έκθεση {0} είναι απενεργοποιημένη
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +24,Recommended for inserting new records.,Συνιστάται για εισαγωγή νέων εγγραφών.
-DocType: Comment,Core,Πυρήνας
-DocType: DocField,Set non-standard precision for a Float or Currency field,Ορισμός μη-πρότυπο ακριβείας για ένα πεδίο Float ή Νόμισμα
-DocType: Email Account,Ignore attachments over this size,Αγνοήστε τα συνημμένα πάνω από αυτό το μέγεθος
-apps/frappe/frappe/database.py +211,Too many writes in one request. Please send smaller requests,Πάρα πολλοί γράφει σε ένα αίτημα . Παρακαλούμε να στείλετε τα μικρότερα αιτήσεις
-DocType: Workflow State,arrow-up,arrow-up
-DocType: DocField,Allow on Submit,Αφήστε για Υποβολή
-apps/frappe/frappe/core/page/desktop/desktop.js +50,All Applications,Όλες οι αιτήσεις θα
-DocType: Web Page,Add code as &lt;script&gt;,Προσθήκη κώδικα ως &lt;script&gt;
-apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +7,Select Type,Επιλέξτε Τύπο
-apps/frappe/frappe/core/doctype/file_data/file_data.py +42,No permission to write / remove.,Δεν έχετε άδεια για να γράψει / αφαίρεση.
-DocType: Workflow,"All possible Workflow States and roles of the workflow. <br>Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Όλες οι πιθανές κράτη Workflow και τους ρόλους της ροής εργασίας. <br> Docstatus Επιλογές: 0 είναι &quot;Saved&quot;, 1 &quot;Υποβλήθηκε&quot; και 2 &quot;Ακυρώθηκε&quot;"
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_layout.html +3,Drag elements from the sidebar to add. Drag them back to trash.,Σύρετε στοιχεία από την πλαϊνή μπάρα για να προσθέσετε. Σύρετε τους πίσω σε σκουπίδια.
-DocType: Workflow State,resize-small,resize-small
-sites/assets/js/editor.min.js +128,Horizontal Line Break,Οριζόντια αλλαγή γραμμής
-DocType: Top Bar Item,Right,Δεξιά
-DocType: User,User Type,Τύπος χρήστη
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +68,Select User,Επιλέξτε User
-DocType: Communication,Keep a track of all communications,Κρατήστε ένα κομμάτι του συνόλου των επικοινωνιών
-apps/frappe/frappe/desk/form/save.py +29,Did not save,Δεν αποθηκεύσετε
-DocType: Property Setter,Property,Ιδιοκτησία
-DocType: Website Slideshow,"Note: For best results, images must be of the same size and width must be greater than height.","Σημείωση: Για βέλτιστα αποτελέσματα, οι εικόνες θα πρέπει να είναι του ίδιου μεγέθους και πλάτους πρέπει να είναι μεγαλύτερη από το ύψος."
-DocType: DocType,Auto Name,Όνομα Auto
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +154,Permissions can be managed via Setup &gt; Role Permissions Manager,Μπορούν να αντιμετωπιστούν μέσω Δικαιώματα Εγκατάστασης & gt? Δικαιώματα Ρόλος Διευθυντής
-apps/frappe/frappe/core/page/data_import_tool/importer.py +67,Please make sure that there are no empty columns in the file.,Παρακαλούμε βεβαιωθείτε ότι δεν υπάρχουν κενές στήλες στο αρχείο.
-sites/assets/js/desk.min.js +572,You have unsaved changes in this form. Please save before you continue.,Έχετε μη αποθηκευμένες αλλαγές σε αυτή τη μορφή .
-DocType: User,User Image,Εικόνα Εικόνα
-apps/frappe/frappe/email/bulk.py +126,Emails are muted,Emails είναι σε σίγαση
-apps/frappe/frappe/desk/page/applications/applications.py +34,You cannot install this app,Δεν μπορείτε να εγκαταστήσετε αυτό το app
-DocType: Scheduler Log,Error,Σφάλμα
-DocType: Workflow State,Share,Μετοχή
-apps/frappe/frappe/model/document.py +428,Cannot link cancelled document: {0},Δεν είναι δυνατή η σύνδεση ακυρώνεται έγγραφο: {0}
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +446,Select Table Columns for {0},Επιλέξτε Πίνακας Στήλες για {0}
-DocType: Custom Field,Options Help,Επιλογές Βοήθεια
-DocType: DocField,Report Hide,Έκθεση Απόκρυψη
-DocType: Custom Field,Label Help,Βοήθεια Label
-DocType: Workflow State,star-empty,star-άδειο
-DocType: Style Settings,Font Size (Text),Μέγεθος γραμματοσειράς (κείμενο)
-DocType: Workflow State,ok,εντάξει
-DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,"Οι τιμές αυτές θα πρέπει να ενημερώνονται αυτόματα σε συναλλαγές και, επίσης, θα ήταν χρήσιμο να περιορίσετε τα δικαιώματα για το χρήστη για τις συναλλαγές που περιέχουν αυτές τις αξίες."
-apps/frappe/frappe/desk/page/applications/application_row.html +15,Publisher,Εκδότης
-sites/assets/js/desk.min.js +710,Browse,Αναζήτηση
-apps/frappe/frappe/templates/includes/comments.py +50,View it in your browser,Δείτε το στο πρόγραμμα περιήγησής σας
-apps/frappe/frappe/templates/pages/update-password.html +1,Reset Password,Επαναφορά κωδικού πρόσβασης
-DocType: Workflow State,hand-left,χέρι-αριστερά
-DocType: Email Account,Use SSL,Χρήση SSL
-DocType: Workflow State,play-circle,play-κύκλο
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +58,Select Print Format to Edit,Επιλέξτε Εκτύπωση Format για Επεξεργασία
-DocType: Workflow State,circle-arrow-down,κύκλο βέλος προς τα κάτω
-DocType: DocField,Datetime,Datetime
-DocType: Workflow State,arrow-right,βέλος δεξιά
-DocType: Style Settings,Font (Heading),Font (Τομέας)
-DocType: Workflow State,Workflow state represents the current state of a document.,Κατάσταση Workflow αντιπροσωπεύει την τρέχουσα κατάσταση ενός εγγράφου.
-DocType: Style Settings,Page Header Text,Σελίδα Κείμενο κεφαλίδας
-DocType: User,Set Password,Ορισμός κωδικού πρόσβασης
-sites/assets/js/editor.min.js +152,Open Link in a new Window,Άνοιγμα συνδέσμου σε νέο παράθυρο
-apps/frappe/frappe/utils/file_manager.py +218,Removed {0},Αφαιρέθηκε {0}
-DocType: Company History,Highlight,Επισημάνετε
-apps/frappe/frappe/print/doctype/print_format/print_format.py +14,Standard Print Format cannot be updated,Τυπική Μορφή εκτύπωσης δεν μπορούν να ενημερωθούν
-apps/frappe/frappe/core/doctype/doctype/doctype.py +366,"{0}: Create, Submit, Cancel and Amend only valid at level 0","{0} : Δημιουργία , Υποβολή , Άκυρο και τροποποιούνται μόνο στο επίπεδο 0"
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +131,Help: Field Properties,Βοήθεια: Ακίνητα πεδίο
-apps/frappe/frappe/model/document.py +614,Incorrect value in row {0}: {1} must be {2} {3},Λανθασμένη τιμή στη γραμμή {0} : {1} πρέπει να είναι {2} {3}
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py +67,Submitted Document cannot be converted back to draft. Transition row {0},Υποβλήθηκε έγγραφο δεν μπορεί να μετατραπεί ξανά να συντάξει .
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_start.html +2,Select an existing format to edit or start a new format.,Επιλέξτε μια υπάρχουσα μορφή για να επεξεργαστείτε ή να ξεκινήσετε μια νέα μορφή.
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py +38,Created Custom Field {0} in {1},Δημιουργήθηκε προσαρμοσμένου πεδίου {0} {1}
-apps/frappe/frappe/core/page/user_permissions/user_permissions.js +31,A user can be permitted to multiple records of the same DocType.,Ένας χρήστης μπορεί να επιτραπεί σε πολλαπλές εγγραφές του ίδιου DocType .
-DocType: Workflow State,Home,σπίτι
-DocType: Workflow State,question-sign,ερώτηση-σημάδι
-DocType: Email Account,Add Signature,Προσθέστε Υπογραφή
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js +467,Did not set,Δεν ορίζεται
-DocType: ToDo,ToDo,Εκκρεμότητες
-DocType: DocField,No Copy,Δεν Copy
-DocType: Workflow State,qrcode,qrcode
-DocType: Web Form,Breadcrumbs,Τριμμένη φρυγανιά
-apps/frappe/frappe/templates/includes/comments.py +48,{0} by {1},{0} από {1}
-apps/frappe/frappe/core/doctype/comment/comment.py +37,Cannot add more than 50 comments,Δεν μπορείτε να προσθέσετε περισσότερες από 50 σχόλια
-DocType: Website Settings,Top Bar Items,Top Προϊόντα Bar
-DocType: Print Settings,Print Settings,Ρυθμίσεις εκτύπωσης
-DocType: DocType,Max Attachments,Max Συνημμένα
-DocType: Page,Page,Σελίδα
-DocType: Workflow State,briefcase,χαρτοφύλακας
-apps/frappe/frappe/model/base_document.py +390,Value cannot be changed for {0},Η τιμή δεν μπορεί να αλλάξει για {0}
-apps/frappe/frappe/templates/includes/contact.js +17,"You seem to have written your name instead of your email. \
-					Please enter a valid email address so that we can get back.","Μπορείτε φαίνεται να έχουν γράψει το όνομά σας, αντί του ηλεκτρονικού ταχυδρομείου σας. \
- Παρακαλώ εισάγετε μια έγκυρη διεύθυνση e-mail, ώστε να μπορέσουμε να πάρουμε πίσω."
-DocType: Workflow State,"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange","Style αντιπροσωπεύει το χρώμα του κουμπιού: Επιτυχία - Green, Danger - Κόκκινο, Inverse - Μαύρο, Πρωτοβάθμια - Σκούρο Μπλε, Info - Γαλάζιο, Προσοχή - Orange"
-DocType: Workflow Transition,Workflow Transition,Workflow μετάβαση
-DocType: Default Home Page,Default Home Page,Προεπιλεγμένη αρχική σελίδα
-DocType: Workflow State,resize-horizontal,resize-οριζόντια
-DocType: Communication,Content,Περιεχόμενο
-DocType: Web Form,Go to this url after completing the form.,Πηγαίνετε σε αυτό το url μετά τη συμπλήρωση του εντύπου.
-DocType: Custom Field,Document,Έγγραφο
-DocType: DocField,Code,Κωδικός
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +24,"Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document.","Δικαιώματα σε επίπεδο 0 είναι τα δικαιώματα σε επίπεδο εγγράφων, δηλαδή είναι πρωταρχικός για την πρόσβαση στο έγγραφο."
-DocType: Print Format,Print Format,Εκτύπωση Format
-DocType: Outgoing Email Settings,Email Footer,Email Τελικοί
-apps/frappe/frappe/config/website.py +27,User ID of a blog writer.,ID χρήστη του blog συγγραφέας.
-apps/frappe/frappe/config/setup.py +31,Set Permissions on Document Types and Roles,Ορισμός δικαιωμάτων σε τύποι εγγράφων και Ρόλοι
-DocType: About Us Settings,"""Company History""",&quot;Η Εταιρεία Ιστορία&quot;
-apps/frappe/frappe/permissions.py +206,Permission already set,Η άδεια έχει ήδη οριστεί
-apps/frappe/frappe/desk/page/activity/activity_row.html +15,Commented on {0}: {1},Σχολίασε {0}: {1}
-DocType: Email Alert,Days in Advance,Ημέρες Advance
-DocType: Email Alert,Send alert if this field's value changes,Αποστολή ειδοποίησης σε περίπτωση αλλαγής της αξίας αυτού του πεδίου
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +85,Select a DocType to make a new format,Επιλέξτε ένα DocType να κάνει μια νέα μορφή
-DocType: Module Def,Module Def,Ενότητα Def
-DocType: Communication,By,Με
-DocType: Email Account,SMTP Server,SMTP διακομιστή
-DocType: Print Format,Print Format Help,Εκτύπωση Format Βοήθεια
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +70,"If you are updating, please select ""Overwrite"" else existing rows will not be deleted.","Αν κάνετε ενημέρωση, παρακαλούμε επιλέξτε ""Αντικατάσταση"" αλλιώς υπάρχουσες σειρές δεν θα διαγραφούν."
-DocType: Event,Every Month,Κάθε Μήνα
-DocType: Letter Head,Letter Head in HTML,Επιστολή Επικεφαλής σε HTML
-DocType: Web Form,Web Form,Φόρμα Ιστού
-DocType: About Us Settings,Org History Heading,Org Ιστορία Τομέας
-DocType: Web Form,Web Page Link Text,Ιστοσελίδα Σύνδεσμος Κείμενο
-apps/frappe/frappe/config/setup.py +162,"Set default format, page size, print style etc.","Ορίστε την προεπιλεγμένη μορφή, το μέγεθος σελίδας, στυλ εκτύπωσης κλπ."
-DocType: DocType,Naming,ονομάζοντας
-DocType: Event,Every Year,Κάθε έτος
-apps/frappe/frappe/core/doctype/user/user.py +350,Registered but disabled.,Εγγεγραμμένοι αλλά και άτομα με ειδικές ανάγκες.
-sites/assets/js/desk.min.js +780,Search in a document type,Αναζήτηση σε ένα είδος εγγράφου
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +186,Allow field to remain editable even after submission,Αφήστε το πεδίο για να παραμείνει επεξεργάσιμο ακόμη και μετά την υποβολή
-DocType: DocPerm,Role and Level,Ρόλος και Επίπεδο
-apps/frappe/frappe/desk/moduleview.py +31,Custom Reports,Προσαρμοσμένες Αναφορές
-DocType: Website Script,Website Script,Script Website
-apps/frappe/frappe/desk/form/utils.py +99,No further records,Δεν υπάρχουν επιπλέον εγγραφές
-DocType: DocField,Long Text,Long Text
-apps/frappe/frappe/core/page/data_import_tool/importer.py +35,Please do not change the rows above {0},Παρακαλώ μην αλλάξετε τις σειρές πάνω από {0}
-sites/assets/js/desk.min.js +763,Sorry! You are not permitted to view this page.,Συγγνώμη! Δεν επιτρέπεται να δείτε αυτή τη σελίδα.
-DocType: Workflow State,bell,κουδούνι
-apps/frappe/frappe/desk/page/activity/activity.js +153,Jun,Ιούνιος
-apps/frappe/frappe/utils/nestedset.py +227,{0} {1} cannot be a leaf node as it has children,"{0} {1} δεν μπορεί να είναι ένας κόμβος φύλλο , δεδομένου ότι έχει παιδιά"
-DocType: Feed,Info,Πληροφορίες
-apps/frappe/frappe/templates/includes/contact.js +30,Thank you for your message,Σας ευχαριστούμε για το μήνυμά σας
-DocType: Default Home Page,Home Page,Αρχική Σελίδα
-DocType: Email Alert,Filters,Φίλτρα
-DocType: Workflow State,share-alt,μετοχή-alt
-DocType: Role,Role Name,Όνομα Ρόλος
-DocType: Workflow Document State,Workflow Document State,Workflow κράτος εγγράφου
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +32,"To give acess to a role for only specific records, check the Apply User Permissions. User Permissions are used to limit users with such role to specific records.","Για να δώσει acess σε ένα ρόλο για μόνο συγκεκριμένες εγγραφές, ελέγξτε το εφαρμόσετε δικαιώματα χρήσης. Δικαιώματα χρήσης χρησιμοποιούνται για να περιορίσουν τους χρήστες με αυτό το ρόλο σε συγκεκριμένες εγγραφές."
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py +70,Cannot cancel before submitting. See Transition {0},Δεν μπορείτε να ακυρώσετε πριν από την υποβολή .
-apps/frappe/frappe/templates/pages/print.py +136,Print Format {0} is disabled,Εκτύπωση αρχείου {0} είναι απενεργοποιημένη
-DocType: User,Allow user to login only after this hour (0-24),Επιτρέπει στο χρήστη να συνδεθείτε μόνο μετά από αυτή την ώρα (0-24)
-apps/frappe/frappe/core/doctype/doctype/doctype.py +35,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Όχι σε λειτουργία προγραμματιστή! Μέσα σε site_config.json ή να κάνετε «Προσαρμογή» DocType.
-DocType: Workflow State,globe,σφαίρα
-DocType: System Settings,dd.mm.yyyy,ηη.μμ.εεεε
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +178,Hide field in Standard Print Format,Απόκρυψη πεδίου σε τυπική μορφή Εκτύπωση
-DocType: DocField,Float,Επιπλέω
-DocType: Module Def,Module Name,Όνομα Ενότητα
-DocType: DocType,DocType is a Table / Form in the application.,DocType είναι ένας πίνακας / στο δικόγραφο της προσφυγής.
-DocType: Feed,Feed Type,Feed Τύπος
-DocType: Email Account,GMail,GMail
-DocType: Customize Form,"Fields separated by comma (,) will be included in the<br /><b>Search By</b> list of Search dialog box","Τα πεδία που χωρίζονται με κόμμα (,) θα πρέπει να περιλαμβάνονται στο <br /> <b>Αναζήτηση Με</b> λίστα στο παράθυρο διαλόγου Αναζήτηση"
-DocType: Web Page,Template Path,Πρότυπο Διαδρομή
-DocType: User,user_image_show,user_image_show
-DocType: DocField,Print Width,Πλάτος Εκτύπωση
-DocType: User,Allow user to login only before this hour (0-24),Επιτρέπει στο χρήστη να συνδεθείτε μόνο πριν από αυτή την ώρα (0-24)
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_sidebar.html +3,Filter...,Φίλτρο ...
-DocType: Workflow State,bold,τολμηρός
-apps/frappe/frappe/website/doctype/website_settings/website_settings.py +32,{0} does not exist in row {1},{0} δεν υπάρχει στη γραμμή {1}
-DocType: Event,Event Type,Τύπος συμβάντος
-apps/frappe/frappe/config/setup.py +135,Add / Manage Email Accounts.,Προσθήκη / Διαχείριση λογαριασμών ηλεκτρονικού ταχυδρομείου.
-DocType: Blog Category,Published,Δημοσίευση
-apps/frappe/frappe/templates/emails/auto_reply.html +1,Thank you for your email,Σας ευχαριστούμε για το email σας
-DocType: DocField,Small Text,Μικρές Κείμενο
-apps/frappe/frappe/core/doctype/doctype/doctype.py +259,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Επιλογές 'Dynamic Link «τύπος πεδίου πρέπει να είναι στραμμένη σε μια άλλη πεδίου Link με επιλογές όπως« DocType »
-DocType: About Us Settings,Team Members Heading,Μέλη της Ομάδας Τομέας
-DocType: DocField,Do not allow user to change after set the first time,Μην επιτρέψετε στο χρήστη να αλλάξει μετά που την πρώτη φορά
-DocType: User,Third Party Authentication,Τρίτο Κόμμα ταυτότητας
-DocType: Website Settings,Banner is above the Top Menu Bar.,Banner είναι πάνω από το Top Menu Bar.
-DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to <a href=""#Form/Customize Form/Customize Form"">Customize Form</a>.","Εισάγετε πεδία προκαθορισμένη τιμή (πλήκτρα) και αξίες. Αν προσθέσετε πολλαπλές τιμές για ένα πεδίο, το πρώτο θα παρθούν. Αυτές οι προεπιλογές χρησιμοποιούνται επίσης για να ρυθμίσετε το ""παιχνίδι"" κανόνες άδεια. Για να δείτε τη λίστα των πεδίων, μεταβείτε στη διεύθυνση <a href=""#Form/Customize Form/Customize Form""> Προσαρμογή Φόρμα </a>."
-DocType: Outgoing Email Settings,Port,λιμάνι
-DocType: Style Settings,Arial,Arial
-DocType: Website Slideshow,Slideshow like display for the website,Προβολή διαφανειών όπως την απεικόνιση για την ιστοσελίδα
-sites/assets/js/editor.min.js +121,Center (Ctrl/Cmd+E),Κέντρο (Ctrl / Cmd + Ε)
-apps/frappe/frappe/sessions.py +27,Cache Cleared,Cache καθαρίστηκε
-apps/frappe/frappe/core/doctype/user/user.py +66,User with System Manager Role should always have User Type: System User,Χρήστης με το Σύστημα Ρόλος Διευθυντής θα πρέπει να έχει πάντοτε Τύπος χρήστη: Χρήστης Συστήματος
-DocType: DocPerm,Export,Εξαγωγή
-DocType: About Us Settings,More content for the bottom of the page.,Περισσότερο περιεχόμενο για το κάτω μέρος της σελίδας.
-sites/assets/js/desk.min.js +177,Session Expired. Logging you out,Συνεδρία Έληξε. Έξοδος από
-DocType: Workflow,DocType on which this Workflow is applicable.,DOCTYPE την οποία η παρούσα Workflow ισχύει.
-DocType: User,Display Settings,Ρυθμίσεις οθόνης
-DocType: Blog Category,Category Name,Όνομα Κατηγορία
-DocType: Print Settings,PDF Settings,Ρυθμίσεις PDF
-apps/frappe/frappe/core/page/data_import_tool/data_import_tool.py +16,Column Name,Στήλη Όνομα
-DocType: Web Form,"In JSON as <pre>[{""title"":""Jobs"", ""name"":""jobs""}]</pre>","Στην JSON ως <pre> [{""title"": ""Εργασία"", ""όνομα"": ""δουλειές""}] </ pre>"
-DocType: Communication,Email Account,Ο λογαριασμός ηλεκτρονικού ταχυδρομείου
-DocType: Workflow State,Download,Λήψη
-DocType: Blog Post,Blog Intro,Blog Intro
-apps/frappe/frappe/core/doctype/report/report.js +37,Enable Report,Ενεργοποίηση Έκθεση
-DocType: User,Check / Uncheck roles assigned to the User. Click on the Role to find out what permissions that Role has.,Ελέγξτε / ρόλους Αποεπιλέξτε ανατεθεί στο προφίλ. Κάντε κλικ για το ρόλο για να μάθετε ποια είναι τα δικαιώματα που έχει ο ρόλος.
-DocType: Web Page,Insert Code,Εισαγωγή κώδικα
-sites/assets/js/desk.min.js +778,List a document type,Λίστα έναν τύπο εγγράφου
-DocType: Event,Ref Type,Τύπος Ref
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +63,"If you are uploading new records, leave the ""name"" (ID) column blank.","Αν το φόρτωμα νέες εγγραφές, αφήστε κενό το ""όνομα"" (ID) στήλη."
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +328,No of Columns,Αριθμός Στήλες
-DocType: Workflow State,Calendar,Ημερολόγιο
-apps/frappe/frappe/model/rename_doc.py +93,"Another {0} with name {1} exists, select another name","Ένας άλλος {0} με το όνομα {1} υπάρχει, επιλέξτε ένα άλλο όνομα"
-DocType: DocType,Custom?,Προσαρμοσμένη;
-DocType: Workflow State,road,δρόμος
-apps/frappe/frappe/core/doctype/doctype/doctype.js +20,"Cannot Edit {0} directly: To edit {0} properties, create / update {1}, {2} and {3}","Δεν είναι δυνατή η Επεξεργαστείτε {0} άμεσα : Για να επεξεργαστείτε {0} ιδιότητες , τη δημιουργία / ενημέρωση {1} , {2} και {3}"
-DocType: User,Timezone,Χρονική ζώνη
-sites/assets/js/desk.min.js +512,Unable to load: {0},Δεν είναι δυνατή η φόρτιση : {0}
-DocType: DocField,Read Only,Μόνο για ανάγνωση
-DocType: Print Settings,Send Print as PDF,Αποστολή Print as PDF
-DocType: Workflow Transition,Allowed,Επιτρέπεται
-apps/frappe/frappe/core/doctype/doctype/doctype.py +274,There can be only one Fold in a form,Μπορεί να υπάρχει μόνο μία φορές σε μια μορφή
-apps/frappe/frappe/website/doctype/website_settings/website_settings.py +22,Invalid Home Page,Μη έγκυρο Αρχική Σελίδα
-apps/frappe/frappe/core/doctype/doctype/doctype.py +363,{0}: Permission at level 0 must be set before higher levels are set,"{0} : Η άδεια στο επίπεδο 0 , πρέπει να οριστεί πριν θέσει υψηλότερα επίπεδα"
-DocType: Website Settings,Home Page is Products,Αρχική Σελίδα είναι προϊόντα
-apps/frappe/frappe/desk/doctype/todo/todo.py +18,Assignment closed by {0},Ανάθεση κλείσει από {0}
-sites/assets/js/desk.min.js +784,Calculate,Υπολογισμός
-apps/frappe/frappe/print/doctype/print_format/print_format.js +20,Please select DocType first,Παρακαλώ επιλέξτε DocType πρώτα
-DocType: Social Login Keys,GitHub Client ID,GitHub πελάτη ID
-DocType: DocField,Perm Level,Perm Level
-apps/frappe/frappe/desk/doctype/event/event.py +55,Events In Today's Calendar,Εκδηλώσεις Στο Ημερολόγιο Η σημερινή
-DocType: Table of Contents,Web Page,Ιστοσελίδα
-DocType: Blog Category,Blogger,Blogger
-sites/assets/js/desk.min.js +425,Date must be in format: {0},Η ημερομηνία πρέπει να είναι σε μορφή : {0}
-apps/frappe/frappe/core/doctype/doctype/doctype.py +352,"{0}: Only one rule allowed with the same Role, Level and Apply User Permissions","{0} : Μόνο ένα κανόνα επιτρέπονται με τον ίδιο ρόλο , Επίπεδο και Εφαρμογή δικαιώματα χρήσης"
-DocType: Style Settings,Lato,Λατώ
-apps/frappe/frappe/print/page/print_format_builder/print_format_builder_field.html +20,Select Columns,Επιλέξτε Στήλες
-DocType: Workflow State,folder-open,"φάκελο, ανοίξτε"
-apps/frappe/frappe/core/page/desktop/all_applications_dialog.html +1,Search Application,Εφαρμογή αναζήτησης
-apps/frappe/frappe/config/website.py +17,Single Post (article).,Single Post (άρθρο).
-DocType: Property Setter,Set Value,Ορισμός Value
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +174,Hide field in form,Απόκρυψη τομέα με τη μορφή
-DocType: Email Alert,Optional: The alert will be sent if this expression is true,Προαιρετικά: Η ειδοποίηση θα σταλεί εάν αυτή η έκφραση είναι αληθής
-DocType: Style Settings,"000 is black, fff is white","000 είναι μαύρο, fff είναι λευκό"
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +27,You can use Customize Form to set levels on fields.,Μπορείτε να χρησιμοποιήσετε το Προσαρμογή φόρμας για να ρυθμίσετε τα επίπεδα στα χωράφια .
-DocType: DocPerm,Report,Αναφορά
-apps/frappe/frappe/templates/generators/web_form.html +14,Please login to create a new {0},Παρακαλούμε συνδεθείτε για να δημιουργήσετε ένα νέο {0}
-apps/frappe/frappe/desk/reportview.py +72,{0} is saved,{0} έχει αποθηκευτεί
-apps/frappe/frappe/core/doctype/user/user.py +231,User {0} cannot be renamed,Χρήστης {0} δεν μπορεί να μετονομαστεί
-apps/frappe/frappe/website/doctype/website_settings/website_settings.js +18,Exported,εξάγονται
-DocType: User,Background,Φόντο
-DocType: DocPerm,"JSON list of DocTypes used to apply User Permissions. If empty, all linked DocTypes will be used to apply User Permissions.","Λίστα JSON του doctypes χρησιμοποιούνται για την εφαρμογή δικαιωμάτων χρήστη. Εάν κενό, όλα τα συνδεδεμένα doctypes θα χρησιμοποιηθούν για να εφαρμόσετε δικαιώματα χρήσης."
-DocType: Report,Ref DocType,Ref DocType
-apps/frappe/frappe/core/doctype/doctype/doctype.py +375,{0}: Cannot set Amend without Cancel,{0} : Δεν είναι δυνατή η ρύθμιση τροποποιούνται χωρίς Ακύρωση
-DocType: DocType,Is Child Table,Είναι Πίνακας παιδιών
-apps/frappe/frappe/utils/csvutils.py +122,{0} must be one of {1},{0} πρέπει να είναι μία από {1}
-apps/frappe/frappe/core/doctype/user/user.py +151,Password Reset,Επαναφορά Κωδικού
-DocType: Workflow State,chevron-left,Chevron-αριστερά
-DocType: Bulk Email,Sending,Αποστολή
-apps/frappe/frappe/auth.py +181,Not allowed from this IP Address,Δεν επιτρέπεται από αυτήν την IP διεύθυνση
-DocType: Website Slideshow,This goes above the slideshow.,Αυτό πηγαίνει πάνω από το slideshow.
-apps/frappe/frappe/config/setup.py +201,Install Applications.,Εγκατάσταση εφαρμογών .
-DocType: Event,Private,Ιδιωτικός
-DocType: Print Settings,Send Email Print Attachments as PDF (Recommended),Αποστολή Email Print Συνημμένα ως PDF (Συνιστάται)
-DocType: Workflow Action,Workflow Action,Workflow Δράση
-DocType: Event,Send an email reminder in the morning,Στείλτε ένα email υπενθύμισης το πρωί
-DocType: Blog Post,Published On,Δημοσιεύθηκε την
-DocType: Tag,Tag Name,Όνομα Tag
-DocType: Feed,Feed,Τροφή
-DocType: ToDo,Reference Type,Είδος αναφοράς
-DocType: Event,Repeat On,Επαναλάβετε την
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +30,User Permissions,Δικαιώματα χρήστη
-apps/frappe/frappe/desk/page/activity/activity.js +154,Oct,Οκτώβριο
-DocType: Workflow State,warning-sign,προειδοποιητικό σημάδι-
-DocType: Workflow Document State,Update Value,Ενημέρωση Value
-DocType: System Settings,Number Format,Μορφή αριθμών
-DocType: Custom Field,Insert After,Εισαγωγή Μετά την
-DocType: Social Login Keys,GitHub Client Secret,GitHub πελάτη Secret
-DocType: Report,Report Name,Όνομα Έκθεση
-DocType: Email Alert,Save,εκτός
-DocType: Website Settings,Title Prefix,Πρόθεμα Τίτλος
-DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,Ειδοποιήσεις και μηνύματα χύμα θα πρέπει να στέλνονται από αυτόν τον διακομιστή εξερχόμενης αλληλογραφίας.
-DocType: Workflow State,cog,δόντι τροχού
-sites/assets/js/desk.min.js +498,{0} added,{0} προστέθηκε
-DocType: Workflow State,star,αστέρι
-apps/frappe/frappe/desk/page/activity/activity.js +154,Nov,Νοέμβριος
-apps/frappe/frappe/core/doctype/doctype/doctype.py +248,Max width for type Currency is 100px in row {0},Μέγιστο πλάτος για τον τύπο νομίσματος είναι 100px στη γραμμή {0}
-apps/frappe/frappe/config/website.py +12,Content web page.,Το περιεχόμενο της ιστοσελίδας.
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +9,Add a New Role,Προσθέστε ένα νέο ρόλο
-apps/frappe/frappe/templates/includes/login.js +120,Oops! Something went wrong,Ωχ! Κάτι πήγε στραβά
-DocType: Blog Settings,Blog Introduction,Εισαγωγή Blog
-DocType: User,Email Settings,Ρυθμίσεις email
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py +57,{0} not a valid State,{0} δεν είναι έγκυρο κράτος
-DocType: Workflow State,ok-circle,ok-κύκλο
-apps/frappe/frappe/core/doctype/user/user.py +95,Sorry! User should have complete access to their own record.,Συγγνώμη! Χρήστης θα πρέπει να έχουν πλήρη πρόσβαση στα δικά τους ρεκόρ.
-DocType: Custom Field,In Report Filter,Στην έκθεση Filter
-DocType: DocType,Hide Actions,Απόκρυψη Ενέργειες
+apps/frappe/frappe/desk/doctype/feed/feed.py +91,{0} logged in,{0} Συνδεδεμένος
+apps/frappe/frappe/utils/csvutils.py +122,{0} must be one of {1},{0} Πρέπει να είναι μία από {1}
+apps/frappe/frappe/model/base_document.py +336,{0} must be set first,{0} Πρέπει να ορίσετε πρώτα
+apps/frappe/frappe/model/base_document.py +267,{0} must be unique,{0} Πρέπει να είναι μοναδικό
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py +57,{0} not a valid State,{0} Δεν είναι έγκυρη κατάσταση
+apps/frappe/frappe/core/doctype/doctype/doctype.py +222,{0} not allowed in fieldname {1},{0} Δεν επιτρέπεται σε όνομα πεδίου {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py +38,{0} not allowed in name,{0} Δεν επιτρέπονται στο όνομα
+apps/frappe/frappe/model/rename_doc.py +99,{0} not allowed to be renamed,{0} Δεν επιτρέπεται να μετονομαστεί
+apps/frappe/frappe/desk/page/activity/activity.js +197,{0} on {1},{0} Σε {1}
+apps/frappe/frappe/core/doctype/docshare/docshare.py +37,{0} shared this document with {1},{0} Μοιράστηκε αυτό το έγγραφο με {1}
+apps/frappe/frappe/core/doctype/docshare/docshare.py +44,{0} un-shared this document with {1},{0} Σταμάτησε να μοιράζεται αυτό το έγγραφο με {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +96,{0} updated,{0} Ενημερώθηκε
+apps/frappe/frappe/core/doctype/doctype/doctype.py +375,{0}: Cannot set Amend without Cancel,{0} : Δεν είναι δυνατή η ρύθμιση τροποποίησης χωρίς ακύρωση
+apps/frappe/frappe/core/doctype/doctype/doctype.py +400,{0}: Cannot set Assign Amend if not Submittable,"{0} : Δεν είναι δυνατή η ανάθεση τροποποίησης, αν δεν είναι υποβλητέα"
+apps/frappe/frappe/core/doctype/doctype/doctype.py +398,{0}: Cannot set Assign Submit if not Submittable,{0} : Δεν είναι δυνατή η ανάθεση υποβολής αν δεν είναι υποβλητέα
+apps/frappe/frappe/core/doctype/doctype/doctype.py +370,{0}: Cannot set Cancel without Submit,{0} : Δεν είναι δυνατή η ακύρωση χωρίς υποβολή
+apps/frappe/frappe/core/doctype/doctype/doctype.py +404,{0}: Cannot set import as {1} is not importable,{0} : Δεν είναι δυνατή η ρύθμιση των εισαγωγών καθώς το {1} δεν είναι δυνατόν να εισαχθεί
+apps/frappe/frappe/core/doctype/doctype/doctype.py +377,{0}: Cannot set Import without Create,{0} : Δεν είναι δυνατή η ρύθμιση εισαγωγής χωρίς δημιουργία
+apps/frappe/frappe/core/doctype/doctype/doctype.py +373,"{0}: Cannot set Submit, Cancel, Amend without Write","{0} : Δεν είναι δυνατή η ρύθμιση υποβολή, ακύρωση, τροποποίηση χωρίς εγγραφή"
+apps/frappe/frappe/core/doctype/doctype/doctype.py +366,"{0}: Create, Submit, Cancel and Amend only valid at level 0","{0}: Η δημιουργία, υποβολή, ακύρωση και τροποποίηση είναι έγκυρα μόνο στο επίπεδο 0"
+apps/frappe/frappe/core/doctype/doctype/doctype.py +341,{0}: No basic permissions set,{0}: Δεν ρυθμίστηκαν βασικά δικαιώματα
+apps/frappe/frappe/core/doctype/doctype/doctype.py +352,"{0}: Only one rule allowed with the same Role, Level and Apply User Permissions","{0}: Μόνο ένας κανόνας επιτρέπεται με τον ίδιο ρόλο, επίπεδο και εφαρμογή δικαιωμάτων χρήστη"
+apps/frappe/frappe/core/doctype/doctype/doctype.py +363,{0}: Permission at level 0 must be set before higher levels are set,{0}: Το δικαίωμα στο επίπεδο 0 πρέπει να οριστεί πριν οριστούν υψηλότερα επίπεδα
+apps/frappe/frappe/utils/boilerplate.py +223,{app_title},{app_title}
+DocType: Outgoing Email Settings,"<a href=""https://en.wikipedia.org/wiki/Transport_Layer_Security"" target=""_blank"">[?]</a>","<A href=""https://en.Wikipedia.Org/wiki/transport_layer_security"" target=""_blank""> [?] < / a>"
 DocType: DocType,"<a onclick=""msgprint('<ol>\
 <li><b>field:[fieldname]</b> - By Field\
 <li><b>naming_series:</b> - By Naming Series (field called naming_series must be present\
 <li><b>Prompt</b> - Prompt user for a name\
 <li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####\
-</ol>')"">Naming Options</a>","<a onclick=""msgprint('<ol> \
- <li> <b> πεδίο: [ΌνομαΠεδίου] </ b> - ανά τομέα \
- <li> <b> naming_series: </ b > - με την ονομασία Σειρά (πεδίο που ονομάζεται naming_series πρέπει να είναι παρόντες \
- <li> <b> Άμεση </ b> - Προτροπή χρήστη για ένα όνομα \
- <li> <b> [σειρά] </ β.> - Σειρά με πρόθεμα (χωρισμένα με τελείες)? για παράδειγμα PRE ##### \
- </ ol> ') ""> Ονομασία Επιλογές </a>"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py +19,Label is mandatory,Η ετικέτα είναι υποχρεωτική
-DocType: Custom Field,Unique,Μοναδικός
-DocType: File Data,File Name,Όνομα αρχείου
-apps/frappe/frappe/core/page/data_import_tool/importer.py +258,Did not find {0} for {0} ({1}),Δεν βρήκατε {0} για {0} ( {1} )
-apps/frappe/frappe/config/setup.py +38,Set Permissions per User,Ορισμός δικαιωμάτων ανά χρήστη
-DocType: Print Format,Edit Format,Επεξεργασία Μορφή
-apps/frappe/frappe/templates/emails/new_user.html +6,Complete Registration,Πλήρης εγγραφή
-DocType: Style Settings,Enable,Ενεργοποίηση
-apps/frappe/frappe/core/page/data_import_tool/exporter.py +67,You can only upload upto 5000 records in one go. (may be less in some cases),Μπορείτε να φορτώσετε μόνο μέχρι 5000 αρχεία σε μία κίνηση. (Μπορεί να είναι μικρότερη σε ορισμένες περιπτώσεις)
-DocType: Print Settings,Print Style,Εκτύπωση Style
-DocType: DocPerm,Import,Εισαγωγή
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +124,Row {0}: Not allowed to enable Allow on Submit for standard fields,Σειρά {0}: Δεν επιτρέπεται να μπορέσουν να επιτρέπουν στην Υποβολή για τυπικά πεδία
-apps/frappe/frappe/config/setup.py +90,Import / Export Data,Εισαγωγή / Εξαγωγή δεδομένων
-DocType: Workflow State,chevron-right,Chevron-δεξιά
+</ol>')"">Naming Options</a>","<a onclick=""msgprint('<ol>\
+<li><b>Πεδίο:[fieldname]</b> - By Field\
+<li><b>Σειρά ονομασίας:</b> - Κατά σειρά ονομασίας(το πεδίο naming_series πρέπει να υπάρχει\
+<li><b>Προτροπή</b> - Προτροπή χρήστη να εισάγει όνομα\
+<li><b>[series]</b> - Σειρά κατά πρόθεμα (χωρισμένη με τελεία) για παράδειγμα PRE.#####\
+</ol>')"">Επιλογές ονομασίας</a>"
+sites/assets/js/desk.min.js +777,<b>new</b> <i>type of document</i>,<B>νέο</ b> <i>τύπο εγγράφου </i>
+sites/assets/js/desk.min.js +779,"<i>document type...</i>, e.g. <b>customer</b>","<I>τύπος εγγράφου ... </ I>, π.Χ. <B> πελάτης </ b>"
+sites/assets/js/desk.min.js +785,<i>e.g. <strong>(55 + 434) / 4</strong> or <strong>=Math.sin(Math.PI/2)</strong>...</i>,<I> π.Χ. <Strong> (55 + 434) / 4 </ strong> ή = <strong> math.Sin(math.Pi/2) </ strong> ... </ I>
+sites/assets/js/desk.min.js +783,<i>module name...</i>,<I>όνομα της λειτουργικής μονάδας ... </ I>
+sites/assets/js/desk.min.js +781,<i>text</i> <b>in</b> <i>document type</i>,<I> κείμενο </ i> <b> σε </ b> <i> τύπο εγγράφου </ i>
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_layout.html +11,<span class=text-muted data-no-content=1>,<span class=text-muted data-no-content=1>
+DocType: Workflow Document State,0 - Draft; 1 - Submitted; 2 - Cancelled,0 - Προσχέδιο; 1 - υποβλήθηκε; 2 - ακυρώθηκε
+DocType: Web Page,0 is highest,0 Είναι η υψηλότερη
+DocType: Style Settings,"000 is black, fff is white","000 Είναι μαύρο, fff είναι λευκό"
+apps/frappe/frappe/templates/pages/blog.py +53,1 comment,1 Σχόλιο
+DocType: Currency,"1 Currency = [?] Fraction
+For e.g. 1 USD = 100 Cent","1 Νόμισμα = [?] κλάσμα 
+ για παράδειγμα 1 usd = 100 cent"
+apps/frappe/frappe/templates/emails/new_user.html +3,A new account has been created for you,Ένας νέος λογαριασμός έχει δημιουργηθεί για εσάς
+apps/frappe/frappe/desk/form/assign_to.py +126,"A new task, %s, has been assigned to you by %s. %s","Ένα νέο έργο, %s, έχει ανατεθεί σε σας από τοn % s. % S"
+DocType: Currency,A symbol for this currency. For e.g. $,Ένα σύμβολο για το νόμισμα αυτό. Για παράδειγμα $
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +31,A user can be permitted to multiple records of the same DocType.,Ένας χρήστης μπορεί να επιτραπεί σε πολλαπλές εγγραφές του ίδιου τύπου εγγράφου.
+sites/assets/js/desk.min.js +804,About,Σχετικά
+DocType: About Us Settings,About Us Settings,Ρυθμίσεις σχετικά με εμάς
+DocType: About Us Team Member,About Us Team Member,Μέλος της ομάδας σχετικά με εμάς
+DocType: Workflow Transition,Action,Ενέργεια
+DocType: Email Account,Actions,Ενέργειες
+apps/frappe/frappe/config/setup.py +124,"Actions for workflow (e.g. Approve, Cancel).","Ενέργειες για τη ροή εργασίας ( π.Χ. Έγκριση , ακύρωση ) ."
+,Activity,Δραστηριότητα
+apps/frappe/frappe/desk/page/activity/activity.js +20,Activity,Δραστηριότητα
+apps/frappe/frappe/config/setup.py +135,Add / Manage Email Accounts.,Προσθήκη / διαχείριση λογαριασμών ηλεκτρονικού ταχυδρομείου.
+DocType: Website Settings,Add a banner to the site. (small banners are usually good),Προσθέστε ένα banner στο site. (Τα μικρά banners είναι συνήθως καλά)
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +9,Add a New Role,Προσθήκη νέου ρόλου
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +359,Add A New Rule,Προσθήκη νέου κανόνα
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +285,Add A User Permission,Προσθήκη δικαιώματος ενός χρήστη
+apps/frappe/frappe/core/doctype/user/user.js +117,Add all roles,Προσθέστε όλους τους ρόλους
+sites/assets/js/desk.min.js +829,Add Attachments,Προσθήκη συνημμένων
+DocType: Web Page,Add code as &lt;script&gt;,Προσθήκη κώδικα ως <script>
+DocType: Style Settings,Add CSS,Προσθήκη css
+apps/frappe/frappe/config/setup.py +189,Add custom javascript to forms.,Προσθήκη προσαρμοσμένων javascript για τις φόρμες.
+apps/frappe/frappe/config/setup.py +184,Add fields to forms.,Προσθήκη πεδίων σε φόρμες.
+DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Προσθέστε το google analytics id: παράδειγμα. Ua-89xxx57-1. Παρακαλώ ψάξτε στη βοήθεια του google analytics για περισσότερες πληροφορίες.
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +363,Add New Permission Rule,Προσθήκη νέου κανόνα άδειας
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +289,Add New User Permission,Προσθήκη νέου δικαιώματος χρήστη
+sites/assets/js/desk.min.js +822,Add Reply,Προσθήκη απάντησης
+DocType: Email Account,Add Signature,Προσθέστε υπογραφή
+DocType: Style Settings,"Add the name of <a href=""http://google.com/webfonts"" target=""_blank"">Google Web Font</a> e.g. ""Open Sans""","Προσθέστε το όνομα της <a href=""http://google.Com/webfonts"" target=""_blank"">γραμματοσειράς google web font </a> π.Χ. ""Open sans"""
+apps/frappe/frappe/core/doctype/communication/communication.js +17,Add To,Προσθήκη στο
+DocType: Report,Add Total Row,Προσθήκη γραμμής συνόλου
+DocType: Style Settings,add your own CSS (careful!),Προσθέσετε το δικό σας css (προσοχή!)
+apps/frappe/frappe/utils/file_manager.py +40,Added {0},Προστέθηκε {0}
+sites/assets/js/desk.min.js +497,Added {0} ({1}),Προστέθηκε {0} ({1})
+apps/frappe/frappe/core/doctype/user/user.py +56,Adding System Manager to this User as there must be atleast one System Manager,Γίνεται πρόσθεση αυτού του χρήστη στους διαχειριστές συστήματος καθώς πρέπει να υπάρχει τουλάχιστον ένας διαχειριστής συστήματος
+DocType: Communication,Additional Info,Πρόσθετες πληροφορίες
+DocType: DocPerm,Additional Permissions,Πρόσθετα δικαιώματα
+DocType: Website Settings,Address and other legal information you may want to put in the footer.,Η διεύθυνση και άλλα νομικά στοιχεία που μπορεί να θέλετε να βάλετε στο υποσέλιδο.
+DocType: Custom Field,Adds a custom field to a DocType,Προσθέτει ένα προσαρμοσμένο πεδίο σε έναν τύπο εγγράφου
+DocType: Custom Script,Adds a custom script (client or server) to a DocType,Προσθέτει ένα προσαρμοσμένο script (client ή server) σε έναν τύπο εγγράφου
+DocType: Workflow State,adjust,Προσαρμογή
+DocType: Web Form,Advanced,Για προχωρημένους
+sites/assets/js/desk.min.js +468,Advanced Search,Σύνθετη αναζήτηση
+sites/assets/js/editor.min.js +119,Align Left (Ctrl/Cmd+L),Στοίχιση αριστερά (Ctrl / Cmd + L)
+DocType: Workflow State,align-center,Ευθυγράμμιση στο κέντρο
+DocType: Workflow State,align-justify,Ευθυγράμμιση σε όλη τη γραμμή
+DocType: Workflow State,align-left,Ευθυγράμμιση αριστερά
+DocType: Workflow State,align-right,Ευθυγράμμιση δεξιά
+apps/frappe/frappe/core/page/desktop/desktop.js +50,All Applications,Όλες οι εφαρμογές
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +94,All customizations will be removed. Please confirm.,Όλες οι προσαρμογές θα αφαιρεθούν. Παρακαλώ επιβεβαιώστε.
+DocType: Workflow,"All possible Workflow States and roles of the workflow. <br>Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Όλες οι πιθανές καταστάσεις και οι ρόλοι της ροής εργασίας. <Br>επιλογές κατάστασης εγγράφου: 0 είναι ""αποθηκευμένο"", 1 έχει ""υποβληθεί"" και 2 είναι ""ακυρωμένο"""
+DocType: Web Form,Allow Comments,Επιτρέψτε σχόλια
+DocType: Web Form,Allow Delete,Επιτρέψτε διαγραφή
+DocType: Web Form,Allow Edit,Επιτρέψτε επεξεργασία
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +186,Allow field to remain editable even after submission,Επιτρέψτε στο πεδίο να παραμείνει επεξεργάσιμο ακόμη και μετά την υποβολή
+DocType: DocType,Allow Import,Επιτρέπεται μαζική εισαγωγή
+DocType: DocType,Allow Import via Data Import Tool,Επιτρέπεται η μαζική εισαγωγή μέσω του εργαλείου μαζικής εισαγωγής δεδομένων
+DocType: Web Form,Allow Multiple,Επιτρέπονται πολλαπλά
+DocType: DocField,Allow on Submit,Επιτρέπεται κατά την υποβολή
+DocType: DocType,Allow Rename,Επιτρέπεται η μετονομασία
+DocType: User,Allow user to login only after this hour (0-24),Επίτρεψε στο χρήστη να συνδεθεί μόνο μετά από αυτή την ώρα (0-24)
+DocType: User,Allow user to login only before this hour (0-24),Επίτρεψε στο χρήστη να συνδεθεί μόνο πριν από αυτή την ώρα (0-24)
+DocType: Workflow Transition,Allowed,Επιτρέπεται
+apps/frappe/frappe/desk/form/assign_to.py +40,Already in user's To Do list,Ήδη στη λίστα εκκρεμοτήτων του χρήστη
+apps/frappe/frappe/core/doctype/user/user.py +352,Already Registered,Ήδη εγγεγραμμένος
+sites/assets/js/desk.min.js +667,Alternative download link,Εναλλακτικός σύνδεσμος μεταφόρτωσης
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +47,"Always insert, even if ID is given.","Εισάγετε πάντα, ακόμη και εάν το αναγνωριστικό έχει δοθεί."
+DocType: Outgoing Email Settings,Always use above Login Id as sender,Πάντα να χρησιμοποιείτε το παραπάνω ID σύνδεσης ως αποστολέα
+DocType: DocPerm,Amend,Τροποποίηση
+DocType: Website Settings,"An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [<a href=""http://favicon-generator.org/"" target=""_blank"">favicon-generator.org</a>]","Ένα αρχείο εικονιδίου με επέκταση ico θα πρέπει να είναι 16 x 16 px. Δημιουργημένο χρησιμοποιώντας μια γεννήτρια favicon. [ <A href=""http://favicon-generator.Org/"" target=""_blank"">favicon-generator.Org</a> ]"
+apps/frappe/frappe/model/rename_doc.py +93,"Another {0} with name {1} exists, select another name","Ένας άλλος {0} με το όνομα {1} υπάρχει, επιλέξτε ένα άλλο όνομα"
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +133,Any existing permission will be deleted / overwritten.,Κάθε υπάρχων δικαίωμα θα διαγραφεί / αντικατασταθεί.
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +19,"Apart from Role based Permission Rules, you can apply User Permissions based on DocTypes.","Εκτός από τους κανόνες δικαιωμάτων που βασίζονται σε ρόλους, μπορείτε να εφαρμόσετε δικαιώματα χρηστών με βάση τύπους εγγράφων"
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +36,"Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type.","Εκτός από το διαχειριστή του συστήματος, οι ρόλοι με το δικαίωμα 'ρύθμιση δικαιωμάτων χρήστη' μπορούν να ορίσουν δικαιώματα για άλλους χρήστες για αυτόν τον τύπο εγγράφου."
+DocType: Module Def,App Name,Όνομα εφαρμογής
+apps/frappe/frappe/modules/__init__.py +77,App not found,Δεν βρέθηκε η εφαρμογή
+DocType: Email Account,"Append as communication against this DocType (must have fields, ""Status"", ""Subject"")","Προσάρτηση ως επικοινωνία αυτού του τύπου εγγράφου (πρέπει να έχει πεδία, ""Κατάσταση"", ""θέμα"")"
+DocType: Email Account,Append To,Προσάρτηση σε
+apps/frappe/frappe/desk/page/applications/applications.js +93,Application Installer,Εγκατάσταση εφαρμογών
+,Applications,Εφαρμογές
+DocType: Style Settings,Apply Style,Εφαρμογή στυλ
+DocType: DocPerm,Apply User Permissions,Εφαρμογή δικαιωμάτων χρηστών
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +426,Apply User Permissions of these Document Types,Εφαρμόστε δικαιώματα χρήσης αυτών των τύπων εγγράφων
+apps/frappe/frappe/desk/page/activity/activity.js +153,Apr,Απρίλιος
+DocType: Communication,Archived,Αρχειοθετήθηκε
+DocType: Style Settings,Arial,Arial
+DocType: Workflow State,arrow-down,Βέλος προς τα κάτω
+DocType: Workflow State,arrow-left,Βέλος αριστερά
+DocType: Workflow State,arrow-right,Βέλος δεξιά
+DocType: Workflow State,arrow-up,Βέλος πάνω
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +11,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","Ως βέλτιστη πρακτική, μην αποδίδετε το ίδιο σύνολο κανόνων δικαιωμάτων σε διαφορετικούς ρόλους. Αντ'αυτού , ορίστε περισσότερους ρόλους στον ίδιο χρήστη."
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +153,Assign a permission level to the field.,Αντιστοιχίστε ένα επίπεδο δικαιωμάτων στο πεδίο.
+DocType: ToDo,Assigned To,Ανατέθηκε σε
+apps/frappe/frappe/desk/doctype/todo/todo.py +14,Assigned to {0},Ανατέθηκε σε ονοματεπώνυμο
+apps/frappe/frappe/core/report/todo/ToDo.py +21,Assigned To/Owner,Ανατέθηκε σε / ιδιοκτήτης
+apps/frappe/frappe/desk/doctype/todo/todo.py +18,Assignment closed by {0},Η ανάθεση έχει κλείσει από {0}
+DocType: Workflow State,asterisk,Αστερίσκος
+DocType: DocField,Attach,Επισυνάψτε
+sites/assets/js/desk.min.js +822,Attach Document Print,Επισύναψη εκτύπωσης εγγράφου
+DocType: File Data,Attached To DocType,Συνδεδεμένο με τον τύπο εγγράφου
+DocType: File Data,Attached To Name,Συνδεδεμένο με το όνομα
+DocType: Email Account,Attachment Limit (MB),Όριο συνημμένο (mb)
+apps/frappe/frappe/desk/page/activity/activity.js +154,Aug,Αύγουστος
+DocType: Outgoing Email Settings,Auto Email Id,Αυτόματο id email
+DocType: Style Settings,Auto generated,Παράγεται αυτόματα
+DocType: DocType,Auto Name,Αυτόματο όνομα
+DocType: Email Account,Auto Reply,Αυτόματη απάντηση
+DocType: Email Account,Auto Reply Message,Μήνυμα αυτόματης απάντησης
+DocType: Blogger,Avatar,Avatar
+apps/frappe/frappe/templates/includes/sidebar.html +7,Back,Πίσω
+DocType: User,Background,Φόντο
+DocType: Style Settings,Background Color,Χρώμα φόντου
+DocType: User,Background Image,Εικόνα φόντου
+DocType: User,Background Style,Στυλ φόντου
+DocType: Workflow State,backward,Πίσω
+DocType: Workflow State,ban-circle,Ban-circle
+DocType: Website Settings,Banner,Banner
+DocType: Website Settings,Banner HTML,Html banner
+DocType: Website Settings,Banner Image,Εικόνα banner
+DocType: Website Settings,Banner is above the Top Menu Bar.,Το banner είναι πάνω από το top menu bar.
+DocType: Web Page,Begin this page with a slideshow of images,Ξεκινήστε τη σελίδα με ένα slideshow των εικόνων
+apps/frappe/frappe/model/document.py +589,Beginning with,Ξεκινώντας με
+DocType: Workflow State,bell,Κουδούνι
+apps/frappe/frappe/utils/data.py +397,billion,Δισεκατομμύριο
+DocType: User,Birth Date,Ημερομηνία γέννησης
+DocType: Blog Category,Blog Category,Κατηγορία blog
+DocType: Blog Post,Blog Intro,Εισαγωγή blog
+DocType: Blog Settings,Blog Introduction,Εισαγωγή blog
+DocType: Blog Settings,Blog Settings,Ρυθμίσεις blog
+DocType: Blog Settings,Blog Title,Τίτλος blog
+DocType: Blog Category,Blogger,Blogger
+DocType: Workflow State,bold,Έντονη γραφή
+sites/assets/js/editor.min.js +103,Bold (Ctrl/Cmd+B),Bold (Ctrl / Cmd + B)
+DocType: Workflow State,book,Καταχώρηση
+DocType: Workflow State,bookmark,Σελιδοδείκτης
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +103,Both DocType and Name required,Ο τύπος εγγράφου και το όνομα είναι απαραίτητα
+apps/frappe/frappe/templates/includes/login.js +18,Both login and password required,Το όνομα χρήστη και ο κωδικός πρόσβασης είναι απαραίτητα
+DocType: Website Settings,Brand HTML,Html εμπορικού σήματος
+DocType: Web Form,Breadcrumbs,Διαδρομή
+DocType: Workflow State,briefcase,Χαρτοφύλακας
+sites/assets/js/desk.min.js +710,Browse,Αναζήτηση
+apps/frappe/frappe/desk/page/activity/activity.js +48,Build Report,Κατασκευή έκθεσης
+DocType: Bulk Email,Bulk Email,Μαζικά email
+apps/frappe/frappe/email/bulk.py +36,Bulk email limit {0} crossed,Το όριο μαζικής αποστολής email {0} ξεπεράστηκε.
+DocType: Bulk Email,Bulk Email records.,Εγγραφές μαζικών email
+sites/assets/js/editor.min.js +105,Bullet list,Λίστα με κουκκίδες
+DocType: Workflow State,bullhorn,Τηλεβόας
+DocType: DocField,Button,Κουμπί
+DocType: Communication,By,Από
+apps/frappe/frappe/sessions.py +27,Cache Cleared,Cache καθαρίστηκε
+sites/assets/js/desk.min.js +784,Calculate,Υπολογισμός
+DocType: Workflow State,Calendar,Ημερολόγιο
+DocType: Workflow State,camera,Κάμερα
+apps/frappe/frappe/client.py +53,Can not edit Read Only fields,Δεν μπορείτε να επεξεργαστείτε πεδία που είναι μόνο για ανάγνωση
+DocType: DocPerm,Cancel,Ακύρωση
+apps/frappe/frappe/core/doctype/comment/comment.py +37,Cannot add more than 50 comments,Δεν μπορείτε να προσθέσετε περισσότερα από 50 σχόλια
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py +70,Cannot cancel before submitting. See Transition {0},Δεν μπορείτε να ακυρώσετε πριν την υποβολή. Δείτε την μετάβαση {0}
+apps/frappe/frappe/model/document.py +363,Cannot change docstatus from 0 to 2,Δεν είναι δυνατή η αλλαγή κατάστασης εγγράφου από 0 σε 2
+apps/frappe/frappe/model/document.py +373,Cannot change docstatus from 1 to 0,Δεν είναι δυνατή η αλλαγή κατάστασης εγγράφου από 1 σε 0
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py +64,Cannot change state of Cancelled Document. Transition row {0},Δεν μπορεί να αλλάξει η κατάσταση ενός ακυρωμένου εγγράφου. Γραμμή μετάβασης {0}
+apps/frappe/frappe/utils/nestedset.py +201,Cannot delete {0} as it has child nodes,"Δεν είναι δυνατή η διαγραφή {0}, γιατί έχει θυγατρικούς κόμβους"
+apps/frappe/frappe/model/delete_doc.py +149,Cannot delete or cancel because {0} {1} is linked with {2} {3},Δεν είναι δυνατή η διαγραφή ή ακύρωση επειδή το {0} {1} συνδέεται με το {2} {3}
+apps/frappe/frappe/core/doctype/doctype/doctype.js +20,"Cannot Edit {0} directly: To edit {0} properties, create / update {1}, {2} and {3}","Δεν είναι δυνατή η άμεση επεξεργασία {0}: για να επεξεργαστείτε τις {0} ιδιότητες, δημιουργήστε / ενημερώστε τα {1} , {2} και {3}"
+apps/frappe/frappe/model/document.py +376,Cannot edit cancelled document,Δεν μπορείτε να επεξεργαστείτε ακυρωθέν έγγραφο
+apps/frappe/frappe/client.py +42,Cannot edit standard fields,Δεν μπορείτε να επεξεργαστείτε τα τυπικά πεδία
+apps/frappe/frappe/website/doctype/web_page/web_page.py +27,Cannot edit templated page,Δεν μπορείτε να επεξεργαστείτε προτυποποιημένη σελίδα
+apps/frappe/frappe/model/document.py +428,Cannot link cancelled document: {0},Δεν είναι δυνατή η σύνδεση του ακυρωμένου εγγράφου: {0}
+apps/frappe/frappe/core/page/user_permissions/user_permissions.py +58,Cannot remove permission for DocType: {0} and Name: {1},Δεν μπορεί να αφαιρεθεί η άδεια για τον τύπο εγγράφου: {0} και το όνομα : {1}
+apps/frappe/frappe/email/doctype/email_alert/email_alert.py +20,Cannot set Email Alert on Document Type {0},Δεν είναι δυνατή η ρύθμιση ειδοποίησης e-mail στον τύπο εγγράφου {0}
+apps/frappe/frappe/core/page/user_permissions/user_permissions.py +66,Cannot set permission for DocType: {0} and Name: {1},Δεν είναι δυνατός ο ορισμός δικαιώματος για τον τύπο εγγράφου: {0} και όνομα : {1}
+apps/frappe/frappe/core/doctype/user/user.py +330,Cannot Update: Incorrect / Expired Link.,Δεν είναι δυνατή η ενημέρωση : εσφαλμένος / ληγμένος υπερσύνδεσμος.
+apps/frappe/frappe/core/doctype/user/user.py +335,Cannot Update: Incorrect Password,Δεν είναι δυνατή η ενημέρωση : λάθος κωδικός
+apps/frappe/frappe/config/website.py +63,Categorize blog posts.,Κατηγοριοποίηση δημοσιεύσεων blog.
+DocType: Blog Category,Category Name,Όνομα κατηγορίας
+apps/frappe/frappe/utils/data.py +339,Cent,Σεντ
+DocType: Web Page,Center,Κέντρο
+sites/assets/js/editor.min.js +121,Center (Ctrl/Cmd+E),Κέντρο (Ctrl / Cmd + E)
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +16,"Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit.","Ορισμένα έγγραφα, όπως ένα τιμολόγιο, δεν θα πρέπει να αλλάξουν αφού οριστικοποιηθούν. Η τελική κατάσταση των εν λόγω εγγράφων ονομάζεται υποβεβλημένο. Μπορείτε να ορίσετε ποιοι ρόλοι έχουν δικαίωμα υποβολής."
+DocType: Workflow State,certificate,Πιστοποιητικό
+apps/frappe/frappe/config/setup.py +178,"Change field properties (hide, readonly, permission etc.)","Αλλαγή ιδιοτήτων πεδίου ( απόκρυψη , μόνο για ανάγνωση , την άδεια κλπ. )"
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +143,"Change type of field. (Currently, Type change is \
-						allowed among 'Currency and Float')","Αλλάξτε τον τύπο του πεδίου. (Επί του παρόντος, Τύπος αλλαγή \
- επιτρέπεται μεταξύ των «Νόμισμα και Float»)"
-DocType: Workflow State,camera,κάμερα
-DocType: Website Settings,Brand HTML,Μάρκα HTML
-apps/frappe/frappe/templates/includes/login.js +18,Both login and password required,Τόσο χρήστη και κωδικό πρόσβασης που απαιτείται
-apps/frappe/frappe/model/document.py +341,Please refresh to get the latest document.,Παρακαλούμε Ανανέωση για να λάβετε το τελευταίο έγγραφο.
-DocType: User,Security Settings,Ρυθμίσεις ασφαλείας
-,Desktop,Desktop
-DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,"Κείμενο που θα εμφανίζεται για Link με την ιστοσελίδα, αν αυτή η μορφή έχει μια ιστοσελίδα. Link διαδρομής θα δημιουργείται αυτόματα με βάση `` page_name` και parent_website_route`"
-sites/assets/js/desk.min.js +476,Please set {0} first,Παρακαλούμε να ορίσετε {0} Πρώτα
-DocType: Patch Log,Patch,Κηλίδα
-apps/frappe/frappe/utils/data.py +386,hundred,εκατό
+						allowed among 'Currency and Float')","Αλλάξτε τον τύπο του πεδίου. (Επί του παρόντος, η αλλαγή τύπου \
+ επιτρέπεται μεταξύ των «νόμισμα και κινητής υποδιαστολής»)"
+DocType: Communication,Chat,Κουβέντα
+DocType: Workflow State,Check,Έλεγχος
+DocType: User,Check / Uncheck roles assigned to the User. Click on the Role to find out what permissions that Role has.,Επιλέξτε / αποεπιλέξτε ποιοι ρόλοι θα ανατεθούν στον χρήστη. Κάντε κλικ στο ρόλο για να μάθετε ποια είναι τα δικαιώματα που έχει ο ρόλος.
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_column_selector.html +1,"Check columns to select, drag to set order.","Ελέγξτε τις στήλες για να επιλέξετε, σύρετε για να αλλάξετε την σειρά."
+DocType: Outgoing Email Settings,Check this if you want to send emails as this id only (in case of restriction by your email provider).,"Επιλέξτε αυτό, αν θέλετε να στέλνετε μηνύματα ηλεκτρονικού ταχυδρομείου, με αυτό το id μόνο (στην περίπτωση περιορισμού από τον πάροχο email σας)."
+DocType: Letter Head,Check this to make this the default letter head in all prints,Επιλέξτε αυτό για να γίνει η προεπιλεγμένη κεφαλίδα επιστολόχαρτου σε όλες τις εκτυπώσεις
+DocType: Email Account,Check this to pull emails from your mailbox,Επιλέξτε αυτό για να γίνει λήψη των μηνυμάτων από το γραμματοκιβώτιό σας
+apps/frappe/frappe/config/setup.py +46,Check which Documents are readable by a User,Ελέγξτε ποια έγγραφα είναι δυνατόν να αναγνωσθούν από έναν χρήστη
+apps/frappe/frappe/core/page/desktop/all_applications_dialog.html +3,Checked items will be shown on desktop,Τα επιλεγμένα στοιχεία θα εμφανίζονται στην επιφάνεια εργασίας
+DocType: Workflow State,chevron-down,Chevron-down
+DocType: Workflow State,chevron-left,Chevron-αριστερά
+DocType: Workflow State,chevron-right,Chevron-δεξιά
+DocType: Workflow State,chevron-up,Chevron-up
+DocType: DocType,Child Tables are shown as a Grid in other DocTypes.,Οι θυγατρικοί πίνακες απεικονίζονται σαν πλέγμα σε άλλους τύπους εγγράφων
+DocType: Workflow State,circle-arrow-down,Circle-arrow-down
+DocType: Workflow State,circle-arrow-left,Circle-arrow-left
+DocType: Workflow State,circle-arrow-right,Circle-arrow-right
+DocType: Workflow State,circle-arrow-up,Circle-arrow-up
+apps/frappe/frappe/core/doctype/user/user.js +127,Clear all roles,Καταργήστε όλους τους ρόλους
+apps/frappe/frappe/templates/emails/new_user.html +5,Click on the link below to complete your registration and set a new password,Κάντε κλικ στον παρακάτω σύνδεσμο για να ολοκληρωθεί η εγγραφή σας και να ορίσετε έναν νέο κωδικό πρόσβασης
+apps/frappe/frappe/desk/doctype/todo/todo.js +12,Close,Κλείσιμο
+DocType: DocField,Code,Κωδικός
+DocType: Workflow State,cog,Δόντι γραναζιού
+sites/assets/js/desk.min.js +735,Collapse,Σύμπτυξη
+DocType: Feed,Color,Χρώμα
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_column_selector.html +4,Column,Στήλη
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +217,Column Labels:,Ετικέτες στήλης:
+apps/frappe/frappe/core/page/data_import_tool/data_import_tool.py +16,Column Name,Όνομα στήλης
+DocType: Workflow State,Comment,Σχόλιο
+DocType: Comment,Comment By,Σχόλιο από
+DocType: Comment,Comment By Fullname,Σχόλιο από ονοματεπώνυμο
+DocType: Comment,Comment Date,Ημερομηνία σχολίου
+DocType: Comment,Comment Docname,Όνομα εγγράφου σχολίου
+DocType: Comment,Comment Doctype,Τύπος εγγράφου σχολίου
+DocType: Comment,Comment Time,Ώρα σχολίου
+DocType: Comment,Comment Type,Τύπος σχολίου
+apps/frappe/frappe/desk/page/activity/activity_row.html +15,Commented on {0}: {1},Σχολίασε στις {0}: {1}
+DocType: Communication,Communication Medium,Μέσο επικοινωνίας
+DocType: Company History,Company History,Ιστορικό εταιρείας
+DocType: About Us Settings,Company Introduction,Εισαγωγή εταιρείας
+apps/frappe/frappe/templates/emails/new_user.html +6,Complete Registration,Ολοκλήρωση εγγραφής
+DocType: Email Alert,Condition,Συνθήκη
+sites/assets/js/desk.min.js +108,Confirm,Επιβεβαίωση
+DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","Επιλογές επικοινωνίας, όπως ""ερώτημα πωλήσεων, ερώτημα υποστήριξης"" κτλ το καθένα σε καινούρια γραμμή ή διαχωρισμένα με κόμματα."
+DocType: Contact Us Settings,Contact Us Settings,Ρυθμίσεις επικοινωνίας
+DocType: Communication,Content,Περιεχόμενο
+DocType: File Data,Content Hash,Hash περιεχομένου
+DocType: Web Page,Content in markdown format that appears on the main side of your page,Περιεχόμενο σε μορφή κώδικα που εμφανίζεται στην κύρια όψη της σελίδας σας
+apps/frappe/frappe/config/website.py +12,Content web page.,Ιστοσελίδα περιεχομένου
+DocType: Website Settings,Copyright,Πνευματική ιδιοκτησία
+DocType: Comment,Core,Πυρήνας
+apps/frappe/frappe/email/smtp.py +126,Could not connect to outgoing email server,Δεν ήταν δυνατή η σύνδεση με το διακομιστή εξερχόμενων e-mail
+apps/frappe/frappe/model/document.py +423,Could not find {0},Δεν μπόρεσα να βρω {0}
+DocType: Country,Country Name,Όνομα χώρας
+DocType: DocPerm,Create,Δημιουργία
+sites/assets/js/desk.min.js +465,Create a new {0},Δημιουργία νέου {0}
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_start.html +16,Create a New Format,Δημιουργία μιας νέα μορφής
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py +38,Created Custom Field {0} in {1},Δημιουργήθηκε το προσαρμοσμένο πεδίο {0} στο {1}
+sites/assets/js/desk.min.js +510,Created On,Δημιουργήθηκε στις
+apps/frappe/frappe/utils/data.py +407,crore,Crore
+DocType: Currency,Currency Name,Όνομα νομίσματος
+DocType: Style Settings,Custom CSS,Προσαρμοσμένο css
+apps/frappe/frappe/core/doctype/doctype/doctype.js +22,Custom Field,Προσαρμοσμένο πεδίο
+DocType: Print Format,Custom Format,Προσαρμοσμένη μορφή
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +158,Custom HTML,Προσαρμοσμένος κώδικας HTML
+DocType: Web Page,Custom Javascript,Προσαρμοσμένο javascript
+apps/frappe/frappe/desk/moduleview.py +31,Custom Reports,Προσαρμοσμένες αναφορές
+apps/frappe/frappe/core/doctype/doctype/doctype.js +23,Custom Script,Προσαρμοσμένο script
+DocType: DocType,Custom?,Προσαρμοσμένο;
+DocType: Customize Form,Customize Form,Προσαρμογή φόρμας
+DocType: Customize Form Field,Customize Form Field,Προσαρμογή πεδίου φόρμας
+DocType: Customize Form,"Customize Label, Print Hide, Default etc.","Προσαρμογή ετικέτας, απόκρυψη εκτύπωσης, προεπιλογή κλπ."
+apps/frappe/frappe/config/setup.py +167,Customized HTML Templates for printing transctions.,Προσαρμοσμένα πρότυπα html για εκτύπωση συναλλαγών.
+apps/frappe/frappe/desk/doctype/event/event.py +62,Daily Event Digest is sent for Calendar Events where reminders are set.,Το άρθρο καθημερινών γεγονότων απεστάλη για τις εκδηλώσεις του ημερολογίου για τις οποίες έχουν οριστεί υπενθυμίσεις.
+DocType: Workflow State,Danger,Κίνδυνος
+DocType: DocField,Data,Δεδομένα
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +51,Data Import Template,Πρότυπο εισαγωγής δεδομένων
+,Data Import Tool,Εργαλείο εισαγωγής δεδομένων
+apps/frappe/frappe/model/base_document.py +297,Data missing in table,Στοιχεία που λείπουν στον πίνακα
+DocType: System Settings,Date and Number Format,Ημερομηνία και μορφή αριθμών
+DocType: Email Alert,Date Change,Αλλαγή της ημερομηνίας
+DocType: Email Alert,Date Changed,Η ημερομηνία άλλαξε
+DocType: System Settings,Date Format,Μορφή ημερομηνίας
+sites/assets/js/desk.min.js +425,Date must be in format: {0},Η ημερομηνία πρέπει να είναι σε μορφή : {0}
+DocType: DocField,Datetime,Datetime
+DocType: Email Alert,Days in Advance,Ημέρες εκ των προτέρων
+DocType: System Settings,dd.mm.yyyy,Ηη.Μμ.Εεεε
+DocType: System Settings,dd/mm/yyyy,Ηη/μμ/εεεε
+DocType: System Settings,dd-mm-yyyy,Ηη/μμ/εεεε
+sites/assets/js/desk.min.js +843,Dear,Αγαπητέ
+apps/frappe/frappe/desk/page/activity/activity.js +154,Dec,Δεκέμβριος
+apps/frappe/frappe/core/doctype/doctype/doctype.py +263,Default for 'Check' type of field must be either '0' or '1',Η προεπιλογή για τον τύπο πεδίου 'ελέγχου' πρέπει να είναι είτε «0» είτε «1»
+DocType: Default Home Page,Default Home Page,Προεπιλεγμένη αρχική σελίδα
+apps/frappe/frappe/email/doctype/email_account/email_account_list.js +10,Default Inbox,Προεπιλογμένος φάκελος εισερχομένων
+DocType: Email Account,Default Incoming,Προεπιλεγμένα εισερχόμενα
+DocType: User,Default is system timezone,Η προεπιλογή είναι η ζώνη ώρας του συστήματος
+DocType: Email Account,Default Outgoing,Προεπιλογμένα εξερχόμενα
+DocType: DocType,Default Print Format,Προεπιλογμένη μορφή εκτύπωσης
+apps/frappe/frappe/email/doctype/email_account/email_account_list.js +14,Default Sending,Προεπιλογή αποστολής
+apps/frappe/frappe/email/doctype/email_account/email_account_list.js +6,Default Sending and Inbox,Προεπιλογή αποστολής και εισερχομένων
+DocType: Custom Field,Default Value,Προεπιλεγμένη τιμή
+DocType: Contact Us Settings,"Default: ""Contact Us""","Προεπιλογή: ""επικοινωνήστε μαζί μας"""
+DocType: User,Defaults,Προεπιλογές
+DocType: DefaultValue,DefaultValue,Προεπιλεγμένη τιμή
+apps/frappe/frappe/config/setup.py +114,Define workflows for forms.,Ορίστε τις ροές εργασίας για φόρμες.
+DocType: Workflow Transition,Defines actions on states and the next step and allowed roles.,"Καθορίζει τις ενέργειες για τις καταστάσεις, το επόμενο βήμα και τους ρόλους που επιτρέπονται."
+DocType: Workflow,Defines workflow states and rules for a document.,Καθορίζει τις καταστάσεις ροής εργασίας και τους κανόνες για ένα έγγραφο.
+apps/frappe/frappe/model/delete_doc.py +186,Deleted,Διεγραμμένο
+DocType: DocField,Depends On,Εξαρτάται από
+DocType: ToDo,Description and Status,Περιγραφή και κατάσταση
+DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Περιγραφή για τη σελίδα παράθεσης, σε μορφή απλού κειμένου, μόνο μια-δυο γραμμές. (Μέγιστο 140 χαρακτήρες)"
+DocType: Web Page,Description for page header.,Περιγραφή για την κεφαλίδα της σελίδας.
+DocType: Event,Desk,Γραφείο
+,Desktop,Επιφάνεια εργασίας
+sites/assets/js/desk.min.js +487,Dialog box to select a Link Value,Παράθυρο διαλόγου για να επιλέξετε μια τιμή συνδέσμου
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +396,Did not add,Δεν έγινε η προσθήκη
+apps/frappe/frappe/desk/form/save.py +43,Did not cancel,Δεν έγινε η ακύρωση
+apps/frappe/frappe/core/page/data_import_tool/importer.py +258,Did not find {0} for {0} ({1}),Δεν βρέθηκε {0} για {0} ({1})
+apps/frappe/frappe/desk/form/load.py +42,Did not load,Δεν έγινε η φόρτωση
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +316,Did not remove,Δεν έγινε η αφαίρεση
+apps/frappe/frappe/desk/form/save.py +29,Did not save,Δεν έγινε η αποθήκευση
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +467,Did not set,Δεν ορίστηκε
+DocType: Workflow,"Different ""States"" this document can exist in. Like ""Open"", ""Pending Approval"" etc.","Διαφορετικές ""καταστάσεις"" που αυτό το έγγραφο μπορεί να υπάρχει ως ""ανοιχτό"", ""σε εκκρεμότητα έγκρισης"", κλπ."
+DocType: Website Settings,Disable Customer Signup link in Login page,Απενεργοποίηση συνδέσμου εγγραφής πελάτη στη σελίδα σύνδεσης
+apps/frappe/frappe/core/doctype/report/report.js +37,Disable Report,Απενεργοποίηση έκθεσης
+DocType: Website Settings,Disable Signup,Απενεργοποίηση εγγραφής
+DocType: DocField,Display,Εμφάνιση
+DocType: User,Display Settings,Ρυθμίσεις εμφάνισης
+DocType: DocField,Do not allow user to change after set the first time,Απαγόρευση στο χρήστη να αλλάξει μετά τον ορισμό για πρώτη φορά
+DocType: Feed,Doc Name,Όνομα εγγράφου
+DocType: Workflow Document State,Doc Status,Κατάσταση εγγράφου
+DocType: Feed,Doc Type,Τύπος εγγράφου
+DocType: DocField,DocField,Πεδίο εγγράφου
+DocType: Version,Doclist JSON,Λίστα εγγράφων json
+DocType: Version,Docname,Όνομα εγγράφου
+DocType: DocPerm,DocPerm,Άδεια εγγράφου
+DocType: DocShare,DocShare,DocShare
+DocType: DocType,DocType,Τύπος εγγράφου
+apps/frappe/frappe/core/doctype/doctype/doctype.py +126,DocType can not be merged,Οι τύποι εγγράφου δεν μπορούν να συγχωνευθούν
+DocType: DocType,DocType Details,Λεπτομέρειες τύπου εγγράφου
+DocType: DocType,DocType is a Table / Form in the application.,Ο τύπος εγγράφου είναι ένας πίνακας / μια φόρμα στην αίτηση
+DocType: Workflow,DocType on which this Workflow is applicable.,Τύπος εγγράφου για τον οποίο η παρούσα ροή εργασιών ισχύει.
+DocType: Property Setter,DocType or Field,Τύπος εγγράφου ή πεδίο
+DocType: Custom Field,Document,Έγγραφο
+DocType: DocShare,Document Name,Όνομα εγγράφου
+,Document Share Report,Αναφορά κοινοποίησης εγγράφου
+DocType: Workflow,Document States,Καταστάσεις εγγράφου
+sites/assets/js/desk.min.js +510,Document Status,Κατάσταση εγγράφου
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +47,Document Types,Τύποι εγγράφων
+sites/assets/js/desk.min.js +804,Documentation,Τεκμηρίωση
+DocType: Workflow State,Download,Λήψη
+apps/frappe/frappe/config/setup.py +207,Download Backup,Λήψη αντιγράφων ασφαλείας
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +21,Download Blank Template,Κατεβάστε το κενό πρότυπο
+apps/frappe/frappe/utils/backups.py +136,Download link for your backup will be emailed on the following email address: {0},Ο σύνδεσμος λήψης του αντιγράφου ασφαλείας θα σας αποσταλεί στην ακόλουθη διεύθυνση ηλεκτρονικού ταχυδρομείου: {0}
+DocType: Workflow State,download-alt,Download-alt
+apps/frappe/frappe/config/setup.py +157,Drag and Drop tool to build and customize Print Formats.,Drag and drop εργαλείο για την δημιουργία και προσαρμογή των μορφών εκτύπωσης.
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_layout.html +3,Drag elements from the sidebar to add. Drag them back to trash.,Σύρετε στοιχεία από την πλαϊνή μπάρα για να προσθέσετε. Σύρετε τες πίσω για να τις διαγράψετε.
+apps/frappe/frappe/model/base_document.py +243,Duplicate name {0} {1},Διπλότυπο όνομα {0} {1}
+DocType: DocField,Dynamic Link,Δυναμικός σύνδεσμος
+DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","Π.Χ. ""Υποστήριξη "","" Πωλήσεις "","" jerry yang """
+DocType: Email Account,e.g. pop.gmail.com,π.χ. pop.gmail.com
+DocType: Email Account,e.g. replies@yourcomany.com. All replies will come to this inbox.,Π.Χ. replies@yourcomany.Com. Όλες οι απαντήσεις θα έρθουν σε αυτόν τον φάκελο εισερχομένων.
+DocType: Email Account,e.g. smtp.gmail.com,π.χ. smtp.gmail.com
+sites/assets/js/desk.min.js +480,Edit as {0},Επεξεργασία ως {0}
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +499,Edit Custom HTML,Επεξεργασία προσαρμοσμένου κώδικα HTML
+DocType: Print Format,Edit Format,Επεξεργασία μορφής
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +427,Edit Heading,Επεξεργασία επικεφαλίδας
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_field.html +12,Edit HTML,Επεξεργασία κώδικα HTML
+apps/frappe/frappe/core/doctype/role/role.js +9,Edit Permissions,Επεξεργασία δικαιωμάτων
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +14,Edit Role Permissions,Επεξεργασία δικαιωμάτων ρόλου
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +494,Edit to add content,Επεξεργασία για να προσθέσετε περιεχόμενο
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_layout.html +12,Edit to set heading,Επεξεργασία για να ορίσετε επικεφαλίδα
+DocType: Workflow State,eject,Αποβολή
+DocType: Communication,Email Account,Ο λογαριασμός ηλεκτρονικού ταχυδρομείου
+DocType: Email Account,Email Account Name,Όνομα λογαριασμού ηλεκτρονικού ταχυδρομείου
+apps/frappe/frappe/email/smtp.py +114,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Δεν ρυθμίστηκε λογαριασμός ηλεκτρονικού ταχυδρομείου. Παρακαλώ να δημιουργήσετε ένα νέο λογαριασμό ηλεκτρονικού ταχυδρομείου από το μενού Εγκατάσταση > Email > Λογαριασμός ηλεκτρονικού ταχυδρομείου
+DocType: Email Alert,Email Alert,Ειδοποίηση e-mail
+DocType: Email Alert Recipient,Email Alert Recipient,Παραλήπτης ειδοποίησης email
+DocType: Email Alert Recipient,Email By Document Field,Email ανά πεδίο εγγράφου
+DocType: Outgoing Email Settings,Email Footer,Υποσέλιδο email
+apps/frappe/frappe/templates/pages/login.py +158,Email not verified with {1},Τα email δεν επαληθεύονται με {1}
+DocType: Blog Post,Email Sent,Το email απεστάλη
+sites/assets/js/desk.min.js +840,Email sent to {0},Το email απεστάλη σε {0}
+DocType: User,Email Settings,Ρυθμίσεις email
+DocType: Outgoing Email Settings,Email Settings for Outgoing and Incoming Emails.,Ρυθμίσεις email για εξερχόμενες και εισερχόμενες email.
+DocType: User,Email Signature,Υπογραφή email
+apps/frappe/frappe/email/bulk.py +126,Emails are muted,Τα email είναι σε σίγαση
+apps/frappe/frappe/config/website.py +32,Embed image slideshows in website pages.,Ενσωμάτωση slideshows εικόνας σε ιστοσελίδες.
+DocType: Style Settings,Enable,Ενεργοποίηση
+DocType: Email Account,Enable Auto Reply,Ενεργοποίηση αυτόματης απάντησης
+DocType: Web Page,Enable Comments,Ενεργοποίηση σχολίων
+DocType: Email Account,Enable Incoming,Ενεργοποίηση εισερχομένων
+DocType: Email Account,Enable Outgoing,Ενεργοποίηση εξερχομένων
+apps/frappe/frappe/core/doctype/report/report.js +37,Enable Report,Ενεργοποίηση έκθεσης
+DocType: System Settings,Enable Scheduled Jobs,Ενεργοποίηση χρονοπρογραμματισμένων εργασιών
+DocType: Event,Ends on,Λήγει στις
+apps/frappe/frappe/core/doctype/doctype/doctype.py +329,Enter at least one permission row,Εισάγετε τουλάχιστον μία σειρά δικαιωμάτων
+DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to <a href=""#Form/Customize Form/Customize Form"">Customize Form</a>.","Εισάγετε πεδία προκαθορισμένης τιμής (κλειδιά) και αξίες. Αν προσθέσετε πολλαπλές τιμές για ένα πεδίο, η πρώτη θα επιλεγεί. Αυτές οι προκαθορισμένες τιμές, επίσης, χρησιμοποιούνται για να ""ταιριάξουν"" κανόνες δικαιωμάτων. Για να δείτε τη λίστα των πεδίων, πηγαίνετε στη <a href=""#form/customize form/customize form"">προσαρμογή φόρμας</a>."
+DocType: Customize Form,Enter Form Type,Εισάγετε τύπο φόρμας
+apps/frappe/frappe/config/website.py +78,"Enter keys to enable login via Facebook, Google, GitHub.","Εισάγετε κλειδιά για να ενεργοποιήσετε την είσοδο μέσω του facebook, google, github."
+sites/assets/js/desk.min.js +148,Enter Value,Εισάγετε τιμή
+DocType: Workflow State,envelope,Φάκελος
+DocType: Scheduler Log,Error,Σφάλμα
+apps/frappe/frappe/core/doctype/communication/communication.py +201,"Error generating PDF, attachment sent as HTML","Σφάλμα κατά τη δημιουργία pdf, συνημμένο που έχει αποσταλεί ως html"
+apps/frappe/frappe/model/document.py +339,Error: Document has been modified after you have opened it,Σφάλμα: το έγγραφο έχει τροποποιηθεί αφού το έχετε ανοίξει
+DocType: Event,Event,Συμβάν
+apps/frappe/frappe/desk/doctype/event/event.py +16,Event end must be after start,Η λήξη συμβάντος πρέπει να είναι μετά την έναρξη
+DocType: Event Role,Event Role,Ρόλος συμβάντος
+DocType: Event,Event Type,Τύπος συμβάντος
+apps/frappe/frappe/desk/doctype/event/event.py +55,Events In Today's Calendar,Συμβάντα στο σημερινό ημερολόγιο
+DocType: Event,Every Day,Κάθε μέρα
+apps/frappe/frappe/desk/doctype/event/event.py +24,Every day events should finish on the same day.,Τα καθημερινά συμβάντα θα πρέπει να ολοκληρώνονται την ίδια ημέρα.
+DocType: Event,Every Month,Κάθε μήνα
+DocType: Event,Every Week,Κάθε εβδομάδα
+DocType: Event,Every Year,Κάθε έτος
+apps/frappe/frappe/desk/page/messages/messages_sidebar.html +9,Everyone,Όλοι
+DocType: Note,Everyone can read,Ο καθένας μπορεί να διαβάσει
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +161,Example,Παράδειγμα
+apps/frappe/frappe/core/doctype/report/report.js +11,Example:,Παράδειγμα:
+DocType: Workflow State,exclamation-sign,exclamation-sign
+sites/assets/js/desk.min.js +735,Expand,Ανάπτυξη
+DocType: DocPerm,Export,Εξαγωγή
+sites/assets/js/desk.min.js +665,Export not allowed. You need {0} role to export.,Η εξαγωγή δεν επιτρέπεται. Χρειάζεται ο ρόλος {0} για την εξαγωγή.
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +3,Export Template,Πρότυπο εξαγωγής
+apps/frappe/frappe/website/doctype/website_settings/website_settings.js +18,Exported,Εξάγονται
+DocType: Email Alert Recipient,"Expression, Optional","Έκφραση, προαιρετικά"
+DocType: Workflow State,eye-close,Eye-close
+DocType: Workflow State,eye-open,Eye-open
+DocType: Social Login Keys,Facebook,Facebook
+DocType: Social Login Keys,Facebook Client ID,Facebook client id
+DocType: Social Login Keys,Facebook Client Secret,Facebook client secret
+DocType: Website Settings,Facebook Share,Κοινοποίηση facebook
+DocType: User,Facebook User ID,Facebook user id
+DocType: User,Facebook Username,Όνομα χρήστη facebook
+DocType: Workflow State,facetime-video,Facetime-video
+DocType: Workflow State,fast-backward,Fast-backward
+DocType: Workflow State,fast-forward,Fast-forward
+DocType: Website Settings,FavIcon,Favicon
+apps/frappe/frappe/desk/page/activity/activity.js +153,Feb,Φεβρουάριος
+DocType: Feed,Feed,Ροή ειδήσεων
+DocType: Feed,Feed Type,Τύπος ροής
+apps/frappe/frappe/core/doctype/doctype/doctype.py +244,Field {0} in row {1} cannot be hidden and mandatory without default,Το πεδίο {0} στη γραμμή {1} δεν μπορεί να είναι κρυφό και υποχρεωτικό χωρίς προεπιλογμένη τιμή
+apps/frappe/frappe/core/doctype/doctype/doctype.py +231,Field {0} of type {1} cannot be mandatory,Το πεδίο {0} με τύπο {1} δεν μπορεί να είναι υποχρεωτικό
+DocType: Custom Field,Field Description,Περιγραφή πεδίου
+DocType: Property Setter,Field Name,Όνομα πεδίου
+DocType: Workflow,"Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)","Πεδίο που αντιπροσωπεύει την κατάσταση ροής εργασίας της συναλλαγής (εάν το πεδίο δεν υπάρχει, ένα νέο κρυφό προσαρμοσμένο πεδίο θα δημιουργηθεί)"
+DocType: Custom Field,Field Type,Τύπος πεδίου
+DocType: Custom Field,Fieldname,Όνομα πεδίου
+apps/frappe/frappe/core/doctype/doctype/doctype.py +227,Fieldname {0} appears multiple times in rows {1},Το όνομα πεδίου {0} εμφανίζεται πολλαπλές φορές στις γραμμές {1}
+apps/frappe/frappe/model/db_schema.py +406,"Fieldname {0} cannot contain letters, numbers or spaces","Το όνομα πεδίου {0} δεν μπορεί να περιέχει γράμματα , αριθμούς ή κενά"
+apps/frappe/frappe/core/doctype/doctype/doctype.py +298,Fieldname is required in row {0},Το όνομα πεδίου είναι απαραίτητο στη γραμμή {0}
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py +29,Fieldname not set for Custom Field,Το όνομα πεδίου δεν έχει οριστεί για το προσαρμοσμένο πεδίο
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +58,Fieldname which will be the DocType for this link field.,Όνομα πεδίου το οποίο θα είναι ο τύπος εγγράφου για αυτό το πεδίο συνδέσμου.
+DocType: DocType,Fields,Πεδία
+DocType: Customize Form,"Fields separated by comma (,) will be included in the<br /><b>Search By</b> list of Search dialog box","Τα πεδία που χωρίζονται με κόμμα (,) θα πρέπει να περιλαμβάνονται στη λίστα <br /> <b>αναζήτηση με</b> στο παράθυρο διαλόγου της αναζήτησης"
+DocType: Web Form Field,Fieldtype,Τύπος πεδίου
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +247,Fieldtype cannot be changed from {0} to {1} in row {2},Ο τύπος πεδίου δεν μπορεί να αλλάξει από {0} σε {1} στη γραμμή {2}
+DocType: Workflow State,file,Αρχείο
+DocType: File Data,File Data,Αρχείο δεδομένων
+DocType: File Data,File Name,Όνομα αρχείου
+apps/frappe/frappe/utils/csvutils.py +24,File not attached,Δεν έχει γίνει επισύναψη του αρχείου
+DocType: File Data,File Size,Μέγεθος αρχείου
+apps/frappe/frappe/utils/file_manager.py +169,File size exceeded the maximum allowed size of {0} MB,Το μέγεθος αρχείου υπερέβη το μέγιστο επιτρεπόμενο μέγεθος των {0} mb
+DocType: File Data,File URL,Url αρχείου
+DocType: User,Fill Screen,Γέμισε την οθόνη
+DocType: Workflow State,film,Ταινία
+DocType: DocPerm,Filter records based on User Permissions defined for a user,Φιλτράρισμα εγγραφών με βάση τα δικαιώματα χρήσης που ορίστηκαν για ένα χρήστη
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_sidebar.html +3,Filter...,Φίλτρο ...
+DocType: Email Alert,Filters,Φίλτρα
+sites/assets/js/desk.min.js +788,Find {0} in {1},Βρες {0} σε {1}
+DocType: Workflow State,fire,Φωτιά
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +62,First data column must be blank.,Η πρώτη στήλη των δεδομένων πρέπει να είναι κενή.
+DocType: Workflow State,flag,Σημαία
+DocType: DocField,Float,Κινητής υποδιαστολής
+DocType: System Settings,Float Precision,Ακρίβεια αριθμού κινητής υποδιαστολής
+apps/frappe/frappe/core/doctype/doctype/doctype.py +282,Fold can not be at the end of the form,Η αναδίπλωση δεν μπορεί να είναι στο τέλος της φόρμας
+apps/frappe/frappe/core/doctype/doctype/doctype.py +280,Fold must come before a labelled Section Break,Η αναδίπλωση πρέπει να έρθει πριν από ένα μια επισημασμένη αλλαγή τμήματος
+DocType: Workflow State,folder-close,Folder-close
+DocType: Workflow State,folder-open,Folder-open
+DocType: Workflow State,font,Γραμματοσειρά
+DocType: Style Settings,Font (Heading),Γραμματοσειρά (κεφαλίδα)
+DocType: Style Settings,Font (Text),Γραμματοσειρά (κείμενο)
+DocType: Print Settings,Font Size,Μέγεθος γραμματοσειράς
+DocType: Style Settings,Font Size (Text),Μέγεθος γραμματοσειράς (κείμενο)
+DocType: Style Settings,Fonts,Γραμματοσειρές
+DocType: Email Account,Footer,Υποσέλιδο
+DocType: Style Settings,Footer Background,Φόντο υποσέλιδου
+DocType: Website Settings,Footer Items,Αντικείμενα υποσέλιδου
+DocType: Style Settings,Footer Text,Κείμενο υποσέλιδου
+apps/frappe/frappe/core/doctype/doctype/doctype.py +337,For {0} at level {1} in {2} in row {3},Για {0} σε επίπεδο {1} στο {2} στη γραμμή {3}
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +19,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Για παράδειγμα, αν έχετε ακυρώσει και τροποποιήσει το «inv004» θα γίνει ένα νέο έγγραφο «inv004-1». Αυτό σας βοηθά να παρακολουθείτε κάθε τροπολογία."
+DocType: DocField,"For Links, enter the DocType as range
+For Select, enter list of Options separated by comma","Για συνδέσμους, εισάγετε τον τύπο εγγράφου σαν εύρος λίστα επιλογής και τη λίστα επιλογών διαχωρισμένες με κόμμα"
+DocType: Top Bar Item,For top bar,Για την μπάρα κορυφής
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +66,"For updating, you can update only selective columns.","Για ενημέρωση, μπορείτε να ενημερώσετε επιλεκτικές μόνο στήλες."
+DocType: Print Format,Format Data,Μορφοποίηση δεδομένων
+sites/assets/js/desk.min.js +804,Forums,Φόρουμ
+DocType: Workflow State,forward,Εμπρός
+DocType: Contact Us Settings,Forward To Email Address,Προώθηση στις διευθύνσεις ηλεκτρονικού ταχυδρομείου
+DocType: Currency,Fraction,Κλάσμα
+DocType: Currency,Fraction Units,Μονάδες κλάσματος
+sites/assets/js/desk.min.js +791,Frappe Framework,Frappe framework
+DocType: Workflow State,fullscreen,Πλήρης οθόνη
+DocType: Country,Geo,Γεωγραφία
+DocType: Style Settings,Georgia,Γεωργία
+sites/assets/js/desk.min.js +575,Get,Λήψη
+DocType: User,"Get your globally recognized avatar from <a href=""https://gravatar.com/"">Gravatar.com</a>","Λήψη του παγκοσμίως αναγνωρισμένου avatar σας από <a href=""https://gravatar.Com/""> gravatar.com </ a>"
+DocType: Workflow State,gift,Δώρο
+DocType: Social Login Keys,GitHub,Github
+DocType: Social Login Keys,GitHub Client ID,Github client ID
+DocType: Social Login Keys,GitHub Client Secret,Github client secret
+DocType: User,Github User ID,ID χρήστη github
+DocType: User,Github Username,Όνομα χρήστη github
+DocType: Workflow State,glass,Ποτήρι
+DocType: Workflow State,globe,Σφαίρα
+DocType: Email Account,GMail,Gmail
+DocType: Web Form,Go to this url after completing the form.,Πηγαίνετε σε αυτό το url μετά τη συμπλήρωση της φόρμας.
+DocType: Social Login Keys,Google,Google
+DocType: Website Settings,Google Analytics ID,Google analytics ID
+DocType: Social Login Keys,Google Client ID,Google client ID
+DocType: Social Login Keys,Google Client Secret,Google client secret
+DocType: Website Settings,Google Plus One,Google plus one
+DocType: User,Google User ID,ID χρήστη google
+DocType: Style Settings,Google Web Font (Heading),Google γραμματοσειρά (κεφαλίδα)
+DocType: Style Settings,Google Web Font (Text),Google γραμματοσειρά (κείμενο)
+DocType: Workflow State,hand-down,Hand-down
+DocType: Workflow State,hand-left,Hand-left
+DocType: Workflow State,hand-right,Hand-right
+DocType: Workflow State,hand-up,Hand-up
+DocType: Workflow State,hdd,hdd
+DocType: Web Page,Header,Κεφαλίδα
+DocType: DocField,Heading,Επικεφαλίδα
+DocType: Style Settings,Heading Text As,Κείμενο επικεφαλίδας ως
+DocType: Workflow State,headphones,Ακουστικά
+DocType: Workflow State,heart,Καρδιά
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +127,Help,Βοήθεια
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +16,Help for User Permissions,Βοήθεια για δικαιώματα χρήσης
+sites/assets/js/desk.min.js +775,Help on Search,Βοήθεια για αναζήτηση
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +131,Help: Field Properties,Βοήθεια: Ιδιότητες πεδίων
+DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Βοήθεια: για να συνδέσετε με άλλη εγγραφή στο σύστημα, χρησιμοποιήστε '""#Form/Note/[Note Name]', σαν διεύθυνση url σύνδεσης. (Δεν χρησιμοποιείται 'http://')"
+DocType: Style Settings,Helvetica Neue,Helvetica neue
+DocType: DocType,Hide Actions,Απόκρυψη ενεργειών
+DocType: DocType,Hide Copy,Απόκρυψη αντιγράφου
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +174,Hide field in form,Απόκρυψη πεδίου στη φόρμα
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +182,Hide field in Report Builder,Απόκρυψη πεδίου στο εργαλείο δημιουργίας εκθέσεων
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +178,Hide field in Standard Print Format,Απόκρυψη πεδίου στη τυπική μορφή εκτύπωσης
+DocType: DocType,Hide Heading,Απόκρυψη κεφαλίδας
+DocType: Website Settings,Hide the sidebar,Απόκρυψη του sidebar
+DocType: DocType,Hide Toolbar,Απόκρυψη της γραμμής εργαλείων
+DocType: Company History,Highlight,Επισήμανση
+DocType: Workflow State,Home,Αρχική
+DocType: Default Home Page,Home Page,Αρχική σελίδα
+DocType: Website Settings,Home Page is Products,Η αρχική σελίδα είναι προϊόντα
+sites/assets/js/editor.min.js +128,Horizontal Line Break,Οριζόντια αλλαγή γραμμής
+DocType: Currency,"How should this currency be formatted? If not set, will use system defaults","Πώς θα πρέπει αυτό το νόμισμα να μορφοποιηθεί; Αν δεν έχει οριστεί, θα χρησιμοποιήσει τις προεπιλογές του συστήματος"
+DocType: Web Page,HTML for header section. Optional,Html για την ενότητα της κεφαλίδας. Προαιρετικός
+apps/frappe/frappe/utils/data.py +386,hundred,Εκατό
+DocType: Page,Icon,Εικονίδιο
+DocType: Workflow State,Icon will appear on the button,Το εικονίδιο θα εμφανιστεί στο κουμπί
+DocType: Property Setter,ID (name) of the entity whose property is to be set,Id (όνομα) της οντότητας της οποίας η ιδιότητα είναι να καθοριστεί
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +25,"If a Role does not have access at Level 0, then higher levels are meaningless.","Εάν ένας ρόλος δεν έχει πρόσβαση στο επίπεδο 0, τότε τα υψηλότερα επίπεδα είναι χωρίς νόημα ."
+DocType: Workflow,"If checked, all other workflows become inactive.","Εάν είναι επιλεγμένο, όλες οι άλλες ροές εργασίας γίνονται ανενεργές."
+DocType: Website Settings,"If checked, the Home page will be the default Item Group for the website.","Εάν επιλεγεί, η αρχική σελίδα θα είναι η προεπιλεγμένη ομάδα ειδών για την ιστοσελίδα."
+DocType: Style Settings,"If image is selected, color will be ignored (attach first)","Εάν η εικόνα έχει επιλεγεί, το χρώμα θα αγνοηθεί (επισυνάψτε πρώτα)"
+DocType: Outgoing Email Settings,If non standard port (e.g. 587),Αν μη τυπική θύρα (π.Χ. 587)
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +38,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Εάν αυτές οι οδηγίες δεν ήταν χρήσιμες, Παρακαλώ να προσθέσετε τις δικές σας προτάσεις σχετικά με τα θέματα github."
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +70,"If you are updating, please select ""Overwrite"" else existing rows will not be deleted.","Αν κάνετε ενημέρωση, Παρακαλώ επιλέξτε ""αντικατάσταση"" αλλιώς οι υπάρχουσες γραμμές δεν θα διαγραφούν."
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +64,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","Αν ανεβάζετε νέες εγγραφές, η ""σειρά ονομασίας"" είναι απαραίτητη, εφόσον υπάρχει."
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +63,"If you are uploading new records, leave the ""name"" (ID) column blank.","Αν το φόρτωμα νέες εγγραφές, αφήστε κενή τη στήλη ""όνομα"" (id) ."
+DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","Αν ορίσετε αυτό, αυτό το είδος θα έρθει σε ένα πεδίο drop-down κάτω από τον επιλεγμένο γονέα."
+DocType: Email Account,Ignore attachments over this size,Αγνοήστε τα συνημμένα πάνω από αυτό το μέγεθος
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +59,Ignore encoding errors.,Αγνοήστε τα σφάλματα κωδικοποίησης.
+DocType: DocField,Ignore User Permissions,Αγνοήστε τα δικαιώματα χρήστη
+DocType: About Us Team Member,Image Link,Σύνδεσμος εικόνας
+DocType: DocPerm,Import,Εισαγωγή
+apps/frappe/frappe/config/setup.py +90,Import / Export Data,Εισαγωγή / εξαγωγή δεδομένων
+apps/frappe/frappe/config/setup.py +92,Import / Export Data from .csv files.,Εισαγωγή / εξαγωγή δεδομένων από .Csv αρχεία.
+apps/frappe/frappe/core/page/data_import_tool/data_import_tool.js +116,Import Failed,Η εισαγωγή απέτυχε
+DocType: DocType,In Dialog,Στο διάλογο
+DocType: DocField,In Filter,Στο φίλτρο
+DocType: Web Form,"In JSON as <pre>[{""title"":""Jobs"", ""name"":""jobs""}]</pre>","Στη λίστα JSON as <pre>[{""title"":""Jobs"", ""name"":""jobs""}]</pre>"
+DocType: DocField,In List View,Στην προβολή λίστας
+apps/frappe/frappe/core/doctype/doctype/doctype.py +252,'In List View' not allowed for type {0} in row {1},«Σε προβολή λίστας» δεν επιτρέπεται για τον τύπο {0} στη γραμμή {1}
+DocType: Print Settings,In points. Default is 9.,Στα σημεία. Η προεπιλογή είναι 9.
+DocType: Custom Field,In Report Filter,Στο φίλτρο εκθέσεων
+DocType: Workflow State,Inbox,Εισερχόμενα
+DocType: Email Account,Incoming Mail Settings,Ρυθμίσεις εισερχομένων email
+apps/frappe/frappe/model/document.py +614,Incorrect value in row {0}: {1} must be {2} {3},Λανθασμένη τιμή στη γραμμή {0} : το {1} πρέπει να είναι {2} {3}
+apps/frappe/frappe/model/document.py +616,Incorrect value: {0} must be {1} {2},Λανθασμένη τιμή: το {0} πρέπει να είναι {1} {2}
+sites/assets/js/editor.min.js +125,Indent (Tab),Εσοχή (tab)
+DocType: Workflow State,indent-left,Εσοχή-αριστερά
+DocType: Workflow State,indent-right,Εσοχή-δεξιά
+DocType: DocField,Index,Δείκτης
+DocType: Feed,Info,Πληροφορίες
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +221,Info:,Πληροφορίες:
+DocType: Workflow State,info-sign,Info-sign
+sites/assets/js/editor.min.js +155,Insert,Εισαγωγή
+DocType: Custom Field,Insert After,Εισαγωγή μετά την
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py +61,"Insert After field '{0}' mentioned in Custom Field '{1}', does not exist","Η εισαγωγή μετά το πεδίο ' {0}' που αναφέρεται στο προσαρμοσμένο πεδίο '{1}', δεν υπάρχει"
+DocType: Web Page,Insert Code,Εισαγωγή κώδικα
+sites/assets/js/editor.min.js +113,Insert Link,Εισαγωγή συνδέσμου
+sites/assets/js/editor.min.js +111,Insert picture (or just drag & drop),Εισαγωγή εικόνας (ή απλά σύρετε)
+DocType: Web Page,Insert Style,Εισαγωγή style
+apps/frappe/frappe/desk/page/applications/application_row.html +7,Install,Εγκατάσταση
+apps/frappe/frappe/config/setup.py +201,Install Applications.,Εγκατάσταση εφαρμογών.
+apps/frappe/frappe/desk/page/applications/application_row.html +5,Installed,Εγκατεστημένο
+apps/frappe/frappe/config/desktop.py +59,Installer,Installer
+DocType: DocField,Int,Ακέραιος
+DocType: Website Settings,Integrations,Ενσωματώσεις
+DocType: DocShare,Internal record of document shares,Εσωτερική εγγραφή των κοινοποιήσεων εγγράφου
+DocType: About Us Settings,Introduce your company to the website visitor.,Συστήστε την εταιρεία σας στον επισκέπτη της ιστοσελίδας
+DocType: Contact Us Settings,Introductory information for the Contact Us Page,Εισαγωγικές πληροφορίες για την σελίδα επικοινωνίας
+sites/assets/js/desk.min.js +420,Invalid Email: {0},Μη έγκυρο email : {0}
+apps/frappe/frappe/website/doctype/website_settings/website_settings.py +22,Invalid Home Page,Μη έγκυρη αρχική σελίδα
+apps/frappe/frappe/templates/includes/login.js +119,Invalid Login,Άκυρη σύνδεση
+apps/frappe/frappe/email/smtp.py +34,Invalid login or password,Μη έγκυρη είσοδος ή κωδικός πρόσβασης
+apps/frappe/frappe/email/receive.py +46,Invalid Mail Server. Please rectify and try again.,Άκυρος διακομιστής mail. Παρακαλώ διορθώστε και δοκιμάστε ξανά .
+apps/frappe/frappe/model/naming.py +88,Invalid naming series (. missing),Μη έγκυρη σειρά ονομασίας (. λείπει)
+apps/frappe/frappe/email/smtp.py +148,Invalid Outgoing Mail Server or Port,Μη έγκυρος διακομιστής εξερχόμενης αλληλογραφίας ή θύρα
+apps/frappe/frappe/email/smtp.py +37,Invalid recipient address,Μη έγκυρη διεύθυνση παραλήπτη
+apps/frappe/frappe/website/doctype/web_form/web_form.py +51,Invalid Request,Άκυρη αίτηση
+apps/frappe/frappe/email/receive.py +50,Invalid User Name or Support Password. Please rectify and try again.,Μη έγκυρο όνομα χρήστη ή κωδικός υποστήριξης. Παρακαλώ διορθώστε και δοκιμάστε ξανά .
+DocType: Workflow State,Inverse,Αντίστροφος
+DocType: DocType,Is Child Table,Είναι θυγατρικός πίνακας
+DocType: Custom Field,Is Mandatory Field,Είναι υποχρεωτικό πεδίο
+DocType: DocType,Is Single,Είναι μονό
+DocType: Report,Is Standard,Είναι πρότυπο
+DocType: DocType,Is Submittable,Είναι υποβλητέο
+DocType: Workflow State,italic,Πλάγια γραφή
+apps/frappe/frappe/utils/nestedset.py +181,Item cannot be added to its own descendents,Το είδος δεν μπορεί να προστεθεί στους δικούς του απογόνους
+apps/frappe/frappe/desk/page/activity/activity.js +153,Jan,Ιαν
+DocType: Report,Javascript,Javascript
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports['REPORTNAME'] = {}
+apps/frappe/frappe/config/website.py +53,Javascript to append to the head section of the page.,Javascript για να προσθέσετε στο τμήμα head της σελίδας.
+DocType: DocPerm,"JSON list of DocTypes used to apply User Permissions. If empty, all linked DocTypes will be used to apply User Permissions.","Λίστα json των τύπων εγγράφων που χρησιμοποιούνται για την εφαρμογή δικαιωμάτων χρήστη. Εάν είναι κενό, όλοι οι συνδεδεμένοι τύποι εγγράφων θα χρησιμοποιηθούν για να εφαρμοστούν τα δικαιώματα χρήσης."
+apps/frappe/frappe/desk/page/activity/activity.js +154,Jul,Ιούλιος
+apps/frappe/frappe/desk/page/activity/activity.js +153,Jun,Ιούνιος
+DocType: User,Karma,Κάρμα
+DocType: Communication,Keep a track of all communications,Παρακολούθηση όλων των επικοινωνιών
+DocType: DefaultValue,Key,Κλειδί
+DocType: DocField,Label and Type,Ετικέτα και τύπος
+DocType: Custom Field,Label Help,Βοήθεια ετικέτας
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py +19,Label is mandatory,Η ετικέτα είναι απαραίτητη
+apps/frappe/frappe/utils/data.py +404,lakh,Λάκκα
+DocType: Website Settings,Landing Page,Σελίδα προσέλευσης
+DocType: System Settings,Language,Γλώσσα
+DocType: User,Language preference for user interface (only if available).,Γλώσσα προτίμησης για την διεπαφή χρήστη (μόνο εάν είναι διαθέσιμο).
+apps/frappe/frappe/config/setup.py +65,"Language, Date and Time settings","Γλώσσα, ρυθμίσεις ημερομηνίας και ώρας"
+DocType: User,Last IP,Τελευταία IP
+DocType: User,Last Login,Τελευταία είσοδος
+sites/assets/js/desk.min.js +510,Last Updated By,Τελευταία ενημέρωση από
+sites/assets/js/desk.min.js +510,Last Updated On,Τελευταία ενημέρωση στις
+DocType: Style Settings,Lato,Lato
+DocType: Workflow State,leaf,Φύλλο
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +91,Leave blank for new records,Αφήστε κενό για νέες εγγραφές
+DocType: Event,Leave blank to repeat always,Αφήστε το κενό για να επαναλαμβάνεται πάντα
+DocType: Print Settings,Letter,Επιστολή
+DocType: Letter Head,Letter Head in HTML,Κεφαλίδα επιστολόχαρτου σε html
+DocType: Letter Head,Letter Head Name,Όνομα κεφαλίδας επιστολόχαρτου
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +371,"Level 0 is for document level permissions, higher levels for field level permissions.","Το επίπεδο 0 είναι για δικαιώματα σε επίπεδο εγγράφων, τα υψηλότερα επίπεδα είναι για δικαιώματα σε επίπεδο πεδίων."
+DocType: DocField,Link,Σύνδεσμος
+DocType: Website Settings,"Link that is the website home page. Standard Links (index, login, products, blog, about, contact)","Σύνδεσμος που είναι η αρχική σελίδα του ιστοτόπου. Τυπικοί σύνδεσμοι (index, login, τα προϊόντα, το blog, προφίλ, επικοινωνία)"
+DocType: Web Page,Link to other pages in the side bar and next section,Σύνδεση με άλλες σελίδες στη sidebar και το επόμενο τμήμα
+DocType: Top Bar Item,Link to the page you want to open,Σύνδεσμος προς τη σελίδα που θέλετε να ανοίξετε
+DocType: Website Settings,Linked In Share,Κοινοποίηση στο linked in
+DocType: Workflow State,List,Λίστα
+sites/assets/js/desk.min.js +778,List a document type,Απαριθμήστε έναν τύπο εγγράφου
+DocType: Patch Log,List of patches executed,Λίστα των δημοσιεύσεων του φόρουμ της ιστοσελίδας.
+DocType: Workflow State,list-alt,List-alt
+DocType: User,Location,Τοποθεσία
+DocType: Workflow State,lock,Κλειδαριά
+apps/frappe/frappe/config/setup.py +222,Log of error on automated events (scheduler).,Αρχείο καταγραφής σφάλματος για αυτοματοποιημένα συμβάντα (scheduler).
+DocType: Scheduler Log,Log of Scheduler Errors,Αρχείο καταγραφής των σφαλμάτων του scheduler
+apps/frappe/frappe/desk/page/activity/activity_row.html +11,Logged in,Συνδεδεμένος
+DocType: Feed,Login,Σύνδεση
+DocType: User,Login After,Είσοδος μετά
+DocType: User,Login Before,Είσοδος πριν από
+DocType: Outgoing Email Settings,Login Id,ID εισόδου
+apps/frappe/frappe/auth.py +195,Login not allowed at this time,Η είσοδος δεν επιτρέπεται αυτή τη στιγμή
+DocType: Web Form,Login Required,Απαιτείται σύνδεση
+sites/assets/js/desk.min.js +804,Logout,Αποσύνδεση
+DocType: DocField,Long Text,Μεγάλο κείμενο
+DocType: Style Settings,lowercase,Πεζά
+DocType: Style Settings,Lucida Grande,Lucida grande
+DocType: Workflow State,magnet,Μαγνήτης
+DocType: Outgoing Email Settings,Mail Password,Κωδικός mail
+DocType: Web Page,Main Section,Κύριο τμήμα
+sites/assets/js/desk.min.js +496,Make a new,Δημιουργία νέου
+sites/assets/js/desk.min.js +776,Make a new record,Δημιουργία νέας εγγραφής
+apps/frappe/frappe/config/setup.py +216,Manage cloud backups on Dropbox,Διαχείριση αντιγράφων ασφαλείας στο dropbox
+apps/frappe/frappe/config/setup.py +103,Manage uploaded files.,Διαχειριστείτε τα αρχεία που απεστάλησαν στο διακομιστή.
+DocType: DocField,Mandatory,Υποχρεωτικό
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +219,Mandatory:,Υποχρεωτικό:
+DocType: Workflow State,map-marker,Σήμανση χάρτη
+apps/frappe/frappe/desk/page/activity/activity.js +153,Mar,Mar
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +166,Mark the field as Mandatory,Σημειώστε το πεδίο ως υποχρεωτικό
+sites/assets/js/desk.min.js +480,Markdown,Κώδικας σελίδας
+DocType: DocType,Master,Κύρια εγγραφή
+DocType: DocType,Max Attachments,Μέγιστα συνημμένα
+apps/frappe/frappe/core/doctype/doctype/doctype.py +248,Max width for type Currency is 100px in row {0},Το μέγιστο πλάτος για τον τύπο νόμισμα είναι 100px στη γραμμή {0}
+apps/frappe/frappe/desk/page/activity/activity.js +153,May,Μάιος
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +14,"Meaning of Submit, Cancel, Amend","Σημασία των υποβολή, ακύρωση, τροποποίηση"
+sites/assets/js/desk.min.js +315,Menu,Μενού
+DocType: Website Settings,"Menu items in the Top Bar. For setting the color of the Top Bar, go to <a href=""#Form/Style Settings"">Style Settings</a>","Τα στοιχεία μενού στην πάνω μπάρα. Για τον καθορισμό του χρώματος της πάνω μπάρας, πηγαίνετε στις <a href=""#form/style settings"">ρυθμίσεις στυλ</a>"
+sites/assets/js/desk.min.js +527,Merge with existing,Συγχώνευση με τις υπάρχουσες
+apps/frappe/frappe/utils/nestedset.py +210,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,Η συγχώνευση είναι δυνατή μόνο μεταξύ ομάδας-σε-ομάδα ή κόμβου-σε-κόμβο
+DocType: Email Alert,Message Examples,Παραδείγματα μηνύματος
+DocType: Web Form,Message to be displayed on successful completion,Μήνυμα που θα εμφανίζεται μετά την επιτυχή ολοκλήρωση
+,Messages,Μηνύματα
+DocType: Scheduler Log,Method,Μέθοδος
+DocType: User,Middle Name (Optional),Πατρώνυμο (προαιρετικό)
+apps/frappe/frappe/utils/data.py +394,million,Εκατομμύριο
+DocType: Workflow State,minus,Πλην
+DocType: Workflow State,minus-sign,Minus-sign
+DocType: Website Settings,Misc,Διάφορα
+sites/assets/js/desk.min.js +385,Missing Values Required,Οι τιμές που λείπουν είναι απαραίτητες
+DocType: System Settings,mm/dd/yyyy,μμ/ηη/εεεε
+DocType: System Settings,mm-dd-yyyy,μμ/ηη/εεεε
+DocType: DocType,Module,Λειτουργική μονάδα
+DocType: Module Def,Module Def,Ορισμός λειτουργικής μονάδας
+DocType: Module Def,Module Name,Όνομα λειτουργικής μονάδας
+apps/frappe/frappe/desk/moduleview.py +57,Module Not Found,Η λειτουργική μονάδα δεν βρέθηκε
+,Modules Setup,Ρυθμίσεις λειτουργικής μονάδας
+DocType: Print Settings,Monochrome,Μονόχρωμος
+DocType: About Us Settings,More content for the bottom of the page.,Περισσότερο περιεχόμενο για το κάτω μέρος της σελίδας.
+DocType: Workflow State,move,Μεταφορά
+apps/frappe/frappe/utils/nestedset.py +221,Multiple root nodes not allowed.,Δεν επιτρέπονται πολλαπλοί κόμβοι ρίζες.
+apps/frappe/frappe/desk/query_report.py +69,Must have report permission to access this report.,Πρέπει να έχετε δικαιώματα πρόσβασης σε αυτή την έκθεση.
+apps/frappe/frappe/desk/query_report.py +75,Must specify a Query to run,Πρέπει να ορίσετε ένα ερώτημα για να τρέξει
+sites/assets/js/desk.min.js +804,My Settings,Οι ρυθμίσεις μου
+DocType: DocType,Name Case,Περίπτωση ονόματος
+apps/frappe/frappe/model/naming.py +47,Name not set via Prompt,Το όνομα δεν έχει οριστεί μέσω διαλόγου προτροπής
+apps/frappe/frappe/model/naming.py +160,Name of {0} cannot be {1},Το όνομα του {0} δεν μπορεί να είναι {1}
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +52,Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer,Όνομα του τύπου εγγράφου (doctype) με τον οποίο θέλετε αυτό το πεδίο να συνδέεται με (π.Χ. Πελάτη)
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +94,Name of the new Print Format,Όνομα της νέας μορφοποίησης εκτύπωσης
+DocType: DocType,Naming,Ονομασία
+apps/frappe/frappe/model/naming.py +60,Naming Series mandatory,Η σειρά ονομασίας είναι απαραίτητη
+apps/frappe/frappe/utils/nestedset.py +77,Nested set error. Please contact the Administrator.,Σφάλμα εμφωλευμένου συνόλου. Παρακαλώ επικοινωνήστε με το διαχειριστή .
+apps/frappe/frappe/templates/includes/comments.py +57,New comment on {0} {1},Νέο σχόλιο για {0} {1}
+sites/assets/js/desk.min.js +527,New Name,Νέο όνομα
+DocType: User,New Password,Νέος κωδικός
+apps/frappe/frappe/core/doctype/user/user.py +73,New password emailed,Ο νέος κωδικός απεστάλη μέσω e-mail
+DocType: Property Setter,New value to be set,Νέα τιμή που θα καθοριστεί
+DocType: Workflow Transition,Next State,Επόμενη κατάσταση
+apps/frappe/frappe/templates/pages/print.py +124,No {0} permission,Δεν υπάρχει το δικαίωμα {0}
+apps/frappe/frappe/desk/page/applications/applications.js +24,No Apps Installed,Δεν υπάρχουν εγκατεστημένες εφαρμογές
+apps/frappe/frappe/templates/pages/blog.py +51,No comments yet,Δεν υπάρχουν ακόμη σχόλια
+DocType: DocField,No Copy,Δεν υπάρχει αντίγραφο
 apps/frappe/frappe/core/page/data_import_tool/importer.py +40,No data found,Δεν βρέθηκαν δεδομένα
-DocType: Style Settings,Add CSS,Προσθήκη CSS
-DocType: Web Form,Allow Comments,Αφήστε Σχόλια
-DocType: User,Background Style,Ιστορικό Style
-DocType: System Settings,mm-dd-yyyy,mm-dd-yyyy
-apps/frappe/frappe/desk/doctype/feed/feed.py +91,{0} logged in,{0} συνδεδεμένος
+apps/frappe/frappe/utils/file_manager.py +83,No file attached,Δεν βρέθηκε συνημμένο αρχείο
+apps/frappe/frappe/desk/form/utils.py +99,No further records,Δεν υπάρχουν επιπλέον εγγραφές
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +328,No of Columns,Αριθμός στηλών
+apps/frappe/frappe/model/db_query.py +268,No permission to read {0},Δεν έχετε άδεια για να διαβάσετε {0}
+apps/frappe/frappe/core/doctype/file_data/file_data.py +42,No permission to write / remove.,Δεν έχετε άδεια για να γράψετε / αφαιρέσετε.
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +162,No Permissions set for this criteria.,Δεν έχουν οριστεί δικαιώματα για τα εν λόγω κριτήρια.
+apps/frappe/frappe/templates/includes/blog.js +37,No posts written yet.,Δεν υπάρχουν γραμμένες αναρτήσεις ακόμα.
+sites/assets/js/desk.min.js +494,No Results,Δεν υπάρχουν αποτελέσματα
+DocType: Website Settings,No Sidebar,Δεν υπάρχει sidebar
+apps/frappe/frappe/templates/pages/print.py +150,No template found at path: {0},Δεν βρέθηκε πρότυπο στην διαδρομή: {0}
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +193,No User Permissions found.,Δεν βρέθηκαν δικαιώματα χρήσης.
+apps/frappe/frappe/model/document.py +588,none of,Κανένας από
+apps/frappe/frappe/utils/csvutils.py +73,Not a valid Comma Separated Value (CSV File),Μη έγκυρο αρχείο διαχωρισμένο με κόμματα (csv ​​αρχείο)
+apps/frappe/frappe/auth.py +181,Not allowed from this IP Address,Δεν επιτρέπεται από αυτήν την διεύθυνση IP
+apps/frappe/frappe/permissions.py +148,Not allowed to access {0} with {1} = {2},Δεν επιτρέπεται η πρόσβαση στο {0} με {1} = {2}
+apps/frappe/frappe/model/base_document.py +398,Not allowed to change {0} after submission,Δεν επιτρέπεται να αλλάξετε {0} μετά την υποβολή
+apps/frappe/frappe/core/page/data_import_tool/importer.py +175,Not allowed to Import,Δεν επιτρέπεται η εισαγωγή
+apps/frappe/frappe/core/doctype/user/user.py +374,Not allowed to reset the password of {0},Δεν επιτρέπεται να επαναφέρετε τον κωδικό πρόσβασης του {0}
+sites/assets/js/desk.min.js +168,Not Found,Δεν βρέθηκε
+apps/frappe/frappe/core/doctype/doctype/doctype.py +35,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Όχι σε λειτουργία προγραμματιστή! Ορίστε στο αρχείο site_config.json ή κάντε ένα τροποποιημένο τύπο εγγράφου.
+apps/frappe/frappe/website/doctype/blog_post/blog_post_list.js +7,Not Published,Δεν έχει δημοσιευθεί
+DocType: Note,Note is a free page where users can share documents / notes,Η σημείωση είναι μια δωρεάν σελίδα όπου οι χρήστες μπορούν να μοιράζονται έγγραφα / σημειώσεις
+DocType: Website Slideshow,"Note: For best results, images must be of the same size and width must be greater than height.","Σημείωση: για βέλτιστα αποτελέσματα, οι εικόνες θα πρέπει να είναι του ίδιου μεγέθους και το πλάτος πρέπει να είναι μεγαλύτερο από το ύψος."
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +60,Notes:,Σημειώσεις:
+apps/frappe/frappe/templates/includes/blog.js +34,Nothing more to show.,Τίποτα περισσότερο για προβολή.
+DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,Οι ειδοποιήσεις και τα μαζικά email θα πρέπει να στέλνονται από αυτόν τον διακομιστή εξερχόμενης αλληλογραφίας.
+apps/frappe/frappe/desk/page/activity/activity.js +154,Nov,Νοέμβριος
+DocType: System Settings,Number Format,Μορφοποίηση αριθμών
+sites/assets/js/editor.min.js +107,Number list,Λίστα αριθμών
+apps/frappe/frappe/desk/page/activity/activity.js +154,Oct,Οκτώβριος
+DocType: Workflow State,off,Μακριά από
+DocType: Workflow State,ok,Εντάξει
+DocType: Workflow State,ok-circle,Ok-circle
+DocType: Workflow State,ok-sign,Ok-sign
+apps/frappe/frappe/templates/pages/update-password.html +17,Old Password,Παλιός κωδικός
+DocType: Communication,On,Στις
+sites/assets/js/desk.min.js +848,"On {0}, {1} wrote:","Στις {0}, ο {1} έγραψε:"
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +35,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Αφού οριστεί, οι χρήστες θα έχουν πρόσβαση μονο σε έγγραφα ( π.Χ. Blog post), όπου υπάρχει σύνδεσμος ( π.Χ. Blogger ) ."
+apps/frappe/frappe/core/doctype/report/report.py +29,Only Administrator allowed to create Query / Script Reports,Μόνο ο διαχειριστής έχει τη δυνατότητα να δημιουργήσει εκθέσεις με βάση query / script
+apps/frappe/frappe/core/doctype/report/report.py +24,Only Administrator can save a standard report. Please rename and save.,Μόνο ο διαχειριστής μπορεί να αποθηκεύσει μια πρότυπη έκθεση. Παρακαλώ να μετονομάσετε και να αποθηκεύσετε.
+DocType: Workflow Document State,Only Allow Edit For,Επίτρεψε επεξεργασία μόνο για
+apps/frappe/frappe/core/page/data_import_tool/importer.py +42,Only allowed {0} rows in one import,Επιτρέπεται μόνο {0} σειρές σε μία εισαγωγή
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +65,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,Μόνο τα υποχρεωτικά πεδία είναι απαραίτητα για νέες εγγραφές. Μπορείτε να διαγράψετε μη υποχρεωτικές στήλες εάν το επιθυμείτε.
+apps/frappe/frappe/utils/data.py +356,only.,Μόνο.
+apps/frappe/frappe/templates/includes/login.js +120,Oops! Something went wrong,Ωχ! κάτι πήγε στραβά
+sites/assets/js/desk.min.js +788,Open {0},Άνοιγμα {0}
+sites/assets/js/desk.min.js +782,Open a module or tool,Ανοίξτε μια λειτουργική μονάδα ή ένα εργαλείο
+sites/assets/js/desk.min.js +456,Open Link,Άνοιγμα συνδέσμου
+sites/assets/js/editor.min.js +152,Open Link in a new Window,Άνοιγμα συνδέσμου σε νέο παράθυρο
+DocType: Style Settings,Open Sans,Open sans
+sites/assets/js/desk.min.js +793,Open Source Web Applications for the Web,Εφαρμογές ανοιχτού κώδικα για το διαδίκτυο
+DocType: Email Alert Recipient,Optional: Alert will only be sent if value is a valid email id.,Προαιρετικά: οι ειδοποιήσεις θα αποστέλλονται μόνο αν η τιμή είναι ένα έγκυρο ID ηλεκτρονικού ταχυδρομείου.
+DocType: Email Alert Recipient,Optional: Always send to these ids. Each email id on a new row,Προαιρετικά: πάντα αποστολή σε αυτά τα id. Κάθε email id σε μια νέα σειρά
+DocType: Email Alert,Optional: The alert will be sent if this expression is true,Προαιρετικά: η ειδοποίηση θα σταλεί εάν αυτή η έκφραση είναι αληθής
+DocType: DocField,Options,Επιλογές
+apps/frappe/frappe/core/doctype/doctype/doctype.py +259,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Οι επιλογές του τύπου πεδίου 'δυναμικός σύνδεσμος' πρέπει να δείχνουν σε ένα άλλο πεδίο συνδέσμου επιλογές σαν τον 'τύπο εγγράφου'
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +55,Options for select. Each option on a new line. e.g.: <br>Option 1<br>Option 2<br>Option 3<br>,Επιλογές για επιλογή. Κάθε επιλογή σε μια νέα γραμμή. Π.Χ.: <Br> επιλογή 1 <br> επιλογή 2 <br> επιλογή 3 <br>
+DocType: Custom Field,Options Help,Βοήθεια επιλογών
+apps/frappe/frappe/core/doctype/doctype/doctype.py +240,Options must be a valid DocType for field {0} in row {1},Οι επιλογές θα πρέπει να είναι ένας έγκυρος τύπος εγγράφου για το πεδίο {0} στη γραμμή {1}
+apps/frappe/frappe/model/base_document.py +332,Options not set for link field {0},Οι επιλογές δεν έχουν οριστεί για το πεδίο συνδέσμου {0}
+apps/frappe/frappe/core/doctype/doctype/doctype.py +236,Options requried for Link or Table type field {0} in row {1},"Επιλογές που απαιτούνται, για το πεδίο τύπου συνδέσμου ή πίνακα {0} στη γραμμή {1}"
+sites/assets/js/desk.min.js +646,or,Ή
+DocType: About Us Settings,Org History,Ιστορικό οργανισμού
+DocType: About Us Settings,Org History Heading,Κεφαλίδα ιστορικού οργανισμού
+DocType: Outgoing Email Settings,Outgoing Email Settings,Ρυθμίσεις εξερχομένων email
+DocType: Outgoing Email Settings,Outgoing Mail Server,Διακομιστής εξερχόμενης αλληλογραφίας
+DocType: Email Account,Outgoing Mail Settings,Ρυθμίσεις εξερχομένων email
+DocType: Email Account,Outlook.com,Outlook.com
+DocType: Page,Page,Σελίδα
+DocType: Style Settings,Page Background,Φόντο σελίδας
+DocType: Web Page,Page content,Περιεχόμενο της σελίδας
 DocType: Style Settings,Page Header,Κεφαλίδα σελίδας
-apps/frappe/frappe/templates/emails/new_user.html +4,Your login id is,Id σύνδεσής σας είναι
-DocType: DocField,Ignore User Permissions,Αγνοήστε τα δικαιώματα χρήσης
+DocType: Style Settings,Page Header Background,Φόντο κεφαλίδας σελίδας
+DocType: Style Settings,Page Header Text,Κείμενο κεφαλίδας σελίδας
+DocType: Page,Page HTML,Html σελίδας
+DocType: Style Settings,Page Links,Σύνδεσμοι σελίδας
+apps/frappe/frappe/templates/pages/404.html +4,Page missing or moved,Η σελίδα λείπει ή έχει μετακινηθεί
+sites/assets/js/desk.min.js +744,Page not found,Η σελίδα δεν βρέθηκε
+DocType: Page Role,Page Role,Ρόλος σελίδας
+DocType: Style Settings,Page Text,Κείμενο σελίδας
+DocType: Web Page,Page url name (auto-generated),Όνομα url σελίδας ( δημιουργείται αυτόματα )
+sites/assets/js/editor.min.js +94,Paragraph,Παράγραφος
+sites/assets/js/desk.min.js +510,Parent,Γονέας
+DocType: Top Bar Item,Parent Label,Γονική ετικέτα
+apps/frappe/frappe/core/page/data_import_tool/data_import_tool.py +15,Parent Table,Γονικός πίνακας
+DocType: Web Page,Parent Web Page,Γονική ιστοσελίδα
+DocType: Event,Participants,Οι συμμετέχοντες
+apps/frappe/frappe/core/doctype/user/user.py +151,Password Reset,Επαναφορά κωδικού
+apps/frappe/frappe/core/doctype/user/user.py +381,Password reset instructions have been sent to your email,Οι οδηγίες επαναφοράς κωδικού πρόσβασης έχουν αποσταλθεί στο e-mail σας
+apps/frappe/frappe/core/doctype/user/user.py +154,Password Update,Ενημέρωση κωδικού
+apps/frappe/frappe/templates/emails/password_update.html +1,Password Update Notification,Ειδοποίηση ενημέρωσης κωδικού
+apps/frappe/frappe/core/doctype/user/user.py +343,Password Updated,Ο κωδικός ενημερώθηκε
+DocType: Patch Log,Patch,Patch
+DocType: Patch Log,Patch Log,Αρχείο καταγραφής patch
+DocType: Workflow State,pause,Παύση
+DocType: Print Settings,PDF Page Size,Μέγεθος σελίδας pdf
+DocType: Print Settings,PDF Settings,Ρυθμίσεις pdf
+DocType: Workflow State,pencil,Μολύβι
+DocType: DocField,Percent,Τοις εκατό
+DocType: DocField,Perm Level,Επίπεδο πρόσβασης
+sites/assets/js/desk.min.js +526,Permanently delete {0}?,Οριστική διαγραφή {0} ;
+apps/frappe/frappe/permissions.py +206,Permission already set,Το δικαίωμα έχει ήδη οριστεί
+DocType: Custom Field,Permission Level,Επίπεδο δικαιωμάτων
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +22,Permission Levels,Επίπεδα δικαιωμάτων
+,Permission Manager,Διαχειριστής δικαιωμάτων
+DocType: DocType,Permission Rules,Κανόνες άδειας
+DocType: DocField,Permissions,Δικαιώματα
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +10,Permissions are automatically translated to Standard Reports and Searches.,Τα δικαιώματα μεταφράζονται αυτόματα σε πρότυπες εκθέσεις και αναζητήσεις .
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +5,"Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions.","Τα δικαιώματα που έχουν οριστεί για ρόλους και τύπους εγγράφων (που ονομάζονται doctypes) με τον καθορισμό των δικαιωμάτων, όπως ανάγνωση, γραφή, δημιουργία, διαγραφή, υποβολή, ακύρωση, τροποποιούνται, έκθεση, εισαγωγή, εξαγωγή, εκτύπωση, e-mail και ορίζουν τα δικαιώματα των χρηστών."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +26,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,Τα δικαιώματα σε υψηλότερα επίπεδα είναι τα δικαιώματα σε 'επίπεδο πεδίου'. Όλα τα πεδία έχουν ένα επίπεδο δικαιώματος ορισμένο και οι κανόνες δικαιωμάτων εφαρμόζονται στο πεδίο. Αυτό χρησιμεύει σε περίπτωση που θέλετε να κρύψετε ή να κάνετε κάποια πεδία μόνο αναγνώσιμα για συγκεκριμμένους ρόλους.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +24,"Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document.","Τα δικαιώματα στο επίπεδο 0 είναι δικαιώματα 'επιπέδου εγγράφου', δηλαδή είναι πρωταρχικά για την πρόσβαση στο έγγραφο."
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +154,Permissions can be managed via Setup &gt; Role Permissions Manager,Μπορεί να γίνει διαχείριση των δικαιωμάτων μέσω του μενού Εγκατάσταση &gt; Διαχειριστής δικαιωμάτων ρόλων
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +6,Permissions get applied on Users based on what Roles they are assigned.,Τα δικαιώματα εφαρμόζονται σε χρήστες με βάση τους ρόλους που τους έχουν ανατεθεί.
+DocType: DocType,Permissions Settings,Ρυθμίσεις δικαιωμάτων
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +149,Permissions Updated,Τα δικαιώματα ενημερώθηκαν
+,Permitted Documents For User,Επιτρεπόμενα έγγραφα για το χρήστη
+DocType: User,Personal Info,Προσωπικές πληροφορίες
+DocType: Communication,Phone No.,Αριθμός τηλεφώνου
+DocType: Workflow State,picture,Εικόνα
+DocType: Workflow State,plane,Αεροπλάνο
+DocType: Workflow State,play,Παιχνίδι
+DocType: Workflow State,play-circle,Play-circle
+sites/assets/js/desk.min.js +452,Please attach a file first.,Παρακαλώ επισυνάψτε ένα αρχείο πρώτα.
+sites/assets/js/desk.min.js +721,Please attach a file or set a URL,Παρακαλώ να επισυνάψετε ένα αρχείο ή να ορίσετε μια διεύθυνση url
+apps/frappe/frappe/templates/emails/password_reset.html +4,Please click on the following link to set your new password,Παρακαλώ κάντε κλικ στον παρακάτω σύνδεσμο για να ορίσετε νέο κωδικό πρόσβασης
+apps/frappe/frappe/core/page/data_import_tool/importer.py +35,Please do not change the rows above {0},Παρακαλώ μην αλλάξετε τις γραμμές πάνω από {0}
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +61,Please do not change the template headings.,Παρακαλώ μην αλλάξετε τις επικεφαλίδες του προτύπου.
+apps/frappe/frappe/print/doctype/print_format/print_format.js +14,Please duplicate this to make changes,Παρακαλώ δημιουργήστε αντίγραφο αυτού για να κάνετε αλλαγές
+apps/frappe/frappe/templates/includes/contact.js +11,"Please enter both your email and message so that we \
+				can get back to you. Thanks!","Παρακαλώ εισάγετε τόσο το email όσο και το μήνυμά σας έτσι ώστε να \
+ μπορέσουμε να επικοινωνήσουμε μαζί σας. Ευχαριστώ!"
+apps/frappe/frappe/templates/generators/web_form.html +14,Please login to create a new {0},Παρακαλώ συνδεθείτε για να υπερψηφίσετε!
+apps/frappe/frappe/core/page/data_import_tool/importer.py +67,Please make sure that there are no empty columns in the file.,Παρακαλώ βεβαιωθείτε ότι δεν υπάρχουν κενές στήλες στο αρχείο.
+apps/frappe/frappe/model/document.py +341,Please refresh to get the latest document.,Παρακαλώ ανανεώστε για να λάβετε το τελευταίο έγγραφο.
+sites/assets/js/desk.min.js +443,Please save the document before uploading.,Παρακαλώ να αποθηκεύσετε το έγγραφο πριν από την αποστολή.
+apps/frappe/frappe/utils/file_manager.py +28,Please select a file or url,Παρακαλώ επιλέξτε ένα αρχείο ή ένα url
+apps/frappe/frappe/model/db_query.py +371,Please select atleast 1 column from {0} to sort,Παρακαλώ επιλέξτε τουλάχιστον μια στήλη από {0} για να ταξινομήσετε
+apps/frappe/frappe/print/doctype/print_format/print_format.js +20,Please select DocType first,Παρακαλώ επιλέξτε τύπο εγγράφου πρώτα
+sites/assets/js/desk.min.js +476,Please set {0} first,Παρακαλώ να ορίσετε {0} πρώτα
+apps/frappe/frappe/email/smtp.py +74,Please setup default Email Account from Setup > Email > Email Account,Παρακαλώ ρυθμίστε τον προεπιλεγμένο λογαριασμό email από τις ρυθμίσεις εγκατάστασης > e-mail> λογαριασμό ηλεκτρονικού ταχυδρομείου
+apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py +28,Please specify doctype,Παρακαλώ ορίστε τον τύπο εγγράφου
+apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py +25,Please specify user,Παρακαλώ ορίστε τον χρήστη
+apps/frappe/frappe/email/doctype/email_alert/email_alert.py +13,Please specify which date field must be checked,Παρακαλώ ορίστε ποιο πεδίο ημερομηνίας πρέπει να ελεγχθεί
+apps/frappe/frappe/email/doctype/email_alert/email_alert.py +16,Please specify which value field must be checked,Παρακαλώ ορίστε ποιο πεδίο τιμής πρέπει να ελεγχθεί
+apps/frappe/frappe/core/page/user_permissions/user_permissions.py +105,Please upload using the same template as download.,Παρακαλώ αποστείλτε στο διακομιστή χρησιμοποιώντας το ίδιο πρότυπο με τη λήψη.
+DocType: DocType,Plugin,Plugin
+DocType: Workflow State,plus,Συν
+DocType: Workflow State,plus-sign,Plus-sign
+DocType: Email Account,POP3 Server,Pop3 διακομιστής
+DocType: Outgoing Email Settings,Port,Θύρα
+apps/frappe/frappe/desk/page/messages/messages_main.html +12,Post,Δημοσίευση
+DocType: Comment,Post Topic,Θέμα δημοσίευσης
+DocType: Blogger,Posts,Δημοσιεύσεις
+DocType: DocField,Precision,Ακρίβεια
+apps/frappe/frappe/core/doctype/doctype/doctype.py +267,Precision should be between 1 and 6,Η ακρίβεια πρέπει να είναι μεταξύ 1 και 6
+DocType: Workflow State,Print,Εκτύπωση
+DocType: Print Format,Print Format,Μορφοποίηση εκτύπωσης
+apps/frappe/frappe/templates/pages/print.py +136,Print Format {0} is disabled,Η μορφοποίηση εκτύπωσης {0} είναι απενεργοποιημένη
+DocType: Print Format,Print Format Builder,Εργαλείο δημιουργίας μορφοποίησης εκτύπωσης
+DocType: Print Format,Print Format Help,Βοήθεια για την μορφοποίηση εκτύπωσης
+DocType: Print Format,Print Format Type,Τύπος μορφοποίησης εκτύπωσης
+DocType: DocField,Print Hide,Απόκρυψη εκτύπωσης
+DocType: Print Settings,Print Settings,Ρυθμίσεις εκτύπωσης
+DocType: Print Settings,Print Style,Στυλ εκτύπωσης
+DocType: Print Settings,Print Style Preview,Προεπισκόπηση στυλ εκτύπωσης
+DocType: DocField,Print Width,Πλάτος εκτύπωσης
+DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Πλάτος εκτύπωσης του πεδίου, εάν το πεδίο είναι μια στήλη σε έναν πίνακα"
+DocType: Print Settings,"Print with Letterhead, unless unchecked in a particular Document","Εκτύπωση με κεφαλίδα επιστολόχαρτου, εκτός εάν δεν είναι επιλεγμένο σε ένα συγκεκριμένο έγγραφο"
+DocType: Event,Private,Ιδιωτικός
+DocType: Custom Field,Properties,Ιδιότητες
+DocType: Property Setter,Property,Ιδιότητα
+apps/frappe/frappe/core/doctype/doctype/doctype.js +24,Property Setter,Ρυθμιστής ιδιότητας
+DocType: Property Setter,Property Setter overrides a standard DocType or Field property,Ο ρυθμιστής ιδιότητας παρακάμπτει έναν πρότυπο τύπο εγγράφου ή μια ιδιότητα πεδίου
+DocType: Property Setter,Property Type,Τύπος ιδιότητας
+DocType: Event,Public,Δημόσιο
+DocType: Blog Category,Published,Δημοσιευμένο
+DocType: Blog Post,Published On,Δημοσιεύθηκε στις
+apps/frappe/frappe/desk/page/applications/application_row.html +15,Publisher,Εκδότης
+DocType: Workflow State,qrcode,Qrcode
+DocType: Report,Query,Ερώτημα
+apps/frappe/frappe/desk/query_report.py +79,Query must be a SELECT,Το ερώτημα πρέπει να είναι μια εντολή select
+DocType: Contact Us Settings,Query Options,Επιλογές ερωτημάτων
+DocType: Report,Query Report,Έκθεση ερωτήματος
+DocType: Workflow State,question-sign,Question-sign
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +3,Quick Help for Setting Permissions,Γρήγορη βοήθεια για τον καθορισμό των δικαιωμάτων
+apps/frappe/frappe/email/doctype/email_account/email_account.py +183,Re:,Απ: 
+DocType: DocPerm,Read,Ανάγνωση
+DocType: DocField,Read Only,Μόνο για ανάγνωση
+DocType: Bulk Email,Recipient,Παραλήπτης
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +33,"Recommended bulk editing records via import, or understanding the import format.","Συνιστάται η μαζική επεξεργασία εγγραφών μέσω εισαγωγών, ή η κατανόηση της μορφής εισαγωγής."
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +24,Recommended for inserting new records.,Συνιστάται για εισαγωγή νέων εγγραφών.
+apps/frappe/frappe/model/document.py +329,Record does not exist,Δεν υπάρχει η εγγραφή
+apps/frappe/frappe/sessions.py +97,Redis cache server not running. Please contact Administrator / Tech support,Ο διακομιστής cache Redis δεν λειτουργεί. Παρακαλώ επικοινωνήστε με το διαχειριστή / τεχνική υποστήριξη
+sites/assets/js/editor.min.js +123,Reduce indent (Shift+Tab),Μείωση εσοχής (shift + tab)
+DocType: Report,Ref DocType,Ref doctype
+DocType: Event,Ref Name,Όνομα αναφοράς
+DocType: Event,Ref Type,Τύπος αναφοράς
+DocType: Bulk Email,Reference DocName,Όνομα εγγράφου αναφοράς
+DocType: Communication,Reference DocType,Τύπος εγγράφου αναφοράς
+DocType: ToDo,Reference Type,Τύπος αναφοράς
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +48,Refresh Form,Ανανέωση φόρμας
+apps/frappe/frappe/core/doctype/user/user.js +41,Refreshing...,Γίνεται ανανέωση...
+apps/frappe/frappe/core/doctype/user/user.py +350,Registered but disabled.,Εγγεγραμμένος αλλά απενεργοποιημένος.
+apps/frappe/frappe/core/doctype/user/user.py +369,Registration Details Emailed.,Τα στοιχεία εγγραφής εστάλησαν με email.
+sites/assets/js/desk.min.js +804,Reload,Επαναφόρτωση
+DocType: Workflow State,remove,Αφαίρεση
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +53,Remove all customizations?,Αφαίρεση όλων των προσαρμογών;
+sites/assets/js/editor.min.js +115,Remove Link,Κατάργηση συνδέσμου
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +334,Remove Section,Κατάργηση τμήματος
+DocType: Workflow State,remove-circle,Remove-circle
+apps/frappe/frappe/utils/file_manager.py +218,Removed {0},Αφαιρέθηκε {0}
+DocType: Workflow State,remove-sign,Remove-sign
+sites/assets/js/desk.min.js +527,Rename {0},Μετονομασία {0}
+apps/frappe/frappe/config/setup.py +97,Rename many items by uploading a .csv file.,Μετονομασία πολλών αντικειμένων με αποστολή στο διακομιστή ενός αρχείου csv . .
+apps/frappe/frappe/desk/doctype/todo/todo.js +20,Re-open,Άνοιγμα ξανά
+DocType: Workflow State,repeat,Επανάληψη
+DocType: Event,Repeat On,Επανάληψη την
+DocType: Event,Repeat this Event,Επανάληψη αυτού του συμβάντος
+DocType: Event,Repeat Till,Επανάληψη εως
+DocType: DocPerm,Report,Έκθεση
+apps/frappe/frappe/desk/query_report.py +25,Report {0} is disabled,Η έκθεση {0} είναι απενεργοποιημένη
+sites/assets/js/desk.min.js +804,Report an Issue,Αναφορά προβλήματος
+DocType: Report,Report Builder,Δημιουργός εκθέσεων
+apps/frappe/frappe/core/doctype/report/report.js +5,Report Builder reports are managed directly by the report builder. Nothing to do.,Οι εκθέσεις του δημιουργού εκθέσεων είναι διαχειρίσημες απευθείας από τον δημιουργό εκθέσεων. Δεν υπάρχει τίποτα να κάνετε.
+apps/frappe/frappe/core/doctype/doctype/doctype.py +384,Report cannot be set for Single types,Η έκθεση δεν μπορεί να οριστεί για μοναδιαίους τύπους
+DocType: DocField,Report Hide,Απόκρυψη έκθεσης
+DocType: Report,Report Manager,Διαχειριστής εκθέσεων
+DocType: Report,Report Name,Όνομα έκθεσης
+apps/frappe/frappe/config/setup.py +53,Report of all document shares,Έκθεση του συνόλου των κοινοποιήσεων του εγγράφου
+sites/assets/js/desk.min.js +197,Report this issue,Αναφορά αυτού του ζητήματος
+DocType: User,Represents a User in the system.,Αντιπροσωπεύει ένα χρήστη στο σύστημα.
+DocType: Workflow Document State,Represents the states allowed in one document and role assigned to change the state.,Αντιπροσωπεύει τις καταστάσεις που επιτρέπονται σε ένα έγγραφο και τον ρόλος που ανατίθεται να αλλάξει την κατάσταση.
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +165,Reqd,Απαιτείται
+apps/frappe/frappe/templates/pages/update-password.html +1,Reset Password,Επαναφορά κωδικού πρόσβασης
+DocType: User,Reset Password Key,Επαναφορά κωδικού
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +95,Reset Permissions for {0}?,Επαναφορά δικαιωμάτων για {0} ;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +52,Reset to defaults,Επαναφορά στις προεπιλογές
+DocType: Workflow State,resize-full,Resize-full
+DocType: Workflow State,resize-horizontal,Resize-horizontal
+DocType: Workflow State,resize-small,Resize-small
+DocType: Workflow State,resize-vertical,Resize-vertical
+DocType: Standard Reply,Response,Απάντηση
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +487,Restore Original Permissions,Επαναφορά των αρχικών δικαιωμάτων
+DocType: User,Restrict IP,Περιορισμός IP
+DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Περιορισμός χρηστών μόνο από αυτην τη διεύθυνση ip. Pολλαπλές διευθύνσεις ip μπορούν να προστεθούν διαχωρiσμένες με κόμμα. Eπίσης γίνονται δεκτές και μερικές διευθύνσεις ip, όπως (111.111.111)"
+DocType: Workflow State,retweet,Retweet
+sites/assets/js/desk.min.js +480,Rich Text,Εμπλουτισμένο κείμενο
+DocType: Top Bar Item,Right,Δεξιά
+DocType: Workflow State,road,Δρόμος
+DocType: Default Home Page,Role,Ρόλος
+DocType: DocPerm,Role and Level,Ρόλος και επίπεδο
+apps/frappe/frappe/core/doctype/userrole/userrole.py +14,Role exists,Ο ρόλος υπάρχει
+DocType: Role,Role Name,Όνομα ρόλου
+apps/frappe/frappe/core/doctype/user/user.js +282,Role Permissions,Δικαιώματα ρόλου
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +4,Role Permissions Manager,Διαχειριστής δικαιωμάτων ρόλου
+DocType: Page,Roles,Ρόλοι
+DocType: User,Roles Assigned,Ανάθεση ρόλων
+DocType: User,Roles Assigned To User,Ρόλοι που ανατέθηκαν στο χρήστη
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +7,Roles can be set for users from their User page.,Οι ρόλοι μπορούν να οριστούν για τους χρήστες από τη σελίδα χρήστη τους.
+DocType: User,Roles HTML,Html ρόλων
+apps/frappe/frappe/utils/nestedset.py +194,Root {0} cannot be deleted,Η ρίζα {0} δεν μπορεί να διαγραφεί
+apps/frappe/frappe/permissions.py +151,Row,Γραμμή
+apps/frappe/frappe/model/base_document.py +373,Row #{0}:,Γραμμή #{0}:
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +124,Row {0}: Not allowed to enable Allow on Submit for standard fields,Γραμμή {0}: αποαγορεύεται να επιτραπεί στην υποβολή για τυπικά πεδία
+DocType: Workflow,Rules defining transition of state in the workflow.,Κανόνες που καθορίζουν τη μετάβαση της κατάστασης στη ροή εργασίας.
+DocType: Workflow,"Rules for how states are transitions, like next state and which role is allowed to change state etc.","Κανόνες για τη μετάβαση μεταξύ καταστάσεων, για παραάδειγμα η επόμενη και κατάσταση και ποιος ρόλος μπορεί να αλλάξει την κατάσταση, κλπ."
+DocType: System Settings,Run scheduled jobs only if checked,Εκτέλεση χρονοπρογραμματισμένων εργασιών μόνο αν είναι επιλεγμένο
+apps/frappe/frappe/core/doctype/file_data/file_data.py +33,Same file has already been attached to the record,Το ίδιο αρχείο έχει ήδη επισυναφθεί στην εγγραφή
+DocType: Custom Script,Sample,Δείγμα
+DocType: Email Alert,Save,Αποθήκευση
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +582,Saved,Αποθηκεύτηκε
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +469,Saved!,Αποθηκεύτηκε!
+DocType: Scheduler Log,Scheduler Log,Αρχείο καταγραφής του χρονοπρογραμματιστή
+DocType: Workflow State,screenshot,Screenshot
+DocType: Custom Script,Script,Script
+DocType: Report,Script Report,Script έκθεσης
+DocType: Website Script,Script to attach to all web pages.,Script για να επισυνάψετε σε όλες τις ιστοσελίδες.
+DocType: Custom Script,Script Type,Τύπος script
+apps/frappe/frappe/core/page/desktop/all_applications_dialog.html +1,Search Application,Εφαρμογή αναζήτησης
+DocType: DocType,Search Fields,Πεδία αναζήτησης
+apps/frappe/frappe/core/doctype/doctype/doctype.py +292,Search Fields should contain valid fieldnames,Τα πεδία αναζήτησης πρέπει να περιέχουν έγκυρα ονόματα πεδίων
+sites/assets/js/desk.min.js +780,Search in a document type,Αναζήτηση σε ένα είδος εγγράφου
+sites/assets/js/desk.min.js +804,Search or type a command,Αναζήτηση ή πληκτρολόγηση μιας εντολής
+DocType: DocField,Section Break,Αλλαγή τμήματος
+DocType: System Settings,Security,Ασφάλεια
+DocType: User,Security Settings,Ρυθμίσεις ασφαλείας
+DocType: DocField,Select,Επιλογή
+sites/assets/js/desk.min.js +487,Select {0},Επιλέξτε {0}
+apps/frappe/frappe/website/doctype/website_settings/website_settings.js +73,Select a Banner Image first.,Επιλέξτε πρώτα μια εικόνα banner.
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +85,Select a DocType to make a new format,Επιλέξτε ένα τύπο εγγράφου για να δημιουργήσετε μια νέα μορφή
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_start.html +2,Select an existing format to edit or start a new format.,Επιλέξτε μια υπάρχουσα μορφή για να επεξεργαστείτε ή ξεκινήστε μια νέα μορφή.
+DocType: Website Settings,Select an image of approx width 150px with a transparent background for best results.,Επιλέξτε μια εικόνα πλάτους 150px περ. Με ένα διαφανές φόντο για καλύτερα αποτελέσματα.
+sites/assets/js/desk.min.js +822,Select Attachments,Επιλογή συνημμένων
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_field.html +20,Select Columns,Επιλέξτε στήλες
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +48,Select Document Type,Επιλογή τύπου εγγράφου
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +140,Select Document Type or Role to start.,Επιλογή τύπου εγγράφου ή ρόλου για να ξεκινήσετε.
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +248,Select Document Types,Επιλέξτε τύπους εγγράφων
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +34,Select Document Types to set which User Permissions are used to limit access.,Επιλέξτε τύπους εγγράφων για να ορίσετε ποια δικαιώματα χρήστη χρησιμοποιούνται για να περιορίσουν την πρόσβαση.
+apps/frappe/frappe/core/page/modules_setup/modules_setup.js +18,"Select modules to be shown (based on permission). If hidden, they will be hidden for all users.","Επιλέξτε λειτουργικές μονάδες για προβολή (με βάση τα δικαιώματα). Αν είναι κρυφά , θα είναι κρυμμένα για όλους τους χρήστες."
+sites/assets/js/desk.min.js +822,Select Print Format,Επιλέξτε μορφοποίηση εκτύπωσης
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +58,Select Print Format to Edit,Επιλέξτε μορφοποίηση εκτύπωσης για επεξεργασία
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +54,Select Role,Επιλέξτε ρόλο
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder.js +446,Select Table Columns for {0},Επιλέξτε στήλες πίνακα για {0}
+DocType: Top Bar Item,"Select target = ""_blank"" to open in a new page.","Επιλέξτε target = "" _blank "" για να ανοίξει σε μια νέα σελίδα ."
+DocType: Custom Field,Select the label after which you want to insert new field.,Επιλέξτε την ετικέτα μετά την οποία θέλετε να εισαγάγετε νέο πεδίο.
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +7,Select Type,Επιλέξτε τύπο
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +5,Select Type of Document to Download,Επιλέξτε τύπο εγγράφου για λήψη
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +68,Select User,Επιλέξτε χρήστη
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +209,Select User or DocType to start.,Επιλέξτε το χρήστη ή τον τύπο εγγράφου για να ξεκινήσετε.
+DocType: Email Alert,Send alert if date matches this field's value,Αποστολή ειδοποίησης σε περίπτωση που η ημερομηνία ταιριάζει με την τιμή αυτού του πεδίου
+DocType: Email Alert,Send alert if this field's value changes,Αποστολή ειδοποίησης σε περίπτωση αλλαγής της τιμής αυτού του πεδίου
+DocType: Email Alert,Send Alert On,Αποστολή ειδοποίησης στις
+DocType: Event,Send an email reminder in the morning,Στείλτε ένα email υπενθύμισης το πρωί
+sites/assets/js/desk.min.js +822,Send As Email,Αποστολή ως e-mail
+apps/frappe/frappe/config/setup.py +210,Send download link of a recent backup to System Managers,Αποστολή συνδέσμου λήψης από ένα πρόσφατο αντίγραφο ασφαλείας στους διαχειριστές συστήματος
+DocType: Print Settings,Send Email Print Attachments as PDF (Recommended),Αποστολή των συννημένων εκτυπώσεων του email ως pdf (συνιστάται)
+DocType: Contact Us Settings,Send enquiries to this email address,Στείλτε ερωτήματα σε αυτή τη διεύθυνση ηλεκτρονικού ταχυδρομείου
+DocType: Print Settings,Send Print as PDF,Αποστολή εκτύπωσης ως pdf
+DocType: Communication,Sender,Αποστολέας
+DocType: Communication,Sender Full Name,Ονοματεπώνυμο αποστολέα
+DocType: Bulk Email,Sending,Αποστολή
+DocType: Communication,Sent or Received,Απεσταλμένα ή ληφθέντα
+apps/frappe/frappe/desk/page/activity/activity.js +154,Sep,Σεπτέμβριος
+DocType: Print Format,Server,Διακομιστής
+DocType: Outgoing Email Settings,Server & Credentials,Διακομιστής & Διαπιστευτήρια
+sites/assets/js/desk.min.js +169,Server Error: Please check your server logs or contact tech support.,Σφάλμα διακομιστή : Παρακαλώ ελέγξτε τα αρχεία καταγραφής του διακομιστή σας ή επικοινωνήστε με την τεχνική υποστήριξη.
+sites/assets/js/desk.min.js +177,Session Expired. Logging you out,Η συνεδρία έληξε. Γίνεται αποσύνδεση
+DocType: System Settings,Session Expiry,Λήξη συνεδρίας
+DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Λήξη συνεδρίας σε ώρες, π.Χ. 6:00"
+apps/frappe/frappe/core/doctype/system_settings/system_settings.py +17,Session Expiry must be in format {0},Η λήξη συνεδρίας θα πρέπει να είναι σε μορφή {0}
+DocType: Website Settings,Set Banner from Image,Ορισμός banner από την εικόνα
+apps/frappe/frappe/config/setup.py +162,"Set default format, page size, print style etc.","Ορίστε την προεπιλεγμένη μορφή, το μέγεθος σελίδας, το στυλ εκτύπωσης κλπ."
+DocType: Email Account,Set Footer,Ορισμός υποσέλιδου
+DocType: Outgoing Email Settings,Set Login and Password if authentication is required.,"Ορισμός ονόματος σύνδεσης και κωδικού, εάν απαιτείται έλεγχος ταυτότητας."
+DocType: DocField,Set non-standard precision for a Float or Currency field,Ορισμός μη τυπικής ακριβείας για ένα πεδίο κινητής υποδιαστολής ή νόμισμα
+apps/frappe/frappe/config/setup.py +78,Set numbering series for transactions.,Ορίστε σειρά αρίθμησης για τις συναλλαγές.
+DocType: DocField,Set Only Once,Ορισμός μόνο μία φορά
+DocType: User,Set Password,Ορισμός κωδικού πρόσβασης
+apps/frappe/frappe/config/setup.py +31,Set Permissions on Document Types and Roles,Ορισμός δικαιωμάτων σε τύπους εγγράφων και ρόλων
+apps/frappe/frappe/config/setup.py +38,Set Permissions per User,Ορισμός δικαιωμάτων ανά χρήστη
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +139,Set the display label for the field,Ρυθμίστε την ετικέτα που εμφανίζεται για το πεδίο
+DocType: DocPerm,Set User Permissions,Ορίστε τα δικαιώματα χρήστη
+DocType: Property Setter,Set Value,Ορίστε τιμή
+DocType: Style Settings,"Set your background color, font and image (tiled)","Ρυθμίστε το χρώμα του φόντου σας, γραμματοσειρά και εικόνα (πλακάκια)"
+apps/frappe/frappe/config/website.py +68,Settings for About Us Page.,Ρυθμίσεις για τη σελίδα προφίλ.
+DocType: Contact Us Settings,Settings for Contact Us Page,Ρυθμίσεις για τη σελίδα επικοινωνίας.
+apps/frappe/frappe/config/website.py +73,Settings for Contact Us Page.,Ρυθμίσεις για τη σελίδα επικοινωνίας.
+DocType: About Us Settings,Settings for the About Us Page,Ρυθμίσεις για τη σελίδα προφίλ.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +8,Setup > User,Εγκατάσταση > χρήστης
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +33,Setup > User Permissions Manager,Εγκατάσταση > διαχειριστής δικαιωμάτων χρήστη
+apps/frappe/frappe/config/setup.py +140,Setup Email Alert based on various criteria.,Ρύθμιση ειδοποήσεων email με βάση διάφορα κριτήρια.
+apps/frappe/frappe/config/website.py +48,Setup of fonts and background.,Ρύθμιση των γραμματοσειρών και του φόντου.
+apps/frappe/frappe/config/website.py +43,"Setup of top navigation bar, footer and logo.","Ρύθμιση της επάνω γραμμή πλοήγησης, του υποσέλιδου και του λογότυπου."
+DocType: Workflow State,Share,Κοινοποίηση
+DocType: Workflow State,share-alt,Share-alt
+DocType: Workflow State,shopping-cart,Καλάθι-αγορών
+DocType: User,Short Bio,Σύντομο βιογραφικό
+DocType: Blogger,Short Name,Σύντομη ονομασία
+apps/frappe/frappe/config/setup.py +71,Show / Hide Modules,Εμφάνιση / απόκρυψη λειτουργικών μονάδων
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +199,Show a description below the field,Δείτε την περιγραφή κάτω από το πεδίο
+sites/assets/js/desk.min.js +358,Show more details,Δείτε περισσότερες λεπτομέρειες
+apps/frappe/frappe/core/page/modules_setup/modules_setup.js +5,Show or Hide Modules,Εμφάνιση ή απόκρυψη λειτουργικών μονάδων
+apps/frappe/frappe/config/setup.py +73,Show or hide modules globally.,Εμφάνιση ή απόκρυψη λειτουργικών μονάδων παντού.
+DocType: DocType,Show Print First,Προβολή εκτύπωσης πρώτα
+DocType: DocType,Show this field as title,"Προβολή αυτού του πεδίου, ως τίτλο"
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +249,Show User Permissions,Προβολή δικαιωμάτων χρήστη
+DocType: Website Settings,Sidebar,Sidebar
+DocType: Website Settings,Sidebar Items,Αντικείμενα της sidebar
+DocType: Website Settings,Sidebar Links for Home Page only,Σύνδεσμοι της sidebar για την αρχική σελίδα μόνο
+DocType: Workflow State,signal,Σήμα
+DocType: Email Account,Signature,Υπογραφή
+apps/frappe/frappe/config/website.py +17,Single Post (article).,Μονή δημοσιεύση (άρθρο).
+DocType: DocType,Single Types have only one record no tables associated. Values are stored in tabSingles,Οι μοναδιαίοι τύποι έχουν μόνο μία εγγραφή και καθόλου πίνακες που συσχετίζονται. Οι τιμές τους αποθηκεύονται σε tabsingles
+DocType: Website Slideshow,Slideshow Items,Παρουσίαση ειδών
+DocType: Website Slideshow,Slideshow like display for the website,Προβολή παρουσίασης διαφανειών για την ιστοσελίδα
+DocType: Website Slideshow,Slideshow Name,Όνομα παρουσίασης
+DocType: DocField,Small Text,Μικρό κείμενο
+DocType: Email Account,SMTP Server,Διακομιστής SMTP
+DocType: Outgoing Email Settings,SMTP Server (e.g. smtp.gmail.com),Διακομιστής εξερχόμενης αλληλλογραφίας (smtp) (π.Χ. Smtp.Gmail.Com)
+DocType: Email Account,SMTP Settings for outgoing emails,Ρυθμίσεις smtp για εξερχόμενα μηνύματα ηλεκτρονικού ταχυδρομείου
+DocType: Social Login Keys,Social Login Keys,Social login keys
+DocType: Style Settings,Solid background color (default light gray),Στέρεο χρώμα φόντου (προεπιλογή ανοιχτό γκρι)
+sites/assets/js/desk.min.js +762,Sorry! I could not find what you were looking for.,Συγγνώμη! δεν μπόρεσα να βρω αυτό που ψάχνατε.
+apps/frappe/frappe/core/doctype/user/user.py +97,Sorry! Sharing with Website User is prohibited.,Συγγνώμη! Η κοινοποίηση με χρήστες του δικτυακού τόπου απαγορεύεται.
+apps/frappe/frappe/core/doctype/user/user.py +95,Sorry! User should have complete access to their own record.,Συγγνώμη! Ο χρήστης θα πρέπει να έχει πλήρη πρόσβαση στο δικό τους αρχείο.
+sites/assets/js/desk.min.js +763,Sorry! You are not permitted to view this page.,Συγγνώμη! δεν επιτρέπεται να δείτε αυτή τη σελίδα.
+DocType: DocType,Sort Field,Πεδίο ταξινόμησης
+DocType: DocType,Sort Order,Σειρά ταξινόμησης
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +203,Specify a default value,Καθορίστε μια προεπιλεγμένη τιμή
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +148,Specify the value of the field,Καθορίστε την τιμή του πεδίου
+apps/frappe/frappe/print/doctype/print_format/print_format.py +14,Standard Print Format cannot be updated,Η πρότυπη μορφή εκτύπωσης δεν μπορεί να ενημερωθεί
+apps/frappe/frappe/config/setup.py +145,Standard replies to common queries.,Πρότυπες απαντήσεις σε συχνά ερωτήματα.
+DocType: Standard Reply,Standard Reply,Πρότυπη απάντηση
+DocType: Workflow State,star,Αστέρι
+DocType: Workflow State,star-empty,Star-empty
+sites/assets/js/desk.min.js +510,Starred By,Με αστέρι από
+apps/frappe/frappe/core/page/data_import_tool/data_import_tool.py +13,Start entering data below this line,Ξεκινήστε την εισαγωγή δεδομένων κάτω από αυτή τη γραμμή
+DocType: Event,Starts on,Ξεκινά στις
+DocType: Workflow,States,Καταστάσεις
+apps/frappe/frappe/config/setup.py +119,"States for workflow (e.g. Draft, Approved, Cancelled).","Καταστάσεις ροής εργασίας ( π.Χ. Σχέδιο , εγκεκριμένη, ακυρομένη ) ."
+apps/frappe/frappe/print/doctype/letter_head/letter_head.js +7,Step 1: Set the name and save.,Βήμα 1 : ορίστε το όνομα και αποθηκεύστε.
+apps/frappe/frappe/print/doctype/letter_head/letter_head.js +9,Step 2: Set Letterhead content.,Βήμα 2: ορίστε το περιεχόμενο του επιστολόχαρτου.
+DocType: Workflow State,step-backward,Βήμα προς τα πίσω
+DocType: Workflow State,step-forward,Βήμα προς τα εμπρός
+DocType: Workflow State,Style,Στυλ
+DocType: Workflow State,"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange","Το στυλ αντιπροσωπεύει το χρώμα του κουμπιού: επιτυχία - πράσινο, κίνδυνος - κόκκινο, αντίστροφη - μαύρο, πρωτεύουσα - σκούρο μπλε, πληροφορία - γαλάζιο, προσοχή - πορτοκαλί"
+DocType: Style Settings,Style Settings,Ρυθμίσεις στυλ
+DocType: Currency,"Sub-currency. For e.g. ""Cent""",Υπο-νόμισμα. Για παράδειγμα &quot;cent&quot;
+DocType: Website Settings,Subdomain,Subdomain
+DocType: Website Settings,Sub-domain provided by erpnext.com,Sub-domain που παρέχεται από την erpnext.com
+DocType: DocPerm,Submit,Υποβολή
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +53,Submit after importing.,Υποβολή μετά την εισαγωγή.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +39,Submit an Issue,Υποβολή προβλήματος
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py +67,Submitted Document cannot be converted back to draft. Transition row {0},Το υποβλημένο έγγραφο δεν μπορεί να μετατραπεί ξανά σε προσχέδιο. Γραμμή μετάβασης {0}
+DocType: Workflow State,Success,Επιτυχία
+DocType: Web Form,Success Message,Μήνυμα επιτυχίας
+DocType: Web Form,Success URL,URL επιτυχίας
+DocType: Currency,Symbol,Σύμβολο
+apps/frappe/frappe/print/doctype/print_format/print_format.py +26,Syntax error in Jinja template,Συντακτικό σφάλμα στην τζίντζα ​​πρότυπο
+apps/frappe/frappe/config/setup.py +13,System and Website Users,Χρήστες συστήματος και ιστοσελίδας
+DocType: Outgoing Email Settings,System generated mails will be sent from this email id.,Τα μηνύματα που δημιουργούνται από το σύστημα θα αποστέλλονται από αυτό το email id.
+DocType: User,System User,Χρήστης συστήματος
+DocType: DocField,Table,Πίνακας
+apps/frappe/frappe/model/document.py +625,Table {0} cannot be empty,Ο πίνακας {0} δεν μπορεί να είναι κενός
+DocType: Table of Contents,Table of Contents,Πίνακας περιεχομένων
+DocType: Workflow State,Tag,Ετικέτα
+DocType: Tag,Tag Name,Όνομα ετικέτας
+DocType: Workflow State,Tags,Ετικέτες
+DocType: Style Settings,Tahoma,Tahoma
+DocType: Top Bar Item,"target = ""_blank""","Target = ""_blank"""
+DocType: About Us Settings,Team Members,Μέλη της ομάδας
+DocType: About Us Settings,Team Members Heading,Κεφαλίδα των μελών της ομάδας
+DocType: Web Page,Template Path,Διαδρομή προτύπου
+DocType: DocField,Text,Κείμενο
+DocType: Web Page,Text Align,Στίχοιση κειμένου
+DocType: DocField,Text Editor,Επεξεργαστής κειμένου
+DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,"Το κείμενο που θα εμφανίζεται για το σύνδεσμο προς την ιστοσελίδα, αν αυτή η φόρμα έχει μια ιστοσελίδα. Η διαδρομή του συνδέσμου θα δημιουργείται αυτόματα με βάση τα πεδία `page_name` και `parent_website_route`"
+DocType: Workflow State,text-height,Text-height
+DocType: Workflow State,text-width,Text-width
+DocType: Workflow State,th,Th
+apps/frappe/frappe/templates/emails/new_user.html +9,Thank you,Σας ευχαριστούμε
+apps/frappe/frappe/templates/emails/auto_reply.html +1,Thank you for your email,Σας ευχαριστούμε για το email σας
+apps/frappe/frappe/templates/includes/contact.js +30,Thank you for your message,Σας ευχαριστούμε για το μήνυμά σας
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +9,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Το σύστημα παρέχει πολλούς προκαθορισμένες ρόλους. Μπορείτε να προσθέσετε νέους ρόλους για να ορίσετε ειδικότερα δικαιώματα .
+apps/frappe/frappe/desk/form/assign_to.py +118,"The task %s, that you assigned to %s, has been closed by %s.","Η εργασία %s, που αναθέσατε στον/στην %s, έχει κλείσει από τον/την %s."
+apps/frappe/frappe/desk/form/assign_to.py +112,"The task %s, that you assigned to %s, has been closed.","Η εργασία %s, που αναθέσατε στον/στην %s, έχει κλείσει."
+apps/frappe/frappe/core/doctype/doctype/doctype.py +274,There can be only one Fold in a form,Μπορεί να υπάρχει μόνο μία αναδίπλωση σε μια φόρμα
+apps/frappe/frappe/core/doctype/user/user.py +194,There should remain at least one System Manager,Θα πρέπει να παραμείνει τουλάχιστον ένας διαχειριστής συστήματος
+apps/frappe/frappe/core/page/modules_setup/modules_setup.js +55,There were errors,Υπήρξαν σφάλματα
+sites/assets/js/desk.min.js +841,There were errors while sending email. Please try again.,Υπήρξαν σφάλματα κατά την αποστολή ηλεκτρονικού ταχυδρομείου. Παρακαλώ δοκιμάστε ξανά .
+apps/frappe/frappe/model/naming.py +154,"There were some errors setting the name, please contact the administrator","Εμφανίστηκαν κάποια σφάλματα κατά τη ρύθμιση του ονόματος, Παρακαλώ επικοινωνήστε με το διαχειριστή"
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +23,"These permissions will apply for all transactions where the permitted record is linked. For example, if Company C is added to User Permissions of user X, user X will only be able to see transactions that has company C as a linked value.","Αυτά τα δικαιώματα θα ισχύουν για όλες τις συναλλαγές όπου το επιτρεπόμενο αρχείο είναι συνδεδεμένο. Για παράδειγμα αν η εταιρία c προστεθή στα δικαιώματα του χρήστη χ, ο χρήστης χ θα μπορεί να δει μόνο τις συναλλαγές που έχουν την εταιρία c σαν συνδεδεμένη τιμή."
+DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,"Οι τιμές αυτές θα πρέπει να ενημερώνονται αυτόματα σε συναλλαγές και, επίσης, θα ήταν χρήσιμο να περιορίσετε τα δικαιώματα για το χρήστη για τις συναλλαγές που περιέχουν αυτές τις αξίες."
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +27,"These will also be set as default values for those links, if only one such permission record is defined.","Αυτά θα οριστούν επίσης ως προεπιλεγμένες τιμές για αυτούς τους συνδεσμούς , αν έχει καθοριστεί μόνο μια τέτοια εγγραφη δικαιωμάτων."
+DocType: User,Third Party Authentication,Ταυτοποίηση μέσω τρίτου
+apps/frappe/frappe/geo/doctype/currency/currency.js +7,This Currency is disabled. Enable to use in transactions,Αυτό το νόμισμα είναι απενεργοποιημένο . Ενεργοποιήστε το για να  το χρησιμοποιήσετε στις συναλλαγές
+DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): <br>
+myfield
+eval:doc.myfield=='My Value'<br>
+eval:doc.age>18",Το πεδίο αυτό θα εμφανιστεί μόνο αν το όνομα πεδίου που ορίστηκε εδώ έχει τιμη ή οι κανόνες είναι αληθείς (παραδείγματα): <br>myfieldeval:doc.Myfield=='my value'<br>eval:doc.Age>18
+sites/assets/js/desk.min.js +351,This form does not have any input,Αυτή η φόρμα δεν έχει καμία είσοδο
+DocType: Website Slideshow,This goes above the slideshow.,Αυτό πηγαίνει πάνω από το προβολή παρουσίασης.
+apps/frappe/frappe/templates/emails/auto_reply.html +4,This is an automatically generated reply,Αυτή η απάντηση έχει δημιουργηθεί αυτόματα 
+DocType: Style Settings,This must be checked if Style Settings are applicable,Αυτό πρέπει να επιλεγεί εάν οι ρυθμίσεις στυλ είναι εφαρμοστέες
+DocType: DocPerm,This role update User Permissions for a user,Αυτός ο ρόλος ενημερώνει τα δικαιώματα χρήστη για ένα χρήστη
+DocType: Workflow State,th-large,Th-large
+DocType: Workflow State,th-list,Th-list
+apps/frappe/frappe/utils/data.py +391,thousand,Χίλια
+DocType: Workflow State,thumbs-down,Thumbs-down
+DocType: Workflow State,thumbs-up,Thumbs-up
+DocType: User,Tile,Πλακάκι
+DocType: Country,Time Zones,Ζώνες ώρας
+DocType: User,Timezone,Ζώνη ώρας
+DocType: Workflow State,tint,Απόχρωση
+DocType: Web Page,Title / headline of your page,Τίτλος / επικεφαλίδα της σελίδας σας
+DocType: DocType,Title Case,Γραφή τίτλου
+DocType: DocType,Title Field,Πεδίο τίτλου
+apps/frappe/frappe/core/doctype/doctype/doctype.py +80,Title field must be a valid fieldname,Το πεδίο τίτλου πρέπει να είναι ένα έγκυρο όνομα πεδίου
+DocType: Website Settings,Title Prefix,Πρόθεμα τίτλου
+apps/frappe/frappe/desk/doctype/todo/todo_list.js +7,To Do,Εκκρεμότητες
+apps/frappe/frappe/core/doctype/report/report.js +9,"To format columns, give column labels in the query.","Για να διαμορφώσετε τις στήλες, εισάγετε τις ετικέτες των στηλών στο ερώτημα."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +32,"To give acess to a role for only specific records, check the Apply User Permissions. User Permissions are used to limit users with such role to specific records.","Για να δώσετε πρόσβαση σε ένα ρόλο μόνο για συγκεκριμένες εγγραφές, επιλέξτε 'εφαρμογή δικαιωμάτων χρήσης'. Τα δικαιώματα χρήστη χρησιμοποιούνται για να περιορίσουν τους χρήστες με αυτούς τους ρόλους σε συγκεκριμένες εγγραφές."
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +4,"To import or update records, you must first download the template for importing.","Για να εκτελέσετε μια δοκιμή προσθέστε τη λειτουργική μονάδα στη διαδρομή μετά από το '{0}' . Για παράδειγμα, το {1}"
+DocType: ToDo,ToDo,Εκκρεμότητες
+apps/frappe/frappe/database.py +211,Too many writes in one request. Please send smaller requests,Πάρα πολλές εγγραφές σε ένα αίτημα. Παρακαλώ να στέλνετε μικρότερα αιτήματα.
+DocType: Style Settings,Top Bar,Top bar
+DocType: Style Settings,Top Bar Background,Φόντο top bar
+DocType: Top Bar Item,Top Bar Item,Αντικείμενο top bar
+DocType: Website Settings,Top Bar Items,Αντικείμενα top bar
+DocType: Style Settings,Top Bar Text,Κείμενο top bar
+apps/frappe/frappe/website/doctype/style_settings/style_settings.py +21,Top Bar text and background is same color. Please change.,Το κείμενο και το φόντο έχουν το ίδιο χρώμα στη top bar. Παρακαλώ αλλάξτε.
+DocType: Workflow,Transition Rules,Κανόνες μετάβασης
+DocType: Workflow,Transitions,Μεταβάσεις
+DocType: Workflow State,trash,Σκουπίδια
+DocType: Website Settings,Tweet will be shared via your user account (if specified),Τα tweet θα κοινοποιηθούν μέσω του λογαριασμού χρήστη σας (αν έχει οριστεί)
+DocType: Website Settings,Twitter Share,Κοινοποιήστε το στο twitter
+DocType: Website Settings,Twitter Share via,Κοινοποιήστε στο twitter μέσω
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +220,Type:,Τύπος:
+apps/frappe/frappe/core/doctype/communication/communication.py +82,Unable to find attachment {0},Δεν βρέθηκε το συνημμένο {0}
+sites/assets/js/desk.min.js +512,Unable to load: {0},Δεν είναι δυνατή η φόρτωση: {0}
+apps/frappe/frappe/utils/csvutils.py +32,Unable to open attached file. Please try again.,Δεν είναι δυνατό το άνοιγμα του συνημμένου αρχείου. Παρακαλώ δοκιμάστε ξανά.
+apps/frappe/frappe/email/smtp.py +152,Unable to send emails at this time,Δεν μπορεί να γίνει αποστοή e-mail αυτή τη στιγμή
+DocType: Custom Field,Unique,Μοναδικός
+sites/assets/js/desk.min.js +510,Unknown Column: {0},Άγνωστη στήλη: {0}
+apps/frappe/frappe/utils/csvutils.py +49,"Unknown file encoding. Tried utf-8, windows-1250, windows-1252.","Άγνωστη κωδικοποίηση αρχείου. Δοκιμάστηκε utf-8, windows-1250, windows-1252."
+sites/assets/js/desk.min.js +804,Unread Messages,Μη αναγνωσμένα μηνύματα
+apps/frappe/frappe/desk/doctype/event/event.py +64,Upcoming Events for Today,Επερχόμενα συμβάντα για σήμερα
+DocType: Workflow Document State,Update Field,Ενημέρωση πεδίου
+apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +40,Update the template and save in CSV (Comma Separate Values) format before attaching.,Ενημερώστε το πρότυπο και αποθηκεύστε το σε μορφή csv (Comma Separated Values) πριν την επισύναψη.
+DocType: Workflow Document State,Update Value,Ενημέρωση τιμής
+apps/frappe/frappe/desk/page/activity/activity_row.html +17,Updated {0}: {1},Ενημερώθηκε {0}: {1}
+DocType: Workflow State,Upload,Αποστολή στο διακομιστή
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +140,Upload and Sync,Αποστολή στο διακομιστή και συγχρονισμός
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +132,Upload CSV file containing all user permissions in the same format as Download.,Ανεβάστε το αρχείο csv που περιέχει όλα τα δικαιώματα των χρηστών στην ίδια μορφή όπως οι λήψεις.
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +127,Upload User Permissions,Αποστολή στο διακομιστή των δικαιωμάτων χρήστη
+sites/assets/js/desk.min.js +722,Uploading...,Γίνεται αποστολή στο διακομιστή...
+DocType: Email Account,Use SSL,Χρήση ssl
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +170,Use the field to filter records,Χρησιμοποιήστε το πεδίο για να φιλτράρετε τις εγγραφές
+DocType: Outgoing Email Settings,Use TLS,Χρήση tls
+apps/frappe/frappe/core/doctype/user/user.py +199,User {0} cannot be deleted,Ο χρήστης {0} δεν μπορεί να διαγραφεί
+apps/frappe/frappe/core/doctype/user/user.py +40,User {0} cannot be disabled,Ο χρήστης {0} δεν μπορεί να απενεργοποιηθεί
+apps/frappe/frappe/core/doctype/user/user.py +231,User {0} cannot be renamed,Ο χρήστης {0} δεν μπορεί να μετονομαστεί
+apps/frappe/frappe/core/doctype/user/user.py +384,User {0} does not exist,Ο χρήστης {0} δεν υπάρχει
+DocType: DocType,User Cannot Create,Ο χρήστης δεν μπορεί να δημιουργήσει
+DocType: DocType,User Cannot Search,Ο χρήστης δεν μπορεί να αναζητήσει
+DocType: User,User Defaults,Προεπιλογές προφίλ χρήστη
+apps/frappe/frappe/config/website.py +22,User editable form on Website.,Η φόρμα στην ιστοσελίδα είναι επεξεργάσιμη από το χρήστη.
+apps/frappe/frappe/config/website.py +27,User ID of a blog writer.,Id χρήστη του συγγραφέα ενός blog
+DocType: Blogger,User ID of a Blogger,Αναγνωριστικό χρήστη του blogger
+DocType: User,User Image,Εικόνα εικόνα
+apps/frappe/frappe/model/delete_doc.py +127,User not allowed to delete {0}: {1},Ο χρήστης δεν επιτρέπεται να διαγράψει {0}: {1}
+apps/frappe/frappe/core/page/user_permissions/user_permissions.js +234,User Permission,Δικαίωμα χρήστη
+DocType: DocPerm,User Permission DocTypes,Τύποι εγγράφου δικαιωμάτων χρήστη
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +30,User Permissions,Δικαιώματα χρήστη
+,User Permissions Manager,Διαχειριστής δικαιωμάτων χρήστη
+DocType: DocField,User permissions should not apply for this Link,Τα δικαιώματα χρήστη δεν πρέπει να εφαρμόζονται για αυτή την σύνδεση
+apps/frappe/frappe/config/setup.py +18,User Roles,Ρόλοι χρηστών
+DocType: Communication,User Tags,Ετικέτες χρηστών
+DocType: User,User Type,Τύπος χρήστη
+DocType: User,"User Type ""System User"" can access Desktop. ""Website User"" can only be logged into the website and portal pages.","Ο τύπος χρήστη ""χρήστης συστήματος"" έχει πρόσβαση στην επιφάνεια εργασίας. Ο ""χρήστης ιστοσελίδας"" μπορεί να συνδεθεί στην ιστοσελίδα και στις σελίδες της δικτυακής πύλης."
+apps/frappe/frappe/core/doctype/user/user.py +66,User with System Manager Role should always have User Type: System User,Ο χρήστης με το ρόλο διαχειριστή συστήματος  θα πρέπει να έχει πάντοτε τον τύπο χρήστη: χρήστης συστήματος
+DocType: User,user_image_show,User_image_show
+DocType: UserRole,UserRole,Ρόλος χρήστη
+apps/frappe/frappe/config/setup.py +7,Users,Χρήστες
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +292,Users with role {0}:,Χρήστες με ρόλο {0}:
+apps/frappe/frappe/templates/includes/login.js +31,Valid email and name required,Απαιτείται ένα έγκυρο e-mail και όνομα
+apps/frappe/frappe/templates/includes/login.js +43,Valid Login id required.,Απαιτείται ένα έγκυρο id σύνδεσης.
+apps/frappe/frappe/model/base_document.py +390,Value cannot be changed for {0},Η τιμή δεν μπορεί να αλλάξει για {0}
+DocType: Email Alert,Value Change,Αλλαγή τιμής
+DocType: Email Alert,Value Changed,Η τιμή άλλαξε
+apps/frappe/frappe/custom/doctype/property_setter/property_setter.js +7,Value for a check field can be either 0 or 1,Η τιμή για ένα πεδίο ελέγχου μπορεί να είναι είτε 0 είτε 1
+apps/frappe/frappe/model/base_document.py +301,Value missing for,Η τιμή λείπει για
+DocType: Style Settings,Verdana,Verdana
+apps/frappe/frappe/core/doctype/user/user.py +163,Verify Your Account,Επαληθεύσετε το λογαριασμό σας
+DocType: Version,Version,Έκδοση
+apps/frappe/frappe/core/doctype/version/version.js +10,Version restored,Η έκδοση αποκαταστάθηκε
+apps/frappe/frappe/templates/includes/comments.py +50,View it in your browser,Δείτε το στο πρόγραμμα περιήγησής σας
+apps/frappe/frappe/templates/emails/print_link.html +2,View this in your browser,Δείτε αυτό στο πρόγραμμα περιήγησής σας
+sites/assets/js/desk.min.js +804,View Website,Δείτε την ιστοσελίδα
+DocType: Communication,Visit,Επίσκεψη
+DocType: Workflow State,volume-down,Volume-down
+DocType: Workflow State,volume-off,Volume-off
+DocType: Workflow State,volume-up,Volume-up
+DocType: Workflow State,Warning,Προειδοποίηση
+DocType: Workflow State,warning-sign,Warning-sign
+apps/frappe/frappe/templates/pages/404.html +11,"We are very sorry for this, but the page you are looking for is missing (this could be because of a typo in the address) or moved.","Λυπούμαστε πολύ για αυτό, αλλά η σελίδα που ψάχνετε λείπει (αυτό μπορεί να οφείλεται σε λάθος πληκτρολόγησης διεύθυνσης) ή να έχει μετακινηθεί."
+DocType: Web Form,Web Form,Φόρμα ιστοσελίδας
+DocType: Web Form Field,Web Form Field,Πεδίο φόρμας ιστοσελίδας
+DocType: Web Form,Web Form Fields,Πεδία φόρμας ιστοσελίδας
+sites/assets/js/desk.min.js +710,Web Link,Σύνδεσμος ιστού
+DocType: Table of Contents,Web Page,Ιστοσελίδα
+DocType: Web Form,Web Page Link Text,Κείμενο συνδέσμου ιστοσελίδας
+DocType: Website Script,Website Script,Script ιστοτόπου
+DocType: Website Slideshow,Website Slideshow,Παρουσίαση ιστοσελίδας
+DocType: Website Slideshow Item,Website Slideshow Item,Αντικείμενο παρουσίασης ιστοτόπου
+DocType: Web Form,Website URL,Url ιστοτόπου
+DocType: User,Website User,Χρήστης ιστοτόπου
+apps/frappe/frappe/core/doctype/user/user.py +113,Welcome email sent,Το email καλωσορίσματος εστάλη.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +18,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Όταν τροποποιείτε ένα έγγραφο μετά ακυρώστε και αποθηκεύστε το, θα πάρει ένα νέο αριθμό που είναι μια έκδοση του παλιού αριθμού."
+DocType: DocField,Width,Πλάτος
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +160,Width of the input box,Το πλάτος του πεδίου εισόδου
+apps/frappe/frappe/print/page/print_format_builder/print_format_builder_column_selector.html +2,Widths can be set in px or %.,Τα πλάτη μπορούν να ρυθμιστούν σε px ή %.
+DocType: Blogger,Will be used in url (usually first name).,Θα χρησιμοποιηθεί στο url (συνήθως το πρώτο όνομα).
+DocType: Print Settings,With Letterhead,Με κεφαλίδα επιστολόχαρτου
+DocType: Workflow,Workflow,Ροή εργασίας
+DocType: Workflow Action,Workflow Action,Ενέργεια ροής εργασίας
+DocType: Workflow Action,Workflow Action Master,Κύρια εγγραφή ενέργειας ροής εργασίας
+DocType: Workflow Action,Workflow Action Name,Όνομα ενέργειας ροής εργασιών
+DocType: Workflow Document State,Workflow Document State,Κατάσταση εγγράφου ροής εργασίας
+DocType: Workflow,Workflow Name,Όνομα ροής εργασιών
+DocType: Workflow State,Workflow State,Κατάσταση ροής εργασίας
+DocType: Workflow,Workflow State Field,Πεδίο κατάστασης ροής εργασίας
+DocType: Workflow State,Workflow state represents the current state of a document.,Η κατάσταση ροής εργασίας αντιπροσωπεύει την τρέχουσα κατάσταση ενός εγγράφου.
+DocType: Workflow Transition,Workflow Transition,Μετάβαση ροής εργασίας
+DocType: Workflow State,wrench,Wrench
+DocType: DocPerm,Write,Γράφω
+apps/frappe/frappe/core/doctype/report/report.js +16,Write a Python file in the same folder where this is saved and return column and result.,Γράψτε ένα αρχείο python στον ίδιο φάκελο όπου αυτό αποθηκεύεται και επέστρεψε στήλη και αποτέλεσμα.
+apps/frappe/frappe/core/doctype/report/report.js +8,Write a SELECT query. Note result is not paged (all data is sent in one go).,Γράψτε ένα ερώτημα select. Σημείωση: το αποτέλεσμα δεν σελιδοποιείται (όλα τα δεδομένα αποστέλλονται σε μια δόση).
+apps/frappe/frappe/config/website.py +58,Write titles and introductions to your blog.,Γράψτε τους τίτλους και τις εισαγωγές στο blog σας.
+DocType: Blog Settings,Writers Introduction,Εισαγωγή συγγραφέων
+DocType: Email Account,Yahoo Mail,Yahoo mail
+sites/assets/js/desk.min.js +615,You,Εσείς
+sites/assets/js/desk.min.js +838,You are not allowed to send emails related to this document,Δεν επιτρέπεται να στείλετε μηνύματα ηλεκτρονικού ταχυδρομείου που σχετίζονται με αυτό το έγγραφο
+apps/frappe/frappe/templates/pages/desk.py +20,You are not permitted to access this page.,Δεν σας επιτρέπεται η πρόσβαση σε αυτήν τη σελίδα.
+apps/frappe/frappe/templates/emails/new_user.html +8,You can also copy-paste this link in your browser,Μπορείτε επίσης να αντιγράψετε και να επικολλήσετε αυτό το σύνδεσμο στο πρόγραμμα περιήγησής σας
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +17,"You can change Submitted documents by cancelling them and then, amending them.",Μπορείτε να αλλάξετε υποβληθέντα έγγραφα ακυρώνοντας τα και στη συνέχεια τροποποιώντας τα.
+apps/frappe/frappe/core/page/data_import_tool/exporter.py +67,You can only upload upto 5000 records in one go. (may be less in some cases),Μπορείτε να ανεβάσετε μόνο μέχρι 5000 εγγραφές με μία κίνηση. (Μπορεί να είναι λιγότερα σε ορισμένες περιπτώσεις)
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +27,You can use Customize Form to set levels on fields.,Μπορείτε να χρησιμοποιήσετε την προσαρμογή φόρμας για να ρυθμίσετε τα επίπεδα στα πεδία.
+sites/assets/js/desk.min.js +487,You can use wildcard %,Μπορείτε να χρησιμοποιήσετε το χαρακτήρα μπαλαντέρ%
+apps/frappe/frappe/desk/page/applications/applications.py +34,You cannot install this app,Δεν μπορείτε να εγκαταστήσετε αυτήν την εφαρμογή
+apps/frappe/frappe/desk/query_report.py +18,You don't have access to Report: {0},Δεν έχετε πρόσβαση στην έκθεση: {0}
+apps/frappe/frappe/desk/query_report.py +21,You don't have permission to get a report on: {0},Δεν έχετε άδεια για να πάρετε μια έκθεση σχετικά με: {0}
+sites/assets/js/desk.min.js +572,You have unsaved changes in this form. Please save before you continue.,Έχετε μη αποθηκευμένες αλλαγές σε αυτή τη φόρμα. Παρακαλώ αποθηκεύστε πριν συνεχίσετε.
+apps/frappe/frappe/website/doctype/web_form/web_form.py +85,You must login to submit this form,Θα πρέπει να συνδεθείτε για να υποβάλετε το αυτή τη φόρμα
+apps/frappe/frappe/utils/response.py +108,You need to be logged in and have System Manager Role to be able to access backups.,Θα πρέπει να είστε συνδεδεμένοι στο σύστημα και να έχετε ρόλο διαχειριστή συστήματος για να έχετε πρόσβαση σε αντίγραφα ασφαλείας.
+apps/frappe/frappe/core/doctype/docshare/docshare.py +33,"You need to have ""Share"" permission","Θα πρέπει να έχετε άδεια ""Κοινοποίησης"""
+apps/frappe/frappe/model/rename_doc.py +96,You need write permission to rename,Χρειάζεται δικαίωμα εγγραφής για να μετονομάσετε
+apps/frappe/frappe/templates/includes/contact.js +17,"You seem to have written your name instead of your email. \
+					Please enter a valid email address so that we can get back.","Φαίνεται πως γράψατε το όνομά σας, αντί του ηλεκτρονικού ταχυδρομείου σας. \ Παρακαλώ εισάγετε μια έγκυρη διεύθυνση e-mail έτσι ώστε να μπορούμε να επικοινωνήσουμε."
+sites/assets/js/desk.min.js +818,"Your download is being built, this may take a few moments...","Η λήψη σας δημιουργείται, αυτό μπορεί να διαρκέσει λίγα λεπτά ..."
+apps/frappe/frappe/templates/emails/new_user.html +4,Your login id is,Το Id σύνδεσής σας είναι
+apps/frappe/frappe/templates/emails/password_update.html +3,Your password has been updated. Here is your new password,Ο κωδικός σας έχει ενημερωθεί. Εδώ είναι ο νέος κωδικός σας
+apps/frappe/frappe/templates/emails/auto_reply.html +2,"Your query has been received. We will back reply shortly. If you have any additional information, please reply to this mail.","Το ερώτημά σας έχει παραληφθεί. Θα σας απαντήσουμε σύντομα. Εάν έχετε οποιεσδήποτε πρόσθετες πληροφορίες, παρακαλώ απαντήστε σε αυτό το μήνυμα."
+DocType: System Settings,yyyy-mm-dd,Εεεε-μμ-ηη
+DocType: Workflow State,zoom-in,Zoom-in
+DocType: Workflow State,zoom-out,Zoom-out


### PR DESCRIPTION
Here are the rest of the translations for frappe. I modified the file el.csv so it's proper Greek now but I noticed that a lot of the words in Frappe & ERPNext remain unchanged and they were not included in either frappe or erpnext el.csv files like: "Buying" , "Selling", "Website" . 

I don't know where those come from but it would be nice if I could update those as well. 
