### PR TITLE
Changed CSS inline style to ensure list items lines are not cropped

### DIFF
--- a/frappe/public/js/frappe/list/list_item_subject.html
+++ b/frappe/public/js/frappe/list/list_item_subject.html
@@ -1,5 +1,5 @@
 {% if (_checkbox) { %}
-<input class="list-delete" type="checkbox" style="margin: 0; vertical-align: middle;">
+<input class="list-delete" type="checkbox" style="margin: 0 7px 0 0; vertical-align: middle;">
 {% } %}
 <i class="icon-star {% if (_starred_by.indexOf(_user)===-1) {
     %}text-extra-muted not-starred{% } else { %}{% }%}

--- a/frappe/public/js/frappe/list/list_item_subject.html
+++ b/frappe/public/js/frappe/list/list_item_subject.html
@@ -1,5 +1,5 @@
 {% if (_checkbox) { %}
-<input class="list-delete" type="checkbox" style="margin-right: 7px;">
+<input class="list-delete" type="checkbox" style="margin: 0; vertical-align: middle;">
 {% } %}
 <i class="icon-star {% if (_starred_by.indexOf(_user)===-1) {
     %}text-extra-muted not-starred{% } else { %}{% }%}


### PR DESCRIPTION
This change should resolve this issue in Firefox where the lines are sitting too low and the overflow is getting cropped.
![userlistsquash](https://cloud.githubusercontent.com/assets/12224661/7514398/d93a7faa-f4b4-11e4-8e6a-f4807a647403.jpg)
