### PR TITLE
[fix] Don't overwrite docfield properties while rendering, if it's modifed on refresh event

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -43,7 +43,7 @@ frappe.ui.form.Layout = Class.extend({
 				fieldobj.doc = me.doc;
 				fieldobj.doctype = me.doc.doctype;
 				fieldobj.docname = me.doc.name;
-				fieldobj.df = frappe.meta.get_docfield(me.doc.doctype,
+				if(!fieldobj.df) fieldobj.df = frappe.meta.get_docfield(me.doc.doctype,
 					fieldobj.df.fieldname, me.frm.doc.name);
 				// on form change, permissions can change
 				fieldobj.perm = me.frm.perm;


### PR DESCRIPTION
This PR to fix dynamic label issue, which we set in all transactions for total fields based on currency. Label are changed on "refresh" event, after that when system renders form, docfield obj is reloading based on meta, which resets label.

@rmehta / @anandpdoshi Is this right fix? I am not sure about this, though I tested and it is working.
