### PR TITLE
Fix for "New Stock Reconciliation Encoding" erpnext#3361

### DIFF
--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -137,6 +137,7 @@ frappe.upload = {
 			var a = parts[1];
 		}
 
-		return atob(a);
+		return decodeURIComponent(escape(atob(a)));
+
 	}
 }


### PR DESCRIPTION
This is for Issue erpnext#3361
https://github.com/frappe/erpnext/issues/3361

"atob()" (and also "btoa()") does not accept Unicode strings.
https://developer.mozilla.org/en/docs/Web/API/WindowBase64/btoa#Unicode_Strings
