### PR TITLE
Fix SysManager Perms

### DIFF
--- a/frappe/core/doctype/module_def/module_def.json
+++ b/frappe/core/doctype/module_def/module_def.json
@@ -47,9 +47,19 @@
    "write": 1
   }, 
   {
-   "permlevel": 0, 
-   "read": 1, 
+   "amend": 0,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "permlevel": 0,
+   "print": 1,
+   "read": 1,
+   "report": 1,
    "role": "System Manager"
+   "share": 1,
+   "submit": 0,
+   "write": 1
   }
  ]
 }


### PR DESCRIPTION
Currently the system manager only can Read the Module Def, this is a violation of the rule https://github.com/frappe/frappe/blob/develop/frappe/installer.py#L114, that only enable the app installation by the System Manager, but if the app needs create module defs, the modules aren't created and the install crash.
