### PR TITLE
Fix Validation Error While importing fixtures

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -30,7 +30,7 @@ class CustomField(Document):
 
 	def on_update(self):
 		frappe.clear_cache(doctype=self.dt)
-		if not self.flags.ignore_validate:
+		if not self.flags.ignore_validate and not self.flags.ignore_links:
 			# validate field
 			from frappe.core.doctype.doctype.doctype import validate_fields_for_doctype
 			validate_fields_for_doctype(self.dt)


### PR DESCRIPTION
``` python
vagrant@vagrant-ubuntu-trusty-64:~/frappe-bench$ bench use argentina
vagrant@vagrant-ubuntu-trusty-64:~/frappe-bench$ bench migrate
Migrating argentina
Updating frappe                     : [========================================]
Updating erpnext                    : [========================================]
Updating argentina                  : [========================================]
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/vagrant/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 77, in <module>
    main()
  File "/vagrant/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 14, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/vagrant/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 610, in __call__
    return self.main(*args, **kwargs)
  File "/vagrant/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 590, in main
    rv = self.invoke(ctx)
  File "/vagrant/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 936, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/vagrant/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 936, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/vagrant/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 782, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/vagrant/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/vagrant/frappe-bench/apps/frappe/frappe/commands.py", line 27, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/vagrant/frappe-bench/apps/frappe/frappe/commands.py", line 206, in migrate
    sync_fixtures()
  File "/vagrant/frappe-bench/apps/frappe/frappe/utils/fixtures.py", line 19, in sync_fixtures
    import_doc(frappe.get_app_path(app, "fixtures", fname), ignore_links=True, overwrite=True)
  File "/vagrant/frappe-bench/apps/frappe/frappe/core/page/data_import_tool/data_import_tool.py", line 94, in import_doc
    frappe.modules.import_file.import_file_by_path(f, data_import=True, force=True, pre_process=pre_process)
  File "/vagrant/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 54, in import_file_by_path
    import_doc(doc, force=force, data_import=data_import, pre_process=pre_process)
  File "/vagrant/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 122, in import_doc
    doc.insert()
  File "/vagrant/frappe-bench/apps/frappe/frappe/model/document.py", line 196, in insert
    self.run_post_save_methods()
  File "/vagrant/frappe-bench/apps/frappe/frappe/model/document.py", line 561, in run_post_save_methods
    self.run_method("on_update")
  File "/vagrant/frappe-bench/apps/frappe/frappe/model/document.py", line 509, in run_method
    return Document.hook(fn)(self, *args, **kwargs)
  File "/vagrant/frappe-bench/apps/frappe/frappe/model/document.py", line 625, in composer
    return composed(self, method, *args, **kwargs)
  File "/vagrant/frappe-bench/apps/frappe/frappe/model/document.py", line 608, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/vagrant/frappe-bench/apps/frappe/frappe/model/document.py", line 503, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/vagrant/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 36, in on_update
    validate_fields_for_doctype(self.dt)
  File "/vagrant/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 203, in validate_fields_for_doctype
    validate_fields(frappe.get_meta(doctype))
  File "/vagrant/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 321, in validate_fields
    check_link_table_options(d)
  File "/vagrant/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 245, in check_link_table_options
    frappe.throw(_("Options must be a valid DocType for field {0} in row {1}").format(d.label, d.idx))
  File "/vagrant/frappe-bench/apps/frappe/frappe/__init__.py", line 252, in throw
    msgprint(msg, raise_exception=exc)
  File "/vagrant/frappe-bench/apps/frappe/frappe/__init__.py", line 245, in msgprint
    _raise_exception()
  File "/vagrant/frappe-bench/apps/frappe/frappe/__init__.py", line 230, in _raise_exception
    raise raise_exception, encode(msg)
frappe.exceptions.ValidationError: Options must be a valid DocType for field AFIP Transacion in row 139

```
