### PR TITLE
Watchdog version updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ html2text
 email_reply_parser
 click
 num2words
-watchdog
+watchdog==0.8.0


### PR DESCRIPTION
Executing the 'bench init frappe-bench' command in OSX the latest version of watchdog fails. Using watchdog 0.8.0 it works properly.
