### PR TITLE
[enhancement] Added progress bar in data import tool

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -112,6 +112,7 @@ def init(site, sites_path=None):
 	local.request_method = request.method if request else None
 	local.request_ip = None
 	local.response = _dict({"docs":[]})
+	local.task_id = None
 
 	local.conf = _dict(get_site_config())
 	local.lang = local.conf.lang or "en"

--- a/frappe/core/page/data_import_tool/data_import_tool.js
+++ b/frappe/core/page/data_import_tool/data_import_tool.js
@@ -75,27 +75,37 @@ frappe.DataImportTool = Class.extend({
 			onerror: function(r) {
 				me.onerror(r);
 			},
+			start: function() {
+				me.write_messages([__("Importing")]);
+			},
+			progress: function(data) {
+				frappe.hide_msgprint(true);
+				if(data.progress) {
+					frappe.show_progress(__("Importing"), data.progress[0], data.progress[1]);
+				}
+			},
 			callback: function(attachment, r) {
 				if(r.message.error) {
 					me.onerror(r);
 				} else {
-					// replace links if error has occured
+					frappe.show_progress(__("Importing"), 1, 1);
+
 					r.messages = ["<h5 style='color:green'>" + __("Import Successful!") + "</h5>"].
 						concat(r.message.messages)
 
-					me.write_messages(r);
+					me.write_messages(r.messages);
 				}
 			}
 		});
 
 	},
-	write_messages: function(r) {
+	write_messages: function(data) {
 		this.page.main.find(".import-log").removeClass("hide");
 		var parent = this.page.main.find(".import-log-messages").empty();
 
 		// TODO render using template!
-		for (var i=0, l=r.messages.length; i<l; i++) {
-			var v = r.messages[i];
+		for (var i=0, l=data.length; i<l; i++) {
+			var v = data[i];
 			var $p = $('<p></p>').html(frappe.markdown(v)).appendTo(parent);
 			if(v.substr(0,5)=='Error') {
 				$p.css('color', 'red');

--- a/frappe/core/page/data_import_tool/importer.py
+++ b/frappe/core/page/data_import_tool/importer.py
@@ -193,6 +193,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 
 	ret = []
 	error = False
+	total = len(data)
 	for i, row in enumerate(data):
 		# bypass empty rows
 		if main_doc_empty(row):
@@ -200,6 +201,8 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 
 		row_idx = i + start_row
 		doc = None
+
+		frappe.publish_realtime(message = {"progress": [i, total]})
 
 		doc = get_doc(row_idx)
 		if pre_process:

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -121,6 +121,18 @@ frappe.msgprint = function(msg, title) {
 	return msg_dialog;
 }
 
+frappe.hide_msgprint = function(instant) {
+	if(msg_dialog && msg_dialog.$wrapper.is(":visible")) {
+		if(instant) {
+			msg_dialog.$wrapper.removeClass("fade");
+		}
+		msg_dialog.hide();
+		if(instant) {
+			msg_dialog.$wrapper.addClass("fade");
+		}
+	}
+}
+
 frappe.verify_password = function(callback) {
 	frappe.prompt({
 		fieldname: "password",
@@ -143,6 +155,25 @@ frappe.verify_password = function(callback) {
 }
 
 var msgprint = frappe.msgprint;
+
+frappe.show_progress = function(title, count, total) {
+	if(frappe.cur_progress && frappe.cur_progress.title === title
+			&& frappe.cur_progress.$wrapper.is(":visible")) {
+		var dialog = frappe.cur_progress;
+	} else {
+		var dialog = new frappe.ui.Dialog({
+			title: title,
+		});
+		dialog.progress = $('<div class="progress"><div class="progress-bar"></div></div>')
+			.appendTo(dialog.body);
+			dialog.progress_bar = dialog.progress.css({"margin-top": "10px"})
+				.find(".progress-bar");
+		dialog.$wrapper.removeClass("fade");
+		dialog.show();
+		frappe.cur_progress = dialog;
+	}
+	dialog.progress_bar.css({"width": cint(flt(count) * 100 / total) + "%" });
+}
 
 // Floating Message
 function show_alert(txt, seconds) {

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -78,6 +78,9 @@ frappe.upload = {
 				opts.on_attach(args, dataurl)
 			} else {
 				var msgbox = msgprint(__("Uploading..."));
+				if(opts.start) {
+					opts.start();
+				}
 				return frappe.call({
 					"method": "uploadfile",
 					args: args,
@@ -92,6 +95,16 @@ frappe.upload = {
 						var attachment = r.message;
 						opts.callback(attachment, r);
 						$(document).trigger("upload_complete", attachment);
+					},
+					progress: function(data) {
+						if(opts.progress) {
+							opts.progress(data);
+						}
+					},
+					always: function(data) {
+						if(opts.always) {
+							opts.always(data);
+						}
 					},
 					error: function(r) {
 						// if no onerror, assume callback will handle errors


### PR DESCRIPTION
- **async.py:** in `publish_realtime`, `event` is now optional, if called from within task
- **importer.py:** send record count being updated using `frappe.publish_realtime`
- **ui/messages.js:** added new tool `frappe.get_progress(title, count, total)` that will show progress bar realtime

![screen shot 2015-09-02 at 11 55 30 am](https://cloud.githubusercontent.com/assets/140076/9624354/8fc1a2ec-5169-11e5-8a6d-fddfc9438e11.png)
