### PR TITLE
avoid overlapping text and breaking row text in wkhtmltopdf output

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -37,7 +37,7 @@
 						<td>{{ d.idx }}</td>
 						{% for tdf in visible_columns %}
 							<td class="{{ get_align_class(tdf.fieldtype) }}">
-                                {{ print_value(tdf, d, doc) }}</td>
+                                <div>{{ print_value(tdf, d, doc) }}</div></td>
 						{% endfor %}
 					</tr>
 					{% endfor %}

--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -85,3 +85,15 @@ table.no-border, table.no-border td {
 .print-format p {
 	margin: 3px 0px 3px;
 }
+
+table td div {
+	/* needed to avoid partial cutting of text between page break in wkhtmltopdf */
+	page-break-inside: avoid !important;
+}
+
+/* hack for webkit specific browser */
+@media (-webkit-min-device-pixel-ratio:0) {
+	thead, tfoot { display: table-row-group; }
+}
+
+


### PR DESCRIPTION
Prevents this:

![screen shot 2015-09-08 at 12 42 46 pm](https://cloud.githubusercontent.com/assets/836785/9729031/c0a98aae-5629-11e5-8938-3915eb5fe55b.png)
