### PR TITLE
Add filters to export fixtures

### DIFF
--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -51,7 +51,7 @@ def export_fixtures():
 			if isinstance(fixture, dict):
 				filters = fixture.get("filters")
 				fixture = fixture.get("doctype") or fixture.get("dt")
-			print "Exporting {0} {1} {2}".format(fixture, app, filters or "")
+			print "Exporting {0} app {1} filters {2}".format(fixture, app, filters)
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))
 

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -51,7 +51,7 @@ def export_fixtures():
 			if isinstance(fixture, dict):
 				filters = fixture.get("filters")
 				fixture = fixture.get("doctype") or fixture.get("dt")
-			print "Exporting {0} {1} {2}".format(fixture, app, filters)
+			print "Exporting {0} {1} {2}".format(fixture, app, filters or "")
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))
 

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -47,8 +47,12 @@ def export_fixtures():
 	"""Export fixtures as JSON to `[app]/fixtures`"""
 	for app in frappe.get_installed_apps():
 		for fixture in frappe.get_hooks("fixtures", app_name=app):
-			print "Exporting {0}".format(fixture)
+			filters = None
+			if isinstance(fixture, dict):
+				filters = fixture.get("filters")
+				fixture = fixture.get("doctype") or fixture.get("dt")
+			print "Exporting {0} {1} {2}".format(fixture, app, filters)
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))
 
-			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"))
+			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"), filters=filters)


### PR DESCRIPTION
Add Filters to export fixtures.

Then in hooks.py we only need to use the special filters if we want to.

If we want we only have to do in our app hooks.py file:

```
    fixtures = [
    "Custom Script",
    {"dt":"Custom Field", "filters": [["dt", "in", ("Customer", "Company")]]}
    ]
```

or:

```
fixtures = [
    {"dt":"Custom Field", "filters": {"dt": "File"}}
]
```

We can use dt as key or doctype.

Of course we can be more specific, like: 

Example:

```
{"dt":"Custom Field", "filters": [["fieldname", "in", ("vies_vat_check", "validate_vat", "vat_or_nif ")]]}
```

or:

```
{"dt":"Custom Field", "filters": {"fieldname": "attached_to_report_name"}}
```
