### PR TITLE
Update save.js

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -110,7 +110,7 @@ frappe.ui.form.save = function(frm, action, callback, btn) {
 			$.each(frappe.meta.docfield_list[doc.doctype] || [], function(i, docfield) {
 				if(docfield.fieldname) {
 					var df = frappe.meta.get_docfield(doc.doctype,
-						docfield.fieldname, frm.doc.name);
+						docfield.fieldname, doc.name);
 
 					if(df.fieldtype==="Fold") {
 						folded = frm.layout.folded;


### PR DESCRIPTION
frm.doc.name is global value assign to df filter but for child table it is creating an error when we use this mandatory attribute dynamically at run time. To resolve this issue, we need to use local document value as filter for function
