### PR TITLE
Updated fieldtype from Data to Text for 'description' fieldname

### DIFF
--- a/frappe/public/js/frappe/form/footer/assign_to.js
+++ b/frappe/public/js/frappe/form/footer/assign_to.js
@@ -150,7 +150,7 @@ frappe.ui.to_do_dialog = function(opts){
 			{fieldtype:'Link', fieldname:'assign_to', options:'User',
 				label:__("Assign To"),
 				description:__("Add to To Do List Of"), reqd:true},
-			{fieldtype:'Data', fieldname:'description', label:__("Comment"), reqd:true},
+			{fieldtype:'Text', fieldname:'description', label:__("Comment"), reqd:true},
 			{fieldtype:'Check', fieldname:'notify',
 				label:__("Notify by Email"), "default":1},
 			{fieldtype:'Date', fieldname:'date', label: __("Complete By")},


### PR DESCRIPTION
In the database, the field size is defined as Text for Description but in the java script it is being used as Data field. Hence the user are not able to enter the full text when assigning a ToDo to another user. Please accept this change as it will be very helpful for the user. Thanks.
Mayur
