### PR TITLE
Fixed broken link

### DIFF
--- a/frappe/docs/user/tutorial/before.md
+++ b/frappe/docs/user/tutorial/before.md
@@ -44,5 +44,5 @@ If you are customizing Print templates, you need to learn the [Jinja Templating 
 
 ---
 
-When you are ready, [try building a sample application on Frappe](/tutorial/app)
+When you are ready, [try building a sample application on Frappe](/frappe/user/tutorial/app)
 

--- a/frappe/docs/user/tutorial/before.md
+++ b/frappe/docs/user/tutorial/before.md
@@ -44,5 +44,5 @@ If you are customizing Print templates, you need to learn the [Jinja Templating 
 
 ---
 
-When you are ready, [try building a sample application on Frappe](/frappe/user/tutorial/app)
+When you are ready, [try building a sample application on Frappe]({{ docs_base_url }}/user/tutorial/app)
 


### PR DESCRIPTION
This should now link to the page : https://frappe.github.io/frappe/user/tutorial/app.html
