### PR TITLE
always use per site queue, don't add queue when in maintenance mode

### DIFF
--- a/frappe/celery_app.py
+++ b/frappe/celery_app.py
@@ -49,8 +49,7 @@ def get_celery_app():
 		app.conf.CELERY_SEND_EVENTS = True
 		app.conf.CELERY_SEND_TASK_SENT_EVENT = True
 
-	if conf.celery_queue_per_site:
-		app.conf.CELERY_ROUTES = (SiteRouter(), AsyncTaskRouter())
+	app.conf.CELERY_ROUTES = (SiteRouter(), AsyncTaskRouter())
 
 	app.conf.CELERYBEAT_SCHEDULE = get_beat_schedule(conf)
 
@@ -90,11 +89,10 @@ def get_beat_schedule(conf):
 		},
 	}
 
-	if conf.celery_queue_per_site:
-		schedule['sync_queues'] = {
-			'task': 'frappe.tasks.sync_queues',
-			'schedule': timedelta(seconds=conf.scheduler_interval or DEFAULT_SCHEDULER_INTERVAL)
-		}
+	schedule['sync_queues'] = {
+		'task': 'frappe.tasks.sync_queues',
+		'schedule': timedelta(seconds=conf.scheduler_interval or DEFAULT_SCHEDULER_INTERVAL)
+	}
 
 	return schedule
 

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -117,11 +117,11 @@ class EmailAccount(Document):
 		try:
 			email_server.connect()
 		except (error_proto, imaplib.IMAP4.error), e:
-			if in_receive and e.message=="-ERR authentication failed":
+			if in_receive and (e.message=="-ERR authentication failed" or "log in via your web browser" in e.message):
 				# if called via self.receive and it leads to authentication error, disable incoming
 				# and send email to system manager
 				self.handle_incoming_connect_error(
-					description=_('Authentication failed while receiving emails from Email Account {0}'.format(self.name))
+					description=_('Authentication failed while receiving emails from Email Account {0}. Message from server: {1}'.format(self.name, e.message))
 				)
 
 				return None

--- a/frappe/utils/doctor.py
+++ b/frappe/utils/doctor.py
@@ -16,11 +16,11 @@ def get_redis_conn():
 def get_queues(site=None):
 	"Returns the name of queues where frappe enqueues tasks as per the configuration"
 	queues = ["celery"]
-	if frappe.conf.celery_queue_per_site:
-		sites = [site] if site else frappe.utils.get_sites()
-		for site in sites:
-			queues.append(site)
-			queues.append('longjobs@' + site)
+	sites = [site] if site else frappe.utils.get_sites()
+	for site in sites:
+		queues.append(site)
+		queues.append('longjobs@' + site)
+
 	return queues
 
 def get_task_body(taskstr):


### PR DESCRIPTION
@pdvyas There is no reason in having queues per site as optional. We should have this as default.

Also, added a check for maintenance mode when syncing queues
