### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -64,7 +64,7 @@ def get_snapshot(exception, context=10):
 		'traceback': traceback.format_exc(),
 		'frames': [],
 		'etype': cstr(etype),
-		'evalue': cstr(evalue),
+		'evalue': cstr(`evalue`),
 		'exception': {},
 		'locals': {}
 	}


### PR DESCRIPTION
```
19:38:09 web.1                | Traceback (innermost last):
19:38:09 web.1                |   File "/vagrant/frappe-bench/apps/frappe/frappe/utils/error.py", line 36, in make_error_snapshot
19:38:09 web.1                |     snapshot = get_snapshot(exception)
19:38:09 web.1                |   File "/vagrant/frappe-bench/apps/frappe/frappe/utils/error.py", line 67, in get_snapshot
19:38:09 web.1                |     'evalue': cstr(evalue),
19:38:09 web.1                |   File "/vagrant/frappe-bench/apps/frappe/frappe/utils/data.py", line 256, in cstr
19:38:09 web.1                |     return unicode(s)
19:38:09 web.1                |  UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 14: ordinal not in range(128)
```

Dont ask me why this silly change works, but it works!
