### PR TITLE
[fix] is_a_user_permission_key: also check if key contains ':'

### DIFF
--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -19,30 +19,33 @@ def add_user_default(key, value, user=None, parenttype=None):
 def get_user_default(key, user=None):
 	user_defaults = get_defaults(user or frappe.session.user)
 	d = user_defaults.get(key, None)
-	
-	if key != frappe.scrub(key):
+
+	if is_a_user_permission_key(key):
 		if d and isinstance(d, (list, tuple)) and len(d)==1:
 			# Use User Permission value when only when it has a single value
 			d = d[0]
-			
+
 		else:
 			d = user_defaults.get(frappe.scrub(key), None)
-	
+
 	return isinstance(d, (list, tuple)) and d[0] or d
 
 def get_user_default_as_list(key, user=None):
 	user_defaults = get_defaults(user or frappe.session.user)
 	d = user_defaults.get(key, None)
-	
-	if key != frappe.scrub(key):
+
+	if is_a_user_permission_key(key):
 		if d and isinstance(d, (list, tuple)) and len(d)==1:
 			# Use User Permission value when only when it has a single value
 			d = [d[0]]
-			
+
 		else:
 			d = user_defaults.get(frappe.scrub(key), None)
 
 	return (not isinstance(d, (list, tuple))) and [d] or d
+
+def is_a_user_permission_key(key):
+	return ":" not in key and key != frappe.scrub(key)
 
 def get_user_permissions(user=None):
 	if not user:

--- a/frappe/public/js/frappe/defaults.js
+++ b/frappe/public/js/frappe/defaults.js
@@ -5,7 +5,7 @@ frappe.defaults = {
 	get_user_default: function(key) {
 		var defaults = frappe.boot.user.defaults;
 		var d = defaults[key];
-		if(!d && (key !== frappe.model.scrub(key)))
+		if(!d && frappe.defaults.is_a_user_permission_key(key))
 			d = defaults[frappe.model.scrub(key)];
 		if($.isArray(d)) d = d[0];
 		return d;
@@ -13,8 +13,8 @@ frappe.defaults = {
 	get_user_defaults: function(key) {
 		var defaults = frappe.boot.user.defaults;
 		var d = defaults[key];
-		
-		if (key !== frappe.model.scrub(key)) {
+
+		if (frappe.defaults.is_a_user_permission_key(key)) {
 			if (d && $.isArray(d) && d.length===1) {
 				// Use User Permission value when only when it has a single value
 				d = d[0];
@@ -52,14 +52,14 @@ frappe.defaults = {
 	get_default: function(key) {
 		var defaults = frappe.boot.user.defaults;
 		var value = defaults[key];
-		if (key !== frappe.model.scrub(key)) {
+		if (frappe.defaults.is_a_user_permission_key(key)) {
 			if (value && $.isArray(value) && value.length===1) {
 				value = value[0];
 			} else {
 				value = defaults[frappe.model.scrub(key)];
 			}
 		}
-		
+
 		if(value) {
 			try {
 				return JSON.parse(value)
@@ -68,6 +68,11 @@ frappe.defaults = {
 			}
 		}
 	},
+
+	is_a_user_permission_key: function(key) {
+		return key.indexOf(":")===-1 && key !== frappe.model.scrub(key);
+	},
+
 	get_user_permissions: function() {
 		return frappe.defaults.user_permissions;
 	},


### PR DESCRIPTION
This fixes the auto-save of picked columns in an unsaved report
