### PR TITLE
changed Chinese to adequate characters

### DIFF
--- a/frappe/data/languages.txt
+++ b/frappe/data/languages.txt
@@ -49,5 +49,5 @@ th	ไทย
 tr	Türk
 uk	українська
 vi	việt
-zh-cn	簡體中文
-zh-tw	正體中文
+zh-cn	简本中文
+zh-tw	繁體中文


### PR DESCRIPTION
简本中文 = "Simplified Chinese" (using actually Simplified Chinese)
繁體中文 = "Traditional Chinese" (using Traditional Chinese characters)
