### PR TITLE
Fix for Error "ValueError: No JSON object could be decoded"

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -156,9 +156,12 @@ def has_permission(doctype, docname, perm_type="read"):
 
 @frappe.whitelist()
 def get_js(src):
-	if src[0]=="/":
-		src = src[1:]
-	contentpath = os.path.join(frappe.local.sites_path, src)
+	src = src.strip("/").split("/")
+
+	if ".." in src:
+		frappe.throw(_("Invalid file path: {0}").format("/".join(src)))
+
+	contentpath = os.path.join(frappe.local.sites_path, *src)
 	with open(contentpath, "r") as srcfile:
 		code = frappe.utils.cstr(srcfile.read())
 


### PR DESCRIPTION
Issue: There is an error appear "ValueError: No JSON object could be decoded" when data is sent from SAP to ERPNext in http request body.

Root cause: Http request is not well formed on SAP side, as result no data is coming to ERPNext.

Description: The issue was fixed on SAP side by forming http request which ERPNext could process.

Notes:
Http request is still coming to ERPNext not completely in expected format: the data are present in request body but not in form data.
I've added the following code to ERPNext to handle this case:

file frappe-bench/apps/frappe/frappe/app.py:
--- app.py.old 2015-11-18 16:47:40.297103843 +0530
+++ app.py.new 2015-11-20 23:48:44.482411978 +0530
@@ -70,10 +70,6 @@
response = frappe.handler.handle()

```
    elif frappe.request.path.startswith("/api/"):
```

+

if frappe.local.form_dict.data is None:
frappe.local.form_dict.data = request.get_data()
response = frappe.api.handle()

```
elif frappe.request.path.startswith('/backups'):
```

Also in regards to the max 100 row Validation in the Stock Reconciliation Document, we have commented out the following code part:

75> if len(self.items) > 100:
76> frappe.throw(_("""Max 100 rows for Stock Reconciliation."""))

@rmehta If it would be possible to include the first HTTP change to the core version as well as to add an option to submit a flag thru the HTTP call to eliminate the 100-row validation, that would be great.

Thanks, David
