### PR TITLE
Enchancement - provide header/footer HTML code and adjust margins on the fly in custom print formats

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -2,9 +2,10 @@
 # MIT License. See license.txt
 from __future__ import unicode_literals
 
-import pdfkit, os, frappe
+import pdfkit, os, frappe, sys
 from frappe.utils import scrub_urls
 from frappe import _
+from bs4 import BeautifulSoup
 
 def get_pdf(html, options=None):
 	if not options:
@@ -22,6 +23,13 @@ def get_pdf(html, options=None):
 		'quiet': None,
 		'no-outline': None,
 	})
+
+	#create file from input html based on the divs content or create an empty file
+	header_html_file = make_html_file(html, "header")
+	footer_html_file = make_html_file(html, "footer")
+
+	#update the printing options like margin-top based on variables in html or predefined settings
+	options = read_options_from_html(html, header_html_file[0], footer_html_file[0])
 
 	if frappe.session and frappe.session.sid:
 		options['cookie'] = [('sid', '{0}'.format(frappe.session.sid))]
@@ -55,4 +63,136 @@ def get_pdf(html, options=None):
 		if os.path.exists(fname):
 			os.remove(fname)
 
+	try:
+		os.remove(header_html_file[1])
+	except:
+		pass
+	try:
+		os.remove(footer_html_file[1])
+	except:
+		pass
 	return filedata
+
+
+
+def read_options_from_html(html, header_html_file, footer_html_file):
+	options = {}
+
+	soup = BeautifulSoup(html, "html5lib")
+	if (header_html_file):
+		header_html_file_url = frappe.utils.get_request_site_address() + "/files/" + header_html_file
+		options.update({
+			'header-html': header_html_file_url,
+		})
+	if (footer_html_file):
+		footer_html_file_url = frappe.utils.get_request_site_address() + "/files/" + footer_html_file
+		options.update({
+			'footer-html': footer_html_file_url,
+		})
+
+	try:
+		margin_top = soup.find('span', id='margintop')
+		margin_top = margin_top.contents
+	except:
+		margin_top = "15mm"
+	options.update({
+		'margin-top': margin_top,
+	})
+
+	options.update({
+		"print-media-type": None,
+		"background": None,
+		"images": None,
+		'margin-right': '15mm',
+		'margin-bottom': '15mm',
+		'margin-left': '15mm',
+		'encoding': "UTF-8",
+		'quiet': None,
+		'no-outline': None,
+	})
+	return options
+
+#this function will copy all head info from the soup of the parent document's html and will then return a head element string
+def copy_head_info(soup):
+	html_style = ""
+	html_styles = soup.findAll('style')
+	try:
+		for style in html_styles:
+			html_style += style.prettify()
+	except:
+		pass
+
+	try:
+		html_head = ''.join(map(str, soup.find('head').contents))
+	except:
+		html_head = ''
+
+	html_head += """
+	  <script>
+			function subst() {
+				var vars={};
+			var x=window.location.search.substring(1).split('&');
+			for (var i in x) {var z=x[i].split('=',2);vars[z[0]] = unescape(z[1]);}
+			var x=['frompage','topage','page','webpage','section','subsection','subsubsection'];
+			for (var i in x) {
+			var y = document.getElementsByClassName(x[i]);
+			for (var j=0; j<y.length; ++j) y[j].textContent = vars[x[i]];
+			}
+			}
+			subst()
+		</script>
+	"""
+	html_head = "<head>"+ html_head + html_style + "</head>"
+	return html_head
+
+
+#this function will create a file with the contents we need for header and footer
+def make_html_file(html, type="header"):
+
+	#make sure we use the correct encoding utf8
+	reload(sys)
+	sys.setdefaultencoding('utf8')
+	soup = BeautifulSoup(html, "html5lib")
+
+	#set doctype to html5
+	html_doctype = """<!DOCTYPE html>"""
+
+	#make sure we get all styles / scripts of the parent document
+	html_head = copy_head_info(soup)
+
+	#get the header div
+	if (type=="header"):
+		pdf_header = soup.find('div', id='htmlheader')
+	else:
+		pdf_header = soup.find('div', id='htmlfooter')
+
+	try:
+		html_content = ''.join(map(str, pdf_header))
+	except:
+		html_content = ''
+
+	#create the html body content
+	html_body = """<body onload="subst()" style="margin:0; padding:0;"><div class="print-format"><div class="wrapper">""" + html_content  + """</div></div></body></html>"""
+
+	#create the complete html of the page
+	header_html = html_doctype + html_head + html_body
+
+	fname = type
+	temp_file = create_temp_html_file(fname, header_html)
+	return temp_file
+
+#this function will create a random filename and then return the filename and filepath
+def create_temp_html_file(fname, html):
+	reload(sys)
+	sys.setdefaultencoding('utf8')
+	temp_name = fname + os.urandom(16).encode('hex') + ".html"
+	fpath = frappe.utils.get_files_path() + "/" + temp_name
+
+	while(os.path.exists(fpath)):
+		temp_name = fname + os.urandom(16).encode('hex') + ".html"
+		fpath = frappe.utils.get_files_path() + "/" + temp_name
+
+	f = open(fpath,'w')
+	f.write(html)
+	f.close()
+	return temp_name, fpath

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ num2words
 watchdog==0.8.0
 bleach
 Pillow
+beautifulsoup4


### PR DESCRIPTION
Hi after @rmehta 's suggestion I'm starting a pull request for this function to implement PDF repeatable headers and footers on the fly. 
Here's the original discussion
https://discuss.erpnext.com/t/header-footer-development/7442/53

and here's a detailed help text of how my implementation currently works 
## Creating custom headers / footers dynamically in custom print formats

When defining a new custom print format you now have the option to add a PDF header / footer that will get repeated in each page by inserting a special div in your HTML custom print format.

For example by adding the

```
<div id="htmlheader"><!-- content here --></div>
```

your content will appear in the header of each PDF  page. In order to use this module you need to have BeautifulSoup4 installed in your virtual environment (see "Troubleshooting Section")
#### 1. Defining a PDF Header

In order for your PDF Header to appear you need to create a custom print format and add the special `<div id="htmlheader">` with your code inside like this:

```
<div id="htmlheader"><!-- content here --></div>
```

You also need to set a variable for the header size but we'll about that later
#### 2. Defining a PDF Footer

In order for your PDF Footer to appear you need to create a custom print format and add the special `<div id="htmlfooter">` with your code inside like this:

```
<div id="htmlfooter"><!-- content here --></div>
```
#### 3. Variables

You now have the ability to set variables for the print options on the fly from within your template

Currently only one variable is recognized which is `margintop`

To set the variable put it in a `<span>` tag like this:

```
<span id="margintop">120mm</span>
```

In order to hide the variables from the prints you should wrap them in a special hidden `<div>` container like this:

```
<div id="variables" style="display:none;">
    <span id="margintop">120mm</span>
</div>
```

The variables that can currently be set are:

```
1. margintop: It defines the size of the header
```
#### 4. Positioning of the elements

The elements can be positioned anywhere in the document however it's strongly suggested that you position the elements in an orderly fashion so that you can easily match the HTML print with the PDF print using styles.
#### 5. How to hide something in HTML but not in print

Let's assume that you want to hide an element from the PDF you can do so by using styles.
For example

```
<div class="toHideInPDF"></div>
```

in your styles you can use

```
@media screen {
    .toHideInPDF{
        display: block;
    }
}

@media print {
    #toHideInPDF{
        display:none;
    }
}
```

the reverse of course applies too. This is especially useful to avoid repetition of the header or footer in the PDF.
#### 6. Substitutions

wkHTMLtoPDF provides us with a way to substitute variables in the header and footer section of the PDF file. For example [page] will get substituted with the current page number but that't not the case when it comes to a HTML Header/Footer. However we can define for example in the footer a div to display the current page number like this:

```
<div id="htmlfooter" class="has-variables">
    <div class="col-xs-12 pull-right" style="text-align:right">
        {{ ("Page") }} <span class="page"></span> {{ _("of") }} <span class="topage"></span>
    </div>
</div>
```

And by using a substitution function for the HTML page, the contents of the div will be set. Notice the class `has-variables` which is set there to hide the current div from the HTML output since no substitution will happen there and the result would be meaningless.

Of course you need to have the associated style with it:

```
@media screen {
    .has-variables{
        display: none;
    }
}
@media print {
    #.has-variables{
        display:block;
    }
}
```

In this case though the item belongs to the `htmlfooter` so even if we define it as hidden for prints it will still show up in the footer
#### 7. Troubleshooting
##### 1. bs4 python module does not exist

To rectify this please add BeautifulSoup4 to your python virtualenv by executing

`<path_to_frappe_bench>/env/bin/pip install beautifulsoup4`
#### 8. TODO

Need to implement a celery task garbage collecting function to clean up files in the public site folder in order to clean up temporary files that were created by users who repeatedly reloaded the PDF page and still remain in the folder. These files are named as "header<16 characters hash code>.html" and "footer<16 characters hash code>.html"
