### PR TITLE
[fix] Query filters for share with User field

### DIFF
--- a/frappe/docs/current/models/core/user.html
+++ b/frappe/docs/current/models/core/user.html
@@ -1511,7 +1511,7 @@ The mentions will be separated by non-word characters or may appear at the start
     
     
 	<p class="docs-attr-name">
-        <a name="frappe.core.doctype.user.user.user_query" href="#frappe.core.doctype.user.user.user_query" class="text-muted small">
+        <a name="frappe.desk.reportview.user_query" href="#frappe.desk.reportview.user_query" class="text-muted small">
             <i class="icon-link small" style="color: #ccc;"></i></a>
 		frappe.core.doctype.user.user.<b>user_query</b>
         <i class="text-muted">(doctype, txt, searchfield, start, page_len, filters)</i>

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -83,7 +83,7 @@ has_permission = {
 }
 
 standard_queries = {
-	"User": "frappe.core.doctype.user.user.user_query"
+	"User": "frappe.desk.reportview.user_query"
 }
 
 doc_events = {

--- a/frappe/public/js/frappe/form/footer/assign_to.js
+++ b/frappe/public/js/frappe/form/footer/assign_to.js
@@ -175,7 +175,7 @@ frappe.ui.to_do_dialog = function(opts){
 		primary_action_label: __("Add")
 	});
 
-	dialog.fields_dict.assign_to.get_query = "frappe.core.doctype.user.user.user_query";
+	dialog.fields_dict.assign_to.get_query = "frappe.desk.reportview.user_query";
 
 	return dialog
 }

--- a/frappe/public/js/frappe/form/set_sharing.html
+++ b/frappe/public/js/frappe/form/set_sharing.html
@@ -12,7 +12,7 @@
         <div class="col-xs-2"><input type="checkbox" name="read"
             {% if(cint(everyone.read)) { %}checked{% } %} class="edit-share"></div>
         <div class="col-xs-2"><input type="checkbox" name="write"
-            {% if(cint(everyone.write)) { %}checked{% } %} class="edit-share"></div>
+            {% if(cint(everyone.write)) { %}checked{% } %} class="edit-share edit-write"></div>
         <div class="col-xs-2"><input type="checkbox" name="share"
             {% if(cint(everyone.share)) { %}checked{% } %} class="edit-share"></div>
 	</div>
@@ -25,7 +25,7 @@
 	        <div class="col-xs-2"><input type="checkbox" name="read"
 	            {% if(cint(s.read)) { %}checked{% } %} class="edit-share"></div>
 	        <div class="col-xs-2"><input type="checkbox" name="write"
-	            {% if(cint(s.write)) { %}checked{% } %} class="edit-share"></div>
+	            {% if(cint(s.write)) { %}checked{% } %} class="edit-share edit-write"></div>
 	        <div class="col-xs-2"><input type="checkbox" name="share"
 	            {% if(cint(s.share)) { %}checked{% } %} class="edit-share"></div>
 	    </div>

--- a/frappe/public/js/frappe/form/share.js
+++ b/frappe/public/js/frappe/form/share.js
@@ -117,15 +117,9 @@ frappe.ui.form.Share = Class.extend({
 				label: __("Share With"),
 				fieldname: "share_with",
 				options: "User",
-				get_query: function() {
-					return {
-						query: "frappe.core.doctype.docshare.docshare.docshare_user_query",
-						filters: {
-							'user': user,
-							'doctype': me.frm.doctype,
-							'docname': me.frm.docname
-						}
-					}
+				filters: {
+					"user_type": "System User",
+					"name": ["not in", me.get_shared_user_list()]
 				}
 			},
 			only_input: true,
@@ -210,4 +204,10 @@ frappe.ui.form.Share = Class.extend({
 			});
 		});
 	},
+	get_shared_user_list: function(){
+		// return the list of users to whome the document is already shared
+		exclude_users =  $.map(this.shared, function(d){ return d.user })
+		exclude_users.push(user)
+		return exclude_users
+	}
 });


### PR DESCRIPTION
Hello Team,

Added get_query for share with user field, ignored the session user and the user's to whom the document is already shared.

also added validation, raised error if the owner don't have the permission to 'write' the document. Disabled the write checkbox for such users.

Thanks,
Makarand Bauskar 
