### PR TITLE
Set default encoding = utf-8

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -6,6 +6,10 @@ globals attached to frappe module
 """
 from __future__ import unicode_literals
 
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 from werkzeug.local import Local, release_local
 from functools import wraps
 import os, importlib, inspect, logging, json


### PR DESCRIPTION
Set default encoding = utf-8 or UnicodeError will be raised in `errprint` (print error in console)

``` python
def errprint(msg):
    """Log error. This is sent back as `exc` in response.
    :param msg: Message."""
    from utils import cstr
    if not request or (not "cmd" in local.form_dict):
        print cstr(msg)  # <==== UnicodeError will be raised.

    error_log.append(cstr(msg))
```
