### PR TITLE
email receive improvement

### DIFF
--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -70,7 +70,34 @@ class TestEmailAccount(unittest.TestCase):
 		existing_file = frappe.get_doc({'doctype': 'File', 'file_name': 'erpnext-conf-14.png'})
 		frappe.delete_doc("File", existing_file.name)
 		delete_file_from_filesystem(existing_file)
+		
+	def test_incoming_attached_email_from_outlook_plain_text_only(self):
+		frappe.db.sql("delete from tabCommunication where sender='test_sender@example.com'")
 
+		with open(os.path.join(os.path.dirname(__file__), "test_mails", "incoming-3.raw"), "r") as f:
+			test_mails = [f.read()]
+
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		email_account.receive(test_mails=test_mails)
+
+		comm = frappe.get_doc("Communication", {"sender": "test_sender@example.com"})
+		self.assertTrue("From: test_sender@example.com" in comm.content)
+		self.assertTrue("This is an e-mail message sent automatically by Microsoft Outlook while" in comm.content)	
+	
+	
+	def test_incoming_attached_email_from_outlook_layers(self):
+		frappe.db.sql("delete from tabCommunication where sender='test_sender@example.com'")
+
+		with open(os.path.join(os.path.dirname(__file__), "test_mails", "incoming-4.raw"), "r") as f:
+			test_mails = [f.read()]
+
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		email_account.receive(test_mails=test_mails)
+
+		comm = frappe.get_doc("Communication", {"sender": "test_sender@example.com"})
+		self.assertTrue("From: test_sender@example.com" in comm.content)
+		self.assertTrue("This is an e-mail message sent automatically by Microsoft Outlook while" in comm.content)
+		
 	def test_outgoing(self):
 		frappe.flags.sent_mail = None
 		make(subject = "test-mail-000", content="test mail 000", recipients="test_receiver@example.com",

--- a/frappe/email/doctype/email_account/test_mails/incoming-3.raw
+++ b/frappe/email/doctype/email_account/test_mails/incoming-3.raw
@@ -1,0 +1,183 @@
+Return-path: <test_sender@example.com>
+Envelope-to: test_receiver@example.com
+Delivery-date: Wed, 27 Jan 2016 16:24:20 +0800
+Received: from 23-59-23-10.perm.iinet.net.au ([23.59.23.10]:62191 helo=DESKTOP7C66I2M)
+	by webcloud85.au.syrahost.com with esmtp (Exim 4.86)
+	(envelope-from <test_sender@example.com>)
+	id 1aOLOj-002xFL-CP
+	for test_receiver@example.com; Wed, 27 Jan 2016 16:24:20 +0800
+From: <test_sender@example.com>
+To: <test_receiver@example.com>
+References: <COMM-02154@site1.local>
+In-Reply-To: <COMM-02154@site1.local>
+Subject: RE: Sales Invoice: SINV-12276
+Date: Wed, 27 Jan 2016 16:24:09 +0800
+Message-ID: <000001d158dc$1b8363a0$528a2ae0$@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_NextPart_000_0001_01D1591F.29A7DC20"
+X-Mailer: Microsoft Outlook 14.0
+Thread-Index: AQJZfZxrgcB9KnMqoZ+S4Qq9hcoSeZ3+vGiQ
+Content-Language: en-au
+
+This is a multipart message in MIME format.
+
+------=_NextPart_000_0001_01D1591F.29A7DC20
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_001_0002_01D1591F.29A7DC20"
+
+
+------=_NextPart_001_0002_01D1591F.29A7DC20
+Content-Type: text/plain;
+	charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+Test purely for testing with the debugger has email attached
+
+=20
+
+From: Notification [mailto:test_receiver@example.com]=20
+Sent: Wednesday, 27 January 2016 9:30 AM
+To: test_receiver@example.com
+Subject: Sales Invoice: SINV-12276
+
+=20
+
+test no 6 sent from bench to outlook to be replied to with messaging
+
+
+
+
+------=_NextPart_001_0002_01D1591F.29A7DC20
+Content-Type: text/html;
+	charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+<html xmlns:v=3D"urn:schemas-microsoft-com:vml" =
+xmlns:o=3D"urn:schemas-microsoft-com:office:office" =
+xmlns:w=3D"urn:schemas-microsoft-com:office:word" =
+xmlns:m=3D"http://schemas.microsoft.com/office/2004/12/omml" =
+xmlns=3D"http://www.w3.org/TR/REC-html40"><head><meta =
+http-equiv=3DContent-Type content=3D"text/html; charset=3Dutf-8"><meta =
+name=3DGenerator content=3D"Microsoft Word 14 (filtered =
+medium)"><title>hi there</title><style><!--
+/* Font Definitions */
+@font-face
+	{font-family:Helvetica;
+	panose-1:2 11 6 4 2 2 2 2 2 4;}
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:0 0 0 0 0 0 0 0 0 0;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+@font-face
+	{font-family:Tahoma;
+	panose-1:2 11 6 4 3 5 4 4 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	margin-bottom:.0001pt;
+	font-size:12.0pt;
+	font-family:"Times New Roman","serif";}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:blue;
+	text-decoration:underline;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-priority:99;
+	color:purple;
+	text-decoration:underline;}
+p
+	{mso-style-priority:99;
+	mso-margin-top-alt:auto;
+	margin-right:0cm;
+	mso-margin-bottom-alt:auto;
+	margin-left:0cm;
+	font-size:12.0pt;
+	font-family:"Times New Roman","serif";}
+span.EmailStyle18
+	{mso-style-type:personal-reply;
+	font-family:"Calibri","sans-serif";
+	color:#1F497D;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-size:10.0pt;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext=3D"edit" spidmax=3D"1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext=3D"edit">
+<o:idmap v:ext=3D"edit" data=3D"1" />
+</o:shapelayout></xml><![endif]--></head><body lang=3DEN-AU link=3Dblue =
+vlink=3Dpurple><div class=3DWordSection1><p class=3DMsoNormal><span =
+style=3D'font-size:11.0pt;font-family:"Calibri","sans-serif";color:#1F497=
+D'>Test purely for testing with the debugger has email =
+attached<o:p></o:p></span></p><p class=3DMsoNormal><a =
+name=3D"_MailEndCompose"><span =
+style=3D'font-size:11.0pt;font-family:"Calibri","sans-serif";color:#1F497=
+D'><o:p>&nbsp;</o:p></span></a></p><div><div =
+style=3D'border:none;border-top:solid #B5C4DF 1.0pt;padding:3.0pt 0cm =
+0cm 0cm'><p class=3DMsoNormal><b><span lang=3DEN-US =
+style=3D'font-size:10.0pt;font-family:"Tahoma","sans-serif"'>From:</span>=
+</b><span lang=3DEN-US =
+style=3D'font-size:10.0pt;font-family:"Tahoma","sans-serif"'> =
+Notification [mailto:test_receiver@example.com] <br><b>Sent:</b> Wednesday, 27 =
+January 2016 9:30 AM<br><b>To:</b> =
+test_receiver@example.com<br><b>Subject:</b> Sales Invoice: =
+SINV-12276<o:p></o:p></span></p></div></div><p =
+class=3DMsoNormal><o:p>&nbsp;</o:p></p><div><p><span =
+style=3D'font-size:10.5pt;font-family:"Helvetica","sans-serif";color:#364=
+14C'>test no 3 sent from bench to outlook to be replied to with =
+messaging<o:p></o:p></span></p><p><span =
+style=3D'font-size:10.5pt;font-family:"Helvetica","sans-serif";color:#364=
+14C'>fizz buzz <o:p></o:p></span></p></div><div =
+style=3D'border:none;border-top:solid #D1D8DD 1.0pt;padding:0cm 0cm 0cm =
+0cm;margin-top:22.5pt;margin-bottom:11.25pt'><div =
+style=3D'margin-top:11.25pt;margin-bottom:11.25pt'><p class=3DMsoNormal =
+align=3Dcenter style=3D'text-align:center'><span =
+style=3D'font-size:8.5pt;font-family:"Helvetica","sans-serif";color:#8D99=
+A6'>This email was sent to <a =
+href=3D"mailto:test_receiver@example.com">test_receiver@example.=
+com</a> and copied to SuperUser <o:p></o:p></span></p><p =
+align=3Dcenter =
+style=3D'mso-margin-top-alt:11.25pt;margin-right:0cm;margin-bottom:11.25p=
+t;margin-left:0cm;text-align:center'><span =
+style=3D'font-size:8.5pt;font-family:"Helvetica","sans-serif";color:#8D99=
+A6'><span =
+style=3D'color:#8D99A6'>Leave this conversation =
+</span></a><o:p></o:p></span></p></div><div =
+style=3D'margin-top:11.25pt;margin-bottom:11.25pt'><p class=3DMsoNormal =
+align=3Dcenter style=3D'text-align:center'><span =
+style=3D'font-size:8.5pt;font-family:"Helvetica","sans-serif";color:#8D99=
+A6'>hi<o:p></o:p></span></p></div></div></div></body></html>
+------=_NextPart_001_0002_01D1591F.29A7DC20--
+
+------=_NextPart_000_0001_01D1591F.29A7DC20
+Content-Type: message/rfc822
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment
+
+Received: from 203-59-223-10.perm.iinet.net.au ([23.59.23.10]:49772 helo=DESKTOP7C66I2M)
+	by webcloud85.au.syrahost.com with esmtpsa (TLSv1.2:DHE-RSA-AES256-GCM-SHA384:256)
+	(Exim 4.86)
+	(envelope-from <test_sender@example.com>)
+	id 1aOEtO-003tI4-Kv
+	for test_receiver@example.com; Wed, 27 Jan 2016 09:27:30 +0800
+Return-Path: <test_sender@example.com>
+From: "Microsoft Outlook" <test_sender@example.com>
+To: <test_receiver@example.com>
+Subject: Microsoft Outlook Test Message
+MIME-Version: 1.0
+Content-Type: text/plain;
+	charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+X-Mailer: Microsoft Outlook 14.0
+Thread-Index: AdFYoeN8x8wUI/+QSoCJkp33NKPVmw==
+
+This is an e-mail message sent automatically by Microsoft Outlook while =
+testing the settings for your account.

--- a/frappe/email/doctype/email_account/test_mails/incoming-4.raw
+++ b/frappe/email/doctype/email_account/test_mails/incoming-4.raw
@@ -1,0 +1,138 @@
+Return-path: <test_sender@example.com>
+Envelope-to: test_receiver@example.com
+Delivery-date: Tue, 09 Feb 2016 14:53:22 +0800
+Received: from 23-59-23-10.perm.iinet.net.au ([23.59.23.10]:56280)
+	by webcloud85.au.syrahost.com with esmtp (Exim 4.86)
+	(envelope-from <test_sender@example.com>)
+	id 1aT2As-003QlT-B0
+	for test_receiver@example.com; Tue, 09 Feb 2016 14:53:22 +0800
+From: <test_sender@example.com>
+To: <test_receiver@example.com>
+Subject: test email 
+Date: Tue, 9 Feb 2016 14:53:13 +0800
+Message-ID: <000001d16306$8b9e5c60$a2db1520$@ia-group.com.au>
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_NextPart_000_0005_01D16349.99C37120"
+X-Mailer: Microsoft Outlook 14.0
+Thread-Index: AdFjBjqdYnxyziyBQVK9mLTYYu+9Og==
+Content-Language: en-au
+
+This is a multipart message in MIME format.
+
+------=_NextPart_000_0005_01D16349.99C37120
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_001_0006_01D16349.99C37120"
+
+
+------=_NextPart_001_0006_01D16349.99C37120
+Content-Type: text/plain;
+	charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+
+4th test email 
+
+
+------=_NextPart_001_0006_01D16349.99C37120
+Content-Type: text/html;
+	charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+<html xmlns:v=3D"urn:schemas-microsoft-com:vml" =
+xmlns:o=3D"urn:schemas-microsoft-com:office:office" =
+xmlns:w=3D"urn:schemas-microsoft-com:office:word" =
+xmlns:m=3D"http://schemas.microsoft.com/office/2004/12/omml" =
+xmlns=3D"http://www.w3.org/TR/REC-html40"><head><meta =
+http-equiv=3DContent-Type content=3D"text/html; =
+charset=3Dus-ascii"><meta name=3DGenerator content=3D"Microsoft Word 14 =
+(filtered medium)"><style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:0 0 0 0 0 0 0 0 0 0;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	margin-bottom:.0001pt;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";
+	mso-fareast-language:EN-US;}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:blue;
+	text-decoration:underline;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-priority:99;
+	color:purple;
+	text-decoration:underline;}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Calibri","sans-serif";
+	color:windowtext;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-size:10.0pt;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext=3D"edit" spidmax=3D"1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext=3D"edit">
+<o:idmap v:ext=3D"edit" data=3D"1" />
+</o:shapelayout></xml><![endif]--></head><body lang=3DEN-AU link=3Dblue =
+vlink=3Dpurple><div class=3DWordSection1><p =
+class=3DMsoNormal>4<sup>th</sup> test email =
+<o:p></o:p></p></div></body></html>
+------=_NextPart_001_0006_01D16349.99C37120--
+
+------=_NextPart_000_0005_01D16349.99C37120
+Content-Type: message/rfc822
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment
+
+Received: from 23-59-23-10.perm.iinet.net.au ([23.59.23.10]:49772 helo=DESKTOP7C66I2M)
+	by webcloud85.au.syrahost.com with esmtpsa (TLSv1.2:DHE-RSA-AES256-GCM-SHA384:256)
+	(Exim 4.86)
+	(envelope-from <test_sender@example.com>)
+	id 1aOEtO-003tI4-Kv
+	for test_receiver@example.com; Wed, 27 Jan 2016 09:27:30 +0800
+Return-Path: <test_sender@example.com>
+From: "Microsoft Outlook" <test_sender@example.com>
+To: <test_receiver@example.com>
+Subject: Microsoft Outlook Test Message
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_000_0001_01D16349.99C25FB0"
+X-Mailer: Microsoft Outlook 14.0
+Thread-Index: AdFYoeN8x8wUI/+QSoCJkp33NKPVmw==
+
+This is a multipart message in MIME format.
+
+------=_NextPart_000_0001_01D16349.99C25FB0
+Content-Type: text/plain;
+	charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+This is an e-mail message sent automatically by Microsoft Outlook while =
+testing the settings for your account.=20
+
+------=_NextPart_000_0001_01D16349.99C25FB0
+Content-Type: text/html;
+	charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+
+<META HTTP-EQUIV=3D"Content-Type" CONTENT=3D"text/html; =
+charset=3Dutf-8">
+This is an e-mail message sent automatically by Microsoft Outlook while =
+testing the settings for your account.
+
+------=_NextPart_000_0001_01D16349.99C25FB0--
+
+------=_NextPart_000_0005_01D16349.99C37120--

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -282,8 +282,9 @@ class Email:
 
 	def parse(self):
 		"""Walk and process multi-part email."""
+		last=[False]
 		for part in self.mail.walk():
-			self.process_part(part)
+			self.process_part(part,last)
 
 	def set_subject(self):
 		"""Parse and decode `Subject` header."""
@@ -306,12 +307,18 @@ class Email:
 		else:
 			self.content, self.content_type = EmailReplyParser.parse_reply(self.text_content), 'text/plain'
 
-	def process_part(self, part):
+	def process_part(self, part,last):
 		"""Parse email `part` and set it to `text_content`, `html_content` or `attachments`."""
 		content_type = part.get_content_type()
 		charset = part.get_content_charset()
 		if not charset: charset = self.get_charset(part)
 
+		if content_type == 'message/rfc822' or last[0] == True: #test to see if within a attached message
+			if self.get_attached_message(part): #check and get for email headers
+				last[0] =False
+			else:
+				last[0] = True # within attached message headers not found repeat within message
+				
 		if content_type == 'text/plain':
 			self.text_content += self.get_payload(part, charset)
 
@@ -320,6 +327,46 @@ class Email:
 
 		if part.get_filename():
 			self.get_attachment(part, charset)
+
+	def get_attached_message(self,part):
+		list=[None]*4
+		list[0]=part.__getitem__('from')
+		list[1]=part.__getitem__('to')
+		list[2]=part.__getitem__('subject')
+		list[3]=part.__getitem__('Date')
+
+		if None in list[:3]:#check if date returned if it didnt find a recieved field and get date from there
+			return False
+		if list[3]==None:
+			list[3] = part.__getitem__('Received')
+			temp = list[3].split(';')
+			list[3] = temp[len(temp)-1]
+
+		self.html_content +=  '<hr>'
+		list[0] = list[0][list[0].find("<")+1:list[0].find(">")]#From: cleaner
+
+		temp =""#To: cleaner
+		for d in list[1].split(','):
+			temp += d[d.find("<")+1:d.find(">")] +','
+		list[1] = temp.strip(',')
+
+		self.text_content +=   'From: {0}\nTo: {1}\nSent: {2}\nSubject: {3}\n'.format(list[0],list[1],list[3],list[2])
+		self.html_content +=   '<p>From: {0}</p><p>To: {1}</p><p>Sent: {2}</p><p>Subject: {3}</p><br>'.format(list[0],list[1],list[3],list[2])
+
+		check = ["",False,False]# store plain text , bool for if plain text found ,bool for html found
+		if part.is_multipart() : # check if there is multipart message within header part
+			for d in part.get_payload():
+				if d.get_content_type()=='text/plain':
+					check[1] = True
+					check[0] = self.get_payload(d,d.get_content_charset())
+				if d.get_content_type()=='text/html':
+					check[2] =True
+			if check[1] and not check[2]:
+				self.html_content += '<p>'+check[0]+'</p>'
+		else: #if headers only have single plain text add to html
+			if part.get_content_type()=='text/plain':
+				self.html_content += '<p>'+self.get_payload(part, part.get_content_charset())+'</p>'
+		return True
 
 	def get_charset(self, part):
 		"""Detect chartset."""


### PR DESCRIPTION
Hi,
fix for attached emails sent from outlook not appearing:
fix adds the headers into the body and then adds the body (if needed depending on the outlook version)

issues with outlook version 14.0.6023.1000:
only sends attached email in plain text not html for plain/text emails 
meaning the body is ignored

issues with outlook version 14.0.7165.500:
has additional layers in mime formatting before the message start and headers compared to older versions but has both plain and html versions of body.
