### PR TITLE
Enable Custom Fields in Naming Series # 3019 of ERPNext Issue

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -62,6 +62,7 @@ def set_name_by_naming_series(doc):
 		frappe.throw(frappe._("Naming Series mandatory"))
 
 	doc.name = make_autoname(doc.naming_series+'.#####', '', doc) 
+
 def make_autoname(key='', doctype='', doc=''):
 	"""
    Creates an autoname from the given key:
@@ -108,8 +109,8 @@ def make_autoname(key='', doctype='', doc=''):
 			en = today.strftime("%d")
 		elif e=='YYYY':
 			en = today.strftime('%Y')
-		elif doc and doc.get(e,None):
-			en = doc.get(e,None)
+		elif doc and doc.get(e):
+			en = doc.get(e)
 		else: en = e
 		n+=en
 	return n

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -61,9 +61,8 @@ def set_name_by_naming_series(doc):
 	if not doc.naming_series:
 		frappe.throw(frappe._("Naming Series mandatory"))
 
-	doc.name = make_autoname(doc.naming_series+'.#####')
-
-def make_autoname(key, doctype=''):
+	doc.name = make_autoname(doc.naming_series+'.#####', '', doc) 
+def make_autoname(key='', doctype='', doc=''):
 	"""
    Creates an autoname from the given key:
 
@@ -109,6 +108,8 @@ def make_autoname(key, doctype=''):
 			en = today.strftime("%d")
 		elif e=='YYYY':
 			en = today.strftime('%Y')
+		elif doc and doc.get(e,None):
+			en = doc.get(e,None)
 		else: en = e
 		n+=en
 	return n


### PR DESCRIPTION
Hello Team,

We have developed feature to add custom field in naming series.

e.g **QTN-.YYYY.-.customer.-.####** 
Resulting in  **QTN-2016-SBK-0001** (Asuming SBK is selected customer in Quotation)

ERPNext Issue Reference: https://github.com/frappe/erpnext/issues/3019

Thanks,
Sambhaji
New Indictrans Technologies Pvt Ltd 
