### PR TITLE
Add suport to unicode chars in Labels of Reports

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -109,7 +109,7 @@ def add_total_row(result, columns):
 		for i, col in enumerate(columns):
 			fieldtype = None
 			if isinstance(col, basestring):
-				col = col.split(":")
+				col = col.decode('utf-8').split(":")
 				if len(col) > 1:
 					fieldtype = col[1]
 			else:
@@ -125,7 +125,7 @@ def add_total_row(result, columns):
 
 	first_col_fieldtype = None
 	if isinstance(columns[0], basestring):
-		first_col = columns[0].split(":")
+		first_col = columns[0].decode('utf-8').split(":")
 		if len(first_col) > 1:
 			first_col_fieldtype = first_col[1].split("/")[0]
 	else:
@@ -264,7 +264,7 @@ def get_columns_dict(columns):
 
 		# string
 		if isinstance(col, basestring):
-			col = col.split(":")
+			col = col.decode('utf-8').split(":")
 			if len(col) > 1:
 				if "/" in col[1]:
 					col_dict["fieldtype"], col_dict["options"] = col[1].split("/")


### PR DESCRIPTION
``` python
Traceback (innermost last):
  File "/vagrant/frappe-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/vagrant/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/vagrant/frappe-bench/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/vagrant/frappe-bench/apps/frappe/frappe/__init__.py", line 806, in call
    return fn(*args, **newargs)
  File "/vagrant/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 91, in run
    result = get_filtered_data(report.ref_doctype, columns, result)
  File "/vagrant/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 145, in get_filtered_data
    linked_doctypes = get_linked_doctypes(columns, data)
  File "/vagrant/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 225, in get_linked_doctypes
    columns_dict = get_columns_dict(columns)
  File "/vagrant/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 267, in get_columns_dict
    col = col.split(":")
 UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 3: ordinal not in range(128)
```
