### PR TITLE
Multi Doc PDF Printing

### DIFF
--- a/frappe/public/js/frappe/list/doclistview.js
+++ b/frappe/public/js/frappe/list/doclistview.js
@@ -463,15 +463,38 @@ frappe.views.DocListView = frappe.ui.Listing.extend({
 			})
 
 			if(docname.length >= 1){
-				var json_string = JSON.stringify(docname);								
-				var w = window.open("/api/method/frappe.templates.pages.print.download_multi_pdf?"
-					+"doctype="+encodeURIComponent(me.doctype)
-					+"&name="+encodeURIComponent(json_string)
-					+"&format="+encodeURIComponent("Standard")
-					+"&no_letterhead="+encodeURIComponent('0'));
-				if(!w) {
-					msgprint(__("Please enable pop-ups")); return;
-				}
+				
+				var dialog = new frappe.ui.Dialog({
+					title: "Print Documents",
+					fields: [
+						{"fieldtype": "Check", "label": __("Print Letterhead"), "fieldname": "print_letterhead"},
+						{"fieldtype": "Select", "label": __("Print Format"), "fieldname": "print_sel"},
+						
+						{"fieldtype": "Button", "label": __("Print"), "fieldname": "print"},
+					]
+				});
+				
+				print_formats = frappe.meta.get_print_formats(me.doctype);
+				dialog.fields_dict.print_sel.$input.empty().add_options(print_formats);
+				
+				dialog.fields_dict.print.$input.click(function() {
+					args = dialog.get_values();
+					if(!args) return;
+					var default_print_format = locals.DocType[me.doctype].default_print_format;
+					with_letterhead = args.print_letterhead ? 1 : 0;
+					print_format = args.print_sel ? args.print_sel:default_print_format;
+					
+					var json_string = JSON.stringify(docname);								
+					var w = window.open("/api/method/frappe.templates.pages.print.download_multi_pdf?"
+						+"doctype="+encodeURIComponent(me.doctype)
+						+"&name="+encodeURIComponent(json_string)
+						+"&format="+encodeURIComponent(print_format)
+						+"&no_letterhead="+(with_letterhead ? "0" : "1"));
+					if(!w) {
+						msgprint(__("Please enable pop-ups")); return;
+					}
+				});
+				dialog.show();
 			}
 			else{
 				frappe.msgprint(__("Select records for assignment"))

--- a/frappe/public/js/frappe/list/doclistview.js
+++ b/frappe/public/js/frappe/list/doclistview.js
@@ -452,6 +452,31 @@ frappe.views.DocListView = frappe.ui.Listing.extend({
 				frappe.msgprint(__("Select records for assignment"))
 			}
 		}, true)
+		
+		//bulk assignment
+		me.page.add_menu_item(__("Print"), function(){
+
+			docname = [];
+
+			$.each(me.get_checked_items(), function(i, doc){
+				docname.push(doc.name);
+			})
+
+			if(docname.length >= 1){
+				var json_string = JSON.stringify(docname);								
+				var w = window.open("/api/method/frappe.templates.pages.print.download_multi_pdf?"
+					+"doctype="+encodeURIComponent(me.doctype)
+					+"&name="+encodeURIComponent(json_string)
+					+"&format="+encodeURIComponent("Standard")
+					+"&no_letterhead="+encodeURIComponent('0'));
+				if(!w) {
+					msgprint(__("Please enable pop-ups")); return;
+				}
+			}
+			else{
+				frappe.msgprint(__("Select records for assignment"))
+			}
+		}, true)
 	},
 
 	init_like: function() {

--- a/frappe/templates/pages/print.py
+++ b/frappe/templates/pages/print.py
@@ -144,6 +144,38 @@ def get_html_and_style(doc, name=None, print_format=None, meta=None,
 	}
 
 @frappe.whitelist()
+def download_multi_pdf(doctype, name, format=None):
+	# name can include names of many docs of the same doctype.
+	totalhtml = ""
+	# Pagebreak to be added between each doc html
+	pagebreak = """<p style="page-break-after:always;"></p>"""
+	
+	options = {}
+	
+	import json
+	result = json.loads(name)
+	# Get html of each doc and combine including page breaks
+	for i, ss in enumerate(result):
+		html = frappe.get_print(doctype, ss, format)
+		if i == len(result)-1:
+			totalhtml = totalhtml + html
+		else:
+			totalhtml = totalhtml + html + pagebreak
+			
+	
+	
+	frappe.local.response.filename = "{doctype}.pdf".format(doctype=doctype.replace(" ", "-").replace("/", "-"))
+
+	
+	# Title of pdf
+	options.update({
+		'title': doctype,
+	})
+
+	frappe.local.response.filecontent = get_pdf(totalhtml,options)
+	frappe.local.response.type = "download"
+	
+@frappe.whitelist()
 def download_pdf(doctype, name, format=None):
 	html = frappe.get_print(doctype, name, format)
 	frappe.local.response.filename = "{name}.pdf".format(name=name.replace(" ", "-").replace("/", "-"))

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -72,7 +72,7 @@ def prepare_options(html, options):
 
 def read_options_from_html(html):
 	options = {}
-	soup = BeautifulSoup(html, "html5lib")
+	soup = BeautifulSoup(html, "html.parser")
 
 	# extract pdfkit options from html
 	for html_id in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size"):


### PR DESCRIPTION
Compiles multiple docs into one html and prints a pdf. Requires a list of doc names, which have to be of the same doctype. Compatible with built-in pdf printing features (letterheads and print formats)
Calling the method is similar to the current doc printing method. I use it in process payroll, but a more useful way would be with a dropdown button in the listview. Example Code:

```
var callback = function(r, rt){
            if (r.message)
            {
                var names = [];

                r.message.forEach(function (element, index) {
                    names.push(element[0]);
                });

                var json_string = JSON.stringify(names);                                
                var w = window.open("/api/method/frappe.templates.pages.print.download_multi_pdf?"
                    +"doctype="+encodeURIComponent("Salary Slip")
                    +"&name="+encodeURIComponent(json_string)
                    +"&format="+encodeURIComponent("Salary Slip")
                    +"&no_letterhead="+"0");
                    if(!w) {
                        msgprint(__("Please enable pop-ups")); return;
                    }
            }
        }
// method returns dict of doc names
        return $c('runserverobj', args={'method':'print_salary_slips','docs':doc},callback);
```
