### PR TITLE
Fix table header background color in pdf view

### DIFF
--- a/frappe/print/doctype/print_format/test_print_format.py
+++ b/frappe/print/doctype/print_format/test_print_format.py
@@ -23,7 +23,7 @@ class TestPrintFormat(unittest.TestCase):
 
 	def test_print_user_modern(self):
 		print_html = self.test_print_user("Modern")
-		self.assertTrue(re.findall('th {[\s]*background-color: #eee;[\s]*}', print_html))
+		self.assertTrue(re.findall('th {[\s]*background-color: #eee !important;[\s]*}', print_html))
 
 	def test_print_user_classic(self):
 		print_html = self.test_print_user("Classic")

--- a/frappe/templates/styles/modern.css
+++ b/frappe/templates/styles/modern.css
@@ -13,5 +13,5 @@
 }
 
 .print-format th {
-	background-color: #eee;
+	background-color: #eee !important;
 }


### PR DESCRIPTION
wkhtmltopdf removes div/th background color
reference: http://stackoverflow.com/questions/25118343/wkhtmltopdf-div-background-color

```
background-color: #eee !important; //will fix the problem in Modern Print Pdf View
```

Check this url

Table Header border is comming in print priview
https://demo.erpnext.com/api/method/frappe.templates.pages.print.download_pdf?doctype=Sales%20Invoice&name=%5BSelect%5D00024&format=Standard&no_letterhead=0

but Table Header background color is removed in pdf
https://demo.erpnext.com/print?doctype=Sales%20Invoice&name=%5BSelect%5D00024&format=Standard&no_letterhead=0

![pdf](https://cloud.githubusercontent.com/assets/6648915/13547846/67e0511c-e307-11e5-800f-304aa12ba94c.png)
