### PR TITLE
[minor][enhancment] modyfication to money_in_words to adapt it to tax requirements of Peru

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -422,11 +422,19 @@ def money_in_words(number, main_currency = None, fraction_currency=None):
 	in_million = True
 	if number_format == "#,##,###.##": in_million = False
 
-	out = main_currency + ' ' + in_words(main, in_million).title()
-	if cint(fraction):
-		out = out + ' ' + _('and') + ' ' + in_words(fraction, in_million).title() + ' ' + fraction_currency
+	if main_currency == "PEN":
+                out = in_words(main, in_million).title()
+                if cint(fraction):
+                        out = out + ' ' + _('and') + ' ' + fraction + '/100'
+                else:
+                        out = out + ' ' + _('and') + ' 00/100'
 
-	return out + ' ' + _('only.')
+                return out + ' soles'
+
+        else:
+                out = main_currency + ' ' + in_words(main, in_million).title()
+                if cint(fraction):
+                        out = out + ' ' + _('and') + ' ' + in_words(fraction, in_million).title() + ' ' + fraction_currency
 
 #
 # convert number to words


### PR DESCRIPTION
Peruvian tax requirement for the sales invoice indicates that the fractional part of the total amount of the invoice is written as a fraction for example "00/100" or "20/100"

It is therefore not necessary for the fractional part is converted to num2words function. There is no way to tell the num2words function that does not convert the fractional part of the amount because this only receives the number you want to convert.

If the main_currency is 'PEN', the currency of Peru money_in_words will only convert to word the amount without the fraction part and will give the fraction part the  "00/100" and end the text with ' soles' as required by Peruvian tax laws for a sales invoice has value.

This change avoid the fraction part to be converted to words.
