### PR TITLE
[Enhancement] Added feature to bench restore command to restore the public and private files

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -6,7 +6,7 @@
 
 from __future__ import unicode_literals
 
-import os, json, sys
+import os, json, sys, subprocess, shutil
 import frappe
 import frappe.database
 import getpass
@@ -336,6 +336,43 @@ def check_if_ready_for_barracuda():
 			print "="*80
 			sys.exit(1)
 			# raise Exception, "MariaDB needs to be configured!"
+
+def extract_sql_gzip(sql_gz_path):
+	success = -1
+	try:
+		success = subprocess.check_output(['gzip', '-d', '-v', '-f', sql_gz_path])
+	except Exception as subprocess.CalledProcessError:
+		print subprocess.CalledProcessError.output
+	finally:
+	# subprocess.check_call returns '0' on success. On success, return path to sql file
+		return sql_gz_path[:-3]
+
+def extract_tar_files(site_name, file_path, folder_name):
+	# Need to do frappe.init to maintain the site locals
+	frappe.init(site=site_name)
+	abs_site_path = os.path.abspath(frappe.get_site_path())
+
+	# While creating tar files during backup, a complete recursive structure is created.
+	# For example, <site_name>/<private>/<files>/*.*
+	# Shift to parent directory and make it as current directory and do the extraction.
+	_parent_dir = os.path.dirname(abs_site_path)
+	os.chdir(_parent_dir)
+
+	# Copy the files to the parent directory and extract
+	shutil.copy2(os.path.abspath(file_path), _parent_dir)
+
+	# Get the file name splitting the file path on
+	filename = file_path.split('/')[-1]
+	filepath = os.path.join(_parent_dir, filename)
+
+	try:
+		error = subprocess.check_output(['tar', 'xvf', filepath])
+	except Exception as subprocess.CalledProcessError:
+		print subprocess.CalledProcessError.output
+	finally:
+		# On successful extraction delete the tarfile to avoid any abuse through command line
+		os.remove(filepath)
+		frappe.destroy()
 
 expected_config_for_barracuda = """[mysqld]
 innodb-file-format=barracuda


### PR DESCRIPTION
- Extract the public and private tar files for a site while restore by using switch --with-public-files, --with-private-files
- Extracts gzipped database backup. If the user has accidentally mentioned the path to gzipped file instead of SQL file.
