### PR TITLE
Apply filters for Doctype List View from Menu definition

### DIFF
--- a/frappe/desk/page/modules/modules.js
+++ b/frappe/desk/page/modules/modules.js
@@ -102,6 +102,9 @@ frappe.pages['modules'].on_page_load = function(wrapper) {
 						if(frappe.model.is_single(item.doctype)) {
 							item.route = 'Form/' + item.doctype;
 						} else {
+							if (item.filters) {
+								frappe.route_options=item.filters;
+							}
 							item.route="List/" + item.doctype
 							//item.style = 'font-weight: 500;';
 						}


### PR DESCRIPTION
Allow to Set filters in Menu Definition of Doctypes. 
Helps in defining multiple Menus for a single Doctype filtered by different fields eg: Invoices Overdue, Leaves to Approve etc.
    {
        "type": "doctype",
        "name": "Item",
        "description": _("All Products or Services."),
        "filters" : {"is_sales_item" : "Yes", "disabled": "No"},
    },
This would apply filter for Items menu under Sales module

If filters field is tracked in Doctype "Desktop Icon", users can add frequently used filtered views to Desktop.
Share your thoughts,
Thanks
