### PR TITLE
Fix TypeError

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -89,7 +89,6 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 				limit_page_length=page_len,
 				order_by="if(_relevance, _relevance, 99999), idx desc, modified desc".format(doctype),
 				ignore_permissions = True if doctype == "DocType" else False, # for dynamic links
-				as_dict=as_dict,
 				as_list=not as_dict)
 
 			# remove _relevance from results


### PR DESCRIPTION
Traceback (innermost last):
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, *_frappe.form_dict)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/**init**.py", line 808, in call
    return fn(_args, *_newargs)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/desk/search.py", line 13, in search_link
    search_widget(doctype, txt, query, searchfield=searchfield, page_len=page_len, filters=filters)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/desk/search.py", line 93, in search_widget
    as_list=not as_dict)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/desk/reportview.py", line 17, in execute
    return DatabaseQuery(doctype).execute(_args, **kwargs)
 TypeError: execute() got an unexpected keyword argument 'as_dict'
