### PR TITLE
[Fix] Escape quotes in user name while rendering the modules_setup template

### DIFF
--- a/frappe/core/page/modules_setup/modules_setup.html
+++ b/frappe/core/page/modules_setup/modules_setup.html
@@ -13,7 +13,9 @@
 				{% for user in users %}
 				<option value="{{ user.name }}"
 					{% if user.name == frappe.user %}selected{% endif %}>
-					{{ user.first_name or "" }} {{ user.last_name or "" }} ({{ user.name }})</option>
+					<!-- {{ variable | e }} "e" or "escape(s)" will escape the characters such "<, >, &, '"
+					in the HTML text (http://jinja.pocoo.org/docs/dev/templates/#escape) -->
+					{{ user.first_name | e or "" }} {{ user.last_name | e or "" }} ({{ user.name }})</option>
 				{% endfor %}
 			</select>
 		</div>


### PR DESCRIPTION
- If username contains special characters, then escape those characters while rendering the HTML from jinja template.
