### PR TITLE
Problem on ‘Created On’/'Last Updated On' filter

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -297,9 +297,14 @@ class DatabaseQuery(object):
 			if isinstance(value, basestring):
 				value = '"{0}"'.format(frappe.db.escape(value, percent=False))
 
-			condition = 'ifnull({tname}.{fname}, {fallback}) {operator} {value}'.format(
-				tname=tname, fname=f.fieldname, fallback=fallback, operator=f.operator,
-				value=value)
+			if f.fieldname in ("creation", "modified"):
+				condition = '''ifnull(date_format({tname}.{fname},'%Y-%m-%d'), {fallback}) {operator} {value}'''.format(
+					tname=tname, fname=f.fieldname, fallback=fallback, operator=f.operator,
+					value=value)
+			else:
+				condition = 'ifnull({tname}.{fname}, {fallback}) {operator} {value}'.format(
+					tname=tname, fname=f.fieldname, fallback=fallback, operator=f.operator,
+					value=value)
 
 		return condition
 


### PR DESCRIPTION
Related to https://discuss.erpnext.com/t/problem-on-created-on-filter/11937.
We found there is a bug on 'Created On' filter on list view page. I found list data will not include the data whose creation is '2016-04-08' When I put filter Created On <= 2016-04-08. 
The same problem will happen when using 'Equal', it will not get any data by using condition ifnull(`tabTime Log`.creation, "") = "2016-04-08".
'Last Updated On' filter has same issue.
