### PR TITLE
[feature] Redirect to message page with a detailed message

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -952,6 +952,40 @@ def respond_as_web_page(title, html, success=None, http_status_code=None, contex
 	if context:
 		local.response['context'] = context
 
+def redirect_to_message(title, html, http_status_code=None, context=None):
+	"""Redirects to /message?id=random
+	Similar to respond_as_web_page, but used to 'redirect' and show message pages like success, failure, etc. with a detailed message
+
+	:param title: Page title and heading.
+	:param message: Message to be shown.
+	:param http_status_code: HTTP status code.
+
+	Example Usage:
+		frappe.redirect_to_message(_('Thank you'), "<div><p>You will receive an email at test@example.com</p></div>")
+
+	"""
+
+	message_id = generate_hash(length=32)
+	message = {
+		'context': context or {},
+		'http_status_code': http_status_code or 200
+	}
+	message['context'].update({
+		'header': title,
+		'title': title,
+		'message': html
+	})
+
+	cache().set_value("message_id:{0}".format(message_id), message, expires_in_sec=60)
+	location = '/message?id={0}'.format(message_id)
+
+	if not getattr(local, 'is_ajax', False):
+		local.response["type"] = "redirect"
+		local.response["location"] = location
+
+	else:
+		return location
+
 def build_match_conditions(doctype, as_condition=True):
 	"""Return match (User permissions) for given doctype as list or SQL."""
 	import frappe.desk.reportview

--- a/frappe/templates/pages/message.py
+++ b/frappe/templates/pages/message.py
@@ -18,4 +18,18 @@ def get_context(context):
 		if hasattr(frappe.local, "message_success"):
 			message_context["success"] = frappe.local.message_success
 
+	elif frappe.local.form_dict.id:
+		message_id = frappe.local.form_dict.id
+		key = "message_id:{0}".format(message_id)
+		message = frappe.cache().get_value(key, expires=True)
+		if message:
+			message_context.update(message.get('context', {}))
+			if message.get('http_status_code'):
+				frappe.local.response['http_status_code'] = message['http_status_code']
+
+		else:
+			message_context = {
+				'message': ''
+			}
+
 	return message_context


### PR DESCRIPTION
Observe the change in URL. This message will be valid for upto 60 seconds.

Although this might look as over-engineering for short messages, it makes sense when the description message is an HTML and if passed as query strings, would look ugly.

Usage example:

```
frappe.redirect_to_message(_('Thank you for signing up'),
            """<div><p>You will receive an email at {},
            asking you to verify this account request.<br>
            If you are unable to find the email in your inbox, please check your SPAM folder.
            It may take a few minutes before you receive this email.</p>
            <p>Once you click on the verification link, your account will be ready in a few minutes.</p>
            </div>""".format(email), context=context)
```

Success:

![redirect-to-message](https://cloud.githubusercontent.com/assets/836785/14714230/e0a5b1ae-0801-11e6-8012-bc9305d3950f.gif)

Failure:

![redirect-to-message](https://cloud.githubusercontent.com/assets/836785/14713956/d8832cc8-0800-11e6-95e1-9e2c78b88cd9.gif)
