### PR TITLE
Unset `toolbar.current_status` on `disable_save`

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -803,6 +803,7 @@ _f.Frm.prototype.amend_doc = function() {
 _f.Frm.prototype.disable_save = function() {
 	// IMPORTANT: this function should be called in refresh event
 	this.save_disabled = true;
+	this.toolbar.current_status = null;
 	this.page.clear_primary_action();
 }
 


### PR DESCRIPTION
If the `cur_frm.toolbar.current_status` is not unset, when, `cur_frm.toolbar.enable_save` is called the `Save` button on form is not reloaded!

To certify just go to a form, open the browser console and run

```
cur_frm.disable_save();
cur_frm.enable_save();
```

Without this fix, the button will not released!
