### PR TITLE
Fix: AttributeError: 'dict' object has no attribute 'parenttype'

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -75,7 +75,7 @@ def insert(doc=None):
 
 	if doc.get("parent") and doc.get("parenttype"):
 		# inserting a child record
-		parent = frappe.get_doc(doc.parenttype, doc.parent)
+		parent = frappe.get_doc(doc.get("parenttype"), doc.get("parent"))
 		parent.append(doc)
 		parent.save()
 		return parent.as_dict()

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -76,7 +76,7 @@ def insert(doc=None):
 	if doc.get("parent") and doc.get("parenttype"):
 		# inserting a child record
 		parent = frappe.get_doc(doc.get("parenttype"), doc.get("parent"))
-		parent.append(doc)
+		parent.append(doc.get("parentfield"), doc)
 		parent.save()
 		return parent.as_dict()
 	else:


### PR DESCRIPTION
``` python
Traceback (innermost last):
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/__init__.py", line 805, in call
    return fn(*args, **newargs)
  File "/usr/frappe5/frappe-bench/apps/frappe/frappe/client.py", line 78, in insert
    parent = frappe.get_doc(doc.parenttype, doc.parent)
 AttributeError: 'dict' object has no attribute 'parenttype'
```
