### PR TITLE
[minor-fix] replaced frm.call with frappe.call

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -3,7 +3,7 @@
 
 frappe.db = {
 	get_value: function(doctype, filters, fieldname, callback) {
-		frm.call({
+		frappe.call({
 			method: "frappe.client.get_value",
 			args: {
 				doctype: doctype,


### PR DESCRIPTION
Getting Uncaught ReferenceError: frm is not defined, if frappe.db.get_value() used in custom scripts.
![image](https://cloud.githubusercontent.com/assets/11224291/15747221/5be89302-28f7-11e6-9869-fadbbddc2468.png)
