### PR TITLE
fix bug for "duplicate key name" when db init

### DIFF
--- a/frappe/model/db_schema.py
+++ b/frappe/model/db_schema.py
@@ -190,7 +190,7 @@ class DbTable:
 	def get_index_definitions(self):
 		ret = []
 		for key, col in self.columns.items():
-			if col.set_index and col.fieldtype in type_map and \
+			if col.set_index and not col.unique and col.fieldtype in type_map and \
 					type_map.get(col.fieldtype)[0] not in ('text', 'longtext'):
 				ret.append('index `' + key + '`(`' + key + '`)')
 		return ret


### PR DESCRIPTION
During the first init process for creating tables, if one field marked True for both "unique" and "search_index" , table creation will be failed. 

for example :

create table `tabItem Barcode` (
            name varchar(140) not null primary key,
            creation datetime(6),
            modified datetime(6),
            modified_by varchar(140),
            owner varchar(140),
            docstatus int(1) not null default '0',
            parent varchar(140),
            parentfield varchar(140),
            parenttype varchar(140),
            idx int(8) not null default '0',
            `item_barcode` varchar(140) unique,
`sku_id` varchar(140),
`unit_qty` varchar(140),
`_comments` text,
`_assign` text,
`_liked_by` text,
`store` varchar(140),
`retail_price` varchar(140),
`_user_tags` text,
`uom` varchar(140),
index `item_barcode`(`item_barcode`),
index parent(parent))
            ENGINE=InnoDB
            ROW_FORMAT=COMPRESSED
            CHARACTER SET=utf8mb4
            COLLATE=utf8mb4_unicode_ci
