### PR TITLE
[minor] fixed can not read property 'filters' for Page List

### DIFF
--- a/frappe/public/js/frappe/ui/listing.js
+++ b/frappe/public/js/frappe/ui/listing.js
@@ -198,7 +198,7 @@ frappe.ui.Listing = Class.extend({
 	save_list_settings_locally: function(args) {
 		if(this.opts.save_list_settings && this.doctype && !this.docname) {
 			// save list settings locally
-			list_settings = frappe.model.list_settings[this.doctype];
+			list_settings = frappe.model.list_settings[this.doctype] || {};
 
 			var different = false;
 


### PR DESCRIPTION
Hi,

I got following error on page list.

![image](https://cloud.githubusercontent.com/assets/11224291/15983418/c3e5c528-2fc4-11e6-8861-85e93bcb2a4f.png)

I have checked and found `frappe.model.list_settings['Page']` returns undefind.
