### PR TITLE
[fix] set default value as 0 to image_view for doctype DocType

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -245,6 +245,7 @@
    "bold": 0, 
    "collapsible": 0, 
    "depends_on": "eval: doc.image_field", 
+   "default": 0,
    "fieldname": "image_view", 
    "fieldtype": "Check", 
    "hidden": 0, 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -1,7 +1,7 @@
 execute:frappe.db.sql("""update `tabPatch Log` set patch=replace(patch, '.4_0.', '.v4_0.')""") #2014-05-12
 frappe.patches.v5_0.convert_to_barracuda_and_utf8mb4
 frappe.patches.v6_1.rename_file_data
-execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2016-05-02
+execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2016-06-15
 execute:frappe.reload_doc('core', 'doctype', 'docfield', force=True) #2016-02-26
 execute:frappe.reload_doc('core', 'doctype', 'docperm') #2014-06-24
 execute:frappe.reload_doc('custom', 'doctype', 'custom_field') #2015-10-19
@@ -129,4 +129,3 @@ frappe.patches.v7_0.update_send_after_in_bulk_email
 frappe.patches.v7_0.setup_list_settings
 execute:frappe.db.sql('''delete from `tabSingles` where doctype="Email Settings"''') # 2016-06-13
 frappe.patches.v7_0.update_auth
-


### PR DESCRIPTION
```
➜  frappe-bench bench migrate
Migrating frappe.com
Updating frappe                     : [=                                       ]Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 700, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 680, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 873, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 508, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 16, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/commands/site.py", line 163, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/migrate.py", line 29, in migrate
    frappe.model.sync.sync_all(verbose=verbose)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/sync.py", line 19, in sync_all
    sync_for(app, force, verbose=verbose)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/sync.py", line 43, in sync_for
    import_file_by_path(doc_path, force=force)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 54, in import_file_by_path
    import_doc(doc, force=force, data_import=data_import, pre_process=pre_process)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 122, in import_doc
    doc.insert()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 205, in insert
    self.db_insert()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/base_document.py", line 283, in db_insert
    ), d.values())
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/database.py", line 136, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
    self.errorhandler(self, exc, value)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
_mysql_exceptions.OperationalError: (1048, "Column 'image_view' cannot be null")

```
