### PR TITLE
the user can now add multiple comments without refreshing the page

### DIFF
--- a/frappe/templates/includes/comments/comments.html
+++ b/frappe/templates/includes/comments/comments.html
@@ -110,9 +110,10 @@
 					} else {
 						$(r.message).appendTo("#comment-list");
 						$(".no-comment, .add-comment").toggle(false);
-						$("#comment-form")
-							.replaceWith('<div class="text-muted">Thank you for your comment!</div>')
+						$("#comment-form").toggle();
 					}
+					$(".add-comment").text('{{ _("Add Another Comment") }}');
+					$(".add-comment").toggle();
 				}
 			})
 


### PR DESCRIPTION
removed replaceWith because it also deleted all the event binders and listeners attached to the elements being replaced; thereby inhibiting multiple comments. 
