### PR TITLE
Fix for new-site --install-app

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -55,7 +55,7 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 		install_db(root_login=mariadb_root_username, root_password=mariadb_root_password, db_name=db_name,
 			admin_password=admin_password, verbose=verbose, source_sql=source_sql,force=force, reinstall=reinstall)
 
-		apps_to_install = ['frappe'] + (frappe.conf.get("install_apps") or []) + (install_apps or [])
+		apps_to_install = ['frappe'] + (frappe.conf.get("install_apps") or []) + (list(install_apps) or [])
 		for app in apps_to_install:
 			_install_app(app, verbose=verbose, set_as_patched=not source_sql)
 


### PR DESCRIPTION
Fix for : 

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/vjfalk/frappe-subcription/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/home/vjfalk/frappe-subcription/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/vjfalk/frappe-subcription/env/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/vjfalk/frappe-subcription/env/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/vjfalk/frappe-subcription/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/vjfalk/frappe-subcription/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/vjfalk/frappe-subcription/env/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/vjfalk/frappe-subcription/env/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/vjfalk/frappe-subcription/apps/frappe/frappe/commands/site.py", line 29, in new_site
    verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force)
  File "/home/vjfalk/frappe-subcription/apps/frappe/frappe/commands/site.py", line 58, in _new_site
    apps_to_install = ['frappe'] + (frappe.conf.get("install_apps") or []) + (install_apps or [])
TypeError: can only concatenate list (not "tuple") to list
```
