### PR TITLE
[minor] re-rendered the headers while switching views

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -99,6 +99,11 @@ frappe.views.ListSidebar = Class.extend({
 					image_view = 1
 
 				me.doclistview.meta.image_view = image_view;
+
+				// clear and render the headers again while switching
+				me.doclistview.page.main.find(".list-headers").empty();
+				me.doclistview.init_headers();
+
 				me.doclistview.refresh(true);
 			};
 


### PR DESCRIPTION
- manually cleared and re-rendered the headers while switching in between List View and Image View
