### PR TITLE
Logout issue on not providing password fixed for Email Account

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -93,6 +93,8 @@ class EmailAccount(Document):
 		if self.enable_outgoing:
 			if not self.smtp_server:
 				frappe.throw(_("{0} is required").format("SMTP Server"))
+			if not self.password:
+				frappe.throw(_("{0} is required").format("Password"))	
 
 			server = SMTPServer(login = getattr(self, "login_id", None) \
 					or self.email_id,
@@ -105,6 +107,9 @@ class EmailAccount(Document):
 
 	def get_server(self, in_receive=False):
 		"""Returns logged in POP3 connection object."""
+		if not self.password:
+			frappe.throw(_("{0} is required").format("Password"))
+			
 		args = {
 			"host": self.email_server,
 			"use_ssl": self.use_ssl,


### PR DESCRIPTION
While creating new Email Account, if Password is not provided and try to set STMP or Email Server,  you get logged out because of get_password(). Now it will check if password is provided or not.

It was reported in megathread: https://discuss.erpnext.com/t/erpnext-7-issues-and-info-megathread/14352/25?u=kanchanchauhan
