### PR TITLE
Add return to the wrapper for save

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -239,7 +239,7 @@ class Document(BaseDocument):
 
 	def save(self, *args, **kwargs):
 		"""Wrapper for _save"""
-		self._save(*args, **kwargs)
+		return self._save(*args, **kwargs)
 
 	def _save(self, ignore_permissions=None):
 		"""Save the current document in the database in the **DocType**'s table or


### PR DESCRIPTION
Save mistakenly removed the return function when a wrapper was added for it. This has created downstream issues, including preventing PUT requests through the API.
