### PR TITLE
Added -H to sudo

### DIFF
--- a/frappe/docs/user/en/bench/guides/lets-encrypt-ssl-setup.md
+++ b/frappe/docs/user/en/bench/guides/lets-encrypt-ssl-setup.md
@@ -12,7 +12,7 @@
 
 Just run: 
 
-    sudo bench setup lets-encrypt [site-name]
+    sudo -H bench setup lets-encrypt [site-name]
 
 You will be faced with several prompts, respond to them accordingly. This command will also add an entry to the crontab of the user that will attempt to renew the certificate every month.
 


### PR DESCRIPTION
Without -H permission on Ubuntu 14.04 LTS got messed up as pip was update installed by apt-get with root permission.
