### PR TITLE
minifiying doctype json's

### DIFF
--- a/frappe/modules/export_file.py
+++ b/frappe/modules/export_file.py
@@ -30,6 +30,9 @@ def write_document_file(doc, record_module=None, create_init=None):
 			for fieldname in frappe.model.default_fields:
 				if fieldname in d:
 					del d[fieldname]
+			for fieldname in d.keys():
+				if d[fieldname] == 0 or d[fieldname] == "":
+					del d[fieldname]
 
 	module = record_module or get_module_name(doc)
 	if create_init is None:


### PR DESCRIPTION
sick and tired of a change to the doctype meaning one small change to a doctype adds all the fields to the json 
strips out the values that doesnt contain value's

probably should patch to minify all json's so future changes are only the changes
