### PR TITLE
Should be able to debug dynamic js files out of the box

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/controller.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller.js
@@ -6,3 +6,5 @@ frappe.ui.form.on('{doctype}', {{
 
 	}}
 }});
+
+//@ sourceURL={classname}.js

--- a/frappe/core/doctype/doctype/boilerplate/controller.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller.js
@@ -7,4 +7,4 @@ frappe.ui.form.on('{doctype}', {{
 	}}
 }});
 
-//@ sourceURL={classname}.js
+//# sourceURL={classname}.js

--- a/frappe/core/doctype/doctype/boilerplate/controller_list.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller_list.js
@@ -3,4 +3,4 @@ frappe.listview_settings['{doctype}'] = {{
 	filters:[["status","=", "Open"]]
 }};
 
-//@ sourceURL={classname}_listview.js
+//# sourceURL={classname}_listview.js

--- a/frappe/core/doctype/doctype/boilerplate/controller_list.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller_list.js
@@ -2,3 +2,5 @@ frappe.listview_settings['{doctype}'] = {{
 	add_fields: ["status"],
 	filters:[["status","=", "Open"]]
 }};
+
+//@ sourceURL={classname}_listview.js


### PR DESCRIPTION
New users may have troubles with debugging custom scripts since they are injected.
To mitigate this issue we need sourceURL in each newly created doctype js files.
