### PR TITLE
Bugfix cropped email text

### DIFF
--- a/frappe/public/js/frappe/misc/tools.js
+++ b/frappe/public/js/frappe/misc/tools.js
@@ -45,7 +45,7 @@ frappe.markdown = function(txt) {
 	var whitespace_len = 0,
 		first_line = txt.split("\n")[0];
 
-	while([" ", "\n", "\t"].indexOf(first_line.substr(0,1))!== -1) {
+	while(["\n", "\t"].indexOf(first_line.substr(0,1))!== -1) {
 		whitespace_len++;
 		first_line = first_line.substr(1);
 	}


### PR DESCRIPTION
hi guys 
i cant work out the purpose of the space search but it cause's issues if an email starts with spaces then a newline
as it cause's the markdown to remove extra characters based on number of spaces after each newline

im assuming could be some edgecase that i dont have a clue about if not then fix should be all good
