### PR TITLE
[minor] Razorpay app title typo fix

### DIFF
--- a/frappe/data/app_listing/razorpay_integration.json
+++ b/frappe/data/app_listing/razorpay_integration.json
@@ -7,7 +7,7 @@
 	"app_publisher": "Frappe",
 	"app_email": "hello@frappe.io",
 	"repo_url": "https://github.com/frappe/razorpay_integration.git",
-	"app_title": "Razorpay Integation",
+	"app_title": "Razorpay Integration",
 	"app_version": "1.0.0",
 	"app_category": "Integrations",
 	"featured": 1


### PR DESCRIPTION
"app_title": "Razorpay Integation" → "app_title": "Razorpay Integration"
