### PR TITLE
Error Snapshot templates missing in build.json

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -139,7 +139,10 @@
 		"public/js/frappe/desk.js",
 		"public/js/frappe/query_string.js",
 
-		"public/js/frappe/ui/charts.js"
+		"public/js/frappe/ui/charts.js",
+		
+		"public/html/error_object.html",
+		"public/html/error_snapshot.html"
 	],
 	"js/d3.min.js": [
 		"public/js/lib/d3.min.js",


### PR DESCRIPTION
Reported via https://discuss.erpnext.com/t/freezing-error-snapshot/15203/4
