### PR TITLE
[fix][minor] fix get_visible_columns in standard print format

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -18,7 +18,7 @@
 		{% include doc.print_templates[df.fieldname] %}
 	{%- else -%}
 		{%- if data -%}
-		{%- set visible_columns = get_visible_columns(doc.get(df.fieldname),
+		{%- set visible_columns = frappe.get_visible_columns(doc.get(df.fieldname),
 			table_meta, df) -%}
 		<div {{ fieldmeta(df) }}>
 			<table class="table table-bordered table-condensed">


### PR DESCRIPTION
## WN-SUP19998

```
Traceback (most recent call last):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 880, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/www/print.py", line 171, in get_html_and_style
    no_letterhead=no_letterhead, trigger_print=trigger_print),
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/www/print.py", line 142, in get_html
    html = template.render(args, filters={"len": len})
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/./templates/print_formats/standard.html", line 28, in top-level template code
    {{ render_field(df, doc) }}
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/./templates/print_formats/standard_macros.html", line 3, in template
    {{ render_table(df, doc) }}
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/./templates/print_formats/standard_macros.html", line 21, in template
    {%- set visible_columns = get_visible_columns(doc.get(df.fieldname),
UndefinedError: 'get_visible_columns' is undefined
```
