### PR TITLE
fix for write share permission #1996

### DIFF
--- a/frappe/core/doctype/docshare/docshare.py
+++ b/frappe/core/doctype/docshare/docshare.py
@@ -19,8 +19,6 @@ class DocShare(Document):
 		self.get_doc().run_method("validate_share", self)
 
 	def cascade_permissions_downwards(self):
-		if self.share:
-			self.write = 1
 		if self.write:
 			self.read = 1
 

--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -34,7 +34,7 @@ class TestDocShare(unittest.TestCase):
 		self.assertTrue(self.event.has_permission())
 
 	def test_share_permission(self):
-		frappe.share.add("Event", self.event.name, self.user, share=1)
+		frappe.share.add("Event", self.event.name, self.user, write=1, share=1)
 
 		frappe.set_user(self.user)
 		self.assertTrue(self.event.has_permission("share"))
@@ -60,14 +60,14 @@ class TestDocShare(unittest.TestCase):
 		self.assertRaises(frappe.PermissionError, frappe.share.add, "Event", self.event.name, self.user)
 
 		frappe.set_user("Administrator")
-		frappe.share.add("Event", self.event.name, self.user, share=1)
+		frappe.share.add("Event", self.event.name, self.user, write=1, share=1)
 
 		# test not raises
 		frappe.set_user(self.user)
-		frappe.share.add("Event", self.event.name, "test1@example.com", share=1)
+		frappe.share.add("Event", self.event.name, "test1@example.com", write=1, share=1)
 
 	def test_remove_share(self):
-		frappe.share.add("Event", self.event.name, self.user, share=1)
+		frappe.share.add("Event", self.event.name, self.user, write=1, share=1)
 
 		frappe.set_user(self.user)
 		self.assertTrue(self.event.has_permission("share"))

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -131,7 +131,7 @@ class User(Document):
 
 	def share_with_self(self):
 		if self.user_type=="System User":
-			frappe.share.add(self.doctype, self.name, self.name, share=1,
+			frappe.share.add(self.doctype, self.name, self.name, write=1, share=1,
 				flags={"ignore_share_permission": True})
 		else:
 			frappe.share.remove(self.doctype, self.name, self.name,

--- a/frappe/patches/v5_0/update_shared.py
+++ b/frappe/patches/v5_0/update_shared.py
@@ -13,7 +13,7 @@ def execute():
 	users = frappe.get_all("User", filters={"user_type": "System User"})
 	usernames = [user.name for user in users]
 	for user in usernames:
-		frappe.share.add("User", user, user, share=1)
+		frappe.share.add("User", user, user, write=1, share=1)
 
 	# move event user to shared
 	if frappe.db.exists("DocType", "Event User"):

--- a/frappe/public/js/frappe/form/templates/set_sharing.html
+++ b/frappe/public/js/frappe/form/templates/set_sharing.html
@@ -12,7 +12,7 @@
         <div class="col-xs-2"><input type="checkbox" name="read"
             {% if(cint(everyone.read)) { %}checked{% } %} class="edit-share"></div>
         <div class="col-xs-2"><input type="checkbox" name="write"
-            {% if(cint(everyone.write)) { %}checked{% } %} class="edit-share"></div>
+            {% if(cint(everyone.write)) { %}checked{% } %} class="edit-share"{% if (!frm.perm[0].write){ %} disabled="disabled"{% } %}></div>
         <div class="col-xs-2"><input type="checkbox" name="share"
             {% if(cint(everyone.share)) { %}checked{% } %} class="edit-share"></div>
 	</div>
@@ -25,7 +25,7 @@
 	        <div class="col-xs-2"><input type="checkbox" name="read"
 	            {% if(cint(s.read)) { %}checked{% } %} class="edit-share"></div>
 	        <div class="col-xs-2"><input type="checkbox" name="write"
-	            {% if(cint(s.write)) { %}checked{% } %} class="edit-share"></div>
+	            {% if(cint(s.write)) { %}checked{% } %} class="edit-share"{% if (!frm.perm[0].write){ %} disabled="disabled"{% } %}></div>
 	        <div class="col-xs-2"><input type="checkbox" name="share"
 	            {% if(cint(s.share)) { %}checked{% } %} class="edit-share"></div>
 	    </div>

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -69,13 +69,6 @@ def set_permission(doctype, name, user, permission_to, value=1, everyone=0):
 		share.flags.ignore_permissions = True
 		share.set(permission_to, value)
 
-		if not value:
-			# un-set higher-order permissions too
-			if permission_to=="read":
-				share.read = share.write = share.share = 0
-			elif permission_to=="write":
-				share.write = share.share = 0
-
 		share.save()
 
 		if not (share.read or share.write or share.share):

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -69,6 +69,11 @@ def set_permission(doctype, name, user, permission_to, value=1, everyone=0):
 		share.flags.ignore_permissions = True
 		share.set(permission_to, value)
 
+		if not value:
+			# un-set higher-order permissions too
+			if permission_to=="read":
+				share.read = share.write = share.share = 0
+
 		share.save()
 
 		if not (share.read or share.write or share.share):


### PR DESCRIPTION
last fix didn't include existing shares and doc-share cascade overwrote the write field
so cascade permissions has been removed to allow users who only have read perm to have sharing permissions
