### PR TITLE
Fixes issue where field 'javascript' in 'Website Script' Doctype brea…

### DIFF
--- a/frappe/www/website_script.py
+++ b/frappe/www/website_script.py
@@ -10,7 +10,7 @@ no_sitemap = 1
 base_template_path = "templates/www/website_script.js"
 
 def get_context(context):
-	context.javascript = frappe.db.get_single_value('Website Script', 'javascript')
+	context.javascript = frappe.db.get_single_value('Website Script', 'javascript') or ""
 
 	theme = get_active_theme()
 	js = strip(theme and theme.js or "")


### PR DESCRIPTION
…ks scripts delivery on website_script.py

Hi Team

I found a small compounded issue which involves the About page, Theme and Website Settings.

If you have javascript code in your Theme doctype, but empty javascript field in the Website Script doctype. When you Visit the About Us page, the javascript code previously entered in the theme doctype would not be added to the site. This was due to a silent error where the Website Script javascript field was returning None and failing to concatenate all javascript in website_script.py

The fix was simple thankfully, on frappe/www/website_script.py line 13

from:

> `context.javascript = frappe.db.get_single_value('Website Script', 'javascript')`

to:

> `context.javascript = frappe.db.get_single_value('Website Script', 'javascript') or ""`

Not sure why it was only happening on the About page for me but the above fixed it.
