### PR TITLE
Fix build error - Gantt

### DIFF
--- a/frappe/public/js/frappe/views/gantt.js
+++ b/frappe/public/js/frappe/views/gantt.js
@@ -167,8 +167,7 @@ var Gantt = Class.extend({
 	},
 	set_scroll_position: function() {
 		document.querySelector(this.opts.parent_selector).parentElement.scrollLeft =
-				this.get_min_date().diff(this.start, 'hours')
-				/ this.opts.step * this.opts.column_width;
+				this.get_min_date().diff(this.start, 'hours') / this.opts.step * this.opts.column_width;
 	},
 	get_min_date: function() {
 		return this.tasks.reduce(function(acc, curr) {


### PR DESCRIPTION
Fixes the following error when trying to do "bench build":

```
--Error in:/home/frappe/frappe-bench/apps/frappe/frappe/public/js/frappe/views/gantt.js--
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/build.py", line 130, in pack jsm.minify(tmpin, tmpout)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/minify.py", line 210, in minify self._jsmin()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/minify.py", line 180, in _jsmin self._action(3)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/minify.py", line 156, in _action raise UnterminatedRegularExpression()
UnterminatedRegularExpression
```

I think this problem is a case that is not controlled by the minifier but could not fix is there...
