### PR TITLE
Set e-mail attachments to checked by default

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -272,7 +272,7 @@ frappe.views.CommunicationComposer = Class.extend({
 				f.file_url = frappe.urllib.get_full_url(f.file_url);
 
 				$(repl('<p class="checkbox">'
-					+	'<label><span><input type="checkbox" data-file-name="%(name)s"></input></span>'
+					+	'<label><span><input type="checkbox" data-file-name="%(name)s" checked></input></span>'
 					+		'<span class="small">%(file_name)s</span>'
 					+	' <a href="%(file_url)s" target="_blank" class="text-muted small">'
 					+		'<i class="icon-share" style="vertical-align: middle; margin-left: 3px;"></i>'


### PR DESCRIPTION
The default setting for email attachments should be to attach, if there are files added to the document.
