### PR TITLE
[Fix] Prevent site creation failure in case installing.lock is not found

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -66,7 +66,9 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 		print "*** Scheduler is", scheduler_status, "***"
 
 	finally:
-		os.remove(installing)
+		if os.path.exists(installing):
+			os.remove(installing)
+
 		frappe.destroy()
 
 @click.command('restore')


### PR DESCRIPTION
- Many sites on central fail during install because no "installing.lock" file was present.
