### PR TITLE
Allow control over loading scripts in base.

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -78,13 +78,13 @@
 			{%- block footer -%}{% include "templates/includes/footer/footer.html" %}{%- endblock -%}
 		</div>
 	</div>
-
+	{% block base_scripts %}
 	<!-- js should be loaded in body! -->
 	<script type="text/javascript"
 		src="/assets/frappe/js/lib/jquery/jquery.min.js"></script>
 	<script type="text/javascript"
 		src="/assets/js/frappe-web.min.js"></script>
-
+	{% endblock %}
     {%- if js_globals is defined %}
     <script>
     {%- for key, value in js_globals.iteritems() %}


### PR DESCRIPTION
Some control over how base scripts are loaded would be helpful. Faced issue while integrating summernote within web page.
https://github.com/summernote/summernote/issues/138

For now, we have overridden base.html in custom app.
