### PR TITLE
[minor][fix] check workflow document state messages is translatable

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -364,7 +364,7 @@ def get_messages_from_workflow(doctype=None, app_name=None):
 			(w['name'],), as_dict=True)
 
 		messages.extend([("Workflow: " + w['name'], states['message'])
-			for state in states if is_translatable(state['state'])])
+			for state in states if is_translatable(state['message'])])
 
 		actions = frappe.db.sql(
 			'select distinct action from `tabWorkflow Transition` where parent=%s',


### PR DESCRIPTION
## WN-SUP20760

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/__init__.py", line 879, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/desk/form/load.py", line 70, in getdoctype
    docs = get_meta_bundle(doctype)
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/desk/form/load.py", line 81, in get_meta_bundle
    bundle = [frappe.desk.form.meta.get_meta(doctype)]
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/desk/form/meta.py", line 25, in get_meta
    meta.set_translations(frappe.local.lang)
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/desk/form/meta.py", line 159, in set_translations
    self.set("__messages", frappe.get_lang_dict("doctype", self.name))
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/__init__.py", line 61, in get_lang_dict
    return get_dict(fortype, name)
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/translate.py", line 107, in get_dict
    messages = get_messages_from_doctype(name)
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/translate.py", line 334, in get_messages_from_doctype
    messages.extend(get_messages_from_workflow(doctype=name))
  File "/home/frappe/benches/bench-2016-09-29/apps/frappe/frappe/translate.py", line 367, in get_messages_from_workflow
    for state in states if is_translatable(state['state'])])
KeyError: u'state'
```
