### PR TITLE
[hotfix] readd error_snapshot templates

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -140,6 +140,8 @@
 		"public/js/frappe/desk.js",
 		"public/js/frappe/query_string.js",
 
+		"public/html/error_object.html", 
+	  	"public/html/error_snapshot.html",
 		"public/js/frappe/ui/charts.js"
 	],
 	"js/d3.min.js": [


### PR DESCRIPTION
error snapshot templates where removed
https://github.com/frappe/frappe/commit/1e9bdec22dc692a272d87e89d3fb8dc97d13e1ad
have been moved in v7.1 but remains unusable in current master
https://github.com/frappe/frappe/commit/20d07706e7c5937e85e83559f740c27f6bded77e
