### PR TITLE
Will not redirect to document link after logged in

### DIFF
--- a/frappe/public/js/frappe/query_string.js
+++ b/frappe/public/js/frappe/query_string.js
@@ -5,8 +5,13 @@ function get_url_arg(name) {
 function get_query_params(query_string) {
 	var query_params = {};
 	if (!query_string) {
-		query_string = location.search.substring(1);
-	}
+        if (location.hash) {
+            query_string = location.search.substring(1) + location.hash;
+        }
+        else {
+            query_string = location.search.substring(1)
+        }
+    }
 
 	var query_list = query_string.split("&");
 	for (var i=0, l=query_list.length; i < l; i++ ){


### PR DESCRIPTION
Problem Summary

What we are trying to solve is we want to send a link that will redirect to a doctype for ex. http://localhost:8000/login?redirect-to=/Purchase%20Invoice/PINV-00006 this link should redirect the user to the doctype purchase invoice, but will ask for password first. What we failed to do is it should not ask the user to log in if the user is already logged in. But changing the link to http://localhost:8000/desk?redirect-to=/Purchase%20Invoice/PINV-00006 it will directly go to the invoice, but the problem is if the user is not logged in it will go to 403 page, but if the user will log in it will redirect the user to desk not to the invoice.

Steps to Reproduce the Problem
1. get a 'direct link' ex. http://localhost:8000/desk?redirect-to=/Purchase%20Invoice/PINV-00006
2. go to link 'direct link'
3. it will ask you to login
4. login successfully but it will just go to desk not to the invoice
5. get a direct link ex. http://localhost:8000/login?redirect-to=/Purchase%20Invoice/PINV-00006, but should change http://localhost:8000/desk? to http://localhost:8000/login?
6. go to the link
7. it will go to the invoice or any doctype