### PR TITLE
[Fix] Set default value for the backup_limit

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -144,3 +144,4 @@ execute:frappe.db.set_value("Print Settings", "Print Settings", "add_draft_headi
 frappe.patches.v7_0.cleanup_list_settings
 execute:frappe.db.set_default('language', '')
 frappe.patches.v7_1.refactor_integration_broker
+execute: frappe.db.set_value('System Settings', 'System Settings', 'backup_limit', 3)


### PR DESCRIPTION
- For existing users, we need to set default backup limit to 3.