### PR TITLE
Reorganise footer links

### DIFF
--- a/frappe/public/css/website.css
+++ b/frappe/public/css/website.css
@@ -827,6 +827,9 @@ a.active {
 .content-header {
   padding-bottom: 20px;
 }
+.footer-group {
+	margin-bottom: 28px;
+}
 .footer-group-label {
   display: inline-block;
   font-size: 11px;

--- a/frappe/public/less/website.less
+++ b/frappe/public/less/website.less
@@ -554,6 +554,10 @@ a.active {
 	padding-bottom:20px;
 }
 
+.footer-group {
+	margin-bottom: 28px;
+}
+
 .footer-group-label {
 	display:inline-block;
 	font-size: 11px;

--- a/frappe/templates/includes/footer/footer.html
+++ b/frappe/templates/includes/footer/footer.html
@@ -5,11 +5,9 @@
 				<div class="col-sm-6 text-left">
 					<div class="row">
 					{% if footer_items -%}
-						<div class="col-sm-3">
-							<ul class="list-unstyled navbar-nav">
-								{% include "templates/includes/footer/footer_items.html" %}
-							</ul>
-						</div>
+								<ul class="list-unstyled navbar-nav col-sm-12">
+									{% include "templates/includes/footer/footer_items.html" %}
+								</ul>
 					{% endif %}
 					</div>
 				</div>

--- a/frappe/templates/includes/footer/footer_items.html
+++ b/frappe/templates/includes/footer/footer_items.html
@@ -1,4 +1,5 @@
 {% for page in footer_items %}
+<div class="col-sm-4 footer-group">
 	{% if not page.parent_label -%}
 		<li data-label='{{ page.label }}'>
 		<a {% if not page.child_items -%} href="{{ (page.url or '')|abs_url }}" {%- endif %}
@@ -21,5 +22,6 @@
 		{%- endif -%}
 		</li>
 	{%- endif -%}
+	</div>
 {% endfor %}
 


### PR DESCRIPTION
Enabled stacking of footer link groups across three columns within outer col-sm-6. Added a new class to help style on group level.