### PR TITLE
Fix for Footer Address not showing in website

### DIFF
--- a/frappe/templates/includes/footer/footer.html
+++ b/frappe/templates/includes/footer/footer.html
@@ -21,7 +21,8 @@
 					{% if copyright %}
 						&copy; {{ copyright }}
 					{% endif %}
-					{% if footer_address%}
+					<br>
+					{% if footer_address %}
 						{{ footer_address }}
 					{% endif %}
 				</div>

--- a/frappe/templates/includes/footer/footer.html
+++ b/frappe/templates/includes/footer/footer.html
@@ -20,7 +20,8 @@
 				<div class="text-muted small col-sm-6">
 					{% if copyright %}
 						&copy; {{ copyright }}
-					{% elif footer_address%}
+					{% endif %}
+					{% if footer_address%}
 						{{ footer_address }}
 					{% endif %}
 				</div>


### PR DESCRIPTION
This is a probable fix for https://github.com/frappe/frappe/issues/2267
Due to earlier condition, only either copyright or the footer address was showing.
This is my first pull request. Kindly merge if everything seems right.