### PR TITLE
Remove rigidity with text css classes

### DIFF
--- a/frappe/public/css/website.css
+++ b/frappe/public/css/website.css
@@ -22,13 +22,13 @@ p {
   margin: 10px 0px;
 }
 .text-color {
-  color: #36414C !important;
+  color: #36414C;
 }
 .text-muted {
-  color: #8D99A6 !important;
+  color: #8D99A6;
 }
 .text-extra-muted {
-  color: #d1d8dd !important;
+  color: #d1d8dd;
 }
 a,
 .badge,


### PR DESCRIPTION
.text-muted {
  color: #8D99A6;
}
The above is already being set by [bootstrap.css](https://github.com/frappe/frappe/blob/develop/frappe/public/css/bootstrap.css)
By removing the !important tag, user can now easily set his own text color for these classes via the "Style using CSS" in a custom Website Theme.
I hope my hypothesis is right and this PR can be merged.
Only one concern is that I am not sure if the same classes are being used elsewhere where the color property is necessary to be fixed.