### PR TITLE
[fix] check page columns before appending fields

### DIFF
--- a/frappe/www/print.py
+++ b/frappe/www/print.py
@@ -270,6 +270,9 @@ def make_layout(doc, meta, format_data=None):
 			doc.set(df.fieldname, True) # show this field
 
 		if is_visible(df, doc) and has_value(df, doc):
+			if page[-1]['columns'] == []:
+				page[-1]['columns'].append({'fields': []})
+
 			page[-1]['columns'][-1]['fields'].append(df)
 
 			# section has fields


### PR DESCRIPTION
WN-SUP21672
---

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-11-14/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-11-14/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-11-14/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-11-14/apps/frappe/frappe/__init__.py", line 890, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-11-14/apps/frappe/frappe/www/print.py", line 175, in get_html_and_style
    no_letterhead=no_letterhead, trigger_print=trigger_print),
  File "/home/frappe/benches/bench-2016-11-14/apps/frappe/frappe/www/print.py", line 138, in get_html
    "layout": make_layout(doc, meta, format_data),
  File "/home/frappe/benches/bench-2016-11-14/apps/frappe/frappe/www/print.py", line 273, in make_layout
    page[-1]['columns'][-1]['fields'].append(df)
IndexError: list index out of range
```