### PR TITLE
[minor] check if file is image file using either file name or url

### DIFF
--- a/frappe/public/js/frappe/list/imageview.js
+++ b/frappe/public/js/frappe/list/imageview.js
@@ -37,7 +37,7 @@ frappe.views.ImageView = Class.extend({
 					} else{
 						// filter image files from other
 						images = r.message.filter(function(image){
-							return frappe.utils.is_image_file(image.title);
+							return frappe.utils.is_image_file(image.title? image.title: image.href);
 						});
 
 						if(images){


### PR DESCRIPTION
file_name is not available if web link is attached instead of file, So check if file is image or not using url