### PR TITLE
[fix] check for column field dict before appending child table data field

### DIFF
--- a/frappe/www/print.py
+++ b/frappe/www/print.py
@@ -232,6 +232,11 @@ def make_layout(doc, meta, format_data=None):
 
 	def get_new_section(): return  {'columns': [], 'has_data': False}
 
+	def append_empty_field_dict_to_page_column(page):
+		""" append empty columns dict to page layout """
+		if not page[-1]['columns']:
+			page[-1]['columns'].append({'fields': []})
+
 	for df in format_data or meta.fields:
 		if format_data:
 			# embellish df with original properties
@@ -263,16 +268,13 @@ def make_layout(doc, meta, format_data=None):
 
 		else:
 			# add a column if not yet added
-			if not page[-1]['columns']:
-				page[-1]['columns'].append({'fields': []})
+			append_empty_field_dict_to_page_column(page)
 
 		if df.fieldtype=="HTML" and df.options:
 			doc.set(df.fieldname, True) # show this field
 
 		if is_visible(df, doc) and has_value(df, doc):
-			if page[-1]['columns'] == []:
-				# if no column, add one
-				page[-1]['columns'].append({'fields': []})
+			append_empty_field_dict_to_page_column(page)
 
 			page[-1]['columns'][-1]['fields'].append(df)
 
@@ -293,6 +295,7 @@ def make_layout(doc, meta, format_data=None):
 						# new page, with empty section and column
 						page = [get_new_section()]
 						layout.append(page)
+						append_empty_field_dict_to_page_column(page)
 
 						# continue the table in a new page
 						df = copy.copy(df)


### PR DESCRIPTION
WN-SUP21811
---
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-11-17/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-11-17/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-11-17/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-11-17/apps/frappe/frappe/__init__.py", line 890, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-11-17/apps/frappe/frappe/www/print.py", line 175, in get_html_and_style
    no_letterhead=no_letterhead, trigger_print=trigger_print),
  File "/home/frappe/benches/bench-2016-11-17/apps/frappe/frappe/www/print.py", line 138, in get_html
    "layout": make_layout(doc, meta, format_data),
  File "/home/frappe/benches/bench-2016-11-17/apps/frappe/frappe/www/print.py", line 301, in make_layout
    page[-1]['columns'][-1]['fields'].append(df)
IndexError: list index out of range
```