### PR TITLE
Missing fields in unordered list

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -141,7 +141,7 @@ frappe.ui.form.save = function(frm, action, callback, btn) {
 			if(error_fields.length)
 				msgprint(__('Mandatory fields required in {0}', [(doc.parenttype
 					? (__(frappe.meta.docfield_map[doc.parenttype][doc.parentfield].label) + ' ('+ __("Table") + ')')
-					: __(doc.doctype))]) + '\n' + error_fields.join('\n'));
+					: __(doc.doctype))]) + '<br> <ul><li>' + error_fields.join('</li><li>') + "</ul>");
 		});
 
 		return !has_errors;


### PR DESCRIPTION
Change from:
![screen shot 2016-11-24 at 5 48 19 pm](https://cloud.githubusercontent.com/assets/1133954/20621046/059a388a-b2fd-11e6-837a-ec6da8e796d7.png)

To:
![screen shot 2016-11-24 at 5 48 36 pm](https://cloud.githubusercontent.com/assets/1133954/20621047/05ad1338-b2fd-11e6-8b83-d4b6aac7ab68.png)

I think it's much more readable, what do you think?

Regards