### PR TITLE
Fix error missing fields on fixtures translation

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -392,7 +392,7 @@ def get_messages_from_custom_fields(app_name):
 
 	for fixture in fixtures:
 		if isinstance(fixture, basestring) and fixture == 'Custom Field':
-			custom_fields = frappe.get_all('Custom Field')
+			custom_fields = frappe.get_all('Custom Field', fields=['name','label', 'description', 'fieldtype', 'options'])
 			break
 		elif isinstance(fixture, dict) and fixture.get('dt', fixture.get('doctype')) == 'Custom Field':
 			custom_fields.extend(frappe.get_all('Custom Field', filters=fixture.get('filters'),


### PR DESCRIPTION
Only name is currently taken from DB, other fields are mandatory to generate translations:

I was getting this error:

      File "/Users/pau/frappe-bench/env/lib/python2.7/site-packages/frappe/translate.py", line 407, in get_messages_from_custom_fields
        if cf['fieldtype'] == 'Selection' and cf.get('options'):
    KeyError: u'fieldtype'