### PR TITLE
[URGENT] Prevent accessing sensitive files in client.get_js

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -203,7 +203,7 @@ def get_js(items):
 	for src in items:
 		src = src.strip("/").split("/")
 
-		if ".." in src:
+		if ".." in src or src[0] != "assets":
 			frappe.throw(_("Invalid file path: {0}").format("/".join(src)))
 
 		contentpath = os.path.join(frappe.local.sites_path, *src)


### PR DESCRIPTION
Logged in user (any permissions) can access sensitive files by calling frappe.client.get_js

Consider the following scenario:
1- Login to system
2- http://HOST/?items=["currentsite.txt"]&cmd=frappe.client.get_js  (this will give you site directory name)
3- http://HOST/?items=["SITE_DIR_NAME%2Fsite_config.json"]&cmd=frappe.client.get_js (this will show you site config including database name and password and any other sensitive data

The suggested fix prevent accessing any file outside the assets folder. (or atleast you should prevent access to .py files and private folder which includes backup and sensetive files and logs folders)

There should be a hot fix asap