### PR TITLE
Carry over file attachments in email communications

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -66,6 +66,9 @@ def make(doctype=None, name=None, content=None, subject=None, sent_or_received =
 		comm.db_set(dict(reference_doctype='Communication', reference_name=comm.name))
 
 	# if not committed, delayed task doesn't find the communication
+	if attachments:
+		add_attachments(comm.name,attachments)
+	
 	frappe.db.commit()
 
 	if cint(send_email):
@@ -319,6 +322,20 @@ def get_cc(doc, recipients=None, fetched_from_email_account=False):
 		cc = filter_email_list(doc, cc, exclude, is_cc=True)
 
 	return cc
+
+
+def add_attachments(dn,attachments):
+	
+	from frappe.utils.file_manager import save_url
+
+	attachments = json.loads(attachments)
+	
+	# loop through attachments
+	for a in attachments:
+		attach = frappe.db.get_value("File",{"name":a},["file_name", "file_url", "is_private"],as_dict=1)
+				
+		# save attachments to new doc
+		save_url(attach.file_url, attach.file_name, "Communication", dn, "Home/Attachments", attach.is_private)
 
 def filter_email_list(doc, email_list, exclude, is_cc=False):
 	# temp variables

--- a/frappe/public/js/frappe/form/footer/attachments.js
+++ b/frappe/public/js/frappe/form/footer/attachments.js
@@ -228,7 +228,7 @@ frappe.ui.get_upload_dialog = function(opts){
 			'method': 'frappe.client.get_value',
 			'args': {
 			'doctype': 'File',
-			'fieldname': ['file_url','file_name'],
+			'fieldname': ['file_url','file_name','is_private'],
 			  'filters': {
 			      'name': dialog.get_value("file")
 			    }
@@ -236,6 +236,8 @@ frappe.ui.get_upload_dialog = function(opts){
 			callback: function(r){
 			    dialog.$wrapper.find('[name="file_url"]').val(r.message.file_url);
 				opts.args.filename = r.message.file_name
+				dialog.$wrapper.find('.private-file input').prop('checked',r.message.is_private)
+				
 			}
 	    });
 	});

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -31,10 +31,10 @@ frappe.views.CommunicationComposer = Class.extend({
 				});
 
 				// reset attachment list
-				me.setup_attach();
+				me.render_attach();
 
 				// check latest added
-				checked_items.push(attachment.file_name);
+				checked_items.push(attachment.name);
 
 				$.each(checked_items, function(i, filename) {
 					wrapper.find('[data-file-name="'+ filename +'"]').prop("checked", true);
@@ -258,15 +258,42 @@ frappe.views.CommunicationComposer = Class.extend({
 
 	},
 	setup_attach: function() {
-		if (!cur_frm) return;
-
 		var fields = this.dialog.fields_dict;
 		var attach = $(fields.select_attachments.wrapper);
 
-		var files = cur_frm.get_files();
+		var me = this
+		me.attachments = []
+		$("<h6 class='text-muted add-attachment' style='margin-top: 12px;cursor:pointer;'>"
+				+__("Add Attachments")+"<i class=\"octicon octicon-plus\" style=\"margin-left: 4px;\"></i></h6><div class='attach-list'></div>").appendTo(attach.empty())
+			attach.find(".add-attachment").on('click',this,function() {
+			me.upload = frappe.ui.get_upload_dialog(me.frm ? {
+				"args": me.frm ? me.frm.attachments.get_args() : {from_form: 1,folder:"Home/Attachments"},
+				"callback": function (attachment, r) {
+					me.frm.attachments.attachment_uploaded(attachment, r)
+				},
+				"max_width": me.frm.cscript ? me.frm.cscript.attachment_max_width : null,
+				"max_height": me.frm.cscript ? me.frm.cscript.attachment_max_height : null
+			}:
+			{
+			"args": {from_form: 1,folder:"Home/Attachments"},
+			"callback": function(attachment, r) { me.attachments.push(attachment)},
+			"max_width": null,
+			"max_height": null
+		});
+		})
+		me.render_attach()
+		
+	},
+	render_attach:function(){
+		var fields = this.dialog.fields_dict;
+		var attach = $(fields.select_attachments.wrapper).find(".attach-list").empty();
+
+		if (cur_frm){
+			var files = cur_frm.get_files();
+		}else {
+			var files = this.attachments
+		}
 		if(files.length) {
-			$("<h6 class='text-muted' style='margin-top: 12px;'>"
-				+__("Add Attachments")+"</h6>").appendTo(attach.empty());
 			$.each(files, function(i, f) {
 				if (!f.file_name) return;
 				f.file_url = frappe.urllib.get_full_url(f.file_url);

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -35,7 +35,7 @@ def upload():
 	if frappe.form_dict.filedata:
 		filedata = save_uploaded(dt, dn, folder, is_private)
 	elif file_url:
-		filedata = save_url(file_url, filename, dt, dn, folder)
+		filedata = save_url(file_url, filename, dt, dn, folder, is_private)
 
 	comment = {}
 	if dt and dn:
@@ -60,7 +60,7 @@ def save_uploaded(dt, dn, folder, is_private):
 	else:
 		raise Exception
 
-def save_url(file_url, filename, dt, dn, folder):
+def save_url(file_url, filename, dt, dn, folder, is_private):
 	# if not (file_url.startswith("http://") or file_url.startswith("https://")):
 	# 	frappe.msgprint("URL must start with 'http://' or 'https://'")
 	# 	return None, None
@@ -70,10 +70,11 @@ def save_url(file_url, filename, dt, dn, folder):
 	f = frappe.get_doc({
 		"doctype": "File",
 		"file_url": file_url,
-		"fieldname": filename,
+		"file_name": filename,
 		"attached_to_doctype": dt,
 		"attached_to_name": dn,
-		"folder": folder
+		"folder": folder,
+		"is_private": is_private
 	})
 	f.flags.ignore_permissions = True
 	try:


### PR DESCRIPTION
fix to add filename to links
added the ability to attach attachments from email dialog
add attachment links to communications sent from system
carry over is_private on file links