### PR TITLE
[FIXED] Problem with re-ordering grid items for non editable grid

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -629,6 +629,8 @@ frappe.ui.form.GridRow = Class.extend({
 		}
 	},
 	render_template: function() {
+		this.set_row_index();
+		
 		if(this.row_display) {
 			this.row_display.remove();
 		}


### PR DESCRIPTION
Re-ordering grid items for non editable grid results in a greyed out screen.