### PR TITLE
[fix] minor fix in dropbox callback response #6875

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -131,6 +131,7 @@ def get_dropbox_authorize_url():
 @frappe.whitelist(allow_guest=True)
 def dropbox_callback(oauth_token=None, not_approved=False):
 	doc = frappe.get_doc("Dropbox Settings")
+	close = '<p class="text-muted">' + _('Please close this window') + '</p>'
 
 	if not not_approved:
 		if doc.get_password(fieldname="dropbox_access_key", raise_exception=False)==oauth_token:
@@ -145,7 +146,6 @@ def dropbox_callback(oauth_token=None, not_approved=False):
 
 			frappe.db.commit()
 		else:
-			close = '<p class="text-muted">' + _('Please close this window') + '</p>'
 			frappe.respond_as_web_page(_("Dropbox Setup"),
 				_("Illegal Access Token. Please try again") + close,
 				success=False, http_status_code=frappe.AuthenticationError.http_status_code)


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/6875#issuecomment-270769906


```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 40, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 896, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 158, in dropbox_callback
    _("Dropbox access is approved!") + close,
UnboundLocalError: local variable 'close' referenced before assignment
```