### PR TITLE
[fix] remove dropbox backup from hooks, backup call is handled by integration service

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -139,12 +139,6 @@ scheduler_events = {
 		"frappe.email.doctype.auto_email_report.auto_email_report.send_daily",
 		"frappe.desk.page.backups.backups.delete_downloadable_backups"
 	],
-	"daily_long": [
-		"frappe.integrations.dropbox_integration.take_backups_daily"
-	],
-	"weekly_long": [
-		"frappe.integrations.dropbox_integration.take_backups_weekly"
-	],
 	"monthly": [
 		"frappe.email.doctype.auto_email_report.auto_email_report.send_monthly"
 	]

--- a/frappe/integration_broker/doctype/integration_service/test_integration_service.py
+++ b/frappe/integration_broker/doctype/integration_service/test_integration_service.py
@@ -15,6 +15,6 @@ class TestIntegrationService(unittest.TestCase):
 		dropbox_settings.db_set('enabled', 1)
 
 		events = get_scheduler_events('daily_long')
-		self.assertTrue('frappe.integrations.dropbox_integration.take_backups_daily' in events)
+		self.assertTrue('frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily' in events)
 
 		dropbox_settings.db_set('enabled', 0)

--- a/frappe/integration_broker/doctype/integration_service/test_integration_service.py
+++ b/frappe/integration_broker/doctype/integration_service/test_integration_service.py
@@ -11,10 +11,16 @@ from frappe.utils.scheduler import get_scheduler_events
 
 class TestIntegrationService(unittest.TestCase):
 	def test_scheudler_events(self):
-		dropbox_settings = frappe.get_doc('Dropbox Settings')
-		dropbox_settings.db_set('enabled', 1)
+		if not frappe.db.exists("Integration Service", "Dropbox"):
+			frappe.get_doc({
+				"doctype": "Integration Service",
+				"service": "Dropbox"
+			}).insert(ignore_permissions=True)
 
+		frappe.db.set_value("Integration Service", "Dropbox", "enabled", 1)
+		frappe.cache().delete_key('scheduler_events')
 		events = get_scheduler_events('daily_long')
+
 		self.assertTrue('frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily' in events)
 
-		dropbox_settings.db_set('enabled', 0)
+		frappe.db.set_value("Integration Service", "Dropbox", "enabled", 0)


### PR DESCRIPTION
https://discuss.erpnext.com/t/dropbox-background-job-error/19203