### PR TITLE
[FIXED] Unable to progress through workflow if "Only Allow Edit For" is Selected

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -933,7 +933,7 @@ _f.Frm.prototype.validate_form_action = function(action) {
 		var allowed_for_workflow = true;
 	}
 
-	if (!this.perm[0][perm_to_check]) {
+	if (!this.perm[0][perm_to_check] && !allowed_for_workflow) {
 		frappe.throw (__("No permission to '{0}' {1}", [__(action), __(this.doc.doctype)]));
 	}
 };

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -922,6 +922,16 @@ _f.Frm.prototype.action_perm_type_map = {
 
 _f.Frm.prototype.validate_form_action = function(action) {
 	var perm_to_check = this.action_perm_type_map[action];
+	var allowed_for_workflow = false;
+	var perms = frappe.perm.get_perm(this.doc.doctype)[0];
+
+	// Allow submit, write and create permissions for read only documents that are assigned by 
+	// workflows if the user already have those permissions. This is to allow for users to 
+	// continue through the workflow states and to allow execution of functions like Duplicate.
+	if (frappe.workflow.is_read_only(this.doctype, this.docname) && (perms["write"] ||
+		perms["create"] || perms["submit"])) {
+		var allowed_for_workflow = true;
+	}
 
 	if (!this.perm[0][perm_to_check]) {
 		frappe.throw (__("No permission to '{0}' {1}", [__(action), __(this.doc.doctype)]));


### PR DESCRIPTION
This issue arose from PR https://github.com/frappe/frappe/pull/2477 where set_read_only actually removed all permissions for the entire document except read. This effectively gave the user no permissions to perform workflow actions and functions like duplicate.

This also fixes the problem where a user is unable to duplicate a document if it is part of a workflow (create permissions required).