### PR TITLE
[enhance] provision to set default view for calendar

### DIFF
--- a/frappe/public/js/frappe/views/calendar.js
+++ b/frappe/public/js/frappe/views/calendar.js
@@ -94,6 +94,11 @@ frappe.views.Calendar = frappe.views.CalendarBase.extend({
 
 		this.$cal.fullCalendar(this.cal_options);
 		this.set_css();
+
+		if (this.setview) {
+			//can change view to ["agendaDay", "agendaWeek", "month"]
+			this.$cal.fullCalendar("changeView", this.setview);
+		}
 	},
 	set_css: function() {
 		// flatify buttons


### PR DESCRIPTION
https://discuss.erpnext.com/t/change-calendar-default-view-filter-data-using-default-date-filter/19201

- set view param value in _calendar.js file
```
frappe.views.calendar["Event"] = {
	field_map: {
		"start": "starts_on",
		"end": "ends_on",
		"id": "name",
		"allDay": "all_day",
		"title": "subject",
		"status": "event_type",
	},
	style_map: {
		"Public": "success",
		"Private": "info"
	},
	get_events_method: "frappe.desk.doctype.event.event.get_events",
	setview: "agendaWeek"
}
```
- view

<img width="1179" alt="screen shot 2017-01-11 at 4 29 28 pm" src="https://cloud.githubusercontent.com/assets/3784093/21846101/7b7cc2c8-d81b-11e6-8649-bc8e51a61909.png">
