### PR TITLE
Add validation for duplicate records when using 'sync_customizations'

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -104,7 +104,6 @@ def sync_customizations_for_doctype(data):
 			if not frappe.db.exists('Custom Field', d['name']):
 				doc = frappe.get_doc(d)
 				doc.db_insert()
-				doc.save()
 
 	if data['property_setters']:
 		frappe.db.sql('delete from `tabProperty Setter` where doc_type=%s', doctype)
@@ -114,9 +113,7 @@ def sync_customizations_for_doctype(data):
 			if not frappe.db.exists('Property Setter', d['name']):
 				doc = frappe.get_doc(d)
 				doc.db_insert()
-				doc.save()
-
-
+				
 def scrub(txt):
 	return frappe.scrub(txt)
 

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -99,22 +99,32 @@ def sync_customizations_for_doctype(data):
 	doctype = data['doctype']
 	if data['custom_fields']:
 		frappe.db.sql('delete from `tabCustom Field` where dt=%s', doctype)
-
 		for d in data['custom_fields']:
 			d['doctype'] = 'Custom Field'
-			doc = frappe.get_doc(d)
-			doc.db_insert()
+			# There are case where sync_customizations can cause conflict
+			# of duplicate records ex. myapp/setup/custom_install_script
+			# record_exists ensures that record in not there
+			record_exists = frappe.get_all('Custom Field',
+									       filters={'name': d['name']})
+			if not record_exists:
+				doc = frappe.get_doc(d)
+				doc.db_insert()
+				doc.save()
 
 	if data['property_setters']:
 		frappe.db.sql('delete from `tabProperty Setter` where doc_type=%s', doctype)
 
 		for d in data['property_setters']:
 			d['doctype'] = 'Property Setter'
-			doc = frappe.get_doc(d)
-			doc.db_insert()
-
-	print 'Updating customizations for {0}'.format(doctype)
-	validate_fields_for_doctype(doctype)
+			# There are case where sync_customizations can cause conflict
+			# of duplicate records ex. myapp/setup/custom_install_script
+			# record_exists ensures that record in not there
+			record_exists = frappe.get_all('Property Setter',
+									       filters={'name': d['name']})
+			if not record_exists:
+				doc = frappe.get_doc(d)
+				doc.db_insert()
+				doc.save()
 
 
 def scrub(txt):

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -101,12 +101,7 @@ def sync_customizations_for_doctype(data):
 		frappe.db.sql('delete from `tabCustom Field` where dt=%s', doctype)
 		for d in data['custom_fields']:
 			d['doctype'] = 'Custom Field'
-			# There are case where sync_customizations can cause conflict
-			# of duplicate records ex. myapp/setup/custom_install_script
-			# record_exists ensures that record in not there
-			record_exists = frappe.get_all('Custom Field',
-									       filters={'name': d['name']})
-			if not record_exists:
+			if not frappe.db.exists('Custom Field', d['name']):
 				doc = frappe.get_doc(d)
 				doc.db_insert()
 				doc.save()
@@ -116,12 +111,7 @@ def sync_customizations_for_doctype(data):
 
 		for d in data['property_setters']:
 			d['doctype'] = 'Property Setter'
-			# There are case where sync_customizations can cause conflict
-			# of duplicate records ex. myapp/setup/custom_install_script
-			# record_exists ensures that record in not there
-			record_exists = frappe.get_all('Property Setter',
-									       filters={'name': d['name']})
-			if not record_exists:
+			if not frappe.db.exists('Property Setter', d['name']):
 				doc = frappe.get_doc(d)
 				doc.db_insert()
 				doc.save()


### PR DESCRIPTION
There are case there sync_customization may cause duplicate error. 

For example if you use the pattern : myapp/myapp/custom (A folder that hold the custom json files using for UI "Customize Form" utility and export customization btn)

This a minor improvement for that problem and is test to dev production. 
