### PR TITLE
make report results ltr to work with SlickGrid

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -55,7 +55,8 @@
 	],
 	"css/frappe-rtl.css": [
 		"public/css/bootstrap-rtl.css",
-		"public/css/desk-rtl.css"
+		"public/css/desk-rtl.css",
+		"public/css/report-rtl.css"
 	],
 	"js/libs.min.js": [
 		"public/js/lib/awesomplete/awesomplete.min.js",

--- a/frappe/public/css/report-rtl.css
+++ b/frappe/public/css/report-rtl.css
@@ -1,0 +1,3 @@
+.results {
+  direction: ltr;
+}

--- a/frappe/public/css/report-rtl.css
+++ b/frappe/public/css/report-rtl.css
@@ -1,3 +1,3 @@
-.results {
+.grid-report {
   direction: ltr;
 }


### PR DESCRIPTION
Since no clear answer were given in the [forums](https://discuss.erpnext.com/t/remove-inline-and-code-generated-css/19137), I am not sure when (or if) another grid system will be implemented.
 I think we should exclude the report results of the RTL support. 