### PR TITLE
[fix] fix restore timeout

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -38,6 +38,7 @@ def install_db(root_login="root", root_password=None, db_name=None, source_sql=N
 	frappe.connect(db_name=db_name)
 	check_if_ready_for_barracuda()
 	import_db_from_sql(source_sql, verbose)
+	frappe.connect(db_name=db_name) #previous step creates own connection and can cause db timeout
 	remove_missing_apps()
 
 	create_auth_table()

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -37,6 +37,7 @@ def install_db(root_login="root", root_password=None, db_name=None, source_sql=N
 
 	frappe.connect(db_name=db_name)
 	check_if_ready_for_barracuda()
+	frappe.db.close()
 	import_db_from_sql(source_sql, verbose)
 	frappe.connect(db_name=db_name) #previous step creates own connection and can cause db timeout
 	remove_missing_apps()


### PR DESCRIPTION
for crappy servers where the restore connection takes longer than 10 mins the create auth table has no connection as it's timed out so just create a new