### PR TITLE
Add or_filters filter for export_fixtures, to filter by doctype, fieldnames etc

### DIFF
--- a/frappe/core/page/data_import_tool/data_import_tool.py
+++ b/frappe/core/page/data_import_tool/data_import_tool.py
@@ -40,7 +40,7 @@ def export_csv(doctype, path):
 		get_template(doctype=doctype, all_doctypes="Yes", with_data="Yes")
 		csvfile.write(frappe.response.result.encode("utf-8"))
 
-def export_json(doctype, path, filters=None, name=None):
+def export_json(doctype, path, filters=None, or_filters=None, name=None):
 	def post_process(out):
 		del_keys = ('parent', 'parentfield', 'parenttype', 'modified_by', 'creation', 'owner', 'idx')
 		for doc in out:
@@ -60,7 +60,7 @@ def export_json(doctype, path, filters=None, name=None):
 	elif frappe.db.get_value("DocType", doctype, "issingle"):
 		out.append(frappe.get_doc(doctype).as_dict())
 	else:
-		for doc in frappe.get_all(doctype, fields=["name"], filters=filters, limit_page_length=0, order_by="creation asc"):
+		for doc in frappe.get_all(doctype, fields=["name"], filters=filters, or_filters=or_filters, limit_page_length=0, order_by="creation asc"):
 			out.append(frappe.get_doc(doctype, doc.name).as_dict())
 	post_process(out)
 

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -55,11 +55,13 @@ def export_fixtures():
 	for app in frappe.get_installed_apps():
 		for fixture in frappe.get_hooks("fixtures", app_name=app):
 			filters = None
+			or_filters = None
 			if isinstance(fixture, dict):
 				filters = fixture.get("filters")
+				or_filters = fixture.get("or_filters")
 				fixture = fixture.get("doctype") or fixture.get("dt")
-			print "Exporting {0} app {1} filters {2}".format(fixture, app, filters)
+			print "Exporting {0} app {1} filters {2}".format(fixture, app, (filters if filters else or_filters))
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))
 
-			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"), filters=filters)
+			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"), filters=filters, or_filters=or_filters)


### PR DESCRIPTION
Add or_filters filter for export_fixtures, to filter by doctype or fieldnames
Eg:
fixtures = [
        {
        "doctype": "Custom Field",
        "or_filters": {
            "dt": ["in", [
                "Process Payroll",
                "Journal Entry Account"
            ]],
            "name": ["in", [
                "Print Settings-compact_item_print",
                "Account-account_id",
                "Account-some_bank_name"
            ]]
        }
    }
]