### PR TITLE
Set Only Once for Datetime

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -545,7 +545,7 @@ class BaseDocument(object):
 			df = self.meta.get_field(fieldname)
 
 			# This conversion to string only when fieldtype is Date
-			if df.fieldtype == 'Date':
+			if df.fieldtype == 'Date' or df.fieldtype == 'Datetime':
 				value = str(values.get(fieldname))
 
 			else:


### PR DESCRIPTION
The same problem that Date was facing appears with Datetime, otherwise it fails as it is comparing different types.