### PR TITLE
[FIX] rss.xml broken on all instances of frappe

### DIFF
--- a/frappe/www/rss.py
+++ b/frappe/www/rss.py
@@ -20,7 +20,7 @@ def get_context(context):
 		order by published_on desc limit 20""", as_dict=1)
 
 	for blog in blog_list:
-		blog_page = cstr(urllib.quote(blog.route.encode("utf-8")))
+		blog_page = cstr(urllib.quote(blog.name.encode("utf-8")))
 		blog.link = urllib.basejoin(host, blog_page)
 		blog.content = escape_html(blog.content or "")
 


### PR DESCRIPTION
rss.xml is broken on all frappe instances I've checked, including the frappe.io site. The culprit was a small column alias change a few months back. This fixes that change.