### PR TITLE
[minor][fix] consider route options only if report filters not exists

### DIFF
--- a/frappe/public/js/frappe/views/reports/reportview.js
+++ b/frappe/public/js/frappe/views/reports/reportview.js
@@ -212,7 +212,7 @@ frappe.views.ReportView = frappe.ui.Listing.extend({
 
 	set_route_filters: function(first_load) {
 		var me = this;
-		if(frappe.route_options) {
+		if(frappe.route_options && !this.list_settings.filters) {
 			this.set_filters_from_route_options();
 			return true;
 		} else if(this.list_settings


### PR DESCRIPTION
WN-SUP22618
---

As frappe.route_options are set in issue_list.js, the system not settings filters specified in a report via report builder.