### PR TITLE
alternative fix for allow page break inside tables

### DIFF
--- a/frappe/www/print.py
+++ b/frappe/www/print.py
@@ -433,6 +433,15 @@ def column_has_value(data, fieldname):
 
 trigger_print_script = """
 <script>
+//allow wrapping of long tr
+var elements = document.getElementsByTagName("tr");
+var i = elements.length;
+while (i--) {
+	if(elements[i].clientHeight>300){
+		elements[i].setAttribute("style", "page-break-inside: auto;");
+	}
+}
+
 window.print();
 
 // close the window after print


### PR DESCRIPTION
alternative solution to page breaking inside tables frappe/frappe#2518

but rather than just turning on of off page breaks dynamicly allow based on the row height means small rows arent split but big rows can be