### PR TITLE
Check if doc.status has indexOf method, e.g. not a number

### DIFF
--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -67,7 +67,7 @@ frappe.get_indicator = function(doc, doctype) {
 	}
 
 	// based on status
-	if(doc.status) {
+	if(doc.status && doc.status.indexOf !== undefined) {
 		return [__(doc.status), frappe.utils.guess_colour(doc.status)];
 	}
 


### PR DESCRIPTION
We have a bug that causes the page to not load showing the following exception:

    TypeError: item.indexOf is not a function[Learn More]           desk.min.js:2332:6

I tracked the issue down to `has_words`.

```javascript
function has_words(list, item) {
	if(!item) return true;
	if(!list) return false;
	for(var i=0, j=list.length; i<j; i++) {
		if(item.indexOf(list[i])!=-1) // item is number in my case
			return true;
	}
	return false;
}
```

In my case, `doc.status` is a custom filed that holds _an integer_. `frappe.utils.guess_colour` will eventually call `has_words` that calls `doc.status.indexOf`. This fix checks if `doc.status` actually has `indexOf` before calling `frappe.utils.guess_colour`.