### PR TITLE
[hotfix] stop frappe sending automatic responses from non user genera…

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -361,6 +361,12 @@ class EmailAccount(Document):
 			communication.reference_doctype = parent.doctype
 			communication.reference_name = parent.name
 
+		# check if message is notification and disable notifications for this message
+		isnotification = email.mail.get("isnotification")
+		if isnotification:
+			if "notification" in isnotification:
+				communication.unread_notification_sent = 1
+
 	def set_sender_field_and_subject_field(self):
 		'''Identify the sender and subject fields from the `append_to` DocType'''
 		# set subject_field and sender_field

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -188,6 +188,7 @@ class EMail:
 			self.msg_root["Message-Id"] = '<' + message_id + '>'
 		else:
 			self.msg_root["Message-Id"] = get_message_id()
+			self.msg_root["isnotification"] = '<notification>'
 
 	def set_in_reply_to(self, in_reply_to):
 		"""Used to send the Message-Id of a received email back as In-Reply-To"""


### PR DESCRIPTION
…ted emails

stops automated response from anything not sent by user by attaching a customer header that should be ignored by everything other than frappe
will also stop 2 frappe servers infinitely sending emails