### PR TITLE
[fix] show action after duplicate having no action

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -234,6 +234,7 @@ frappe.ui.form.Toolbar = Class.extend({
 			}
 		} else {
 			this.page.clear_actions();
+			this.current_status = null
 		}
 	},
 	get_action_status: function() {


### PR DESCRIPTION
fix's missing save button after duplicate

issue caused when 
user loads a doc with save permission ie draft
user loads doc they dont have permission to perform primary action ie cancel submitted doc
![image](https://cloud.githubusercontent.com/assets/15826176/22675741/6dbd5eb0-ed22-11e6-8687-1566de3d8093.png)

user duplicates the doc
new doc wont contain save as last current_status = "save"
![image](https://cloud.githubusercontent.com/assets/15826176/22675730/5a09edc0-ed22-11e6-8bc0-8aefa3f00925.png)
