### PR TITLE
[optimize] reduces performance impact of filter dashboard and cleanup

### DIFF
--- a/frappe/public/css/bootstrap.css
+++ b/frappe/public/css/bootstrap.css
@@ -3405,7 +3405,7 @@ tbody.collapse.in {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 1000;
+  z-index: 100;
   display: none;
   float: left;
   min-width: 160px;

--- a/frappe/public/css/bootstrap.css
+++ b/frappe/public/css/bootstrap.css
@@ -3405,7 +3405,7 @@ tbody.collapse.in {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 100;
+  z-index: 1000;
   display: none;
   float: left;
   min-width: 160px;

--- a/frappe/public/css/filter_dashboard.css
+++ b/frappe/public/css/filter_dashboard.css
@@ -106,13 +106,13 @@
 }
 .filter-loading-background {
   position: absolute;
-  background-color:#e6e6e6;
+  background-color: #e6e6e6;
   top: 0px;
   left: 0px;
   bottom: 0px;
   right: 0px;
-  z-index:100;
-  opacity:0.2;
+  z-index: 100;
+  opacity: 0.2;
 }
 .filter-loading-message {
   position: absolute;
@@ -122,6 +122,6 @@
   transform: translate(-50%, -50%);
   -webkit-transform: translate(-50%, -50%);
   text-align: center;
-  opacity:1 !important;
+  opacity: 1 !important;
   color: #36414C !important;
 }

--- a/frappe/public/css/filter_dashboard.css
+++ b/frappe/public/css/filter_dashboard.css
@@ -10,6 +10,7 @@
   padding-bottom: 0px;
 }
 .list-filter-dashboard {
+  position: relative;
   border-top: 1px solid #d1d8dd;
   overflow-x: scroll;
   overflow-y: hidden;
@@ -103,6 +104,14 @@
 }
 .filter-dash-controls > .filter-label {
   padding-bottom: 5px;
+}
+.age-dropdown {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+.age-wrapper {
+  border-top: 1px solid #d1d8dd;
+  padding-bottom: 2px;
 }
 .filter-loading-background {
   position: absolute;

--- a/frappe/public/css/filter_dashboard.css
+++ b/frappe/public/css/filter_dashboard.css
@@ -104,3 +104,24 @@
 .filter-dash-controls > .filter-label {
   padding-bottom: 5px;
 }
+.filter-loading-background {
+  position: absolute;
+  background-color:#e6e6e6;
+  top: 0px;
+  left: 0px;
+  bottom: 0px;
+  right: 0px;
+  z-index:100;
+  opacity:0.2;
+}
+.filter-loading-message {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  text-align: center;
+  opacity:1 !important;
+  color: #36414C !important;
+}

--- a/frappe/public/js/frappe/list/doclistview.js
+++ b/frappe/public/js/frappe/list/doclistview.js
@@ -388,9 +388,6 @@ frappe.views.DocListView = frappe.ui.Listing.extend({
 	execute_run: function() {
 		if(this.dirty) {
 			this.run();
-			if (this.clean_dash != true) {
-				this.filter_list.reload_stats();
-			}
 		} else {
 			if(new Date() - (this.last_updated_on || 0) > 30000) {
 				// older than 5 mins, refresh

--- a/frappe/public/js/frappe/ui/filters/filter_dashboard.html
+++ b/frappe/public/js/frappe/ui/filters/filter_dashboard.html
@@ -1,5 +1,9 @@
 <div class="filter_area">
     <div class="filter-dashboard-wrapper">
+        <div class="filter-loading">
+        <div class="filter-loading-background"></div>
+        <div class="filter-loading-message">Loading</div>
+            </div>
         <div class="list-filter-dashboard">
             <div class="filter-dashboard-items">
 

--- a/frappe/public/js/frappe/ui/filters/filter_dashboard.html
+++ b/frappe/public/js/frappe/ui/filters/filter_dashboard.html
@@ -1,9 +1,9 @@
 <div class="filter_area">
     <div class="filter-dashboard-wrapper">
         <div class="filter-loading">
-        <div class="filter-loading-background"></div>
-        <div class="filter-loading-message">Loading</div>
-            </div>
+            <div class="filter-loading-background"></div>
+            <div class="filter-loading-message">{%= __("Loading filters") %}</div>
+        </div>
         <div class="list-filter-dashboard">
             <div class="filter-dashboard-items">
 

--- a/frappe/public/js/frappe/ui/filters/filter_dashboard.html
+++ b/frappe/public/js/frappe/ui/filters/filter_dashboard.html
@@ -1,10 +1,35 @@
 <div class="filter_area">
     <div class="filter-dashboard-wrapper">
-        <div class="filter-loading">
-            <div class="filter-loading-background"></div>
-            <div class="filter-loading-message">{%= __("Loading filters") %}</div>
+        <div class="age-wrapper clearfix">
+            <div class="pull-left dropdown age-dropdown">
+	            <a class="dropdown-toggle text-muted small" data-toggle="dropdown" 
+	               aria-haspopup="true" aria-expanded="true">
+		            <span class="field_label">{{ __(field_label) }}</span><span class="caret"></span>
+	            </a>
+	            <ul class="dropdown-menu">
+	                {% for value in dashboard_age_fields %}
+		            <li><a class="age_fields" data-field="{{ value.fieldname }}">{{ __(value.label) }}</a></li>
+	                {% endfor %}
+	            </ul>
+            </div>
+            <div class="pull-left dropdown">
+                <a class="dropdown-toggle text-muted small" data-toggle="dropdown" 
+                   aria-haspopup="true" aria-expanded="true">
+	                <span class="date_label">{{ __(date_label) }}</span><span class="caret"></span>
+                </a>
+	            <ul class="dropdown-menu">
+                {% for value in dashboard_age_dates %}
+	                <li><a class="age_dates" data-date="{{ value.label }}">{{ __(value.label) }}</a></li>
+                {% endfor %}
+	            </ul>
+            </div>
         </div>
+        
         <div class="list-filter-dashboard">
+            <div class="filter-loading">
+                <div class="filter-loading-background"></div>
+                <div class="filter-loading-message">{%= __("Loading filters") %}</div>
+            </div>
             <div class="filter-dashboard-items">
 
             </div>

--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -58,12 +58,12 @@ frappe.ui.FilterList = Class.extend({
 	},
 	show_filter_list: function(){
 		$(this.filter_list_wrapper).toggle(true);
-		this.show_filter_button.prop('title',__("Hide Filters"));
+		this.show_filter_button.text(__("Hide Filters"));
 		this.filters_visible = true;
 	},
 	hide_filter_list: function(){
 		$(this.filter_list_wrapper).toggle(false);
-		this.show_filter_button.prop('title',__("Show Filters"));
+		this.show_filter_button.text(__("Show Filters"));
 		this.filters_visible = false;
 	},
 	render_dashboard_headers: function(field){

--- a/frappe/public/less/filter_dashboard.less
+++ b/frappe/public/less/filter_dashboard.less
@@ -15,6 +15,7 @@
 }
 
 .list-filter-dashboard {
+    position: relative;
 	border-top: 1px solid @border-color;
     overflow-x: scroll;
 	overflow-y: hidden;
@@ -128,25 +129,34 @@
     padding-bottom: 5px;
 }
 
+.age-dropdown {
+    padding-left:10px;
+    padding-right:10px;
+}
+.age-wrapper {
+  border-top: 1px solid @border-color;
+  padding-bottom: 2px;
+}
+
 .filter-loading-background {
-  position: absolute;
-  background-color: #e6e6e6;
-  top: 0px;
-  left: 0px;
-  bottom: 0px;
-  right: 0px;
-  z-index: 100;
-  opacity: 0.2;
+    position: absolute;
+    background-color: #e6e6e6;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+    z-index: 100;
+    opacity: 0.2;
 }
 
 .filter-loading-message {
-  position: absolute;  
-  top: 50%;
-  left: 50%;
-  width: 100%;
-  transform: translate(-50%, -50%);
-  -webkit-transform: translate(-50%, -50%);  
-  text-align: center;
-  opacity: 1 !important;
-  color: @text-color !important;
+    position: absolute;  
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    transform: translate(-50%, -50%);
+    -webkit-transform: translate(-50%, -50%);  
+    text-align: center;
+    opacity: 1 !important;
+    color: @text-color !important;
 }

--- a/frappe/public/less/filter_dashboard.less
+++ b/frappe/public/less/filter_dashboard.less
@@ -127,3 +127,26 @@
 .filter-dash-controls >.filter-label {
     padding-bottom: 5px;
 }
+
+.filter-loading-background {
+  position: absolute;
+  background-color: #e6e6e6;
+  top: 0px;
+  left: 0px;
+  bottom: 0px;
+  right: 0px;
+  z-index: 100;
+  opacity: 0.2;
+}
+
+.filter-loading-message {
+  position: absolute;  
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);  
+  text-align: center;
+  opacity: 1 !important;
+  color: @text-color !important;
+}


### PR DESCRIPTION
filter dashboard only loaded now when user opens
dashboard now has temp table optimisation to shorten query time 10x
dashboard now has age filters to reduce data fetch and show dashboard for timeframe saves in list_settings
also fix for dropdown menu being under top banner when scrolling down

