### PR TITLE
[minor] Changed a link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/frappe/frappe.png)](https://travis-ci.org/frappe/frappe)
 
-Full-stack web application framework that uses Python and MariaDB on the server side and a tightly integrated client side library. [Built for ERPNext](https://erpnext.com)
+Full-stack web application framework that uses Python and MariaDB on the server side and a tightly integrated client side library. Built for [ERPNext](https://erpnext.com)
 
 ### Installation
 


### PR DESCRIPTION
[Built for ERPNext](https://erpnext.com)
This link does not describe stuff built for ERPNext it is actually the website of ERPNext and so the link was changed to:
Built for [ERPNext](https://erpnext.com)