### PR TITLE
[patch] reload document before running patch && remove whitespaces

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -158,6 +158,6 @@ frappe.patches.v7_0.update_report_builder_json
 frappe.patches.v7_2.set_in_standard_filter_property #1
 execute:frappe.db.sql("update tabCommunication set communication_date = creation where time(communication_date) = 0")
 frappe.patches.v7_2.fix_email_queue_recipient
-frappe.patches.v7_2.update_feedback_request
+frappe.patches.v7_2.update_feedback_request # 2017-02-27
 execute:frappe.rename_doc('Country', 'Macedonia, Republic of', 'Macedonia', ignore_if_exists=True)
 execute:frappe.rename_doc('Country', 'Tanzania, United Republic of', 'Tanzania', ignore_if_exists=True)

--- a/frappe/patches/v7_2/update_feedback_request.py
+++ b/frappe/patches/v7_2/update_feedback_request.py
@@ -1,33 +1,34 @@
 import frappe
 
 def execute():
-    """
-        rename feedback request documents,
-        update the feedback request and save the rating and communication
-        reference in Feedback Request document
-    """
-    
-    feedback_requests = frappe.get_all("Feedback Request")
-    for request in feedback_requests:
-        communication, rating = frappe.db.get_value("Communication", { "feedback_request": request.get("name") },
-            ["name", "rating"]) or [None, 0]
-        
-        if communication:
-            frappe.db.sql("""update `tabFeedback Request` set reference_communication='{communication}',
-                rating={rating} where name='{feedback_request}'""".format(
-                    communication=communication,
-                    rating=rating or 0,
-                    feedback_request=request.get("name")
-                ))
-        
-        if "Feedback" not in request.get("name"):
-            # rename the feedback request doc
-            reference_name, creation = frappe.db.get_value("Feedback Request", request.get("name"), ["name", "creation"])
-            oldname = request.get("name")
-            newname = "Feedback for {doctype} {docname} on {datetime}".format(
-    			doctype="Feedback Request",
-    			docname=reference_name,
-    			datetime=creation
-    		)
-            frappe.rename_doc("Feedback Request", oldname, newname, ignore_permissions=True)
-            if communication: frappe.db.set_value("Communication", communication, "feedback_request", newname)
+	"""
+		rename feedback request documents,
+		update the feedback request and save the rating and communication
+		reference in Feedback Request document
+	"""
+
+	frappe.reload_doc("core", "doctype", "feedback_request")
+	feedback_requests = frappe.get_all("Feedback Request")
+	for request in feedback_requests:
+		communication, rating = frappe.db.get_value("Communication", { "feedback_request": request.get("name") },
+			["name", "rating"]) or [None, 0]
+
+		if communication:
+			frappe.db.sql("""update `tabFeedback Request` set reference_communication='{communication}',
+				rating={rating} where name='{feedback_request}'""".format(
+					communication=communication,
+					rating=rating or 0,
+					feedback_request=request.get("name")
+			))
+
+		if "Feedback" not in request.get("name"):
+			# rename the feedback request doc
+			reference_name, creation = frappe.db.get_value("Feedback Request", request.get("name"), ["name", "creation"])
+			oldname = request.get("name")
+			newname = "Feedback for {doctype} {docname} on {datetime}".format(
+				doctype="Feedback Request",
+				docname=reference_name,
+				datetime=creation
+			)
+			frappe.rename_doc("Feedback Request", oldname, newname, ignore_permissions=True)
+			if communication: frappe.db.set_value("Communication", communication, "feedback_request", newname)


### PR DESCRIPTION
```
INFO:bench.app:pulling razorpay_integration
From https://github.com/frappe/razorpay_integration
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Requirement already up-to-date: pip in ./env/lib/python2.7/site-packages
Migrating erpnext-fix
Executing frappe.patches.v7_2.update_feedback_request in erpnext-fix (d05df03cf4)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/commands/site.py", line 210, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/migrate.py", line 30, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/patches/v7_2/update_feedback_request.py", line 20, in execute
    feedback_request=request.get("name")
  File "/Users/umairsayyed/frappe-bench/apps/frappe/frappe/database.py", line 149, in sql
    self._cursor.execute(query)
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
    self.errorhandler(self, exc, value)
  File "/Users/umairsayyed/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
_mysql_exceptions.OperationalError: (1054, "Unknown column 'reference_communication' in 'field list'")
```