### PR TITLE
Export parent field in fixtures for Custom DocPerm

### DIFF
--- a/frappe/core/page/data_import_tool/data_import_tool.py
+++ b/frappe/core/page/data_import_tool/data_import_tool.py
@@ -46,7 +46,10 @@ def export_json(doctype, path, filters=None, or_filters=None, name=None):
 		for doc in out:
 			for key in del_keys:
 				if key in doc:
-					del doc[key]
+					if doc.doctype == 'Custom DocPerm' and key == 'parent':
+						pass
+					else:
+						del doc[key]
 			for k, v in doc.items():
 				if isinstance(v, list):
 					for child in v:


### PR DESCRIPTION
Modified to be able to export parent field for Custom DocPerm, the intent is to merge 1 file only, see:

https://github.com/joezsweet/frappe/commit/dcfbb057838be97f22fcd511cb338a6fb16c950a

Not sure why it's showing so many changes !!!!

Can you please double check?

