### PR TITLE
Fix _ translation function to handle the correct passed lang

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -48,7 +48,8 @@ def _(msg, lang=None):
 	# msg should always be unicode
 	msg = as_unicode(msg).strip()
 
-	return get_full_dict(local.lang).get(msg) or msg
+	# Retrun lang_full_dict according to lang passed parameter
+	return get_full_dict(lang).get(msg) or msg
 
 def as_unicode(text, encoding='utf-8'):
 	'''Convert to unicode if required'''

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -180,7 +180,9 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if getattr(frappe.local, 'lang_full_dict', None) is not None:
+	# Check if the passed lang exists in lang_full_dict cash in frappe
+	if not getattr(frappe.local, 'lang_full_dict',
+				None) is None and frappe.local.lang_full_dict and lang in frappe.local.lang_full_dict:
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)


### PR DESCRIPTION
This pull request handles a seems-to-be bug. The _ translation function of frappe, for the first time running, it uploads the translation cash in lang_full_dict. if the user asks for another translation or even the original English translation, the _ returns the cashed translated language.
I have edited the condition of getting translations from frappe.cash() so that every request of a new language will be uploaded to cash and then called from cash.
Another fix is that the passed parameter to _ function: lang is ignored, and the translation is always done according to the frappe.local.lang value, no matter the passed lang is.
Previously:
if  frappe.local.lang = "ar" and having the translation of "Refunded" in .csv file:
 _("Refunded", "en") >>u'Refunded' >> Returns right value for the cash has lang_full_dict None
    message2 = _("Refunded") >>  u'مرجع' >> AR translation file is uploaded to frappe.cash()
 _("Refunded", "en") >>  u'مرجع' >> Still having the arabic translated word back since the passed lang is ignored.
If frappe.local.lang = "en" and having the translation of "Refunded" in .csv file:
    message3 = _("Refunded", "ar") >> If arabic in cash, returns  u'مرجع', if translation cash is None, returns u'Refunded'
    message4 = _("Refunded", "en") >> If arabic in cash, returns  u'مرجع', if translation cash is None, returns u'Refunded'
    message25 = _("Refunded")  If arabic in cash, returns مرجع, if translation cash is None, returns u'Refunded'

After this pull request:
If  frappe.local.lang = "ar" and having the translation of "Refunded" in .csv file:
    message = _("Refunded", "en") >> u'Refunded'
    message2 = _("Refunded") >> u'مرجع'
 If frappe.local.lang = "en"  and having the translation of "Refunded" in .csv file:
    message3 = _("Refunded", "ar") >>  u'مرجع'
    message4 = _("Refunded", "en") >> u'Refunded'
    message25 = _("Refunded") >> u'Refunded'
