### PR TITLE
Translate the msg in _ function according to the passed lang, support…

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -48,7 +48,7 @@ def _(msg, lang=None):
 	# msg should always be unicode
 	msg = as_unicode(msg).strip()
 
-	# Retrun lang_full_dict according to lang passed parameter
+	# retrun lang_full_dict according to lang passed parameter
 	return get_full_dict(lang).get(msg) or msg
 
 def as_unicode(text, encoding='utf-8'):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -48,7 +48,7 @@ def _(msg, lang=None):
 	# msg should always be unicode
 	msg = as_unicode(msg).strip()
 
-	# Retrun lang_full_dict according to lang passed parameter
+	# return lang_full_dict according to lang passed parameter
 	return get_full_dict(lang).get(msg) or msg
 
 def as_unicode(text, encoding='utf-8'):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -48,7 +48,8 @@ def _(msg, lang=None):
 	# msg should always be unicode
 	msg = as_unicode(msg).strip()
 
-	return get_full_dict(local.lang).get(msg) or msg
+	# Retrun lang_full_dict according to lang passed parameter
+	return get_full_dict(lang).get(msg) or msg
 
 def as_unicode(text, encoding='utf-8'):
 	'''Convert to unicode if required'''

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -179,7 +179,9 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if getattr(frappe.local, 'lang_full_dict', None) is not None:
+	# Check if the passed lang exists in lang_full_dict cash in frappe
+	if not getattr(frappe.local, 'lang_full_dict',
+				   None) is None and frappe.local.lang_full_dict and lang in frappe.local.lang_full_dict:
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -179,7 +179,7 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if (lambda: frappe.local.lang_full_dict, lambda: {})[getattr(frappe.local, 'lang_full_dict', None) is None]().get(lang, None):
+	if not getattr(frappe.local, 'lang_full_dict', None) and frappe.local.lang_full_dict.get(lang, None):
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -179,7 +179,7 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if (lambda: frappe.local.lang_full_dict, lambda: {})[getattr(frappe.local, 'lang_full_dict', None) is None]().get(lang, None):
+	if getattr(frappe.local, 'lang_full_dict', None) and frappe.local.lang_full_dict.get(lang, None):
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -179,7 +179,7 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if getattr(frappe.local, 'lang_full_dict', {}).get(lang, None):
+	if (lambda: {}, lambda: frappe.local.lang_full_dict)[hasattr(frappe.local, 'lang_full_dict')]().get(lang, None):
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -179,7 +179,7 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if getattr(frappe.local, 'lang_full_dict', {}).get(lang, None):
+	if (lambda: {}, lambda: frappe.local.lang_full_dict)[getattr(frappe.local, 'lang_full_dict', None)]().get(lang, None):
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -178,10 +178,7 @@ def get_full_dict(lang):
 	if not lang:
 		return {}
 
-	# found in local, return!
-	# Check if the passed lang exists in lang_full_dict cash in frappe
-	if not getattr(frappe.local, 'lang_full_dict',
-				   None) is None and frappe.local.lang_full_dict and lang in frappe.local.lang_full_dict:
+	if getattr(frappe.local, 'lang_full_dict', {}).get(lang, None):
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -180,8 +180,7 @@ def get_full_dict(lang):
 
 	# found in local, return!
 	# Check if the passed lang exists in lang_full_dict cash in frappe
-	if not getattr(frappe.local, 'lang_full_dict',
-				   None) is None and frappe.local.lang_full_dict and lang in frappe.local.lang_full_dict:
+	if getattr(frappe.local, 'lang_full_dict', {}).get(lang, None):
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)


### PR DESCRIPTION
 Support multiple language in frappe.cash()


This pull request handles a seems-to-be bug. The _ translation function of frappe, for the first time running, it uploads the translation cash in lang_full_dict. if the user asks for another translation or even the original English translation, the _ returns the cashed translated language.
I have edited the condition of getting translations from frappe.cash() so that every request of a new language will be uploaded to cash and then called from cash.
Another fix is that the passed parameter to _ function: lang is ignored, and the translation is always done according to the frappe.local.lang value, no matter the passed lang is.
Previously:
if frappe.local.lang = "ar" and having the translation of "Refunded" in .csv file:
_("Refunded", "en") >>u'مرجع'  >> Returns wrong value for the cash has lang_full_dict None then it loads the local.lang .csv file to lang and get the translation of it.
message2 = _("Refunded") >> u'مرجع' >> AR translation file is uploaded to frappe.cash()
_("Refunded", "en") >> u'مرجع' >> Still having the arabic translated word back since the passed lang is ignored.
If frappe.local.lang = "en" and having the translation of "Refunded" in .csv file:
message3 = _("Refunded", "ar") >> If arabic in cash, returns u'مرجع', if translation cash is None, returns u'Refunded'
message4 = _("Refunded", "en") >> If arabic in cash, returns u'مرجع', if translation cash is None, returns u'Refunded'
message25 = _("Refunded") If arabic in cash, returns مرجع, if translation cash is None, returns u'Refunded'

![translate1](https://cloud.githubusercontent.com/assets/19221463/23400220/efd520ec-fdab-11e6-8418-3aab14b4e6c0.png)

After this pull request:
If frappe.local.lang = "ar" and having the translation of "Refunded" in .csv file:
message = _("Refunded", "en") >> u'Refunded'
message2 = _("Refunded") >> u'مرجع'
If frappe.local.lang = "en" and having the translation of "Refunded" in .csv file:
message3 = _("Refunded", "ar") >> u'مرجع'
message4 = _("Refunded", "en") >> u'Refunded'
message25 = _("Refunded") >> u'Refunded'

![translate](https://cloud.githubusercontent.com/assets/19221463/23380748/a87f6a84-fd44-11e6-95d4-d3dd3d401afd.png)
