### PR TITLE
[minor][fix] create global search table first

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -1,5 +1,6 @@
 execute:frappe.db.sql("""update `tabPatch Log` set patch=replace(patch, '.4_0.', '.v4_0.')""") #2014-05-12
 frappe.patches.v5_0.convert_to_barracuda_and_utf8mb4
+execute:frappe.utils.global_search.setup_global_search_table()
 frappe.patches.v7_0.update_auth
 frappe.patches.v7_1.rename_scheduler_log_to_error_log
 frappe.patches.v6_1.rename_file_data

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -9,8 +9,8 @@ frappe.patches.v7_2.remove_in_filter
 execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2017-03-09
 execute:frappe.reload_doc('core', 'doctype', 'docfield', force=True) #2017-03-03
 execute:frappe.reload_doc('core', 'doctype', 'docperm') #2017-03-03
-execute:frappe.reload_doc('core', 'doctype', 'custom_docperm')
 frappe.patches.v7_2.setup_custom_perms #2017-01-19
+execute:frappe.reload_doc('core', 'doctype', 'custom_docperm')
 frappe.patches.v8_0.rename_page_role_to_has_role
 execute:frappe.utils.global_search.setup_global_search_table()
 frappe.patches.v8_0.drop_in_dialog


### PR DESCRIPTION
_mysql_exceptions.ProgrammingError: (1146, "Table 'aa5fcd02f0633e25.__global_search' doesn't exist")

```
➜  frappe-bench bench --site sam.erpnext.dev migrate
Migrating sam.erpnext.dev
Executing frappe.patches.v7_2.remove_in_filter in sam.erpnext.dev (aa5fcd02f0633e25)
Success
Executing execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2017-03-09 in sam.erpnext.dev (aa5fcd02f0633e25)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 700, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 680, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 873, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 508, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 16, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/commands/site.py", line 210, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 81, in execute_patch
    exec patchmodule.split("execute:")[1] in globals()
  File "<string>", line 1, in <module>
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 660, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/utils.py", line 152, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 19, in import_files
    reset_permissions=reset_permissions)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 24, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 58, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 121, in import_doc
    frappe.delete_doc(doc.doctype, doc.name, force=1, ignore_doctypes=ignore, for_reload=True)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 638, in delete_doc
    ignore_permissions, flags)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 93, in delete_doc
    delete_for_document(doc)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/global_search.py", line 107, in delete_for_document
    name = %s''', (doc.doctype, doc.name), as_dict=True)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/database.py", line 138, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
    self.errorhandler(self, exc, value)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
_mysql_exceptions.ProgrammingError: (1146, "Table 'aa5fcd02f0633e25.__global_search' doesn't exist")
```