### PR TITLE
Corrections of the document generation guide

### DIFF
--- a/frappe/docs/user/en/guides/app-development/generating-docs.md
+++ b/frappe/docs/user/en/guides/app-development/generating-docs.md
@@ -100,17 +100,15 @@ Note > The branch name `gh-pages` is only if you are using GitHub. If you are ho
 
 Putting it all together:
 
+    # build the apps/docs folder and write the compiled docs at docs/appname
     bench --site [site] build-docs [appname]
-    git add appname/docs
-    git commit -m "Documentation Initialization"
-    git push origin master
-    bench --site [site] write-docs [appname]
+
+    # commit to the gh-pages branch (for GitHub Pages)
     cd docs/appname
     git checkout --orphan gh-pages
     git remote add origin [remote git repository]
     git add *
     git commit -m "Documentation Initialization"
     git push origin gh-pages
-
 
 To check your documentation online go to: https://[orgname].github.io/[reponame]

--- a/frappe/docs/user/en/guides/app-development/generating-docs.md
+++ b/frappe/docs/user/en/guides/app-development/generating-docs.md
@@ -67,29 +67,15 @@ You can add images in the `/docs/assets` folder. You can add links to the images
 
 ## Setting up output docs
 
-1. Create a `/docs` folder in your bench, parallel to your `/sites` folder. e.g. `/frappe-bench/docs`
-2. Copy the repo of your app to the docs folder. e.g. `cp -R apps/myapp docs/myapp` (you can also clone it here using `git clone`).
-3. Go to your docs folder `cd docs/myapp`
-4. Checkout the gh-pages branch `git checkout --orphan gh-pages`
-5. Clean everything `git rm -rf .`
-
-Note > The branch name `gh-pages` is only if you are using GitHub. If you are hosting this on any other static file server, can just skip this and just create your docs folder for your app like `docs/myapp`
-
-Putting it all together:
-
-    mkdir docs
-    cp -R apps/myapp docs/myapp
-    cd docs/myapp
-    git checkout --orphan gh-pages
-    git rm -rf .
+The output docs are generated in your `docs/appname` folder using the `write-docs` command.
 
 ---
 
 ## Viewing Locally
 
-To test your docs locally, add a `--local` option to the `build-docs` command.
+To test your docs locally, add a `--local` option to the `write-docs` command.
 
-    bench --site [site] build-docs [appname] --local
+    bench --site [site] write-docs [appname] --local
 
 Then it will build urls so that you can view these files locally. To view them locally in your browser, you can use the Python SimpleHTTPServer
 
@@ -101,10 +87,30 @@ Run this from your `docs/myapp` folder:
 
 ## Publishing to GitHub Pages
 
-To publish your docs on GitHub pages, you will have to create an empty and orphan branch in your repository called `gh-pages` and write yours there
+To publish your docs on GitHub pages, you will have to create an empty and orphan branch in your repository called `gh-pages` and push your documentation there.
 
-Now go back to your bench folder and write these docs to this branch. For example if your path to the `gh-pages` repo is `docs/reponame`
+1. To easily publish your docs on gh-pages, commit and push your `apps/docs` folder on you master branch first.
+2. The `/docs` generation will also generate a `/docs` folder in your bench, parallel to your `/sites` folder. e.g. `/frappe-bench/docs`
+3. Generate you documentation using the `write-docs` command.
+4. Go to your docs folder `cd docs/myapp`
+5. Checkout the gh-pages branch `git checkout --orphan gh-pages`
+6. Push your documentation to Github.
+
+Note > The branch name `gh-pages` is only if you are using GitHub. If you are hosting this on any other static file server, you can create any other orphan branch instead.
+
+Putting it all together:
 
     bench --site [site] build-docs [appname]
+    git add appname/docs
+    git commit -m "Documentation Initialization"
+    git push origin master
+    bench --site [site] write-docs [appname]
+    cd docs/appname
+    git checkout --orphan gh-pages
+    git remote add origin [remote git repository]
+    git add *
+    git commit -m "Documentation Initialization"
+    git push origin gh-pages
+
 
 To check your documentation online go to: https://[orgname].github.io/[reponame]


### PR DESCRIPTION
Dear Frappe Team,

Following this morning's discussion regarding the documentation of the doc generator, I have updated the related user guide.

Can you please review it and merge it if it is correct ?

Furthermore, do you then generate the update on the `gh-pages` branch or should I generate it on my end and send another pull request ?

Because I noticed that some updates had been done on the `develop` branch 3 months ago, were merged in `master` but are not generated in `gh-pages` yet.

Thanks in advance for your feedback.

Best regards,
Charles-Henri