### PR TITLE
Disable SignUp

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -13,6 +13,7 @@ import frappe.permissions
 import frappe.share
 import re
 from frappe.limits import get_limits
+from frappe.website.utils import is_signup_enabled
 
 STANDARD_USERS = ("Guest", "Administrator")
 
@@ -588,6 +589,9 @@ def verify_password(password):
 
 @frappe.whitelist(allow_guest=True)
 def sign_up(email, full_name, redirect_to):
+	if not is_signup_enabled():
+		frappe.throw('Sign Up is disabled', title='Not Allowed')
+		
 	user = frappe.db.get("User", {"email": email})
 	if user:
 		if user.disabled:

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -590,7 +590,7 @@ def verify_password(password):
 @frappe.whitelist(allow_guest=True)
 def sign_up(email, full_name, redirect_to):
 	if not is_signup_enabled():
-		frappe.throw('Sign Up is disabled', title='Not Allowed')
+		frappe.throw(_('Sign Up is disabled'), title='Not Allowed')
 		
 	user = frappe.db.get("User", {"email": email})
 	if user:


### PR DESCRIPTION
Disabled signup from setting only hides signup link but users can signup anyway if they know the url.

This commit disables the sign_up function depending on the settings