### PR TITLE
Fix total sum report

### DIFF
--- a/frappe/public/js/frappe/ui/listing.js
+++ b/frappe/public/js/frappe/ui/listing.js
@@ -324,6 +324,9 @@ frappe.ui.Listing = Class.extend({
 		}
 
 		if(r.values.length || this.force_render_view) {
+		    if (this.data.length && this.data[this.data.length - 1]._totals_row) {
+                this.data.pop();
+            }
 			this.data = this.data.concat(r.values);
 			this.render_view(r.values);
 			// this.render_list(r.values);

--- a/frappe/public/js/frappe/ui/listing.js
+++ b/frappe/public/js/frappe/ui/listing.js
@@ -324,9 +324,9 @@ frappe.ui.Listing = Class.extend({
 		}
 
 		if(r.values.length || this.force_render_view) {
-		    if (this.data.length && this.data[this.data.length - 1]._totals_row) {
-                this.data.pop();
-            }
+			if (this.data.length && this.data[this.data.length - 1]._totals_row) {
+				this.data.pop();
+			}
 			this.data = this.data.concat(r.values);
 			this.render_view(r.values);
 			// this.render_list(r.values);


### PR DESCRIPTION
Removes last row if it is a **Totals Row** before loading more items

You can test this on master and development branch with the following steps:
- Generate more than 40 items of a document containing an Integer Field
- Go to Report Generator 
- Click the Show Totals button
- Click More a few times

You will be able to see that there are several "Total Rows" in the report and all of them are added in the last Total Row.

Example:
![screen shot 2017-03-24 at 12 49 39 am](https://cloud.githubusercontent.com/assets/1133954/24274947/40095d5c-102c-11e7-88b1-dab8927353fd.png)

Total sum should be 14, not 25 (it is adding the 11 that was the previous total)

Regards!
