### PR TITLE
[fix] Allow Print and Cancel during a Workflow

### DIFF
--- a/frappe/public/js/legacy/clientscriptAPI.js
+++ b/frappe/public/js/legacy/clientscriptAPI.js
@@ -354,7 +354,7 @@ _f.Frm.prototype.set_read_only = function() {
 	var docperms = frappe.perm.get_perm(cur_frm.doc.doctype);
 	for (var i=0, l=docperms.length; i<l; i++) {
 		var p = docperms[i];
-		perm[p.permlevel || 0] = {read:1};
+		perm[p.permlevel || 0] = {read:1, print:1, cancel:1};
 	}
 	cur_frm.perm = perm;
 }

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -939,11 +939,11 @@ _f.Frm.prototype.validate_form_action = function(action) {
 	var allowed_for_workflow = false;
 	var perms = frappe.perm.get_perm(this.doc.doctype)[0];
 
-	// Allow submit, write and create permissions for read only documents that are assigned by
+	// Allow submit, write, cancel and create permissions for read only documents that are assigned by
 	// workflows if the user already have those permissions. This is to allow for users to
 	// continue through the workflow states and to allow execution of functions like Duplicate.
 	if (frappe.workflow.is_read_only(this.doctype, this.docname) && (perms["write"] ||
-		perms["create"] || perms["submit"])) {
+		perms["create"] || perms["submit"] || perms["cancel"])) {
 		var allowed_for_workflow = true;
 	}
 


### PR DESCRIPTION
Currently when traversing the workflow print and cancelling is not allowed.