### PR TITLE
[fix] On change of permission from the role permission manager do not save the doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -591,17 +591,11 @@ def validate_fields(meta):
 def validate_permissions_for_doctype(doctype, for_remove=False):
 	"""Validates if permissions are set correctly."""
 	doctype = frappe.get_doc("DocType", doctype)
+	validate_permissions(doctype, for_remove)
 
-	if frappe.conf.developer_mode and not frappe.flags.in_test:
-		# save doctype
-		doctype.save()
-
-	else:
-		validate_permissions(doctype, for_remove)
-
-		# save permissions
-		for perm in doctype.get("permissions"):
-			perm.db_update()
+	# save permissions
+	for perm in doctype.get("permissions"):
+		perm.db_update()
 
 def validate_permissions(doctype, for_remove=False):
 	permissions = doctype.get("permissions")

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -29,9 +29,9 @@ def get_permissions(doctype=None, role=None):
 		if doctype:
 			out = [p for p in out if p.parent == doctype]
 	else:
-		out = frappe.get_all('Custom DocPerm', fields='*', filters=dict(parent = doctype))
+		out = frappe.get_all('Custom DocPerm', fields='*', filters=dict(parent = doctype), order_by="permlevel")
 		if not out:
-			out = frappe.get_all('DocPerm', fields='*', filters=dict(parent = doctype))
+			out = frappe.get_all('DocPerm', fields='*', filters=dict(parent = doctype), order_by="permlevel")
 
 	linked_doctypes = {}
 	for d in out:


### PR DESCRIPTION
Fixed 
https://github.com/frappe/erpnext/issues/8185
https://github.com/frappe/erpnext/issues/8186

No need to save the doctype, on change of permission from the role permission manager