### PR TITLE
fix breadcrumb error rised if user has no module permission

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -60,7 +60,7 @@ frappe.breadcrumbs = {
 					label = module_info ? module_info.label : breadcrumbs.module;
 
 
-				if(module_info && !module_info.blocked) {
+				if(module_info && !module_info.blocked && !module_info.hidden) {
 					$(repl('<li><a href="#modules/%(module)s">%(label)s</a></li>',
 						{ module: breadcrumbs.module, label: __(label) }))
 						.appendTo($breadcrumbs);


### PR DESCRIPTION
error: 
`Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 42, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 903, in call
    return fn(*args, **newargs)
TypeError: get() takes exactly 1 argument (0 given)`