### PR TITLE
[minor] fixes in the scheduler events to sync user settings

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -132,7 +132,7 @@ scheduler_events = {
 	],
 	"hourly": [
 		"frappe.model.utils.link_count.update_link_count",
-		'frappe.model.utils.list_settings.sync_list_settings',
+		'frappe.model.utils.user_settings.sync_user_settings',
 		"frappe.utils.error.collect_error_snapshots",
 		"frappe.desk.page.backups.backups.delete_downloadable_backups",
 		"frappe.limits.update_space_usage"


### PR DESCRIPTION
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/rq/worker.py", line 700, in perform_job
    rv = job.perform()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/rq/job.py", line 503, in perform
    self._result = self.func(*self.args, **self.kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 60, in execute_job
    method = frappe.get_attr(method)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 887, in get_attr
    return getattr(get_module(modulename), methodname)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 672, in get_module
    return importlib.import_module(modulename)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named list_settings