### PR TITLE
[patch][fix] handle enqueuing while deleting document when redis is not connected

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -627,7 +627,7 @@ def get_meta_module(doctype):
 	return frappe.modules.load_doctype_module(doctype)
 
 def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reload=False,
-	ignore_permissions=False, flags=None):
+	ignore_permissions=False, flags=None, trigger_feedback_on_delete=True):
 	"""Delete a document. Calls `frappe.model.delete_doc.delete_doc`.
 
 	:param doctype: DocType of document to be delete.
@@ -638,7 +638,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 	:param ignore_permissions: Ignore user permissions."""
 	import frappe.model.delete_doc
 	frappe.model.delete_doc.delete_doc(doctype, name, force, ignore_doctypes, for_reload,
-		ignore_permissions, flags)
+		ignore_permissions, flags, trigger_feedback_on_delete)
 
 def delete_doc_if_exists(doctype, name, force=0):
 	"""Delete document if exists."""

--- a/frappe/core/doctype/feedback_trigger/feedback_trigger.py
+++ b/frappe/core/doctype/feedback_trigger/feedback_trigger.py
@@ -27,7 +27,7 @@ class FeedbackTrigger(Document):
 def trigger_feedback_request(doc, method):
 	""" trigger the feedback alert"""
 
-	if doc.flags.in_delete:
+	if doc.flags.trigger_feedback_on_delete:
 		frappe.enqueue('frappe.core.doctype.feedback_trigger.feedback_trigger.delete_feedback_request_and_feedback',
 			reference_doctype=doc.doctype, reference_name=doc.name, now=frappe.flags.in_test)
 	else:

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -14,7 +14,7 @@ from frappe.model.naming import revert_series_if_last
 from frappe.utils.global_search import delete_for_document 
 
 def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reload=False,
-	ignore_permissions=False, flags=None, ignore_on_trash=False):
+	ignore_permissions=False, flags=None, ignore_on_trash=False, trigger_feedback_on_delete=True):
 	"""
 		Deletes a doc(dt, dn) and validates if it is not submitted and not linked in a live record
 	"""
@@ -71,11 +71,11 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 
 				if not ignore_on_trash:
 					doc.run_method("on_trash")
-					doc.flags.in_delete = True
+					doc.flags.trigger_feedback_on_delete = trigger_feedback_on_delete
 					doc.run_method('on_change')
 
 				frappe.enqueue('frappe.model.delete_doc.delete_dynamic_links', doctype=doc.doctype, name=doc.name,
-					async=False if frappe.flags.in_test else True)
+					async=False if frappe.flags.in_test else True, now=frappe.flags.in_test)
 
 				# check if links exist
 				if not force:

--- a/frappe/patches/v8_0/deprecate_integration_broker.py
+++ b/frappe/patches/v8_0/deprecate_integration_broker.py
@@ -15,7 +15,8 @@ def execute():
 		frappe.delete_doc("DocType", doctype)
 	
 	if not frappe.db.get_value("DocType", {"module": "Integration Broker"}, "name"):
-		frappe.delete_doc("Module Def", "Integration Broker")
+		frappe.flags.in_test = True
+		frappe.delete_doc("Module Def", "Integration Broker", trigger_feedback_on_delete=False)
 
 def setup_enabled_integrations():
 	if not frappe.db.exists("DocType", "Integration Service"):


### PR DESCRIPTION
```
Executing frappe.patches.v8_0.deprecate_integration_broker in testuser10.erpnext.dev (8998a47e72a8f27a)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 700, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 680, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 873, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 508, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 16, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/commands/site.py", line 210, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/patches/v8_0/deprecate_integration_broker.py", line 18, in execute
    frappe.delete_doc("Module Def", "Integration Broker")
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 641, in delete_doc
    ignore_permissions, flags)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 75, in delete_doc
    doc.run_method('on_change')
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 667, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 890, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/core/doctype/feedback_trigger/feedback_trigger.py", line 32, in trigger_feedback_request
    reference_doctype=doc.doctype, reference_name=doc.name, now=frappe.flags.in_test)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 1298, in enqueue
    return frappe.utils.background_jobs.enqueue(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 46, in enqueue
    "kwargs": kwargs
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/rq/queue.py", line 216, in enqueue_call
    job = self.enqueue_job(job, at_front=at_front)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/rq/queue.py", line 282, in enqueue_job
    pipe.execute()
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/redis/client.py", line 2593, in execute
    return execute(conn, stack, raise_on_error)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/redis/client.py", line 2447, in _execute_transaction
    connection.send_packed_command(all_cmds)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 532, in send_packed_command
    self.connect()
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 436, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 61 connecting to localhost:6379. Connection refused.
```