### PR TITLE
[minor] minor fixes in email_account and added has_attachment in comm…

### DIFF
--- a/frappe/core/doctype/communication/communication_list.js
+++ b/frappe/core/doctype/communication/communication_list.js
@@ -2,7 +2,8 @@ frappe.listview_settings['Communication'] = {
 	add_fields: [
 		"sent_or_received","recipients", "subject",
 		"communication_medium", "communication_type",
-		"sender", "seen", "reference_doctype", "reference_name"
+		"sender", "seen", "reference_doctype", "reference_name",
+		"has_attachment"
 	],
 
 	filters: [["status", "=", "Open"]],

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -247,6 +247,9 @@ class EmailAccount(Document):
 				email_sync_rule = self.build_email_sync_rule()
 
 				email_server = self.get_incoming_server(in_receive=True, email_sync_rule=email_sync_rule)
+				if not email_server:
+					return
+
 				emails = email_server.get_messages()
 
 				incoming_mails = emails.get("latest_messages")
@@ -595,6 +598,9 @@ class EmailAccount(Document):
 		uid_list = { flag.get("uid", None): flag.get("action", "Read") for flag in flags }
 		if flags and uid_list:
 			email_server = self.get_incoming_server()
+			if not email_server:
+				return
+
 			email_server.update_flag(uid_list=uid_list)
 
 			# mark communication as read


### PR DESCRIPTION
Traceback (most recent call last):
   File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/rq/worker.py", line 700, in perform_job
     rv = job.perform()
   File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/rq/job.py", line 500, in perform
     self._result = self.func(*self.args, **self.kwargs)
   File "/home/travis/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 65, in execute_job
     method(**kwargs)
   File "/home/travis/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 694, in pull_from_email_account
     email_account.receive()
   File "/home/travis/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 250, in receive
     emails = email_server.get_messages()
 AttributeError: 'NoneType' object has no attribute 'get_messages'