### PR TITLE
Correction of the currency format for France

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -846,7 +846,7 @@
   "currency_fraction": "Cent",
   "currency_fraction_units": 100,
   "currency_symbol": "\u20ac",
-  "number_format": "#,###.##",
+  "number_format": "# ###,##",
   "timezones": [
    "Europe/Paris"
   ]


### PR DESCRIPTION
Hi,

Just a small correction related to the monetary format in France.
We usually use # ###,## instead of #,###.##

Thank you