### PR TITLE
[minor] Summernote image insert style fix

### DIFF
--- a/frappe/public/css/desk.css
+++ b/frappe/public/css/desk.css
@@ -668,6 +668,9 @@ fieldset[disabled] .form-control {
   max-height: 300px;
   overflow: auto;
 }
+.note-editor .note-image-input {
+  height: auto;
+}
 .modal .note-editor .note-btn-italic,
 .modal .note-editor .note-btn-underline,
 .modal .note-editor [data-original-title="Font Size"],

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -534,6 +534,9 @@ textarea.form-control {
 		max-height: 300px;
 		overflow: auto;
 	}
+	.note-image-input {
+		height: auto;
+	}
 }
 
 // hide some buttons in modal


### PR DESCRIPTION
Mozilla:
![screen shot 2017-04-05 at 10 57 49 am](https://cloud.githubusercontent.com/assets/5196925/24691023/ba9c081e-19ee-11e7-9a15-538f7a922ee6.png)