### PR TITLE
[minor][fix] parameter naming fix

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1067,9 +1067,9 @@ def redirect_to_message(title, html, http_status_code=None, context=None, indica
 		'message': html
 	})
 
-	if indicator:
+	if indicator_color:
 		message['context'].update({
-			"indicator_color": indicator
+			"indicator_color": indicator_color
 		})
 
 	cache().set_value("message_id:{0}".format(message_id), message, expires_in_sec=60)


### PR DESCRIPTION
```
redirect_to_message(title, html, http_status_code=None, context=None, indicator_color=None)
```
method's input parameter is `indicator_color` thus check for `indicator_color` instead `indicator` paramerer 