### PR TITLE
Summernote image insert modal

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1605,7 +1605,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 		this.make_editor();
 		this.hide_elements_on_mobile();
 		this.setup_drag_drop();
-		this.setup_dialog();
+		this.setup_image_dialog();
 	},
 	make_editor: function() {
 		var me = this;
@@ -1761,11 +1761,95 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 	set_focus: function() {
 		return this.editor.summernote('focus');
 	},
-	setup_dialog: function() {
-		this.note_editor.find('[data-original-title="Picture"]').on('click', function(e) {
+	set_upload_options: function() {
+		var me = this;
+		this.upload_options = {
+			parent: this.image_dialog.get_field("upload_area").$wrapper,
+			args: {},
+			max_width: this.df.max_width,
+			max_height: this.df.max_height,
+			options: this.df.options,
+			btn: this.image_dialog.set_primary_action(__("Insert")),
+			on_no_attach: function() {
+				// if no attachmemts,
+				// check if something is selected
+				var selected = me.image_dialog.get_field("select").get_value();
+				if(selected) {
+					me.editor.summernote('insertImage', selected);
+					me.image_dialog.hide();
+				} else {
+					msgprint(__("Please attach a file or set a URL"));
+				}
+			},
+			callback: function(attachment, r) {
+				me.editor.summernote('insertImage', attachment.file_url, attachment.file_name);
+				me.image_dialog.hide();
+			},
+			onerror: function() {
+				me.image_dialog.hide();
+			}
+		}
+
+		if ("is_private" in this.df) {
+			this.upload_options.is_private = this.df.is_private;
+		}
+
+		if(this.frm) {
+			this.upload_options.args = {
+				from_form: 1,
+				doctype: this.frm.doctype,
+				docname: this.frm.docname
+			}
+		} else {
+			this.upload_options.on_attach = function(fileobj, dataurl) {
+				me.image_dialog.hide();
+				me.fileobj = fileobj;
+				me.dataurl = dataurl;
+				if(me.on_attach) {
+					me.on_attach()
+				}
+				if(me.df.on_attach) {
+					me.df.on_attach(fileobj, dataurl);
+				}
+			}
+		}
+	},
+
+	setup_image_dialog: function() {
+		this.note_editor.find('[data-original-title="Image"]').on('click', (e) => {
 			e.preventDefault();
 			e.stopPropagation();
-			console.log("preventeds and stopPropagation");
+			if(!this.image_dialog) {
+				this.image_dialog = new frappe.ui.Dialog({
+					title: __("Image"),
+					fields: [
+						{fieldtype:"HTML", fieldname:"upload_area"},
+						{fieldtype:"HTML", fieldname:"or_attach", options: __("Or")},
+						{fieldtype:"Select", fieldname:"select", label:__("Select from existing attachments") },
+					]
+				});
+			}
+
+			this.image_dialog.show();
+			this.image_dialog.get_field("upload_area").$wrapper.empty();
+
+			// select from existing attachments
+			var attachments = this.frm && this.frm.attachments.get_attachments() || [];
+			var select = this.image_dialog.get_field("select");
+			if(attachments.length) {
+				attachments = $.map(attachments, function(o) { return o.file_url; })
+				select.df.options = [""].concat(attachments);
+				select.toggle(true);
+				this.image_dialog.get_field("or_attach").toggle(true);
+				select.refresh();
+			} else {
+				this.image_dialog.get_field("or_attach").toggle(false);
+				select.toggle(false);
+			}
+			select.$input.val("");
+
+			this.set_upload_options();
+			frappe.upload.make(this.upload_options);
 		});
 	}
 });

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1605,6 +1605,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 		this.make_editor();
 		this.hide_elements_on_mobile();
 		this.setup_drag_drop();
+		this.setup_dialog();
 	},
 	make_editor: function() {
 		var me = this;
@@ -1654,7 +1655,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 								.trigger('click');
 						}
 					}
-				}
+				},
 			},
 			icons: {
 				'align': 'fa fa-align',
@@ -1759,6 +1760,13 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 	},
 	set_focus: function() {
 		return this.editor.summernote('focus');
+	},
+	setup_dialog: function() {
+		this.note_editor.find('[data-original-title="Picture"]').on('click', function(e) {
+			e.preventDefault();
+			e.stopPropagation();
+			console.log("preventeds and stopPropagation");
+		});
 	}
 });
 

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1768,7 +1768,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 			args: {},
 			max_width: this.df.max_width,
 			max_height: this.df.max_height,
-			options: this.df.options,
+			options: "Image",
 			btn: this.image_dialog.set_primary_action(__("Insert")),
 			on_no_attach: function() {
 				// if no attachmemts,
@@ -1817,8 +1817,6 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 
 	setup_image_dialog: function() {
 		this.note_editor.find('[data-original-title="Image"]').on('click', (e) => {
-			e.preventDefault();
-			e.stopPropagation();
 			if(!this.image_dialog) {
 				this.image_dialog = new frappe.ui.Dialog({
 					title: __("Image"),

--- a/frappe/public/js/lib/summernote/summernote.js
+++ b/frappe/public/js/lib/summernote/summernote.js
@@ -1944,8 +1944,11 @@
       '  <div class="modal-content">',
       (options.title ?
       '    <div class="modal-header">' +
-      '      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
-      '      <h4 class="modal-title">' + options.title + '</h4>' +
+      '      <div class="row"><div class="col-xs-7"><h4 class="modal-title" style="font-weight: bold;">' + options.title + '</h4></div>' +
+      '      <div class="col-xs-5"><div class="text-right buttons"> <button type="button" class="btn btn-default btn-sm btn-modal-close" data-dismiss="modal">' +
+      '         <i class="octicon octicon-x visible-xs" style="padding: 1px 0px;"></i> <span class="hidden-xs">Close</span></button>'+
+      '         <button type="button" class="btn btn-primary btn-sm ' + options.button_class + ' disabled" disabled>' + options.action + '</button>' +
+      '      </div></div></div>' +
       '    </div>' : ''
       ),
       '    <div class="modal-body">' + options.body + '</div>',
@@ -2073,8 +2076,8 @@
         size: 'Font Size'
       },
       image: {
-        image: 'Picture',
-        insert: 'Insert Image',
+        image: 'Image',
+        insert: 'Insert',
         resizeFull: 'Resize Full',
         resizeHalf: 'Resize Half',
         resizeQuarter: 'Resize Quarter',
@@ -2096,13 +2099,13 @@
       video: {
         video: 'Video',
         videoLink: 'Video Link',
-        insert: 'Insert Video',
+        insert: 'Insert',
         url: 'Video URL?',
         providers: '(YouTube, Vimeo, Vine, Instagram, DailyMotion or Youku)'
       },
       link: {
         link: 'Link',
-        insert: 'Insert Link',
+        insert: 'Insert',
         unlink: 'Unlink',
         edit: 'Edit',
         textToDisplay: 'Text to display',
@@ -5918,10 +5921,11 @@
 
       this.$dialog = ui.dialog({
         className: 'link-dialog',
-        title: lang.link.insert,
+        title: lang.link.link,
+        action: lang.link.insert,
+        button_class: 'note-link-btn',
         fade: options.dialogsFade,
         body: body,
-        footer: footer
       }).render().appendTo($container);
     };
 
@@ -6139,10 +6143,11 @@
       var footer = '<button href="#" class="btn btn-primary note-image-btn disabled" disabled>' + lang.image.insert + '</button>';
 
       this.$dialog = ui.dialog({
-        title: lang.image.insert,
+        title: lang.image.image,
+        action: lang.image.insert,
+        button_class: 'note-image-btn',
         fade: options.dialogsFade,
         body: body,
-        footer: footer
       }).render().appendTo($container);
     };
 
@@ -6285,10 +6290,11 @@
       var footer = '<button href="#" class="btn btn-primary note-video-btn disabled" disabled>' + lang.video.insert + '</button>';
 
       this.$dialog = ui.dialog({
-        title: lang.video.insert,
+        title: lang.video.video,
+        action: lang.video.insert,
+        button_class: 'note-video-btn',
         fade: options.dialogsFade,
         body: body,
-        footer: footer
       }).render().appendTo($container);
     };
 

--- a/frappe/public/js/lib/summernote/summernote.js
+++ b/frappe/public/js/lib/summernote/summernote.js
@@ -1935,7 +1935,7 @@
     });
   });
 
-  var dialog = renderer.create('<div class="modal" aria-hidden="false" tabindex="-1"/>', function ($node, options) {
+  var dialog = renderer.create('<div class="modal fade in" aria-hidden="false" tabindex="-1"/>', function ($node, options) {
     if (options.fade) {
       $node.addClass('fade');
     }
@@ -1947,7 +1947,8 @@
       '      <div class="row"><div class="col-xs-7"><h4 class="modal-title" style="font-weight: bold;">' + options.title + '</h4></div>' +
       '      <div class="col-xs-5"><div class="text-right buttons"> <button type="button" class="btn btn-default btn-sm btn-modal-close" data-dismiss="modal">' +
       '         <i class="octicon octicon-x visible-xs" style="padding: 1px 0px;"></i> <span class="hidden-xs">Close</span></button>'+
-      '         <button type="button" class="btn btn-primary btn-sm ' + options.button_class + ' disabled" disabled>' + options.action + '</button>' +
+                (options.action && options.button_class ?
+                '     <button type="button" class="btn btn-primary btn-sm ' + options.button_class + ' disabled" disabled>' + options.action + '</button>' : '') +
       '      </div></div></div>' +
       '    </div>' : ''
       ),
@@ -5553,7 +5554,6 @@
         return ui.button({
           contents: ui.icon(options.icons.picture),
           tooltip: lang.image.image,
-          click: context.createInvokeHandler('imageDialog.show')
         }).render();
       });
 
@@ -5905,11 +5905,11 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group">' +
-                   '<label>' + lang.link.textToDisplay + '</label>' +
+                   '<span>' + lang.link.textToDisplay + '</span>' +
                    '<input class="note-link-text form-control" type="text" />' +
                  '</div>' +
                  '<div class="form-group">' +
-                   '<label>' + lang.link.url + '</label>' +
+                   '<span>' + lang.link.url + '</span>' +
                    '<input class="note-link-url form-control" type="text" value="http://" />' +
                  '</div>' +
                  (!options.disableLinkTarget ?
@@ -6284,7 +6284,7 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group row-fluid">' +
-          '<label>' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
+          '<span>' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></span>' +
           '<input class="note-video-url form-control span12" type="text" />' +
           '</div>';
       var footer = '<button href="#" class="btn btn-primary note-video-btn disabled" disabled>' + lang.video.insert + '</button>';


### PR DESCRIPTION
Lots of duplicated code from ControlAttach. Any advice or pattern on how to fix that?

Meanwhile, the modal fixes:

![image_insert](https://cloud.githubusercontent.com/assets/5196925/24786353/66604332-1b7e-11e7-9072-d4c82b2ef0e3.gif)


![screen shot 2017-04-07 at 10 28 08 am](https://cloud.githubusercontent.com/assets/5196925/24786268/c47351cc-1b7d-11e7-8a5e-83f5a887e12a.png)

![screen shot 2017-04-07 at 10 28 19 am](https://cloud.githubusercontent.com/assets/5196925/24786270/c6762b0c-1b7d-11e7-9a84-5a04e1236d41.png)