### PR TITLE
Language order for the setup wizard

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -172,7 +172,7 @@ def load_messages(language):
 def load_languages():
 	return {
 		"default_language": frappe.db.get_value('Language', frappe.local.lang, 'language_name') or frappe.local.lang,
-		"languages": sorted(frappe.db.sql_list('select language_name from tabLanguage'))
+		"languages": sorted(frappe.db.sql_list('select language_name from tabLanguage order by name'))
 	}
 
 


### PR DESCRIPTION
Hi,

Following our discussion with @joezsweet in PR #3028, please find hereby a PR to add an `order by name` in the language list sql query.

Please let us know if this should be achieved by any other way.

Thank you!