### PR TITLE
Country settings and currency format for shared currencies

### DIFF
--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -134,3 +134,5 @@ def add_country_and_currency(name, country):
 			"docstatus": 0
 		}).db_insert()
 
+	elif country.currency and frappe.db.exists("Currency", country.currency):
+		frappe.db.set_value("Currency", country.currency, "number_format", "")


### PR DESCRIPTION
Hi,

As explained in ERPNext issue #8366, the currency format should be blank when a currency is shared between several countries. The global settings should take precedence in this case.

Thank you for your feedback.