### PR TITLE
[urgent][fix] if first name not exits then set full name as first name

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -79,13 +79,14 @@ def update_system_settings(args):
 	system_settings.save()
 
 def update_user_name(args):
+	first_name, last_name = args.get('full_name'), ''
+	if ' ' in first_name:
+		first_name, last_name = first_name.split(' ', 1)
+
 	if args.get("email"):
 		args['name'] = args.get("email")
 
 		_mute_emails, frappe.flags.mute_emails = frappe.flags.mute_emails, True
-		first_name, last_name = args.get('full_name'), ''
-		if ' ' in first_name:
-			first_name, last_name = first_name.split(' ', 1)
 		doc = frappe.get_doc({
 			"doctype":"User",
 			"email": args.get("email"),
@@ -98,11 +99,12 @@ def update_user_name(args):
 		update_password(args.get("email"), args.get("password"))
 
 	else:
-		args['name'] = frappe.session.user
+		args.update({
+			"name": frappe.session.user,
+			"first_name": first_name,
+			"last_name": last_name
+		})
 
-		# Update User
-		if not args.get('last_name') or args.get('last_name')=='None':
-				args['last_name'] = None
 		frappe.db.sql("""update `tabUser` SET first_name=%(first_name)s,
 			last_name=%(last_name)s WHERE name=%(name)s""", args)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 42, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 907, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 35, in setup_complete
    update_user_name(args)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 107, in update_user_name
    last_name=%(last_name)s WHERE name=%(name)s""", args)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/database.py", line 138, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 185, in execute
    for key, item in args.iteritems())
KeyError: 'first_name'

```