### PR TITLE
[fix] Invalid login credentials not throwing an error during login

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -134,7 +134,7 @@ def handle_exception(e):
 			# code 409 represents conflict
 			http_status_code = 508
 
-	if http_status_code==401:
+	if http_status_code==440:
 		frappe.respond_as_web_page(_("Session Expired"),
 			_("Your session has expired, please login again to continue."),
 			http_status_code=http_status_code,  indicator_color='red')

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -15,7 +15,7 @@ class AuthenticationError(Exception):
 	http_status_code = 401
 
 class SessionExpired(Exception):
-	http_status_code = 401
+	http_status_code = 440
 
 class PermissionError(Exception):
 	http_status_code = 403


### PR DESCRIPTION
![screen shot 2017-04-11 at 12 55 59 pm](https://cloud.githubusercontent.com/assets/8780500/24897457/99649dec-1eb6-11e7-93ea-d24e2144ae58.png)
