### PR TITLE
[fix] read apps dir if setting up global help else get installed apps from respective site

### DIFF
--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -102,7 +102,9 @@ class HelpDatabase(object):
 	def sync_pages(self):
 		self.db.sql('truncate help')
 		doc_contents = '<ol>'
-		for app in frappe.get_installed_apps():
+		apps = os.listdir('../apps') if self.global_help_setup else frappe.get_installed_apps()
+
+		for app in apps:
 			docs_folder = '../apps/{app}/{app}/docs/user'.format(app=app)
 			self.out_base_path = '../apps/{app}/{app}/docs'.format(app=app)
 			if os.path.exists(docs_folder):


### PR DESCRIPTION
```
Syncing help database...
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-2017-04-12/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-04-12/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-2017-04-12/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-04-12/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-04-12/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-2017-04-12/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/commands/utils.py", line 426, in setup_global_help
    sync()
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/utils/help.py", line 24, in sync
    help_db.sync_pages()
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/utils/help.py", line 105, in sync_pages
    for app in frappe.get_installed_apps():
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/__init__.py", line 740, in get_installed_apps
    connect()
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/__init__.py", line 168, in connect
    set_user("Administrator")
  File "/home/frappe/benches/bench-2017-04-12/apps/frappe/frappe/__init__.py", line 340, in set_user
    local.session.user = username
  File "/home/frappe/benches/bench-2017-04-12/env/lib/python2.7/site-packages/werkzeug/local.py", line 72, in __getattr__
    raise AttributeError(name)
AttributeError: session
```