### PR TITLE
Added reset password button to User doctype

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -64,6 +64,16 @@ frappe.ui.form.on('User', {
 
 				frm.toggle_display(['sb1', 'sb3', 'modules_access'], true);
 			}
+			
+			frm.add_custom_button(__("Reset Password"), function() {
+				frappe.call({
+					method: "frappe.core.doctype.user.user.reset_password",
+					args: {
+						"user": frm.doc.name
+					}
+				})
+			})
+
 			frm.trigger('enabled');
 
 			frm.roles_editor && frm.roles_editor.show();


### PR DESCRIPTION
Will send the forgot password email with link and instructions to reset the password.

Did this because setting a password manually using change password is not elegant.

![screen shot 2017-04-13 at 6 04 33 pm](https://cloud.githubusercontent.com/assets/8401344/25004835/ebf3cbd2-2073-11e7-8d9f-61c3125bd61d.png)
