### PR TITLE
[minor] check document type in get_query for user permissions

### DIFF
--- a/frappe/core/page/user_permissions/user_permissions.js
+++ b/frappe/core/page/user_permissions/user_permissions.js
@@ -328,6 +328,10 @@ frappe.UserPermissions = Class.extend({
 				}
 
 				d.fields_dict["defvalue"].get_query = function(txt) {
+					if(!d.get_value("defkey")) {
+						frappe.throw(__("Please select Document Type"));
+					}
+
 					return {
 						doctype: d.get_value("defkey")
 					}


### PR DESCRIPTION
fixes for https://github.com/frappe/frappe/issues/3097

![user_permission](https://cloud.githubusercontent.com/assets/11224291/25079977/9a386f62-235e-11e7-899c-1ed0a941c988.gif)

![user_permission 1](https://cloud.githubusercontent.com/assets/11224291/25079950/672b022e-235e-11e7-8738-325259e5ecd3.gif)
