### PR TITLE
Fixed checkbox not showing on edge browser

### DIFF
--- a/frappe/public/css/desk.css
+++ b/frappe/public/css/desk.css
@@ -975,3 +975,8 @@ input[type="checkbox"]:checked:before {
     visibility: visible;
   }
 }
+@supports (-ms-ime-align:auto) {
+  input[type="checkbox"] {
+    visibility: visible;
+  }
+}

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -882,10 +882,19 @@ input[type="checkbox"] {
 		color: @checkbox-color;
 	}
 }
-// mozilla doesn't support
-// pseudo elements on checkbox
+
+
+// mozilla doesn't support pseudo elements on checkbox
 @-moz-document url-prefix() {
 	input[type="checkbox"] {
 		visibility: visible;
+	}
+}
+
+// edge doesn't support pseudo elements on checkbox
+//Microsoft Edge Browser 12+ (All)
+@supports (-ms-ime-align:auto) {
+	input[type="checkbox"] {
+		 visibility: visible;
 	}
 }


### PR DESCRIPTION
The checkbox was not showing on edge.
Added an exception in desk.less for the edge browser.

Earlier

![8d172cfa-1e19-11e7-9b35-8f9c9cd9c9f8](https://cloud.githubusercontent.com/assets/22857645/25086330/a2d7b800-2384-11e7-9881-9ab619d28f81.png)

Now

![screenshot from 2017-04-17 15-45-07](https://cloud.githubusercontent.com/assets/22857645/25086382/f3531a40-2384-11e7-95f4-d92088ad5b6e.png)


Based on 
https://github.com/frappe/frappe/issues/3057
