### PR TITLE
Fixed help message container which was not showing properly on mobile…

### DIFF
--- a/frappe/public/css/desktop.css
+++ b/frappe/public/css/desktop.css
@@ -190,12 +190,13 @@ body[data-route="desktop"] .navbar-set-desktop-icons {
   position: fixed;
   bottom: 30px;
   width: 100%;
+  padding: 0px 10px;
 }
 .help-message-wrapper .help-message-container {
   position: relative;
   text-align: left;
   margin: auto;
-  width: 500px;
+  max-width: 500px;
   background-color: #fff;
   padding: 10px 15px 15px 15px;
   border-radius: 3px;

--- a/frappe/public/less/desktop.less
+++ b/frappe/public/less/desktop.less
@@ -239,12 +239,13 @@ body[data-route="desktop"] .navbar-set-desktop-icons {
 	position: fixed;
 	bottom: 30px;
 	width: 100%;
+	padding: 0px 10px;
 
 	.help-message-container {
 		position: relative;
 		text-align: left;
 	    margin: auto;
-	    width: 500px;
+	    max-width: 500px;
 	    background-color: #fff;
 	    padding: 10px 15px 15px 15px;
 	    border-radius: 3px;


### PR DESCRIPTION
Help message container was not showing properly on mobile devices

Before

![help-earlier](https://cloud.githubusercontent.com/assets/22857645/25087618/d1d1011c-238d-11e7-9924-8377d54198e8.png)

Now

![screenshot from 2017-04-17 16-43-40](https://cloud.githubusercontent.com/assets/22857645/25087629/e7ff3396-238d-11e7-9766-38bcd65d746d.png)

