### PR TITLE
Kanban Fixes

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -237,8 +237,12 @@ frappe.provide("frappe.views");
 		self.cur_list = opts.cur_list;
 		self.board_name = opts.board_name;
 
-		self.update_cards = function(cards) {
-			fluxify.doAction('update_cards', cards);
+		self.update = function(cards) {
+			if(self.wrapper.find('.kanban').length > 0) {
+				fluxify.doAction('update_cards', cards);
+			} else {
+				init();
+			}
 		}
 
 		function init() {
@@ -250,8 +254,13 @@ frappe.provide("frappe.views");
 		}
 
 		function prepare() {
-			self.$kanban_board = $(frappe.render_template("kanban_board"));
-			self.$kanban_board.appendTo(self.wrapper);
+			self.$kanban_board = self.wrapper.find('.kanban');
+
+			if(self.$kanban_board.length === 0) {
+				self.$kanban_board = $(frappe.render_template("kanban_board"));
+				self.$kanban_board.appendTo(self.wrapper);
+			}
+
 			self.$filter_area = self.cur_list.$page.find('.set-filters');
 			bind_events();
 			setup_sortable();

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -5,7 +5,7 @@ frappe.views.KanbanView = frappe.views.ListRenderer.extend({
 	render_view: function(values) {
 		var board_name = this.get_board_name();
 		if(this.kanban && board_name === this.kanban.board_name) {
-			this.kanban.update_cards(values);
+			this.kanban.update(values);
 			return;
 		}
 


### PR DESCRIPTION
- When you click on **Refresh**, kanban board disappears
- When you click on **More**, another kanban board is created and appended
- When you perform any invalid operation, like move a card to **Closed** column, when it is dependent on another card, the card doesn't revert to original column

This PR fixes these issues