### PR TITLE
Breadcrumb

### DIFF
--- a/frappe/public/css/website.css
+++ b/frappe/public/css/website.css
@@ -816,7 +816,7 @@ a.active {
 }
 .page-head h1 {
   letter-spacing: 0.5px;
-  font-size: 24px;
+  font-size: 20px;
 }
 .btn-next-wrapper {
   margin-top: 60px;

--- a/frappe/public/css/website.css
+++ b/frappe/public/css/website.css
@@ -817,6 +817,7 @@ a.active {
 .page-head h1 {
   letter-spacing: 0.5px;
   font-size: 20px;
+  margin: auto;
 }
 .btn-next-wrapper {
   margin-top: 60px;

--- a/frappe/public/less/website.less
+++ b/frappe/public/less/website.less
@@ -536,7 +536,7 @@ a.active {
 
 .page-head h1 {
 	letter-spacing: 0.5px;
-	font-size: 24px;
+	font-size: 20px;
 }
 
 .btn-next-wrapper {

--- a/frappe/public/less/website.less
+++ b/frappe/public/less/website.less
@@ -537,6 +537,7 @@ a.active {
 .page-head h1 {
 	letter-spacing: 0.5px;
 	font-size: 20px;
+	margin: auto;
 }
 
 .btn-next-wrapper {

--- a/frappe/templates/web.html
+++ b/frappe/templates/web.html
@@ -13,7 +13,7 @@
 		<div class="{% if show_sidebar %}page-content with-sidebar col-sm-9{% else %} page-content col-sm-12 {% endif %}">
 			<div class="page-content-wrapper">
 				<div class="row page-head">
-					<div class='col-sm-12'>
+					<div class='col-sm-12 hidden-xs'>
 						{% if not no_breadcrumbs and parents %}
 						<div class="page-breadcrumbs">
 							{% block breadcrumbs %}


### PR DESCRIPTION
Portal sidebar fix, showing two links earlier.
 
Before

![photo_2017-04-07_14-48-44](https://cloud.githubusercontent.com/assets/22857645/25130342/6ddebbe0-245f-11e7-8d83-d1d00868b6d6.jpg)

Now 

![after](https://cloud.githubusercontent.com/assets/22857645/25130358/7844c3cc-245f-11e7-9643-23ce85e868b9.png)

