### PR TITLE
White background in the note section of the Note doctype. Fix #3052

### DIFF
--- a/frappe/desk/doctype/note/note.css
+++ b/frappe/desk/doctype/note/note.css
@@ -1,0 +1,3 @@
+.like-disabled-input{
+    background-color: #fff;
+}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/13694115/25181279/b2ca4796-2519-11e7-9f12-ea7fe2d5bd9b.png)
