### PR TITLE
Javascript modification to allow translation

### DIFF
--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -320,11 +320,11 @@ frappe.views.ListRenderer = Class.extend({
 			const $item_container = $('<div class="list-item-container">').append($item);
 
 			$list_items.append($item_container);
-			
+
 			if (this.settings.post_render_item) {
 				this.settings.post_render_item(this, $item_container, value);
 			}
-			
+
 			this.render_tags($item_container, value);
 		});
 
@@ -541,7 +541,7 @@ frappe.views.ListRenderer = Class.extend({
 		var new_button = frappe.boot.user.can_create.includes(this.doctype)
 			? (`<p><button class='btn btn-primary btn-sm'
 				list_view_doc='${this.doctype}'>
-					${__('Make a new ' + __(this.doctype))}
+					${__('Make a new {0}'), [__(this.doctype)])}
 				</button></p>`)
 			: '';
 		var no_result_message =


### PR DESCRIPTION
Hi,

The former syntax didn't allow the sentence 'Make a new ' to be translated.

The white space inside and the combination with the doctype lead it to never be translated in other languages.

This modification should correct it.

![image](https://cloud.githubusercontent.com/assets/4903591/25194137/bf845c2c-2539-11e7-8567-11e6b75c5a0f.png)

Thank you!

PS: 'Make a new {0}' is already part of the current translations so it should improve the UI immediately for everyone.