### PR TITLE
[minor] added missing toggle_display to grid.js

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -348,6 +348,10 @@ frappe.ui.form.Grid = Class.extend({
 		this.get_docfield(fieldname).read_only = enable ? 0 : 1;;
 		this.refresh();
 	},
+	toggle_display: function(fieldname, show) {
+		this.get_docfield(fieldname).hidden = show ? 0 : 1;;
+		this.refresh();
+	},
 	get_docfield: function(fieldname) {
 		return frappe.meta.get_docfield(this.doctype, fieldname, this.frm ? this.frm.docname : null);
 	},


### PR DESCRIPTION
https://discuss.erpnext.com/t/changing-the-properties-of-child-table-fields-using-custom-script/21820

`frm.fields_dict.childtable_field_name.grid.toggle_display("fieldname", true or false)`

added missing toggle_display function in grid.js

![toggle_hide](https://cloud.githubusercontent.com/assets/11224291/25224388/e11f0740-25db-11e7-92fa-ce517f8fda6f.gif)
