### PR TITLE
[fixes] invalid left-hand side expression in postfix operation fixes

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -204,7 +204,7 @@ frappe.socket = {
 		frappe.socket.file_watcher.on('reload_css', function(filename) {
 			let abs_file_path = "assets/" + filename;
 			const link = $(`link[href*="${abs_file_path}"]`);
-			abs_file_path = abs_file_path.split('?')[0] + '?v=' + +moment();
+			abs_file_path = abs_file_path.split('?')[0] + '?v='+ moment();
 			link.attr('href', abs_file_path);
 			frappe.show_alert({
 				indicator: 'orange',


### PR DESCRIPTION
fixes for https://discuss.erpnext.com/t/how-to-get-stable-version-from-git/22780/5?u=makarand_b

before: on reload
<img width="1206" alt="screen shot 2017-04-21 at 2 32 16 pm" src="https://cloud.githubusercontent.com/assets/11224291/25270920/e4f6cec4-269f-11e7-98d1-ab3ccd671dad.png">

after:
![socket](https://cloud.githubusercontent.com/assets/11224291/25270925/e7d90c24-269f-11e7-8aea-ccbed7e4d478.gif)
