### PR TITLE
Fix for localhost SMTP servers without authentication

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -61,7 +61,7 @@ class EmailAccount(Document):
 
 		if (not self.awaiting_password and not frappe.local.flags.in_install
 			and not frappe.local.flags.in_patch):
-			if self.smtp_server == "127.0.0.1" or self.smtp_server == "localhost" or self.password:
+			if self.password or self.smtp_server in ('127.0.0.1' or 'localhost'):
 				if self.enable_incoming:
 					self.get_incoming_server()
 					self.no_failed = 0

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -61,7 +61,7 @@ class EmailAccount(Document):
 
 		if (not self.awaiting_password and not frappe.local.flags.in_install
 			and not frappe.local.flags.in_patch):
-			if self.password:
+			if self.smtp_server == "127.0.0.1" or self.smtp_server == "localhost" or self.password:
 				if self.enable_incoming:
 					self.get_incoming_server()
 					self.no_failed = 0

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -59,7 +59,7 @@ def get_outgoing_email_account(raise_exception_not_set=True, append_to=None):
 
 		if email_account:
 			if email_account.enable_outgoing and not getattr(email_account, 'from_site_config', False):
-				email_account.password = email_account.get_password()
+				email_account.password = email_account.get_password(raise_exception=False)
 			email_account.default_sender = email.utils.formataddr((email_account.name, email_account.get("email_id")))
 
 		frappe.local.outgoing_email_account[append_to or "default"] = email_account

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -59,7 +59,11 @@ def get_outgoing_email_account(raise_exception_not_set=True, append_to=None):
 
 		if email_account:
 			if email_account.enable_outgoing and not getattr(email_account, 'from_site_config', False):
-				email_account.password = email_account.get_password(raise_exception=False)
+				if email_account.smtp_server in ('localhost', '127.0.0.1'):
+					raise_exception = False
+				else:
+					raise_exception = True
+				email_account.password = email_account.get_password(raise_exception)
 			email_account.default_sender = email.utils.formataddr((email_account.name, email_account.get("email_id")))
 
 		frappe.local.outgoing_email_account[append_to or "default"] = email_account

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -59,11 +59,10 @@ def get_outgoing_email_account(raise_exception_not_set=True, append_to=None):
 
 		if email_account:
 			if email_account.enable_outgoing and not getattr(email_account, 'from_site_config', False):
-				if email_account.smtp_server in ('localhost', '127.0.0.1'):
+				raise_exception = True
+				if email_account.smtp_server in ['localhost','127.0.0.1']:
 					raise_exception = False
-				else:
-					raise_exception = True
-				email_account.password = email_account.get_password(raise_exception)
+				email_account.password = email_account.get_password(raise_exception=raise_exception)
 			email_account.default_sender = email.utils.formataddr((email_account.name, email_account.get("email_id")))
 
 		frappe.local.outgoing_email_account[append_to or "default"] = email_account


### PR DESCRIPTION
The fixes the issue of preventing users with self hosted SMTP servers from adding user accounts & sending emails.

See issue here:
https://github.com/frappe/erpnext/issues/6581