### PR TITLE
[minor] set default_letter head to '' if defaul company is not set

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -223,7 +223,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 frappe.ui.get_print_settings = function(pdf, callback, letter_head) {
 	var print_settings = locals[":Print Settings"]["Print Settings"];
 
-	var default_letter_head = locals[":Company"]
+	var default_letter_head = locals[":Company"] && frappe.defaults.get_default('company')
 		? locals[":Company"][frappe.defaults.get_default('company')]["default_letter_head"]
 		: '';
 


### PR DESCRIPTION
Steps to recreate

1. Set the Default Company to ""/blank in Global Defaults
2. Check the Profit and Loss Statement and click on Print from Menu 

![printjs_before](https://cloud.githubusercontent.com/assets/11224291/25323934/692560ec-28e0-11e7-972e-8a6fb8692232.gif)

`After`
![printjs_after](https://cloud.githubusercontent.com/assets/11224291/25323938/6ccfc282-28e0-11e7-9260-397b0d860ccd.gif)
