### PR TITLE
[fixed] Cannot read property 'summernote' of undefined

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1760,7 +1760,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 		}
 	},
 	get_value: function() {
-		return this.editor.summernote('code');
+		return this.editor? this.editor.summernote('code'): '';
 	},
 	set_input: function(value) {
 		if(value == null) value = "";


### PR DESCRIPTION
`before`

![summnernote_before](https://cloud.githubusercontent.com/assets/11224291/25327726/d97966ba-28f2-11e7-9dbd-a1d883873e3c.gif)

`after`

![summnernote_after](https://cloud.githubusercontent.com/assets/11224291/25327731/df35f578-28f2-11e7-95d9-58e6a7fa2750.gif)
