### PR TITLE
[fixes] append the summernote dialogs to body instead of editor

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1648,6 +1648,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 				}
 			},
 			prettifyHtml: true,
+			dialogsInBody: true,
 			callbacks: {
 				onChange: function(value) {
 					me.parse_validate_and_set_in_model(value);


### PR DESCRIPTION
`before`

![summnernote_before](https://cloud.githubusercontent.com/assets/11224291/25332785/6809ff36-2905-11e7-82c5-d787264e8fba.gif)

`after`

dialogInBody attribute will append the summernote dialogs to **body** instead of **editor**

![summnernote_after](https://cloud.githubusercontent.com/assets/11224291/25332787/69f702bc-2905-11e7-8dd4-423f08b34802.gif)
