### PR TITLE
Fix for #3136

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -324,7 +324,8 @@ def uninstall(context, app, dry_run=False, yes=False):
 @click.option('--root-login', default='root')
 @click.option('--root-password')
 @click.option('--archived-sites-path')
-def drop_site(site, root_login='root', root_password=None, archived_sites_path=None):
+@click.option('--force', help='Force restore if site/database already exists', is_flag=True, default=False)
+def drop_site(site, root_login='root', root_password=None, archived_sites_path=None, force=False):
 	"Remove site from database and filesystem"
 	from frappe.installer import get_root_connection
 	from frappe.model.db_schema import DbManager

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -324,7 +324,7 @@ def uninstall(context, app, dry_run=False, yes=False):
 @click.option('--root-login', default='root')
 @click.option('--root-password')
 @click.option('--archived-sites-path')
-@click.option('--force', help='Force restore if site/database already exists', is_flag=True, default=False)
+@click.option('--force', help='Force drop-site even if an error is encountered', is_flag=True, default=False)
 def drop_site(site, root_login='root', root_password=None, archived_sites_path=None, force=False):
 	"Remove site from database and filesystem"
 	from frappe.installer import get_root_connection

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -338,9 +338,17 @@ def drop_site(site, root_login='root', root_password=None, archived_sites_path=N
 		scheduled_backup(ignore_files=False, force=True)
 	except ProgrammingError as err:
 		if err[0] == 1146:
-			# ProgrammingError(1146) is thrown when there is a missing table.
-			# We want to delete all tables so its safe to ignore the Error.
-			pass
+			if force:
+				pass
+			else:
+				click.echo("="*80)
+				click.echo("Error: The operation has stopped because backup of {s}'s database failed.".format(s=site))
+				click.echo("Reason: {reason}{sep}".format(reason=err[1], sep="\n"))
+				click.echo("Fix the issue and try again.")
+				click.echo(
+					"Hint: Use 'bench drop-site {s} --force' to force the removal of {s}".format(sep="\n", tab="\t", s=site)
+				)
+				sys.exit(1)
 
 	db_name = frappe.local.conf.db_name
 	frappe.local.db = get_root_connection(root_login, root_password)


### PR DESCRIPTION
A side effect of #3135 is that users cannot run `bench drop-site site-name` successfully. This is because the program looks for a non-existing table and this is not accounted for.

This fixes the issue by simply catching the exception and allowing the program to ignore the fact that the table is not needed.