### PR TITLE
Issue 3136

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -342,7 +342,7 @@ def drop_site(site, root_login='root', root_password=None, archived_sites_path=N
 					"{reason}{sep}{sep}"
 				).format(dec = "="*80, s=site, sep="\n", reason=err[1])
 
-			print("\n"*80)
+			print("="*80)
 			print(msg)
 
 			# Python 3 compatibility. Can this project incorporate six?

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -337,9 +337,33 @@ def drop_site(site, root_login='root', root_password=None, archived_sites_path=N
 		scheduled_backup(ignore_files=False, force=True)
 	except ProgrammingError as err:
 		if err[0] == 1146:
-			# ProgrammingError(1146) is thrown when there is a missing table.
-			# We want to delete all tables so its safe to ignore the Error.
-			pass
+			msg = (
+					"Backup of the {s}'s database failed. The reason is:{sep}"
+					"{reason}{sep}{sep}"
+				).format(dec = "="*80, s=site, sep="\n", reason=err[1])
+
+			print("\n"*80)
+			print(msg)
+
+			# Python 3 compatibility. Can this project incorporate six?
+			py3 = sys.version_info[0] > 2
+			kontinue = ""
+
+			while kontinue not in ['y', 'Y', 'n', 'N']:
+				if py3:
+					kontinue = input("Do you want to continue with the drop-site operation?: (y/N)")
+				else:
+					kontinue = raw_input("Do you want to continue with the drop-site operation?: (y/N)")
+
+			if kontinue.lower() == 'y':
+				pass
+			else:
+				msg = (
+						"{s} has not been removed. Please rectify the problem then run the {sep}"
+						"drop-site command again"
+					).format(s=site, sep="\n")
+				print(msg)
+				sys.exit(1)
 
 	db_name = frappe.local.conf.db_name
 	frappe.local.db = get_root_connection(root_login, root_password)


### PR DESCRIPTION
A side effect of #3135 is that users cannot run `bench drop-site site-name` successfully. This is because the program looks for a non-existing table and this is not accounted for.

This fixes the issue by simply catching the exception and allowing the program to ignore the fact that the table is not needed.