### PR TITLE
[minor] added ignore_mandatory flag if setup wizard is not completed

### DIFF
--- a/frappe/patches/v8_0/set_currency_field_precision.py
+++ b/frappe/patches/v8_0/set_currency_field_precision.py
@@ -17,5 +17,6 @@ def execute():
 			
 		ss = frappe.get_doc("System Settings")
 		ss.currency_precision = precision
+		ss.flags.ignore_mandatory = True
 		ss.save()
 		


### PR DESCRIPTION
Error Traceback

```
Executing frappe.patches.v8_0.set_currency_field_precision in 1980.erpnext.com (69b79dd2bceae9d1)
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-2017-04-25/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-04-25/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-2017-04-25/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-04-25/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-04-25/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-2017-04-25/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-04-25/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/commands/site.py", line 210, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/patches/v8_0/set_currency_field_precision.py", line 20, in execute
    ss.save()
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/model/document.py", line 231, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/model/document.py", line 267, in _save
    self._validate()
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/model/document.py", line 400, in _validate
    self._validate_mandatory()
  File "/home/frappe/benches/bench-2017-04-25/apps/frappe/frappe/model/document.py", line 620, in _validate_mandatory
    name=self.name))
frappe.exceptions.MandatoryError: [System Settings, System Settings]: language, time_zone
```