### PR TITLE
Escaping single quotes in translated filter stats

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -116,7 +116,8 @@ frappe.ui.FilterList = Class.extend({
 		if (['Date', 'Datetime'].indexOf(field.type)!=-1) {
 			return
 		}
-    var field_label = __(field.label).replace(/'/g, "\\'");
+
+		var field_label = __(field.label).replace(/'/g, "\\'");
 		var active = this.wrapper.find(".filter-sort-active[data-name='"+ field_label +"']");
 
 		// sort filters

--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -116,8 +116,8 @@ frappe.ui.FilterList = Class.extend({
 		if (['Date', 'Datetime'].indexOf(field.type)!=-1) {
 			return
 		}
-
-		var active = this.wrapper.find(".filter-sort-active[data-name='"+__(field.label)+"']");
+    var field_label = __(field.label).replace(/'/g, "\\'");
+		var active = this.wrapper.find(".filter-sort-active[data-name='"+ field_label +"']");
 
 		// sort filters
 		if(active.attr('data-sort-by')==='alphabet') {
@@ -168,7 +168,7 @@ frappe.ui.FilterList = Class.extend({
 			label: __(field.label),
 			labels:labels
 		};
-		var dashboard_filter = this.wrapper.find(".filter-stat[data-name='" + __(field.label) + "']")
+		var dashboard_filter = this.wrapper.find(".filter-stat[data-name='" + field_label + "']")
 		dashboard_filter.html(frappe.render_template("filter_dashboard_value", context))
 			.on("click", ".filter-stat-link", function() {
 				var fieldname = $(this).attr('data-field');


### PR DESCRIPTION
Hi,

This correction is related to the filters in list views.

In some languages, french for example, some words are preceded by a single quote, e.g "Type d'évènement" for "Event Type".
In the current implementation, the filters are taking the labels and therefore in some cases a single quote is inserted in jQuery, causing the functionality to freeze.

I just inserted a replace function to escape the single quotes in case they exist in words.

Let me know if you think of a better way to handle this.

Thank you!

PS: Related to #3128 