### PR TITLE
Correction of the heatmap init and selector for double words doctypes

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -333,7 +333,7 @@ frappe.ui.form.Dashboard = Class.extend({
 		if(!this.heatmap) {
 			this.heatmap = new CalHeatMap();
 			this.heatmap.init({
-				itemSelector: "#heatmap-" + this.frm.doctype,
+				itemSelector: "#heatmap-" + this.frm.doctype.split(' ').join('_'),
 				domain: "month",
 				subDomain: "day",
 				start: moment().subtract(1, 'year').add(1, 'month').toDate(),

--- a/frappe/public/js/frappe/form/templates/form_dashboard.html
+++ b/frappe/public/js/frappe/form/templates/form_dashboard.html
@@ -4,7 +4,8 @@
 	<div class="progress-area hidden form-dashboard-section">
 	</div>
 	<div class="form-heatmap hidden form-dashboard-section">
-		<div id="heatmap-{{ frm.doctype }}"></div>
+		{% doctype = frm.doctype.replace(" ", "_") %}
+		<div id="heatmap-{{ doctype }}"></div>
 		<div class="text-muted small heatmap-message hidden"></div>
 	</div>
 	<div class="form-chart form-dashboard-section hidden"></div>


### PR DESCRIPTION
Hi,

When trying to implement an heatmap on a doctype containing two words, I realized that it could not be rendered because the system could not match the item selector.

I therefore propose the below correction to allow heatmaps on doctypes with two words in its name.

Thank you!

PS: Sorry I previously closed this PR by mistake