### PR TITLE
[minor] don't show reply link if the timeline message was send by current user

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline_item.html
+++ b/frappe/public/js/frappe/form/footer/timeline_item.html
@@ -73,7 +73,7 @@
 						</a>
 						{% } %}
 
-						{% if (data.communication_medium === "Email") { %}
+						{% if (data.communication_medium === "Email" && data.sender !== user_email) { %}
 						<a class="text-muted reply-link pull-right timeline-content-show"
 							data-name="{%= data.name %}">{%= __("Reply") %}</a>
 						{% } %}


### PR DESCRIPTION
`before`

<img width="786" alt="screen shot 2017-04-25 at 6 39 10 pm" src="https://cloud.githubusercontent.com/assets/11224291/25386914/99ce5bc0-29e6-11e7-9bd0-2a3804f25de0.png">

`after`

<img width="774" alt="screen shot 2017-04-25 at 6 38 35 pm" src="https://cloud.githubusercontent.com/assets/11224291/25386912/96ff541c-29e6-11e7-937b-1520ffc236b8.png">
