### PR TITLE
enable tooltip in full calander

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -130,6 +130,9 @@ frappe.views.Calendar = Class.extend({
 					}
 				})
 			},
+			eventRender: function(event, element) {
+				element.attr('title', event.tooltip);
+			},
 			eventClick: function(event, jsEvent, view) {
 				// edit event description or delete
 				var doctype = event.doctype || me.doctype;


### PR DESCRIPTION
We need to pass this event data in field map to show tooltip
	field_map: {
		"start": "date",
		"end": "date",
		"id": "name",
		"tooltip": "doctor",
		"title": "doctor",
		"allDay": "allDay",
		"child_name": "name"
	},