### PR TITLE
[minor][fix] add indicator for finished status

### DIFF
--- a/frappe/core/page/background_jobs/background_jobs.html
+++ b/frappe/core/page/background_jobs/background_jobs.html
@@ -28,9 +28,10 @@
 		</tbody>
 	</table>
 	<p>
-		<span class="indicator green" style="margin-right: 20px;">Started</span>
+		<span class="indicator blue" style="margin-right: 20px;">Started</span>
 		<span class="indicator orange" style="margin-right: 20px;">Queued</span>
-		<span class="indicator red">Failed</span>
+		<span class="indicator red" style="margin-right: 20px;">Failed</span>
+		<span class="indicator green">Finished</span>
 	</p>
 	{% else %}
 	<p class="text-muted">No pending or current jobs for this site</p>

--- a/frappe/core/page/background_jobs/background_jobs.py
+++ b/frappe/core/page/background_jobs/background_jobs.py
@@ -11,7 +11,8 @@ from frappe.utils import format_datetime, cint
 colors = {
 	'queued': 'orange',
 	'failed': 'red',
-	'started': 'green'
+	'started': 'blue',
+	'finished': 'green'
 }
 
 @frappe.whitelist()


### PR DESCRIPTION
Error
---

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/handler.py", line 42, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/__init__.py", line 907, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/core/page/background_jobs/background_jobs.py", line 43, in get_info
    for j in q.get_jobs(): add_job(j, q.name)
  File "/home/frappe/benches/bench-2016-07-23/apps/frappe/frappe/core/page/background_jobs/background_jobs.py", line 31, in add_job
    'color': colors[j.status]
KeyError: u'finished'
```

---

After Fix Background Job page will look like 
---
<img width="1222" alt="screen shot 2017-04-26 at 3 13 38 pm" src="https://cloud.githubusercontent.com/assets/3784093/25429897/28c561aa-2a98-11e7-827e-dd0439ce6320.png">
