### PR TITLE
remove html tags when exporting report in excel format

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -8,7 +8,9 @@ from frappe.utils import encode, cstr, cint, flt, comma_or
 import openpyxl
 from cStringIO import StringIO
 from openpyxl.styles import Font
-import re
+
+import html2text
+
 # return xlsx file object
 def make_xlsx(data, sheet_name):
 
@@ -21,9 +23,14 @@ def make_xlsx(data, sheet_name):
 	for row in data:
 		clean_row = []
 		for item in row:
-			cleaner = re.compile('<.*?>')
-			clean_row.append(re.sub(cleaner, '', item))
+			obj = html2text.HTML2Text()
+			obj.ignore_links = True
+			obj.body_width = 0
+			obj = obj.handle(item)
+			obj = obj.rsplit('\n', 1)
+			clean_row.append(obj[0])
 		ws.append(clean_row)
+
 
 	xlsx_file = StringIO()
 	wb.save(xlsx_file)

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -8,7 +8,7 @@ from frappe.utils import encode, cstr, cint, flt, comma_or
 import openpyxl
 from cStringIO import StringIO
 from openpyxl.styles import Font
-
+import re
 # return xlsx file object
 def make_xlsx(data, sheet_name):
 
@@ -19,7 +19,11 @@ def make_xlsx(data, sheet_name):
 	row1.font = Font(name='Calibri',bold=True)
 
 	for row in data:
-		ws.append(row)
+		clean_row = []
+		for item in row:
+			cleaner = re.compile('<.*?>')
+			clean_row.append(re.sub(cleaner, '', item))
+		ws.append(clean_row)
 
 	xlsx_file = StringIO()
 	wb.save(xlsx_file)


### PR DESCRIPTION
When a report contains html formatted texts, exporting it in excel format would show html tags along with data in cells such as shown is the attached image.
![image](https://cloud.githubusercontent.com/assets/15218854/25478274/258f13bc-2b49-11e7-9979-cf0a58e6e307.png)

I've added code to remove html tags if they exist when exporting a report to excel sheet.