### PR TITLE
[fixes] check if print for Draft and Cancelled document is allowed or not before sending email alert

### DIFF
--- a/frappe/www/print.py
+++ b/frappe/www/print.py
@@ -76,10 +76,10 @@ def get_html(doc, name=None, print_format=None, meta=None,
 		validate_print_permission(doc)
 
 	if doc.meta.is_submittable:
-		if doc.docstatus==0 and not print_settings.allow_print_for_draft:
+		if doc.docstatus==0 and not cint(print_settings.allow_print_for_draft):
 			frappe.throw(_("Not allowed to print draft documents"), frappe.PermissionError)
 
-		if doc.docstatus==2 and not print_settings.allow_print_for_cancelled:
+		if doc.docstatus==2 and not cint(print_settings.allow_print_for_cancelled):
 			frappe.throw(_("Not allowed to print cancelled documents"), frappe.PermissionError)
 
 	if hasattr(doc, "before_print"):


### PR DESCRIPTION
`before`

![email-alert-before](https://cloud.githubusercontent.com/assets/11224291/25481605/8ec54578-2b6b-11e7-814f-9c0b33aba2b3.gif)

`after`

![email-alert-after](https://cloud.githubusercontent.com/assets/11224291/25481607/9073034c-2b6b-11e7-997c-de9c2a8c1b6e.gif)
