### PR TITLE
[hotfix] local veriable data reference before assignment fixes

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -15,6 +15,7 @@ from werkzeug.wrappers import Response
 def handle():
 	"""handle request"""
 	cmd = frappe.local.form_dict.cmd
+	data = None
 
 	if cmd!='login':
 		data = execute_cmd(cmd)


### PR DESCRIPTION
`before`

![login](https://cloud.githubusercontent.com/assets/11224291/25514410/8b823d6e-2bfa-11e7-8102-ad1b91ea0a6c.gif)

`after`

![login-after](https://cloud.githubusercontent.com/assets/11224291/25514414/8de5f122-2bfa-11e7-81bb-41376bf78000.gif)
