### PR TITLE
[fix] On the module page reports not showing of the doctype which had option User Cannot Search

### DIFF
--- a/frappe/desk/page/modules/modules.js
+++ b/frappe/desk/page/modules/modules.js
@@ -133,9 +133,9 @@ frappe.pages['modules'].on_page_load = function(wrapper) {
 						return encodeURIComponent(key) + "=" + encodeURIComponent(value) }).join('&')
 				}
 
-				if(item.type==="page" || item.type==="help" ||
-					(item.doctype && frappe.model.can_read(item.doctype))) {
-						item.shown = true;
+				if(item.type==="page" || item.type==="help" || item.type==="report" ||
+				(item.doctype && frappe.model.can_read(item.doctype))) {
+					item.shown = true;
 				}
 			});
 		});


### PR DESCRIPTION
**Description about the issue**
Recently we have enabled the option User Cannot Search for the doctype GL Entry. After this change user not able to view the reports like Trial Balance, Balance Sheet which are based on the GL Entry on the module page of accounts. They are able to search and open the reports using awesome search bar. 

**Issue**
![screen shot 2017-04-29 at 10 39 40 am](https://cloud.githubusercontent.com/assets/8780500/25553164/40616fe6-2cca-11e7-9aec-3ad729641adc.png)

**Fixed**
![screen shot 2017-04-29 at 10 55 03 am](https://cloud.githubusercontent.com/assets/8780500/25553168/5797a266-2cca-11e7-8a3f-94e6b295f4c4.png)
