### PR TITLE
[fix][hot] fix for AttributeError: 'NoneType' object has no attribute 'get'

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -251,8 +251,10 @@ class EmailAccount(Document):
 					return
 
 				emails = email_server.get_messages()
+				if not emails:
+					return
 
-				incoming_mails = emails.get("latest_messages")
+				incoming_mails = emails.get("latest_messages", [])
 				uid_list = emails.get("uid_list", [])
 				seen_status = emails.get("seen_status", [])
 				uid_reindexed = emails.get("uid_reindexed", False)

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -100,7 +100,7 @@ class EmailServer:
 		frappe.db.commit()
 
 		if not self.connect():
-			return []
+			return
 
 		uid_list = []
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-04-28/env/lib/python2.7/site-packages/rq/worker.py", line 700, in perform_job
    rv = job.perform()
  File "/home/frappe/benches/bench-2017-04-28/env/lib/python2.7/site-packages/rq/job.py", line 500, in perform
    self._result = self.func(*self.args, **self.kwargs)
  File "/home/frappe/benches/bench-2017-04-28/apps/frappe/frappe/utils/background_jobs.py", line 65, in execute_job
    method(**kwargs)
  File "/home/frappe/benches/bench-2017-04-28/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 700, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/benches/bench-2017-04-28/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 255, in receive
    incoming_mails = emails.get("latest_messages")
AttributeError: 'NoneType' object has no attribute 'get'
```