### PR TITLE
[minor] type casting value to string causes email alerts to be sent on every save action

### DIFF
--- a/frappe/email/doctype/email_alert/email_alert.py
+++ b/frappe/email/doctype/email_alert/email_alert.py
@@ -8,6 +8,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.core.doctype.role.role import get_emails_from_role
 from frappe.utils import validate_email_add, nowdate
+from frappe.utils.data import parse_val
 from frappe.utils.jinja import validate_template
 from frappe.modules.utils import export_module_json, get_doc_module
 from markdown2 import markdown
@@ -194,7 +195,7 @@ def evaluate_alert(doc, alert, event):
 
 		if event=="Value Change" and not doc.is_new():
 			db_value = frappe.db.get_value(doc.doctype, doc.name, alert.value_changed)
-
+			db_value = parse_val(db_value)
 			if (doc.get(alert.value_changed) == db_value) or \
 				(not db_value and not doc.get(alert.value_changed)):
 

--- a/frappe/email/doctype/email_alert/email_alert.py
+++ b/frappe/email/doctype/email_alert/email_alert.py
@@ -195,10 +195,6 @@ def evaluate_alert(doc, alert, event):
 		if event=="Value Change" and not doc.is_new():
 			db_value = frappe.db.get_value(doc.doctype, doc.name, alert.value_changed)
 
-			# cast to string if not already for comparing to doc.get's value
-			if not isinstance(db_value, basestring):
-				db_value = str(frappe.db.get_value(doc.doctype, doc.name, alert.value_changed))
-
 			if doc.get(alert.value_changed) == db_value:
 				return # value not changed
 

--- a/frappe/email/doctype/email_alert/email_alert.py
+++ b/frappe/email/doctype/email_alert/email_alert.py
@@ -195,7 +195,9 @@ def evaluate_alert(doc, alert, event):
 		if event=="Value Change" and not doc.is_new():
 			db_value = frappe.db.get_value(doc.doctype, doc.name, alert.value_changed)
 
-			if doc.get(alert.value_changed) == db_value:
+			if (doc.get(alert.value_changed) == db_value) or \
+				(not db_value and not doc.get(alert.value_changed)):
+
 				return # value not changed
 
 		if event != "Value Change" and not doc.is_new():

--- a/frappe/email/doctype/email_alert/test_email_alert.py
+++ b/frappe/email/doctype/email_alert/test_email_alert.py
@@ -78,7 +78,7 @@ class TestEmailAlert(unittest.TestCase):
 		event.subject = "test 1"
 		event.save()
 
-		self.assertTrue(frappe.db.get_value("Email Queue", {"reference_doctype": "Event",
+		self.assertFalse(frappe.db.get_value("Email Queue", {"reference_doctype": "Event",
 			"reference_name": event.name, "status":"Not Sent"}))
 
 		event.description = "test"
@@ -106,7 +106,9 @@ class TestEmailAlert(unittest.TestCase):
 		event.starts_on  = frappe.utils.add_days(frappe.utils.nowdate(), 2) + " 12:00:00"
 		event.save()
 
-		self.assertTrue(frappe.db.get_value("Email Queue", {"reference_doctype": "Event",
+		# Value Change email alert alert will be trigger as description is not changed
+		# mail will not be sent 
+		self.assertFalse(frappe.db.get_value("Email Queue", {"reference_doctype": "Event",
 			"reference_name": event.name, "status":"Not Sent"}))
 
 		frappe.utils.scheduler.trigger(frappe.local.site, "daily", now=True)


### PR DESCRIPTION
`before`

Email alert is sent even if the value is not changed as it compare the string value with doc value

e.g. document value for `send` is `1` is compared with `"1"` hence system send the email alert on each save/update action if the Email Alert event is **Value Changed**

![email-alert](https://cloud.githubusercontent.com/assets/11224291/25556052/ed4aa1ee-2d12-11e7-9cd6-70f336ee0771.gif)

`after`

![email-alert](https://cloud.githubusercontent.com/assets/11224291/25556060/587f65a8-2d13-11e7-858d-e7d8b0d761f2.gif)
