### PR TITLE
[fixes] minor fix for between operator filter

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -299,9 +299,16 @@ class DatabaseQuery(object):
 
 			if f.operator.lower() == 'between' and \
 				(f.fieldname in ('creation', 'modified') or (df and (df.fieldtype=="Date" or df.fieldtype=="Datetime"))):
+
+				from_date = None
+				to_date = None
+				if f.value and isinstance(f.value, (list, tuple)):
+					if len(f.value) >= 1: from_date = f.value[0]
+					if len(f.value) >= 2: to_date = f.value[1]
+
 				value = "'%s' AND '%s'" % (
-					add_to_date(get_datetime(f.value[0]),days=-1).strftime("%Y-%m-%d %H:%M:%S.%f"),
-					get_datetime(f.value[1]).strftime("%Y-%m-%d %H:%M:%S.%f"))
+					add_to_date(get_datetime(from_date),days=-1).strftime("%Y-%m-%d %H:%M:%S.%f"),
+					get_datetime(to_date).strftime("%Y-%m-%d %H:%M:%S.%f"))
 				fallback = "'0000-00-00 00:00:00'"
 
 			elif df and df.fieldtype=="Date":

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -38,3 +38,48 @@ class TestReportview(unittest.TestCase):
 		self.assertTrue({"fieldtype":"Table", "fieldname":"fields"} in data)
 		self.assertTrue({"fieldtype":"Select", "fieldname":"document_type"} in data)
 		self.assertFalse({"fieldtype":"Check", "fieldname":"issingle"} in data)
+
+	def test_between_filters(self):
+		""" test case to check between filter for date fields """
+		frappe.db.sql("delete from tabEvent")
+
+		# create events to test the between operator filter
+		todays_event = create_event()
+		event = create_event(starts_on="2016-07-06 12:00:00")
+
+		# if the values are not passed in filters then todays event should be return
+		data = DatabaseQuery("Event").execute(
+			filters={"starts_on": ["between", None]}, fields=["name"])
+
+		self.assertTrue({ "name": todays_event.name } in data)
+		self.assertTrue({ "name": event.name } not in data)
+
+		# if both from and to_date values are passed
+		data = DatabaseQuery("Event").execute(
+			filters={"starts_on": ["between", ["2016-07-05 12:00:00", "2016-07-07 12:00:00"]]},
+			fields=["name"])
+
+		self.assertTrue({ "name": event.name } in data)
+		self.assertTrue({ "name": todays_event.name } not in data)
+
+		# if only one value is passed in the filter
+		data = DatabaseQuery("Event").execute(
+			filters={"starts_on": ["between", ["2016-07-05 12:00:00"]]},
+			fields=["name"])
+
+		self.assertTrue({ "name": todays_event.name } in data)
+		self.assertTrue({ "name": event.name } in data)
+
+def create_event(subject="_Test Event", starts_on=None):
+	""" create a test event """
+
+	from frappe.utils import get_datetime
+
+	event = frappe.get_doc({
+		"doctype": "Event",
+		"subject": subject,
+		"event_type": "Public",
+		"starts_on": get_datetime(starts_on),
+	}).insert(ignore_permissions=True)
+
+	return event


### PR DESCRIPTION
`steps to recreate the issue`

1. In filters select the field with fieldtype date or datetime
2. Select the operator as Between and set the value as Null 

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/handler.py", line 40, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/__init__.py", line 901, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/desk/reportview.py", line 17, in get
    data = compress(execute(**args), args = args)
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/desk/reportview.py", line 22, in execute
    return DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/model/db_query.py", line 80, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/model/db_query.py", line 92, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/model/db_query.py", line 110, in prepare_args
    self.build_conditions()
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/model/db_query.py", line 240, in build_conditions
    self.build_filter_conditions(self.filters, self.conditions)
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/model/db_query.py", line 258, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "/home/frappe/benches/bench-2017-03-30/apps/frappe/frappe/model/db_query.py", line 299, in prepare_filter_condition
    get_datetime(f.value[0]).strftime("%Y-%m-%d %H:%M:%S.%f"),
TypeError: 'NoneType' object has no attribute '__getitem__'
```