### PR TITLE
Update generators.md

### DIFF
--- a/frappe/docs/user/en/guides/portal-development/generators.md
+++ b/frappe/docs/user/en/guides/portal-development/generators.md
@@ -86,3 +86,5 @@ If you add a method `get_list_view` in the controller file (job_opening.py), you
 	def get_list_context(context):
 		context.title = _("Jobs")
 		context.introduction = _('Current Job Openings')
+
+{next}


### PR DESCRIPTION
add {next} markup missing at bottom of page

reported here https://discuss.erpnext.com/t/documentation-page-error/23225