### PR TITLE
[minor] added int, float, long in eval globals

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1324,11 +1324,19 @@ def bold(text):
 
 def safe_eval(code, eval_globals=None, eval_locals=None):
 	'''A safer `eval`'''
+	whitelisted_globals = {
+		"int": int,
+		"float": float,
+		"long": long
+	}
+	
 	if '__' in code:
 		throw('Illegal rule {0}. Cannot use "__"'.format(bold(code)))
 
 	if not eval_globals:
 		eval_globals = {}
 	eval_globals['__builtins__'] = {}
+
+	eval_globals.update(whitelisted_globals)
 
 	return eval(code, eval_globals, eval_locals)


### PR DESCRIPTION
fix for https://github.com/frappe/erpnext/issues/8643

`before`

<img width="1068" alt="screen shot 2017-05-01 at 6 22 47 pm" src="https://cloud.githubusercontent.com/assets/11224291/25580077/366c4fba-2e9b-11e7-88d4-eabd5d190dde.png">

`after`

![after](https://cloud.githubusercontent.com/assets/11224291/25580108/88199246-2e9b-11e7-8abb-76080ac4d7f9.gif)
