### PR TITLE
[minor] Don't override subject in Standard Reply

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -166,6 +166,7 @@ frappe.views.CommunicationComposer = Class.extend({
 				var content_field = me.dialog.fields_dict.content;
 				var subject_field = me.dialog.fields_dict.subject;
 				var content = content_field.get_value() || "";
+				var subject = subject_field.get_value() || "";
 
 				parts = content.split('<!-- salutation-ends -->');
 
@@ -176,7 +177,9 @@ frappe.views.CommunicationComposer = Class.extend({
 				}
 
 				content_field.set_input(content.join(''));
-				subject_field.set_input(reply.subject);
+				if(subject === "") {
+					subject_field.set_input(reply.subject);
+				}
 
 				me.reply_added = standard_reply;
 			}


### PR DESCRIPTION
![screen shot 2017-05-02 at 1 12 56 am](https://cloud.githubusercontent.com/assets/5196925/25591996/8803edd6-2ed4-11e7-8fb2-cfc275512eb8.png)


Subject field filled with Standard Reply subject only if empty; doesn't override already present (often more meaningful) subject