### PR TITLE
In global search property not allowed for no_value_fields

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -419,6 +419,11 @@ def validate_fields(meta):
 	def check_in_list_view(d):
 		if d.in_list_view and (d.fieldtype in not_allowed_in_list_view):
 			frappe.throw(_("'In List View' not allowed for type {0} in row {1}").format(d.fieldtype, d.idx))
+			
+	def check_in_global_search(d):
+		if d.in_global_search and d.fieldtype in no_value_fields:
+			frappe.throw(_("'In Global Search' not allowed for type {0} in row {1}")
+				.format(d.fieldtype, d.idx))
 
 	def check_dynamic_link_options(d):
 		if d.fieldtype=="Dynamic Link":
@@ -582,6 +587,7 @@ def validate_fields(meta):
 		check_dynamic_link_options(d)
 		check_hidden_and_mandatory(d)
 		check_in_list_view(d)
+		check_in_global_search(d)
 		check_illegal_default(d)
 		check_unique_and_text(d)
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -97,7 +97,7 @@ class Meta(Document):
 
 	def get_global_search_fields(self):
 		'''Returns list of fields with `in_global_search` set and `name` if set'''
-		fields = self.get("fields", {"in_global_search": 1 })
+		fields = self.get("fields", {"in_global_search": 1, "fieldtype": ["not in", no_value_fields]})
 		if getattr(self, 'show_name_in_global_search', None):
 			fields.append(frappe._dict(fieldtype='Data', fieldname='name', label='Name'))
 


### PR DESCRIPTION
- Added validation to not allow In_global_search property for no_value_fields
<img width="1057" alt="screen shot 2017-05-02 at 1 17 34 pm" src="https://cloud.githubusercontent.com/assets/836784/25610343/87e7dfc6-2f40-11e7-851d-dc590a3352ac.png">

- Fixed https://github.com/frappe/erpnext/issues/8600