### PR TITLE
[fixed] draggable grid view for row template

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -744,7 +744,7 @@ frappe.ui.form.GridRow = Class.extend({
 			this.row_index.find('span').html(this.doc.idx);
 		}
 
-		this.row_display = $('<div class="row-data template-row">'+
+		this.row_display = $('<div class="row-data sortable-handle template-row">'+
 			+'</div>').appendTo(this.row)
 			.html(frappe.render(this.grid.template, {
 				doc: this.doc ? frappe.get_format_helper(this.doc) : null,


### PR DESCRIPTION
Fix for draggable rows if editable grid is disabled

`before`

![before](https://cloud.githubusercontent.com/assets/11224291/25673978/eb475418-3056-11e7-93c7-d37a850fd933.gif)

`after`

![after](https://cloud.githubusercontent.com/assets/11224291/25673981/ecd95164-3056-11e7-9ec7-dc5c88797ddc.gif)
