### PR TITLE
[minor][fix] do not return instead check for submitted doctype

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -176,13 +176,12 @@ frappe.ui.form.Toolbar = Class.extend({
 
 		// feedback
 		if(!this.frm.doc.__unsaved) {
-			if(is_submittable && docstatus != 1)
-				return
-
-			this.page.add_menu_item(__("Request Feedback"), function() {
-				feedback = new frappe.utils.Feedback();
-				feedback.manual_feedback_request(me.frm.doc);
-			}, true)
+			if(is_submittable && docstatus == 1) {
+				this.page.add_menu_item(__("Request Feedback"), function() {
+					feedback = new frappe.utils.Feedback();
+					feedback.manual_feedback_request(me.frm.doc);
+				}, true)
+			}
 		}
 
 		// New


### PR DESCRIPTION
Before
-----
Due to 
```
if(is_submittable && docstatus != 1)
    return
```

New Document option is missing in the menu for Draft documents.

<img width="1200" alt="screen shot 2017-05-05 at 7 24 03 pm" src="https://cloud.githubusercontent.com/assets/3784093/25748481/d75cf714-31c8-11e7-92fb-77a757020895.png">

---
After
-----

<img width="1158" alt="screen shot 2017-05-05 at 7 24 41 pm" src="https://cloud.githubusercontent.com/assets/3784093/25748488/e4c58f24-31c8-11e7-9f15-0d7af1569b55.png">

Note: Reported WN-SUP24851