### PR TITLE
[WIP] Setup Wizard tweaks

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -28,8 +28,14 @@
 	padding: 30px;
 }
 
+.setup-wizard-slide .slide-empty-state {
+	padding: 30px;
+	text-align: center;
+}
+
 .setup-wizard-progress {
     padding: 15px;
+	margin-bottom: 25px;
 }
 
 .setup-wizard-slide .fa-fw {

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -204,37 +204,37 @@ def email_setup_wizard_exception(traceback, args):
 		user_agent = frappe._dict()
 
 	message = """
-#### Basic Information
+		#### Basic Information
 
-- **Site:** {site}
-- **User:** {user}
-- **Browser:** {user_agent.platform} {user_agent.browser} version: {user_agent.version} language: {user_agent.language}
-- **Browser Languages**: `{accept_languages}`
+		- **Site:** {site}
+		- **User:** {user}
+		- **Browser:** {user_agent.platform} {user_agent.browser} version: {user_agent.version} language: {user_agent.language}
+		- **Browser Languages**: `{accept_languages}`
 
----
+		---
 
-#### Traceback
+		#### Traceback
 
-<pre>{traceback}</pre>
+		<pre>{traceback}</pre>
 
----
+		---
 
-#### Setup Wizard Arguments
+		#### Setup Wizard Arguments
 
-<pre>{args}</pre>
+		<pre>{args}</pre>
 
----
+		---
 
-#### Request Headers
+		#### Request Headers
 
-<pre>{headers}</pre>""".format(
-		site=frappe.local.site,
-		traceback=traceback,
-		args="\n".join(pretty_args),
-		user=frappe.session.user,
-		user_agent=user_agent,
-		headers=frappe.local.request.headers,
-		accept_languages=", ".join(frappe.local.request.accept_languages.values()))
+		<pre>{headers}</pre>""".format(
+			site=frappe.local.site,
+			traceback=traceback,
+			args="\n".join(pretty_args),
+			user=frappe.session.user,
+			user_agent=user_agent,
+			headers=frappe.local.request.headers,
+			accept_languages=", ".join(frappe.local.request.accept_languages.values()))
 
 	frappe.sendmail(recipients=frappe.local.conf.setup_wizard_exception_email,
 		sender=frappe.session.user,

--- a/frappe/desk/page/setup_wizard/setup_wizard_page.html
+++ b/frappe/desk/page/setup_wizard/setup_wizard_page.html
@@ -1,7 +1,13 @@
 <div class="container setup-wizard-slide {%= css_class %} with-form" data-slide-name="{%= name %}">
-	<div class="text-center setup-wizard-progress text-extra-muted">
+	<div class="text-center setup-wizard-progress">
 		{% for (var i=0; i < slides_count; i++) { %}
-		<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i>
+		<span style="position: relative;">
+			<a href="#setup-wizard/{%= i %}" class="text-extra-muted">
+				<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i></a>
+			<span class="slide-name-tooltip text-extra-muted hide" style="position: absolute; margin-top: 20px;">
+				<span style="position: relative; left:-65%;">{%= names[i] %}</span>
+			</span>
+		</span>
 		{% } %}
 	</div>
     <p class="text-center lead">{%= title %}</p>


### PR DESCRIPTION
Adding entries:
![taxes_add](https://cloud.githubusercontent.com/assets/5196925/25790998/e80aa2e6-33da-11e7-94e2-53d32e1ab600.gif)


Slide links in progress:
![untitled](https://cloud.githubusercontent.com/assets/5196925/25791012/06af5f84-33db-11e7-855e-8dcfa6fa8a8c.png)


Autocomplete instead of select?
![screen shot 2017-05-08 at 10 35 32 am](https://cloud.githubusercontent.com/assets/5196925/25791019/17b86a5a-33db-11e7-8a96-20e1bad99412.png)


- An initial roadmap for what some of the tweaks could target. Could be used to build upon.
- Perhaps there’s a less obtrusive way to enter and edit entries than a dialog.
- The added entries can look better with a custom template, rather than a list.
- The ability to jump over may be convenient (with only completed states marked active), but it also in some ways breaks the flow.

UI is arbitrary, just to get ideas across.

(WIP. Feel free to close)