### PR TITLE
Add horizontal border in writable fields for mobile view #2693

### DIFF
--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -565,8 +565,14 @@ select.form-control {
   .form-section .section-head {
     padding: 15px 15px 15px 0px;
   }
+  .form-section .section-body .form-column:first-child .radio,
+  .form-section .section-body .form-column:first-child .checkbox {
+    margin-top: 0;
+  }
   .form-column {
     border-bottom: 1px solid #EBEFF2;
+    padding-top: 15px;
+    padding-bottom: 15px;
   }
   .form-column:last-child {
     border-bottom: 0px;
@@ -612,6 +618,7 @@ select.form-control {
   }
   .form-page .form-control {
     border: none;
+    border-bottom: 1px solid #d1d8dd;
     box-shadow: none;
     background-color: inherit;
     height: auto;

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -713,10 +713,17 @@ select.form-control {
 		.section-head {
 			padding: 15px 15px 15px 0px;
 		}
+		.section-body .form-column:first-child{
+			.radio, .checkbox{
+				margin-top: 0;
+			}
+		}
 	}
 
 	.form-column {
 		border-bottom: 1px solid @light-border-color;
+		padding-top: 15px;
+		padding-bottom: 15px;
 	}
 
 	.form-column:last-child {
@@ -781,6 +788,7 @@ select.form-control {
 
 		.form-control {
 			border: none;
+			border-bottom: 1px solid @border-color;
 			box-shadow: none;
 			background-color: inherit;
 			height: auto;


### PR DESCRIPTION
Previous View : Editable fields without bottom border.
![screen shot 2017-05-08 at 1 40 44 pm](https://cloud.githubusercontent.com/assets/28141909/25795743/5a0333ea-33f4-11e7-8eda-24b42b3ee705.png)

Fixed : Added bottom border for editable fields in mobile view, updated space in between column for mobile view.
![screen shot 2017-05-08 at 1 34 31 pm](https://cloud.githubusercontent.com/assets/28141909/25795780/8a017a5c-33f4-11e7-80f5-83f4cd9dbec4.png)

