### PR TITLE
[minor] fixes for patch set_currency_field_precision

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -179,7 +179,7 @@ execute:frappe.db.sql("update `tabDesktop Icon` set type='list' where _doctype='
 frappe.patches.v8_0.fix_non_english_desktop_icons # 2017-04-12
 frappe.patches.v8_0.set_doctype_values_in_custom_role
 frappe.patches.v8_0.install_new_build_system_requirements
-frappe.patches.v8_0.set_currency_field_precision
+frappe.patches.v8_0.set_currency_field_precision	# 2017-05-09
 frappe.patches.v8_0.rename_print_to_printing
 frappe.patches.v7_1.disabled_print_settings_for_custom_print_format
 frappe.patches.v8_0.update_desktop_icons

--- a/frappe/patches/v8_0/set_currency_field_precision.py
+++ b/frappe/patches/v8_0/set_currency_field_precision.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.utils import get_number_format_info
 
 def execute():
+	frappe.reload_doc('core', 'doctype', 'system_settings')
 	if not frappe.db.get_value("System Settings", None, "currency_precision"):
 		default_currency = frappe.db.get_default("currency")
 		number_format = frappe.db.get_value("Currency", default_currency, "number_format") \


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/8736

`ERROR LOG`

```

Executing frappe.patches.v8_0.set_currency_field_precision in hackathon.erpnext.dev (5d0ea68e802deb55)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/commands/site.py", line 214, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/patches/v8_0/set_currency_field_precision.py", line 22, in execute
    ss.save()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 231, in save
    return self._save(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 264, in _save
    self.run_before_save_methods()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_before_save_methods
    self.run_method("validate")
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 667, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 892, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 661, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/core/doctype/system_settings/system_settings.py", line 15, in validate
    enable_password_policy = cint(self.enable_password_policy) and True or False
AttributeError: 'SystemSettings' object has no attribute 'enable_password_policy'

```