### PR TITLE
Set readonly of selected Inbox to False

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -173,7 +173,7 @@ class EmailServer:
 			email_list = []
 			self.check_imap_uidvalidity()
 
-			self.imap.select("Inbox", readonly=True)
+			self.imap.select("Inbox", readonly=False)
 			response, message = self.imap.uid('search', None, self.settings.email_sync_rule)
 			if message[0]:
 				email_list =  message[0].split()


### PR DESCRIPTION
Mails are not marked as SEEN, when the readonly parameter is True. That's a problem since tickets are being refreshed all few minutes, and, if you have more than 50 unread mails in your inbox, most of them will never be imported to Frappe / ERPNext.