### PR TITLE
[minor] disabled the password strength test in tearDown

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -16,6 +16,11 @@ from frappe.core.doctype.user.user import MaxUsersReachedError, test_password_st
 test_records = frappe.get_test_records('User')
 
 class TestUser(unittest.TestCase):
+	def tearDown(self):
+		# disable password strength test
+		frappe.db.set_value("System Settings", "System Settings", "enable_password_policy", 0)
+		frappe.db.set_value("System Settings", "System Settings", "minimum_password_score", "")
+
 	def test_user_type(self):
 		new_user = frappe.get_doc(dict(doctype='User', email='test-for-type@example.com',
 			first_name='Tester')).insert()


### PR DESCRIPTION

```
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/hr/doctype/employee_loan_application/test_employee_loan_application.py", line 13, in setUp
    self.employee = make_employee("kate_loan@loan.com")
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_structure/test_salary_structure.py", line 55, in make_employee
    "roles": [{"doctype": "Has Role", "role": "Employee"}]
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 193, in insert
    self.run_before_save_methods()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_before_save_methods
    self.run_method("validate")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 667, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 892, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 661, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 52, in validate
    self.password_strength_test()
  File "/home/travis/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 417, in password_strength_test
    handle_password_test_fail(result)
  File "/home/travis/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 872, in handle_password_test_fail
    frappe.throw(_('Invalid Password: ' + ' '.join([warning, suggestions])))
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 316, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 306, in msgprint
    _raise_exception()
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 279, in _raise_exception
    raise raise_exception, encode(msg)
ValidationError: Invalid Password: This is a top-10 common password. <br>Hint: Include symbols, numbers and capital letters in the password<br>
```