### PR TITLE
Make hidden fields work in query report

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -369,6 +369,10 @@ frappe.ui.Page = Class.extend({
 		$(f.wrapper)
 			.addClass('col-md-2')
 			.attr("title", __(df.label)).tooltip();
+
+		// hidden fields dont have $input
+		if(!f.$input) f.make_input();
+
 		f.$input.addClass("input-sm").attr("placeholder", __(df.label));
 
 		if(df.fieldtype==="Check") {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -207,8 +207,8 @@ frappe.views.QueryReport = Class.extend({
 	},
 	pdf_report: function() {
 		var me = this;
-		base_url = frappe.urllib.get_base_url();
-		print_css = frappe.boot.print_css;
+		var base_url = frappe.urllib.get_base_url();
+		var print_css = frappe.boot.print_css;
 
 		if(!frappe.model.can_print(this.report_doc.ref_doctype)) {
 			msgprint(__("You are not allowed to make PDF for this report"));
@@ -246,7 +246,7 @@ frappe.views.QueryReport = Class.extend({
 			});
 		}
 
-		orientation = this.print_settings.orientation;
+		var orientation = this.print_settings.orientation;
 		this.open_pdf_report(html, orientation)
 	},
 	open_pdf_report: function(html, orientation) {
@@ -407,6 +407,8 @@ frappe.views.QueryReport = Class.extend({
 		var mandatory_fields = [];
 		$.each(this.filters || [], function(i, f) {
 			var v = f.get_parsed_value();
+			// TODO: hidden fields dont have $input
+			if(f.df.hidden) v = f.value;
 			if(v === '%') v = null;
 			if(f.df.reqd && !v) mandatory_fields.push(f.df.label);
 			if(v) filters[f.df.fieldname] = v;


### PR DESCRIPTION
Hidden fields (in filters) didn't work very well in query reports. 

Use case:
In General Ledger, we needed to show **party name** in the print format and not the ID. So we added a hidden field which was updated when the party was changed. And then we could access this field in the `general_ledger.html`