### PR TITLE
Fixes for showing version changes for grid values

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -447,8 +447,9 @@ frappe.ui.form.Timeline = Class.extend({
 				var parts = [], count = 0;
 				data.row_changed.every(function(row) {
 					row[3].every(function(p) {
-						var df = frappe.meta.get_docfield(me.frm.fields_dict[row[0]].grid.doctype,
-							p[0], me.frm.docname);
+						var df = me.frm.fields_dict[row[0]] && 
+							frappe.meta.get_docfield(me.frm.fields_dict[row[0]].grid.doctype, 
+								p[0], me.frm.docname);
 
 						if(df && !df.hidden) {
 							field_display_status = frappe.perm.get_field_display_status(df,


### PR DESCRIPTION
![screen shot 2017-05-11 at 3 42 06 pm](https://cloud.githubusercontent.com/assets/836784/25950865/9bc0697e-3679-11e7-94cf-601b952ed050.png)

While showing version changes in the timelines this error comes, if we deprecate a child table from a doctype. 