### PR TITLE
Correction of doctype translations in modal dialog

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -31,7 +31,7 @@ frappe.ui.form.quick_entry = function(doctype, success) {
 		}
 
 		var dialog = new frappe.ui.Dialog({
-			title: __("New {0}", [doctype]),
+			title: __("New {0}", [__(doctype)]),
 			fields: mandatory,
 		});
 


### PR DESCRIPTION
Hi,

This is a small correction to allow the doctype title to be translated in modal dialogs when creating a new document.

![image](https://cloud.githubusercontent.com/assets/4903591/25972671/4227461c-36a1-11e7-97b4-eee64ba41d89.png)

vs.

![image](https://cloud.githubusercontent.com/assets/4903591/25972724/77204e72-36a1-11e7-8866-0d6c0f6ea6e9.png)


Thank you !