### PR TITLE
Escape fix for chrome, edge etc.

### DIFF
--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -68,11 +68,11 @@ frappe.ui.keys.on('ctrl+b', function(e) {
 });
 
 frappe.ui.keys.on('escape', function(e) {
-	close_open_grid_and_dialog();
+	close_grid_and_dialog();
 });
 
 frappe.ui.keys.on('esc', function(e) {
-	close_open_grid_and_dialog();
+	close_grid_and_dialog();
 });
 
 frappe.ui.keys.on('Enter', function(e) {
@@ -118,7 +118,7 @@ frappe.ui.keyCode = {
 	SPACE: 32
 }
 
-function close_open_grid_and_dialog() {
+function close_grid_and_dialog() {
 	// close open grid row
 	var open_row = $(".grid-row-open");
 	if (open_row.length) {

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -8,7 +8,6 @@ frappe.ui.keys.setup = function() {
 			for(var i=0, l = frappe.ui.keys.handlers[key].length; i<l; i++) {
 				var handler = frappe.ui.keys.handlers[key][i];
 				var _out = handler.apply(this, [e]);
-
 				if(_out===false) {
 					out = _out;
 				}
@@ -23,10 +22,9 @@ frappe.ui.keys.get_key = function(e) {
 	//safari doesn't have key property
 	if(!key) {
 		var keycode = e.keyCode || e.which;
-		key = frappe.ui.keys.key_map[keycode] ||
-			String.fromCharCode(keycode);
+		key = frappe.ui.keys.key_map[keycode] || String.fromCharCode(keycode);
 	}
-	if(key.substr(0, 5)==='Arrow') {
+	if(key.substr(0, 5) === 'Arrow') {
 		// ArrowDown -> down
 		key = key.substr(5).toLowerCase();
 	}
@@ -69,22 +67,13 @@ frappe.ui.keys.on('ctrl+b', function(e) {
 	}
 });
 
-frappe.ui.keys.on('Escape', function(e) {
-	// close open grid row
-	var open_row = $(".grid-row-open");
-	if(open_row.length) {
-		var grid_row = open_row.data("grid_row");
-		grid_row.toggle_view(false);
-		return false;
-	}
-
-	// close open dialog
-	if(cur_dialog && !cur_dialog.no_cancel_flag) {
-		cur_dialog.cancel();
-		return false;
-	}
+frappe.ui.keys.on('escape', function(e) {
+	close_open_grid_and_dialog();
 });
 
+frappe.ui.keys.on('esc', function(e) {
+	close_open_grid_and_dialog();
+});
 
 frappe.ui.keys.on('Enter', function(e) {
 	if(cur_dialog && cur_dialog.confirm_dialog) {
@@ -127,4 +116,20 @@ frappe.ui.keyCode = {
 	ENTER: 13,
 	TAB: 9,
 	SPACE: 32
+}
+
+function close_open_grid_and_dialog() {
+	// close open grid row
+	var open_row = $(".grid-row-open");
+	if (open_row.length) {
+		var grid_row = open_row.data("grid_row");
+		grid_row.toggle_view(false);
+		return false;
+	}
+
+	// close open dialog
+	if (cur_dialog && !cur_dialog.no_cancel_flag) {
+		cur_dialog.cancel();
+		return false;
+	}
 }


### PR DESCRIPTION
On pressing escape, modal was not closing while editing doctype. 
Made changes in the keyboard.js file.

Based on 
https://github.com/frappe/erpnext/issues/8539