### PR TITLE
Made seprate method to parse the naming series

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -94,12 +94,15 @@ def make_autoname(key='', doctype='', doc=''):
 	elif not "." in key:
 		frappe.throw(_("Invalid naming series (. missing)") + (_(" for {0}").format(doctype) if doctype else ""))
 
+	parts = key.split('.')
+	n = parse_naming_series(parts, doctype, doc)
+	return n
+
+def parse_naming_series(parts, doctype= '', doc = ''):
 	n = ''
-	l = key.split('.')
 	series_set = False
 	today = now_datetime()
-
-	for e in l:
+	for e in parts:
 		part = ''
 		if e.startswith('#'):
 			if not series_set:
@@ -120,6 +123,7 @@ def make_autoname(key='', doctype='', doc=''):
 
 		if isinstance(part, basestring):
 			n+=part
+
 	return n
 
 def getseries(key, digits, doctype=''):


### PR DESCRIPTION
Write separate method to parse the naming series, this method is used to get the information of the year and month mentioned in the format
For example: 
If the naming series is INV.YY.MM.#####
then methods returns INV201705

Used in https://github.com/frappe/erpnext/pull/8836