### PR TITLE
[minor_fix-major_debugging]Removed report_hide condition, fixes frappe/erpnext#8778

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -829,8 +829,8 @@ frappe.ui.FieldSelect = Class.extend({
 		// main table
 		var main_table_fields = std_filters.concat(frappe.meta.docfield_list[me.doctype]);
 		$.each(frappe.utils.sort(main_table_fields, "label", "string"), function(i, df) {
-			// show fields where user has read access and if report hide flag is not set
-			if(frappe.perm.has_perm(me.doctype, df.permlevel, "read") && !df.report_hide)
+			// show fields where user has read access
+			if(frappe.perm.has_perm(me.doctype, df.permlevel, "read"))
 				me.add_field_option(df);
 		});
 
@@ -839,8 +839,8 @@ frappe.ui.FieldSelect = Class.extend({
 			if(table_df.options) {
 				var child_table_fields = [].concat(frappe.meta.docfield_list[table_df.options]);
 				$.each(frappe.utils.sort(child_table_fields, "label", "string"), function(i, df) {
-					// show fields where user has read access and if report hide flag is not set
-					if(frappe.perm.has_perm(me.doctype, df.permlevel, "read") && !df.report_hide)
+					// show fields where user has read access
+					if(frappe.perm.has_perm(me.doctype, df.permlevel, "read"))
 						me.add_field_option(df);
 				});
 			}


### PR DESCRIPTION
The value original_docfield = me.fieldselect.fields_by_name[doctype][fieldname] was always null since the fieldname we wanted was never added to the the fields_by_name object.

Steps followed to reproduce error
https://github.com/frappe/erpnext/issues/8778

