### PR TITLE
[minor] fixed UnicodeEncode error for item name

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -66,7 +66,7 @@ def get_page_context_from_template(path):
 			options = (search_path, search_path + '.html', search_path + '.md',
 				search_path + '/index.html', search_path + '/index.md')
 			for o in options:
-				option = unicode(o)
+				option = frappe.as_unicode(o)
 				if os.path.exists(option) and not os.path.isdir(option):
 					return get_page_info(option, app, app_path=app_path)
 

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -66,8 +66,9 @@ def get_page_context_from_template(path):
 			options = (search_path, search_path + '.html', search_path + '.md',
 				search_path + '/index.html', search_path + '/index.md')
 			for o in options:
-				if os.path.exists(o) and not os.path.isdir(o):
-					return get_page_info(o, app, app_path=app_path)
+				option = unicode(o)
+				if os.path.exists(option) and not os.path.isdir(option):
+					return get_page_info(option, app, app_path=app_path)
 
 	return None
 


### PR DESCRIPTION
`Error Traceback`
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 32, in render
    data = render_page_by_language(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 101, in render_page_by_language
    return render_page(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 117, in render_page
    return build(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 124, in build
    return build_page(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 137, in build_page
    context = get_context(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/context.py", line 15, in get_context
    context = get_page_context(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/router.py", line 35, in get_page_context
    page_context = make_page_context(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/router.py", line 44, in make_page_context
    context = resolve_route(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/router.py", line 18, in resolve_route
    context = get_page_context_from_template(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/router.py", line 69, in get_page_context_from_template
    if os.path.exists(o) and not os.path.isdir(o):
  File "/home/frappe/frappe-bench/env/lib64/python2.7/genericpath.py", line 18, in exists
    os.stat(path)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf8' in position 237: ordinal not in range(128)
```