### PR TITLE
[fix] hide popovers on blur frappe/erpnext#8721

### DIFF
--- a/frappe/public/js/lib/summernote/summernote.js
+++ b/frappe/public/js/lib/summernote/summernote.js
@@ -3833,6 +3833,13 @@
         context.triggerEvent('focusout', event);
       });
 
+      // hack
+      $editable.on('blur', function (event) {
+        setTimeout(function() {
+          $('.note-popover, .note-control-selection').hide();
+        }, 500);
+      });
+
       if (!options.airMode) {
         if (options.width) {
           $editor.outerWidth(options.width);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5196925/26187331/ae07fdcc-3bb5-11e7-8ce0-1123d110ebe0.gif)

The popover bug is, however, not uncommon :) ...
![screen shot 2017-05-18 at 10 20 50 am](https://cloud.githubusercontent.com/assets/5196925/26187342/cad55e54-3bb5-11e7-8721-52f111405f37.png)

