### PR TITLE
Fix Ctrl + G not working in other languages (frappe/erpnext#7627)

### DIFF
--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -18,12 +18,9 @@ frappe.ui.keys.setup = function() {
 }
 
 frappe.ui.keys.get_key = function(e) {
-	var key = e.key;
-	//safari doesn't have key property
-	if(!key) {
-		var keycode = e.keyCode || e.which;
-		key = frappe.ui.keys.key_map[keycode] || String.fromCharCode(keycode);
-	}
+	var keycode = e.keyCode || e.which;
+	var key = frappe.ui.keys.key_map[keycode] || String.fromCharCode(keycode);
+
 	if(key.substr(0, 5) === 'Arrow') {
 		// ArrowDown -> down
 		key = key.substr(5).toLowerCase();


### PR DESCRIPTION
`frappe.ui.keys.get_key` returned the actual character in the respective language.
So, keyboard shortcuts like **ctrl+g** didn't work.
Now it returns the keyboard character rather than the language character.