### PR TITLE
Update Custom Field background color in Customize Form (frappe/erpnext#6432)

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -149,6 +149,7 @@ frappe.customize_form.set_primary_action = function(frm) {
 				callback: function(r) {
 					if(!r.exc) {
 						frappe.customize_form.clear_locals_and_refresh(frm);
+						frm.script_manager.trigger("doc_type");
 					}
 				}
 			});


### PR DESCRIPTION
Trigger Refresh when Custom field is added, which sets the background of the Custom Field row to light yellow.

![customizeform](https://cloud.githubusercontent.com/assets/9355208/26194765/1c66633c-3bd7-11e7-9e6c-f615aa2cba5c.gif)
