### PR TITLE
[fix] Refresh the page error during configuration in dropbox

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js
@@ -14,7 +14,9 @@ frappe.ui.form.on('Dropbox Settings', {
 				freeze: true,
 				callback: function(r) {
 					if(!r.exc) {
-						frm.save();
+						frm.set_value('dropbox_access_key', r.message.dropbox_access_key)
+						frm.set_value('dropbox_access_secret', r.message.dropbox_access_secret)
+						frm.save()
 						window.open(r.message.url);
 					}
 				}

--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -58,8 +58,6 @@ def get_dropbox_authorize_url():
 		"dropbox_access_secret": request_token.secret
 	})
 
-	doc.save(ignore_permissions=False)
-
 	return_address = get_request_site_address(True) \
 		+ "?cmd=frappe.integrations.doctype.dropbox_settings.dropbox_settings.dropbox_callback"
 


### PR DESCRIPTION
When User clicks on Allow Dropbox Access, following error is coming
![screen shot 2017-05-16 at 3 42 29 pm](https://cloud.githubusercontent.com/assets/8780500/26200906/20ddf1a2-3bee-11e7-9c9c-f5d51bcd33c1.png)
 