### PR TITLE
Email praseaddr fix, fixes frappe/issues#3004

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -11,7 +11,8 @@ from frappe.core.doctype.communication.comment import (notify_mentions,
 from frappe.core.doctype.communication.email import (validate_email,
 	notify, _notify, update_parent_status)
 from frappe.utils.bot import BotReply
-from email.utils import parseaddr
+from frappe.utils import parse_email
+
 from collections import Counter
 
 exclude_from_linked_with = True
@@ -140,13 +141,11 @@ class Communication(Document):
 			else:
 				if self.sent_or_received=='Sent':
 					validate_email_add(self.sender, throw=True)
-
-				sender_name, sender_email = parseaddr(self.sender)
-
-				if not sender_name:
-					sender_name = get_fullname(sender_email)
-					if sender_name == sender_email:
-						sender_name = None
+				
+ 
+				sender_name, sender_email = parse_email(self.sender)
+				if sender_name == sender_email:
+					sender_name = None
 
 				self.sender = sender_email
 				self.sender_full_name = sender_name or get_fullname(frappe.session.user) if frappe.session.user!='Administrator' else None

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -11,7 +11,7 @@ from frappe.core.doctype.communication.comment import (notify_mentions,
 from frappe.core.doctype.communication.email import (validate_email,
 	notify, _notify, update_parent_status)
 from frappe.utils.bot import BotReply
-from frappe.utils import parse_email
+from frappe.utils import parse_addr
 
 from collections import Counter
 
@@ -141,12 +141,9 @@ class Communication(Document):
 			else:
 				if self.sent_or_received=='Sent':
 					validate_email_add(self.sender, throw=True)
-				
- 
-				sender_name, sender_email = parse_email(self.sender)
+				sender_name, sender_email = parse_addr(self.sender)
 				if sender_name == sender_email:
 					sender_name = None
-
 				self.sender = sender_email
 				self.sender_full_name = sender_name or get_fullname(frappe.session.user) if frappe.session.user!='Administrator' else None
 

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -7,7 +7,7 @@ import frappe
 import json
 from email.utils import formataddr
 from frappe.utils import (get_url, get_formatted_email, cint,
-	validate_email_add, split_emails, time_diff_in_seconds, parse_email)
+	validate_email_add, split_emails, time_diff_in_seconds, parse_addr)
 from frappe.utils.file_manager import get_file
 from frappe.email.queue import check_email_limit
 from frappe.utils.scheduler import log
@@ -321,11 +321,11 @@ def get_cc(doc, recipients=None, fetched_from_email_account=False):
 		# exclude unfollows, recipients and unsubscribes
 		exclude = [] #added to remove account check
 		exclude += [d[0] for d in frappe.db.get_all("User", ["name"], {"thread_notify": 0}, as_list=True)]
-		exclude += [(parse_email(email)[1] or "").lower() for email in recipients]
+		exclude += [(parse_addr(email)[1] or "").lower() for email in recipients]
 
 		if fetched_from_email_account:
 			# exclude sender when pulling email
-			exclude += [parse_email(doc.sender)[1]]
+			exclude += [parse_addr(doc.sender)[1]]
 
 		if doc.reference_doctype and doc.reference_name:
 			exclude += [d[0] for d in frappe.db.get_all("Email Unsubscribe", ["email"],
@@ -356,7 +356,7 @@ def filter_email_list(doc, email_list, exclude, is_cc=False):
 	email_address_list = []
 
 	for email in list(set(email_list)):
-		email_address = (parse_email(email)[1] or "").lower()
+		email_address = (parse_addr(email)[1] or "").lower()
 		if not email_address:
 			continue
 

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -5,9 +5,9 @@ from __future__ import unicode_literals, absolute_import
 from six.moves import range
 import frappe
 import json
-from email.utils import formataddr, parseaddr
+from email.utils import formataddr
 from frappe.utils import (get_url, get_formatted_email, cint,
-	validate_email_add, split_emails, time_diff_in_seconds)
+	validate_email_add, split_emails, time_diff_in_seconds, parse_email)
 from frappe.utils.file_manager import get_file
 from frappe.email.queue import check_email_limit
 from frappe.utils.scheduler import log
@@ -321,11 +321,11 @@ def get_cc(doc, recipients=None, fetched_from_email_account=False):
 		# exclude unfollows, recipients and unsubscribes
 		exclude = [] #added to remove account check
 		exclude += [d[0] for d in frappe.db.get_all("User", ["name"], {"thread_notify": 0}, as_list=True)]
-		exclude += [(parseaddr(email)[1] or "").lower() for email in recipients]
+		exclude += [(parse_email(email)[1] or "").lower() for email in recipients]
 
 		if fetched_from_email_account:
 			# exclude sender when pulling email
-			exclude += [parseaddr(doc.sender)[1]]
+			exclude += [parse_email(doc.sender)[1]]
 
 		if doc.reference_doctype and doc.reference_name:
 			exclude += [d[0] for d in frappe.db.get_all("Email Unsubscribe", ["email"],
@@ -356,7 +356,7 @@ def filter_email_list(doc, email_list, exclude, is_cc=False):
 	email_address_list = []
 
 	for email in list(set(email_list)):
-		email_address = (parseaddr(email)[1] or "").lower()
+		email_address = (parse_email(email)[1] or "").lower()
 		if not email_address:
 			continue
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -15,10 +15,12 @@ class TestCommunication(unittest.TestCase):
 		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>', 
 		'foo@bar@google.com', 'Surname, Name <name.surname@domain.com>', 
 		'Purchase@ABC <purchase@abc.com>', 'xyz@abc2.com <xyz@abc.com>',
-		'Name [something else] <name@domain.com>']
+		'Name [something else] <name@domain.com>',
+		'.com@test@yahoo.com']
 
 		invalid_email_list = ['[invalid!email]', 'invalid-email',
-		'tes2', 'e', 'rrrrrrrr', 'manas','[[[sample]]]']
+		'tes2', 'e', 'rrrrrrrr', 'manas','[[[sample]]]',
+		'[invalid!email].com']
 
 		for x in valid_email_list:
 			self.assertTrue(frappe.utils.parse_addr(x))

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -4,8 +4,25 @@ from __future__ import unicode_literals
 
 import frappe
 import unittest
-
 test_records = frappe.get_test_records('Communication')
 
+
 class TestCommunication(unittest.TestCase):
-	pass
+
+	def test_parse_addr(self):
+		valid_email_list = ["me@example.com", "a.nonymous@example.com", "name@tag@example.com",
+		"foo@example.com", 'Full Name <full@example.com>', 
+		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>', 
+		'foo@bar@google.com', 'Surname, Name <name.surname@domain.com>', 
+		'Purchase@ABC <purchase@abc.com>', 'xyz@abc2.com <xyz@abc.com>',
+		'Name [something else] <name@domain.com>']
+
+		invalid_email_list = ['[invalid!email]', 'invalid-email',
+		'tes2', 'e', 'rrrrrrrr', 'manas','[[[sample]]]']
+
+		for x in valid_email_list:
+			self.assertTrue(frappe.utils.parse_addr(x))
+
+		for x in invalid_email_list:
+			self.assertFalse(frappe.utils.parse_addr(x)[0])
+

--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.utils import validate_email_add
 from frappe.model.document import Document
-from frappe.utils import parse_email
+from frappe.utils import parse_addr
 
 class EmailGroup(Document):
 	def onload(self):
@@ -26,7 +26,7 @@ class EmailGroup(Document):
 
 		for user in frappe.db.get_all(doctype, [email_field, unsubscribed_field or "name"]):
 			try:
-				email = parse_email(user.get(email_field))[1]
+				email = parse_addr(user.get(email_field))[1]
 				if email:
 					frappe.get_doc({
 						"doctype": "Email Group Member",

--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.utils import validate_email_add
 from frappe.model.document import Document
-from email.utils import parseaddr
+from frappe.utils import parse_email
 
 class EmailGroup(Document):
 	def onload(self):
@@ -26,7 +26,7 @@ class EmailGroup(Document):
 
 		for user in frappe.db.get_all(doctype, [email_field, unsubscribed_field or "name"]):
 			try:
-				email = parseaddr(user.get(email_field))[1]
+				email = parse_email(user.get(email_field))[1]
 				if email:
 					frappe.get_doc({
 						"doctype": "Email Group Member",

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -14,6 +14,7 @@ from frappe.utils.scheduler import log
 from frappe.email.queue import send
 from frappe.email.doctype.email_group.email_group import add_subscribers
 from frappe.utils.file_manager import get_file
+from frappe.utils import parse_email
 
 
 class Newsletter(Document):
@@ -135,17 +136,15 @@ def return_unsubscribed_page(email, name):
 
 def create_lead(email_id):
 	"""create a lead if it does not exist"""
-	from email.utils import parseaddr
 	from frappe.model.naming import get_default_naming_series
-	real_name, email_id = parseaddr(email_id)
-
+	full_name, email_id = parse_email(email_id)
 	if frappe.db.get_value("Lead", {"email_id": email_id}):
 		return
 
 	lead = frappe.get_doc({
 		"doctype": "Lead",
 		"email_id": email_id,
-		"lead_name": real_name or email_id,
+		"lead_name": full_name or email_id,
 		"status": "Lead",
 		"naming_series": get_default_naming_series("Lead"),
 		"company": frappe.db.get_default("Company"),

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -14,7 +14,7 @@ from frappe.utils.scheduler import log
 from frappe.email.queue import send
 from frappe.email.doctype.email_group.email_group import add_subscribers
 from frappe.utils.file_manager import get_file
-from frappe.utils import parse_email
+from frappe.utils import parse_addr
 
 
 class Newsletter(Document):
@@ -137,7 +137,7 @@ def return_unsubscribed_page(email, name):
 def create_lead(email_id):
 	"""create a lead if it does not exist"""
 	from frappe.model.naming import get_default_naming_series
-	full_name, email_id = parse_email(email_id)
+	full_name, email_id = parse_addr(email_id)
 	if frappe.db.get_value("Lead", {"email_id": email_id}):
 		return
 

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -8,7 +8,7 @@ from frappe.email.smtp import get_outgoing_email_account
 from frappe.utils import (get_url, scrub_urls, strip, expand_relative_urls, cint,
 	split_emails, to_markdown, markdown, encode, random_string)
 import email.utils
-from frappe.utils import parse_email
+from frappe.utils import parse_addr
 
 def get_email(recipients, sender='', msg='', subject='[No Subject]',
 	text_content = None, footer=None, print_html=None, formatted=None, attachments=None,
@@ -180,7 +180,7 @@ class EMail:
 	def replace_sender(self):
 		if cint(self.email_account.always_use_account_email_id_as_sender):
 			self.set_header('X-Original-From', self.sender)
-			sender_name, sender_email = parse_email(self.sender)
+			sender_name, sender_email = parse_addr(self.sender)
 			self.sender = email.utils.formataddr((sender_name or self.email_account.name, self.email_account.email_id))
 
 	def set_message_id(self, message_id, is_notification=False):

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -8,6 +8,7 @@ from frappe.email.smtp import get_outgoing_email_account
 from frappe.utils import (get_url, scrub_urls, strip, expand_relative_urls, cint,
 	split_emails, to_markdown, markdown, encode, random_string)
 import email.utils
+from frappe.utils import parse_email
 
 def get_email(recipients, sender='', msg='', subject='[No Subject]',
 	text_content = None, footer=None, print_html=None, formatted=None, attachments=None,
@@ -179,8 +180,7 @@ class EMail:
 	def replace_sender(self):
 		if cint(self.email_account.always_use_account_email_id_as_sender):
 			self.set_header('X-Original-From', self.sender)
-
-			sender_name, sender_email = email.utils.parseaddr(self.sender)
+			sender_name, sender_email = parse_email(self.sender)
 			self.sender = email.utils.formataddr((sender_name or self.email_account.name, self.email_account.email_id))
 
 	def set_message_id(self, message_id, is_notification=False):

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -9,7 +9,7 @@ from email.header import decode_header
 import frappe
 from frappe import _
 from frappe.utils import (extract_email_id, convert_utc_to_user_timezone, now,
-	cint, cstr, strip, markdown)
+	cint, cstr, strip, markdown, parse_email)
 from frappe.utils.scheduler import log
 from frappe.utils.file_manager import get_random_filename, save_file, MaxFileSizeReachedError
 import re
@@ -411,7 +411,7 @@ class Email:
 		if self.from_email:
 			self.from_email = self.from_email.lower()
 
-		self.from_real_name = email.utils.parseaddr(_from_email)[0] if "@" in _from_email else _from_email
+		self.from_real_name = parse_email(_from_email)[0] if "@" in _from_email else _from_email
 
 	def decode_email(self, email):
 		if not email: return

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -9,7 +9,7 @@ from email.header import decode_header
 import frappe
 from frappe import _
 from frappe.utils import (extract_email_id, convert_utc_to_user_timezone, now,
-	cint, cstr, strip, markdown, parse_email)
+	cint, cstr, strip, markdown, parse_addr)
 from frappe.utils.scheduler import log
 from frappe.utils.file_manager import get_random_filename, save_file, MaxFileSizeReachedError
 import re
@@ -411,7 +411,7 @@ class Email:
 		if self.from_email:
 			self.from_email = self.from_email.lower()
 
-		self.from_real_name = parse_email(_from_email)[0] if "@" in _from_email else _from_email
+		self.from_real_name = parse_addr(_from_email)[0] if "@" in _from_email else _from_email
 
 	def decode_email(self, email):
 		if not email: return

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -88,12 +88,12 @@ def validate_email_add(email_str, throw=False):
 			e = extract_email_id(e)
 			match = re.match("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", e.lower()) if e else None
 
-			if match:
+			if not match:
+				_valid = False
+			else:
 				matched = match.group(0)
 				if match:
 					match = matched==e.lower()
-			else:
-				_valid = False
 
 		if not _valid:
 			if throw:

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -458,7 +458,6 @@ def sanitize_email(emails):
 
 def parse_email(email_string):
 	"""Return email_id and user_name based on email string"""
-	
 	name, email = parseaddr(email_string)
 	if validate_email_id(email):
 		return (name, email)
@@ -472,6 +471,7 @@ def parse_email(email_string):
 		frappe.InvalidEmailAddressError)
 
 def validate_email_id(email_id):
+	"""Check if email_id is valid. ex:text@example.com"""
 	if ("@" in email_id) and (".com" in email_id) and (email_id.index("@") + 1 < email_id.index(".com")):
 		return True
 	return False

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -461,7 +461,8 @@ def sanitize_email(emails):
 def parse_email(email_string):
 	email_regex = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
 	#get the first email adrress only
-	email_id = re.findall(email_regex, email_string)[0]
+	email_list = re.findall(email_regex, email_string)
+	email_id = email_list[0] if len(email_list) > 0 else parseaddr(email_string)[1]
 	name = filter(lambda x: len(x) > 0,
 		[x for x in parseaddr(email_string)])[0] or email_id
 	return (name, email_id)

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -92,10 +92,8 @@ def validate_email_add(email_str, throw=False):
 				_valid = False
 			else:
 				matched = match.group(0)
-
 				if match:
 					match = matched==e.lower()
-
 		if not _valid:
 			if throw:
 				frappe.throw(frappe._("{0} is not a valid Email Address").format(e),
@@ -459,13 +457,24 @@ def sanitize_email(emails):
 	return ", ".join(sanitized)
 
 def parse_email(email_string):
-	email_regex = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
-	#get the first email adrress only
-	email_list = re.findall(email_regex, email_string)
-	email_id = email_list[0] if len(email_list) > 0 else parseaddr(email_string)[1]
-	name = filter(lambda x: len(x) > 0,
-		[x for x in parseaddr(email_string)])[0] or email_id
-	return (name, email_id)
+	"""Return email_id and user_name based on email string"""
+	
+	name, email = parseaddr(email_string)
+	if validate_email_id(email):
+		return (name, email)
+	else:
+		email_regex = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
+		email_list = re.findall(email_regex, email_string)
+		if len(email_list) > 0 and validate_email_id(email_list[0]):
+			#take only first email address
+			return (name, email_list[0])
+	frappe.throw(frappe._("{0} is not a valid Email Address").format(email_string),
+		frappe.InvalidEmailAddressError)
+
+def validate_email_id(email_id):
+	if ("@" in email_id) and (".com" in email_id) and (email_id.index("@") + 1 < email_id.index(".com")):
+		return True
+	return False
 
 
 def get_installed_apps_info():

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -96,7 +96,7 @@ def validate_email_add(email_str, throw=False):
 				_valid = False
 
 		if not _valid:
-			if throw is True:
+			if throw:
 				frappe.throw(frappe._("{0} is not a valid Email Address").format(e),
 					frappe.InvalidEmailAddressError)
 			return None

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -8,10 +8,9 @@ from werkzeug.test import Client
 import os, re, urllib, sys, json, hashlib, requests, traceback
 from markdown2 import markdown as _markdown
 from .html_utils import sanitize_html
-
 import frappe
 from frappe.utils.identicon import Identicon
-
+from email.utils import parseaddr, formataddr
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *
 
@@ -62,8 +61,7 @@ def get_formatted_email(user):
 
 def extract_email_id(email):
 	"""fetch only the email part of the Email Address"""
-	from email.utils import parseaddr
-	fullname, email_id = parseaddr(email)
+	full_name, email_id = parse_email(email)
 	if isinstance(email_id, basestring) and not isinstance(email_id, unicode):
 		email_id = email_id.decode("utf-8", "ignore")
 	return email_id
@@ -450,17 +448,24 @@ def markdown(text, sanitize=True, linkify=True):
 	return html
 
 def sanitize_email(emails):
-	from email.utils import parseaddr, formataddr
-
 	sanitized = []
 	for e in split_emails(emails):
 		if not validate_email_add(e):
 			continue
 
-		fullname, email_id = parseaddr(e)
-		sanitized.append(formataddr((fullname, email_id)))
+		full_name, email_id = parse_email(e)
+		sanitized.append(formataddr((full_name, email_id)))
 
 	return ", ".join(sanitized)
+
+def parse_email(email_string):
+	email_regex = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
+	#get the first email adrress only
+	email_id = re.findall(email_regex, email_string)[0]
+	name = filter(lambda x: len(x) > 0,
+		[x for x in parseaddr(email_string)])[0] or email_id
+	return (name, email_id)
+
 
 def get_installed_apps_info():
 	out = []


### PR DESCRIPTION
There were few problems in parseaddr while parsing strings, a two-step verification is added to ensure that email address is extracted from the input string. Wrote a test case for verification.

Based on 
https://github.com/frappe/frappe/issues/3004