### PR TITLE
deleted da-DK language translation CSV

### DIFF
--- a/frappe/translations/da-DK.csv
+++ b/frappe/translations/da-DK.csv
@@ -1,9 +1,0 @@
-apps/frappe/frappe/utils/nestedset.py +235,{0} {1} cannot be a leaf node as it has children,"{0} {1} kan ikke være en blad node, da den har undernoder"
-apps/frappe/frappe/utils/csvutils.py +51,"Unknown file encoding. Tried utf-8, windows-1250, windows-1252.","Ukendt fil kodning. Prøvede utf-8, vinduer-1250, vinduer-1252."
-DocType: About Us Settings,"""Company History""",'Virksomhedshistorie'
-DocType: Currency,"1 Currency = [?] Fraction
-For e.g. 1 USD = 100 Cent",1 Valuta = [?] Fraktion For eksempel 1 USD = 100 Cent
-DocType: Workflow State,zoom-in,zoom-in
-DocType: Workflow State,zoom-out,zoom-out
-apps/frappe/frappe/public/js/frappe/form/workflow.js +32, by Role ,af rolle
-apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js +99,Half Day,Half Day


### PR DESCRIPTION
- da-DK.csv contains only 5 translated messages
- Danish translation is already available in da.csv