### PR TITLE
Email parse addr fix.

### DIFF
--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -22,8 +22,6 @@ class TestCommunication(unittest.TestCase):
 		'tes2', 'e', 'rrrrrrrr', 'manas','[[[sample]]]',
 		'[invalid!email].com']
 
-		print([frappe.utils.parse_addr(x) for x in valid_email_list + invalid_email_list])
-
 		for x in valid_email_list:
 			self.assertTrue(frappe.utils.parse_addr(x))
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -22,6 +22,8 @@ class TestCommunication(unittest.TestCase):
 		'tes2', 'e', 'rrrrrrrr', 'manas','[[[sample]]]',
 		'[invalid!email].com']
 
+		print([frappe.utils.parse_addr(x) for x in valid_email_list + invalid_email_list])
+
 		for x in valid_email_list:
 			self.assertTrue(frappe.utils.parse_addr(x))
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -10,9 +10,9 @@ test_records = frappe.get_test_records('Communication')
 class TestCommunication(unittest.TestCase):
 
 	def test_email(self):
-		valid_email_list = ["Full Name <full@example.com>", 
-		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>', 
-		"Surname, Name <name.surname@domain.com>", 
+		valid_email_list = ["Full Name <full@example.com>",
+		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>',
+		"Surname, Name <name.surname@domain.com>",
 		"Purchase@ABC <purchase@abc.com>", "xyz@abc2.com <xyz@abc.com>",
 		"Name [something else] <name@domain.com>"]
 
@@ -27,9 +27,9 @@ class TestCommunication(unittest.TestCase):
 			self.assertFalse(frappe.utils.parse_addr(x)[0])
 
 	def test_name(self):
-		valid_email_list = ["Full Name <full@example.com>", 
-		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>', 
-		"Surname, Name <name.surname@domain.com>", 
+		valid_email_list = ["Full Name <full@example.com>",
+		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>',
+		"Surname, Name <name.surname@domain.com>",
 		"Purchase@ABC <purchase@abc.com>", "xyz@abc2.com <xyz@abc.com>",
 		"Name [something else] <name@domain.com>"]
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -9,21 +9,36 @@ test_records = frappe.get_test_records('Communication')
 
 class TestCommunication(unittest.TestCase):
 
-	def test_parse_addr(self):
-		valid_email_list = ["me@example.com", "a.nonymous@example.com", "name@tag@example.com",
-		"foo@example.com", 'Full Name <full@example.com>', 
+	def test_email(self):
+		valid_email_list = ["Full Name <full@example.com>", 
 		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>', 
-		'foo@bar@google.com', 'Surname, Name <name.surname@domain.com>', 
-		'Purchase@ABC <purchase@abc.com>', 'xyz@abc2.com <xyz@abc.com>',
-		'Name [something else] <name@domain.com>',
-		'.com@test@yahoo.com']
+		"Surname, Name <name.surname@domain.com>", 
+		"Purchase@ABC <purchase@abc.com>", "xyz@abc2.com <xyz@abc.com>",
+		"Name [something else] <name@domain.com>"]
 
-		invalid_email_list = ['[invalid!email]', 'invalid-email',
-		'tes2', 'e', 'rrrrrrrr', 'manas','[[[sample]]]',
-		'[invalid!email].com']
+		invalid_email_list = ["[invalid!email]", "invalid-email",
+		"tes2", "e", "rrrrrrrr", "manas","[[[sample]]]",
+		"[invalid!email].com"]
 
 		for x in valid_email_list:
-			self.assertTrue(frappe.utils.parse_addr(x))
+			self.assertTrue(frappe.utils.parse_addr(x)[1])
+
+		for x in invalid_email_list:
+			self.assertFalse(frappe.utils.parse_addr(x)[0])
+
+	def test_name(self):
+		valid_email_list = ["Full Name <full@example.com>", 
+		'"Full Name with quotes and <weird@chars.com>" <weird@example.com>', 
+		"Surname, Name <name.surname@domain.com>", 
+		"Purchase@ABC <purchase@abc.com>", "xyz@abc2.com <xyz@abc.com>",
+		"Name [something else] <name@domain.com>"]
+
+		invalid_email_list = ["[invalid!email]", "invalid-email",
+		"tes2", "e", "rrrrrrrr", "manas","[[[sample]]]",
+		"[invalid!email].com"]
+
+		for x in valid_email_list:
+			self.assertTrue(frappe.utils.parse_addr(x)[0])
 
 		for x in invalid_email_list:
 			self.assertFalse(frappe.utils.parse_addr(x)[0])

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -482,7 +482,7 @@ def check_format(email_id):
 	try:
 		pos = email_id.rindex("@")
 		is_valid = pos > 0 and (email_id.rindex(".") > pos) and (len(email_id) - pos > 4)
-	except:
+	except Exception:
 		#print(e)
 		pass
 	return is_valid

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -464,13 +464,13 @@ def parse_addr(email_string):
 	"""
 	name, email = parseaddr(email_string)
 	if check_format(email):
-		name = clean_name(email_string, email, name)
+		name = get_name_from_email_string(email_string, email, name)
 		return (name, email)
 	else:
 		email_regex = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
 		email_list = re.findall(email_regex, email_string)
 		if len(email_list) > 0 and check_format(email_list[0]):
-			name = clean_name(email_string, email_list[0], name)
+			name = get_name_from_email_string(email_string, email_list[0], name)
 			#take only first email address
 			return (name, email_list[0])
 	return (None, email)
@@ -490,7 +490,7 @@ def check_format(email_id):
 		pass
 	return is_valid
 
-def clean_name(email_string, email_id, name):
+def get_name_from_email_string(email_string, email_id, name):
 	name = email_string.replace(email_id, '')
 	name = re.sub('[^A-Za-z0-9 ]+', '', name).strip()
 	return name

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -55,13 +55,12 @@ def get_formatted_email(user):
 	"""get Email Address of user formatted as: `John Doe <johndoe@example.com>`"""
 	if user == "Administrator":
 		return user
-	from email.utils import formataddr
 	fullname = get_fullname(user)
 	return formataddr((fullname, user))
 
 def extract_email_id(email):
 	"""fetch only the email part of the Email Address"""
-	full_name, email_id = parse_addr(email)
+	email_id = parse_addr(email)[1]
 	if email_id and isinstance(email_id, basestring) and not isinstance(email_id, unicode):
 		email_id = email_id.decode("utf-8", "ignore")
 	return email_id
@@ -69,8 +68,6 @@ def extract_email_id(email):
 def validate_email_add(email_str, throw=False):
 	"""Validates the email string"""
 	email = email_str = (email_str or "").strip()
-
-	valid = True
 
 	def _check(e):
 		_valid = True
@@ -387,7 +384,6 @@ def is_markdown(text):
 		return not re.search("<p[\s]*>|<br[\s]*>", text)
 
 def get_sites(sites_path=None):
-	import os
 	if not sites_path:
 		sites_path = getattr(frappe.local, 'sites_path', None) or '.'
 
@@ -479,14 +475,14 @@ def parse_addr(email_string):
 def check_format(email_id):
 	"""
 	Check if email_id is valid. valid email:text@example.com
-	String check ensures that email_id contains both '.' and 
-	'@' and index of '@' is less than '.' 
+	String check ensures that email_id contains both '.' and
+	'@' and index of '@' is less than '.'
 	"""
-	is_valid = False 
+	is_valid = False
 	try:
 		pos = email_id.rindex("@")
 		is_valid = pos > 0 and (email_id.rindex(".") > pos) and (len(email_id) - pos > 4)
-	except Exception, e:
+	except:
 		#print(e)
 		pass
 	return is_valid

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -464,11 +464,13 @@ def parse_addr(email_string):
 	"""
 	name, email = parseaddr(email_string)
 	if check_format(email):
+		name = clean_name(email_string, email, name)
 		return (name, email)
 	else:
 		email_regex = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
 		email_list = re.findall(email_regex, email_string)
 		if len(email_list) > 0 and check_format(email_list[0]):
+			name = clean_name(email_string, email_list[0], name)
 			#take only first email address
 			return (name, email_list[0])
 	return (None, email)
@@ -487,6 +489,11 @@ def check_format(email_id):
 		#print(e)
 		pass
 	return is_valid
+
+def clean_name(email_string, email_id, name):
+	name = email_string.replace(email_id, '')
+	name = re.sub('[^A-Za-z0-9 ]+', '', name).strip()
+	return name
 
 def get_installed_apps_info():
 	out = []

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -470,9 +470,10 @@ def parse_addr(email_string):
 		email_regex = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
 		email_list = re.findall(email_regex, email_string)
 		if len(email_list) > 0 and check_format(email_list[0]):
-			name = get_name_from_email_string(email_string, email_list[0], name)
 			#take only first email address
-			return (name, email_list[0])
+			email = email_list[0]
+			name = get_name_from_email_string(email_string, email, name)
+			return (name, email)
 	return (None, email)
 
 def check_format(email_id):


### PR DESCRIPTION
The main problem was email_id was not getting fetched from string address string which was solved in last pull request. Now added a filter to name also which will remove email_id from email address string and remove all special characters from email address string and email address string will be assigned to name.

Example:
`parse_addr('Surname, Name <name.surname@domain.com>')`
`// output  (name: Surname Name, email: name.surname@domain.com)`

All special characters will be removed from name string.