### PR TITLE
[charts.erpnext.com] superficial in_list fix

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -319,7 +319,7 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 
 	set_disp_area: function() {
 		let value = this.get_value();
-		if(inList(["Currency", "Int", "Float"], this.df.fieldtype) && (this.value === 0 || value === 0)) {
+		if(in_list(["Currency", "Int", "Float"], this.df.fieldtype) && (this.value === 0 || value === 0)) {
 			// to set the 0 value in readonly for currency, int, float field
 			value = 0;
 		} else {


### PR DESCRIPTION
With frappe/chart_of_accounts_builder#19

![screen shot 2017-05-23 at 4 37 58 pm](https://cloud.githubusercontent.com/assets/5196925/26359216/7d252e64-3ff2-11e7-8e94-bc5f060eacf7.png)

Using `in_list` is better any day, but I have no idea why the `inList` defining `datatype.js` isn't loaded there, or even why `in_list` works, even though its definition isn't loaded as well.