### PR TITLE
Global Date Format localization

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -246,7 +246,8 @@ def format_datetime(datetime_string, format_string=None):
 
 def global_date_format(date):
 	"""returns date as 1 January 2012"""
-	formatted_date = getdate(date).strftime("%d %B %Y")
+	date = getdate(date)
+	formatted_date = babel.dates.format_date(date, locale=(frappe.local.lang or "").replace("-", "_"))
 	return formatted_date.startswith("0") and formatted_date[1:] or formatted_date
 
 def has_common(l1, l2):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -247,7 +247,7 @@ def format_datetime(datetime_string, format_string=None):
 def global_date_format(date):
 	"""returns date as 1 January 2012"""
 	date = getdate(date)
-	formatted_date = babel.dates.format_date(date, locale=(frappe.local.lang or "").replace("-", "_"))
+	formatted_date = babel.dates.format_date(date, locale=(frappe.local.lang or "").replace("-", "_"), format="long")
 	return formatted_date.startswith("0") and formatted_date[1:] or formatted_date
 
 def has_common(l1, l2):


### PR DESCRIPTION
Hi,

This is a proposal to change the global_date_format util in Frappe.

It is currently not localized and for example the weekly digest is sent with an english date even if the rest of the email is in french:
![image](https://cloud.githubusercontent.com/assets/4903591/26392637/99ab4b8e-4067-11e7-90f3-5838e3ea33d7.png)

After correction:
![image](https://cloud.githubusercontent.com/assets/4903591/26392700/c7f474ca-4067-11e7-9b3e-edf50aec1ca8.png)


I modified the util using babel, but don't hesitate to let me know if you prefer another solution.

Thank you.