### PR TITLE
[Minor]Add Note on Markdown Usage In Comments

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.html
+++ b/frappe/public/js/frappe/form/footer/timeline.html
@@ -9,7 +9,12 @@
         <div class="comment-input-container">
     		<textarea class="form-control comment-input"></textarea>
 			<input type="data" class="hidden mention-input">
-			<div class="text-muted small">{{ __("Ctrl+Enter to add comment") }}</div>
+			<div class="text-muted small">
+				{{ __("Ctrl+Enter to add comment") }}
+				<span class="pull-right">
+					{{ __("To use Markdown syntax, type &lt;!-- markdown --&gt; on the first line") }}
+				</span>
+			</div>
         </div>
     </div>
 	<div class="timeline-new-email">


### PR DESCRIPTION
This adds a note to the comment box to prevent issues like frappe/erpnext#8979.