### PR TITLE
Avatar next to login name missing, fixes erpnext/issues#8605

### DIFF
--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -262,7 +262,7 @@ frappe.upload = {
 		var freader = new FileReader();
 
 		freader.onload = function() {
-			args.filename = fileobj.name;
+			args.filename = fileobj.name.split(' ').join('_');
 			if(opts.options && opts.options.toLowerCase()=="image") {
 				if(!frappe.utils.is_image_file(args.filename)) {
 					msgprint(__("Only image extensions (.gif, .jpg, .jpeg, .tiff, .png, .svg) allowed"));


### PR DESCRIPTION
The avatar was not showing next to navbar.

ex:

man image.jpg // not getting shown because of space[Previous]
man_image.jpg // fix to show image[Now]

![screenshot from 2017-05-25 13-35-33](https://cloud.githubusercontent.com/assets/22857645/26441739/4b3052f4-414f-11e7-9d79-7be88298a3e4.png)
