### PR TITLE
[minor] fixes for default print format appears twice

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -77,4 +77,7 @@ def make_default(name):
 			'value': name,
 		})
 
-	frappe.msgprint(frappe._("Done"))
+	frappe.msgprint(frappe._("{0} is now default print format for {1} doctype").format(
+		frappe.bold(name),
+		frappe.bold(print_format.doc_type)
+	))

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -208,8 +208,8 @@ $.extend(frappe.meta, {
 		});
 
 		if(default_print_format && default_print_format != "Standard") {
-			var index = print_format_list.indexOf(default_print_format) - 1;
-			print_format_list.sort().splice(index, 1);
+			var index = print_format_list.indexOf(default_print_format);
+			print_format_list.splice(index, 1).sort();
 			print_format_list.unshift(default_print_format);
 		}
 


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/8985

`before`

<img width="1174" alt="screen shot 2017-05-26 at 11 39 04 am" src="https://cloud.githubusercontent.com/assets/11224291/26482960/f302ebe6-4207-11e7-9226-e3fb71410218.png">

`after`

<img width="1187" alt="screen shot 2017-05-26 at 11 37 57 am" src="https://cloud.githubusercontent.com/assets/11224291/26482961/f5972e94-4207-11e7-82ce-d6a6705987fc.png">
