### PR TITLE
Multiple issues fixed in auto email report

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -100,12 +100,18 @@ class Report(Document):
 			data = frappe.desk.query_report.run(self.name, filters=filters, user=user)
 			for d in data.get('columns'):
 				if isinstance(d, dict):
-					columns.append(frappe._dict(d))
+					col = frappe._dict(d)
+					if not col.fieldname:
+						col.fieldname = col.label
+					columns.append(col)
 				else:
+					fieldtype, options = "Data", None
 					parts = d.split(':')
-					fieldtype, options = parts[1], None
-					if fieldtype and '/' in fieldtype:
-						fieldtype, options = fieldtype.split('/')
+					if len(parts) > 1:
+						if parts[1]:
+							fieldtype, options = parts[1], None
+							if fieldtype and '/' in fieldtype:
+								fieldtype, options = fieldtype.split('/')
 
 					columns.append(frappe._dict(label=parts[0], fieldtype=fieldtype, fieldname=parts[0]))
 
@@ -145,7 +151,7 @@ class Report(Document):
 				for c in columns]
 
 			out = out + [list(d) for d in result]
-
+			
 		if as_dict:
 			data = []
 			for row in out:
@@ -155,7 +161,6 @@ class Report(Document):
 					_row[columns[i].get('fieldname')] = val
 		else:
 			data = out
-
 		return columns, data
 
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -104,7 +104,7 @@ def run(report_name, filters=None, user=None):
 
 	if cint(report.add_total_row) and result:
 		result = add_total_row(result, columns)
-
+		
 	return {
 		"result": result,
 		"columns": columns,
@@ -182,9 +182,12 @@ def add_total_row(result, columns, meta = None):
 			else:
 				col = col.split(":")
 				if len(col) > 1:
-					fieldtype = col[1]
-					if "/" in fieldtype:
-						fieldtype, options = fieldtype.split("/")
+					if col[1]:
+						fieldtype = col[1]
+						if "/" in fieldtype:
+							fieldtype, options = fieldtype.split("/")
+					else:
+						fieldtype = "Data"
 		else:
 			fieldtype = col.get("fieldtype")
 			options = col.get("options")
@@ -210,7 +213,7 @@ def add_total_row(result, columns, meta = None):
 	else:
 		first_col_fieldtype = columns[0].get("fieldtype")
 
-	if first_col_fieldtype not in ["Currency", "Int", "Float", "Percent"]:
+	if first_col_fieldtype not in ["Currency", "Int", "Float", "Percent", "Date"]:
 		if first_col_fieldtype == "Link":
 			total_row[0] = "'" + _("Total") + "'"
 		else:

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -124,9 +124,9 @@ class AutoEmailReport(Document):
 
 		report_doctype = frappe.db.get_value('Report', self.report, 'ref_doctype')
 		report_footer = frappe.render_template(self.get_report_footer(),
-						dict(report_url = frappe.utils.get_url_to_report(self.report, self.report_type, report_doctype),
-							report_name = self.report,
-							edit_report_settings = frappe.utils.get_link_to_form('Auto Email Report', self.name)))
+			dict(report_url = frappe.utils.get_url_to_report(self.report, self.report_type, report_doctype),
+			report_name = self.report,
+			edit_report_settings = frappe.utils.get_link_to_form('Auto Email Report', self.name)))
 
 		message += report_footer
 

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -432,7 +432,8 @@ def prepare_message(email, recipient, recipients_list):
 	if email.add_unsubscribe_link and email.reference_doctype: # is missing the check for unsubscribe message but will not add as there will be no unsubscribe url
 		unsubscribe_url = get_unsubcribed_url(email.reference_doctype, email.reference_name, recipient,
 		email.unsubscribe_method, email.unsubscribe_params)
-		message = message.replace("<!--unsubscribe url-->", quopri.encodestring(unsubscribe_url))
+		if message:
+			message = message.replace("<!--unsubscribe url-->", quopri.encodestring(unsubscribe_url))
 
 	if email.expose_recipients == "header":
 		pass


### PR DESCRIPTION
1. Fixed frappe/erpnext#9055

2. Fixed another issue in sending receivable report. The outstanding, paid amounts are showing as zero.
<img width="1226" alt="screen shot 2017-05-27 at 4 41 40 pm" src="https://cloud.githubusercontent.com/assets/836784/26521145/0124d2d2-42ff-11e7-9c81-7ed0d7550627.png">

After fix:
<img width="1226" alt="screen shot 2017-05-27 at 5 09 12 pm" src="https://cloud.githubusercontent.com/assets/836784/26521154/3bd57760-42ff-11e7-95ac-80f3f8e681ee.png">

3. Fixed an error on Error log:
```
'NoneType' object has no attribute 'replace'
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/email/queue.py", line 368, in send_one
    message = prepare_message(email, recipient.recipient, recipients_list)
  File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/email/queue.py", line 453, in prepare_message
    message = message.replace("<!--recipient-->", recipient)
AttributeError: 'NoneType' object has no attribute 'replace'
```
