### PR TITLE
Fix Feedback Trigger  …

### DIFF
--- a/frappe/core/doctype/feedback_trigger/feedback_trigger.py
+++ b/frappe/core/doctype/feedback_trigger/feedback_trigger.py
@@ -13,6 +13,8 @@ from frappe.utils.jinja import validate_template
 class FeedbackTrigger(Document):
 	def validate(self):
 		frappe.cache().delete_value('feedback_triggers')
+		if not self.message:
+			frappe.throw("Please insert MESSAGE field")
 		validate_template(self.subject)
 		validate_template(self.message)
 		self.validate_condition()


### PR DESCRIPTION
when message is empty  validate_template(self.message) take empty argument , 
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/compiler.py", line 78, in generate
    raise TypeError('Can\'t compile non template nodes')
TypeError: Can't compile non template nodes