### PR TITLE
[fix] OAuth2 Frappe Server URL Validation

### DIFF
--- a/frappe/integrations/doctype/social_login_keys/social_login_keys.py
+++ b/frappe/integrations/doctype/social_login_keys/social_login_keys.py
@@ -5,9 +5,16 @@
 
 from __future__ import unicode_literals
 import frappe
+import requests
+import socket
 
 from frappe.model.document import Document
 from frappe import _
+
+try:
+	from urllib.parse import urlparse
+except ImportError:
+	from urlparse import urlparse
 
 class SocialLoginKeys(Document):
 	def validate(self):
@@ -17,10 +24,14 @@ class SocialLoginKeys(Document):
 		if self.frappe_server_url:
 			if self.frappe_server_url.endswith('/'):
 				self.frappe_server_url = self.frappe_server_url[:-1]
-			import requests
+
 			try:
-				r = requests.get(self.frappe_server_url + "/api/method/frappe.handler.version", timeout=5)
+				frappe_server_hostname = urlparse(self.frappe_server_url).netloc
 			except:
-				frappe.throw(_("Unable to make request to the Frappe Server URL"))
-			if r.status_code != 200:
 				frappe.throw(_("Check Frappe Server URL"))
+
+			if socket.gethostname() != frappe_server_hostname:
+				try:
+					r = requests.get(self.frappe_server_url + "/api/method/frappe.handler.version", timeout=5)
+				except:
+					frappe.throw(_("Unable to make request to the Frappe Server URL"))

--- a/frappe/integrations/doctype/social_login_keys/social_login_keys.py
+++ b/frappe/integrations/doctype/social_login_keys/social_login_keys.py
@@ -30,7 +30,9 @@ class SocialLoginKeys(Document):
 			except:
 				frappe.throw(_("Check Frappe Server URL"))
 
-			if socket.gethostname() != frappe_server_hostname:
+			if socket.gethostname() != frappe_server_hostname or \
+				(frappe.local.conf.domains is not None) and \
+				(frappe_server_hostname not in frappe.local.conf.domains):
 				try:
 					r = requests.get(self.frappe_server_url + "/api/method/frappe.handler.version", timeout=5)
 				except:

--- a/frappe/integrations/doctype/social_login_keys/social_login_keys.py
+++ b/frappe/integrations/doctype/social_login_keys/social_login_keys.py
@@ -34,6 +34,6 @@ class SocialLoginKeys(Document):
 				(frappe.local.conf.domains is not None) and \
 				(frappe_server_hostname not in frappe.local.conf.domains):
 				try:
-					r = requests.get(self.frappe_server_url + "/api/method/frappe.handler.version", timeout=5)
+					requests.get(self.frappe_server_url + "/api/method/frappe.handler.version", timeout=5)
 				except:
 					frappe.throw(_("Unable to make request to the Frappe Server URL"))


### PR DESCRIPTION
Only request and validate the frappe_server_url if hostname is not equal to frappe_server_hostname
request.get to localhost by using hostname results into timeout

https://github.com/frappe/frappe/issues/3466