### PR TITLE
[minor] select the Inbox in readonly false mode while pulling emails

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -174,7 +174,9 @@ class EmailServer:
 			email_list = []
 			self.check_imap_uidvalidity()
 
-			self.imap.select("Inbox", readonly=True)
+			readonly = False if self.settings.email_sync_rule == "UNSEEN" else True
+
+			self.imap.select("Inbox", readonly=readonly)
 			response, message = self.imap.uid('search', None, self.settings.email_sync_rule)
 			if message[0]:
 				email_list =  message[0].split()
@@ -261,14 +263,16 @@ class EmailServer:
 				if not cint(self.settings.use_imap):
 					self.pop.dele(msg_num)
 				else:
-					# mark as seen
-					self.imap.uid('STORE', message_meta, '+FLAGS', '(\\SEEN)')
+					# mark as seen if email sync rule is UNSEEN (syncing only unseen mails)
+					if self.settings.email_sync_rule == "UNSEEN":
+						self.imap.uid('STORE', message_meta, '+FLAGS', '(\\SEEN)')
 		else:
 			if not cint(self.settings.use_imap):
 				self.pop.dele(msg_num)
 			else:
-				# mark as seen
-				self.imap.uid('STORE', message_meta, '+FLAGS', '(\\SEEN)')
+				# mark as seen if email sync rule is UNSEEN (syncing only unseen mails)
+				if self.settings.email_sync_rule == "UNSEEN":
+					self.imap.uid('STORE', message_meta, '+FLAGS', '(\\SEEN)')
 
 	def get_email_seen_status(self, uid, flag_string):
 		""" parse the email FLAGS response """


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/commands/utils.py", line 111, in execute
    ret = frappe.get_attr(method)(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 685, in pull
    pull_from_email_account(email_account.name)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 698, in pull_from_email_account
    email_account.receive()
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 253, in receive
    emails = email_server.get_messages()
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/email/receive.py", line 136, in get_messages
    self.retrieve_message(message_meta, i+1)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/email/receive.py", line 271, in retrieve_message
    self.imap.uid('STORE', message_meta, '+FLAGS', '(\\SEEN)')
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/imaplib.py", line 773, in uid
    typ, dat = self._simple_command(name, command, *args)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/imaplib.py", line 1088, in _simple_command
    return self._command_complete(name, self._command(name, *args))
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/imaplib.py", line 918, in _command_complete
    raise self.error('%s command error: %s %s' % (name, typ, data))
imaplib.error: UID command error: BAD ['[CANNOT] UID STORE failed - Mailbox has read-only access']
```