### PR TITLE
Row with label like Opening not displaying in the General Ledger report if user has set user permissions

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -287,7 +287,7 @@ def has_match(row, linked_doctypes, doctype_match_filters, ref_doctype, if_owner
 					if dt=="User" and columns_dict[idx]==columns_dict.get("owner"):
 						continue
 
-					if dt in match_filters and row[idx] not in match_filters[dt]:
+					if dt in match_filters and row[idx] not in match_filters[dt] and frappe.db.exists(dt, row[idx]):
 						match = False
 						break
 


### PR DESCRIPTION
**Issue**
I have set a User permissions to the user for the accounts. Its Working fine. But in a general ledger if we select a specific account which is allocated to the user, that user couldn't able to see the Opening, Closing and total of that account.

![screen shot 2017-06-01 at 12 25 04 pm](https://cloud.githubusercontent.com/assets/8780500/26668023/76855dd4-46c5-11e7-8905-1bafac812378.png)



**Fixed**

![screen shot 2017-06-01 at 12 25 14 pm](https://cloud.githubusercontent.com/assets/8780500/26668028/7c2c61ce-46c5-11e7-9e8c-fa4cbe6c8556.png)
