### PR TITLE
[minor] changed the message field property reqd to 1 in Feedback Trigger

### DIFF
--- a/frappe/core/doctype/feedback_trigger/feedback_trigger.json
+++ b/frappe/core/doctype/feedback_trigger/feedback_trigger.json
@@ -1,5 +1,26 @@
+Skip to content
+This repository
+Search
+Pull requests
+Issues
+Marketplace
+Gist
+ @ahmadRagheb
+ Sign out
+ Watch 0
+  Star 0
+  Fork 474 ahmadRagheb/frappe
+forked from frappe/frappe
+ Code  Pull requests 0  Projects 0  Wiki  Settings Insights 
+Tree: 6c7e742c4c Find file Copy pathfrappe/frappe/core/doctype/feedback_trigger/feedback_trigger.json
+6c7e742  10 hours ago
+@ahmadRagheb ahmadRagheb First commit
+2 contributors @mbauskar @ahmadRagheb
+RawBlameHistory    
+517 lines (517 sloc)  11.8 KB
 {
  "allow_copy": 0, 
+ "allow_guest_to_view": 0, 
  "allow_import": 0, 
  "allow_rename": 0, 
  "autoname": "field:document_type", 
@@ -13,6 +34,7 @@
  "engine": "InnoDB", 
  "fields": [
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -42,6 +64,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -70,6 +93,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -100,6 +124,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -130,6 +155,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -159,6 +185,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -187,6 +214,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -217,6 +245,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -245,6 +274,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -276,6 +306,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -306,6 +337,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -334,6 +366,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -363,6 +396,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -392,6 +426,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -415,12 +450,13 @@
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
-   "reqd": 0, 
+   "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -451,17 +487,17 @@
    "unique": 0
   }
  ], 
+ "has_web_view": 0, 
  "hide_heading": 0, 
  "hide_toolbar": 0, 
  "idx": 0, 
  "image_view": 0, 
  "in_create": 0, 
- "in_dialog": 0, 
  "is_submittable": 0, 
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-02-17 05:19:08.819230", 
+ "modified": "2017-05-29 16:36:04.178592", 
  "modified_by": "Administrator", 
  "module": "Core", 
  "name": "Feedback Trigger", 

--- a/frappe/core/doctype/feedback_trigger/feedback_trigger.json
+++ b/frappe/core/doctype/feedback_trigger/feedback_trigger.json
@@ -1,23 +1,3 @@
-Skip to content
-This repository
-Search
-Pull requests
-Issues
-Marketplace
-Gist
- @ahmadRagheb
- Sign out
- Watch 0
-  Star 0
-  Fork 474 ahmadRagheb/frappe
-forked from frappe/frappe
- Code  Pull requests 0  Projects 0  Wiki  Settings Insights 
-Tree: 6c7e742c4c Find file Copy pathfrappe/frappe/core/doctype/feedback_trigger/feedback_trigger.json
-6c7e742  10 hours ago
-@ahmadRagheb ahmadRagheb First commit
-2 contributors @mbauskar @ahmadRagheb
-RawBlameHistory    
-517 lines (517 sloc)  11.8 KB
 {
  "allow_copy": 0, 
  "allow_guest_to_view": 0, 


### PR DESCRIPTION
when message is empty validate_template(self.message) take empty argument ,
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/compiler.py", line 78, in generate
raise TypeError('Can't compile non template nodes')
TypeError: Can't compile non template nodes

I made message mandatory
