### PR TITLE
Password strength fix

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -545,9 +545,9 @@ def test_password_strength(new_password, key=None, old_password=None, user_data=
 		enable_password_policy = cint(frappe.db.get_single_value("System Settings", "enable_password_policy")) and True or False
 		minimum_password_score = cint(frappe.db.get_single_value("System Settings", "minimum_password_score")) or 0
 
-		password_policy_validation_passed = True
-		if enable_password_policy and result['score'] < minimum_password_score:
-			password_policy_validation_passed = False
+		password_policy_validation_passed = False
+		if result['score'] > minimum_password_score:
+			password_policy_validation_passed = True
 
 		result['feedback']['password_policy_validation_passed'] = password_policy_validation_passed
 

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -148,28 +148,24 @@ frappe.ready(function() {
 		var message = [];
 		feedback.help_msg = "";
 		if(!feedback.password_policy_validation_passed){
-			feedback.help_msg = __("Hint: Include symbols, numbers and capital letters in the password");
+			feedback.help_msg = "<br>" + __("Hint: Include symbols, numbers and capital letters in the password");
 		}
 		if (feedback) {
 			if(!feedback.password_policy_validation_passed){
 				if (feedback.suggestions && feedback.suggestions.length) {
-					feedback.suggestions = feedback.suggestions + ' ' + feedback.help_msg;
 					message = message.concat(feedback.suggestions);
 				} else if (feedback.warning) {
-					feedback.warning = feedback.warning + ' ' + feedback.help_msg;
 					message.push(feedback.warning);
 				}
+				message.push(feedback.help_msg);
 
-				if (!message.length) {
-					message.push(feedback.help_msg);
-				}
-			}else{
+			} else {
 				message.push(__('Success! You are good to go 👍'));
 			}
 		}
 
 		strength_indicator.removeClass().addClass('password-strength-indicator indicator ' + color);
-		strength_message.text(message.join(' ') || '').removeClass('hidden');
+		strength_message.html(message.join(' ') || '').removeClass('hidden');
 		// strength_indicator.attr('title', message.join(' ') || '');
 	}
 


### PR DESCRIPTION
#3194 unintentionally caused a side-effect in password feedback:
![screen shot 2017-06-02 at 12 48 22 pm](https://cloud.githubusercontent.com/assets/5196925/26716170/0c2f9ef0-4796-11e7-85b5-39cc66515545.png)

Post-fix (haha):
![screen shot 2017-06-02 at 1 13 45 pm](https://cloud.githubusercontent.com/assets/5196925/26716433/f46f4d0a-4796-11e7-9c6f-533dd4a1a8d4.png)
![screen shot 2017-06-02 at 1 14 17 pm](https://cloud.githubusercontent.com/assets/5196925/26716434/f5107d9c-4796-11e7-8bcb-427e1eb802c7.png)
![screen shot 2017-06-02 at 1 09 23 pm](https://cloud.githubusercontent.com/assets/5196925/26716439/f7c56476-4796-11e7-8911-53ba7871ad22.png)

This PR does not, however, restrict users from setting weak passwords (no behavioural change). Perhaps it's a good standard that we can introduce (with maybe a leeway for dev-mode ;) )