### PR TITLE
[minor] ignore password strength test in frappe.in_test

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -409,7 +409,8 @@ class User(Document):
 			self.username = ""
 
 	def password_strength_test(self):
-		if self.__new_password:
+		""" test password strength """
+		if frappe.db.get_single_value("System Settings", "enable_password_policy") and self.__new_password:
 			user_data = (self.first_name, self.middle_name, self.last_name, self.email, self.birth_date)
 			result = test_password_strength(self.__new_password, '', None, user_data)
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -49,7 +49,9 @@ class User(Document):
 		self.__new_password = self.new_password
 		self.new_password = ""
 
-		self.password_strength_test()
+		if not frappe.flags.in_test:
+			self.password_strength_test()
+
 		if self.name not in STANDARD_USERS:
 			self.validate_email_type(self.email)
 			self.validate_email_type(self.name)

--- a/frappe/utils/password_strength.py
+++ b/frappe/utils/password_strength.py
@@ -132,7 +132,9 @@ def get_match_feedback(match, is_sole_match):
 		"date": fun_date,
 		"year": fun_date
 	}
-	return(patterns[match['pattern']]())
+	pattern_fn = patterns.get(match['pattern'])
+	if pattern_fn:
+		return(pattern_fn())
 
 def get_dictionary_match_feedback(match, is_sole_match):
 	"""

--- a/frappe/utils/password_strength.py
+++ b/frappe/utils/password_strength.py
@@ -2,8 +2,10 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-from frappe import _
+
 import zxcvbn
+import frappe
+from frappe import _
 
 def test_password_strength(password, user_inputs=None):
 	'''Wrapper around zxcvbn.password_strength'''

--- a/frappe/utils/password_strength.py
+++ b/frappe/utils/password_strength.py
@@ -35,12 +35,14 @@ def get_feedback (score, sequence):
 	"""
 	Returns the feedback dictionary consisting of ("warning","suggestions") for the given sequences.
 	"""
+	minimum_password_score = frappe.db.get_single_value("System Settings", "minimum_password_score")
+
 	global default_feedback
 	# Starting feedback
 	if len(sequence) == 0:
 		return default_feedback
 	# No feedback if score is good or great
-	if score > 2:
+	if score > minimum_password_score:
 		return dict({"warning": "","suggestions": []})
 	# Tie feedback to the longest match for longer sequences
 	longest_match = max(sequence, key=lambda x: len(x['token']))


### PR DESCRIPTION
Ignore password strength test while running test cases

<img width="922" alt="screen shot 2017-06-02 at 4 31 58 pm" src="https://cloud.githubusercontent.com/assets/11224291/26723222/153d59c2-47b1-11e7-9c4d-510b8e23577e.png">

keyError digits

```
Traceback (most recent call last):
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
doc.save()
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/model/document.py", line 230, in save
return self._save(*args, **kwargs)
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/model/document.py", line 263, in _save
self.run_before_save_methods()
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/model/document.py", line 771, in run_before_save_methods
self.run_method("validate")
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/model/document.py", line 666, in run_method
out = Document.hook(fn)(self, *args, **kwargs)
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/model/document.py", line 891, in composer
return composed(self, method, *args, **kwargs)
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/model/document.py", line 874, in runner
add_to_return_value(self, fn(self, *args, **kwargs))
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/model/document.py", line 660, in
fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/core/doctype/user/user.py", line 52, in validate
self.password_strength_test()
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/core/doctype/user/user.py", line 414, in password_strength_test
result = test_password_strength(self.__new_password, '', None, user_data)
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/core/doctype/user/user.py", line 543, in test_password_strength
result = _test_password_strength(new_password, user_inputs=user_data)
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/utils/password_strength.py", line 11, in test_password_strength
result['feedback'] = get_feedback(result['score'], result['match_sequence'])
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/utils/password_strength.py", line 48, in get_feedback
feedback = get_match_feedback(longest_match, len(sequence) == 1)
File "/home/frappe/benches/bench-2017-05-25/apps/frappe/frappe/utils/password_strength.py", line 135, in get_match_feedback
return(patternsmatch['pattern'])
KeyError: 'digits'
```