### PR TITLE
[minor] fixes in Search term label

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -23,7 +23,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 		let fields = [
 			{
 				fieldtype: "Data",
-				label: __("Search term"),
+				label: __("Search Term"),
 				fieldname: "search_term"
 			},
 			{


### PR DESCRIPTION
`before`
<img width="599" alt="screen shot 2017-06-02 at 4 42 36 pm" src="https://cloud.githubusercontent.com/assets/11224291/26723551/ae29d164-47b2-11e7-9b84-83459080b7ac.png">
`After`
<img width="595" alt="screen shot 2017-06-02 at 4 43 48 pm" src="https://cloud.githubusercontent.com/assets/11224291/26723554/b04c3892-47b2-11e7-992a-10e6ca58fff6.png">