### PR TITLE
dialogs-types.md: Missing `+` operator

### DIFF
--- a/frappe/docs/user/en/guides/app-development/dialogs-types.md
+++ b/frappe/docs/user/en/guides/app-development/dialogs-types.md
@@ -85,7 +85,7 @@ This dialog have 2 arguments, they are:
     			+ "<li><b>28%</b> Memory</li>"
     			+ "<li><b>12%</b> Processor</li>"
     			+ "<li><b>0.3%</b> Disk</li>"
-		"</ul>", 'Server Info')
+		+ "</ul>", 'Server Info')
 
 ---
 


### PR DESCRIPTION
`msgprint` has a missing `+` operator, which is syntactically incorrect.