### PR TITLE
Make 'by' translatable in blog posts

### DIFF
--- a/frappe/website/doctype/blog_post/templates/blog_post.html
+++ b/frappe/website/doctype/blog_post/templates/blog_post.html
@@ -9,7 +9,7 @@
 	<div class="blog-info">
 	<h1 itemprop="headline" class="blog-header">{{ title }}</h1>
 	<p class="post-by text-muted">
-		<a href="/blog?blogger={{ blogger }}" class="no-decoration">By {{ blogger_info and blogger_info.full_name or full_name }}</a>
+		<a href="/blog?blogger={{ blogger }}" class="no-decoration">{{ _("By") }} {{ blogger_info and blogger_info.full_name or full_name }}</a>
 		<i class="blog-dot"></i> {{ frappe.format_date(published_on) }}
 		<i class="blog-dot"></i> <a href="/blog?blog_category={{ blog_category }}" class="no-decoration">{{ category.title }}</a>
 		<i class="blog-dot"></i> {{ comment_text }}

--- a/frappe/website/doctype/blog_post/templates/blog_post_row.html
+++ b/frappe/website/doctype/blog_post/templates/blog_post_row.html
@@ -11,7 +11,7 @@
 			<p class="post-description">{{ post.intro }}</p>
 			<p class="post-by text-muted small">
 				<a href="/blog?blogger={{ post.blogger }}"
-					class="no-decoration">By {{ post.full_name }}</a>
+					class="no-decoration">{{ _("By") }} {{ post.full_name }}</a>
 				<i class="blog-dot"></i> {{ frappe.format_date(post.published_on) }}
 				<i class="blog-dot"></i>
 				<a href="/blog?blog_category={{ post.blog_category }}"


### PR DESCRIPTION
Hi,

This is a small PR to correct the fact that "By" was is currently not translatable in blog posts.

After the correction it can be translated ("By" = "Par" in French) :
![image](https://user-images.githubusercontent.com/4903591/26937418-95dcfece-4c71-11e7-86a8-05000b2ef857.png)

![image](https://user-images.githubusercontent.com/4903591/26937443-a76cd7ea-4c71-11e7-8759-43638c280fcd.png)


Thank you!