### PR TITLE
[fix] Enqueue syncing global search

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -803,12 +803,7 @@ class Document(BaseDocument):
 		self.clear_cache()
 		self.notify_update()
 
-		try:
-			frappe.enqueue('frappe.utils.global_search.update_global_search',
-				now=frappe.flags.in_test or frappe.flags.in_install or frappe.flags.in_migrate,
-				doc=self)
-		except redis.exceptions.ConnectionError:
-			update_global_search(self)
+		update_global_search(self)
 
 		if self._doc_before_save and not self.flags.ignore_version:
 			self.save_version()

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -244,11 +244,11 @@ def get_formatted_value(value, field):
 		value = ' '.join(value.split())
 	return field.label + " : " + strip_html_tags(unicode(value))
 
-def sync_global_search(flags):
+def sync_global_search(flags = frappe.flags.update_global_search):
 	'''Add values from `flags` (frappe.flags.update_global_search) to __global_search.
 		This is called internally at the end of the request.'''
 
-	# As frappe.flags.update_global_search isn't reliable at a later time,
+	# Can pass flags manually as frappe.flags.update_global_search isn't reliable at a later time,
 	# when syncing is enqueued
 	for value in flags:
 		frappe.db.sql('''
@@ -258,6 +258,8 @@ def sync_global_search(flags):
 				(%(doctype)s, %(name)s, %(content)s, %(published)s, %(title)s, %(route)s)
 			on duplicate key update
 				content = %(content)s''', value)
+
+	frappe.flags.update_global_search = []
 
 def delete_for_document(doc):
 	'''Delete the __global_search entry of a document that has

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -244,9 +244,12 @@ def get_formatted_value(value, field):
 		value = ' '.join(value.split())
 	return field.label + " : " + strip_html_tags(unicode(value))
 
-def sync_global_search(flags = frappe.flags.update_global_search):
+def sync_global_search(flags=None):
 	'''Add values from `flags` (frappe.flags.update_global_search) to __global_search.
 		This is called internally at the end of the request.'''
+
+	if not flags:
+		flags = frappe.flags.update_global_search
 
 	# Can pass flags manually as frappe.flags.update_global_search isn't reliable at a later time,
 	# when syncing is enqueued

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -244,11 +244,13 @@ def get_formatted_value(value, field):
 		value = ' '.join(value.split())
 	return field.label + " : " + strip_html_tags(unicode(value))
 
-def sync_global_search():
-	'''Add values from `frappe.flags.update_global_search` to __global_search.
+def sync_global_search(flags):
+	'''Add values from `flags` (frappe.flags.update_global_search) to __global_search.
 		This is called internally at the end of the request.'''
 
-	for value in frappe.flags.update_global_search:
+	# As frappe.flags.update_global_search isn't reliable at a later time,
+	# when syncing is enqueued
+	for value in flags:
 		frappe.db.sql('''
 			insert into __global_search
 				(doctype, name, content, published, title, route)
@@ -256,8 +258,6 @@ def sync_global_search():
 				(%(doctype)s, %(name)s, %(content)s, %(published)s, %(title)s, %(route)s)
 			on duplicate key update
 				content = %(content)s''', value)
-
-	frappe.flags.update_global_search = []
 
 def delete_for_document(doc):
 	'''Delete the __global_search entry of a document that has


### PR DESCRIPTION
Enqueueing only the `sync_global_search` operation, and not `update_global_search`, and only on a commit, not on every save. The previous code feels shocking in hindsight.

Can implement a buffer that occasionally inserts, in future.