### PR TITLE
Add jinja support to leader_head.content and letter_head.footer

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -136,6 +136,8 @@ def get_html(doc, name=None, print_format=None, meta=None,
 
 	letter_head = frappe._dict(get_letter_head(doc, no_letterhead) or {})
 	
+	convert_markdown(doc, meta)
+	
 	args = {
 		"doc": doc,
 		"meta": frappe.get_meta(doc.doctype),

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -135,17 +135,15 @@ def get_html(doc, name=None, print_format=None, meta=None,
 		template = jenv.get_template(standard_format)
 
 	letter_head = frappe._dict(get_letter_head(doc, no_letterhead) or {})
-
-	convert_markdown(doc, meta)
-
+	
 	args = {
 		"doc": doc,
 		"meta": frappe.get_meta(doc.doctype),
 		"layout": make_layout(doc, meta, format_data),
 		"no_letterhead": no_letterhead,
 		"trigger_print": cint(trigger_print),
-		"letter_head": letter_head.content,
-		"footer": letter_head.footer,
+		"letter_head": frappe.utils.jinja.render_template(letter_head.content, {"doc": doc.as_dict()}),
+		"footer": frappe.utils.jinja.render_template(letter_head.footer, {"doc": doc.as_dict()}),
 		"print_settings": frappe.get_doc("Print Settings")
 	}
 


### PR DESCRIPTION
Add jinja support to leader_head.content and letter_head.footer

1. Create Letter Head with jinja tags

![image](https://user-images.githubusercontent.com/8351245/27132496-69f87598-510f-11e7-9fed-3fe88fdcc839.png)

2. Print something with letter head

![image](https://user-images.githubusercontent.com/8351245/27132534-841068b4-510f-11e7-9474-60a2121a1431.png)

As you can see, its working fine.