### PR TITLE
[fix] move dropbox backup upload from short queue to long queue to avoid timeout exceptions

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -149,10 +149,12 @@ scheduler_events = {
 		"frappe.utils.scheduler.restrict_scheduler_events_if_dormant",
 		"frappe.email.doctype.auto_email_report.auto_email_report.send_daily",
 		"frappe.core.doctype.feedback_request.feedback_request.delete_feedback_request",
-		"frappe.core.doctype.authentication_log.authentication_log.clear_authentication_logs",
+		"frappe.core.doctype.authentication_log.authentication_log.clear_authentication_logs"
+	],
+	"daily_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily"
 	],
-	"weekly": [
+	"weekly_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_weekly"
 	],
 	"monthly": [


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-06-07/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 124, in take_backup_to_dropbox
    did_not_upload, error_log = backup_to_dropbox()
  File "/home/frappe/benches/bench-2017-06-07/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 165, in backup_to_dropbox
    dropbox_client = upload_file_to_dropbox(filename, "/database", dropbox_client)
  File "/home/frappe/benches/bench-2017-06-07/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 211, in upload_file_to_dropbox
    uploader.upload_chunked()
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/dropbox/client.py", line 1187, in upload_chunked
    BytesIO(self.last_block), next_chunk_size, self.offset, self.upload_id)
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/dropbox/client.py", line 261, in upload_chunk
    reply = self.rest_client.PUT(url, file_obj, headers)
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/dropbox/rest.py", line 330, in PUT
    return cls.IMPL.PUT(*n, **kw)
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/dropbox/rest.py", line 267, in PUT
    return self.request("PUT", url, body=body, headers=headers, raw_response=raw_response)
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/dropbox/rest.py", line 229, in request
    preload_content=False
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/urllib3/poolmanager.py", line 321, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/urllib3/connectionpool.py", line 379, in _make_request
    httplib_response = conn.getresponse(buffering=True)
  File "/usr/lib64/python2.7/httplib.py", line 1089, in getresponse
    response.begin()
  File "/usr/lib64/python2.7/httplib.py", line 444, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python2.7/httplib.py", line 400, in _read_status
    line = self.fp.readline(_MAXLINE + 1)
  File "/usr/lib64/python2.7/socket.py", line 476, in readline
    data = self._sock.recv(self._rbufsize)
  File "/usr/lib64/python2.7/ssl.py", line 736, in recv
    return self.read(buflen)
  File "/usr/lib64/python2.7/ssl.py", line 630, in read
    v = self._sslobj.read(len or 1024)
  File "/home/frappe/benches/bench-2017-06-07/env/lib/python2.7/site-packages/rq/timeouts.py", line 51, in handle_death_penalty
    'value ({0} seconds)'.format(self._timeout))
JobTimeoutException: Job exceeded maximum timeout value (300 seconds)
```