### PR TITLE
Prepare email message only if there is message

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -429,11 +429,13 @@ where name=%s""", (unicode(e), email.name), auto_commit=auto_commit)
 
 def prepare_message(email, recipient, recipients_list):
 	message = email.message
+	if not message:
+		return ""
+		
 	if email.add_unsubscribe_link and email.reference_doctype: # is missing the check for unsubscribe message but will not add as there will be no unsubscribe url
 		unsubscribe_url = get_unsubcribed_url(email.reference_doctype, email.reference_name, recipient,
 		email.unsubscribe_method, email.unsubscribe_params)
-		if message:
-			message = message.replace("<!--unsubscribe url-->", quopri.encodestring(unsubscribe_url))
+		message = message.replace("<!--unsubscribe url-->", quopri.encodestring(unsubscribe_url))
 
 	if email.expose_recipients == "header":
 		pass


### PR DESCRIPTION
The below error is coming while sending Auto Email Report, if no message defined.

```
'NoneType' object has no attribute 'replace'
Traceback (most recent call last):
File "/home/frappe/benches/bench-2017-06-07/apps/frappe/frappe/email/queue.py", line 368, in send_one
message = prepare_message(email, recipient.recipient, recipients_list)
File "/home/frappe/benches/bench-2017-06-07/apps/frappe/frappe/email/queue.py", line 454, in prepare_messag
e
message = message.replace("", recipient)
AttributeError: 'NoneType' object has no attribute 'replace'
```