### PR TITLE
[Fix] Email digest, Email By Document Field's value not refreshing on change of document type

### DIFF
--- a/frappe/email/doctype/email_alert/email_alert.js
+++ b/frappe/email/doctype/email_alert/email_alert.js
@@ -34,6 +34,7 @@ frappe.email_alert = {
 				// set first option as blank to allow email alert not to be defaulted to the owner
 				frm.doc.name).options = [""].concat(["owner"].concat(email_fields));
 
+			frm.fields_dict.recipients.grid.refresh();
 		});
 	}
 }


### PR DESCRIPTION
**Issue**
If user has select document type as "Quotation" and again reselect another doctype as 'Material Request'. System showing the columns of quotation in the Email By Document Field.
For more details check below GIF

![email_alert_bug](https://user-images.githubusercontent.com/8780500/27121525-60c6fefe-5105-11e7-86cb-79771a88eee4.gif)

Fixed issue https://github.com/frappe/erpnext/issues/9259