### PR TITLE
In currency if no value after decimal, default precion set to 2

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -56,8 +56,13 @@ frappe.form.formatters = {
 		if (precision > 2) {
 			let parts = cstr(value).split('.');
 			let decimals = parts.length > 1 ? parts[1] : '';
-			// force 2 decimals irrespective of currency precision if there are less than 3 decimals
-			precision = decimals.length < 3 ? 2 : decimals.length;
+			if (decimals.length < 3) {
+				// min precision 2
+				precision = 2;
+			} else if (decimals.length < precision) {
+				// or min decimals
+				precision = decimals.length;
+			}
 		}
 		return frappe.form.formatters._right((value==null || value==="")
 			? "" : format_currency(value, currency, precision), options);

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -53,6 +53,12 @@ frappe.form.formatters = {
 	Currency: function(value, docfield, options, doc) {
 		var currency = frappe.meta.get_field_currency(docfield, doc);
 		var precision = docfield.precision || cint(frappe.boot.sysdefaults.currency_precision) || 2;
+		if (precision > 2) {
+			let parts = cstr(value).split('.');
+			let decimals = parts.length > 1 ? parts[1] : '';
+			// force 2 decimals irrespective of currency precision if there are less than 3 decimals
+			precision = decimals.length < 3 ? 2 : decimals.length;
+		}
 		return frappe.form.formatters._right((value==null || value==="")
 			? "" : format_currency(value, currency, precision), options);
 	},


### PR DESCRIPTION
<img width="459" alt="screen shot 2017-06-14 at 2 49 01 pm" src="https://user-images.githubusercontent.com/16913064/27125237-4ae9ccea-5111-11e7-82bd-b4ac507eb21c.png">
For currency precision 4 if no value after decimal, precision is set to 2.

<img width="358" alt="screen shot 2017-06-14 at 2 48 15 pm" src="https://user-images.githubusercontent.com/16913064/27125240-4b3a7d5c-5111-11e7-9a64-657cc49edf3d.png">
Else it is set to 4 only.
<img width="350" alt="screen shot 2017-06-14 at 2 48 44 pm" src="https://user-images.githubusercontent.com/16913064/27125239-4b227824-5111-11e7-846c-ea5744979449.png">
Fixed https://github.com/frappe/erpnext/issues/8130