### PR TITLE
Can't delete TAG #9239

### DIFF
--- a/frappe/desk/tags.py
+++ b/frappe/desk/tags.py
@@ -84,7 +84,6 @@ class DocTags:
 	def remove(self, dn, tag):
 		"""remove a user tag"""
 		tl = self.get_tags(dn).split(',')
-		print(tag, filter(lambda x:x!=tag, tl))
 		self.update(dn, filter(lambda x:x.lower()!=tag.lower(), tl))
 
 	def remove_all(self, dn):


### PR DESCRIPTION
fixes frappe/erpnext#9239

When trying to delete a tag using unicode special characters, the following exception with traceback:
```(python)
Traceback (most recent call last):
  File "/home/tunde/PycharmProjects/bench/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/tunde/PycharmProjects/bench/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/tunde/PycharmProjects/bench/frappe-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/tunde/PycharmProjects/bench/frappe-bench/apps/frappe/frappe/__init__.py", line 907, in call
    return fn(*args, **newargs)
  File "/home/tunde/PycharmProjects/bench/frappe-bench/apps/frappe/frappe/desk/tags.py", line 48, in remove_tag
    DocTags(dt).remove(dn, tag)
  File "/home/tunde/PycharmProjects/bench/frappe-bench/apps/frappe/frappe/desk/tags.py", line 87, in remove
    print(tag, filter(lambda x:x!=tag, tl))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe1' in position 2: ordinal not in range(128)
```