### PR TITLE
[hot] fixed ValueError: need more than 1 value to unpack for vnd currency

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -441,7 +441,9 @@ def money_in_words(number, main_currency = None, fraction_currency=None):
 	fraction_length = get_number_format_info(number_format)[2]
 
 	n = "%.{0}f".format(fraction_length) % number
-	main, fraction = n.split('.')
+
+	numbers = n.split('.')
+	main, fraction =  numbers if len(numbers) > 1 else [n, '00']
 
 	if len(fraction) < fraction_length:
 		zeros = '0' * (fraction_length - len(fraction))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 253, in _save
    self.insert()
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 192, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 772, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 892, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/model/document.py", line 660, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-06-15/apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 44, in validate
    super(PurchaseInvoice, self).validate()
  File "/home/frappe/benches/bench-2017-06-15/apps/erpnext/erpnext/controllers/buying_controller.py", line 29, in validate
    super(BuyingController, self).validate()
  File "/home/frappe/benches/bench-2017-06-15/apps/erpnext/erpnext/controllers/stock_controller.py", line 16, in validate
    super(StockController, self).validate()
  File "/home/frappe/benches/bench-2017-06-15/apps/erpnext/erpnext/controllers/accounts_controller.py", line 44, in validate
    self.set_total_in_words()
  File "/home/frappe/benches/bench-2017-06-15/apps/erpnext/erpnext/controllers/buying_controller.py", line 91, in set_total_in_words
    self.base_in_words = money_in_words(self.base_grand_total, self.company_currency)
  File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/utils/data.py", line 444, in money_in_words
    main, fraction = n.split('.')
ValueError: need more than 1 value to unpack
```