### PR TITLE
Invalid comparisison of password strenth score with minimum password score

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -549,7 +549,7 @@ def test_password_strength(new_password, key=None, old_password=None, user_data=
 		minimum_password_score = cint(frappe.db.get_single_value("System Settings", "minimum_password_score")) or 0
 
 		password_policy_validation_passed = False
-		if result['score'] > minimum_password_score:
+		if result['score'] >= minimum_password_score:
 			password_policy_validation_passed = True
 
 		result['feedback']['password_policy_validation_passed'] = password_policy_validation_passed


### PR DESCRIPTION
Description of an Issue
I have set the minimum password score as 2 in System Settings, then while trying to save &o00kySSP password in user. Getting following error
![screen shot 2017-06-19 at 2 37 37 pm](https://user-images.githubusercontent.com/8780500/27277737-dc614556-54fc-11e7-95e4-cab272644659.png)

The score of password &o00kySSP is 2 still getting an error