### PR TITLE
Make reports LTR for RTL theme

### DIFF
--- a/frappe/public/css/desk-rtl.css
+++ b/frappe/public/css/desk-rtl.css
@@ -78,4 +78,6 @@ ul.tree-children {
   left: auto !important;
   right: 23px;
 }
-
+.results {
+  direction: ltr;
+}


### PR DESCRIPTION
Fix display issues with query-report by allowing it to be LTR.
Before:
![beforeltr](https://user-images.githubusercontent.com/4618082/27290478-02b3e9a2-5516-11e7-998f-a79b3da9e6c3.PNG)
After:
![afterltr](https://user-images.githubusercontent.com/4618082/27290487-077774c2-5516-11e7-9658-0da4fe2e7283.PNG)
