### PR TITLE
Maintain aspect ratio in thumbnail

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -184,18 +184,15 @@ class File(NestedSet):
 				except (requests.exceptions.HTTPError, requests.exceptions.SSLError, IOError):
 					return
 
-			thumbnail = ImageOps.fit(
-				image,
-				(300, 300),
-				Image.ANTIALIAS
-			)
+			size = 300, 300
+			image.thumbnail(size)
 
 			thumbnail_url = filename + "_small." + extn
 
 			path = os.path.abspath(frappe.get_site_path("public", thumbnail_url.lstrip("/")))
 
 			try:
-				thumbnail.save(path)
+				image.save(path)
 				self.db_set("thumbnail_url", thumbnail_url)
 			except IOError:
 				frappe.msgprint(_("Unable to write file format for {0}").format(path))


### PR DESCRIPTION
**Original Image:**
![t5 led](https://user-images.githubusercontent.com/9355208/27321942-dc82f2f6-55b9-11e7-99b6-d4c9d1345991.png)

**Old `make_thumbnail` output:**
![t5 led_small](https://user-images.githubusercontent.com/9355208/27321949-e27f60f4-55b9-11e7-9a07-3b2181b0d622.png)

**New `make_thumbnail` output:**
![t5 led_thum](https://user-images.githubusercontent.com/9355208/27321947-dfa07b7a-55b9-11e7-8203-6d17a825c814.png)
