### PR TITLE
[fix] Auto email report not working

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -66,7 +66,9 @@ frappe.ui.form.on('Auto Email Report', {
 
 			var filters = JSON.parse(frm.doc.filters || '{}');
 			var report_filters = frappe.query_reports[frm.doc.report].filters;
-			frm.set_value('filter_meta', JSON.stringify(report_filters));
+			if(report_filters.length > 0) {
+				frm.set_value('filter_meta', JSON.stringify(report_filters));
+			}
 
 			report_filters_list = []
 			$.each(report_filters, function(key, val){

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -66,7 +66,7 @@ frappe.ui.form.on('Auto Email Report', {
 
 			var filters = JSON.parse(frm.doc.filters || '{}');
 			var report_filters = frappe.query_reports[frm.doc.report].filters;
-			if(report_filters.length > 0) {
+			if(report_filters && report_filters.length > 0) {
 				frm.set_value('filter_meta', JSON.stringify(report_filters));
 			}
 


### PR DESCRIPTION
Issue:
![screen shot 2017-06-20 at 2 56 42 pm](https://user-images.githubusercontent.com/8780500/27326527-4f5f17aa-55c9-11e7-9bcb-75470bf5f5f4.png)

filter_meta has value "[]" and filters has null value
```
if self.filter_meta and not self.filters:
			frappe.throw(_("Please set filters value in Report Filter table."))
```
Therefore system throwing an error 

{'retry': 0, 'log': , 'site': u'auxeye.erpnext.com', 'event': u'daily', 'method_name': u'frappe.email.doctype.auto_email_report.auto_email_report.send_daily', 'method': , 'user': u'Administrator', 'kwargs': {}, 'async': True, 'job_name': u'frappe.email.doctype.auto_email_report.auto_email_report.send_daily'}
Traceback (most recent call last):
File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/utils/background_jobs.py", line 65, in execute_job
method(**kwargs)
File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 183, in send_daily
auto_email_report.send()
File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 103, in send
frappe.throw(_("Please set filters value in Report Filter table."))
File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/init.py", line 316, in throw
msgprint(msg, raise_exception=exc, title=title, indicator='red')
File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/init.py", line 306, in msgprint
_raise_exception()
File "/home/frappe/benches/bench-2017-06-15/apps/frappe/frappe/init.py", line 279, in _raise_exception
raise raise_exception, encode(msg)
ValidationError: Please set filters value in Report Filter table.


Fixed

https://github.com/frappe/erpnext/issues/9378