### PR TITLE
[Feature] Enable overriding Quick Entry in custom app

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1293,7 +1293,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		var controller_name = "QuickEntryController";
 
 		if(frappe.ui.form[trimmed_doctype + "QuickEntry"]){
-			var controller_name = trimmed_doctype + "QuickEntry";
+			controller_name = trimmed_doctype + "QuickEntry";
 		}
 
 		new frappe.ui.form[controller_name](doctype, function(doc) {

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1290,10 +1290,10 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		frappe._from_link_scrollY = $(document).scrollTop();
 
 		var trimmed_doctype = doctype.replace(/ /g, '');
-		var controller_name = "QuickEntryController";
+		var controller_name = "QuickEntryForm";
 
-		if(frappe.ui.form[trimmed_doctype + "QuickEntry"]){
-			controller_name = trimmed_doctype + "QuickEntry";
+		if(frappe.ui.form[trimmed_doctype + "QuickEntryForm"]){
+			controller_name = trimmed_doctype + "QuickEntryForm";
 		}
 
 		new frappe.ui.form[controller_name](doctype, function(doc) {

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1289,7 +1289,14 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		frappe._from_link = this;
 		frappe._from_link_scrollY = $(document).scrollTop();
 
-		frappe.ui.form.quick_entry(doctype, function(doc) {
+		var trimmed_doctype = doctype.replace(/ /g, '');
+		var controller_name = "QuickEntryController";
+
+		if(frappe.ui.form[trimmed_doctype + "QuickEntry"]){
+			var controller_name = trimmed_doctype + "QuickEntry";
+		}
+
+		new frappe.ui.form[controller_name](doctype, function(doc) {
 			if(me.frm) {
 				me.parse_validate_and_set_in_model(doc.name);
 			} else {

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -1,129 +1,178 @@
 frappe.provide('frappe.ui.form');
 
-frappe.ui.form.quick_entry = function(doctype, success) {
-	frappe.model.with_doctype(doctype, function() {
-		var mandatory = $.map(frappe.get_meta(doctype).fields,
-			function(d) { return (d.reqd || d.bold && !d.read_only) ? d : null });
-		var meta = frappe.get_meta(doctype);
+frappe.ui.form.QuickEntryController = Class.extend({
+	init: function(doctype, success_function){
+		this.doctype = doctype;
+		this.success_function = success_function;
+		this.setup();
+	},
 
-		var doc = frappe.model.get_new_doc(doctype, null, null, true);
-
-		if(meta.quick_entry != 1) {
-			frappe.set_route('Form', doctype, doc.name);
-			return;
-		}
-
-		if(mandatory.length > 7) {
-			// too many fields, show form
-			frappe.set_route('Form', doctype, doc.name);
-			return;
-		}
-
-		if($.map(mandatory, function(d) { return d.fieldtype==='Table' ? d : null }).length) {
-			// has mandatory table, quit!
-			frappe.set_route('Form', doctype, doc.name);
-			return;
-		}
-
-		if(meta.autoname && meta.autoname.toLowerCase()==='prompt') {
-			mandatory = [{fieldname:'__name', label:__('{0} Name', [meta.name]),
-				reqd: 1, fieldtype:'Data'}].concat(mandatory);
-		}
-
-		var dialog = new frappe.ui.Dialog({
-			title: __("New {0}", [__(doctype)]),
-			fields: mandatory,
-		});
-
-		var update_doc = function() {
-			var data = dialog.get_values(true);
-			$.each(data, function(key, value) {
-				if(key==='__name') {
-					dialog.doc.name = value;
-				} else {
-					if(!is_null(value)) {
-						dialog.doc[key] = value;
-					}
-				}
-			});
-			return dialog.doc;
-		}
-
-		var open_doc = function() {
-			dialog.hide();
-			update_doc();
-			frappe.set_route('Form', doctype, doc.name);
-		}
-
-		dialog.doc = doc;
-
-		// refresh dependencies etc
-		dialog.refresh();
-
-		dialog.set_primary_action(__('Save'), function() {
-			if(dialog.working) return;
-			var data = dialog.get_values();
-
-			if(data) {
-				dialog.working = true;
-				var values = update_doc();
-				frappe.call({
-					method: "frappe.client.insert",
-					args: {
-						doc: values
-					},
-					callback: function(r) {
-						dialog.hide();
-						// delete the old doc
-						frappe.model.clear_doc(dialog.doc.doctype, dialog.doc.name);
-						var doc = r.message;
-						if(success) {
-							success(doc);
-						}
-						frappe.ui.form.update_calling_link(doc.name);
-					},
-					error: function() {
-						open_doc();
-					},
-					always: function() {
-						dialog.working = false;
-					},
-					freeze: true
-				});
+	setup: function(){
+		var me = this;
+		frappe.model.with_doctype(this.doctype, function() {
+			me.set_meta_and_mandatory_fields();
+			var validate_flag = me.validate_quick_entry();
+			if(!validate_flag){
+				me.render_dialog();
 			}
 		});
+	},
 
-		var $link = $('<div class="text-muted small" style="padding-left: 10px; padding-top: 15px;">' +
-			__("Ctrl+enter to save") + ' | <a class="edit-full">' + __("Edit in full page") + '</a></div>').appendTo(dialog.body);
+	set_meta_and_mandatory_fields: function(){
+		this.mandatory = $.map(frappe.get_meta(this.doctype).fields,
+				function(d) { return (d.reqd || d.bold && !d.read_only) ? d : null });
+		this.meta = frappe.get_meta(this.doctype);
+		this.doc = frappe.model.get_new_doc(this.doctype, null, null, true);
+	},
 
-		$link.find('.edit-full').on('click', function() {
-			// edit in form
-			open_doc();
+	validate_quick_entry: function(){
+		if(this.meta.quick_entry != 1) {
+			frappe.set_route('Form', this.doctype, this.doc.name);
+			return true;
+		}
+		var mandatory_flag = this.validate_mandatory_length();
+		var child_table_flag = this.validate_for_child_table();
+
+		if (mandatory_flag || child_table_flag){
+			return true;
+		}
+		this.validate_for_prompt_autoname();
+	},
+
+	validate_mandatory_length: function(){
+		if(this.mandatory.length > 7) {
+			// too many fields, show form
+			frappe.set_route('Form', this.doctype, this.doc.name);
+			return true;
+		}
+	},
+
+	validate_for_child_table: function(){
+		if($.map(this.mandatory, function(d) { return d.fieldtype==='Table' ? d : null }).length) {
+			// has mandatory table, quit!
+			frappe.set_route('Form', this.doctype, this.doc.name);
+			return true;
+		}
+	},
+
+	validate_for_prompt_autoname: function(){
+		if(this.meta.autoname && this.meta.autoname.toLowerCase()==='prompt') {
+			this.mandatory = [{fieldname:'__name', label:__('{0} Name', [this.meta.name]),
+				reqd: 1, fieldtype:'Data'}].concat(this.mandatory);
+		}
+	},
+
+	render_dialog: function(){
+		var me = this;
+		this.dialog = new frappe.ui.Dialog({
+			title: __("New {0}", [__(this.doctype)]),
+			fields: this.mandatory,
 		});
+		this.dialog.doc = this.doc;
+		// refresh dependencies etc
+		this.dialog.refresh();
 
+		this.register_primary_action();
+		this.render_edit_in_full_page_link();
 		// ctrl+enter to save
-		dialog.wrapper.keydown(function(e) {
+		this.dialog.wrapper.keydown(function(e) {
 			if((e.ctrlKey || e.metaKey) && e.which==13) {
 				if(!frappe.request.ajax_count) {
 					// not already working -- double entry
-					dialog.get_primary_btn().trigger("click");
+					me.dialog.get_primary_btn().trigger("click");
 					e.preventDefault();
 					return false;
 				}
 			}
 		});
 
-		dialog.show();
+		this.dialog.show();
+		this.set_defaults();
+	},
 
-		// set defaults
-		$.each(dialog.fields_dict, function(fieldname, field) {
-			field.doctype = doc.doctype;
-			field.docname = doc.name;
+	register_primary_action: function(){
+		var me = this;
+		this.dialog.set_primary_action(__('Save'), function() {
+			if(me.dialog.working) return;
+			var data = me.dialog.get_values();
 
-			if(!is_null(doc[fieldname])) {
-				field.set_input(doc[fieldname]);
+			if(data) {
+				me.dialog.working = true;
+				var values = me.update_doc();
+				me.insert_document(values);
 			}
 		});
+	},
 
-	});
-}
+	insert_document: function(values){
+		var me = this;
+		frappe.call({
+			method: "frappe.client.insert",
+			args: {
+				doc: values
+			},
+			callback: function(r) {
+				me.dialog.hide();
+				// delete the old doc
+				frappe.model.clear_doc(me.dialog.doc.doctype, me.dialog.doc.name);
+				var doc = r.message;
+				if(me.success_function) {
+					me.success_function(doc);
+				}
+				frappe.ui.form.update_calling_link(doc.name);
+			},
+			error: function() {
+				me.open_doc();
+			},
+			always: function() {
+				me.dialog.working = false;
+			},
+			freeze: true
+		});
+	},
+
+	update_doc: function(){
+		var me = this;
+		var data = this.dialog.get_values(true);
+		$.each(data, function(key, value) {
+			if(key==='__name') {
+				me.dialog.doc.name = value;
+			} else {
+				if(!is_null(value)) {
+					me.dialog.doc[key] = value;
+				}
+			}
+		});
+		return this.dialog.doc;
+	},
+
+	open_doc: function(){
+		this.dialog.hide();
+		this.update_doc();
+		frappe.set_route('Form', this.doctype, this.doc.name);
+	},
+
+	render_edit_in_full_page_link: function(){
+		var me = this;
+		var $link = $('<div class="text-muted small" style="padding-left: 10px; padding-top: 15px;">' +
+			__("Ctrl+enter to save") + ' | <a class="edit-full">' + __("Edit in full page") + '</a></div>').appendTo(this.dialog.body);
+
+		$link.find('.edit-full').on('click', function() {
+			// edit in form
+			me.open_doc();
+		});
+	},
+
+	set_defaults: function(){
+		var me = this;
+		// set defaults
+		$.each(this.dialog.fields_dict, function(fieldname, field) {
+			field.doctype = me.doc.doctype;
+			field.docname = me.doc.name;
+
+			if(!is_null(me.doc[fieldname])) {
+				field.set_input(me.doc[fieldname]);
+			}
+		});
+	}
+});

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -20,7 +20,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 
 	set_meta_and_mandatory_fields: function(){
 		this.mandatory = $.map(frappe.get_meta(this.doctype).fields,
-				function(d) { return (d.reqd || d.bold && !d.read_only) ? d : null });
+		function(d) { return (d.reqd || d.bold && !d.read_only) ? d : null; });
 		this.meta = frappe.get_meta(this.doctype);
 		this.doc = frappe.model.get_new_doc(this.doctype, null, null, true);
 	},
@@ -48,7 +48,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 	},
 
 	validate_for_child_table: function(){
-		if($.map(this.mandatory, function(d) { return d.fieldtype==='Table' ? d : null }).length) {
+		if($.map(this.mandatory, function(d) { return d.fieldtype==='Table' ? d : null; }).length) {
 			// has mandatory table, quit!
 			frappe.set_route('Form', this.doctype, this.doc.name);
 			return true;

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -1,6 +1,6 @@
 frappe.provide('frappe.ui.form');
 
-frappe.ui.form.QuickEntryController = Class.extend({
+frappe.ui.form.QuickEntryForm = Class.extend({
 	init: function(doctype, success_function){
 		this.doctype = doctype;
 		this.success_function = success_function;

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -20,7 +20,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 
 	set_meta_and_mandatory_fields: function(){
 		this.mandatory = $.map(frappe.get_meta(this.doctype).fields,
-		function(d) { return (d.reqd || d.bold && !d.read_only) ? d : null; });
+			function(d) { return (d.reqd || d.bold && !d.read_only) ? d : null; });
 		this.meta = frappe.get_meta(this.doctype);
 		this.doc = frappe.model.get_new_doc(this.doctype, null, null, true);
 	},

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -318,7 +318,14 @@ frappe.new_doc = function (doctype, opts) {
 		if(frappe.create_routes[doctype]) {
 			frappe.set_route(frappe.create_routes[doctype]);
 		} else {
-			frappe.ui.form.quick_entry(doctype, function(doc) {
+			var trimmed_doctype = doctype.replace(/ /g, '');
+			var controller_name = "QuickEntryController";
+
+			if(frappe.ui.form[trimmed_doctype + "QuickEntry"]){
+				controller_name = trimmed_doctype + "QuickEntry";
+			}
+
+			new frappe.ui.form[controller_name](doctype, function(doc) {
 				//frappe.set_route('List', doctype);
 				var title = doc.name;
 				var title_field = frappe.get_meta(doc.doctype).title_field;

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -319,10 +319,10 @@ frappe.new_doc = function (doctype, opts) {
 			frappe.set_route(frappe.create_routes[doctype]);
 		} else {
 			var trimmed_doctype = doctype.replace(/ /g, '');
-			var controller_name = "QuickEntryController";
+			var controller_name = "QuickEntryForm";
 
-			if(frappe.ui.form[trimmed_doctype + "QuickEntry"]){
-				controller_name = trimmed_doctype + "QuickEntry";
+			if(frappe.ui.form[trimmed_doctype + "QuickEntryForm"]){
+				controller_name = trimmed_doctype + "QuickEntryForm";
 			}
 
 			new frappe.ui.form[controller_name](doctype, function(doc) {


### PR DESCRIPTION
1. Enable overriding Quick Entry in the custom app.
2. Rewritten Quick entry function as Class.
3. Above changes are done for overriding quick entry in ERPNext for creation of  
   item variants from quick entry(considering item template already created).
![out123](https://user-images.githubusercontent.com/10596607/27336869-77e063ee-55ee-11e7-8ceb-b9dd6e3b09b8.gif)

4. If  PR gets merged will share ERPNext PR for the creation of item variants from Quick Entry.