### PR TITLE
Make upload files private by default

### DIFF
--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -53,7 +53,7 @@ frappe.upload = {
 				$uploaded_files_wrapper.removeClass('hidden').empty();
 
 				file_array = file_array.map(
-					file => Object.assign(file, {is_private: opts.is_private || 0})
+					file => Object.assign(file, {is_private: opts.is_private || 1})
 				)
 				$upload.data('attached_files', file_array);
 


### PR DESCRIPTION
This unchecks the private box when uploading files by default. It's better to accidentally attach as private something that is meant to be public than to accidentally attach something as public which is meant to be private.