### PR TITLE
[Fix] Don't allow user to change the select fieldtype to data from the customize form

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -943,6 +943,7 @@ def make_property_setter(args, ignore_validate=False, validate_fields_for_doctyp
 		})
 		ps.flags.ignore_validate = ignore_validate
 		ps.flags.validate_fields_for_doctype = validate_fields_for_doctype
+		ps.validate_fieldtype_change()
 		ps.insert()
 
 def import_doc(path, ignore_links=False, ignore_insert=False, insert=False):

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -3,8 +3,11 @@
 
 from __future__ import unicode_literals
 import frappe
+from frappe import _
 
 from frappe.model.document import Document
+
+not_allowed_fieldtype_change = ['naming_series']
 
 class PropertySetter(Document):
 	def autoname(self):
@@ -13,6 +16,18 @@ class PropertySetter(Document):
 			+ self.property
 
 	def validate(self):
+		self.validate_fieldtype_change()
+		self.delete_property_setter()
+
+		# clear cache
+		frappe.clear_cache(doctype = self.doc_type)
+
+	def validate_fieldtype_change(self):
+		if self.field_name in not_allowed_fieldtype_change and \
+			self.property == 'fieldtype':
+			frappe.throw(_("Field type cannot be changed for {0}").format(self.field_name))
+
+	def delete_property_setter(self):
 		"""delete other property setters on this, if this is new"""
 		if self.get('__islocal'):
 			frappe.db.sql("""delete from `tabProperty Setter` where
@@ -20,9 +35,6 @@ class PropertySetter(Document):
 				and doc_type = %(doc_type)s
 				and ifnull(field_name,'') = ifnull(%(field_name)s, '')
 				and property = %(property)s""", self.get_valid_dict())
-
-		# clear cache
-		frappe.clear_cache(doctype = self.doc_type)
 
 	def get_property_list(self, dt):
 		return frappe.db.sql("""select fieldname, label, fieldtype


### PR DESCRIPTION
Issue
n the Stock Entry, Naming Series is a standard field, based on which Stock Entry ID is generated. From Customize Form, User can change the Field Type of Naming Series field from Select to Data.

This also led to an issue when user creating new item

Fixed
![screen shot 2017-06-22 at 1 48 28 pm](https://user-images.githubusercontent.com/8780500/27424100-84f8ee70-5751-11e7-80e2-45971777d128.png)
