### PR TITLE
Fix for success message and redirect url in webforms

### DIFF
--- a/frappe/website/js/web_form.js
+++ b/frappe/website/js/web_form.js
@@ -280,19 +280,11 @@ frappe.ready(function() {
 			callback: function(data) {
 				if(!data.exc) {
 					frappe.doc_name = data.message;
-					if(!frappe.login_required) {
-						$form.addClass("hide");
-						$(".comments, .introduction, .page-head").addClass("hide");
-						scroll(0, 0);
-						set_message(frappe.success_link, true);
-					} else {
-						set_message(__('Saved'));
-					}
+					$form.addClass("hide");
+					$(".comments, .introduction, .page-head").addClass("hide");
+					scroll(0, 0);
+					set_message(frappe.success_link, true);
 
-					if(frappe.is_new && frappe.login_required) {
-						// reload page (with ID)
-						window.location.href = window.location.pathname + "?name=" + frappe.doc_name;
-					}
 					if(for_payment && data.message) {
 						// redirect to payment
 						window.location.href = data.message;


### PR DESCRIPTION
fixes https://github.com/frappe/erpnext/issues/9073

When 'login required' is checked in webforms, then it didn't show the success message instead only "Saved" is shown to the user. and instead of the redirect URL, as specified in the webforms it redirects to the created records with ID

![webform](https://user-images.githubusercontent.com/20757311/27386096-5ba69148-56b2-11e7-89d0-cba46873682a.gif)

