### PR TITLE
Bug after migration of contacts

### DIFF
--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -19,7 +19,7 @@ frappe.ui.form.on("Contact", {
 		if(!frm.doc.user && !frm.is_new() && frm.perm[0].write) {
 			frm.add_custom_button(__("Invite as User"), function() {
 				frappe.call({
-					method: "frappe.email.doctype.contact.contact.invite_user",
+					method: "frappe.contacts.doctype.contact.contact.invite_user",
 					args: {
 						contact: frm.doc.name
 					},


### PR DESCRIPTION
Hi,

This is a small correction of a bug spotted in the contact form.

The method was no longuer valid to automatically create a website user directly from a contact.

The 'invite_user' function is now located in the contact.py file.

Thanks!