### PR TITLE
Setup wizard refactor

### DIFF
--- a/frappe/build.js
+++ b/frappe/build.js
@@ -272,6 +272,7 @@ function watch_js(ondirty) {
 			if (sources.includes(filename)) {
 				pack(target, sources);
 				ondirty && ondirty(target);
+				// break;
 			}
 		}
 	});

--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -107,9 +107,13 @@
 	/*to change as per removing heading*/
 	height: 180px;
 	text-align: center;
+
+	/*Temp for gravatar demo*/
+	margin-left: 33%;
 }
 
-.setup-wizard-slide .frappe-control[data-fieldtype="Attach Image"] .form-control {
+.setup-wizard-slide .frappe-control[data-fieldtype="Attach Image"] .form-group,
+.setup-wizard-slide .frappe-control[data-fieldtype="Attach Image"] .clearfix {
 	display: none;
 }
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -102,16 +102,28 @@
 }
 
 .setup-wizard-slide .frappe-control[data-fieldtype="Attach Image"] {
+	/*hardcoded measures*/
+	width: 140px;
+	/*to change as per removing heading*/
+	height: 180px;
 	text-align: center;
+}
+
+.setup-wizard-slide .frappe-control[data-fieldtype="Attach Image"] .form-control {
+	display: none;
 }
 
 .setup-wizard-slide .missing-image,
 .setup-wizard-slide .attach-image-display {
 	display: block;
 	position: relative;
-	left: 50%;
-	transform: translate(-50%, 0);
-	-webkit-transform: translate(-50%, 0);
+	border-radius: 4px;
+}
+
+.setup-wizard-slide .missing-image {
+	border: 1px solid #d1d8dd;
+    border-radius: 6px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
 }
 
 .setup-wizard-slide .missing-image .octicon {
@@ -120,6 +132,40 @@
 	transform: translate(0px, -50%);
 	-webkit-transform: translate(0px, -50%);
 }
+
+/*commonify container and overlay*/
+
+.setup-wizard-slide .img-container {
+	height: 100%;
+    width: 100%;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+	border: 1px solid #d1d8dd;
+    border-radius: 6px;
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+}
+
+.setup-wizard-slide .img-overlay {
+	display: flex;
+    align-items: center;
+    justify-content: center;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	color: #777777;
+	background-color: rgba(255, 255, 255, 0.7);
+	opacity: 0;
+}
+
+.setup-wizard-slide .img-overlay:hover {
+	opacity: 1;
+	cursor: pointer;
+}
+
+/*=================================*/
 
 .setup-wizard-message-image {
 	margin: 15px auto;

--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -114,10 +114,8 @@
 }
 
 .setup-wizard-slide .frappe-control[data-fieldtype="Attach Image"] {
-	/*hardcoded measures*/
 	width: 140px;
-	/*to change as per removing heading*/
-	height: 180px;
+	height: 180px; /*depends on presence of heading*/
 	text-align: center;
 	margin-left: 33%;
 }

--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -1,3 +1,22 @@
+.setup-wizard-brand {
+	margin: 40px;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center
+}
+
+.setup-wizard-brand .brand-icon {
+	width: 36px;
+	height: 36px;
+}
+
+.setup-wizard-brand .brand-name {
+	font-size: 20px;
+    margin-left: 8px;
+    color: #36414C;
+}
+
 .setup-wizard-slide {
 	padding-left: 0px;
 	padding-right: 0px;
@@ -14,18 +33,51 @@
 }
 
 .setup-wizard-slide .lead {
-	margin-bottom: 10px;
+    margin: 40px;
+	color: #777777;
+	text-align: center;
+	font-size: 30px;
+}
+
+.setup-wizard-slide .col-sm-12 {
+	padding: 0px;
+}
+
+.setup-wizard-slide .section-body .col-sm-6:first-child {
+    padding-left: 0px;
+}
+
+.setup-wizard-slide .section-body .col-sm-6:last-child {
+    padding-right: 0px;
+}
+
+.setup-wizard-slide .form-control {
+	height: 35px;
 	font-weight: 500;
+}
+
+.setup-wizard-slide .has-error .control-label {
+	color: #ffa00a;
+}
+
+.setup-wizard-slide .has-error .form-control{
+	border-color: #ffa00a;
 }
 
 .setup-wizard-slide.with-form {
 	margin: 40px auto;
+	padding: 10px 50px;
 	border: 1px solid #d1d8dd;
 	box-shadow: 0px 3px 5px rgba(0, 0, 0, 0.1);
 }
 
 .setup-wizard-slide .footer {
-	padding: 30px;
+	padding: 30px 0px;
+}
+
+.setup-wizard-slide a.next-btn {
+    font-size: 14px;
+    padding: 7px 25px;
 }
 
 .setup-wizard-progress {

--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -119,8 +119,6 @@
 	/*to change as per removing heading*/
 	height: 180px;
 	text-align: center;
-
-	/*Temp for gravatar demo*/
 	margin-left: 33%;
 }
 
@@ -149,7 +147,6 @@
 	-webkit-transform: translate(0px, -50%);
 }
 
-/*commonify container and overlay*/
 
 .setup-wizard-slide .img-container {
 	height: 100%;
@@ -181,7 +178,6 @@
 	cursor: pointer;
 }
 
-/*=================================*/
 
 .setup-wizard-message-image {
 	margin: 15px auto;

--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -64,6 +64,10 @@
 	border-color: #ffa00a;
 }
 
+.setup-wizard-slide .form-control.bold {
+	background-color: #fff;
+}
+
 .setup-wizard-slide.with-form {
 	margin: 40px auto;
 	padding: 10px 50px;
@@ -75,9 +79,17 @@
 	padding: 30px 0px;
 }
 
-.setup-wizard-slide a.next-btn {
+.setup-wizard-slide a.next-btn,
+.setup-wizard-slide a.complete-btn {
     font-size: 14px;
     padding: 7px 25px;
+}
+
+.setup-wizard-slide a.next-btn.disabled,
+.setup-wizard-slide a.complete-btn.disabled {
+    background-color: #b1bdca;
+    color: #fff;
+    border-color: #b1bdca;
 }
 
 .setup-wizard-progress {

--- a/frappe/desk/page/setup_wizard/setup_wizard.css
+++ b/frappe/desk/page/setup_wizard/setup_wizard.css
@@ -1,9 +1,9 @@
 .setup-wizard-brand {
 	margin: 40px;
-    text-align: center;
-    display: flex;
-    justify-content: center;
-    align-items: center
+	text-align: center;
+	display: flex;
+	justify-content: center;
+	align-items: center
 }
 
 .setup-wizard-brand .brand-icon {
@@ -13,8 +13,8 @@
 
 .setup-wizard-brand .brand-name {
 	font-size: 20px;
-    margin-left: 8px;
-    color: #36414C;
+	margin-left: 8px;
+	color: #36414C;
 }
 
 .setup-wizard-slide {
@@ -33,7 +33,7 @@
 }
 
 .setup-wizard-slide .lead {
-    margin: 40px;
+	margin: 40px;
 	color: #777777;
 	text-align: center;
 	font-size: 30px;
@@ -44,11 +44,11 @@
 }
 
 .setup-wizard-slide .section-body .col-sm-6:first-child {
-    padding-left: 0px;
+	padding-left: 0px;
 }
 
 .setup-wizard-slide .section-body .col-sm-6:last-child {
-    padding-right: 0px;
+	padding-right: 0px;
 }
 
 .setup-wizard-slide .form-control {
@@ -81,19 +81,19 @@
 
 .setup-wizard-slide a.next-btn,
 .setup-wizard-slide a.complete-btn {
-    font-size: 14px;
-    padding: 7px 25px;
+	font-size: 14px;
+	padding: 7px 25px;
 }
 
 .setup-wizard-slide a.next-btn.disabled,
 .setup-wizard-slide a.complete-btn.disabled {
-    background-color: #b1bdca;
-    color: #fff;
-    border-color: #b1bdca;
+	background-color: #b1bdca;
+	color: #fff;
+	border-color: #b1bdca;
 }
 
 .setup-wizard-progress {
-    padding: 15px;
+	padding: 15px;
 }
 
 .setup-wizard-slide .fa-fw {
@@ -134,8 +134,8 @@
 
 .setup-wizard-slide .missing-image {
 	border: 1px solid #d1d8dd;
-    border-radius: 6px;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+	border-radius: 6px;
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
 }
 
 .setup-wizard-slide .missing-image .octicon {
@@ -148,21 +148,21 @@
 
 .setup-wizard-slide .img-container {
 	height: 100%;
-    width: 100%;
-    padding: 2px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
+	width: 100%;
+	padding: 2px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: relative;
 	border: 1px solid #d1d8dd;
-    border-radius: 6px;
+	border-radius: 6px;
 	box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
 }
 
 .setup-wizard-slide .img-overlay {
 	display: flex;
-    align-items: center;
-    justify-content: center;
+	align-items: center;
+	justify-content: center;
 	position: absolute;
 	width: 100%;
 	height: 100%;

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -1,9 +1,6 @@
 frappe.provide("frappe.wiz");
 frappe.provide("frappe.wiz.events");
 
-// frappe.wiz.slide_config.welcome (user, password etc)
-// frappe.wiz.utils.regional (lang etc.)
-
 frappe.wiz = {
 	slides: [],
 	events: {},
@@ -74,7 +71,8 @@ frappe.wiz.Wizard = Class.extend({
 		this.slide_dict = {};
 		this.values = {};
 		this.welcomed = true;
-		frappe.set_route("setup-wizard/0");
+		// CHANGE: revert
+		frappe.set_route("setup-wizard/2");
 	},
 	make: function() {
 		this.parent = $('<div class="setup-wizard-wrapper">').appendTo(this.parent);
@@ -321,7 +319,7 @@ frappe.wiz.WizardSlide = Class.extend({
 				.click(this.next_or_complete.bind(this));
 		}
 
-		//setup mousefree navigation
+		// setup mousefree navigation
 		this.$body.on('keypress', function(e) {
 			if(e.which === 13) {
 				var $target = $(e.target);
@@ -400,42 +398,10 @@ slides = [
 			frappe.wiz.utils.bind_language_events(slide);
 		},
 
-		setup_awesomplete: function(slide) {
+		setup_values: function(slide) {
 			var me = this;
 			var languauge_field = slide.get_field("language");
-			// this.awesomplete = frappe.wiz.setup_awesomplete(this, slide, "language", frappe.wiz.data.lang.languages);
 
-			var fn = "language";
-			var list = frappe.wiz.data.lang.languages;
-
-			var input_field = slide.get_field(fn);
-			var $input = input_field.$input;
-			var input = $input.get(0);
-			var awesomplete = new Awesomplete(input, {
-				minChars: 0,
-				maxItems: 99,
-				list: list
-			});
-			$input.on("awesomplete-select", function(e) {
-				var o = e.originalEvent;
-				var value = o.text.value;
-				var item = awesomplete.get_item(value);
-			});
-			$input.on("input", function(e) {
-				var value = e.target.value;
-				awesomplete.list = list;
-			});
-			$input.on("focus", function(e) {
-				$input.trigger("input");
-			});
-
-			$input.on("blur", function(e) {
-				if(!list.includes($input.val())) {
-					$input.val("");
-					}
-			});
-
-			this.awesomplete = awesomplete;
 			language_field.refresh();
 
 		}
@@ -480,12 +446,12 @@ slides = [
 		title: __("The First User: You"),
 		icon: "fa fa-user",
 		fields: [
-			{"fieldname": "full_name", "label": __("Full Name"), "fieldtype": "Data",
-				reqd:1},
-			{"fieldname": "email", "label": __("Email Address"), "fieldtype": "Data",
-				reqd:1, "description": __("Login id"), "options":"Email"},
-			{fieldtype:"Attach Image", fieldname:"attach_user",
+			{ "fieldtype":"Attach Image", "fieldname":"attach_user",
 				label: __("Attach Your Picture"), is_private: 0},
+			{ "fieldname": "full_name", "label": __("Full Name"), "fieldtype": "Data",
+				reqd:1},
+			{ "fieldname": "email", "label": __("Email Address"), "fieldtype": "Data",
+				reqd:1, "description": __("Login id"), "options":"Email"},
 		],
 		help: __('The first user will become the System Manager (you can change this later).'),
 		onload: function(slide) {
@@ -664,34 +630,6 @@ frappe.wiz.utils = {
 			});
 		});
 	},
-
-	setup_awesomplete: (context, slide, fn, list) => {
-		console.log("hello");
-		var input_field = slide.get_field(fn);
-		var $input = input_field.$input;
-		var input = $input.get(0);
-		var awesomplete = new Awesomplete(input, {
-			minChars: 0,
-			maxItems: 99,
-			list: list
-		});
-		$input.on("awesomplete-open", function(e){
-			$input.attr('state', 'open');
-		});
-		$input.on("awesomplete-close", function(e){
-			$input.attr('state', 'closed');
-		});
-		$input.on("input", function(e) {
-			var value = e.target.value;
-		});
-		$input.on("focus", function(e) {
-			if($input.attr('state') != 'open') {
-				$input.trigger("input");
-			}
-		});
-
-		return awesomplete;
-	}
 
 }
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -231,6 +231,11 @@ frappe.setup.WizardSlide = Class.extend({
 		var me = this;
 		if(this.$body) this.$body.remove();
 
+		if(this.add_more) {
+			this.item_count = 1;
+			this.field_set = this.fields;
+		}
+
 		if(this.before_load) {
 			this.before_load(this);
 		}
@@ -261,6 +266,7 @@ frappe.setup.WizardSlide = Class.extend({
 		this.set_reqd_fields();
 		this.set_init_values();
 		this.make_prev_next_buttons();
+		if(this.add_more) this.bind_more_button();
 
 		var $primary_btn = this.$next ? this.$next : this.$complete;
 
@@ -271,7 +277,6 @@ frappe.setup.WizardSlide = Class.extend({
 		}
 		this.reset_next($primary_btn);
 		this.focus_first_input();
-
 	},
 	set_reqd_fields: function() {
 		var dict = this.form.fields_dict;
@@ -304,6 +309,15 @@ frappe.setup.WizardSlide = Class.extend({
 			return false;
 		}
 		return true;
+	},
+
+	bind_more_button: function() {
+		this.$more = this.$body.find('.more-btn')
+			.removeClass('hide')
+			.on('click', () => {
+				this.item_count++;
+				this.form.add_fields(this.fields);
+			});
 	},
 
 	make_prev_next_buttons: function() {
@@ -347,6 +361,9 @@ frappe.setup.WizardSlide = Class.extend({
 				}
 			}
 		});
+	},
+	bind_add_more: function() {
+
 	},
 	bind_fields_to_next: function($primary_btn) {
 		var me = this;

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -525,19 +525,16 @@ var frappe_slides = [
 				delete slide.form.fields_dict.email;
 
 			} else {
-				this.setup_fields(slide);
+				utils.load_user_details(slide, this.setup_fields);
 			}
 		},
 
 		setup_fields: function(slide) {
-			// sample data:
-			var name = 'Prateeksha Singh';
-			var email = 'prateeksha@erpnext.com';
-
-			if(name) {
-				slide.form.fields_dict.full_name.set_input(name);
+			if(frappe.setup.data.full_name) {
+				slide.form.fields_dict.full_name.set_input(frappe.setup.data.full_name);
 			}
-			if(email) {
+			if(frappe.setup.data.email) {
+				email = frappe.setup.data.email;
 				slide.form.fields_dict.email.set_input(email);
 				if (frappe.get_gravatar(email, 200)) {
 					var $attach_user_image = slide.form.fields_dict.attach_user_image.$wrapper;
@@ -580,6 +577,18 @@ var utils = {
 				callback(slide);
 			}
 		});
+	},
+
+	load_user_details: function(slide, callback) {
+		frappe.call({
+			method: "frappe.desk.page.setup_wizard.setup_wizard.load_user_details",
+			freeze: true,
+			callback: function(r) {
+				frappe.setup.data.full_name = r.message.full_name;
+				frappe.setup.data.email = r.message.email;
+				callback(slide);
+			}
+		})
 	},
 
 	setup_language_field: function(slide) {
@@ -712,3 +721,5 @@ frappe.setup.on("before_load", function() {
 	frappe_slides.map(frappe.setup.add_slide);
 	// console.log(frappe.setup.slides);
 });
+
+

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -179,7 +179,7 @@ def load_messages(language):
 
 @frappe.whitelist()
 def load_languages():
-	language_codes = frappe.db.sql('select language_code, language_name from tabLanguage order by name', as_dict=True);
+	language_codes = frappe.db.sql('select language_code, language_name from tabLanguage order by name', as_dict=True)
 	codes_to_names = {}
 	for d in language_codes:
 		codes_to_names[d.language_code] = d.language_name
@@ -191,11 +191,8 @@ def load_languages():
 
 @frappe.whitelist()
 def load_country():
-	import requests
-	response = requests.get("http://freegeoip.net/json/")
-	response.raise_for_status()
-	country = response.json()["country_name"]
-	return country
+	from frappe.sessions import get_geo_ip_country
+	return get_geo_ip_country(frappe.local.request_ip) if frappe.local.request_ip else None
 
 @frappe.whitelist()
 def load_user_details():

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -200,7 +200,7 @@ def load_country():
 @frappe.whitelist()
 def load_user_details():
 	return {
-		"full_name": frappe.cache().hget("full_name", "signup")
+		"full_name": frappe.cache().hget("full_name", "signup"),
 		"email": frappe.cache().hget("email", "signup")
 	}
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -197,6 +197,13 @@ def load_country():
 	country = response.json()["country_name"]
 	return country
 
+@frappe.whitelist()
+def load_user_details():
+	return {
+		"full_name": frappe.cache().hget("full_name", "signup")
+		"email": frappe.cache().hget("email", "signup")
+	}
+
 def prettify_args(args):
 	# remove attachments
 	for key, val in args.items():

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -179,11 +179,23 @@ def load_messages(language):
 
 @frappe.whitelist()
 def load_languages():
+	language_codes = frappe.db.sql('select language_code, language_name from tabLanguage order by name', as_dict=True);
+	codes_to_names = {}
+	for d in language_codes:
+		codes_to_names[d.language_code] = d.language_name
 	return {
 		"default_language": frappe.db.get_value('Language', frappe.local.lang, 'language_name') or frappe.local.lang,
-		"languages": sorted(frappe.db.sql_list('select language_name from tabLanguage order by name'))
+		"languages": sorted(frappe.db.sql_list('select language_name from tabLanguage order by name')),
+		"codes_to_names": codes_to_names
 	}
 
+@frappe.whitelist()
+def load_country():
+	import requests
+	response = requests.get("http://freegeoip.net/json/")
+	response.raise_for_status()
+	country = response.json()["country_name"]
+	return country
 
 def prettify_args(args):
 	# remove attachments

--- a/frappe/desk/page/setup_wizard/setup_wizard_page.html
+++ b/frappe/desk/page/setup_wizard/setup_wizard_page.html
@@ -1,7 +1,7 @@
 <div class="container setup-wizard-slide single-column with-form" data-slide-name="{%= name %}">
 	<div class="text-center setup-wizard-progress text-extra-muted">
 		{% for (var i=0; i < slides_count; i++) { %}
-		<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i>
+		<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}"><i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></a></i>
 		{% } %}
 	</div>
     <p class="lead">{%= title %}</p>
@@ -9,6 +9,7 @@
 		<div class="setup-wizard-body col-sm-12">
 			<!-- {% if (help) { %} <p class="text-center">{%= help %}</p> {% } %} -->
 			<div class="form"></div>
+			<a class="more-btn hide btn btn-default btn-sm">{%= __("More") %}</a>
 		</div>
 	</div>
 	<div class="footer text-right">

--- a/frappe/desk/page/setup_wizard/setup_wizard_page.html
+++ b/frappe/desk/page/setup_wizard/setup_wizard_page.html
@@ -1,12 +1,12 @@
-<div class="container setup-wizard-slide {%= css_class %} with-form" data-slide-name="{%= name %}">
+<div class="container setup-wizard-slide single-column with-form" data-slide-name="{%= name %}">
 	<div class="text-center setup-wizard-progress text-extra-muted">
 		{% for (var i=0; i < slides_count; i++) { %}
 		<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i>
 		{% } %}
 	</div>
-    <p class="text-center lead">{%= title %}</p>
+    <p class="lead">{%= title %}</p>
 	<div class="row">
-		<div class="col-sm-12">
+		<div class="setup-wizard-body col-sm-12">
 			<!-- {% if (help) { %} <p class="text-center">{%= help %}</p> {% } %} -->
 			<div class="form"></div>
 		</div>

--- a/frappe/desk/page/setup_wizard/setup_wizard_page.html
+++ b/frappe/desk/page/setup_wizard/setup_wizard_page.html
@@ -2,9 +2,9 @@
 	<div class="text-center setup-wizard-progress text-extra-muted">
 		{% for (var i=0; i < slides_count; i++) { %}
 		<!--dev_mode: link element-->
-		<!--<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}">-->
+		<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}">
 			<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i>
-		<!--</a>-->
+		</a>
 		{% } %}
 	</div>
     <p class="lead">{%= title %}</p>

--- a/frappe/desk/page/setup_wizard/setup_wizard_page.html
+++ b/frappe/desk/page/setup_wizard/setup_wizard_page.html
@@ -2,9 +2,9 @@
 	<div class="text-center setup-wizard-progress text-extra-muted">
 		{% for (var i=0; i < slides_count; i++) { %}
 		<!--dev_mode: link element-->
-		<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}">
+		<!--<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}">-->
 			<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i>
-		</a>
+		<!--</a>-->
 		{% } %}
 	</div>
     <p class="lead">{%= title %}</p>

--- a/frappe/desk/page/setup_wizard/setup_wizard_page.html
+++ b/frappe/desk/page/setup_wizard/setup_wizard_page.html
@@ -1,7 +1,10 @@
 <div class="container setup-wizard-slide single-column with-form" data-slide-name="{%= name %}">
 	<div class="text-center setup-wizard-progress text-extra-muted">
 		{% for (var i=0; i < slides_count; i++) { %}
-		<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}"><i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></a></i>
+		<!--dev_mode: link element-->
+		<!--<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}">-->
+			<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i>
+		<!--</a>-->
 		{% } %}
 	</div>
     <p class="lead">{%= title %}</p>
@@ -9,7 +12,7 @@
 		<div class="setup-wizard-body col-sm-12">
 			<!-- {% if (help) { %} <p class="text-center">{%= help %}</p> {% } %} -->
 			<div class="form"></div>
-			<a class="more-btn hide btn btn-default btn-sm">{%= __("More") %}</a>
+			<a class="more-btn hide btn btn-default btn-sm" style="margin-left: 41%;">{%= __("Add More") %}</a>
 		</div>
 	</div>
 	<div class="footer text-right">

--- a/frappe/desk/page/setup_wizard/setup_wizard_page.html
+++ b/frappe/desk/page/setup_wizard/setup_wizard_page.html
@@ -1,7 +1,7 @@
 <div class="container setup-wizard-slide single-column with-form" data-slide-name="{%= name %}">
 	<div class="text-center setup-wizard-progress text-extra-muted">
 		{% for (var i=0; i < slides_count; i++) { %}
-		<!--dev_mode: link element-->
+		<!--dev_mode: link progress bubbles-->
 		<!--<a href="http://erpnext.domainify:8000/desk#setup-wizard/{%= i %}">-->
 			<i class="fa fa-fw fa-circle{% if (i+1<=step) { %} active {% } %}"></i>
 		<!--</a>-->

--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -530,6 +530,18 @@ select.form-control {
   font-weight: bold;
   background-color: #fffdf4;
 }
+.form-control[data-fieldtype="Password"] {
+  position: inherit;
+}
+.password-strength-indicator {
+  float: right;
+  padding: 15px;
+  margin-top: -41px;
+  margin-right: -7px;
+}
+.password-strength-message {
+  margin-top: -10px;
+}
 .form-headline {
   padding: 0px 15px;
   margin: 0px;

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -517,7 +517,6 @@ frappe.ui.form.ControlReadOnly = frappe.ui.form.ControlData.extend({
 	},
 });
 
-
 frappe.ui.form.ControlPassword = frappe.ui.form.ControlData.extend({
 	input_type: "password",
 	make: function() {
@@ -555,44 +554,19 @@ frappe.ui.form.ControlPassword = frappe.ui.form.ControlData.extend({
 						feedback = r.message.feedback;
 
 					feedback.crack_time_display = r.message.crack_time_display;
-					feedback.score = score;
 
-					if(feedback.password_policy_validation_passed){
-						me.set_strength_indicator('green', feedback);
-					} else {
-						me.set_strength_indicator('red', feedback);
-					}
+					var indicators = ['grey', 'red', 'orange', 'yellow', 'green'];
+					me.set_strength_indicator(indicators[score]);
+
 				}
 			}
 
 		});
 	},
-	set_strength_indicator: function(color, feedback) {
-		var message = [];
-		feedback.help_msg = "";
-		if(!feedback.password_policy_validation_passed){
-			feedback.help_msg = "<br>" + __("Hint: Include symbols, numbers and capital letters in the password");
-		}
-		if (feedback) {
-			if(!feedback.password_policy_validation_passed){
-				if (feedback.suggestions && feedback.suggestions.length) {
-					feedback.suggestions = feedback.suggestions + ' ' + feedback.help_msg;
-					message = message.concat(feedback.suggestions);
-				} else if (feedback.warning) {
-					feedback.warning = feedback.warning + ' ' + feedback.help_msg;
-					message.push(feedback.warning);
-				}
-
-				if (!message.length) {
-					message.push(feedback.help_msg);
-				}
-			}else{
-				message.push(__('Success! You are good to go 👍'));
-			}
-		}
-
+	set_strength_indicator: function(color) {
+		var message = __("Include symbols, numbers and capital letters in the password");
 		this.indicator.removeClass().addClass('password-strength-indicator indicator ' + color);
-		this.message.html(message.join(' ') || '').removeClass('hidden');
+		this.message.html(message).removeClass('hidden');
 	}
 });
 

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -531,7 +531,7 @@ frappe.ui.form.ControlPassword = frappe.ui.form.ControlData.extend({
 		this.indicator = this.$wrapper.find('.password-strength-indicator');
 		this.message = this.$wrapper.find('.help-box');
 
-		this.$input.on('input', (e) => {
+		this.$input.on('input', () => {
 			var $this = $(this);
 			clearTimeout($this.data('timeout'));
 			$this.data('timeout', setTimeout(() => {

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -519,7 +519,8 @@ frappe.ui.form.ControlReadOnly = frappe.ui.form.ControlData.extend({
 
 
 frappe.ui.form.ControlPassword = frappe.ui.form.ControlData.extend({
-	input_type: "password"
+	input_type: "password",
+
 });
 
 frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
@@ -1094,31 +1095,55 @@ frappe.ui.form.ControlAttachImage = frappe.ui.form.ControlAttach.extend({
 	make: function() {
 		var me = this;
 		this._super();
-		this.img_wrapper = $('<div style="margin: 7px 0px;">\
-			<div class="missing-image attach-missing-image"><i class="octicon octicon-circle-slash"></i></div></div>')
+		this.img_wrapper = $('<div style="width: 100%; height: calc(100% - 40px); position: relative;">\
+			<div class="missing-image attach-missing-image"><i class="octicon octicon-device-camera"></i></div></div>')
 			.appendTo(this.wrapper);
-		this.img = $("<img class='img-responsive attach-image-display'>")
-			.appendTo(this.img_wrapper).toggle(false);
+
+		this.img_container = $(`<div class='img-container'></div>`);
+		this.img = $(`<img class='img-responsive attach-image-display'>`)
+			.appendTo(this.img_container);
+
+		this.img_overlay = $(`<div class='img-overlay'>
+				<span class="overlay-text">Change</span>
+			</div>`).appendTo(this.img_container);
+
+		this.remove_image_link = $('<a style="font-size: 12px;color: #8D99A6;">Remove</a>');
+
+		this.img_wrapper.append(this.img_container).append(this.remove_image_link);
+		// this.img.toggle(false);
+		// this.img_overlay.toggle(false);
+		this.img_container.toggle(false);
+		this.remove_image_link.toggle(false);
 
 		// propagate click to Attach button
 		this.img_wrapper.find(".missing-image").on("click", function() { me.$input.click(); });
-		this.img.on("click", function() { me.$input.click(); });
+		this.img_container.on("click", function() { me.$input.click(); });
+		this.remove_image_link.on("click", function() { me.$value.find(".close").click(); });
 
 		this.$wrapper.on("refresh", function() {
+			$(me.wrapper).find('.btn-attach').addClass('hidden');
 			me.set_image();
 			if(me.get_status()=="Read") {
 				$(me.disp_area).toggle(false);
 			}
 		});
+
 		this.set_image();
 	},
 	set_image: function() {
 		if(this.get_value()) {
 			$(this.img_wrapper).find(".missing-image").toggle(false);
-			this.img.attr("src", this.dataurl ? this.dataurl : this.value).toggle(true);
+			// this.img.attr("src", this.dataurl ? this.dataurl : this.value).toggle(true);
+			// this.img_overlay.toggle(true);
+			this.img.attr("src", this.dataurl ? this.dataurl : this.value);
+			this.img_container.toggle(true);
+			this.remove_image_link.toggle(true);
 		} else {
 			$(this.img_wrapper).find(".missing-image").toggle(true);
-			this.img.toggle(false);
+			// this.img.toggle(false);
+			// this.img_overlay.toggle(false);
+			this.img_container.toggle(false);
+			this.remove_image_link.toggle(false);
 		}
 	}
 });

--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -520,7 +520,80 @@ frappe.ui.form.ControlReadOnly = frappe.ui.form.ControlData.extend({
 
 frappe.ui.form.ControlPassword = frappe.ui.form.ControlData.extend({
 	input_type: "password",
+	make: function() {
+		this._super();
+	},
+	make_input: function() {
+		var me = this;
+		this._super();
+		this.$input.parent().append($('<span class="password-strength-indicator indicator"></span>'));
+		this.$wrapper.find('.control-input-wrapper').append($('<p class="password-strength-message text-muted small hidden"></p>'));
 
+		this.indicator = this.$wrapper.find('.password-strength-indicator');
+		this.message = this.$wrapper.find('.help-box');
+
+		this.$input.on('input', (e) => {
+			var $this = $(this);
+			clearTimeout($this.data('timeout'));
+			$this.data('timeout', setTimeout(() => {
+				var txt = me.$input.val();
+				me.get_password_strength(txt);
+			}), 300);
+		});
+	},
+	get_password_strength: function(value) {
+		var me = this;
+		frappe.call({
+			type: 'GET',
+			method: 'frappe.core.doctype.user.user.test_password_strength',
+			args: {
+				new_password: value || ''
+			},
+			callback: function(r) {
+				if (r.message && r.message.entropy) {
+					var score = r.message.score,
+						feedback = r.message.feedback;
+
+					feedback.crack_time_display = r.message.crack_time_display;
+					feedback.score = score;
+
+					if(feedback.password_policy_validation_passed){
+						me.set_strength_indicator('green', feedback);
+					} else {
+						me.set_strength_indicator('red', feedback);
+					}
+				}
+			}
+
+		});
+	},
+	set_strength_indicator: function(color, feedback) {
+		var message = [];
+		feedback.help_msg = "";
+		if(!feedback.password_policy_validation_passed){
+			feedback.help_msg = "<br>" + __("Hint: Include symbols, numbers and capital letters in the password");
+		}
+		if (feedback) {
+			if(!feedback.password_policy_validation_passed){
+				if (feedback.suggestions && feedback.suggestions.length) {
+					feedback.suggestions = feedback.suggestions + ' ' + feedback.help_msg;
+					message = message.concat(feedback.suggestions);
+				} else if (feedback.warning) {
+					feedback.warning = feedback.warning + ' ' + feedback.help_msg;
+					message.push(feedback.warning);
+				}
+
+				if (!message.length) {
+					message.push(feedback.help_msg);
+				}
+			}else{
+				message.push(__('Success! You are good to go 👍'));
+			}
+		}
+
+		this.indicator.removeClass().addClass('password-strength-indicator indicator ' + color);
+		this.message.html(message.join(' ') || '').removeClass('hidden');
+	}
 });
 
 frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -44,29 +44,33 @@ frappe.ui.form.Layout = Class.extend({
 			this.message.empty().addClass('hidden');
 		}
 	},
-	render: function() {
+	render: function(fields) {
 		var me = this;
 
-
+		var fields = fields || this.fields;
 		this.section = null;
 		this.column = null;
-		if((this.fields[0] && this.fields[0].fieldtype!="Section Break") || !this.fields.length) {
+		if((fields[0] && fields[0].fieldtype!="Section Break") || !fields.length) {
 			this.make_section();
 		}
-		$.each(this.fields, function(i, df) {
-			if(df.fieldtype === "Fold") {
-				me.make_page(df);
-			} else if (df.fieldtype === "Section Break") {
-				me.make_section(df);
-			} else if (df.fieldtype === "Column Break") {
-				me.make_column(df);
-			} else {
-				me.make_field(df);
+		$.each(fields, function(i, df) {
+			switch(df.fieldtype) {
+				case "Fold":
+					me.make_page(df);
+					break;
+				case "Section Break":
+					me.make_section(df);
+					break;
+				case "Column Break":
+					me.make_column(df);
+					break;
+				default:
+					me.make_field(df);
 			}
 		});
 
 	},
-	make_field: function(df, colspan) {
+	make_field: function(df, colspan, render = false) {
 		!this.section && this.make_section();
 		!this.column && this.make_column();
 
@@ -74,7 +78,8 @@ frappe.ui.form.Layout = Class.extend({
 			df: df,
 			doctype: this.doctype,
 			parent: this.column.wrapper.get(0),
-			frm: this.frm
+			frm: this.frm,
+			render_input: render
 		});
 
 		fieldobj.layout = this;
@@ -224,6 +229,11 @@ frappe.ui.form.Layout = Class.extend({
 			}
 			refresh && fieldobj.refresh && fieldobj.refresh();
 		}
+		refresh && this.refresh_fields();
+	},
+
+	refresh_fields: function() {
+		this.fields_list.map(fieldobj => fieldobj.refresh());
 	},
 
 	refresh_section_count: function() {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -44,10 +44,10 @@ frappe.ui.form.Layout = Class.extend({
 			this.message.empty().addClass('hidden');
 		}
 	},
-	render: function(fields) {
+	render: function(new_fields) {
 		var me = this;
 
-		var fields = fields || this.fields;
+		var fields = new_fields || this.fields;
 		this.section = null;
 		this.column = null;
 		if((fields[0] && fields[0].fieldtype!="Section Break") || !fields.length) {
@@ -232,7 +232,7 @@ frappe.ui.form.Layout = Class.extend({
 	},
 
 	refresh_fields: function(fields) {
-		fieldnames = fields.map((field) => {
+		let fieldnames = fields.map((field) => {
 			if(field.label) return field.label;
 		});
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -229,11 +229,18 @@ frappe.ui.form.Layout = Class.extend({
 			}
 			refresh && fieldobj.refresh && fieldobj.refresh();
 		}
-		refresh && this.refresh_fields();
 	},
 
-	refresh_fields: function() {
-		this.fields_list.map(fieldobj => fieldobj.refresh());
+	refresh_fields: function(fields) {
+		fieldnames = fields.map((field) => {
+			if(field.label) return field.label;
+		});
+
+		this.fields_list.map(fieldobj => {
+			if(fieldnames.includes(fieldobj._label)) {
+				fieldobj.refresh();
+			}
+		});
 	},
 
 	refresh_section_count: function() {

--- a/frappe/public/js/frappe/misc/common.js
+++ b/frappe/public/js/frappe/misc/common.js
@@ -82,9 +82,11 @@ frappe.get_abbr = function(txt, max_length) {
 }
 
 frappe.gravatars = {};
-frappe.get_gravatar = function(email_id) {
+frappe.get_gravatar = function(email_id, size = 0) {
+	var param = size ? ('s=' + size) : 'd=retro';
 	if(!frappe.gravatars[email_id]) {
-		frappe.gravatars[email_id] = "https://secure.gravatar.com/avatar/" + md5(email_id) + "?d=retro";
+		// TODO: check if gravatar exists
+		frappe.gravatars[email_id] = "https://secure.gravatar.com/avatar/" + md5(email_id) + "?" + param;
 	}
 	return frappe.gravatars[email_id];
 }

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -41,6 +41,10 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			})
 		}
 	},
+	add_fields: function(fields) {
+		this.render(fields);
+		this.refresh_fields();
+	},
 	first_button: false,
 	catch_enter_as_submit: function() {
 		var me = this;
@@ -112,5 +116,5 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 				f.set_input(f.df['default'] || '');
 			}
 		}
-	}
+	},
 });

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -43,7 +43,7 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 	},
 	add_fields: function(fields) {
 		this.render(fields);
-		this.refresh_fields();
+		this.refresh_fields(fields);
 	},
 	first_button: false,
 	catch_enter_as_submit: function() {

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -666,6 +666,21 @@ select.form-control {
 	background-color: @extra-light-yellow;
 }
 
+.form-control[data-fieldtype="Password"] {
+	position: inherit;
+}
+
+.password-strength-indicator {
+    float: right;
+    padding: 15px;
+    margin-top: -41px;
+    margin-right: -7px;
+}
+
+.password-strength-message {
+	margin-top: -10px;
+}
+
 .form-headline {
 	padding: 0px 15px;
 	margin: 0px;

--- a/frappe/tests/ui/setup_wizard.js
+++ b/frappe/tests/ui/setup_wizard.js
@@ -1,0 +1,43 @@
+var login = require("./login.js")['Login']
+
+module.exports = {
+	before: browser => {
+		browser
+			.url(browser.launch_url + '/login')
+			.waitForElementVisible('body', 5000)
+	},
+	'Login': login,
+	'Welcome': browser => {
+		let slide_selector = '[data-slide-name="welcome"]';
+		browser
+			.assert.title('Frappe Desk')
+			.pause(5000)
+			.assert.visible(slide_selector, 'Check if welcome slide is visible')
+			.assert.value('select[data-fieldname="language"]', 'English')
+			.click(slide_selector + ' .next-btn');
+	},
+	'Region': browser => {
+		let slide_selector = '[data-slide-name="region"]';
+		browser
+			.waitForElementVisible(slide_selector , 2000)
+			.pause(6000)
+			.setValue('select[data-fieldname="language"]', "India")
+			.pause(4000)
+			.assert.containsText('div[data-fieldname="timezone"]', 'India Time - Asia/Kolkata')
+			.click(slide_selector + ' .next-btn');
+	},
+	'User': browser => {
+		let slide_selector = '[data-slide-name="user"]';
+		browser
+			.waitForElementVisible(slide_selector, 2000)
+			.pause(3000)
+			.setValue('input[data-fieldname="full_name"]', "John Doe")
+			.setValue('input[data-fieldname="email"]', "john@example.com")
+			.setValue('input[data-fieldname="password"]', "vbjwearghu")
+			.click(slide_selector + ' .next-btn');
+	},
+
+	after: browser => {
+		browser.end();
+	},
+};

--- a/frappe/tests/ui/setup_wizard.js
+++ b/frappe/tests/ui/setup_wizard.js
@@ -1,10 +1,10 @@
-var login = require("./login.js")['Login']
+var login = require("./login.js")['Login'];
 
 module.exports = {
 	before: browser => {
 		browser
 			.url(browser.launch_url + '/login')
-			.waitForElementVisible('body', 5000)
+			.waitForElementVisible('body', 5000);
 	},
 	'Login': login,
 	'Welcome': browser => {


### PR DESCRIPTION
With frappe/erpnext#9441

![screen shot 2017-06-23 at 8 20 31 am](https://user-images.githubusercontent.com/5196925/27465347-9c91ab2c-57f0-11e7-943a-19168a753348.png)
----------------------------------------------------
- Fetch country based on IP address:
![screen shot 2017-06-23 at 8 20 53 am](https://user-images.githubusercontent.com/5196925/27465349-9de86d58-57f0-11e7-9608-1d2e2e5ca62e.png)
----------------------------------------------------
- Fetch user detail from redis cache stored at the time of signup, then fetch gravatar from email
- New Attach Image and password controls
![screen shot 2017-06-23 at 8 35 42 am](https://user-images.githubusercontent.com/5196925/27465350-a0060974-57f0-11e7-9ad9-67fb946bf7b2.png)
----------------------------------------------------
- Disable next button until mandatory fields filled:
![disable next](https://user-images.githubusercontent.com/5196925/27465570-04877f26-57f2-11e7-954f-6dbd9f201acc.gif)
----------------------------------------------------
- Add more records:
![add_more_setup_wiz](https://user-images.githubusercontent.com/5196925/27465353-a1d3c00c-57f0-11e7-8440-e4b0b14e51c2.gif)
----------------------------------------------------
- UI tests (following screenshot for erpnext test):
![screen shot 2017-06-23 at 8 24 57 am](https://user-images.githubusercontent.com/5196925/27465355-a3ca2036-57f0-11e7-991a-65e77f140728.png)
----------------------------------------------------
- Moved sample data to last slide, but we can remove it altogether, and include bootstrapped stuff by default … maybe let them know about it in a later message.
![screen shot 2017-06-23 at 8 48 39 am](https://user-images.githubusercontent.com/5196925/27465373-cc1d1f70-57f0-11e7-9d95-ac1eb3ce378c.png)

----------------------------------------------------
- Breaking up a PR will have to be thought of from the beginning. Unfortunately, work on this had already begun :(    Insights on this will be helpful.