### PR TITLE
remove the CSRF token even if the device is mobile

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -120,6 +120,8 @@ def export_query():
 	data = frappe._dict(frappe.local.form_dict)
 
 	del data["cmd"]
+	if "csrf_token" in data:
+		del data["csrf_token"]
 
 	if isinstance(data.get("filters"), basestring):
 		filters = json.loads(data["filters"])

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -27,6 +27,8 @@ def get_form_params():
 	data = frappe._dict(frappe.local.form_dict)
 
 	del data["cmd"]
+	if "csrf_token" in data:
+		del data["csrf_token"]
 
 	if isinstance(data.get("filters"), basestring):
 		data["filters"] = json.loads(data["filters"])


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/9443

Delete the csrf_token from the form_dict, as in the mobile app it isn't validated and deleted during boot.