### PR TITLE
Assorted minor fixes

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager_help.html
+++ b/frappe/core/page/permission_manager/permission_manager_help.html
@@ -36,6 +36,6 @@
 		<li>{%= __("Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type.") %}</li>
 	</ol>
     <p>{%= __("If these instructions where not helpful, please add in your suggestions on GitHub Issues.") %}
-    	 <a href="https://github.com/frappe/frappe/issues" target="_blank">{%= __("Submit an Issue") %}</a>
+    	 <a href="https://github.com/frappe/frappe/issues" target="_blank" rel="noopener noreferrer">{%= __("Submit an Issue") %}</a>
     </p>
 </div>

--- a/frappe/desk/page/applications/application_row.html
+++ b/frappe/desk/page/applications/application_row.html
@@ -5,7 +5,7 @@
 	<div class="media">
 		<div class="pull-right app-buttons">
 			<a class="btn btn-default btn-xs"
-                href="{{ app.app_url }}" target="_blank">{{ __("Website") }}</a>
+                href="{{ app.app_url }}" target="_blank" rel="noopener noreferrer">{{ __("Website") }}</a>
 			{% if (app.installed) { %}
 			<button class="btn btn-danger btn-xs btn-remove"
                 data-title="{{ app.app_title }}"

--- a/frappe/desk/page/backups/backups.html
+++ b/frappe/desk/page/backups/backups.html
@@ -21,7 +21,7 @@
                 {{ f[1] }}
             </td>
             <td>
-                <a href="{{ f[0] }}" target="_blank">{{ f[0] }}</a>
+                <a href="{{ f[0] }}" target="_blank" rel="noopener noreferrer">{{ f[0] }}</a>
             </td>
             <td>
                 {{ f[2] }}

--- a/frappe/public/js/frappe/form/footer/timeline_item.html
+++ b/frappe/public/js/frappe/form/footer/timeline_item.html
@@ -110,7 +110,7 @@
 					{% $.each(data.attachments, function(i, a) { %}
 					<div class="ellipsis">
 						<a href="{%= encodeURI(a.file_url).replace(/#/g, \'%23\') %}"
-							class="text-muted small" target="_blank">
+							class="text-muted small" target="_blank" rel="noopener noreferrer">
 							<i class="fa fa-paperclip"></i>
 							{%= a.file_url.split("/").slice(-1)[0] %}
 							{% if (a.is_private) { %}

--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -233,25 +233,13 @@ frappe.views.ListRenderer = Class.extend({
 	},
 	add_column: function (df) {
 		// field width
-		var colspan = 3;
-		if (in_list(['Int', 'Percent'], df.fieldtype)) {
-			colspan = 2;
-		} else if (in_list(['Check', 'Image'], df.fieldtype)) {
-			colspan = 1;
-		} else if (in_list(['name', 'subject', 'title'], df.fieldname)) {
-			// subjects are longer
-			colspan = 4;
-		} else if (df.fieldtype == 'Text Editor' || df.fieldtype == 'Text') {
-			colspan = 4;
-		}
-
+		var colspan = 2;
 		if (df.columns && df.columns > 0) {
 			colspan = df.columns;
 		} else if (this.settings.column_colspan && this.settings.column_colspan[df.fieldname]) {
 			colspan = this.settings.column_colspan[df.fieldname];
-		} else {
-			colspan = 2;
 		}
+
 		this.total_colspans += parseInt(colspan);
 		var col = {
 			colspan: colspan,

--- a/frappe/public/js/frappe/misc/common.js
+++ b/frappe/public/js/frappe/misc/common.js
@@ -4,7 +4,6 @@ frappe.avatar = function(user, css_class, title) {
 	if(user) {
 		// desk
 		var user_info = frappe.user_info(user);
-		var image = frappe.utils.get_file_link(user_info.image);
 	} else {
 		// website
 		user_info = {

--- a/frappe/public/js/frappe/query_string.js
+++ b/frappe/public/js/frappe/query_string.js
@@ -23,7 +23,7 @@ function get_query_params(query_string) {
 		}
 
 		if (key in query_params) {
-			if (typeof query_params[key] === undefined) {
+			if (typeof query_params[key] === "undefined") {
 				query_params[key] = [];
 			} else if (typeof query_params[key] === "string") {
 				query_params[key] = [query_params[key]];

--- a/frappe/public/js/frappe/toolbar.js
+++ b/frappe/public/js/frappe/toolbar.js
@@ -3,8 +3,6 @@
 
 $(document).on("toolbar_setup", function() {
 	var help_links = [];
-	var support_link = "#upgrade";
-	var chat_link = "#upgrade";
 	var limits = frappe.boot.limits;
 
 	if(frappe.boot.expiry_message) {
@@ -24,7 +22,7 @@ $(document).on("toolbar_setup", function() {
 	}
 
 	if(limits.support_email) {
-		support_link = 'mailto:'+frappe.boot.limits.support_email;
+		var support_link = 'mailto:'+frappe.boot.limits.support_email;
 		help_links.push('<li><a href="'+support_link+'">' + frappe._('Email Support') + '</a></li>');
 	}
 

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -28,7 +28,7 @@
 					    {%= __("My Settings") %}</a></li>
 					<li><a href="#" onclick="return frappe.ui.toolbar.clear_cache();">
 					    {%= __("Reload") %}</a></li>
-					<li><a href="/index" target="_blank">
+					<li><a href="/index" target="_blank" rel="noopener noreferrer">
 						{%= __("View Website") %}</a></li>
 					<li><a href="#background_jobs">
 						{%= __("Background Jobs") %}</a></li>
@@ -54,7 +54,7 @@
 					<li class="divider"></li>
 					<li>
 						<a data-link-type="documentation"
-							data-path="/documentation/index" target="_blank">{{ __("Documentation") }}</a>
+							data-path="/documentation/index" target="_blank" rel="noopener noreferrer">{{ __("Documentation") }}</a>
 					</li>
 					<li class="divider documentation-links"></li>
 					<li><a href="#" onclick="return frappe.ui.toolbar.show_about();">

--- a/frappe/public/js/frappe/views/reports/grid_report.js
+++ b/frappe/public/js/frappe/views/reports/grid_report.js
@@ -767,7 +767,6 @@ frappe.views.TreeGridReport = frappe.views.GridReportWithPlot.extend({
 	},
 	tree_formatter: function (row, cell, value, columnDef, dataContext) {
 		var me = frappe.cur_grid_report;
-		value = value.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
 		var data = me.data;
 		var spacer = "<span style='display:inline-block;height:1px;width:" +
 			(15 * dataContext["indent"]) + "px'></span>";

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -228,7 +228,6 @@ frappe.views.QueryReport = Class.extend({
 
 			//Render Report in HTML
 			var html = frappe.render_template("print_template", {
-				columns:columns,
 				content:content,
 				title:__(this.report_name),
 				base_url: base_url,

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -35,7 +35,7 @@
 	{%- if allow_print and not is_list and not _login_required -%}
 	<div class='text-right'>
 		<a class='text-muted small' href='/printview?doctype={{ doc.doctype}}&name={{ doc.name }}
-			{%- if print_format -%}&format={{ print_format }}{%- endif -%}' target="_blank">
+			{%- if print_format -%}&format={{ print_format }}{%- endif -%}' target="_blank" rel="noopener noreferrer">
 			<i class='fa fa-print'></i> {{ _("Print") }}</a>
 	</div>
 	{%- endif -%}
@@ -250,7 +250,7 @@
 	<div class="row">
 		<div class="col-sm-9">
 			<p class="text-muted">
-				<a class="btn btn-default btn-sm" href="{{ doc.route }}" target="_blank">
+				<a class="btn btn-default btn-sm" href="{{ doc.route }}" target="_blank" rel="noopener noreferrer">
 					{{ web_page_link_text }}</a>
 			</p>
 		</div>

--- a/frappe/website/js/web_form.js
+++ b/frappe/website/js/web_form.js
@@ -166,7 +166,7 @@ frappe.ready(function() {
 			$(this).find('[data-child-row=1]').each(function() {
 				if(!$(this).hasClass('hidden')) {
 					frappe.mandatory_missing_in_last_doc = [];
-					var d = get_data_for_doctype($(this), doctype, true);
+					var d = get_data_for_doctype($(this), doctype);
 
 					// set name of child record (if set)
 					var name = $(this).attr('data-name');


### PR DESCRIPTION
This PR fixes a few inconsistencies and potential bugs.

Commit-by-commit changes:
- Replace a `typeof x === undefined` test (always false) with `typeof x === "undefined"`
- Add `rel="noopener noreferrer"` to links with `target="_blank"` attribute. See https://mathiasbynens.github.io/rel-noopener/ for why you may want this.
- `columns: columns` was specified twice in an object definition
- `get_data_for_doctype` takes only two arguments
- Moved/removed a couple of variable declarations where the assigned value was never read
- Removed an assignment to a function argument variable that was never read
- Simplified the logic for computing the colspan in `ListRenderer.add_column`. This change warrants some closer inspection - I believe it to be semantics preserving as before the first block of possible assignments to `colspan` would always be overwritten by the next if-then-else block before `colspan` was read, but it seems unlikely that this was the intended behaviour. I can amend or drop this commit if desired.

These results were found on https://lgtm.com/projects/g/frappe/frappe/alerts/ - there are further results there, most of which would probably be best handled by people more familiar with the codebase. If you are interested in this kind of analysis, then [Pull Request Integration](https://lgtm.com/projects/g/frappe/frappe/ci/ ) is available. (Full disclosure - I work on lgtm.com).