### PR TITLE
[fix] skipped awesome bar options

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -18,7 +18,6 @@ frappe.search.AwesomeBar = Class.extend({
 			autoFirst: true,
 			list: [],
 			filter: function (text, term) {
-				this.get_item(text.value).boo = "foo";
 				return true;
 			},
 			data: function (item, input) {
@@ -194,6 +193,7 @@ frappe.search.AwesomeBar = Class.extend({
 				}
 			} else {
 				out.push(option);
+				routes.push("");
 			}
 		});
 		return out;


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/5196925/27587479-277f0152-5b62-11e7-9d41-92b9eaba0476.gif)

After:
![after](https://user-images.githubusercontent.com/5196925/27587471-23b83d7c-5b62-11e7-95db-0ddbfb802220.gif)