### PR TITLE
[Fix] Date fields not changing when viewing another records

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -609,6 +609,7 @@ frappe.ui.form.ControlDate = frappe.ui.form.ControlData.extend({
 		this.set_t_for_today();
 	},
 	set_formatted_input: function(value) {
+		this._super(value);
 		if(value
 			&& ((this.last_value && this.last_value !== value)
 				|| (!this.datepicker.selectedDates.length))) {


### PR DESCRIPTION
**Issue**
After 1st employee record is viewed, any other employee records viewed have the same values in all date fields unless the web page is manually refreshed. Same issue occurs when Customer records are viewed

![date_issue](https://user-images.githubusercontent.com/8780500/27588909-590e8832-5b67-11e7-8c12-87bba0b4982c.gif)

Fixed https://github.com/frappe/erpnext/issues/9475