### PR TITLE
Email configurable footer

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -298,8 +298,12 @@ def get_footer(email_account, footer=None):
 	company_address = frappe.db.get_default("email_footer_address")
 
 	if company_address:
-		footer += '<tr style="margin: 15px auto; text-align: center; color: #8d99a6"><td>{0}</td></tr>'\
-			.format(company_address.replace("\n", '</tr><tr style="margin: 15px auto; text-align: center; color: #8d99a6">'))
+		company_address = company_address.splitlines(True)
+		footer += '<table width="100%" border=0>'
+		for x in company_address:
+			footer += '<tr style="margin: 15px auto; text-align: center; color: #8d99a6"><td>{0}</td></tr>'\
+				.format(x)
+		footer += "</table>"
 
 	if not cint(frappe.db.get_default("disable_standard_email_footer")):
 		for default_mail_footer in frappe.get_hooks("default_mail_footer"):

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -300,6 +300,7 @@ def get_footer(email_account, footer=None):
 	if company_address:
 		company_address = company_address.splitlines(True)
 		footer += '<table width="100%" border=0>'
+		footer += '<tr><td height=20></td></tr>'
 		for x in company_address:
 			footer += '<tr style="margin: 15px auto; text-align: center; color: #8d99a6"><td>{0}</td></tr>'\
 				.format(x)

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -298,8 +298,8 @@ def get_footer(email_account, footer=None):
 	company_address = frappe.db.get_default("email_footer_address")
 
 	if company_address:
-		footer += '<div style="margin: 15px auto; text-align: center; color: #8d99a6">{0}</div>'\
-			.format(company_address.replace("\n", "<br>"))
+		footer += '<tr style="margin: 15px auto; text-align: center; color: #8d99a6"><td>{0}</td></tr>'\
+			.format(company_address.replace("\n", '</tr><tr style="margin: 15px auto; text-align: center; color: #8d99a6">'))
 
 	if not cint(frappe.db.get_default("disable_standard_email_footer")):
 		for default_mail_footer in frappe.get_hooks("default_mail_footer"):


### PR DESCRIPTION
Email footer content is added from system settings-> Email textfield

![screen shot 2017-06-29 at 4 14 49 pm](https://user-images.githubusercontent.com/28141909/27684432-9b82e132-5ce7-11e7-8e80-f7d0248e8302.png)

System footer > Email -> Email Footer Address:

![screen shot 2017-06-29 at 4 01 38 pm](https://user-images.githubusercontent.com/28141909/27683631-57a860fc-5ce4-11e7-9326-d4800a57bec4.png)

Email Footer Test cases:

1) If we haven't add data to Footer Address in System Settings and Checked the "Disable Standard Email Footer":
      Then there will be no footer

2) If we added text to Footer Address in System Settings  and Not checked "Disable Standard Email Footer":
      Then both footer are show ie. Custom footer from  Footer Address and default footer "Sent via ERPNext"

3) If no Footer address in System Settings and Not checked "Disable Standard Email Footer":
       Then default footer "Sent via ERPNext" shown in email footer.
