### PR TITLE
[hot][fix] set field type

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -216,7 +216,7 @@ frappe.ui.Filter = Class.extend({
 					: __("use % as wildcard"))+'</div>');
 			} else {
 				//if condition selected after refresh
-				me.set_field(me.field.df.parent, me.field.df.fieldname, me.field.df.fieldtype, condition);
+				me.set_field(me.field.df.parent, me.field.df.fieldname, null, condition);
 			}
 		});
 
@@ -345,7 +345,7 @@ frappe.ui.Filter = Class.extend({
 		} else if(['Text','Small Text','Text Editor','Code','Tag','Comments',
 			'Dynamic Link','Read Only','Assign'].indexOf(df.fieldtype)!=-1) {
 			df.fieldtype = 'Data';
-		} else if(df.fieldtype=='Link' && this.wrapper.find('.condition').val()!="=") {
+		} else if(df.fieldtype=='Link' && ['=', '!='].indexOf(this.wrapper.find('.condition').val())==-1) {
 			df.fieldtype = 'Data';
 		}
 		if(df.fieldtype==="Data" && (df.options || "").toLowerCase()==="email") {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/__init__.py", line 914, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/desk/reportview.py", line 18, in get
    data = compress(execute(**args), args = args)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/desk/reportview.py", line 23, in execute
    return DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/model/db_query.py", line 88, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/model/db_query.py", line 100, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/model/db_query.py", line 118, in prepare_args
    self.build_conditions()
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/model/db_query.py", line 249, in build_conditions
    self.build_filter_conditions(self.filters, self.conditions)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/model/db_query.py", line 270, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/model/db_query.py", line 323, in prepare_filter_condition
    value = getdate(f.value).strftime("%Y-%m-%d")
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/utils/data.py", line 40, in getdate
    return parser.parse(string_date).date()
  File "/home/frappe/benches/bench-2017-06-29/env/lib/python2.7/site-packages/dateutil/parser.py", line 1168, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2017-06-29/env/lib/python2.7/site-packages/dateutil/parser.py", line 556, in parse
    res, skipped_tokens = self._parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2017-06-29/env/lib/python2.7/site-packages/dateutil/parser.py", line 675, in _parse
    l = _timelex.split(timestr)         # Splits the timestr into tokens
  File "/home/frappe/benches/bench-2017-06-29/env/lib/python2.7/site-packages/dateutil/parser.py", line 192, in split
    return list(cls(s))
  File "/home/frappe/benches/bench-2017-06-29/env/lib/python2.7/site-packages/dateutil/parser.py", line 61, in __init__
    '{itype}'.format(itype=instream.__class__.__name__))
TypeError: Parser must be a string or character stream, not list
```