### PR TITLE
[fix]if fieldtype is table and come under first 4 mandatory field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -78,7 +78,7 @@ class DocType(Document):
 		if not [d.fieldname for d in self.fields if d.in_list_view]:
 			cnt = 0
 			for d in self.fields:
-				if d.reqd and not d.hidden:
+				if d.reqd and not d.hidden and not d.fieldtype == "Table":
 					d.in_list_view = 1
 					cnt += 1
 					if cnt == 4: break


### PR DESCRIPTION
Summary
before
![listview1](https://user-images.githubusercontent.com/6947417/27780588-75850bba-5fe7-11e7-9d68-250cefc55a8c.png)
after
![anim](https://user-images.githubusercontent.com/6947417/27780580-63829b62-5fe7-11e7-8f04-b828b0f4ecb6.gif)

https://github.com/frappe/erpnext/issues/9575