### PR TITLE
[minor] return None is records are not available

### DIFF
--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -239,9 +239,10 @@ class NestedSet(Document):
 
 def get_root_of(doctype):
 	"""Get root element of a DocType with a tree structure"""
-	return frappe.db.sql("""select t1.name from `tab{0}` t1 where
+	result = frappe.db.sql("""select t1.name from `tab{0}` t1 where
 		(select count(*) from `tab{1}` t2 where
-			t2.lft < t1.lft and t2.rgt > t1.rgt) = 0""".format(doctype, doctype))[0][0]
+			t2.lft < t1.lft and t2.rgt > t1.rgt) = 0""".format(doctype, doctype))
+	return result[0][0] if result else None
 
 def get_ancestors_of(doctype, name):
 	"""Get ancestor elements of a DocType with a tree structure"""


### PR DESCRIPTION
```
Traceback (most recent call last):
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/www/desk.py", line 22, in get_context
     boot = frappe.sessions.get()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/sessions.py", line 150, in get
     bootinfo = get_bootinfo()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/boot.py", line 66, in get_bootinfo
     frappe.get_attr(method)(bootinfo)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext/erpnext/startup/boot.py", line 19, in boot_session
     bootinfo.sysdefaults.territory = get_root_of('Territory')
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/utils/nestedset.py", line 244, in get_root_of
     t2.lft < t1.lft and t2.rgt > t1.rgt) = 0""".format(doctype, doctype))[0][0]
 IndexError: tuple index out of range
```