### PR TITLE
[Fix] On selection standard reply, data not fetching in email message section

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -156,8 +156,9 @@ frappe.views.CommunicationComposer = Class.extend({
 
 	setup_standard_reply: function() {
 		var me = this;
-		this.dialog.get_input("standard_reply").on("change", function() {
-			var standard_reply = $(this).val();
+
+		this.dialog.fields_dict["standard_reply"].df.onchange = () => {
+			var standard_reply = me.dialog.fields_dict.standard_reply.$input.val();
 
 			var prepend_reply = function(reply) {
 				if(me.reply_added===standard_reply) {
@@ -194,8 +195,7 @@ frappe.views.CommunicationComposer = Class.extend({
 					prepend_reply(r.message);
 				}
 			});
-
-		});
+		}
 	},
 
 	setup_last_edited_communication: function() {


### PR DESCRIPTION
**Issue**

In the message view (modal), on a selection of Standard Reply, values are not always fetched. 

![27731248-dab3a9e6-5da9-11e7-9b78-b9a8b060c5fa](https://user-images.githubusercontent.com/8780500/27791186-74d713fa-6011-11e7-94fc-e163f410588c.gif)

**Fixed**
![fix_standard_reply](https://user-images.githubusercontent.com/8780500/27791172-63134332-6011-11e7-9a2b-058850854e78.gif)

Fixed https://github.com/frappe/erpnext/issues/9552