### PR TITLE
Keyboard Shortcuts not working adds new key codes to key_map

### DIFF
--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -100,7 +100,12 @@ frappe.ui.keys.key_map = {
 	17: 'ctrl',
 	91: 'meta',
 	18: 'alt',
-	27: 'escape'
+	27: 'escape',
+	37: 'left',
+	39: 'right',
+	38: 'up',
+	40: 'down',
+	32: 'space'
 }
 
 // keyCode map

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -21,10 +21,6 @@ frappe.ui.keys.get_key = function(e) {
 	var keycode = e.keyCode || e.which;
 	var key = frappe.ui.keys.key_map[keycode] || String.fromCharCode(keycode);
 
-	if(key.substr(0, 5) === 'Arrow') {
-		// ArrowDown -> down
-		key = key.substr(5).toLowerCase();
-	}
 	if(e.ctrlKey || e.metaKey) {
 		// add ctrl+ the key
 		key = 'ctrl+' + key;


### PR DESCRIPTION
On my computer, key code - 40 is being translated to '(' and some other 'weirdnesses'.
![peek 2017-07-03 23-56](https://user-images.githubusercontent.com/818803/27809837-454ff432-604b-11e7-8be1-e70d7e728da9.gif)

### before
![peek 2017-07-03 23-44](https://user-images.githubusercontent.com/818803/27809840-5086abde-604b-11e7-8086-16636d1dc9ab.gif)


### after
![peek 2017-07-03 23-45](https://user-images.githubusercontent.com/818803/27809795-cbf13e16-604a-11e7-94a6-b57a2c8e0c69.gif)

![peek 2017-07-03 23-47](https://user-images.githubusercontent.com/818803/27809797-d1df8fda-604a-11e7-8a13-c8819fb247c0.gif)

fixes frappe/erpnext#9580
