### PR TITLE
Removed unwanted characters from Address display

### DIFF
--- a/frappe/contacts/doctype/address_template/address_template.py
+++ b/frappe/contacts/doctype/address_template/address_template.py
@@ -38,6 +38,6 @@ def get_default_address_template():
 {% if state %}{{ state }}<br>{% endif -%}
 {% if pincode %}{{ pincode }}<br>{% endif -%}
 {{ country }}<br>
-{% if phone %}'''+_('Phone')+''': {{ phone }}<br>{% endif -%}
-{% if fax %}'''+_('Fax')+''': {{ fax }}<br>{% endif -%}
-{% if email_id %}'''+_('Email')+''': {{ email_id }}<br>{% endif -%}'''
+{% if phone %}_('Phone'): {{ phone }}<br>{% endif -%}
+{% if fax %}_('Fax'): {{ fax }}<br>{% endif -%}
+{% if email_id %}_('Email'): {{ email_id }}<br>{% endif -%}'''


### PR DESCRIPTION
Fixed https://github.com/frappe/frappe/issues/3609

Before 
<img width="252" alt="screen shot 2017-07-04 at 5 33 04 pm" src="https://user-images.githubusercontent.com/16913064/27829377-f0826f90-60de-11e7-82fc-1a3ffc3dfd3c.png">

After
<img width="240" alt="screen shot 2017-07-04 at 5 33 15 pm" src="https://user-images.githubusercontent.com/16913064/27829379-f1c6b78a-60de-11e7-83c6-48b9c43c789a.png">

