### PR TITLE
Clear Outbox modification

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -475,8 +475,7 @@ def clear_outbox():
 		frappe.db.sql("""delete from `tabEmail Queue Recipient` where parent in (%s)"""
 			% ','.join(['%s']*len(email_queues)), tuple(email_queues))
 
-	for dt in ("Email Queue", "Email Queue Recipient"):
-		frappe.db.sql("""
-			update `tab{0}`
-			set status='Expired'
-			where datediff(curdate(), modified) > 7 and status='Not Sent'""".format(dt))
+	frappe.db.sql("""
+		update `tabEmail Queue`
+		set status='Expired'
+		where datediff(curdate(), modified) > 7 and status='Not Sent' and send_after < %(now)s""", { 'now': now_datetime() })


### PR DESCRIPTION
Hi,

I encountered an issue with email meant to be sent more than 7 days later: the clear_outbox function was systematically updating their status to "Expired".

Therefore I am proposing the following change to the function, by changing the status of "Expired" emails only if they are not meant to be sent at a later date.
7 Days is fine to clear the Outbox, but it should not include emails not sent on purpose.

I also deliberately removed the update of the child table, since IMHO it is more interesting to have the status "Not Sent" against a particular recipient. The "Expired" status should only be at the email level.
It is already like that for emails in status "Error"

Of course don't hesitate to let me know if I'm missing something here.

Best regards,

Charles-Henri