### PR TITLE
[cleanup] santize get_value, fixes frappe/erpnext#9561

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -137,10 +137,10 @@ frappe.ui.form.Control = Class.extend({
 			this.validate ? this.validate(value, set) : set(value);
 		});
 	},
-	get_parsed_value: function() {
+	get_value: function() {
 		if(this.get_status()==='Write') {
-			return this.get_value ?
-				(this.parse ? this.parse(this.get_value()) : this.get_value()) :
+			return this.get_input_value ?
+				(this.parse ? this.parse(this.get_input_value()) : this.get_input_value()) :
 				undefined;
 		} else if(this.get_status()==='Read') {
 			return this.value || undefined;
@@ -215,7 +215,6 @@ frappe.ui.form.ControlImage = frappe.ui.form.Control.extend({
 		this.$body = $("<div></div>").appendTo(this.$wrapper)
 			.css({"margin-bottom": "10px"})
 		this.$wrapper.on("refresh", function() {
-			var doc = null;
 			me.$body.empty();
 
 			var doc = me.get_doc();
@@ -344,7 +343,7 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 	},
 
 	set_disp_area: function() {
-		let value = this.get_value();
+		let value = this.get_input_value();
 		if(in_list(["Currency", "Int", "Float"], this.df.fieldtype) && (this.value === 0 || value === 0)) {
 			// to set the 0 value in readonly for currency, int, float field
 			value = 0;
@@ -353,13 +352,13 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 		}
 		this.disp_area && $(this.disp_area)
 			.html(frappe.format(value, this.df, {no_icon:true, inline:true},
-					this.doc || (this.frm && this.frm.doc)));
+				this.doc || (this.frm && this.frm.doc)));
 	},
 
 	bind_change_event: function() {
 		var me = this;
 		this.$input && this.$input.on("change", this.change || function(e) {
-			me.parse_validate_and_set_in_model(me.get_value(), e);
+			me.parse_validate_and_set_in_model(me.get_input_value(), e);
 		});
 	},
 	bind_focusout: function() {
@@ -465,7 +464,7 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 	set_formatted_input: function(value) {
 		this.$input && this.$input.val(this.format_for_input(value));
 	},
-	get_value: function() {
+	get_input_value: function() {
 		return this.$input ? this.$input.val() : undefined;
 	},
 	format_for_input: function(val) {
@@ -919,7 +918,7 @@ frappe.ui.form.ControlCheck = frappe.ui.form.ControlData.extend({
 		this.set_mandatory(value);
 		this.set_disp_area();
 	},
-	get_value: function() {
+	get_input_value: function() {
 		if (!this.$input) {
 			return;
 		}
@@ -1355,7 +1354,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		new frappe.ui.form.LinkSelector({
 			doctype: doctype,
 			target: this,
-			txt: this.get_value()
+			txt: this.get_input_value()
 		});
 		return false;
 	},
@@ -1493,7 +1492,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				me.selected = false;
 				return;
 			}
-			var value = me.get_value();
+			var value = me.get_input_value();
 			if(value!==me.last_value) {
 				me.parse_validate_and_set_in_model(value);
 			}
@@ -1870,13 +1869,13 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 				.attr('data-original-title', '');
 		}
 	},
-	get_value: function() {
+	get_input_value: function() {
 		return this.editor? this.editor.summernote('code'): '';
 	},
 	set_input: function(value) {
 		if(value == null) value = "";
 		value = frappe.dom.remove_script_and_style(value);
-		if(value !== this.get_value()) {
+		if(value !== this.get_input_value()) {
 			this.set_in_editor(value);
 		}
 		this.last_value = value;
@@ -2012,7 +2011,7 @@ frappe.ui.form.ControlTable = frappe.ui.form.Control.extend({
 			return false;
 		});
 	},
-	get_parsed_value: function() {
+	get_value: function() {
 		if(this.grid) {
 			return this.grid.get_data();
 		}

--- a/frappe/public/js/frappe/ui/base_list.js
+++ b/frappe/public/js/frappe/ui/base_list.js
@@ -225,7 +225,6 @@ frappe.ui.BaseList = Class.extend({
 	},
 
 	update_standard_filters: function(filters) {
-		let values = {};
 		let me = this;
 		for(let key in this.page.fields_dict) {
 			let field = this.page.fields_dict[key];
@@ -462,7 +461,7 @@ frappe.ui.BaseList = Class.extend({
 	set_filter: function (fieldname, label, no_run, no_duplicate) {
 		var filter = this.filter_list.get_filter(fieldname);
 		if (filter) {
-			var value = cstr(filter.field.get_parsed_value());
+			var value = cstr(filter.field.get_value());
 			if (value.includes(label)) {
 				// already set
 				return false

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -69,8 +69,8 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 		var errors = [];
 		for(var key in this.fields_dict) {
 			var f = this.fields_dict[key];
-			if(f.get_parsed_value) {
-				var v = f.get_parsed_value();
+			if(f.get_value) {
+				var v = f.get_value();
 				if(f.df.reqd && is_null(v))
 					errors.push(__(f.df.label));
 
@@ -90,7 +90,7 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 	},
 	get_value: function(key) {
 		var f = this.fields_dict[key];
-		return f && (f.get_parsed_value ? f.get_parsed_value() : null);
+		return f && (f.get_value ? f.get_value() : null);
 	},
 	set_value: function(key, val){
 		return new Promise(resolve => {

--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -251,8 +251,12 @@ frappe.ui.Filter = Class.extend({
 			else if(value==1) value = 'Yes';
 		}
 
-		if(condition) this.wrapper.find('.condition').val(condition).change();
-		if(value!=null) this.field.set_input(value);
+		if(condition) {
+			this.wrapper.find('.condition').val(condition).change();
+		}
+		if(value!=null) {
+			this.field.set_value(value);
+		}
 	},
 
 	set_field: function(doctype, fieldname, fieldtype, condition) {
@@ -294,7 +298,7 @@ frappe.ui.Filter = Class.extend({
 		// save old text
 		var old_text = null;
 		if(me.field) {
-			old_text = me.field.get_parsed_value();
+			old_text = me.field.get_value();
 		}
 
 		var field_area = me.wrapper.find('.filter_field').empty().get(0);
@@ -376,7 +380,7 @@ frappe.ui.Filter = Class.extend({
 	},
 
 	get_selected_value: function() {
-		var val = this.field.get_parsed_value();
+		var val = this.field.get_value();
 
 		if(typeof val==='string') {
 			val = strip(val);
@@ -451,8 +455,6 @@ frappe.ui.Filter = Class.extend({
 			value = {0:"Draft", 1:"Submitted", 2:"Cancelled"}[value] || value;
 		} else if(this.field.df.original_type==="Check") {
 			value = {0:"No", 1:"Yes"}[cint(value)];
-		} else if (in_list(["Date", "Datetime"], this.field.df.fieldtype)) {
-			value = frappe.datetime.str_to_user(value);
 		} else {
 			value = this.field.get_value();
 		}

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -337,7 +337,7 @@ frappe.views.Calendar = Class.extend({
 		if(this.filters) {
 			$.each(this.filters, function(i, df) {
 				filter_vals[df.fieldname || df.label] =
-					me.page.fields_dict[df.fieldname || df.label].get_parsed_value();
+					me.page.fields_dict[df.fieldname || df.label].get_value();
 			});
 		}
 		return filter_vals;

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -423,7 +423,7 @@ frappe.views.QueryReport = Class.extend({
 		var filters = {};
 		var mandatory_fields = [];
 		$.each(this.filters || [], function(i, f) {
-			var v = f.get_parsed_value();
+			var v = f.get_value();
 			// TODO: hidden fields dont have $input
 			if(f.df.hidden) v = f.value;
 			if(v === '%') v = null;


### PR DESCRIPTION
field.get_value() and field.set_value() should always set and return the logical value, not the parsed or formatted value.

Now 
```
field.get_value -> logical value
field.get_input_value -> input value

field.set_value -> set the logical value
field.set_input -> set in input
```
