### PR TITLE
Add success and error callback

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -506,8 +506,27 @@ frappe.views.CommunicationComposer = Class.extend({
 						cur_frm.timeline.input.val("");
 						cur_frm.reload_doc();
 					}
+					
+					// try the success callback if it exists
+					if (me.success) {
+						try {
+							me.success(r);
+						} catch (e) {
+							console.log(e);
+						}
+					}
+					
 				} else {
 					frappe.msgprint(__("There were errors while sending email. Please try again."));
+					
+					// try the error callback if it exists
+					if (me.error) {
+						try {
+							me.error(r);
+						} catch (e) {
+							console.log(e);
+						}
+					}
 				}
 			}
 		});


### PR DESCRIPTION
Allows developers to use callbacks like following:

	new frappe.views.CommunicationComposer({
		doc: frm.doc,
		frm: frm,
		subject: __(frm.meta.name) + ': ' + frm.docname,
		recipients: frm.doc.email || frm.doc.email_id || frm.doc.contact_email,
		attach_document_print: true,
		message: message,
		real_name: frm.doc.real_name || frm.doc.contact_display || frm.doc.contact_name,
		success: function(r) { console.log(r); alert("Mail sent!"); },
		error: function(r) { console.log(r); alert("Mail not sent!"); }
	});

Screenshots:

# Step 1

Open a mail dialog:

![image](https://user-images.githubusercontent.com/8351245/28016373-5fb3aef8-6574-11e7-9cd0-d4784280ed1a.png)

# Step 2

See the alert message when clicking Send

![image](https://user-images.githubusercontent.com/8351245/28016405-85572e82-6574-11e7-9860-e62b88441098.png)

I am happy for suggestions or feedback. For me this works, and I think since we are using try and catch, there shouldn't be any bad behaviour with existing modules. Thank you.