### PR TITLE
[Fix] Auto increment of series not working if series has multiple dot(.)

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -99,6 +99,9 @@ def make_autoname(key='', doctype='', doc=''):
 
 def parse_naming_series(parts, doctype= '', doc = ''):
 	n = ''
+	if isinstance(parts, basestring):
+		parts = parts.split('.')
+
 	series_set = False
 	today = now_datetime()
 	for e in parts:

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -142,6 +142,9 @@ def getseries(key, digits, doctype=''):
 def revert_series_if_last(key, name):
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
+		if '.' in prefix:
+			prefix = parse_naming_series(prefix.split('.'))
+
 		if "#" not in hashes:
 			return
 	else:


### PR DESCRIPTION
**Issue**

1. Set Naming series as INV/17-18/.abbre./.#### in the invoice

1. Created and deleted 1st record against series, then new transaction gets no. 2. instead of. 1

Facing issues in series like INV/17-18/.abbre./.####, INV.YYYY.MM.#####

Fixed https://github.com/frappe/erpnext/issues/9789