### PR TITLE
[minor] return '' if template is none & ignore if _custom_html field has no options

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -1,7 +1,7 @@
 {% macro render_field(df, doc) -%}
 	{%- if df.fieldtype=="Table" -%}
 		{{ render_table(df, doc) }}
-	{%- elif df.fieldtype=="HTML" -%}
+	{%- elif df.fieldtype=="HTML" and df.options -%}
 		<div>{{ frappe.render_template(df.options, {"doc": doc}) or "" }}</div>
 	{%- elif df.fieldtype in ("Text", "Text Editor", "Code") -%}
 		{{ render_text_field(df, doc) }}

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -41,6 +41,9 @@ def render_template(template, context, is_path=None):
 	:param context: dict of properties to pass to the template
 	:param is_path: (optional) assert that the `template` parameter is a path'''
 
+	if not template:
+		return ""
+
 	# if it ends with .html then its a freaking path, not html
 	if (is_path
 		or template.startswith("templates/")


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/9727
```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 913, in call
    return fn(*args, **newargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/www/printview.py", line 187, in get_html_and_style
    no_letterhead=no_letterhead, trigger_print=trigger_print),
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/www/printview.py", line 158, in get_html
    html = template.render(args, filters={"len": len})
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/./templates/print_formats/standard.html", line 32, in top-level template code
    {{ render_field(df, doc) }}
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/jinja2/runtime.py", line 551, in _invoke
    rv = self._func(*arguments)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/./templates/print_formats/standard_macros.html", line 5, in template
    
{{ frappe.render_template(df.options, {"doc": doc}) or "" }}

  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/utils/jinja.py", line 48, in render_template
    or template.startswith("templates/")
AttributeError: 'NoneType' object has no attribute 'startswith'
```