### PR TITLE
Mobile Screen Title and Timeline Title #9807

### DIFF
--- a/frappe/public/css/mobile.css
+++ b/frappe/public/css/mobile.css
@@ -332,9 +332,3 @@ body {
     right: 90px;
   }
 }
-@media (max-width: 580px) {
-  .timeline-item.user-content .comment-header .btn-add-to-kb {
-    float: none !important;
-    margin-top: 5px !important;
-  }
-}

--- a/frappe/public/css/mobile.css
+++ b/frappe/public/css/mobile.css
@@ -192,6 +192,15 @@ body {
   }
 }
 @media (max-width: 767px) {
+  body[data-route^="Form"] .page-title .title-text {
+    font-size: 16px;
+    width: calc(100% - 30px);
+  }
+  body[data-route^="Form"] .page-title .indicator {
+    float: left;
+    margin-top: 10px;
+    margin-right: 5px;
+  }
   .modal .modal-dialog {
     margin: 0px;
     padding: 0px;
@@ -321,5 +330,11 @@ body {
   }
   body[data-route^="Form"] .page-head .sub-heading {
     right: 90px;
+  }
+}
+@media (max-width: 580px) {
+  .timeline-item.user-content .comment-header .btn-add-to-kb {
+    float: none !important;
+    margin-top: 5px !important;
   }
 }

--- a/frappe/public/css/page.css
+++ b/frappe/public/css/page.css
@@ -146,6 +146,9 @@ select.input-sm {
     right: 101px;
     width: 100%;
   }
+  .page-title h1 {
+    padding-right: 170px;
+  }
   .page-head .page-title h1 {
     font-size: 18px;
   }

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -95,7 +95,7 @@ frappe.ui.Page = Class.extend({
 	},
 
 	set_indicator: function(label, color) {
-		this.clear_indicator().removeClass("hide").html(label).addClass(color);
+		this.clear_indicator().removeClass("hide").html(`<span class='hidden-xs'>${label}</span>`).addClass(color);
 	},
 
 	add_action_icon: function(icon, click) {

--- a/frappe/public/less/mobile.less
+++ b/frappe/public/less/mobile.less
@@ -223,6 +223,19 @@ body {
 }
 
 @media(max-width: 767px) {
+	body[data-route^="Form"]{
+		.page-title {
+			.title-text {
+				font-size: 16px;
+				width: calc(~"100% - 30px");
+			}
+			.indicator {
+				float: left;
+				margin-top: 10px;
+				margin-right: 5px;
+			}
+		}
+	}
 	.modal {
 		.modal-dialog {
 			margin: 0px;
@@ -391,6 +404,16 @@ body {
 	body[data-route^="Form"] {
 		.page-head .sub-heading {
 			right: 90px;
+		}
+	}
+}
+@media(max-width: 580px) {
+	.timeline-item.user-content {
+		.comment-header {
+			.btn-add-to-kb {
+				float: none !important;
+				margin-top: 5px !important;
+			}
 		}
 	}
 }

--- a/frappe/public/less/mobile.less
+++ b/frappe/public/less/mobile.less
@@ -407,13 +407,3 @@ body {
 		}
 	}
 }
-@media(max-width: 580px) {
-	.timeline-item.user-content {
-		.comment-header {
-			.btn-add-to-kb {
-				float: none !important;
-				margin-top: 5px !important;
-			}
-		}
-	}
-}

--- a/frappe/public/less/page.less
+++ b/frappe/public/less/page.less
@@ -178,6 +178,9 @@ select.input-sm {
 		left: 0;
 		right: 101px;
 		width: 100%;
+		h1 {
+			padding-right: 170px;
+		}
 	}
 
 	.page-head .page-title h1 {


### PR DESCRIPTION
Previously title overrides buttons and issue ID for mobile view.
![screen shot 2017-07-12 at 11 11 56 pm](https://user-images.githubusercontent.com/28141909/28131481-9f2c2b84-6757-11e7-944a-556adb2889a3.png)

Added fix: Hide Indicator text for small resolution and only indicator dot will show for small resolution. Also previously title is taking 100% width adjusted to align both title and action buttons.

![screen shot 2017-07-12 at 11 15 26 pm](https://user-images.githubusercontent.com/28141909/28131605-0ae5c16e-6758-11e7-8b15-895542624a01.png)
