### PR TITLE
[Fix] unsupported operand type(s) for /: 'unicode' and 'int'

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -208,7 +208,7 @@ def add_total_row(result, columns, meta = None):
 			total_row[i] = result[0][i]
 
 	for i in has_percent:
-		total_row[i] = total_row[i] / len(result)
+		total_row[i] = flt(total_row[i]) / len(result)
 
 	first_col_fieldtype = None
 	if isinstance(columns[0], basestring):


### PR DESCRIPTION
**Issue**
```
File "/home/frappe/benches/bench-2017-07-13/apps/frappe/frappe/desk/reportview.py", line 18, in get
    data = compress(execute(**args), args = args)
  File "/home/frappe/benches/bench-2017-07-13/apps/frappe/frappe/desk/reportview.py", line 85, in compress
    values = add_total_row(values, keys, meta)
  File "/home/frappe/benches/bench-2017-07-13/apps/frappe/frappe/desk/query_report.py", line 211, in add_total_row
    total_row[i] = total_row[i] / len(result)
TypeError: unsupported operand type(s) for /: 'unicode' and 'int'
```