### PR TITLE
[hotfix] get app version from app.__version__ instead of hooks

### DIFF
--- a/frappe/utils/setup_docs.py
+++ b/frappe/utils/setup_docs.py
@@ -12,7 +12,6 @@ from frappe.website.context import get_context
 from frappe.utils import markdown
 from six import iteritems
 
-
 class setup_docs(object):
 	def __init__(self, app):
 		"""Generate source templates for models reference and module API
@@ -30,7 +29,7 @@ class setup_docs(object):
 
 	def setup_app_context(self):
 		self.docs_config = frappe.get_module(self.app + ".config.docs")
-		version = self.hooks.get("app_version")[0]
+		version = get_version(app=self.app)
 		self.app_context =  {
 			"app": frappe._dict({
 				"name": self.app,
@@ -447,6 +446,11 @@ class setup_docs(object):
 				else:
 					css_file.write(text.replace("/assets/frappe/", self.docs_base_url + '/assets/').encode('utf-8'))
 
+def get_version(app="frappe"):
+	try:
+		return frappe.get_attr(app + ".__version__")
+	except AttributeError:
+		return '0.0.1'
 
 edit_link = '''
 <div class="page-container">


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 17, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/commands/docs.py", line 43, in build_docs
    _build_docs_once(site, app, docs_version, target, local)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/commands/docs.py", line 65, in _build_docs_once
    make = setup_docs(app)
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/utils/setup_docs.py", line 29, in __init__
    self.setup_app_context()
  File "/Users/makarandbauskar/workspace/frappe/hotfix-frappe-bench/apps/frappe/frappe/utils/setup_docs.py", line 33, in setup_app_context
    version = self.hooks.get("app_version")[0]
TypeError: 'NoneType' object has no attribute '__getitem__'
```