### PR TITLE
[Fix] Unable to open calendar view of the task

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -336,6 +336,9 @@ def build_match_conditions(doctype, as_condition=True):
 
 def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with_match_conditions=False):
 	if filters:
+		if isinstance(filters, basestring):
+			filters = json.loads(filters)
+
 		flt = filters
 		if isinstance(filters, dict):
 			filters = filters.items()


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-07-18/apps/erpnext/erpnext/projects/doctype/task/task.py", line 145, in get_events
    }, as_dict=True, update={"allDay": 0})
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/database.py", line 142, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2017-07-18/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/home/frappe/benches/bench-2017-07-18/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'and }' at line 4")
```