### PR TITLE
Allow SSL connections to a remote database server

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -53,8 +53,20 @@ class Database:
 	def connect(self):
 		"""Connects to a database as set in `site_config.json`."""
 		warnings.filterwarnings('ignore', category=MySQLdb.Warning)
-		self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
-			use_unicode=True, charset='utf8mb4')
+		usessl = 0
+                if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+                        usessl = 1
+                        self.ssl = {
+                                'ca':frappe.conf.db_ssl_ca,
+                                'cert':frappe.conf.db_ssl_cert,
+                                'key':frappe.conf.db_ssl_key
+                        }
+                if usessl:
+                        self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
+                                use_unicode=True, charset='utf8', ssl=self.ssl)
+                else:
+                        self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
+                                use_unicode=True, charset='utf8')
 		self._conn.converter[246]=float
 		self._conn.converter[12]=get_datetime
 		self._conn.encoders[UnicodeWithAttrs] = self._conn.encoders[UnicodeType]


### PR DESCRIPTION
Add the following options in site_config.json to use ssl
- db_ssl_ca = "/path/to/ca/cert.pem"
- db_ssl_cert = "/path/to/ssl/cert.pem"
- db_ssl_key = "/path/to/ssl/key.pem"
The files mentioned should be stored on the App server in the location mentioned.

This commit allows for basic ssl connections. X509 is still not supported.

If the above options are not set, the connection will not use an encrypted connection, and connect normally.