### PR TITLE
[minor] link filters should be selectable

### DIFF
--- a/frappe/public/js/frappe/ui/base_list.js
+++ b/frappe/public/js/frappe/ui/base_list.js
@@ -198,7 +198,7 @@ frappe.ui.BaseList = Class.extend({
 					let options = df.options;
 					let condition = '=';
 					let fieldtype = df.fieldtype;
-					if (['Link', 'Text', 'Small Text', 'Text Editor', 'Data'].includes(fieldtype)) {
+					if (['Text', 'Small Text', 'Text Editor', 'Data'].includes(fieldtype)) {
 						fieldtype = 'Data',
 						condition = 'like'
 					}

--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -59,8 +59,11 @@ frappe.ui.FilterList = Class.extend({
 	},
 
 	add_filter: function(doctype, fieldname, condition, value, hidden) {
-		if (this.base_list.page.fields_dict[fieldname]
-			&& ['=', 'like'].includes(condition)) {
+		// allow equal to be used as like
+		let base_filter = this.base_list.page.fields_dict[fieldname];
+		if (base_filter
+			&& (base_filter.df.condition==condition
+				|| (condition==='=' && base_filter.df.condition==='like'))) {
 			// if filter exists in base_list, then exit
 			this.base_list.page.fields_dict[fieldname].set_input(value);
 			return;

--- a/frappe/tests/ui/test_module/test_module_menu.js
+++ b/frappe/tests/ui/test_module/test_module_menu.js
@@ -19,6 +19,7 @@ QUnit.test("Test sidebar menu [Module view]", function(assert) {
 			module_name = $(sidebar_opt)[random_num].innerText;
 		},
 		() => frappe.tests.click_and_wait(sidebar_opt, random_num),
+		() => frappe.timeout(2),
 		() => assert.equal($('.title-text:visible')[0].innerText, module_name, "Module opened successfully using sidebar"),
 		() => done()
 	]);


### PR DESCRIPTION
For ID filters, it makes sense to use "like" but for links, them must be selectable

![link-filters](https://user-images.githubusercontent.com/140076/28351781-9bd3aa62-6c6f-11e7-8308-1150aec8baa6.gif)
