### PR TITLE
[versioning] check for empty field values

### DIFF
--- a/frappe/core/doctype/version/test_version.py
+++ b/frappe/core/doctype/version/test_version.py
@@ -3,9 +3,37 @@
 from __future__ import unicode_literals
 
 import frappe
-import unittest
-
-test_records = frappe.get_test_records('Version')
+import unittest, copy
+from frappe.test_runner import make_test_objects
+from frappe.core.doctype.version.version import get_diff
 
 class TestVersion(unittest.TestCase):
-	pass
+	def test_get_diff(self):
+		test_records = make_test_objects('Event', reset = True)
+		old_doc = frappe.get_doc("Event", test_records[0])
+		new_doc = copy.deepcopy(old_doc)
+
+		old_doc.color = None
+
+		diff = get_diff(old_doc, new_doc)['changed']
+
+		self.assertEquals(get_fieldnames(diff)[0], 'color')
+		self.assertTrue(get_old_values(diff)[0] is None)
+		self.assertEquals(get_new_values(diff)[0], 'blue')
+
+		new_doc.starts_on = "2017-07-20"
+
+		diff = get_diff(old_doc, new_doc)['changed']
+
+		self.assertEquals(get_fieldnames(diff)[0], 'starts_on')
+		self.assertEquals(get_old_values(diff)[0], '01-01-2014 00:00:00')
+		self.assertEquals(get_new_values(diff)[0], '07-20-2017 00:00:00')
+
+def get_fieldnames(change_array):
+	return [d[0] for d in change_array]
+
+def get_old_values(change_array):
+	return [d[1] for d in change_array]
+
+def get_new_values(change_array):
+	return [d[2] for d in change_array]

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -69,10 +69,13 @@ def get_diff(old, new, for_child=False):
 				if not d.name in new_row_by_name:
 					out.removed.append([df.fieldname, d.as_dict()])
 
-		elif (old_value != new_value
-			and old.get_formatted(df.fieldname) != new.get_formatted(df.fieldname)):
-			out.changed.append((df.fieldname, old.get_formatted(df.fieldname),
-				new.get_formatted(df.fieldname)))
+		elif (old_value != new_value):
+			# Check for None values
+			old_data = old.get_formatted(df.fieldname) if old_value else old_value
+			new_data = new.get_formatted(df.fieldname) if new_value else new_value
+
+			if old_data != new_data:
+				out.changed.append((df.fieldname, old_data, new_data))
 
 	# docstatus
 	if not for_child and old.docstatus != new.docstatus:


### PR DESCRIPTION
Detected via support:
When docs are imported via data import, some fields may not be set, causing the old doc version to have None values in them. Formatting these causes problems down the line in core util format function.

Proposed solution: to check if field has a value; format if yes, if not set the change with None itself (whether it was unset before or after)


Here is the issue as replicated with user data:
![fail_submit](https://user-images.githubusercontent.com/5196925/28362429-fb1c2bbe-6c99-11e7-8e35-6ddfe27a3003.gif)

Traceback:
```Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/model/document.py", line 280, in _save
    self.run_post_save_methods()
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/model/document.py", line 809, in run_post_save_methods
    self.save_version()
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/model/document.py", line 844, in save_version
    if version.set_diff(self._doc_before_save, self):
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/core/doctype/version/version.py", line 15, in set_diff
    diff = get_diff(old, new)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/core/doctype/version/version.py", line 73, in get_diff
    and old.get_formatted(df.fieldname) != new.get_formatted(df.fieldname)):
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/model/base_document.py", line 718, in get_formatted
    return format_value(val, df=df, doc=doc, currency=currency)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/utils/formatters.py", line 51, in format_value
    return format_time(value)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/utils/data.py", line 232, in format_time
    formatted_time = babel.dates.format_time(get_time(txt), locale=(frappe.local.lang or "").replace("-", "_"))
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/utils/data.py", line 195, in get_time
    return parser.parse(time_str).time()
  File "/home/frappe/benches/bench-2017-07-18/env/lib/python2.7/site-packages/dateutil/parser.py", line 1182, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2017-07-18/env/lib/python2.7/site-packages/dateutil/parser.py", line 562, in parse
    raise ValueError("String does not contain a date.")
ValueError: String does not contain a date.
```

----------------------------------------------
The `get_formatted` function getting a None value, because the old doc didn't have the posting_time set at server side (due to data being imported):
![screen shot 2017-07-19 at 1 07 36 am](https://user-images.githubusercontent.com/5196925/28362588-87b5637e-6c9a-11e7-9c69-31fd38e26334.png)

Result with check before formatting: doc submitted with version
![pass_submit](https://user-images.githubusercontent.com/5196925/28362606-9e065642-6c9a-11e7-8b56-b71b9534e1be.png)

![screen shot 2017-07-19 at 4 02 43 pm](https://user-images.githubusercontent.com/5196925/28362864-c58d208c-6c9b-11e7-9ff5-247dcc8bcc9c.png)

