### PR TITLE
[fix] add the parsed email id for the email group member

### DIFF
--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -69,15 +69,15 @@ def add_subscribers(name, email_list):
 	count = 0
 	for email in email_list:
 		email = email.strip()
-		valid = validate_email_add(email, False)
+		parsed_email = validate_email_add(email, False)
 
-		if valid:
+		if parsed_email:
 			if not frappe.db.get_value("Email Group Member",
-				{"email_group": name, "email": email}):
+				{"email_group": name, "email": parsed_email}):
 				frappe.get_doc({
 					"doctype": "Email Group Member",
 					"email_group": name,
-					"email": email
+					"email": parsed_email
 				}).insert(ignore_permissions = frappe.flags.ignore_permissions)
 
 				count += 1

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -188,3 +188,4 @@ execute:frappe.db.sql('update tabReport set module="Desk" where name="ToDo"')
 frappe.patches.v8_1.enable_allow_error_traceback_in_system_settings
 frappe.patches.v8_1.update_format_options_in_auto_email_report
 frappe.patches.v8_1.delete_custom_docperm_if_doctype_not_exists
+frappe.patches.v8_1.delete_email_group_member_with_invalid_emails

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -188,4 +188,4 @@ execute:frappe.db.sql('update tabReport set module="Desk" where name="ToDo"')
 frappe.patches.v8_1.enable_allow_error_traceback_in_system_settings
 frappe.patches.v8_1.update_format_options_in_auto_email_report
 frappe.patches.v8_1.delete_custom_docperm_if_doctype_not_exists
-frappe.patches.v8_1.delete_email_group_member_with_invalid_emails
+frappe.patches.v8_5.delete_email_group_member_with_invalid_emails

--- a/frappe/patches/v8_1/delete_email_group_member_with_invalid_emails.py
+++ b/frappe/patches/v8_1/delete_email_group_member_with_invalid_emails.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2017, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+from frappe.utils import validate_email_add
+
+def execute():
+	''' update/delete the email group member with the wrong email '''
+
+	email_group_members = frappe.get_all("Email Group Member", fields=["name", "email"])
+	for member in email_group_members:
+		validated_email = validate_email_add(member.email)
+		if (validated_email==member.email):
+			pass
+		else:
+			try:
+				doc = frappe.get_doc("Email Group Member", member.name)
+				doc.email = validated_email
+				doc.save()
+			except Exception, e:
+				frappe.delete_doc(doctype="Email Group Member", name=member.name, force=1, ignore_permissions=True)

--- a/frappe/patches/v8_5/delete_email_group_member_with_invalid_emails.py
+++ b/frappe/patches/v8_5/delete_email_group_member_with_invalid_emails.py
@@ -15,8 +15,6 @@ def execute():
 			pass
 		else:
 			try:
-				doc = frappe.get_doc("Email Group Member", member.name)
-				doc.email = validated_email
-				doc.save()
-			except Exception, e:
+				frappe.db.set_value("Email Group Member", member.name, "email", validated_email)
+			except Exception:
 				frappe.delete_doc(doctype="Email Group Member", name=member.name, force=1, ignore_permissions=True)


### PR DESCRIPTION
Add the parsed email id for the email group member

![email_parse](https://user-images.githubusercontent.com/20757311/28362594-92586e3e-6c9a-11e7-917f-0feb66086d83.gif)

**Patch**
- For deleting/updating the already added wrong email id.

- Fixes https://github.com/frappe/erpnext/issues/9965