### PR TITLE
Allow SSL connections to a remote database server

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -53,8 +53,20 @@ class Database:
 	def connect(self):
 		"""Connects to a database as set in `site_config.json`."""
 		warnings.filterwarnings('ignore', category=MySQLdb.Warning)
-		self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
-			use_unicode=True, charset='utf8mb4')
+		usessl = 0
+		if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+			usessl = 1
+			self.ssl = {
+				'ca':frappe.conf.db_ssl_ca,
+				'cert':frappe.conf.db_ssl_cert,
+				'key':frappe.conf.db_ssl_key
+			}
+		if usessl:
+			self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
+				use_unicode=True, charset='utf8mb4', ssl=self.ssl)
+		else:
+			self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
+				use_unicode=True, charset='utf8mb4')
 		self._conn.converter[246]=float
 		self._conn.converter[12]=get_datetime
 		self._conn.encoders[UnicodeWithAttrs] = self._conn.encoders[UnicodeType]

--- a/frappe/docs/user/en/guides/basics/site_config.md
+++ b/frappe/docs/user/en/guides/basics/site_config.md
@@ -20,13 +20,20 @@ Example:
 
 ### Optional Settings
 
-- `db_host`: Database host if not `localhost`.
 - `admin_password`: Default Password for "Administrator".
 - `mute_emails`: Stops email sending if true.
 - `deny_multiple_logins`: Stop users from having more than one active session.
 - `root_password`: MariaDB root password.
 
-### Defaut Outgoing Email Settings
+### Remote Database Host Settings
+- `db_host`: Database host if not `localhost`.
+
+To connect to a remote database server using ssl, you must first configure the database host to accept SSL connections. An example of how to do this is available at https://www.digitalocean.com/community/tutorials/how-to-configure-ssl-tls-for-mysql-on-ubuntu-16-04. After you do the configuration, set the following three options. All options must be set for Frappe to attempt to connect using SSL.
+- `db_ssl_ca`: Full path to the ca.pem file used for connecting to a database host using ssl. Example value is `"/etc/mysql/ssl/ca.pem"`.
+- `db_ssl_cert`: Full path to the cert.pem file used for connecting to a database host using ssl. Example value is `"/etc/mysql/ssl/client-cert.pem"`.
+- `db_ssl_key`: Full path to the key.pem file used for connecting to a database host using ssl. Example value is `"/etc/mysql/ssl/client-key.pem"`.
+
+### Default Outgoing Email Settings
 
 - `mail_server`: SMTP server hostname.
 - `mail_port`: STMP port.


### PR DESCRIPTION
Add the following options in site_config.json or common_site_config.json to use ssl

- "db_ssl_ca" = "/path/to/ca/cert.pem"
- "db_ssl_cert" = "/path/to/ssl/cert.pem"
- "db_ssl_key" = "/path/to/ssl/key.pem"

The files mentioned should be stored on the App server in the location mentioned.

This commit allows for basic ssl connections. X509 is still not supported.

If the above options are not set, the connection will not use an encrypted connection, and connect normally.