### PR TITLE
[hotfix][wiz] set defaults on add more

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -263,18 +263,6 @@ frappe.ui.form.Layout = Class.extend({
 		}
 	},
 
-	refresh_fields: function(fields) {
-		let fieldnames = fields.map((field) => {
-			if(field.label) return field.label;
-		});
-
-		this.fields_list.map(fieldobj => {
-			if(fieldnames.includes(fieldobj._label)) {
-				fieldobj.refresh();
-			}
-		});
-	},
-
 	refresh_section_count: function() {
 		this.wrapper.find(".section-count-label:visible").each(function(i) {
 			$(this).html(i+1);

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -45,6 +45,20 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 		this.render(fields);
 		this.refresh_fields(fields);
 	},
+	refresh_fields: function(fields) {
+		let fieldnames = fields.map((field) => {
+			if(field.fieldname) return field.fieldname;
+		});
+
+		this.fields_list.map(fieldobj => {
+			if(fieldnames.includes(fieldobj.df.fieldname)) {
+				fieldobj.refresh();
+				if(fieldobj.df["default"]) {
+					fieldobj.set_input(fieldobj.df["default"]);
+				}
+			}
+		});
+	},
 	first_button: false,
 	catch_enter_as_submit: function() {
 		var me = this;


### PR DESCRIPTION
Addresses: frappe/erpnext#9972

`refresh_fields` (as of now used once only in `field_group.js`) is more applicable to `field_group` than `layout`, as it refreshes a passed group of fields. Also, it can serve to set the defaults after a field refresh with `field_group`’s `set_input` method.

Before:
![wiz_default_not_set](https://user-images.githubusercontent.com/5196925/28367802-e0e14a02-6caf-11e7-8b24-0c63676b37aa.gif)

After:
![setup_wiz default_fix](https://user-images.githubusercontent.com/5196925/28368495-1fe655ba-6cb2-11e7-92ed-774f35a69584.gif)