### PR TITLE
Fix for dropbox settings

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -86,7 +86,7 @@ def backup_to_dropbox():
 		access_token = generate_oauth2_access_token_from_oauth1_token(dropbox_settings)
 
 		if not access_token.get('oauth2_token'):
-			return
+			return 'Failed backup upload', 'No Access Token exists! Please generate the access token for Dropbox.'
 
 		dropbox_settings['access_token'] = access_token['oauth2_token']
 		set_dropbox_access_token(access_token['oauth2_token'])


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/9991


Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 45, in take_backup_to_dropbox
    did_not_upload, error_log = backup_to_dropbox()
TypeError: 'NoneType' object is not iterable