### PR TITLE
[fix] Image control: detach instead of emptying parent

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1242,7 +1242,8 @@ frappe.ui.form.ControlAttachImage = frappe.ui.form.ControlAttach.extend({
 		var me = this;
 		this._super();
 
-		this.container = $('<div class="control-container">').appendTo($(this.parent).empty());
+		$(this.wrapper).detach();
+		this.container = $('<div class="control-container">').appendTo($(this.parent));
 		this.container.attr('data-fieldtype', this.df.fieldtype).append(this.wrapper);
 		if(this.df.align === 'center') {
 			this.container.addClass("flex-justify-center");


### PR DESCRIPTION
A problem with the recent image df PR (went out of my notice):
![screen shot 2017-07-25 at 8 28 06 pm](https://user-images.githubusercontent.com/5196925/28579027-043ae4b8-7179-11e7-86b1-dbb735c49b5a.png)

Fixed:
![screen shot 2017-07-25 at 8 22 29 pm](https://user-images.githubusercontent.com/5196925/28579036-0e46add4-7179-11e7-81d8-7f8496822612.png)
Just to be sure:
![screen shot 2017-07-25 at 8 22 52 pm](https://user-images.githubusercontent.com/5196925/28579054-1ad67c5a-7179-11e7-9c7a-91f6a4010df5.png)

P.S.: The erpnext PR frappe/erpnext#10016 will be needed for header removal