### PR TITLE
[fix][img-control] detach wrapper after inserting

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -1242,8 +1242,8 @@ frappe.ui.form.ControlAttachImage = frappe.ui.form.ControlAttach.extend({
 		var me = this;
 		this._super();
 
+		this.container = $('<div class="control-container">').insertAfter($(this.wrapper));
 		$(this.wrapper).detach();
-		this.container = $('<div class="control-container">').appendTo($(this.parent));
 		this.container.attr('data-fieldtype', this.df.fieldtype).append(this.wrapper);
 		if(this.df.align === 'center') {
 			this.container.addClass("flex-justify-center");


### PR DESCRIPTION
Result of frappe/frappe#3754

`detach()` behaves strangely if the element is succeeded by another. It's more fool-proof to do it at the end.

Before (due to hidden image field):
![screen shot 2017-07-26 at 5 15 16 pm](https://user-images.githubusercontent.com/5196925/28619982-9cb528b6-7228-11e7-9d44-6dc2620fbb08.png)

After:
![screen shot 2017-07-26 at 5 28 08 pm](https://user-images.githubusercontent.com/5196925/28619985-a38d6ae0-7228-11e7-8b41-cb57c8acf77b.png)

