### PR TITLE
Added arg in get_list to allow Sidebar Menu search using Item Name

### DIFF
--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -153,7 +153,7 @@ def get_list_context(context, doctype):
 
 	return list_context
 
-def get_list(doctype, txt, filters, limit_start, limit_page_length=20, ignore_permissions=False,
+def get_list(doctype, txt, filters, or_filters, limit_start, limit_page_length=20, ignore_permissions=False,
 	fields=None, order_by=None):
 	meta = frappe.get_meta(doctype)
 	if not filters:
@@ -162,7 +162,8 @@ def get_list(doctype, txt, filters, limit_start, limit_page_length=20, ignore_pe
 	if not fields:
 		fields = "distinct *"
 
-	or_filters = []
+	if not or_filters:
+		or_filters = []
 
 	if txt:
 		if meta.search_fields:


### PR DESCRIPTION
For web pages in Menu Sidebars, the common column for doctypes with "items" child table include item name's summary as below:

![item names](https://user-images.githubusercontent.com/21003054/28654570-f4706152-72c7-11e7-9ea3-598b417ba1f7.png)

It would be best to allow having this column to look at when using the page's **Search Bar**.

![item name filter](https://user-images.githubusercontent.com/21003054/28654657-a083a0da-72c8-11e7-961d-989645cedb8b.gif)

This is provided that "items" field is included in the doctype's search fields:

![search field](https://user-images.githubusercontent.com/21003054/28654704-ec3e51a0-72c8-11e7-82b1-feac1d118dd6.png)


