### PR TITLE
Email footer refactor

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -237,19 +237,19 @@ def get_emails_sent_this_month():
 
 def get_unsubscribe_message(unsubscribe_message, expose_recipients):
 	if unsubscribe_message:
-		unsubscribe_message = '''<a href="<!--unsubscribe url-->"
+		unsubscribe_html = '''<a href="<!--unsubscribe url-->"
 			target="_blank">{0}</a>'''.format(unsubscribe_message)
 	else:
 		unsubscribe_link = '''<a href="<!--unsubscribe url-->"
 			target="_blank">{0}</a>'''.format(_('Unsubscribe'))
-		unsubscribe_message = _("{0} to stop receiving emails of this type").format(unsubscribe_link)
+		unsubscribe_html = _("{0} to stop receiving emails of this type").format(unsubscribe_link)
 
 	html = """<div class="email-unsubscribe">
 			<!--cc message-->
 			<div>
-				{unsubscribe_message}
+				{0}
 			</div>
-		</div>""".format(unsubscribe_message=unsubscribe_message)
+		</div>""".format(unsubscribe_html)
 
 	if expose_recipients == "footer":
 		text = "\n<!--cc message-->"

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -241,8 +241,8 @@ def get_unsubscribe_message(unsubscribe_message, expose_recipients):
 			target="_blank">{0}</a>'''.format(unsubscribe_message)
 	else:
 		unsubscribe_link = '''<a href="<!--unsubscribe url-->"
-			target="_blank">unsubscribe</a>'''
-		unsubscribe_message = _("To stop recieving these kind of emails, {0}").format(unsubscribe_link)
+			target="_blank">{0}</a>'''.format(_('Unsubscribe'))
+		unsubscribe_message = _("{0} to stop receiving emails of this type").format(unsubscribe_link)
 
 	html = """<div class="email-unsubscribe">
 			<!--cc message-->

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -246,9 +246,9 @@ def get_unsubscribe_message(unsubscribe_message, expose_recipients):
 
 	html = """<div class="email-unsubscribe">
 			<!--cc message-->
-			<p>
+			<div>
 				{unsubscribe_message}
-			</p>
+			</div>
 		</div>""".format(unsubscribe_message=unsubscribe_message)
 
 	if expose_recipients == "footer":

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -75,8 +75,6 @@ def send(recipients=None, sender=None, subject=None, message=None, text_content=
 		except HTMLParser.HTMLParseError:
 			text_content = "See html attachment"
 
-	formatted = get_formatted_html(subject, message, email_account=email_account, header=header)
-
 	if reference_doctype and reference_name:
 		unsubscribed = [d.email for d in frappe.db.get_all("Email Unsubscribe", "email",
 			{"reference_doctype": reference_doctype, "reference_name": reference_name})]
@@ -88,13 +86,21 @@ def send(recipients=None, sender=None, subject=None, message=None, text_content=
 
 	recipients = [r for r in list(set(recipients)) if r and r not in unsubscribed]
 
-	email_content = formatted
 	email_text_context = text_content
 
-	if add_unsubscribe_link and reference_doctype and (unsubscribe_message or reference_doctype=="Newsletter") and add_unsubscribe_link==1:
+	should_append_unsubscribe = (add_unsubscribe_link
+		and reference_doctype
+		and (unsubscribe_message or reference_doctype=="Newsletter")
+		and add_unsubscribe_link==1)
+
+	unsubscribe_link = None
+	if should_append_unsubscribe or True:
 		unsubscribe_link = get_unsubscribe_message(unsubscribe_message, expose_recipients)
-		email_content = email_content.replace("<!--unsubscribe link here-->", unsubscribe_link.html)
 		email_text_context += unsubscribe_link.text
+
+	email_content = get_formatted_html(subject, message,
+		email_account=email_account, header=header,
+		unsubscribe_link=unsubscribe_link)
 
 	# add to queue
 	add(recipients, sender, subject,
@@ -230,17 +236,21 @@ def get_emails_sent_this_month():
 		status='Sent' and MONTH(creation)=MONTH(CURDATE())""")[0][0]
 
 def get_unsubscribe_message(unsubscribe_message, expose_recipients):
-	if not unsubscribe_message:
-		unsubscribe_message = _("Unsubscribe from this list")
+	if unsubscribe_message:
+		unsubscribe_message = '''<a href="<!--unsubscribe url-->"
+			target="_blank">{0}</a>'''.format(unsubscribe_message)
+	else:
+		unsubscribe_link = '''<a href="<!--unsubscribe url-->"
+			target="_blank">unsubscribe</a>'''
+		unsubscribe_message = _("To stop recieving these kind of emails, {0}").format(unsubscribe_link)
 
-	html = """<div style="margin: 15px auto; padding: 0px 7px; text-align: center; color: #8d99a6;">
+	html = """<div class="email-unsubscribe">
 			<!--cc message-->
-			<p style="margin: 15px auto;">
-				<a href="<!--unsubscribe url-->" style="color: #8d99a6; text-decoration: underline;"
-					target="_blank">{unsubscribe_message}
-				</a>
+			<p>
+				{unsubscribe_message}
 			</p>
 		</div>""".format(unsubscribe_message=unsubscribe_message)
+
 	if expose_recipients == "footer":
 		text = "\n<!--cc message-->"
 	else:

--- a/frappe/public/css/email.css
+++ b/frappe/public/css/email.css
@@ -51,6 +51,9 @@ hr {
 .email-footer-container {
   margin-top: 10px;
 }
+.email-footer-container > div:not(:last-child) {
+  margin-bottom: 5px;
+}
 .email-unsubscribe a {
   color: #8D99A6;
   text-decoration: underline;

--- a/frappe/public/css/email.css
+++ b/frappe/public/css/email.css
@@ -48,6 +48,13 @@ hr {
 .body-table.has-header .email-footer {
   border-top: none;
 }
+.email-footer-container {
+  margin-top: 10px;
+}
+.email-unsubscribe a {
+  color: #8D99A6;
+  text-decoration: underline;
+}
 .btn {
   text-decoration: none;
   padding: 7px 10px;

--- a/frappe/public/less/email.less
+++ b/frappe/public/less/email.less
@@ -63,6 +63,15 @@ hr {
 	}
 }
 
+.email-footer-container {
+	margin-top: 10px;
+}
+
+.email-unsubscribe a {
+	color: @text-muted;
+	text-decoration: underline;
+}
+
 .btn {
 	text-decoration: none;
 	padding: 7px 10px;

--- a/frappe/public/less/email.less
+++ b/frappe/public/less/email.less
@@ -65,6 +65,10 @@ hr {
 
 .email-footer-container {
 	margin-top: 10px;
+
+	& > div:not(:last-child) {
+		margin-bottom: 5px;
+	}
 }
 
 .email-unsubscribe a {

--- a/frappe/templates/emails/email_footer.html
+++ b/frappe/templates/emails/email_footer.html
@@ -1,0 +1,29 @@
+<div class="email-footer-container text-muted">
+	<!-- email_account_footer -->
+	{% if email_account_footer %}
+	<div class="email-account-footer">
+		{{ email_account_footer }}
+	</div>
+	{% endif %}
+
+	<!-- company_address -->
+	{% if company_address %}
+	<div class="company-address">
+		{% for line in company_address.splitlines(True) %}
+		<div>{{ line }}</div>
+		{% endfor %}
+	</div>
+	{% endif %}
+
+	<!--unsubscribe link here-->
+
+	<!-- default_mail_footer -->
+	{% if default_mail_footer %}
+	<div class="default-mail-footer">
+		{% for line in default_mail_footer %}
+		<div>{{ line }}</div>
+		{% endfor %}
+	</div>
+	{% endif %}
+
+</div>


### PR DESCRIPTION
- Render email footer using template (`email_footer.html`)

![image](https://user-images.githubusercontent.com/9355208/28715907-fed88bb0-73b7-11e7-815d-6cdee0499b0b.png)

