### PR TITLE
Fixed StringIO and cStringIO imports

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -121,7 +121,11 @@ def get_build_maps():
 timestamps = {}
 
 def pack(target, sources, no_compress, verbose):
-	from cStringIO import StringIO
+	try:
+		from cStringIO import StringIO
+	except ImportError:
+		from io import StringIO
+
 
 	outtype, outtxt = target.split(".")[-1], ''
 	jsm = JavascriptMinify()

--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -5,7 +5,10 @@ from __future__ import unicode_literals, absolute_import, print_function
 import sys
 import click
 import cProfile
-import StringIO
+try:
+	from StringIO import StringIO
+except ImportError:
+	from io import StringIO
 import pstats
 import frappe
 import frappe.utils
@@ -25,7 +28,7 @@ def pass_context(f):
 
 		if profile:
 			pr.disable()
-			s = StringIO.StringIO()
+			s = StringIO()
 			ps = pstats.Stats(pr, stream=s)\
 				.sort_stats('cumtime', 'tottime', 'ncalls')
 			ps.print_stats()

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -15,7 +15,10 @@ import os
 import shutil
 import requests
 import requests.exceptions
-import StringIO
+try:
+	from StringIO import StringIO
+except ImportError:
+	from io import StringIO
 import mimetypes, imghdr
 
 from frappe.utils.file_manager import delete_file_data_content, get_content_hash, get_random_filename
@@ -372,7 +375,7 @@ def get_web_image(file_url):
 			frappe.msgprint(_("Unable to read file format for {0}").format(file_url))
 		raise
 
-	image = Image.open(StringIO.StringIO(r.content))
+	image = Image.open(StringIO(r.content))
 
 	try:
 		filename, extn = file_url.rsplit("/", 1)[1].rsplit(".", 1)

--- a/frappe/desk/form/run_method.py
+++ b/frappe/desk/form/run_method.py
@@ -53,7 +53,11 @@ def make_csv_output(res, dt):
 	"""send method response as downloadable CSV file"""
 	import frappe
 
-	from cStringIO import StringIO
+	try:
+		from cStringIO import StringIO
+	except ImportError:
+		from io import StringIO
+
 	import csv
 
 	f = StringIO()

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -10,7 +10,11 @@ import importlib
 from frappe.modules import load_doctype_module, get_module_name
 from frappe.utils import cstr
 import frappe.utils.scheduler
-import cProfile, StringIO, pstats
+import cProfile, pstats
+try:
+	from StringIO import StringIO
+except ImportError:
+	from io import StringIO
 
 
 unittest_runner = unittest.TextTestRunner
@@ -110,7 +114,7 @@ def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False):
 
 	if profile:
 		pr.disable()
-		s = StringIO.StringIO()
+		s = StringIO()
 		ps = pstats.Stats(pr, stream=s).sort_stats('cumulative')
 		ps.print_stats()
 		print(s.getvalue())
@@ -167,7 +171,7 @@ def _run_unittest(module, verbose=False, tests=(), profile=False):
 
 	if profile:
 		pr.disable()
-		s = StringIO.StringIO()
+		s = StringIO()
 		ps = pstats.Stats(pr, stream=s).sort_stats('cumulative')
 		ps.print_stats()
 		print(s.getvalue())

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -5,7 +5,11 @@ from __future__ import unicode_literals
 import frappe
 from frappe import msgprint, _
 import json
-import csv, cStringIO
+import csv
+try:
+	from cStringIO import StringIO
+except ImportError:
+	from io import StringIO
 from frappe.utils import encode, cstr, cint, flt, comma_or
 
 def read_csv_content_from_uploaded_file(ignore_encoding=False):
@@ -97,7 +101,7 @@ def to_csv(data):
 class UnicodeWriter:
 	def __init__(self, encoding="utf-8"):
 		self.encoding = encoding
-		self.queue = cStringIO.StringIO()
+		self.queue = StringIO()
 		self.writer = csv.writer(self.queue, quoting=csv.QUOTE_NONNUMERIC)
 
 	def writerow(self, row):

--- a/frappe/utils/identicon.py
+++ b/frappe/utils/identicon.py
@@ -1,7 +1,10 @@
 from PIL import Image, ImageDraw
 from hashlib import md5
 import base64
-import StringIO
+try:
+	from StringIO import StringIO
+except ImportError:
+	from io import StringIO
 import random
 
 GRID_SIZE = 5
@@ -98,7 +101,7 @@ class Identicon(object):
 		bug report: https://github.com/liuzheng712/identicons/issues
 		'''
 		self.calculate()
-		fp = StringIO.StringIO()
+		fp = StringIO()
 		self.image.encoderinfo = {}
 		self.image.encoderconfig = ()
 

--- a/frappe/utils/minify.py
+++ b/frappe/utils/minify.py
@@ -28,7 +28,10 @@
 # SOFTWARE.
 # */
 
-from StringIO import StringIO
+try:
+	from StringIO import StringIO
+except ImportError:
+	from io import StringIO
 
 def jsmin(js):
 	ins = StringIO(js)

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -6,7 +6,10 @@ import frappe
 from frappe.utils import encode, cstr, cint, flt, comma_or
 
 import openpyxl
-from cStringIO import StringIO
+try:
+	from cStringIO import StringIO
+except ImportError:
+	from io import StringIO
 from openpyxl.styles import Font
 from openpyxl import load_workbook
 


### PR DESCRIPTION
Frappe port

Trying to install frappe with python3 gives following error

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 174, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.5/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/home/frappe/aditya/b/apps/frappe/frappe/__init__.py", line 15, in <module>
    from .utils.jinja import get_jenv, get_template, render_template, get_email_from_template
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/__init__.py", line 12, in <module>
    from frappe.utils.identicon import Identicon
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/identicon.py", line 4, in <module>
    import StringIO
ImportError: No module named 'StringIO'
```
We've fixed that using [try except blocks](https://stackoverflow.com/a/18284900)