### PR TITLE
Redefine lambdas to accept multiple args instead of a packed tuple

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -667,21 +667,21 @@ def get_url_to_report(name, report_type = None, doctype = None):
 
 operator_map = {
 	# startswith
-	"^": lambda (a, b): (a or "").startswith(b),
+	"^": lambda a, b: (a or "").startswith(b),
 
 	# in or not in a list
-	"in": lambda (a, b): operator.contains(b, a),
-	"not in": lambda (a, b): not operator.contains(b, a),
+	"in": lambda a, b: operator.contains(b, a),
+	"not in": lambda a, b: not operator.contains(b, a),
 
 	# comparison operators
-	"=": lambda (a, b): operator.eq(a, b),
-	"!=": lambda (a, b): operator.ne(a, b),
-	">": lambda (a, b): operator.gt(a, b),
-	"<": lambda (a, b): operator.lt(a, b),
-	">=": lambda (a, b): operator.ge(a, b),
-	"<=": lambda (a, b): operator.le(a, b),
-	"not None": lambda (a, b): a and True or False,
-	"None": lambda (a, b): (not a) and True or False
+	"=": lambda a, b: operator.eq(a, b),
+	"!=": lambda a, b: operator.ne(a, b),
+	">": lambda a, b: operator.gt(a, b),
+	"<": lambda a, b: operator.lt(a, b),
+	">=": lambda a, b: operator.ge(a, b),
+	"<=": lambda a, b: operator.le(a, b),
+	"not None": lambda a, b: a and True or False,
+	"None": lambda a, b: (not a) and True or False
 }
 
 def evaluate_filters(doc, filters):
@@ -704,7 +704,7 @@ def evaluate_filters(doc, filters):
 def compare(val1, condition, val2):
 	ret = False
 	if condition in operator_map:
-		ret = operator_map[condition]((val1, val2))
+		ret = operator_map[condition](val1, val2)
 
 	return ret
 


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3808 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 174, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.5/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/home/frappe/aditya/b/apps/frappe/frappe/__init__.py", line 15, in <module>
    from .utils.jinja import get_jenv, get_template, render_template, get_email_from_template
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/__init__.py", line 15, in <module>
    from frappe.utils.data import *
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/data.py", line 670
    "^": lambda (a, b): (a or "").startswith(b),
                ^
SyntaxError: invalid syntax
```

Unlike Python 2, [Python 3 does not automatically unpack tuple parameters](https://www.python.org/dev/peps/pep-3113/) (See last example for TLDR version).
Redefining lamdas to accept multiple separate arguments instead of a tuple allows them to work in both Python 2 and 3.