### PR TITLE
Replaced HTMLParser imports with six.moves.html_parser

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 from six.moves import range
 import frappe
-import HTMLParser
+from six.moves import html_parser as HTMLParser
 import smtplib, quopri, json
 from frappe import msgprint, throw, _
 from frappe.email.smtp import SMTPServer, get_outgoing_email_account

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -11,7 +11,7 @@ import babel.dates
 from babel.core import UnknownLocaleError
 from dateutil import parser
 from num2words import num2words
-import HTMLParser
+from six.moves import html_parser as HTMLParser
 from html2text import html2text
 from six import iteritems
 

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -235,7 +235,7 @@ def update_global_search(doc):
 def get_formatted_value(value, field):
 	'''Prepare field from raw data'''
 
-	from HTMLParser import HTMLParser
+	from six.moves.html_parser import HTMLParser
 
 	if(getattr(field, 'fieldtype', None) in ["Text", "Text Editor"]):
 		h = HTMLParser()


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3811 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 174, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.5/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/home/frappe/aditya/b/apps/frappe/frappe/__init__.py", line 15, in <module>
    from .utils.jinja import get_jenv, get_template, render_template, get_email_from_template
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/__init__.py", line 15, in <module>
    from frappe.utils.data import *
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/data.py", line 14, in <module>
    import HTMLParser
ImportError: No module named 'HTMLParser'
```


Fixed it by importing `six.moves.html_parser` instead of `HTMLParser`

[Python 3 (PEP 3108) renamed `HTMLParser` module as `html.parser`](https://www.python.org/dev/peps/pep-3108/#html-package). Six provides consistent interface to both `HTMLParser` and `html.parser` using a fake module [six.moves.html_parser](https://pythonhosted.org/six/#module-six.moves)