### PR TITLE
Replaced mixed usage of tabs and spaces for indents with tabs only

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -39,7 +39,7 @@ def make_boilerplate(dest, app_name):
 
 			if hook_key=="app_name" and hook_val.lower().replace(" ", "_") != hook_val:
 				print("App Name must be all lowercase and without spaces")
-  				hook_val = ""
+				hook_val = ""
 			elif hook_key=="app_title" and not re.match("^(?![\W])[^\d_\s][\w -]+$", hook_val, re.UNICODE):
 				print("App Title should start with a letter and it can only consist of letters, numbers, spaces and underscores")
 				hook_val = ""

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -218,9 +218,9 @@ def update_global_search(doc):
 	# Get children
 	for child in doc.meta.get_table_fields():
 		for d in doc.get(child.fieldname):
-		  	if d.parent == doc.name:
-		  		for field in d.meta.get_global_search_fields():
-		  			if d.get(field.fieldname):
+			if d.parent == doc.name:
+				for field in d.meta.get_global_search_fields():
+					if d.get(field.fieldname):
 						content.append(get_formatted_value(d.get(field.fieldname), field))
 
 	if content:

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -47,7 +47,7 @@ def validate_template(html):
 	try:
 		jenv.from_string(html)
 	except TemplateSyntaxError as e:
- 		frappe.msgprint('Line {}: {}'.format(e.lineno, e.message))
+		frappe.msgprint('Line {}: {}'.format(e.lineno, e.message))
 		frappe.throw(frappe._("Syntax error in template"))
 
 def render_template(template, context, is_path=None):


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3812 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 174, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.5/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/home/frappe/aditya/b/apps/frappe/frappe/__init__.py", line 15, in <module>
    from .utils.jinja import get_jenv, get_template, render_template, get_email_from_template
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/jinja.py", line 51
    frappe.throw(frappe._("Syntax error in template"))
                                                     ^
TabError: inconsistent use of tabs and spaces in indentation
```


Fixed it by replacing mixed usage of tabs and spaces with tabs only.

[Python 3 (PEP 8) disallows mixing of tabs and spaces for indentation](https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces). 

Even though the traceback only points to `frappe/utils/jinja.py` the rest two are very much likely to cause `TabError` upon execution