### PR TITLE
Hide links in pdf

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -125,8 +125,19 @@ frappe.ui.form.PrintPreview = Class.extend({
 		var me = this;
 		this.get_print_html(function (out) {
 			me.wrapper.find(".print-format").html(out.html);
+			me.show_footer();
 			me.set_style(out.style);
 		});
+	},
+	show_footer: function() {
+		// footer is hidden by default as reqd by pdf generation
+		// simple hack to show it in print preview
+		this.wrapper.find('.print-format').css('position', 'relative');
+		this.wrapper.find('#footer-html').attr('style', `
+			display: block !important;
+			position: absolute;
+			bottom: 0.75in;
+		`);
 	},
 	printit: function () {
 		this.new_page_preview(true);

--- a/frappe/templates/print_formats/pdf_header_footer.html
+++ b/frappe/templates/print_formats/pdf_header_footer.html
@@ -34,6 +34,13 @@
 			.letter-head-footer {
 				margin-top: -15mm !important;
 			}
+
+			/* Dont show explicit links for <a> tags */
+			@media print {
+				a[href]:after {
+					content: none;
+				}
+			}
 		</style>
 
 		<!-- from: http://wkhtmltopdf.org/usage/wkhtmltopdf.txt -->


### PR DESCRIPTION
Bootstrap adds a link to every `<a>` tag beside it during printing. In most cases, this is unintended. They even [removed it](https://github.com/twbs/bootstrap/issues/17788) in Bootstrap 4.

**Before:**
![image](https://user-images.githubusercontent.com/9355208/28754879-1ee5511c-756c-11e7-8474-934a4518e84a.png)

**After:**
![image](https://user-images.githubusercontent.com/9355208/28754876-14e02ebc-756c-11e7-9e5a-e9bc88b41c51.png)

**Bonus:**

Show footer in print preview:
![image](https://user-images.githubusercontent.com/9355208/28755140-79260e32-7571-11e7-9d59-af195e181f64.png)
