### PR TITLE
Update quick_entry.js

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -13,7 +13,7 @@ frappe.ui.form.make_quick_entry = (doctype, after_insert, init_callback) => {
 };
 
 frappe.ui.form.QuickEntryForm = Class.extend({
-	init: function(doctype, after_insert){
+	init: function(doctype, after_insert, init_callback){
 		this.doctype = doctype;
 		this.after_insert = after_insert;
 		this.init_callback = init_callback;

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -1,6 +1,6 @@
 frappe.provide('frappe.ui.form');
 
-frappe.ui.form.make_quick_entry = (doctype, after_insert) => {
+frappe.ui.form.make_quick_entry = (doctype, after_insert, init_callback) => {
 	var trimmed_doctype = doctype.replace(/ /g, '');
 	var controller_name = "QuickEntryForm";
 
@@ -8,7 +8,7 @@ frappe.ui.form.make_quick_entry = (doctype, after_insert) => {
 		controller_name = trimmed_doctype + "QuickEntryForm";
 	}
 
-	frappe.quick_entry = new frappe.ui.form[controller_name](doctype, after_insert);
+	frappe.quick_entry = new frappe.ui.form[controller_name](doctype, after_insert, init_callback);
 	return frappe.quick_entry.setup();
 };
 
@@ -16,6 +16,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 	init: function(doctype, after_insert){
 		this.doctype = doctype;
 		this.after_insert = after_insert;
+		this.init_callback = init_callback;
 	},
 
 	setup: function() {
@@ -106,6 +107,10 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 		this.dialog.onhide = () => frappe.quick_entry = null;
 		this.dialog.show();
 		this.set_defaults();
+		
+		if (this.init_callback) {
+			this.init_callback(this.dialog);
+		}
 	},
 
 	register_primary_action: function(){
@@ -141,7 +146,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 						frappe.ui.form.update_calling_link(me.dialog.doc);
 					} else {
 						if(me.after_insert) {
-							me.after_insert(me.dialig.doc);
+							me.after_insert(me.dialog.doc);
 						} else {
 							me.open_from_if_not_list();
 						}

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -314,7 +314,7 @@ $.extend(frappe.model, {
 });
 
 frappe.create_routes = {};
-frappe.new_doc = function (doctype, opts) {
+frappe.new_doc = function (doctype, opts, init_callback) {
 	return new Promise(resolve => {
 		if(opts && $.isPlainObject(opts)) {
 			frappe.route_options = opts;
@@ -324,7 +324,7 @@ frappe.new_doc = function (doctype, opts) {
 				frappe.set_route(frappe.create_routes[doctype])
 					.then(() => resolve());
 			} else {
-				frappe.ui.form.make_quick_entry(doctype)
+				frappe.ui.form.make_quick_entry(doctype, null, init_callback)
 					.then(() => resolve());
 			}
 		});


### PR DESCRIPTION
Add init_callback, for having a callback, when the dialog is rendered and having the ability to use client side scripting for quick entry forms.

```
frappe.new_doc("MyDocType", {"customer": frm.doc.customer}, function(dialog) {
    console.log(dialog);

    alert("Success");

    // do some stuff, like using filters with get_query
});
```

# Step 1 

Use the above code in your custom doctype.

# Step 2

See the Success Alert from the Callback.

![image](https://user-images.githubusercontent.com/8351245/28756518-3358fa32-7570-11e7-8bb4-dab1387acb5e.png)
