### PR TITLE
get_value in client.py

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -71,6 +71,11 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False):
 		# name passed, not json
 		pass
 
+	# check whether the used filters were really parseable and usable
+	# and did not just result in an empty string or dict
+	if not filters:
+		filters = None
+
 	return frappe.db.get_value(doctype, filters, fieldname, as_dict=as_dict, debug=debug)
 
 @frappe.whitelist()


### PR DESCRIPTION
Check whether the used filters were really parseable and usable and did not just result in an empty string or dict.

I didn't check correctly whether the values I wanted to filter for are actually there before I called `frappe.db.get_value`.

So I had `frappe.db.get_value('Item Group', {name: item.item_group}`, and this happened here `frappe.ui.form.on('Sales Invoice', 'item_code'` and here `frappe.ui.form.on('Sales Invoice Item', 'item_code'`.

It threw an error because sometimes the resulting sql had no usable filters and the statement was just `where order by modified desc`.

Maybe this modification should be done somewhere else and not in `client.py > get_value` to have this fail-safe be applied to all `filters` variables.