### PR TITLE
Fix patch fail if user was deleted

### DIFF
--- a/frappe/patches/v8_x/update_user_permission.py
+++ b/frappe/patches/v8_x/update_user_permission.py
@@ -5,22 +5,27 @@ def execute():
 	frappe.delete_doc('core', 'page', 'user-permissions')
 	for perm in frappe.db.sql("""
 		select
-			name, parent, defkey, defvalue
+			defval.name, defval.parent, defval.defkey, defval.defvalue
 		from
-			tabDefaultValue
+			tabDefaultValue as defval,
+			tabUser as usr
 		where
-			parent not in ('__default', '__global')
+			defval.parent not in ('__default', '__global')
 		and
-			substr(defkey,1,1)!='_'
+			substr(defval.defkey,1,1)!='_'
 		and
-			parenttype='User Permission'
+			defval.parenttype='User Permission'
+		and 
+			usr.name=defval.parent
 		""", as_dict=True):
-		frappe.get_doc(dict(
-			doctype='User Permission',
-			user=perm.parent,
-			allow=perm.defkey,
-			for_value=perm.defvalue,
-			apply_for_all_roles=0,
-		)).insert(ignore_permissions = True)
+
+			frappe.get_doc(dict(
+				doctype='User Permission',
+				user=perm.parent,
+				allow=perm.defkey,
+				for_value=perm.defvalue,
+				apply_for_all_roles=0,
+			)).insert(ignore_permissions = True)
+
 
 	frappe.db.sql('delete from tabDefaultValue where parenttype="User Permission"')

--- a/frappe/patches/v8_x/update_user_permission.py
+++ b/frappe/patches/v8_x/update_user_permission.py
@@ -15,7 +15,7 @@ def execute():
 			substr(defval.defkey,1,1)!='_'
 		and
 			defval.parenttype='User Permission'
-		and 
+		and
 			usr.name=defval.parent
 		""", as_dict=True):
 


### PR DESCRIPTION
When trying to update frappe, I get this error:

```
Executing frappe.patches.v8_x.update_user_permission in erpnext.vm (d56cb677ea)
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 17, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 216, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/patches/v8_x/update_user_permission.py", line 24, in execute
    )).insert(ignore_permissions = True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 193, in insert
    self._validate()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 400, in _validate
    self._validate_links()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 635, in _validate_links
    frappe.LinkValidationError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 319, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
frappe.exceptions.LinkValidationError: Could not find User: s####d@#######.com

```

This is because the User account was deleted, but the User Permissions still exist. I modified the patch to make sure the User account exists.