### PR TITLE
Replaced all instances of 'unicode' with 'six.text_type'

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -6,7 +6,7 @@ globals attached to frappe module
 """
 from __future__ import unicode_literals, print_function
 
-from six import iteritems
+from six import iteritems, text_type
 from werkzeug.local import Local, release_local
 import os, sys, importlib, inspect, json
 
@@ -57,14 +57,14 @@ def _(msg, lang=None):
 
 def as_unicode(text, encoding='utf-8'):
 	'''Convert to unicode if required'''
-	if isinstance(text, unicode):
+	if isinstance(text, text_type):
 		return text
 	elif text==None:
 		return ''
 	elif isinstance(text, basestring):
-		return unicode(text, encoding)
+		return text_type(text, encoding)
 	else:
-		return unicode(text)
+		return text_type(text)
 
 def get_lang_dict(fortype, name=None):
 	"""Returns the translated language dict for the given type and name.
@@ -880,7 +880,7 @@ def get_file_json(path):
 
 def read_file(path, raise_not_found=False):
 	"""Open a file and return its content as Unicode."""
-	if isinstance(path, unicode):
+	if isinstance(path, text_type):
 		path = path.encode("utf-8")
 
 	if os.path.exists(path):

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 
-from six import iteritems
+from six import iteritems, text_type
 
 """
 bootstrap client session
@@ -68,7 +68,7 @@ def get_bootinfo():
 		frappe.get_attr(method)(bootinfo)
 
 	if bootinfo.lang:
-		bootinfo.lang = unicode(bootinfo.lang)
+		bootinfo.lang = text_type(bootinfo.lang)
 	bootinfo.versions = {k: v['version'] for k, v in get_versions().items()}
 
 	bootinfo.error_report_email = frappe.get_hooks("error_report_email")

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals, print_function
 from frappe.utils.minify import JavascriptMinify
 import subprocess
 
-from six import iteritems
+from six import iteritems, text_type
 
 """
 Build the `public` folders and setup languages
@@ -135,7 +135,7 @@ def pack(target, sources, no_compress, verbose):
 		timestamps[f] = os.path.getmtime(f)
 		try:
 			with open(f, 'r') as sourcefile:
-				data = unicode(sourcefile.read(), 'utf-8', errors='ignore')
+				data = text_type(sourcefile.read(), 'utf-8', errors='ignore')
 
 			extn = f.rsplit(".", 1)[1]
 
@@ -144,7 +144,7 @@ def pack(target, sources, no_compress, verbose):
 				jsm.minify(tmpin, tmpout)
 				minified = tmpout.getvalue()
 				if minified:
-					outtxt += unicode(minified or '', 'utf-8').strip('\n') + ';'
+					outtxt += text_type(minified or '', 'utf-8').strip('\n') + ';'
 
 				if verbose:
 					print("{0}: {1}k".format(f, int(len(minified) / 1024)))

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -9,6 +9,7 @@ from frappe.commands.scheduler import _is_scheduler_enabled
 from frappe.limits import update_limits, get_limits
 from frappe.installer import update_site_config
 from frappe.utils import touch_file, get_site_path
+from six import text_type
 
 @click.command('new-site')
 @click.argument('site')
@@ -428,7 +429,7 @@ def set_limit(context, site, limit, value):
 
 @click.command('set-limits')
 @click.option('--site', help='site name')
-@click.option('--limit', 'limits', type=(unicode, unicode), multiple=True)
+@click.option('--limit', 'limits', type=(text_type, text_type), multiple=True)
 @pass_context
 def set_limits(context, site, limits):
 	_set_limits(context, site, limits)

--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -10,6 +10,7 @@ from frappe.model.utils import render_include
 from frappe import conf, _
 from frappe.desk.form.meta import get_code_files_via_hooks, get_js
 from frappe.core.doctype.custom_role.custom_role import get_custom_allowed_roles
+from six import text_type
 
 class Page(Document):
 	def autoname(self):
@@ -111,13 +112,13 @@ class Page(Document):
 		fpath = os.path.join(path, page_name + '.css')
 		if os.path.exists(fpath):
 			with open(fpath, 'r') as f:
-				self.style = unicode(f.read(), "utf-8")
+				self.style = text_type(f.read(), "utf-8")
 
 		# html as js template
 		for fname in os.listdir(path):
 			if fname.endswith(".html"):
 				with open(os.path.join(path, fname), 'r') as f:
-					template = unicode(f.read(), "utf-8")
+					template = text_type(f.read(), "utf-8")
 					if "<!-- jinja -->" in template:
 						context = frappe._dict({})
 						try:

--- a/frappe/core/page/data_import_tool/importer.py
+++ b/frappe/core/page/data_import_tool/importer.py
@@ -17,6 +17,7 @@ from frappe.utils.file_manager import save_url
 
 from frappe.utils import cint, cstr, flt, getdate, get_datetime, get_url
 from frappe.core.page.data_import_tool.data_import_tool import get_data_keys
+from six import text_type
 
 @frappe.whitelist()
 def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, no_email=True, overwrite=None,
@@ -308,7 +309,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 				doc = parent.append(parentfield, doc)
 				parent.save()
 				log('Inserted row for %s at #%s' % (as_link(parenttype,
-					doc.parent), unicode(doc.idx)))
+					doc.parent),text_type(doc.idx)))
 			else:
 				if overwrite and doc["name"] and frappe.db.exists(doctype, doc["name"]):
 					original = frappe.get_doc(doctype, doc["name"])

--- a/frappe/database.py
+++ b/frappe/database.py
@@ -21,7 +21,7 @@ from frappe import _
 from types import StringType, UnicodeType
 from frappe.utils.global_search import sync_global_search
 from frappe.model.utils.link_count import flush_local_link_count
-from six import iteritems
+from six import iteritems, text_type
 
 
 class Database:
@@ -260,7 +260,7 @@ class Database:
 				else:
 					val = r[i]
 
-				if as_utf8 and type(val) is unicode:
+				if as_utf8 and type(val) is text_type:
 					val = val.encode('utf-8')
 				row_dict[self._cursor.description[i][0]] = val
 			ret.append(row_dict)
@@ -289,13 +289,13 @@ class Database:
 
 		if isinstance(v, (datetime.date, datetime.timedelta, datetime.datetime, long)):
 			if isinstance(v, datetime.date):
-				v = unicode(v)
+				v = text_type(v)
 				if formatted:
 					v = formatdate(v)
 
 			# time
 			elif isinstance(v, (datetime.timedelta, datetime.datetime)):
-				v = unicode(v)
+				v = text_type(v)
 
 			# long
 			elif isinstance(v, long):
@@ -306,7 +306,7 @@ class Database:
 			if isinstance(v, float):
 				v=fmt_money(v)
 			elif isinstance(v, int):
-				v = unicode(v)
+				v = text_type(v)
 
 		return v
 
@@ -321,7 +321,7 @@ class Database:
 					val = self.convert_to_simple_type(c, formatted)
 				else:
 					val = c
-				if as_utf8 and type(val) is unicode:
+				if as_utf8 and type(val) is text_type:
 					val = val.encode('utf-8')
 				nr.append(val)
 			nres.append(nr)
@@ -333,7 +333,7 @@ class Database:
 		for r in res:
 			nr = []
 			for c in r:
-				if type(c) is unicode:
+				if type(c) is text_type:
 					c = c.encode('utf-8')
 					nr.append(self.convert_to_simple_type(c, formatted))
 			nres.append(nr)
@@ -880,10 +880,10 @@ class Database:
 
 	def escape(self, s, percent=True):
 		"""Excape quotes and percent in given string."""
-		if isinstance(s, unicode):
+		if isinstance(s, text_type):
 			s = (s or "").encode("utf-8")
 
-		s = unicode(MySQLdb.escape_string(s), "utf-8").replace("`", "\\`")
+		s = text_type(MySQLdb.escape_string(s), "utf-8").replace("`", "\\`")
 
 		# NOTE separating % escape, because % escape should only be done when using LIKE operator
 		# or when you use python format string to generate query that already has a %s

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -14,7 +14,7 @@ from frappe.model.utils import render_include
 from frappe.build import scrub_html_template
 
 ######
-from six import iteritems
+from six import iteritems, text_type
 
 
 def get_meta(doctype, cached=True):
@@ -99,7 +99,7 @@ class FormMeta(Meta):
 		for fname in os.listdir(path):
 			if fname.endswith(".html"):
 				with open(os.path.join(path, fname), 'r') as f:
-					templates[fname.split('.')[0]] = scrub_html_template(unicode(f.read(), "utf-8"))
+					templates[fname.split('.')[0]] = scrub_html_template(text_type(f.read(), "utf-8"))
 
 		self.set("__templates", templates or None)
 

--- a/frappe/desk/form/run_method.py
+++ b/frappe/desk/form/run_method.py
@@ -6,6 +6,7 @@ import json, inspect
 import frappe
 from frappe import _
 from frappe.utils import cint
+from six import text_type
 
 @frappe.whitelist()
 def runserverobj(method, docs=None, dt=None, dn=None, arg=None, args=None):
@@ -68,6 +69,6 @@ def make_csv_output(res, dt):
 
 	f.seek(0)
 
-	frappe.response['result'] = unicode(f.read(), 'utf-8')
+	frappe.response['result'] = text_type(f.read(), 'utf-8')
 	frappe.response['type'] = 'csv'
 	frappe.response['doctype'] = dt.replace(' ','')

--- a/frappe/desk/query_builder.py
+++ b/frappe/desk/query_builder.py
@@ -8,6 +8,7 @@ out = frappe.response
 
 from frappe.utils import cint
 import frappe.defaults
+from six import text_type
 
 def get_sql_tables(q):
 	if q.find('WHERE') != -1:
@@ -246,10 +247,10 @@ def runquery_csv():
 	writer = csv.writer(f)
 	for r in rows:
 		# encode only unicode type strings and not int, floats etc.
-		writer.writerow(map(lambda v: isinstance(v, unicode) and v.encode('utf-8') or v, r))
+		writer.writerow(map(lambda v: isinstance(v, text_type) and v.encode('utf-8') or v, r))
 
 	f.seek(0)
-	out['result'] = unicode(f.read(), 'utf-8')
+	out['result'] = text_type(f.read(), 'utf-8')
 	out['type'] = 'csv'
 	out['doctype'] = rep_name
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -10,6 +10,7 @@ import frappe.permissions
 import MySQLdb
 from frappe.model.db_query import DatabaseQuery
 from frappe import _
+from six import text_type
 
 @frappe.whitelist()
 def get():
@@ -151,10 +152,10 @@ def export_query():
 		writer = csv.writer(f)
 		for r in data:
 			# encode only unicode type strings and not int, floats etc.
-			writer.writerow(map(lambda v: isinstance(v, unicode) and v.encode('utf-8') or v, r))
+			writer.writerow(map(lambda v: isinstance(v, text_type) and v.encode('utf-8') or v, r))
 
 		f.seek(0)
-		frappe.response['result'] = unicode(f.read(), 'utf-8')
+		frappe.response['result'] = text_type(f.read(), 'utf-8')
 		frappe.response['type'] = 'csv'
 		frappe.response['doctype'] = doctype
 

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -8,7 +8,7 @@ from frappe.email.smtp import get_outgoing_email_account
 from frappe.utils import (get_url, scrub_urls, strip, expand_relative_urls, cint,
 	split_emails, to_markdown, markdown, encode, random_string, parse_addr)
 import email.utils
-from six import iteritems
+from six import iteritems, text_type
 from email.mime.multipart import MIMEMultipart
 
 
@@ -307,7 +307,7 @@ def add_attachment(fname, fcontent, content_type=None,
 	maintype, subtype = content_type.split('/', 1)
 	if maintype == 'text':
 		# Note: we should handle calculating the charset
-		if isinstance(fcontent, unicode):
+		if isinstance(fcontent, text_type):
 			fcontent = fcontent.encode("utf-8")
 		part = MIMEText(fcontent, _subtype=subtype, _charset="utf-8")
 	elif maintype == 'image':

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -15,6 +15,7 @@ from frappe.utils import get_url, nowdate, encode, now_datetime, add_days, split
 from frappe.utils.file_manager import get_file
 from rq.timeouts import JobTimeoutException
 from frappe.utils.scheduler import log
+from six import text_type
 
 class EmailLimitCrossedError(frappe.ValidationError): pass
 
@@ -440,10 +441,10 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 
 		if any("Sent" == s.status for s in recipients_list):
 			frappe.db.sql("""update `tabEmail Queue` set status='Partially Errored', error=%s where name=%s""",
-				(unicode(e), email.name), auto_commit=auto_commit)
+				(text_type(e), email.name), auto_commit=auto_commit)
 		else:
 			frappe.db.sql("""update `tabEmail Queue` set status='Error', error=%s
-where name=%s""", (unicode(e), email.name), auto_commit=auto_commit)
+where name=%s""", (text_type(e), email.name), auto_commit=auto_commit)
 
 		if email.communication:
 			frappe.get_doc('Communication', email.communication).set_delivery_status(commit=auto_commit)
@@ -454,7 +455,7 @@ where name=%s""", (unicode(e), email.name), auto_commit=auto_commit)
 
 		else:
 			# log to Error Log
-			log('frappe.email.queue.flush', unicode(e))
+			log('frappe.email.queue.flush', text_type(e))
 
 def prepare_message(email, recipient, recipients_list):
 	message = email.message

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 
-from six import iteritems
+from six import iteritems, text_type
 from six.moves import range
 import time, _socket, poplib, imaplib, email, email.utils, datetime, chardet, re, hashlib
 from email_reply_parser import EmailReplyParser
@@ -482,7 +482,7 @@ class Email:
 		charset = self.get_charset(part)
 
 		try:
-			return unicode(part.get_payload(decode=True), str(charset), "ignore")
+			return text_type(part.get_payload(decode=True), str(charset), "ignore")
 		except LookupError:
 			return part.get_payload()
 

--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -7,6 +7,7 @@ import frappe
 from frappe.utils import cstr
 from frappe.build import html_to_js_template
 import re
+from six import text_type
 
 
 """
@@ -51,7 +52,7 @@ def render_include(content):
 			for path in paths:
 				app, app_path = path.split('/', 1)
 				with open(frappe.get_app_path(app, app_path), 'r') as f:
-					include = unicode(f.read(), 'utf-8')
+					include = text_type(f.read(), 'utf-8')
 					if path.endswith('.html'):
 						include = html_to_js_template(path, include)
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -19,6 +19,7 @@ from frappe.utils.change_log import get_change_log
 import redis
 from urllib import unquote
 from frappe.desk.notifications import clear_notifications
+from six import text_type
 
 @frappe.whitelist()
 def clear(user=None):
@@ -360,7 +361,7 @@ class Session:
 		now = frappe.utils.now()
 
 		self.data['data']['last_updated'] = now
-		self.data['data']['lang'] = unicode(frappe.lang)
+		self.data['data']['lang'] = text_type(frappe.lang)
 
 		# update session in db
 		last_updated = frappe.cache().hget("last_db_session_update", self.sid)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals, print_function
 
-from six import iteritems
+from six import iteritems, text_type
 
 """
 	frappe.translate
@@ -30,8 +30,8 @@ def guess_language(lang_list=None):
 
 	for l in lang_codes:
 		code = l.strip()
-		if not isinstance(code, unicode):
-			code = unicode(code, 'utf-8')
+		if not isinstance(code, text_type):
+			code = text_type(code, 'utf-8')
 		if code in lang_list or code == "en":
 			guess = code
 			break
@@ -544,7 +544,7 @@ def read_csv_file(path):
 		# for japanese! #wtf
 		data = data.replace(chr(28), "").replace(chr(29), "")
 		data = reader([r.encode('utf-8') for r in data.splitlines()])
-		newdata = [[unicode(val, 'utf-8') for val in row] for row in data]
+		newdata = [[text_type(val, 'utf-8') for val in row] for row in data]
 	return newdata
 
 def write_csv_file(path, app_messages, lang_dict):

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -13,6 +13,7 @@ from frappe.utils.identicon import Identicon
 from email.utils import parseaddr, formataddr
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *
+from six import text_type
 
 default_fields = ['doctype', 'name', 'owner', 'creation', 'modified', 'modified_by',
 	'parent', 'parentfield', 'parenttype', 'idx', 'docstatus']
@@ -61,7 +62,7 @@ def get_formatted_email(user):
 def extract_email_id(email):
 	"""fetch only the email part of the Email Address"""
 	email_id = parse_addr(email)[1]
-	if email_id and isinstance(email_id, basestring) and not isinstance(email_id, unicode):
+	if email_id and isinstance(email_id, basestring) and not isinstance(email_id, text_type):
 		email_id = email_id.decode("utf-8", "ignore")
 	return email_id
 
@@ -303,14 +304,14 @@ def get_request_site_address(full_address=False):
 
 def encode_dict(d, encoding="utf-8"):
 	for key in d:
-		if isinstance(d[key], basestring) and isinstance(d[key], unicode):
+		if isinstance(d[key], basestring) and isinstance(d[key], text_type):
 			d[key] = d[key].encode(encoding)
 
 	return d
 
 def decode_dict(d, encoding="utf-8"):
 	for key in d:
-		if isinstance(d[key], basestring) and not isinstance(d[key], unicode):
+		if isinstance(d[key], basestring) and not isinstance(d[key], text_type):
 			d[key] = d[key].decode(encoding, "ignore")
 
 	return d

--- a/frappe/utils/autodoc.py
+++ b/frappe/utils/autodoc.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals, print_function
 
 import inspect, importlib, re, frappe
 from frappe.model.document import get_controller
+from six import text_type
 
 
 def automodule(name):
@@ -169,6 +170,6 @@ def automodel(doctype):
 def get_obj_doc(obj):
 	'''Return `__doc__` of the given object as unicode'''
 	doc = getattr(obj, "__doc__", "") or ''
-	if not isinstance(doc, unicode):
-		doc = unicode(doc, 'utf-8')
+	if not isinstance(doc, text_type):
+		doc = text_type(doc, 'utf-8')
 	return doc

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import msgprint, _
 import json
 import csv
-from six import StringIO
+from six import StringIO, text_type
 from frappe.utils import encode, cstr, cint, flt, comma_or
 
 def read_csv_content_from_uploaded_file(ignore_encoding=False):
@@ -38,11 +38,11 @@ def read_csv_content_from_attached_file(doc):
 def read_csv_content(fcontent, ignore_encoding=False):
 	rows = []
 
-	if not isinstance(fcontent, unicode):
+	if not isinstance(fcontent, text_type):
 		decoded = False
 		for encoding in ["utf-8", "windows-1250", "windows-1252"]:
 			try:
-				fcontent = unicode(fcontent, encoding)
+				fcontent = text_type(fcontent, encoding)
 				decoded = True
 				break
 			except UnicodeDecodeError:
@@ -60,7 +60,7 @@ def read_csv_content(fcontent, ignore_encoding=False):
 			r = []
 			for val in row:
 				# decode everything
-				val = unicode(val, "utf-8").strip()
+				val = text_type(val, "utf-8").strip()
 
 				if val=="":
 					# reason: in maraidb strict config, one cannot have blank strings for non string datatypes

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -13,7 +13,7 @@ from dateutil import parser
 from num2words import num2words
 from six.moves import html_parser as HTMLParser
 from html2text import html2text
-from six import iteritems
+from six import iteritems, text_type
 
 DATE_FORMAT = "%Y-%m-%d"
 TIME_FORMAT = "%H:%M:%S.%f"
@@ -329,12 +329,12 @@ def encode(obj, encoding="utf-8"):
 	if isinstance(obj, list):
 		out = []
 		for o in obj:
-			if isinstance(o, unicode):
+			if isinstance(o, text_type):
 				out.append(o.encode(encoding))
 			else:
 				out.append(o)
 		return out
-	elif isinstance(obj, unicode):
+	elif isinstance(obj, text_type):
 		return obj.encode(encoding)
 	else:
 		return obj
@@ -342,9 +342,9 @@ def encode(obj, encoding="utf-8"):
 def parse_val(v):
 	"""Converts to simple datatypes from SQL query results"""
 	if isinstance(v, (datetime.date, datetime.datetime)):
-		v = unicode(v)
+		v = text_type(v)
 	elif isinstance(v, datetime.timedelta):
-		v = ":".join(unicode(v).split(":")[:2])
+		v = ":".join(text_type(v).split(":")[:2])
 	elif isinstance(v, long):
 		v = int(v)
 	return v
@@ -570,7 +570,7 @@ def comma_and(some_list):
 def comma_sep(some_list, pattern):
 	if isinstance(some_list, (list, tuple)):
 		# list(some_list) is done to preserve the existing list
-		some_list = [unicode(s) for s in list(some_list)]
+		some_list = [text_type(s) for s in list(some_list)]
 		if not some_list:
 			return ""
 		elif len(some_list) == 1:
@@ -584,7 +584,7 @@ def comma_sep(some_list, pattern):
 def new_line_sep(some_list):
 	if isinstance(some_list, (list, tuple)):
 		# list(some_list) is done to preserve the existing list
-		some_list = [unicode(s) for s in list(some_list)]
+		some_list = [text_type(s) for s in list(some_list)]
 		if not some_list:
 			return ""
 		elif len(some_list) == 1:

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -11,6 +11,7 @@ from frappe import _
 from frappe import conf
 from copy import copy
 import urllib
+from six import text_type
 
 class MaxFileSizeReachedError(frappe.ValidationError): pass
 
@@ -114,8 +115,8 @@ def extract_images_from_html(doc, content):
 			filename = headers.split("filename=")[-1]
 
 			# decode filename
-			if not isinstance(filename, unicode):
-				filename = unicode(filename, 'utf-8')
+			if not isinstance(filename, text_type):
+				filename = text_type(filename, 'utf-8')
 		else:
 			mtype = headers.split(";")[0]
 			filename = get_random_filename(content_type=mtype)
@@ -147,7 +148,7 @@ def get_random_filename(extn=None, content_type=None):
 
 def save_file(fname, content, dt, dn, folder=None, decode=False, is_private=0):
 	if decode:
-		if isinstance(content, unicode):
+		if isinstance(content, text_type):
 			content = content.encode("utf-8")
 
 		if "," in content:

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -7,6 +7,7 @@ import frappe
 import re
 from frappe.utils import cint, strip_html_tags
 from frappe.model.base_document import get_controller
+from six import text_type
 
 def setup_global_search_table():
 	'''Creates __global_seach table'''
@@ -240,9 +241,9 @@ def get_formatted_value(value, field):
 	if(getattr(field, 'fieldtype', None) in ["Text", "Text Editor"]):
 		h = HTMLParser()
 		value = h.unescape(value)
-		value = (re.subn(r'<[\s]*(script|style).*?</\1>(?s)', '', unicode(value))[0])
+		value = (re.subn(r'<[\s]*(script|style).*?</\1>(?s)', '', text_type(value))[0])
 		value = ' '.join(value.split())
-	return field.label + " : " + strip_html_tags(unicode(value))
+	return field.label + " : " + strip_html_tags(text_type(value))
 
 def sync_global_search(flags=None):
 	'''Add values from `flags` (frappe.flags.update_global_search) to __global_search.

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -13,6 +13,7 @@ import os
 from markdown2 import markdown
 from bs4 import BeautifulSoup
 import jinja2.exceptions
+from six import text_type
 
 def sync():
 	# make table
@@ -119,7 +120,7 @@ class HelpDatabase(object):
 							fpath = os.path.join(basepath, fname)
 							with open(fpath, 'r') as f:
 								try:
-									content = frappe.render_template(unicode(f.read(), 'utf-8'),
+									content = frappe.render_template(text_type(f.read(), 'utf-8'),
 										{'docs_base_url': '/assets/{app}_docs'.format(app=app)})
 
 									relpath = self.get_out_path(fpath)

--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import frappe
 import logging
 from logging.handlers import RotatingFileHandler
+from six import text_type
 
 default_log_level = logging.DEBUG
 LOG_FILENAME = '../logs/frappe.log'
@@ -32,7 +33,7 @@ def get_logger(module, with_more_info=True):
 class SiteContextFilter(logging.Filter):
 	"""This is a filter which injects request information (if available) into the log."""
 	def filter(self, record):
-		record.msg = get_more_info_for_log() + unicode(record.msg)
+		record.msg = get_more_info_for_log() + text_type(record.msg)
 		return True
 
 def get_more_info_for_log():

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -19,6 +19,7 @@ from werkzeug.exceptions import NotFound, Forbidden
 from frappe.core.doctype.file.file import check_file_permission
 from frappe.website.render import render
 from frappe.utils import cint
+from six import text_type
 
 def report_error(status_code):
 	'''Build error. Show traceback in developer mode'''
@@ -103,10 +104,10 @@ def json_handler(obj):
 	"""serialize non-serializable data for json"""
 	# serialize date
 	if isinstance(obj, (datetime.date, datetime.timedelta, datetime.datetime)):
-		return unicode(obj)
+		return text_type(obj)
 
 	elif isinstance(obj, LocalProxy):
-		return unicode(obj)
+		return text_type(obj)
 
 	elif isinstance(obj, frappe.model.document.BaseDocument):
 		doc = obj.as_dict(no_nulls=True)

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -6,6 +6,7 @@ import frappe, os
 
 from frappe.website.utils import can_cache, delete_page_cache, extract_title
 from frappe.model.document import get_controller
+from six import text_type
 
 def resolve_route(path):
 	"""Returns the page route object based on searching in pages and generators.
@@ -245,13 +246,13 @@ def setup_source(page_info):
 		js_path = os.path.join(page_info.basepath, (page_info.basename or 'index') + '.js')
 		if os.path.exists(js_path):
 			if not '{% block script %}' in html:
-				js = unicode(open(js_path, 'r').read(), 'utf-8')
+				js = text_type(open(js_path, 'r').read(), 'utf-8')
 				html += '\n{% block script %}<script>' + js + '\n</script>\n{% endblock %}'
 
 		css_path = os.path.join(page_info.basepath, (page_info.basename or 'index') + '.css')
 		if os.path.exists(css_path):
 			if not '{% block style %}' in html:
-				css = unicode(open(css_path, 'r').read(), 'utf-8')
+				css = text_type(open(css_path, 'r').read(), 'utf-8')
 				html += '\n{% block style %}\n<style>\n' + css + '\n</style>\n{% endblock %}'
 
 	page_info.source = html
@@ -348,7 +349,7 @@ def sync_global_search():
 							frappe.flags.update_global_search.append(
 								dict(doctype='Static Web Page',
 									name=route,
-									content=frappe.unicode(text),
+									content=frappe.text_type(text),
 									published=1,
 									title=soup.title.string,
 									route=route))

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -11,6 +11,7 @@ import os, re
 import frappe
 from frappe import _
 import frappe.sessions
+from six import text_type
 
 def get_context(context):
 	if (frappe.session.user == "Guest" or
@@ -62,13 +63,13 @@ def get_desk_assets(build_version):
 				path = path.replace('/assets/', 'assets/')
 			try:
 				with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
-					assets[0]["data"] = assets[0]["data"] + "\n" + unicode(f.read(), "utf-8")
+					assets[0]["data"] = assets[0]["data"] + "\n" + text_type(f.read(), "utf-8")
 			except IOError as e:
 				pass
 
 		for path in data["include_css"]:
 			with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
-				assets[1]["data"] = assets[1]["data"] + "\n" + unicode(f.read(), "utf-8")
+				assets[1]["data"] = assets[1]["data"] + "\n" + text_type(f.read(), "utf-8")
 
 	return {
 		"build_version": data["build_version"],


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 12, in main
    commands = get_app_groups()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 23, in get_app_groups
    for app in get_apps():
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 88, in get_apps
    return frappe.get_all_apps(with_internal_apps=False, sites_path='.')
  File "/home/frappe/aditya/b/apps/frappe/frappe/__init__.py", line 736, in get_all_apps
    apps = get_file_items(os.path.join(sites_path, "apps.txt"), raise_not_found=True)
  File "/home/frappe/aditya/b/apps/frappe/frappe/__init__.py", line 868, in get_file_items
    content = read_file(path, raise_not_found=raise_not_found)
  File "/home/frappe/aditya/b/apps/frappe/frappe/__init__.py", line 883, in read_file
    if isinstance(path, unicode):
NameError: name 'unicode' is not defined
```


Fixed it by replacing all instances of `unicode` with `six.text_type`.

[`six.text_type`](https://pythonhosted.org/six/#six.text_type) is an alias for `unicode` in Python 2 and `str` in Python 3.