### PR TITLE
FileAndRedisStream inherits io.FileIO instead of file

### DIFF
--- a/frappe/async.py
+++ b/frappe/async.py
@@ -9,6 +9,7 @@ import frappe
 import os
 import time
 import redis
+from io import FileIO
 from frappe.utils import get_site_path
 from frappe import conf
 
@@ -138,7 +139,7 @@ def get_redis_server():
 	return redis_server
 
 
-class FileAndRedisStream(file):
+class FileAndRedisStream(FileIO):
 	def __init__(self, *args, **kwargs):
 		ret = super(FileAndRedisStream, self).__init__(*args, **kwargs)
 		self.count = 0


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3825 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 12, in main
    commands = get_app_groups()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 24, in get_app_groups
    app_commands = get_app_commands(app)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 63, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 11, in <module>
    import frappe.database
  File "/home/frappe/aditya/b/apps/frappe/frappe/database.py", line 15, in <module>
    import frappe.async
  File "/home/frappe/aditya/b/apps/frappe/frappe/async.py", line 141, in <module>
    class FileAndRedisStream(file):
NameError: name 'file' is not defined
```


Fixed it by replacing all instances of [`file`](https://docs.python.org/2/library/stdtypes.html#file-objects) with [`io.FileIO`](https://docs.python.org/3/library/io.html#io.FileIO).

`io.FileIO` is available in both [Python 2](https://docs.python.org/2/library/io.html#io.FileIO) and [Python 3](https://docs.python.org/3/library/io.html#io.FileIO)