### PR TITLE
Replaced 'except' clause syntax

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -72,7 +72,7 @@ def get_user_permissions(user=None):
 				out.setdefault("User", []).append(user)
 
 			frappe.cache().hset("user_permissions", user, out)
-		except frappe.SQLError, e:
+		except frappe.SQLError as e:
 			if e.args[0]==1146:
 				# called from patch
 				pass

--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -22,7 +22,7 @@ def update_genders_and_salutations():
 
 		try:
 			doc.insert(ignore_permissions=True)
-		except frappe.DuplicateEntryError, e:
+		except frappe.DuplicateEntryError as e:
 			# pass DuplicateEntryError and continue
 			if e.args and e.args[0]==doc.doctype and e.args[1]==doc.name:
 				# make sure DuplicateEntryError is for the exact same doc and not a related doc

--- a/frappe/email/doctype/email_alert/email_alert.py
+++ b/frappe/email/doctype/email_alert/email_alert.py
@@ -242,7 +242,7 @@ def evaluate_alert(doc, alert, event):
 		alert.send(doc)
 	except TemplateError:
 		frappe.throw(_("Error while evaluating Email Alert {0}. Please fix your template.").format(alert))
-	except Exception, e:
+	except Exception as e:
 		frappe.log_error(message=frappe.get_traceback(), title=e)
 		frappe.throw(_("Error in Email Alert"))
 

--- a/frappe/integrations/doctype/gsuite_settings/gsuite_settings.py
+++ b/frappe/integrations/doctype/gsuite_settings/gsuite_settings.py
@@ -51,7 +51,7 @@ def gsuite_callback(code=None):
 				frappe.db.set_value("Gsuite Settings", None, "refresh_token", r['refresh_token'])
 			frappe.db.commit()
 			return
-		except Exception, e:
+		except Exception as e:
 			frappe.throw(e.message)
 
 def run_gsuite_script(option, filename = None, template_id = None, destination_id = None, json_data = None):
@@ -68,7 +68,7 @@ def run_gsuite_script(option, filename = None, template_id = None, destination_i
 
 		try:
 			r = requests.post(gdoc.script_url, headers=headers, data=dumps(data, default=json_handler, separators=(',',':')))
-		except Exception, e:
+		except Exception as e:
 			frappe.throw(e.message)
 
 		try:

--- a/frappe/model/utils/link_count.py
+++ b/frappe/model/utils/link_count.py
@@ -44,7 +44,7 @@ def update_link_count():
 				try:
 					frappe.db.sql('update `tab{0}` set idx = idx + {1} where name=%s'.format(key[0], count),
 						key[1], auto_commit=1)
-				except Exception, e:
+				except Exception as e:
 					if e.args[0]!=1146: # table not found, single
 						raise e
 	# reset the count

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -180,7 +180,7 @@ def load_doctype_module(doctype, module=None, prefix="", suffix=""):
 	try:
 		if key not in doctype_python_modules:
 			doctype_python_modules[key] = frappe.get_module(module_name)
-	except ImportError, e:
+	except ImportError as e:
 		raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))
 
 	return doctype_python_modules[key]

--- a/frappe/utils/selenium_testdriver.py
+++ b/frappe/utils/selenium_testdriver.py
@@ -115,7 +115,7 @@ class TestDriver(object):
 			elem = self.get_wait(timeout).until(
 				EC.presence_of_element_located((_by, selector)))
 			return elem
-		except Exception, e:
+		except Exception as e:
 			# body = self.driver.find_element_by_id('body_div')
 			# print(body.get_attribute('innerHTML'))
 			self.print_console()


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3826 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 12, in main
    commands = get_app_groups()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 24, in get_app_groups
    app_commands = get_app_commands(app)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 63, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 11, in <module>
    import frappe.database
  File "/home/frappe/aditya/b/apps/frappe/frappe/database.py", line 18, in <module>
    import frappe.model.meta
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/meta.py", line 23, in <module>
    from frappe.model.document import Document
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/document.py", line 10, in <module>
    from frappe.model.base_document import BaseDocument, get_controller
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/base_document.py", line 12, in <module>
    from frappe.model.utils.link_count import notify_link_count
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/utils/link_count.py", line 47
    except Exception, e:
                    ^
SyntaxError: invalid syntax
```


Fixed it by replacing all instances of `except Exception, e:` with `except Exception as e:`

Python 3 [PEP 3110](https://www.python.org/dev/peps/pep-3110/) introduced changed syntax for `except` clause










