### PR TITLE
Replaced mixed usage of tabs and spaces for indents with tabs only

### DIFF
--- a/frappe/core/page/data_import_tool/exporter.py
+++ b/frappe/core/page/data_import_tool/exporter.py
@@ -284,7 +284,7 @@ def get_template(doctype=None, parent_doctype=None, all_doctypes="No", with_data
 	if from_data_import == "Yes" and excel_format == "Yes":
 		filename = frappe.generate_hash("", 10)
 		with open(filename, 'wb') as f:
-		    f.write(cstr(w.getvalue()).encode("utf-8"))
+			f.write(cstr(w.getvalue()).encode("utf-8"))
 		f = open(filename)
 		reader = csv.reader(f)
 

--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -16,12 +16,12 @@ def execute(filters=None):
 	data = frappe.get_list(doctype, fields=fields, as_list=True, user=user)
 
 	if show_permissions:
- 		columns = columns + ["Read", "Write", "Create", "Delete", "Submit", "Cancel", "Amend", "Print", "Email",
- 		                     "Report", "Import", "Export", "Share"]
- 		data = list(data)
- 		for i,item in enumerate(data):
- 			temp = frappe.permissions.get_doc_permissions(frappe.get_doc(doctype, item[0]), False,user)
- 			data[i] = item+(temp.get("read"),temp.get("write"),temp.get("create"),temp.get("delete"),temp.get("submit"),temp.get("cancel"),temp.get("amend"),temp.get("print"),temp.get("email"),temp.get("report"),temp.get("import"),temp.get("export"),temp.get("share"),)
+		columns = columns + ["Read", "Write", "Create", "Delete", "Submit", "Cancel", "Amend", "Print", "Email",
+		                     "Report", "Import", "Export", "Share"]
+		data = list(data)
+		for i,item in enumerate(data):
+			temp = frappe.permissions.get_doc_permissions(frappe.get_doc(doctype, item[0]), False,user)
+			data[i] = item+(temp.get("read"),temp.get("write"),temp.get("create"),temp.get("delete"),temp.get("submit"),temp.get("cancel"),temp.get("amend"),temp.get("print"),temp.get("email"),temp.get("report"),temp.get("import"),temp.get("export"),temp.get("share"),)
 
 	return columns, data
 

--- a/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
@@ -9,5 +9,5 @@ from frappe.model.document import Document
 class OAuthBearerToken(Document):
 	def validate(self):
 		if not self.expiration_time:
-	 		self.expiration_time = frappe.utils.datetime.datetime.strptime(self.creation, "%Y-%m-%d %H:%M:%S.%f") + frappe.utils.datetime.timedelta(seconds=self.expires_in)
+			self.expiration_time = frappe.utils.datetime.datetime.strptime(self.creation, "%Y-%m-%d %H:%M:%S.%f") + frappe.utils.datetime.timedelta(seconds=self.expires_in)
 

--- a/frappe/model/db_schema.py
+++ b/frappe/model/db_schema.py
@@ -464,8 +464,8 @@ class DbManager:
 		"""
 		Pass root_conn here for access to all databases.
 		"""
- 		if db:
- 			self.db = db
+		if db:
+			self.db = db
 
 	def get_current_host(self):
 		return self.db.sql("select user()")[0][0].split('@')[1]


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3827 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 12, in main
    commands = get_app_groups()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 24, in get_app_groups
    app_commands = get_app_commands(app)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 63, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 11, in <module>
    import frappe.database
  File "/home/frappe/aditya/b/apps/frappe/frappe/database.py", line 18, in <module>
    import frappe.model.meta
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/meta.py", line 23, in <module>
    from frappe.model.document import Document
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/document.py", line 10, in <module>
    from frappe.model.base_document import BaseDocument, get_controller
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/base_document.py", line 15, in <module>
    from frappe.model.db_schema import type_map, varchar_len
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/db_schema.py", line 467
    if db:
         ^
TabError: inconsistent use of tabs and spaces in indentation
```

Fixed it by replacing mixed usage of tabs and spaces with tabs only.

[Python 3 (PEP 8) disallows mixing of tabs and spaces for indentation](https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces). 

I somehow failed to catch these in #3813 