### PR TITLE
[minor] fixes in frappe.client.get_value method

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -61,14 +61,15 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False):
 
 	try:
 		filters = json.loads(filters)
-	except ValueError:
-		# name passed, not json
+	except (TypeError, ValueError):
+		# filters are not passesd, not json
 		pass
 
 	try:
 		fieldname = json.loads(fieldname)
-	except ValueError:
+	except (TypeError, ValueError):
 		# name passed, not json
+		fieldname = "name"
 		pass
 
 	return frappe.db.get_value(doctype, filters, fieldname, as_dict=as_dict, debug=debug)


### PR DESCRIPTION
catch the `TypeError` if the filters are not passed to get_value method