### PR TITLE
Print traceback on ImportError in get_app_commands

### DIFF
--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -5,6 +5,7 @@ import os
 import json
 import importlib
 import frappe.utils
+import traceback
 
 click.disable_unicode_literals_warning = True
 
@@ -62,6 +63,7 @@ def get_app_commands(app):
 	try:
 		app_command_module = importlib.import_module(app + '.commands')
 	except ImportError:
+		traceback.print_exc()
 		return []
 
 	ret = {}


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3827 yields following error message without any error Traceback

```
Usage: bench frappe [OPTIONS] COMMAND [ARGS]...

Error: No such command "build".
```

Fixed that by printing traceback

There's no way to know what's going on without printing traceback right before get_app_commands exits. It took me several hours to figure out what was going wrong, with traceback it wouldn't have taken as much. 