### PR TITLE
Replaced types import with six

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -18,7 +18,7 @@ import redis
 import frappe.model.meta
 from frappe.utils import now, get_datetime, cstr
 from frappe import _
-from types import StringType, UnicodeType
+from six import text_type, binary_type
 from frappe.utils.global_search import sync_global_search
 from frappe.model.utils.link_count import flush_local_link_count
 from six import iteritems
@@ -69,8 +69,8 @@ class Database:
 				use_unicode=True, charset='utf8mb4')
 		self._conn.converter[246]=float
 		self._conn.converter[12]=get_datetime
-		self._conn.encoders[UnicodeWithAttrs] = self._conn.encoders[UnicodeType]
-		self._conn.encoders[DateTimeDeltaType] = self._conn.encoders[StringType]
+		self._conn.encoders[UnicodeWithAttrs] = self._conn.encoders[text_type]
+		self._conn.encoders[DateTimeDeltaType] = self._conn.encoders[binary_type]
 
 		MYSQL_OPTION_MULTI_STATEMENTS_OFF = 1
 		self._conn.set_server_option(MYSQL_OPTION_MULTI_STATEMENTS_OFF)


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3833 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 64, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 11, in <module>
    import frappe.database
  File "/home/frappe/aditya/b/apps/frappe/frappe/database.py", line 21, in <module>
    from types import StringType, UnicodeType
ImportError: cannot import name 'StringType'
```

Fixed it by importing `six.text_type` instead of `types.UnicodeType` and
`six.binary_type` instead of `types.StringType`

[`types.StringType`](https://docs.python.org/2/library/types.html#types.StringType) is an alias for Python 2 built-in `str`.
[`types.UnicodeType`](https://docs.python.org/2/library/types.html#types.UnicodeType) is an alias for Python 2 built in `unicode`.

[`six.text_type`](https://pythonhosted.org/six/#six.text_type) is an alias for `unicode` in Python 2 and `str` in Python 3.
[`six.binary_type`](https://pythonhosted.org/six/#six.binary_type) is an alias for `str` in Python 2 and `bytes` in Python 3.
