### PR TITLE
Replaced Python 2 exec syntax usage with Python 3 syntax

### DIFF
--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -78,7 +78,7 @@ def execute_patch(patchmodule, method=None, methodargs=None):
 				frappe.flags.final_patches.append(patchmodule)
 			else:
 				if patchmodule.startswith("execute:"):
-					exec patchmodule.split("execute:")[1] in globals()
+					exec(patchmodule.split("execute:")[1],globals())
 				else:
 					frappe.get_attr(patchmodule.split()[0] + ".execute")()
 				update_patch_log(patchmodule)


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3834 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 93, in <module>
    main()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 13, in main
    commands = get_app_groups()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 25, in get_app_groups
    app_commands = get_app_commands(app)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 64, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 16, in <module>
    from frappe.model.sync import sync_for
  File "/home/frappe/aditya/b/apps/frappe/frappe/model/sync.py", line 12, in <module>
    from frappe.modules.patch_handler import block_user
  File "/home/frappe/aditya/b/apps/frappe/frappe/modules/patch_handler.py", line 81
    exec patchmodule.split("execute:")[1] in globals()
                   ^
SyntaxError: invalid syntax
```


Fixed it by replacing `exec a in b` with `exec(a,b)`

In Python 3 [`exec` is no longer a keyword](https://docs.python.org/3.0/whatsnew/3.0.html#removed-syntax) it remains as a function [`exec()`](https://docs.python.org/3.0/library/functions.html#exec)











