### PR TITLE
Replaced urllib.unquote imports with six.moves.urllib.parse.unquote

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -10,7 +10,6 @@ naming for same name files: file.gif, file-1.gif, file-2.gif etc
 
 import frappe
 import json
-import urllib
 import os
 import shutil
 import requests
@@ -23,6 +22,7 @@ from frappe.utils.nestedset import NestedSet
 from frappe.utils import strip, get_files_path
 from PIL import Image, ImageOps
 from six import StringIO
+from six.moves.urllib.parse import unquote
 import zipfile
 
 class FolderNotEmpty(frappe.ValidationError): pass
@@ -383,7 +383,7 @@ def get_web_image(file_url):
 		extn = None
 
 	extn = get_extension(filename, extn, r.content)
-	filename = "/files/" + strip(urllib.unquote(filename))
+	filename = "/files/" + strip(unquote(filename))
 
 	return image, filename, extn
 

--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import frappe, unittest
 
 from frappe.email.doctype.newsletter.newsletter import confirmed_unsubscribe
-from urllib import unquote
+from six.moves.urllib.parse import unquote
 
 emails = ["test_subscriber1@example.com", "test_subscriber2@example.com",
 			"test_subscriber3@example.com"]

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import frappe, urllib
+import frappe
 import pytz
 
 from frappe import _
@@ -12,6 +12,7 @@ from oauthlib.oauth2.rfc6749.endpoints.token import TokenEndpoint
 from oauthlib.oauth2.rfc6749.endpoints.resource import ResourceEndpoint
 from oauthlib.oauth2.rfc6749.endpoints.revocation import RevocationEndpoint
 from oauthlib.common import Request
+from six.moves.urllib.parse import unquote
 
 def get_url_delimiter(separator_character=" "):
 	return separator_character
@@ -134,7 +135,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		oac.scopes = get_url_delimiter().join(request.scopes)
 		oac.redirect_uri_bound_to_authorization_code = request.redirect_uri
 		oac.client = client_id
-		oac.user = urllib.unquote(cookie_dict['user_id'])
+		oac.user = unquote(cookie_dict['user_id'])
 		oac.authorization_code = code['code']
 		oac.save(ignore_permissions=True)
 		frappe.db.commit()
@@ -159,7 +160,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		except Exception as e:
 			print("Failed body authentication: Application %s does not exist".format(cid=request.client_id))
 
-		return frappe.session.user == urllib.unquote(cookie_dict.get('user_id', "Guest"))
+		return frappe.session.user == unquote(cookie_dict.get('user_id', "Guest"))
 
 	def authenticate_client_id(self, client_id, request, *args, **kwargs):
 		cli_id = frappe.db.get_value('OAuth Client', client_id, 'name')

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -17,7 +17,7 @@ import frappe.defaults
 import frappe.translate
 from frappe.utils.change_log import get_change_log
 import redis
-from urllib import unquote
+from six.moves.urllib.parse import unquote
 from frappe.desk.notifications import clear_notifications
 
 @frappe.whitelist()

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -10,7 +10,7 @@ from frappe.utils import get_hook_method, get_files_path, random_string, encode,
 from frappe import _
 from frappe import conf
 from copy import copy
-import urllib
+from six.moves.urllib.parse import unquote
 
 class MaxFileSizeReachedError(frappe.ValidationError): pass
 
@@ -66,7 +66,7 @@ def save_url(file_url, filename, dt, dn, folder, is_private):
 	# 	frappe.msgprint("URL must start with 'http://' or 'https://'")
 	# 	return None, None
 
-	file_url = urllib.unquote(file_url)
+	file_url = unquote(file_url)
 
 	f = frappe.get_doc({
 		"doctype": "File",


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3835 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 64, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 18, in <module>
    from frappe.website import render
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/render.py", line 7, in <module>
    import frappe.sessions
  File "/home/frappe/aditya/b/apps/frappe/frappe/sessions.py", line 20, in <module>
    from urllib import unquote
ImportError: cannot import name 'unquote'
```

Fixed it by importing `six.moves.urllib.parse.unquote` instead of `urllib.unquote`

[Python 3 (PEP 3108) renamed `urllib` module as `urllib.parse`](https://www.python.org/dev/peps/pep-3108/#urllib-package). Six provides consistent interface to both `urllib` and `urllib.parse` using a fake module [six.moves.urllib.parse](https://pythonhosted.org/six/#module-six.moves.urllib.parse)