### PR TITLE
Replaced urllib.quote imports with six.moves.urllib.parse.quote

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -17,7 +17,7 @@ from frappe.translate import get_lang_code
 from frappe.utils.password import check_password
 from frappe.core.doctype.authentication_log.authentication_log import add_authentication_log
 
-from urllib import quote
+from six.moves.urllib.parse import quote
 
 class HTTPRequest:
 	def __init__(self):

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 import frappe, json
 from frappe.oauth import OAuthWebRequestValidator, WebApplicationServer
 from oauthlib.oauth2 import FatalClientError, OAuth2Error
-from urllib import quote, urlencode
+from urllib import urlencode
+from six.moves.urllib.parse import quote
 from werkzeug import url_fix
 from urlparse import urlparse
 from frappe.integrations.doctype.oauth_provider_settings.oauth_provider_settings import get_oauth_settings

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import unicode_literals, print_function
 from werkzeug.test import Client
-import os, re, urllib, sys, json, hashlib, requests, traceback
+import os, re, sys, json, hashlib, requests, traceback
 from markdown2 import markdown as _markdown
 from .html_utils import sanitize_html
 import frappe
@@ -13,6 +13,7 @@ from frappe.utils.identicon import Identicon
 from email.utils import parseaddr, formataddr
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *
+from six.moves.urllib.parse import quote
 
 default_fields = ['doctype', 'name', 'owner', 'creation', 'modified', 'modified_by',
 	'parent', 'parentfield', 'parenttype', 'idx', 'docstatus']
@@ -177,7 +178,7 @@ def dict_to_str(args, sep='&'):
 	"""
 	t = []
 	for k in args.keys():
-		t.append(str(k)+'='+urllib.quote(str(args[k] or '')))
+		t.append(str(k)+'='+quote(str(args[k] or '')))
 	return sep.join(t)
 
 # Get Defaults

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -12,6 +12,7 @@ from babel.core import UnknownLocaleError
 from dateutil import parser
 from num2words import num2words
 from six.moves import html_parser as HTMLParser
+from six.moves.urllib.parse import quote
 from html2text import html2text
 from six import iteritems
 
@@ -795,7 +796,7 @@ def expand_relative_urls(html):
 	return html
 
 def quoted(url):
-	return cstr(urllib.quote(encode(url), safe=b"~@#$&()*!+=:;,.?/'"))
+	return cstr(quote(encode(url), safe=b"~@#$&()*!+=:;,.?/'"))
 
 def quote_urls(html):
 	def _quote_url(match):

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _
 from frappe.utils import get_request_site_address, encode
 from frappe.model.document import Document
-from urllib import quote
+from six.moves.urllib.parse import quote
 from frappe.website.router import resolve_route
 from frappe.website.doctype.website_theme.website_theme import add_website_theme
 

--- a/frappe/www/rss.py
+++ b/frappe/www/rss.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 import urllib
 from frappe.utils import escape_html, get_request_site_address, now, cstr
+from six.moves.urllib.parse import quote
 
 no_cache = 1
 base_template_path = "templates/www/rss.xml"
@@ -20,7 +21,7 @@ def get_context(context):
 		order by published_on desc limit 20""", as_dict=1)
 
 	for blog in blog_list:
-		blog_page = cstr(urllib.quote(blog.name.encode("utf-8")))
+		blog_page = cstr(quote(blog.name.encode("utf-8")))
 		blog.link = urllib.basejoin(host, blog_page)
 		blog.content = escape_html(blog.content or "")
 

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -8,6 +8,7 @@ import frappe
 from frappe.utils import get_request_site_address, get_datetime, nowdate
 from frappe.website.router import get_pages, get_all_page_context_from_doctypes
 from six import iteritems
+from six.moves.urllib.parse import quote
 
 no_cache = 1
 no_sitemap = 1
@@ -20,13 +21,13 @@ def get_context(context):
 	for route, page in iteritems(get_pages()):
 		if not page.no_sitemap:
 			links.append({
-				"loc": urllib.basejoin(host, urllib.quote(page.name.encode("utf-8"))),
+				"loc": urllib.basejoin(host, quote(page.name.encode("utf-8"))),
 				"lastmod": nowdate()
 			})
 
 	for route, data in iteritems(get_all_page_context_from_doctypes()):
 		links.append({
-			"loc": urllib.basejoin(host, urllib.quote((route or "").encode("utf-8"))),
+			"loc": urllib.basejoin(host, quote((route or "").encode("utf-8"))),
 			"lastmod": get_datetime(data.get("modified")).strftime("%Y-%m-%d")
 		})
 


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3836 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 64, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 18, in <module>
    from frappe.website import render
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/render.py", line 16, in <module>
    from frappe.website.context import get_context
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/context.py", line 7, in <module>
    from frappe.website.doctype.website_settings.website_settings import get_website_settings
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/doctype/website_settings/website_settings.py", line 9, in <module>
    from urllib import quote
ImportError: cannot import name 'quote'
```

Fixed it by importing `six.moves.urllib.parse.quote` instead of `urllib.quote`

[Python 3 (PEP 3108) renamed `urllib` module as `urllib.parse`](https://www.python.org/dev/peps/pep-3108/#urllib-package). Six provides consistent interface to both `urllib` and `urllib.parse` using a fake module [six.moves.urllib.parse](https://pythonhosted.org/six/#module-six.moves.urllib.parse)