### PR TITLE
Replaced Python 2 print syntax with Python 3 syntax

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 import frappe
 from frappe.model.document import Document
 from frappe.utils import cint, has_gravatar, format_datetime, now_datetime, get_formatted_email
@@ -191,7 +191,7 @@ class User(Document):
 				self.email_new_password(new_password)
 
 		except frappe.OutgoingEmailError:
-			print frappe.get_traceback()
+			print(frappe.get_traceback())
 			pass # email server not set, don't send email
 
 	@Document.hook

--- a/frappe/patches/v4_0/file_manager_hooks.py
+++ b/frappe/patches/v4_0/file_manager_hooks.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 import frappe
 import os
@@ -25,7 +25,7 @@ def execute():
 			_file_name, content = get_file(name)
 			b.content_hash = get_content_hash(content)
 		except IOError:
-			print 'Warning: Error processing ', name
+			print('Warning: Error processing ', name)
 			_file_name = old_file_name
 			b.content_hash = None
 

--- a/frappe/website/purifycss.py
+++ b/frappe/website/purifycss.py
@@ -7,6 +7,7 @@ sUpdate source and target apps below and run from CLI
 
 '''
 
+from __future__ import print_function
 import frappe, re, os
 
 source = frappe.get_app_path('frappe_theme', 'public', 'less', 'frappe_theme.less')
@@ -39,4 +40,4 @@ def purifycss():
 							classes.remove(c)
 
 	for c in sorted(classes):
-		print c
+		print(c)

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 import frappe, re, os
 from six import iteritems
 
@@ -302,7 +302,7 @@ def add_missing_headers():
 						else:
 							fname = fname[:-3]
 						h = fname.replace('_', ' ').replace('-', ' ').title()
-						print h
+						print(h)
 						content = '# {0}\n\n'.format(h) + content
 						f.write(content.encode('utf-8'))
 

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals, print_function
+from __future__ import unicode_literals
 import frappe, re, os
 from six import iteritems
 
@@ -302,7 +302,6 @@ def add_missing_headers():
 						else:
 							fname = fname[:-3]
 						h = fname.replace('_', ' ').replace('-', ' ').title()
-						print(h)
 						content = '# {0}\n\n'.format(h) + content
 						f.write(content.encode('utf-8'))
 

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 no_sitemap = 1
 no_cache = 1
@@ -22,7 +22,7 @@ def get_context(context):
 		boot = frappe.sessions.get()
 	except Exception as e:
 		boot = frappe._dict(status='failed', error = str(e))
-		print frappe.get_traceback()
+		print(frappe.get_traceback())
 
 	# this needs commit
 	csrf_token = frappe.sessions.get_csrf_token()


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3837 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 93, in <module>
    main()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 13, in main
    commands = get_app_groups()
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 25, in get_app_groups
    app_commands = get_app_commands(app)
  File "/home/frappe/aditya/b/apps/frappe/frappe/utils/bench_helper.py", line 64, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/b/apps/frappe/frappe/limits.py", line 5, in <module>
    from frappe.installer import update_site_config
  File "/home/frappe/aditya/b/apps/frappe/frappe/installer.py", line 18, in <module>
    from frappe.website import render
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/render.py", line 16, in <module>
    from frappe.website.context import get_context
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/context.py", line 7, in <module>
    from frappe.website.doctype.website_settings.website_settings import get_website_settings
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/doctype/website_settings/website_settings.py", line 10, in <module>
    from frappe.website.router import resolve_route
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/router.py", line 7, in <module>
    from frappe.website.utils import can_cache, delete_page_cache, extract_title
  File "/home/frappe/aditya/b/apps/frappe/frappe/website/utils.py", line 305
    print h
          ^
SyntaxError: Missing parentheses in call to 'print'
```


Fixed it by replacing all instances of `print a ...` with `print(a ...` and adding `from __future__ import print_function`

[PEP 3105](https://www.python.org/dev/peps/pep-3105/) in Python 3 [print is a function](https://docs.python.org/3/whatsnew/3.0.html#print-is-a-function)










