### PR TITLE
[hotfix] fixes for AttributeError: 'NoneType' object has no attribute 'split'

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -291,7 +291,7 @@ class DatabaseQuery(object):
 
 		# prepare in condition
 		if f.operator.lower() in ('in', 'not in'):
-			values = f.value
+			values = f.value or ''
 			if not isinstance(values, (list, tuple)):
 				values = values.split(",")
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -31,6 +31,19 @@ class TestReportview(unittest.TestCase):
 		self.assertTrue({"name":"DocField"} \
 			in DatabaseQuery("DocType").execute(filters={"name": "DocField"}))
 
+	def test_in_not_in_filters(self):
+		self.assertFalse(DatabaseQuery("DocType").execute(filters={"name": ["in", None]}))
+		self.assertTrue({"name":"DocType"} \
+				in DatabaseQuery("DocType").execute(filters={"name": ["not in", None]}))
+
+		for result in [{"name":"DocType"}, {"name":"DocField"}]:
+			self.assertTrue(result
+				in DatabaseQuery("DocType").execute(filters={"name": ["in", 'DocType,DocField']}))
+
+		for result in [{"name":"DocType"}, {"name":"DocField"}]:
+			self.assertFalse(result
+				in DatabaseQuery("DocType").execute(filters={"name": ["not in", 'DocType,DocField']}))
+
 	def test_or_filters(self):
 		data = DatabaseQuery("DocField").execute(
 				filters={"parent": "DocType"}, fields=["fieldname", "fieldtype"],


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/desk/reportview.py", line 18, in get
    data = compress(execute(**args), args = args)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/desk/reportview.py", line 23, in execute
    return DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/model/db_query.py", line 88, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/model/db_query.py", line 100, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/model/db_query.py", line 118, in prepare_args
    self.build_conditions()
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/model/db_query.py", line 249, in build_conditions
    self.build_filter_conditions(self.filters, self.conditions)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/model/db_query.py", line 270, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/model/db_query.py", line 296, in prepare_filter_condition
    values = values.split(",")
AttributeError: 'NoneType' object has no attribute 'split'
```