### PR TITLE
added whitelisted function get_time_zone

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -297,3 +297,8 @@ def get_js(items):
 		out.append(code)
 
 	return out
+
+@frappe.whitelist(allow_guest=True)
+def get_time_zone():
+	'''Returns default time zone'''
+	return {"time_zone": frappe.defaults.get_defaults().get("time_zone")}


### PR DESCRIPTION
Use case:

During syncing data all the DocTypes on Frappe server have modified date. This date can be used to identify which of the entry (Local or Remote) was modified latest and sync accordingly.

Only problem is client device (Android) and Server (Frappe) can be on different timezones.

Need to know timezone to convert both times to epoch time. For that Frappe Server Timezone is required.

I tried to find whitelisted function which could be used, couldn't find any function.