### PR TITLE
Print Format: Ignore Extract Images Error

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -36,7 +36,10 @@ class PrintFormat(Document):
 			data = json.loads(self.format_data)
 			for df in data:
 				if df.get('fieldtype') and df['fieldtype'] in ('HTML', 'Custom HTML') and df.get('options'):
-					df['options'] = extract_images_from_html(self, df['options'])
+					try:
+						df['options'] = extract_images_from_html(self, df['options'])
+					except TypeError:
+						pass
 			self.format_data = json.dumps(data)
 
 	def on_update(self):


### PR DESCRIPTION
Catch exception when try to extract images eg if have a base64 code in a field.

`<img src="data:image/png;base64, {{ doc.barcode }}">
`
[Post in discuss](https://discuss.erpnext.com/t/cant-add-dynamic-base64-image-in-custom-print-format/26770) for more details