### PR TITLE
[revert] Print traceback on ImportError in get_app_commands

### DIFF
--- a/frappe/custom/doctype/customize_form/test_customize_form.js
+++ b/frappe/custom/doctype/customize_form/test_customize_form.js
@@ -11,7 +11,7 @@ QUnit.test("test customize form", function(assert) {
 
 		() => frappe.timeout(2),
 
-		() => assert.equal(cur_frm.doc.fields[1].fieldname, 'status'),
+		() => assert.equal(cur_frm.doc.fields[1].fieldname, 'status', "Status Field"),
 
 		// open "status" row
 		() => cur_frm.fields_dict.fields.grid.grid_rows[1].toggle_view(),
@@ -25,7 +25,7 @@ QUnit.test("test customize form", function(assert) {
 		() => frappe.timeout(0.5),
 
 		// status still exists
-		() => assert.equal(cur_frm.doc.fields[1].fieldname, 'status'),
+		() => assert.equal(cur_frm.doc.fields[1].fieldname, 'status', "Status Field Still Exists"),
 		() => done()
 	]);
 });

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -5,7 +5,6 @@ import os
 import json
 import importlib
 import frappe.utils
-import traceback
 
 click.disable_unicode_literals_warning = True
 
@@ -63,7 +62,6 @@ def get_app_commands(app):
 	try:
 		app_command_module = importlib.import_module(app + '.commands')
 	except ImportError:
-		traceback.print_exc()
 		return []
 
 	ret = {}


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/10253

reverted https://github.com/frappe/frappe/pull/3833

```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/utils/bench_helper.py", line 64, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named commands
```