### PR TITLE
Replaced urlparse imports with six.moves.urllib.parse

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -8,7 +8,7 @@ import frappe.handler
 import frappe.client
 from frappe.utils.response import build_response
 from frappe import _
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 from urllib import urlencode
 
 def handle():

--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -10,7 +10,7 @@ from frappe.model.document import Document
 import dropbox, json
 from frappe.utils.backups import new_backup
 from frappe.utils.background_jobs import enqueue
-from urlparse import urlparse, parse_qs
+from six.moves.urllib.parse import urlparse, parse_qs
 from frappe.integrations.utils import make_post_request
 from frappe.utils import (cint, split_emails, get_request_site_address, cstr,
 	get_files_path, get_backups_path, encode, get_url)

--- a/frappe/integrations/doctype/social_login_keys/social_login_keys.py
+++ b/frappe/integrations/doctype/social_login_keys/social_login_keys.py
@@ -10,11 +10,7 @@ import socket
 
 from frappe.model.document import Document
 from frappe import _
-
-try:
-	from urllib.parse import urlparse
-except ImportError:
-	from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 class SocialLoginKeys(Document):
 	def validate(self):

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -5,7 +5,7 @@ from oauthlib.oauth2 import FatalClientError, OAuth2Error
 from urllib import urlencode
 from six.moves.urllib.parse import quote
 from werkzeug import url_fix
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 from frappe.integrations.doctype.oauth_provider_settings.oauth_provider_settings import get_oauth_settings
 from frappe import _
 
@@ -179,7 +179,6 @@ def openid_profile(*args, **kwargs):
 	frappe.local.response = user_profile
 
 def validate_url(url_string):
-	from urlparse import urlparse
 	try:
 		result = urlparse(url_string)
 		if result.scheme and result.scheme in ["http", "https", "ftp", "ftps"]:

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -4,7 +4,8 @@
 
 from __future__ import unicode_literals
 import frappe
-import json, urlparse
+import json
+from six.moves.urllib.parse import parse_qs
 from frappe.utils import get_request_session
 from frappe import _
 
@@ -40,7 +41,7 @@ def make_post_request(url, auth=None, headers=None, data=None):
 		frappe.flags.integration_request.raise_for_status()
 
 		if frappe.flags.integration_request.headers.get("content-type") == "text/plain; charset=utf-8":
-			return urlparse.parse_qs(frappe.flags.integration_request.text)
+			return parse_qs(frappe.flags.integration_request.text)
 
 		return frappe.flags.integration_request.json()
 	except Exception as exc:

--- a/frappe/limits.py
+++ b/frappe/limits.py
@@ -5,7 +5,8 @@ from frappe.utils import now_datetime, getdate, flt, cint, get_fullname
 from frappe.installer import update_site_config
 from frappe.utils.data import formatdate
 from frappe.utils.user import get_enabled_system_users, disable_users
-import os, subprocess, urlparse, urllib
+import os, subprocess, urllib
+from six.moves.urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 class SiteExpiredError(frappe.ValidationError):
 	http_status_code = 417
@@ -121,8 +122,8 @@ def get_usage_info():
 	return usage_info
 
 def get_upgrade_url(upgrade_url):
-	parts = urlparse.urlsplit(upgrade_url)
-	params = dict(urlparse.parse_qsl(parts.query))
+	parts = urlsplit(upgrade_url)
+	params = dict(parse_qsl(parts.query))
 	params.update({
 		'site': frappe.local.site,
 		'email': frappe.session.user,
@@ -131,7 +132,7 @@ def get_upgrade_url(upgrade_url):
 	})
 
 	query = urllib.urlencode(params, doseq=True)
-	url = urlparse.urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+	url = urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
 	return url
 
 def get_upgrade_link(upgrade_url, label=None):

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -3,7 +3,6 @@ import frappe
 import pytz
 
 from frappe import _
-from urlparse import parse_qs, urlparse
 from oauthlib.oauth2.rfc6749.tokens import BearerToken
 from oauthlib.oauth2.rfc6749.grant_types import AuthorizationCodeGrant, ImplicitGrant, ResourceOwnerPasswordCredentialsGrant, ClientCredentialsGrant,  RefreshTokenGrant, OpenIDConnectAuthCode
 from oauthlib.oauth2 import RequestValidator
@@ -12,7 +11,7 @@ from oauthlib.oauth2.rfc6749.endpoints.token import TokenEndpoint
 from oauthlib.oauth2.rfc6749.endpoints.resource import ResourceEndpoint
 from oauthlib.oauth2.rfc6749.endpoints.revocation import RevocationEndpoint
 from oauthlib.common import Request
-from six.moves.urllib.parse import unquote
+from six.moves.urllib.parse import parse_qs, urlparse, unquote
 
 def get_url_delimiter(separator_character=" "):
 	return separator_character

--- a/frappe/tests/ui/test_oauth20.py
+++ b/frappe/tests/ui/test_oauth20.py
@@ -5,11 +5,7 @@ from __future__ import unicode_literals
 import unittest, frappe, requests, time
 from frappe.test_runner import make_test_records
 from frappe.utils.selenium_testdriver import TestDriver
-
-try:
-	from urllib.parse import urlparse
-except ImportError:
-	from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 class TestOAuth20(unittest.TestCase):
 	def setUp(self):


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3838 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/a7044e86/b/apps/frappe/frappe/utils/bench_helper.py", line 64, in get_app_commands
    app_command_module = importlib.import_module(app + '.commands')
  File "/home/frappe/aditya/a7044e86/b/env/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/frappe/aditya/a7044e86/b/apps/frappe/frappe/commands/__init__.py", line 62, in <module>
    commands = get_commands()
  File "/home/frappe/aditya/a7044e86/b/apps/frappe/frappe/commands/__init__.py", line 56, in get_commands
    from .site import commands as site_commands
  File "/home/frappe/aditya/a7044e86/b/apps/frappe/frappe/commands/site.py", line 9, in <module>
    from frappe.limits import update_limits, get_limits
  File "/home/frappe/aditya/a7044e86/b/apps/frappe/frappe/limits.py", line 8, in <module>
    import os, subprocess, urlparse, urllib
ImportError: No module named 'urlparse'
```

Fixed it by importing `six.moves.urllib.parse` instead of `urlparse`

[Python 3 (PEP 3108) renamed `urlparse` module as `urllib.parse`](https://www.python.org/dev/peps/pep-3108/#urllib-package). Six provides consistent interface to both `urlparse` and `urllib.parse` using a fake module [six.moves.urllib.parse](https://pythonhosted.org/six/#module-six.moves.urllib.parse)