### PR TITLE
Replaced cPickle import with six.moves.cPickle

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import redis, frappe, re
-import cPickle as pickle
+from six.moves import cPickle as pickle
 from frappe.utils import cstr
 from six import iteritems
 


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3847 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/dbc5336b/b/apps/frappe/frappe/utils/bench_helper.py", line 93, in <module>
    main()
  File "/home/frappe/aditya/dbc5336b/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/dbc5336b/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/dbc5336b/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/dbc5336b/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/dbc5336b/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/dbc5336b/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/dbc5336b/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/dbc5336b/b/apps/frappe/frappe/commands/utils.py", line 15, in build
    frappe.init('')
  File "/home/frappe/aditya/dbc5336b/b/apps/frappe/frappe/__init__.py", line 158, in init
    setup_module_map()
  File "/home/frappe/aditya/dbc5336b/b/apps/frappe/frappe/__init__.py", line 844, in setup_module_map
    _cache = cache()
  File "/home/frappe/aditya/dbc5336b/b/apps/frappe/frappe/__init__.py", line 231, in cache
    from frappe.utils.redis_wrapper import RedisWrapper
  File "/home/frappe/aditya/dbc5336b/b/apps/frappe/frappe/utils/redis_wrapper.py", line 6, in <module>
    import cPickle as pickle
ImportError: No module named 'cPickle'

```

Fixed it by importing `six.moves.cPickle` instead of `cPickle`

[Python 3 (PEP 3108) removed `cPickle` module](https://www.python.org/dev/peps/pep-3108/#merging-c-and-python-implementations-of-the-same-interface) (Python 3 `pickle` module attempts to import accelerated version i.e. Python 2 `cPickle` now renamed to `_pickle`). Six provides consistent interface to both `cPickle` and `pickle` using a fake module [six.moves.cPickle](https://pythonhosted.org/six/#module-six.moves)