### PR TITLE
Added order by in_create for dynamic link query

### DIFF
--- a/frappe/model/dynamic_links.py
+++ b/frappe/model/dynamic_links.py
@@ -8,19 +8,21 @@ import frappe
 # For example Journal Entry should be validated before GL Entry (which is an internal doctype)
 
 dynamic_link_queries =  [
-	"""select parent,
-		(select read_only from `tabDocType` where name=tabDocField.parent) as read_only,
-		fieldname, options 
-	from tabDocField 
-	where fieldtype='Dynamic Link' 
-	order by read_only""",
+	"""select tabDocField.parent,
+		`tabDocType`.read_only, `tabDocType`.in_create,
+		tabDocField.fieldname, tabDocField.options
+	from tabDocField, `tabDocType`
+	where `tabDocField`.fieldtype='Dynamic Link' and
+	`tabDocType`.name=`tabDocField`.parent
+	order by `tabDocType`.read_only, `tabDocType`.in_create""",
 
-	"""select dt as parent,
-		(select read_only from `tabDocType` where name=`tabCustom Field`.dt) as read_only,
-		fieldname, options 
-	from `tabCustom Field` 
-	where fieldtype='Dynamic Link' 
-	order by read_only""",
+	"""select `tabCustom Field`.dt as parent,
+		`tabDocType`.read_only, `tabDocType`.in_create,
+		`tabCustom Field`.fieldname, `tabCustom Field`.options
+	from `tabCustom Field`, `tabDocType`
+	where `tabCustom Field`.fieldtype='Dynamic Link' and
+	`tabDocType`.name=`tabCustom Field`.dt
+	order by `tabDocType`.read_only, `tabDocType`.in_create""",
 ]
 
 def get_dynamic_link_map(for_delete=False):


### PR DESCRIPTION
User can not able to see view ledger button in the chart of account because recently we have enabled user can not search option for the GL Entry. If we disabled the field then system shows the GL Entry in the validation link while cancelling the Sales Invoice
![screen shot 2017-08-03 at 1 07 17 pm](https://user-images.githubusercontent.com/8780500/28911151-4b025a18-784d-11e7-9398-08c4ad7e8ee8.png)

So added order by in_create to fix the issue and [disabled](https://github.com/frappe/erpnext/pull/10254) User can not search option in the GL Entry
![screen shot 2017-08-03 at 1 06 51 pm](https://user-images.githubusercontent.com/8780500/28911180-5b08d13a-784d-11e7-81e1-185e37eead50.png)

 Test case https://github.com/frappe/erpnext/pull/10276