### PR TITLE
Title display issue in mobile UI #3799

### DIFF
--- a/frappe/public/css/mobile.css
+++ b/frappe/public/css/mobile.css
@@ -25,6 +25,9 @@ body {
   body[data-route^="Form"] .page-title h1 {
     margin-top: 12px;
   }
+  body[data-route^="Form"] .page-title h1.editable-title {
+    padding-right: 80px;
+  }
   body[data-route^="Form"] .page-title .indicator {
     display: inline-block;
     margin-top: 12px;
@@ -197,7 +200,7 @@ body {
   }
   body[data-route^="Form"] .page-title .title-text {
     font-size: 16px;
-    width: calc(100% - 30px);
+    width: calc(100% - 90px);
   }
   body[data-route^="Form"] .page-title .indicator {
     float: left;

--- a/frappe/public/css/page.css
+++ b/frappe/public/css/page.css
@@ -44,7 +44,6 @@
   vertical-align: middle;
 }
 .page-title .title-image {
-  display: inline-block;
   width: 46px;
   height: 0;
   padding: 23px 0;
@@ -56,6 +55,7 @@
   text-align: center;
   line-height: 0;
   float: left;
+  margin-right: 10px;
 }
 .editable-title .title-text {
   cursor: pointer;

--- a/frappe/public/less/mobile.less
+++ b/frappe/public/less/mobile.less
@@ -34,6 +34,9 @@ body {
 	body[data-route^="Form"] {
 		.page-title h1 {
 			margin-top: 12px;
+			&.editable-title {
+				padding-right: 80px;
+			}
 		}
 
 		.page-title .indicator {
@@ -230,7 +233,7 @@ body {
 		.page-title {
 			.title-text {
 				font-size: 16px;
-				width: calc(~"100% - 30px");
+				width: calc(~"100% - 90px");
 			}
 			.indicator {
 				float: left;

--- a/frappe/public/less/page.less
+++ b/frappe/public/less/page.less
@@ -54,7 +54,6 @@
 	}
 
 	.title-image {
-		display: inline-block;
 		width: 46px;
 		height: 0;
 		padding: 23px 0;
@@ -66,6 +65,7 @@
 		text-align: center;
 		line-height: 0;
 		float: left;
+		margin-right: 10px;
 	}
 }
 


### PR DESCRIPTION
Previously it is looking like below: 

<img width="389" alt="mobile_title_view" src="https://user-images.githubusercontent.com/28141909/28914829-b5c609aa-785a-11e7-8d5a-bcf869dc0f8f.png">

Fixed as below:

![screen shot 2017-08-03 at 2 47 08 pm](https://user-images.githubusercontent.com/28141909/28914874-d965a6ae-785a-11e7-90c5-875c352cde31.png)

Title without profile image:

![screen shot 2017-08-03 at 3 57 03 pm](https://user-images.githubusercontent.com/28141909/28917795-871640ac-7864-11e7-994b-c90e615ffb4b.png)

![screen shot 2017-08-03 at 3 59 30 pm](https://user-images.githubusercontent.com/28141909/28917871-cc929d4c-7864-11e7-8527-cd320e139085.png)
