### PR TITLE
Handle error when _user_tags column is added on the fly

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -240,7 +240,12 @@ def get_stats(stats, doctype, filters=[]):
 		filters = json.loads(filters)
 	stats = {}
 
-	columns = frappe.db.get_table_columns(doctype)
+	try:
+		columns = frappe.db.get_table_columns(doctype)
+	except MySQLdb.OperationalError:
+		# raised when _user_tags column is added on the fly
+		columns = []
+
 	for tag in tags:
 		if not tag in columns: continue
 		try:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/desk/reportview.py", line 232, in get_sidebar_stats
    return {"defined_cat":cat_tags, "stats":get_stats(stats, doctype, filters)}
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/desk/reportview.py", line 243, in get_stats
    columns = frappe.db.get_table_columns(doctype)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/database.py", line 835, in get_table_columns
    return self.get_db_table_columns('tab' + doctype)
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/database.py", line 831, in get_db_table_columns
    return [r[0] for r in self.sql("DESC `%s`" % table)]
  File "/home/frappe/benches/bench-2017-07-31/apps/frappe/frappe/database.py", line 165, in sql
    self._cursor.execute(query)
  File "/home/frappe/benches/bench-2017-07-31/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/home/frappe/benches/bench-2017-07-31/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
OperationalError: (1684, "Table 'aa9c7faf7d000ad9'.'tabTask' was skipped since its definition is being modified by concurrent DDL statement")
```