### PR TITLE
if df.options not available, use doc.company if available

### DIFF
--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -246,6 +246,9 @@ $.extend(frappe.meta, {
 			} else if(cur_frm && cur_frm.doc[df.options]) {
 				currency = cur_frm.doc[df.options];
 			}
+		} else if(doc && doc.Company){
+			currency = frappe.model.get_value("Company", doc.Company, "default_currency");
+			console.log("expected currency",frappe.model.get_value("Company", doc.Company, "default_currency"));
 		}
 		return currency;
 	},

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -248,7 +248,6 @@ $.extend(frappe.meta, {
 			}
 		} else if(doc && doc.Company){
 			currency = frappe.model.get_value("Company", doc.Company, "default_currency");
-			console.log("expected currency",frappe.model.get_value("Company", doc.Company, "default_currency"));
 		}
 		return currency;
 	},


### PR DESCRIPTION
Reference: frappe/erpnext#10099

`get_currency_field` should try to check for more information. In this case, check if a `_Frm` object is available and if it has a company field, attempt to get the company currency using that information.

Example from ERPNext:
### Before
![screenshot from 2017-08-03 11-49-50](https://user-images.githubusercontent.com/818803/28918690-4550a13e-7842-11e7-8d96-98f2fa1e3532.png)


### After
![screenshot from 2017-08-03 11-36-38](https://user-images.githubusercontent.com/818803/28918197-4c0f3f6e-7840-11e7-8cc6-7cdd7304b26e.png)

