### PR TITLE
[minor] pass null instead of false if there are no unsaved changes

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -494,7 +494,7 @@ frappe.Application = Class.extend({
 					if(doc.__unsaved) { unsaved_docs.push(doc.name); }
 				}
 			}
-			return unsaved_docs.length ? true : false;
+			return unsaved_docs.length ? true : null;
 		};
 	},
 


### PR DESCRIPTION
OnBeforeUnload dialog is prompted even if there are no unsaved docs available.

ref https://stackoverflow.com/questions/276660/how-can-i-override-the-onbeforeunload-dialog-and-replace-it-with-my-own