### PR TITLE
[Fix] Workflow is not working even if the user has permission to submit the record

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -941,7 +941,7 @@ _f.Frm.prototype.validate_form_action = function(action, resolve) {
 	// Allow submit, write, cancel and create permissions for read only documents that are assigned by
 	// workflows if the user already have those permissions. This is to allow for users to
 	// continue through the workflow states and to allow execution of functions like Duplicate.
-	if (frappe.workflow.is_read_only(this.doctype, this.docname) && (perms["write"] ||
+	if (!frappe.workflow.is_read_only(this.doctype, this.docname) && (perms["write"] ||
 		perms["create"] || perms["submit"] || perms["cancel"])) {
 		var allowed_for_workflow = true;
 	}


### PR DESCRIPTION
**Issue**
User not able to submit the quotation even if he has permission to submit the quotation and has permission to edit the data in the workflow
![screen shot 2017-08-07 at 6 36 59 pm](https://user-images.githubusercontent.com/8780500/29028793-f966c55a-7ba2-11e7-9b1c-9ccf84ae3912.png)


**Workflow for Quotation**
![screen shot 2017-08-07 at 7 01 05 pm](https://user-images.githubusercontent.com/8780500/29028799-0223681a-7ba3-11e7-878b-4dc90c554b27.png)
