### PR TITLE
[hotfix] encode title and content field for global search

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -349,9 +349,9 @@ def sync_global_search():
 							frappe.flags.update_global_search.append(
 								dict(doctype='Static Web Page',
 									name=route,
-									content=frappe.text_type(text),
+									content=text_type(text),
 									published=1,
-									title=soup.title.string,
+									title=text_type(soup.title.string),
 									route=route))
 
 						except Exception:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/commands/site.py", line 217, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/migrate.py", line 46, in migrate
    router.sync_global_search()
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/website/router.py", line 360, in sync_global_search
    sync_global_search()
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/utils/global_search.py", line 264, in sync_global_search
    content = %(content)s''', value)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/database.py", line 154, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 232, in execute
    args = dict((key, db.literal(item)) for key, item in args.items())
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 232, in <genexpr>
    args = dict((key, db.literal(item)) for key, item in args.items())
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 316, in literal
    s = self.escape(o, self.encoders)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 215, in string_literal
    return db.string_literal(obj)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf3' in position 12: ordinal not in range(128)
```