### PR TITLE
[hotfix] encode file name to unicode

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -324,7 +324,7 @@ def add_attachment(fname, fcontent, content_type=None,
 	# Set the filename parameter
 	if fname:
 		attachment_type = 'inline' if inline else 'attachment'
-		part.add_header(b'Content-Disposition', attachment_type, filename=fname.encode('utf=8'))
+		part.add_header(b'Content-Disposition', attachment_type, filename=text_type(fname))
 	if content_id:
 		part.add_header(b'Content-ID', '<{0}>'.format(content_id))
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 425, in sendmail
    recipients=recipients, cc=cc)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/core/doctype/communication/communication.py", line 207, in _notify
    _notify(self, print_html, print_format, attachments, recipients, cc)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 163, in _notify
    is_notification=True if doc.sent_or_received =="Received" else False
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 432, in sendmail
    inline_images=inline_images, header=header)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/email/queue.py", line 130, in send
    now=now)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/email/queue.py", line 151, in add
    email_queue = get_email_queue(recipients, sender, subject, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/email/queue.py", line 180, in get_email_queue
    header=kwargs.get('header'))
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/email/email_body.py", line 43, in get_email
    emailobj.add_attachment(**attach)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/email/email_body.py", line 159, in add_attachment
    add_attachment(fname, fcontent, content_type, parent, content_id, inline)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/email/email_body.py", line 327, in add_attachment
    part.add_header(b'Content-Disposition', attachment_type, filename=fname.encode('utf8'))
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/email/message.py", line 411, in add_header
    self._headers.append((_name, SEMISPACE.join(parts)))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 18: ordinal not in range(128)
```