### PR TITLE
[Fix] User not able to delete if it's linked with the communication

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -200,6 +200,28 @@ class TestUser(unittest.TestCase):
 		clear_limit("expiry")
 		frappe.local.conf = _dict(frappe.get_site_config())
 
+	def test_delete_user(self):
+		new_user = frappe.get_doc(dict(doctype='User', email='test-for-delete@example.com',
+			first_name='Tester Delete User')).insert()
+		self.assertEquals(new_user.user_type, 'Website User')
+
+		# role with desk access
+		new_user.add_roles('_Test Role 2')
+		new_user.save()
+		self.assertEquals(new_user.user_type, 'System User')
+
+		comm = frappe.get_doc({
+			"doctype":"Communication",
+			"subject": "To check user able to delete even if linked with communication",
+			"content": "To check user able to delete even if linked with communication",
+			"sent_or_received": "Sent",
+			"user": new_user.name
+		})
+		comm.insert(ignore_permissions=True)
+
+		frappe.delete_doc('User', new_user.name)
+		self.assertFalse(frappe.db.exists('User', new_user.name))
+
 	def test_deactivate_additional_users(self):
 		update_limits({'users': get_total_users()+1})
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -178,13 +178,18 @@ def check_if_doc_is_linked(doc, method="Delete"):
 		if not issingle:
 			for item in frappe.db.get_values(link_dt, {link_field:doc.name},
 				["name", "parent", "parenttype", "docstatus"], as_dict=True):
+				linked_doctype = item.parenttype if item.parent else link_dt
+				if linked_doctype in ("Communication", "ToDo", "DocShare", "Email Unsubscribe", 'File', 'Version'):
+					# don't check for communication and todo!
+					continue
+
 				if item and ((item.parent or item.name) != doc.name) \
 						and ((method=="Delete" and item.docstatus<2) or (method=="Cancel" and item.docstatus==1)):
 					# raise exception only if
 					# linked to an non-cancelled doc when deleting
 					# or linked to a submitted doc when cancelling
 					frappe.throw(_('Cannot delete or cancel because {0} <a href="#Form/{0}/{1}">{1}</a> is linked with {2} <a href="#Form/{2}/{3}">{3}</a>')
-						.format(doc.doctype, doc.name, item.parenttype if item.parent else link_dt,
+						.format(doc.doctype, doc.name, linked_doctype,
 						item.parent or item.name), frappe.LinkExistsError)
 
 def check_if_doc_is_dynamically_linked(doc, method="Delete"):


### PR DESCRIPTION
**Issue**
When user trying to delete disabled user, system throwing an error it's linked with communication 
![screen shot 2017-08-09 at 12 39 24 pm](https://user-images.githubusercontent.com/8780500/29109232-f1e708cc-7cff-11e7-89fb-595b7daabd5e.png)

