### PR TITLE
Revert "[hotfix] fixes for Uncaught TypeError: Cannot read property 'doc' of undefined"

### DIFF
--- a/frappe/tests/ui/data/test_lib.js
+++ b/frappe/tests/ui/data/test_lib.js
@@ -55,10 +55,8 @@ frappe.tests = {
 		value.forEach(d => {
 			grid_row_tasks.push(() => {
 				grid.add_new_row();
-				let grid_row = grid.get_row(-1);
+				let grid_row = grid.get_row(-1).toggle_view(true);
 				let grid_value_tasks = [];
-
-				grid_row.toggle_view(true);
 
 				// build tasks to set each row value
 				d.forEach(child_value => {


### PR DESCRIPTION
Reverts frappe/frappe#3886