### PR TITLE
Convert dict.keys() to list

### DIFF
--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -74,7 +74,7 @@ def get_app_commands(app):
 
 @click.command('get-frappe-commands')
 def get_frappe_commands():
-	commands = get_app_commands('frappe').keys()
+	commands = list(get_app_commands('frappe').keys())
 
 	for app in get_apps():
 		app_commands = get_app_commands(app)


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying [Bench PR 470](https://github.com/frappe/bench/pull/470) (and a [debug commit]( https://github.com/adityahase/bench/commit/d06686ad6796d711f4f44235f9ea820b5f704f89)) yields following error traceback

```
Traceback (most recent call last):
  File /usr/lib/python3.5/runpy.py, line 184, in _run_module_as_main
    __main__, mod_spec)
  File /usr/lib/python3.5/runpy.py, line 85, in _run_code
    exec(code, run_globals)
  File /home/frappe/aditya/96fb4880/b/apps/frappe/frappe/utils/bench_helper.py, line 94, in <module>
    main()
  File /home/frappe/aditya/96fb4880/b/apps/frappe/frappe/utils/bench_helper.py, line 18, in main
    click.Group(commands=commands)(prog_name=\'bench\')
  File /home/frappe/aditya/96fb4880/b/env/lib/python3.5/site-packages/click/core.py, line 722, in __call__
    return self.main(*args, **kwargs)
  File /home/frappe/aditya/96fb4880/b/env/lib/python3.5/site-packages/click/core.py, line 697, in main
    rv = self.invoke(ctx)
  File /home/frappe/aditya/96fb4880/b/env/lib/python3.5/site-packages/click/core.py, line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File /home/frappe/aditya/96fb4880/b/env/lib/python3.5/site-packages/click/core.py, line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File /home/frappe/aditya/96fb4880/b/env/lib/python3.5/site-packages/click/core.py, line 535, in invoke
    return callback(*args, **kwargs)
  File /home/frappe/aditya/96fb4880/b/apps/frappe/frappe/utils/bench_helper.py, line 82, in get_frappe_commands
    commands.extend(app_commands.keys())
AttributeError: 'dict_keys' object has no attribute 'extend'
```

Fixed it by explicitly converting `dict.keys()` to `list`

Python 3 `dict` methods `dict.keys()`, `dict.items()` and `dict.values()` return [“views” instead of lists](https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists).