### PR TITLE
Use string.ascii_letters instead of string.letters

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -126,7 +126,7 @@ def random_string(length):
 	"""generate a random string"""
 	import string
 	from random import choice
-	return ''.join([choice(string.letters + string.digits) for i in range(length)])
+	return ''.join([choice(string.ascii_letters + string.digits) for i in range(length)])
 
 
 def has_gravatar(email):


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3901 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/bc138cc5/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/bc138cc5/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/bc138cc5/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/bc138cc5/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/bc138cc5/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/bc138cc5/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/commands/site.py", line 29, in new_site
    verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/commands/site.py", line 60, in _new_site
    admin_password=admin_password, verbose=verbose, source_sql=source_sql,force=force, reinstall=reinstall)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/installer.py", line 26, in install_db
    make_conf(db_name, site_config=site_config)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/installer.py", line 255, in make_conf
    make_site_config(db_name, db_password, site_config)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/installer.py", line 266, in make_site_config
    site_config = get_conf_params(db_name, db_password)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/installer.py", line 311, in get_conf_params
    db_password = random_string(16)
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/utils/__init__.py", line 129, in random_string
    return ''.join([choice(string.letters + string.digits) for i in range(length)])
  File "/home/frappe/aditya/bc138cc5/b/apps/frappe/frappe/utils/__init__.py", line 129, in <listcomp>
    return ''.join([choice(string.letters + string.digits) for i in range(length)])
AttributeError: module 'string' has no attribute 'letters'
```

Fixed it by using `string.ascii_letters` instead of `string.letters`.

In Python 3 [`string.letters` and its friends (`string.lowercase` and `string.uppercase`) are gone](https://docs.python.org/3.0/whatsnew/3.0.html#library-changes).