### PR TITLE
Encode string before passing to hashlib.sha224

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -576,7 +576,7 @@ def generate_hash(txt=None, length=None):
 	"""Generates random hash for given text + current timestamp + random string."""
 	import hashlib, time
 	from .utils import random_string
-	digest = hashlib.sha224((txt or "") + repr(time.time()) + repr(random_string(8))).hexdigest()
+	digest = hashlib.sha224(((txt or "") + repr(time.time()) + repr(random_string(8))).encode()).hexdigest()
 	if length:
 		digest = digest[:length]
 	return digest


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3904 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/dcf7c7ad/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/dcf7c7ad/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/dcf7c7ad/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/dcf7c7ad/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/dcf7c7ad/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/dcf7c7ad/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/commands/site.py", line 29, in new_site
    verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force)
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/commands/site.py", line 64, in _new_site
    _install_app(app, verbose=verbose, set_as_patched=not source_sql)
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/installer.py", line 109, in install_app
    frappe.clear_cache()
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/__init__.py", line 494, in clear_cache
    reset_metadata_version()
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/__init__.py", line 586, in reset_metadata_version
    v = generate_hash()
  File "/home/frappe/aditya/dcf7c7ad/b/apps/frappe/frappe/__init__.py", line 579, in generate_hash
    digest = hashlib.sha224((txt or "") + repr(time.time()) + repr(random_string(8))).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```

Fix same as #3900 