### PR TITLE
Explicitly convert dict.values() to list

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -296,7 +296,7 @@ class BaseDocument(object):
 					doctype = self.doctype,
 					columns = ", ".join(["`"+c+"`" for c in columns]),
 					values = ", ".join(["%s"] * len(columns))
-				), d.values())
+				), list(d.values()))
 		except Exception as e:
 			if e.args[0]==1062:
 				if "PRIMARY" in cstr(e.args[1]):
@@ -338,7 +338,7 @@ class BaseDocument(object):
 				set {values} where name=%s""".format(
 					doctype = self.doctype,
 					values = ", ".join(["`"+c+"`=%s" for c in columns])
-				), d.values() + [name])
+				), list(d.values()) + [name])
 		except Exception as e:
 			if e.args[0]==1062 and "Duplicate" in cstr(e.args[1]):
 				self.show_unique_validation_message(e)


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3908 yields following error traceback

```
Traceback (most recent call last):
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/MySQLdb/cursors.py", line 238, in execute
    query = query % args
TypeError: not enough arguments for format string

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/commands/site.py", line 29, in new_site
    verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/commands/site.py", line 64, in _new_site
    _install_app(app, verbose=verbose, set_as_patched=not source_sql)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/installer.py", line 134, in install_app
    out = frappe.get_attr(before_install)()
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/utils/install.py", line 11, in before_install
    frappe.reload_doc("core", "doctype", "docfield")
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/__init__.py", line 678, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/modules/utils.py", line 152, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/modules/import_file.py", line 19, in import_files
    reset_permissions=reset_permissions)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/modules/import_file.py", line 24, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/modules/import_file.py", line 58, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/modules/import_file.py", line 129, in import_doc
    doc.insert()
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/model/document.py", line 204, in insert
    self.db_insert()
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/model/base_document.py", line 299, in db_insert
    ), d.values())
  File "/home/frappe/aditya/acaaee07/b/apps/frappe/frappe/database.py", line 154, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/MySQLdb/cursors.py", line 240, in execute
    self.errorhandler(self, ProgrammingError, str(m))
  File "/home/frappe/aditya/acaaee07/b/env/lib/python3.5/site-packages/MySQLdb/connections.py", line 52, in defaulterrorhandler
    raise errorclass(errorvalue)
_mysql_exceptions.ProgrammingError: not enough arguments for format string
```

Fixed same as #3899