### PR TITLE
Convert method name to string instead of encoding

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -662,7 +662,7 @@ class Document(BaseDocument):
 			# hack! to run hooks even if method does not exist
 			fn = lambda self, *args, **kwargs: None
 
-		fn.__name__ = method.encode("utf-8")
+		fn.__name__ = str(method)
 		out = Document.hook(fn)(self, *args, **kwargs)
 
 		self.run_email_alerts(method)


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3906  yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/9952e14b/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/9952e14b/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/9952e14b/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/9952e14b/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/9952e14b/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/9952e14b/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/commands/site.py", line 29, in new_site
    verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/commands/site.py", line 64, in _new_site
    _install_app(app, verbose=verbose, set_as_patched=not source_sql)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/installer.py", line 134, in install_app
    out = frappe.get_attr(before_install)()
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/utils/install.py", line 11, in before_install
    frappe.reload_doc("core", "doctype", "docfield")
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/__init__.py", line 678, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/modules/utils.py", line 152, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/modules/import_file.py", line 19, in import_files
    reset_permissions=reset_permissions)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/modules/import_file.py", line 24, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/modules/import_file.py", line 58, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/modules/import_file.py", line 129, in import_doc
    doc.insert()
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/model/document.py", line 186, in insert
    self.run_method("before_insert")
  File "/home/frappe/aditya/9952e14b/b/apps/frappe/frappe/model/document.py", line 665, in run_method
    fn.__name__ = method.encode("utf-8")
TypeError: __name__ must be set to a string object
```

Fixed it by converting `method` to `str` instead of encoding it.