### PR TITLE
Replaced long with six.integer_types

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -18,7 +18,7 @@ import redis
 import frappe.model.meta
 from frappe.utils import now, get_datetime, cstr
 from frappe import _
-from six import text_type, binary_type
+from six import text_type, binary_type, integer_types
 from frappe.utils.global_search import sync_global_search
 from frappe.model.utils.link_count import flush_local_link_count
 from six import iteritems, text_type
@@ -270,7 +270,7 @@ class Database:
 		"""Returns true if the first row in the result has a Date, Datetime, Long Int."""
 		if result and result[0]:
 			for v in result[0]:
-				if isinstance(v, (datetime.date, datetime.timedelta, datetime.datetime, long)):
+				if isinstance(v, (datetime.date, datetime.timedelta, datetime.datetime, integer_types)):
 					return True
 				if formatted and isinstance(v, (int, float)):
 					return True
@@ -287,7 +287,7 @@ class Database:
 
 		from frappe.utils import formatdate, fmt_money
 
-		if isinstance(v, (datetime.date, datetime.timedelta, datetime.datetime, long)):
+		if isinstance(v, (datetime.date, datetime.timedelta, datetime.datetime, integer_types)):
 			if isinstance(v, datetime.date):
 				v = text_type(v)
 				if formatted:
@@ -298,7 +298,7 @@ class Database:
 				v = text_type(v)
 
 			# long
-			elif isinstance(v, long):
+			elif isinstance(v, integer_types):
 				v=int(v)
 
 		# convert to strings... (if formatted)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -14,7 +14,7 @@ from num2words import num2words
 from six.moves import html_parser as HTMLParser
 from six.moves.urllib.parse import quote
 from html2text import html2text
-from six import iteritems, text_type
+from six import iteritems, text_type, integer_types
 
 DATE_FORMAT = "%Y-%m-%d"
 TIME_FORMAT = "%H:%M:%S.%f"
@@ -346,7 +346,7 @@ def parse_val(v):
 		v = text_type(v)
 	elif isinstance(v, datetime.timedelta):
 		v = ":".join(text_type(v).split(":")[:2])
-	elif isinstance(v, long):
+	elif isinstance(v, integer_types):
 		v = int(v)
 	return v
 


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3907 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/1e744c0f/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/1e744c0f/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/1e744c0f/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/1e744c0f/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/1e744c0f/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/1e744c0f/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/commands/site.py", line 29, in new_site
    verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/commands/site.py", line 64, in _new_site
    _install_app(app, verbose=verbose, set_as_patched=not source_sql)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/installer.py", line 134, in install_app
    out = frappe.get_attr(before_install)()
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/utils/install.py", line 11, in before_install
    frappe.reload_doc("core", "doctype", "docfield")
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/__init__.py", line 678, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/modules/utils.py", line 152, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/modules/import_file.py", line 19, in import_files
    reset_permissions=reset_permissions)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/modules/import_file.py", line 24, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/modules/import_file.py", line 58, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/modules/import_file.py", line 129, in import_doc
    doc.insert()
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/document.py", line 219, in insert
    self.run_post_save_methods()
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/document.py", line 790, in run_post_save_methods
    self.run_method("on_update")
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/document.py", line 887, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/document.py", line 870, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/document.py", line 660, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 203, in on_update
    updatedb(self.name, self)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/db_schema.py", line 67, in updatedb
    tab = DbTable(dt, 'tab', meta)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/db_schema.py", line 94, in __init__
    self.get_columns_from_docfields()
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/model/db_schema.py", line 208, in get_columns_from_docfields
    fl = frappe.db.sql("SELECT * FROM tabDocField WHERE parent = %s", self.doctype, as_dict = 1)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/database.py", line 188, in sql
    ret = self.fetch_as_dict(formatted, as_utf8)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/database.py", line 253, in fetch_as_dict
    needs_formatting = self.needs_formatting(result, formatted)
  File "/home/frappe/aditya/1e744c0f/b/apps/frappe/frappe/database.py", line 273, in needs_formatting
    if isinstance(v, (datetime.date, datetime.timedelta, datetime.datetime, long)):
NameError: name 'long' is not defined
```

Fixed it by using `six.integer_types` instead of `long`.

[`six.integer_types`](https://pythonhosted.org/six/#six.integer_types) is `int` and `long` in Python 2 and `int` in Python 3.
