### PR TITLE
Make sure that max_length[0][0] is comparable with new_length

### DIFF
--- a/frappe/model/db_schema.py
+++ b/frappe/model/db_schema.py
@@ -127,7 +127,7 @@ class DbTable:
 					else:
 						raise
 
-				if max_length and max_length[0][0] > new_length:
+				if max_length and max_length[0][0] and max_length[0][0] > new_length:
 					current_type = self.current_columns[col.fieldname]["type"]
 					current_length = re.findall('varchar\(([\d]+)\)', current_type)
 					if not current_length:


### PR DESCRIPTION
Frappe port

Trying to install frappe with Python 3 after applying #3909 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/0630d32e/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/0630d32e/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/0630d32e/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/0630d32e/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/0630d32e/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/0630d32e/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/commands/site.py", line 29, in new_site
    verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/commands/site.py", line 64, in _new_site
    _install_app(app, verbose=verbose, set_as_patched=not source_sql)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/installer.py", line 134, in install_app
    out = frappe.get_attr(before_install)()
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/utils/install.py", line 12, in before_install
    frappe.reload_doc("core", "doctype", "docperm")
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/__init__.py", line 678, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/modules/utils.py", line 152, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/modules/import_file.py", line 19, in import_files
    reset_permissions=reset_permissions)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/modules/import_file.py", line 24, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/modules/import_file.py", line 58, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/modules/import_file.py", line 129, in import_doc
    doc.insert()
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/document.py", line 219, in insert
    self.run_post_save_methods()
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/document.py", line 790, in run_post_save_methods
    self.run_method("on_update")
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/document.py", line 887, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/document.py", line 870, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/document.py", line 660, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 203, in on_update
    updatedb(self.name, self)
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/db_schema.py", line 68, in updatedb
    tab.validate()
  File "/home/frappe/aditya/0630d32e/b/apps/frappe/frappe/model/db_schema.py", line 130, in validate
    if max_length and max_length[0][0] > new_length:
TypeError: unorderable types: NoneType() > int()
```