### PR TITLE
[hotfix] don't allow no value fields in the search fields

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -54,3 +54,21 @@ class TestDocType(unittest.TestCase):
 		doc2.insert()
 		doc1.delete()
 		doc2.delete()
+
+	def test_validate_search_fields(self):
+		doc = self.new_doctype("Test Search Fields")
+		doc.search_fields = "some_fieldname"
+		doc.insert()
+		self.assertEqual(doc.name, "Test Search Fields")
+
+		# check if invalid fieldname is allowed or not
+		doc.search_fields = "some_fieldname_1"
+		self.assertRaises(frappe.ValidationError, doc.save)
+
+		# check if no value fields are allowed in search fields
+		field = doc.append("fields", {})
+		field.fieldname = "some_html_field"
+		field.fieldtype = "HTML"
+		field.label = "Some HTML Field"
+		doc.search_fields = "some_fieldname,some_html_field"
+		self.assertRaises(frappe.ValidationError, doc.save)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/desk/search.py", line 13, in search_link
    search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/desk/search.py", line 34, in search_widget
    searchfield, start, page_length, filters, as_dict=as_dict)
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-08-09/apps/erpnext/erpnext/controllers/queries.py", line 98, in customer_query
    'page_len': page_len
  File "/home/frappe/benches/bench-2017-08-09/apps/frappe/frappe/database.py", line 154, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/home/frappe/benches/bench-2017-08-09/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
OperationalError: (1054, "Unknown column 'address_html' in 'field list'")
```