### PR TITLE
fixed icons not replaced on migration

### DIFF
--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -133,9 +133,7 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 def update_icon(doc):
 
 	link = 'List/{0}'.format(doc.name)
-
-	icon_name = frappe.db.exists('Desktop Icon', {'standard': 1,
-												  'link': link,
+	icon_name = frappe.db.exists('Desktop Icon', {'standard': 1, 'link': link,
 		'owner': frappe.session.user})
 
 	if icon_name:

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -133,8 +133,9 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 def update_icon(doc):
 
 	link = 'List/{0}'.format(doc.name)
-	icon_name = frappe.db.exists('Desktop Icon', {'standard': 1, 'link': link,
-		'owner': frappe.session.user})
+	icon_name = frappe.db.exists('Desktop Icon', {'standard': 1,
+						      'link': link,
+						      'owner': frappe.session.user})
 
 	if icon_name:
 		from frappe.desk.doctype.desktop_icon.desktop_icon import clear_desktop_icons_cache

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -133,7 +133,6 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 def update_icon(doc):
 
 	link = 'List/{0}'.format(doc.name)
-	print("updating icon of ", doc.name)
 
 	icon_name = frappe.db.exists('Desktop Icon', {'standard': 1,
 												  'link': link,
@@ -145,4 +144,3 @@ def update_icon(doc):
 		icon = frappe.get_doc('Desktop Icon', icon_name)
 		icon.db_set('icon', doc.icon)
 		clear_desktop_icons_cache()
-		print("finished updating icon of ", doc.name)

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -127,4 +127,22 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 		doc.flags.ignore_permissions = True
 		doc.flags.ignore_mandatory = True
 	doc.insert()
+	update_icon(doc)
 	frappe.flags.in_import = False
+
+def update_icon(doc):
+
+	link = 'List/{0}'.format(doc.name)
+	print("updating icon of ", doc.name)
+
+	icon_name = frappe.db.exists('Desktop Icon', {'standard': 1,
+												  'link': link,
+		'owner': frappe.session.user})
+
+	if icon_name:
+		from frappe.desk.doctype.desktop_icon.desktop_icon import clear_desktop_icons_cache
+
+		icon = frappe.get_doc('Desktop Icon', icon_name)
+		icon.db_set('icon', doc.icon)
+		clear_desktop_icons_cache()
+		print("finished updating icon of ", doc.name)

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -131,7 +131,8 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 	frappe.flags.in_import = False
 
 def update_icon(doc):
-
+	if not hasattr(doc, "icon"):
+		return
 	link = 'List/{0}'.format(doc.name)
 	icon_name = frappe.db.exists('Desktop Icon', {'standard': 1,
 						      'link': link,


### PR DESCRIPTION
fixed a bug whereby the icon of a doctype is not updated in the "Desktop Icons" if it was updated in the json file, even if the "modified" field was updated