### PR TITLE
Use repr() instead of backticks

### DIFF
--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -64,7 +64,7 @@ def get_snapshot(exception, context=10):
 		'traceback': traceback.format_exc(),
 		'frames': [],
 		'etype': cstr(etype),
-		'evalue': cstr(`evalue`),
+		'evalue': cstr(repr(evalue)),
 		'exception': {},
 		'locals': {}
 	}


### PR DESCRIPTION
Frappe port

Trying to run `bench start` with Python 3 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/commands/utils.py", line 353, in serve
    import frappe.app
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/app.py", line 26, in <module>
    from frappe.utils.error import make_error_snapshot
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/utils/error.py", line 67
    'evalue': cstr(`evalue`),
                   ^
SyntaxError: invalid syntax

```

Fixed it by using `repr()` instead of backticks

`flake8 . --count --select=W604 --show-source --statistics` shows only one such instance

Python 3 [removed backticks](https://docs.python.org/3.0/whatsnew/3.0.html#removed-syntax), recommends use of `repr()`