### PR TITLE
Don't unnecessarily encode os.path.join() and os.path.abspath()

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -213,11 +213,11 @@ def serve(port=8000, profile=False, site=None, sites_path='.'):
 
 	if not os.environ.get('NO_STATICS'):
 		application = SharedDataMiddleware(application, {
-			b'/assets': os.path.join(sites_path, 'assets').encode("utf-8"),
+			b'/assets': os.path.join(sites_path, 'assets'),
 		})
 
 		application = StaticDataMiddleware(application, {
-			b'/files': os.path.abspath(sites_path).encode("utf-8")
+			b'/files': os.path.abspath(sites_path)
 		})
 
 	application.debug = True


### PR DESCRIPTION
Frappe port

Trying to run `bench start` with Python 3 after applying #3923 yields following error traceback

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/commands/utils.py", line 360, in serve
    frappe.app.serve(port=port, profile=profile, site=site, sites_path='.')
  File "/home/frappe/aditya/f2b2e205/b/apps/frappe/frappe/app.py", line 216, in serve
    b'/assets': os.path.join(sites_path, 'assets').encode("utf-8"),
  File "/home/frappe/aditya/f2b2e205/b/env/lib/python3.5/site-packages/werkzeug/wsgi.py", line 507, in __init__
    raise TypeError('unknown def %r' % value)
TypeError: unknown def b'./assets'
```

Fixed it by not encoding `os.path.join()` and `os.path.abspath()` (unnecessarily)