### PR TITLE
[hotfix] filters with the special characters are escaped twice

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -353,8 +353,7 @@ def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with
 				if isinstance(f[1], basestring) and f[1][0] == '!':
 					flt.append([doctype, f[0], '!=', f[1][1:]])
 				else:
-					value = frappe.db.escape(f[1]) if isinstance(f[1], basestring) else f[1]
-					flt.append([doctype, f[0], '=', value])
+					flt.append([doctype, f[0], '=', f[1]])
 
 		query = DatabaseQuery(doctype)
 		query.filters = flt


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/10266

filter values are escaped twice, once in get_filter_cond and second in build_filter_conditions causing empty result set even if records are available.

`before`

![before](https://user-images.githubusercontent.com/11224291/29269499-6c2ea852-810f-11e7-89af-455036ef1540.gif)

`after`
![after](https://user-images.githubusercontent.com/11224291/29269500-6e818d9a-810f-11e7-8aca-452bd0050be8.gif)
