### PR TITLE
[hotfix] doctype field in custom script should be mandatory

### DIFF
--- a/frappe/custom/doctype/custom_script/custom_script.json
+++ b/frappe/custom/doctype/custom_script/custom_script.json
@@ -15,6 +15,7 @@
  "engine": "InnoDB", 
  "fields": [
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -40,12 +41,13 @@
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
-   "reqd": 0, 
+   "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -78,6 +80,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -87,7 +90,7 @@
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
-   "in_filter": 0,
+   "in_filter": 0, 
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
@@ -109,6 +112,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -149,8 +153,8 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-04-03 18:07:28.138437", 
- "modified_by": "faris@erpnext.com", 
+ "modified": "2017-08-17 07:43:08.093341", 
+ "modified_by": "Administrator", 
  "module": "Custom", 
  "name": "Custom Script", 
  "owner": "Administrator", 


### PR DESCRIPTION
`error log`

```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 253, in _save
    self.insert()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 187, in insert
    self.set_new_name()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 333, in set_new_name
    set_new_name(self)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/naming.py", line 37, in set_new_name
    doc.run_method("autoname")
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 887, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 870, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/document.py", line 660, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/custom/doctype/custom_script/custom_script.py", line 12, in autoname
    self.name = self.dt + "-" + self.script_type
TypeError: unsupported operand type(s) for +: 'NoneType' and 'unicode'
```