### PR TITLE
[minor] Skip template validation for js print format

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -27,7 +27,7 @@ class PrintFormat(Document):
 		if not self.module:
 			self.module = frappe.db.get_value('DocType', self.doc_type, 'module')
 
-		if self.html:
+		if self.html and self.print_format_type != 'Js':
 			validate_template(self.html)
 
 	def extract_images(self):


### PR DESCRIPTION
**Getting an error**
got error. “Encountered unknown tag ‘var’.”

For below code
```
	{% var sum=0.0 %}
	{% for item in items %}
		{% var sum = sum+item.qty %}
		{{ sum }}
	{% endfor %}
```