### PR TITLE
[hotfix] check if the operator is passed in filters for get-filter-conditions

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -352,6 +352,10 @@ def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with
 			for f in filters:
 				if isinstance(f[1], basestring) and f[1][0] == '!':
 					flt.append([doctype, f[0], '!=', f[1][1:]])
+				elif isinstance(f[1], list) and \
+					f[1][0] in (">", "<", ">=", "<=", "like", "not like", "in", "not in", "between"):
+
+					flt.append([doctype, f[0], f[1][0], f[1][1]])
 				else:
 					flt.append([doctype, f[0], '=', f[1]])
 

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -200,7 +200,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 
 		let date_val = this.dialog.fields_dict["date_range"].get_value();
 		if(date_val) {
-			filters[this.date_field] = ['Between', me.dialog.fields_dict["date_range"].parse(date_val)];
+			filters[this.date_field] = ['between', date_val];
 		}
 
 		let args = {


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/10495

if we pass filters like `{"posting_date": ["between", ["2017-08-01", "2017-08-01"]]}` to `get_filter_conditions` it will converts the filters to
`["Delivery Note", "posting_date", "=", ["between", ["2017-08-01", "2017-08-01"]]]` instead
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/desk/search.py", line 34, in search_widget
    searchfield, start, page_length, filters, as_dict=as_dict)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/controllers/queries.py", line 241, in get_delivery_notes_to_be_billed
    "fcond": get_filters_cond(doctype, filters, []),
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/desk/reportview.py", line 365, in get_filters_cond
    query.build_filter_conditions(flt, conditions, ignore_permissions)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/db_query.py", line 270, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/db_query.py", line 323, in prepare_filter_condition
    value = getdate(f.value).strftime("%Y-%m-%d")
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/utils/data.py", line 41, in getdate
    return parser.parse(string_date).date()
  File "/home/frappe/benches/bench-2017-08-21/env/lib/python2.7/site-packages/dateutil/parser.py", line 1182, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2017-08-21/env/lib/python2.7/site-packages/dateutil/parser.py", line 556, in parse
    res, skipped_tokens = self._parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2017-08-21/env/lib/python2.7/site-packages/dateutil/parser.py", line 675, in _parse
    l = _timelex.split(timestr)         # Splits the timestr into tokens
  File "/home/frappe/benches/bench-2017-08-21/env/lib/python2.7/site-packages/dateutil/parser.py", line 192, in split
    return list(cls(s))
  File "/home/frappe/benches/bench-2017-08-21/env/lib/python2.7/site-packages/dateutil/parser.py", line 61, in __init__
    '{itype}'.format(itype=instream.__class__.__name__))
TypeError: Parser must be a string or character stream, not list
```