### PR TITLE
Fix some Python 3 incompatibilities issues

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -2,7 +2,7 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-from six import reraise as raise_, iteritems, string_types
+from six import iteritems, string_types
 import frappe, sys
 from frappe import _
 from frappe.utils import (cint, flt, now, cstr, strip_html, getdate, get_datetime, to_timedelta,
@@ -307,8 +307,7 @@ class BaseDocument(object):
 						return
 
 					frappe.msgprint(_("Duplicate name {0} {1}").format(self.doctype, self.name))
-					traceback = sys.exc_info()[2]
-					raise_(frappe.DuplicateEntryError, (self.doctype, self.name, e), traceback)
+					raise frappe.DuplicateEntryError(self.doctype, self.name, e)
 
 				elif "Duplicate" in cstr(e.args[1]):
 					# unique constraint
@@ -361,7 +360,7 @@ class BaseDocument(object):
 		frappe.msgprint(_("{0} must be unique".format(label or fieldname)))
 
 		# this is used to preserve traceback
-		raise_(frappe.UniqueValidationError, (self.doctype, self.name, e), traceback)
+		raise frappe.UniqueValidationError(self.doctype, self.name, e)
 
 	def db_set(self, fieldname, value=None, update_modified=True):
 		'''Set a value in the document object, update the timestamp and update the database.

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -92,7 +92,7 @@ class RedisWrapper(redis.Redis):
 
 		except redis.exceptions.ConnectionError:
 			regex = re.compile(cstr(key).replace("|", "\|").replace("*", "[\w]*"))
-			return [k for k in frappe.local.cache.keys() if regex.match(k)]
+			return [k for k in frappe.local.cache.keys() if regex.match(k.decode())]
 
 	def delete_keys(self, key):
 		"""Delete keys with wildcard `*`."""


### PR DESCRIPTION
Frappe port

Now `bench new-site` runs without any errors on Python 3