### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -407,7 +407,7 @@ def validate_fields(meta):
 		validate_column_name(fieldname)
 
 	def check_unique_fieldname(fieldname):
-		duplicates = filter(None, map(lambda df: df.fieldname==fieldname and str(df.idx) or None, fields))
+		duplicates = list(filter(None, map(lambda df: df.fieldname==fieldname and str(df.idx) or None, fields)))
 		if len(duplicates) > 1:
 			frappe.throw(_("Fieldname {0} appears multiple times in rows {1}").format(fieldname, ", ".join(duplicates)))
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -10,7 +10,7 @@ from frappe.geo.country_info import get_country_info
 from frappe.utils.file_manager import save_file
 from frappe.utils.password import update_password
 from werkzeug.useragents import UserAgent
-import install_fixtures
+from . import install_fixtures
 from six import string_types
 
 @frappe.whitelist()


### PR DESCRIPTION
Frappe port

after [erpnext PR 10519](https://github.com/frappe/erpnext/pull/10519)

while running `bench --site site1.local install-app erpnext` few errors occur this PR fixes that

Now `bench --site site1.local install-app erpnext` runs without errors