### PR TITLE
remove the markup while exporting the reports in csv format

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -10,7 +10,7 @@ import frappe.permissions
 import MySQLdb
 from frappe.model.db_query import DatabaseQuery
 from frappe import _
-from six import text_type, string_types
+from six import text_type, string_types, StringIO
 
 @frappe.whitelist()
 def get():
@@ -146,13 +146,14 @@ def export_query():
 
 		# convert to csv
 		import csv
-		from six import StringIO
+		from frappe.utils.xlsxutils import handle_html
 
 		f = StringIO()
 		writer = csv.writer(f)
 		for r in data:
 			# encode only unicode type strings and not int, floats etc.
-			writer.writerow(map(lambda v: isinstance(v, text_type) and v.encode('utf-8') or v, r))
+			writer.writerow(map(lambda v: isinstance(v, string_types) and
+				handle_html(v.encode('utf-8')) or v, r))
 
 		f.seek(0)
 		frappe.response['result'] = text_type(f.read(), 'utf-8')

--- a/frappe/public/js/frappe/misc/tools.js
+++ b/frappe/public/js/frappe/misc/tools.js
@@ -66,7 +66,7 @@ frappe.tools.to_csv = function(data) {
 	var res = [];
 	$.each(data, function(i, row) {
 		row = $.map(row, function(col) {
-			return typeof(col)==="string" ? ('"' + col.replace(/"/g, '""') + '"') : col;
+			return typeof(col)==="string" ? ('"' + $('<i>').html(col.replace(/"/g, '""')).text() + '"') : col;
 		});
 		res.push(row.join(","));
 	});


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/9625

![remove markup](https://user-images.githubusercontent.com/20757311/29663891-e61d5c0c-88ea-11e7-9584-47b8d0cdf84e.gif)
