### PR TITLE
Enable using templates inside ControlHTML

### DIFF
--- a/frappe/public/js/frappe/form/control.js
+++ b/frappe/public/js/frappe/form/control.js
@@ -173,13 +173,17 @@ frappe.ui.form.ControlHTML = frappe.ui.form.Control.extend({
 	make: function() {
 		this._super();
 		this.disp_area = this.wrapper;
+		this.frm.$wrapper.on('blur change', (e) => {
+			setTimeout(() => this.refresh_input(), 500);
+		});
 	},
 	refresh_input: function() {
 		var content = this.get_content();
 		if(content) this.$wrapper.html(content);
 	},
 	get_content: function() {
-		return this.df.options || "";
+		var content = this.df.options || "";
+		return frappe.render(content, this);
 	},
 	html: function(html) {
 		this.$wrapper.html(html || this.get_content());


### PR DESCRIPTION
This change would enable showing computed data based on other fields in the same doc, without storing the computed data (which avoid unnecessary redundancy).

Simply use template syntax instead of HTML inside options of HTML field, since HTML is a valid template string this won't break anything.

![screenshot from 2017-08-24 14 13 20](https://user-images.githubusercontent.com/1159471/29665983-bced202e-88d6-11e7-9e95-5cbbe863daac.png)

Currently it would render as is :

![screenshot from 2017-08-24 14 18 23](https://user-images.githubusercontent.com/1159471/29666106-4124f538-88d7-11e7-9cd8-b900ab00473a.png)


After the patch it should render the template and produce this result : 


![screenshot from 2017-08-24 14 22 40](https://user-images.githubusercontent.com/1159471/29666247-cb18cd3c-88d7-11e7-9ad6-3e3ce52e0a4f.png)


Also any ControlHTML will be refreshed after any change in any field in the form, _this can be optimized by providing which fields the html field is depending on_.

