### PR TITLE
Enable using templates inside ControlHTML

### DIFF
--- a/frappe/public/js/frappe/form/controls/html.js
+++ b/frappe/public/js/frappe/form/controls/html.js
@@ -2,7 +2,7 @@ frappe.ui.form.ControlHTML = frappe.ui.form.Control.extend({
 	make: function() {
 		this._super();
 		this.disp_area = this.wrapper;
-		this.frm.$wrapper.on('blur change', () => {
+		$(document).on('change', () => {
 			setTimeout(() => this.refresh_input(), 500);
 		});
 	},
@@ -12,7 +12,11 @@ frappe.ui.form.ControlHTML = frappe.ui.form.Control.extend({
 	},
 	get_content: function() {
 		var content = this.df.options || "";
-		return frappe.render(content, this);
+		try {
+			return frappe.render(content, this);
+		} catch (e) {
+			return content;
+		}
 	},
 	html: function(html) {
 		this.$wrapper.html(html || this.get_content());

--- a/frappe/public/js/frappe/form/controls/html.js
+++ b/frappe/public/js/frappe/form/controls/html.js
@@ -2,13 +2,17 @@ frappe.ui.form.ControlHTML = frappe.ui.form.Control.extend({
 	make: function() {
 		this._super();
 		this.disp_area = this.wrapper;
+		this.frm.$wrapper.on('blur change', () => {
+			setTimeout(() => this.refresh_input(), 500);
+		});
 	},
 	refresh_input: function() {
 		var content = this.get_content();
 		if(content) this.$wrapper.html(content);
 	},
 	get_content: function() {
-		return this.df.options || "";
+		var content = this.df.options || "";
+		return frappe.render(content, this);
 	},
 	html: function(html) {
 		this.$wrapper.html(html || this.get_content());

--- a/frappe/tests/ui/test_control_html.js
+++ b/frappe/tests/ui/test_control_html.js
@@ -1,0 +1,51 @@
+QUnit.module('controls');
+
+QUnit.test("Test ControlHTML", function(assert) {
+	assert.expect(3);
+	const random_name = frappe.utils.get_random(3).toLowerCase();
+
+	let done = assert.async();
+
+	frappe.run_serially([
+		() => {
+			return frappe.tests.make('Custom Field', [
+				{dt: 'ToDo'},
+				{fieldtype: 'HTML'},
+				{label: random_name},
+				{options: '<h3> Test </h3>'}
+			]);
+		},
+		() => {
+			return frappe.tests.make('Custom Field', [
+				{dt: 'ToDo'},
+				{fieldtype: 'HTML'},
+				{label: random_name + "_template"},
+				{options: '<h3> Test {%= doc.status %} </h3>'}
+			]);
+		},
+		() => frappe.set_route('List', 'ToDo'),
+		() => frappe.new_doc('ToDo'),
+		() => {
+			if (frappe.quick_entry)
+			{
+				frappe.quick_entry.dialog.$wrapper.find('.edit-full').click();
+				return frappe.timeout(1);
+			}
+		},
+		() => {
+			const control = $(`.frappe-control[data-fieldname="${random_name}"]`)[0];
+			return assert.ok(control.innerHTML === '<h3> Test </h3>');
+		},
+		() => {
+			const control = $(`.frappe-control[data-fieldname="${random_name}_template"]`)[0];
+			return assert.ok(control.innerHTML === '<h3> Test Open </h3>');
+		},
+		() => frappe.tests.set_control("status", "Closed"),
+		() => frappe.timeout(1),
+		() => {
+			const control = $(`.frappe-control[data-fieldname="${random_name}_template"]`)[0];
+			return assert.ok(control.innerHTML === '<h3> Test Closed </h3>');
+		},
+		() => done()
+	]);
+});

--- a/frappe/tests/ui/tests.txt
+++ b/frappe/tests/ui/tests.txt
@@ -13,3 +13,4 @@ frappe/custom/doctype/customize_form/test_customize_form.js
 frappe/desk/doctype/event/test_event.js
 frappe/workflow/doctype/workflow/tests/test_workflow_create.js
 frappe/workflow/doctype/workflow/tests/test_workflow_test.js
+frappe/tests/ui/test_control_html.js


### PR DESCRIPTION
This change would enable showing computed data based on other fields in the same doc, without storing the computed data (which avoid unnecessary redundancy).

Simply use template syntax instead of HTML inside options of HTML field, since HTML is a valid template string this won't break anything.

![screenshot from 2017-08-24 14 13 20](https://user-images.githubusercontent.com/1159471/29665983-bced202e-88d6-11e7-9e95-5cbbe863daac.png)

Currently it would render as is :

![screenshot from 2017-08-24 14 18 23](https://user-images.githubusercontent.com/1159471/29666106-4124f538-88d7-11e7-9cd8-b900ab00473a.png)


After the patch it should render the template and produce this result : 


![screenshot from 2017-08-24 14 22 40](https://user-images.githubusercontent.com/1159471/29666247-cb18cd3c-88d7-11e7-9ad6-3e3ce52e0a4f.png)


Also any ControlHTML will be refreshed after any change in any field in the form, _this can be optimized by providing which fields the html field is depending on_.

