### PR TITLE
[minor] show duplicates instead of hiding

### DIFF
--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -431,8 +431,9 @@ frappe.views.ListRenderer = Class.extend({
 		return `<span class='indicator ${indicator[1]}' title='${__(indicator[0])}'></span>`;
 	},
 	prepare_data: function (data) {
-		if (data.modified)
+		if (data.modified) {
 			this.prepare_when(data, data.modified);
+		}
 
 		// nulls as strings
 		for (var key in data) {
@@ -452,8 +453,24 @@ frappe.views.ListRenderer = Class.extend({
 
 		var title_field = this.meta.title_field || 'name';
 		data._title = strip_html(data[title_field] || data.name);
-		data._full_title = data._title;
 
+		// check for duplicates
+		// add suffix like (1), (2) etc
+		if (data.name) {
+			if (this.values_map[data.name]!==undefined) {
+				if (this.values_map[data.name]===1) {
+					// update first row!
+					this.set_title_with_row_number(this.rows_map[data.name], 1);
+				}
+				this.values_map[data.name]++;
+				this.set_title_with_row_number(data, this.values_map[data.name]);
+			} else {
+				this.values_map[data.name] = 1;
+				this.rows_map[data.name] = data;
+			}
+		}
+
+		data._full_title = data._title;
 
 		data._workflow = null;
 		if (this.workflow_state_fieldname) {
@@ -493,6 +510,11 @@ frappe.views.ListRenderer = Class.extend({
 		return data;
 	},
 
+	set_title_with_row_number: function (data, id) {
+		data._title = data._title + ` (${__("Row")} ${id})`;
+		data._full_title = data._title;
+	},
+
 	prepare_when: function (data, date_str) {
 		if (!date_str) date_str = data.modified;
 		// when
@@ -520,10 +542,12 @@ frappe.views.ListRenderer = Class.extend({
 			|| ($.isArray(this.required_libs) && this.required_libs.length);
 
 		this.render_view = function (values) {
+			me.values_map = {};
+			me.rows_map = {};
 			// prepare data before rendering view
 			values = values.map(me.prepare_data.bind(this));
 			// remove duplicates
-			values = values.uniqBy(value => value.name);
+			// values = values.uniqBy(value => value.name);
 
 			if (lib_exists) {
 				me.load_lib(function () {

--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -456,7 +456,7 @@ frappe.views.ListRenderer = Class.extend({
 
 		// check for duplicates
 		// add suffix like (1), (2) etc
-		if (data.name) {
+		if (data.name && this.values_map) {
 			if (this.values_map[data.name]!==undefined) {
 				if (this.values_map[data.name]===1) {
 					// update first row!

--- a/frappe/tests/ui/test_linked_with.js
+++ b/frappe/tests/ui/test_linked_with.js
@@ -8,7 +8,7 @@ QUnit.test("Test Linked With", function(assert) {
 		() => frappe.set_route('Form', 'Module Def', 'Contacts'),
 		() => frappe.tests.click_page_head_item('Menu'),
 		() => frappe.tests.click_dropdown_item('Links'),
-		() => frappe.timeout(4),
+		() => frappe.timeout(5),
 		() => {
 			assert.equal(cur_dialog.title, 'Linked With', 'Linked with dialog is opened');
 			const link_tables_count = cur_dialog.$wrapper.find('.list-item-table').length;

--- a/frappe/tests/ui/test_linked_with.js
+++ b/frappe/tests/ui/test_linked_with.js
@@ -8,7 +8,7 @@ QUnit.test("Test Linked With", function(assert) {
 		() => frappe.set_route('Form', 'Module Def', 'Contacts'),
 		() => frappe.tests.click_page_head_item('Menu'),
 		() => frappe.tests.click_dropdown_item('Links'),
-		() => frappe.timeout(5),
+		() => frappe.timeout(4),
 		() => {
 			assert.equal(cur_dialog.title, 'Linked With', 'Linked with dialog is opened');
 			const link_tables_count = cur_dialog.$wrapper.find('.list-item-table').length;

--- a/frappe/workflow/doctype/workflow/tests/test_workflow_test.js
+++ b/frappe/workflow/doctype/workflow/tests/test_workflow_test.js
@@ -13,7 +13,7 @@ QUnit.test("Test Workflow", function(assert) {
 			cur_frm.set_value('send_welcome_email', 0);
 			cur_frm.save();
 		},
-		() => frappe.timeout(0.5),
+		() => frappe.timeout(2),
 		() => frappe.tests.click_button('Actions'),
 		() => frappe.timeout(0.5),
 		() => {


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/7432

This is a UX problem, if the filter is in child table, then the query will have to join for each child item, there is no way to guarantee paging then. So, instead of hiding the rows, I am showing all rows, but adding a Row number suffix to each title. See screenshot.

<img width="989" alt="screen shot 2017-08-29 at 1 27 49 pm" src="https://user-images.githubusercontent.com/140076/29810806-f03b971c-8cbe-11e7-9cd0-06bb4dc875d7.png">
