### PR TITLE
[hotfix] socket command error eof while connecting to email server

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -249,7 +249,7 @@ class EmailAccount(Document):
 				email_server = None
 				try:
 					email_server = self.get_incoming_server(in_receive=True, email_sync_rule=email_sync_rule)
-				except Exception as e:
+				except Exception:
 					frappe.log_error(title=_("Error while connecting to email account {0}").format(self.name))
 
 				if not email_server:

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -246,7 +246,12 @@ class EmailAccount(Document):
 			else:
 				email_sync_rule = self.build_email_sync_rule()
 
-				email_server = self.get_incoming_server(in_receive=True, email_sync_rule=email_sync_rule)
+				email_server = None
+				try:
+					email_server = self.get_incoming_server(in_receive=True, email_sync_rule=email_sync_rule)
+				except Exception as e:
+					frappe.log_error(title=_("Error while connecting to email account {0}").format(self.name))
+
 				if not email_server:
 					return
 


### PR DESCRIPTION
log the `command: LOGIN => socket error: EOF` instead of frappe.throw
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-08-28/apps/frappe/frappe/utils/background_jobs.py", line 66, in execute_job
    method(**kwargs)
  File "/home/frappe/benches/bench-2017-08-28/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 699, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/benches/bench-2017-08-28/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 249, in receive
    email_server = self.get_incoming_server(in_receive=True, email_sync_rule=email_sync_rule)
  File "/home/frappe/benches/bench-2017-08-28/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 177, in get_incoming_server
    frappe.throw(e.message)
  File "/home/frappe/benches/bench-2017-08-28/apps/frappe/frappe/__init__.py", line 319, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2017-08-28/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2017-08-28/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
ValidationError: command: LOGIN => socket error: EOF
```