### PR TITLE
Update twofactor.py

### DIFF
--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -352,6 +352,8 @@ def delete_qrimage(user, check_expiry=False):
 
 def delete_all_barcodes_for_users():
 	'''Task to delete all barcodes for user.'''
+	if not two_factor_is_enabled():
+		return
 	users = frappe.get_all('User', {'enabled':1})
 	for user in users:
 		delete_qrimage(user.name, check_expiry=True)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/11255121/30004907-ddc2d152-90df-11e7-9fcc-c65c94071266.png)

As shown in the previous image, despite of the two-factors is disabled, **frappe.twofactor.delete_all_barcodes_for_users** cron still works.

I've add a condition in the beginning of this function to check the two-factors flag.