### PR TITLE
[minor] unscrub field name for download templete filename if lable is not available

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -609,10 +609,11 @@ frappe.ui.form.Grid = Class.extend({
 	},
 	setup_download: function() {
 		var me = this;
+		let title = me.df.label || frappe.model.unscrub(me.df.fieldname);
 		$(this.wrapper).find(".grid-download").removeClass("hide").on("click", function() {
 			var data = [];
 			var docfields = [];
-			data.push([__("Bulk Edit {0}", [me.df.label])]);
+			data.push([__("Bulk Edit {0}", [title])]);
 			data.push([]);
 			data.push([]);
 			data.push([]);
@@ -642,7 +643,7 @@ frappe.ui.form.Grid = Class.extend({
 				data.push(row);
 			});
 
-			frappe.tools.downloadify(data, null, me.df.label);
+			frappe.tools.downloadify(data, null, title);
 			return false;
 		});
 	},


### PR DESCRIPTION
If child table field label is not mentioned then on download filename is saved as `undefined.csv`