### PR TITLE
Add boto3 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto3
 chardet
 cssmin
 dropbox==7.3.1


### PR DESCRIPTION
- Needed for installing boto3 as a python dependency during Frappe setup.