### PR TITLE
Python 3 comapatibility Fixes

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1344,7 +1344,7 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 	whitelisted_globals = {
 		"int": int,
 		"float": float,
-		"long": long,
+		"long": int,
 		"round": round
 	}
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1174,7 +1174,7 @@ def as_json(obj, indent=1):
 	return json.dumps(obj, indent=indent, sort_keys=True, default=json_handler)
 
 def are_emails_muted():
-	from utils import cint
+	from frappe.utils import cint
 	return flags.mute_emails or cint(conf.get("mute_emails") or 0) or False
 
 def get_test_records(doctype):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1360,7 +1360,7 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 	return eval(code, eval_globals, eval_locals)
 
 def get_system_settings(key):
-	if not local.system_settings.has_key(key):
+	if key not in local.system_settings:
 		local.system_settings.update({key: db.get_single_value('System Settings', key)})
 	return local.system_settings.get(key)
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -214,11 +214,11 @@ def serve(port=8000, profile=False, site=None, sites_path='.'):
 
 	if not os.environ.get('NO_STATICS'):
 		application = SharedDataMiddleware(application, {
-			b'/assets': os.path.join(sites_path, 'assets'),
+			'/assets': os.path.join(sites_path, 'assets'),
 		})
 
 		application = StaticDataMiddleware(application, {
-			b'/files': os.path.abspath(sites_path)
+			'/files': os.path.abspath(sites_path)
 		})
 
 	application.debug = True

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -451,7 +451,7 @@ def validate_fields(meta):
 
 	def check_dynamic_link_options(d):
 		if d.fieldtype=="Dynamic Link":
-			doctype_pointer = filter(lambda df: df.fieldname==d.options, fields)
+			doctype_pointer = list(filter(lambda df: df.fieldname==d.options, fields))
 			if not doctype_pointer or (doctype_pointer[0].fieldtype not in ("Link", "Select")) \
 				or (doctype_pointer[0].fieldtype=="Link" and doctype_pointer[0].options!="DocType"):
 				frappe.throw(_("Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType'"))

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -30,7 +30,7 @@ class ModuleDef(Document):
 			with open(frappe.get_app_path(self.app_name, "modules.txt"), "r") as f:
 				content = f.read()
 				if not self.name in content.splitlines():
-					modules = filter(None, content.splitlines())
+					modules = list(filter(None, content.splitlines()))
 					modules.append(self.name)
 
 			if modules:

--- a/frappe/core/page/data_import_tool/importer.py
+++ b/frappe/core/page/data_import_tool/importer.py
@@ -72,7 +72,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 		return [], -1
 
 	def filter_empty_columns(columns):
-		empty_cols = filter(lambda x: x in ("", None), columns)
+		empty_cols = list(filter(lambda x: x in ("", None), columns))
 
 		if empty_cols:
 			if columns[-1*len(empty_cols):] == empty_cols:

--- a/frappe/database.py
+++ b/frappe/database.py
@@ -62,10 +62,10 @@ class Database:
 				'key':frappe.conf.db_ssl_key
 			}
 		if usessl:
-			self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
+			self._conn = MySQLdb.connect(self.host, self.user or '', self.password or '',
 				use_unicode=True, charset='utf8mb4', ssl=self.ssl)
 		else:
-			self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
+			self._conn = MySQLdb.connect(self.host, self.user or '', self.password or '',
 				use_unicode=True, charset='utf8mb4')
 		self._conn.converter[246]=float
 		self._conn.converter[12]=get_datetime

--- a/frappe/database.py
+++ b/frappe/database.py
@@ -607,7 +607,7 @@ class Database:
 		return r
 
 	def _get_value_for_many_names(self, doctype, names, field, debug=False):
-		names = filter(None, names)
+		names = list(filter(None, names))
 
 		if names:
 			return dict(self.sql("select name, `%s` from `tab%s` where name in (%s)" \

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -42,7 +42,7 @@ def get_user_default_as_list(key, user=None):
 		else:
 			d = user_defaults.get(frappe.scrub(key), None)
 
-	return filter(None, (not isinstance(d, (list, tuple))) and [d] or d)
+	return list(filter(None, (not isinstance(d, (list, tuple))) and [d] or d))
 
 def is_a_user_permission_key(key):
 	return ":" not in key and key != frappe.scrub(key)

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -14,7 +14,7 @@ def get_notifications():
 
 	config = get_notification_config()
 
-	groups = config.get("for_doctype").keys() + config.get("for_module").keys()
+	groups = list(config.get("for_doctype").keys()) + list(config.get("for_module").keys())
 	cache = frappe.cache()
 
 	notification_count = {}
@@ -161,7 +161,7 @@ def clear_notifications(user=None):
 		return
 
 	config = get_notification_config()
-	groups = config.get("for_doctype").keys() + config.get("for_module").keys()
+	groups = list(config.get("for_doctype").keys()) + list(config.get("for_module").keys())
 	cache = frappe.cache()
 
 	for name in groups:

--- a/frappe/desk/page/applications/applications.py
+++ b/frappe/desk/page/applications/applications.py
@@ -12,6 +12,7 @@ import json
 from frappe import _
 from distutils.spawn import find_executable
 from frappe.utils.background_jobs import enqueue
+from six.moves import reload_module
 
 @frappe.whitelist()
 def get_app_list():
@@ -65,7 +66,7 @@ def install_app(name):
 			frappe.cache().delete_value(["app_hooks"])
 			# reload sys.path
 			import site
-			reload(site)
+			reload_module(site)
 		else:
 			# will only come via direct API
 			frappe.throw(_("Listing app not allowed"))

--- a/frappe/desk/query_builder.py
+++ b/frappe/desk/query_builder.py
@@ -128,7 +128,7 @@ def build_description_standard(meta, tl):
 			coloptions.append(desc[2] or '')
 			colwidths.append(desc[3] or '100')
 
-		elif meta.get(dt,{}).has_key(fn):
+		elif fn in meta.get(dt,{}):
 			# type specified for a multi-table join
 			# usually from Report Builder
 

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -219,9 +219,6 @@ class EMail:
 			frappe.get_attr(hook)(self)
 
 	def set_header(self, key, value):
-		key = encode(key)
-		value = encode(value)
-
 		if key in self.msg_root:
 			del self.msg_root[key]
 

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -51,7 +51,7 @@ class EMail:
 	Also sets all messages as multipart/alternative for cleaner reading in text-only clients
 	"""
 	def __init__(self, sender='', recipients=(), subject='', alternative=0, reply_to=None, cc=(), email_account=None, expose_recipients=None):
-		from email import Charset
+		from email import charset as Charset
 		Charset.add_charset('utf-8', Charset.QP, Charset.QP, 'utf-8')
 
 		if isinstance(recipients, string_types):

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -222,7 +222,7 @@ class EMail:
 		key = encode(key)
 		value = encode(value)
 
-		if self.msg_root.has_key(key):
+		if key in self.msg_root:
 			del self.msg_root[key]
 
 		self.msg_root[key] = value

--- a/frappe/integrations/doctype/gsuite_settings/gsuite_settings.py
+++ b/frappe/integrations/doctype/gsuite_settings/gsuite_settings.py
@@ -47,7 +47,7 @@ def gsuite_callback(code=None):
 				'grant_type': 'authorization_code'}
 			r = requests.post('https://www.googleapis.com/oauth2/v4/token', data=data).json()
 			frappe.db.set_value("Gsuite Settings", None, "authorization_code", code)
-			if r.has_key('refresh_token'):
+			if 'refresh_token' in r:
 				frappe.db.set_value("Gsuite Settings", None, "refresh_token", r['refresh_token'])
 			frappe.db.commit()
 			return

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -148,9 +148,9 @@ class OAuthWebRequestValidator(RequestValidator):
 			oc = frappe.get_doc("OAuth Client", request.client_id)
 		else:
 			#Extract token, instantiate OAuth Bearer Token and use clientid from there.
-			if frappe.form_dict.has_key("refresh_token"):
+			if "refresh_token" in frappe.form_dict:
 				oc = frappe.get_doc("OAuth Client", frappe.db.get_value("OAuth Bearer Token", {"refresh_token": frappe.form_dict["refresh_token"]}, 'client'))
-			elif frappe.form_dict.has_key("token"):
+			elif "token" in frappe.form_dict:
 				oc = frappe.get_doc("OAuth Client", frappe.db.get_value("OAuth Bearer Token", frappe.form_dict["token"], 'client'))
 			else:
 				oc = frappe.get_doc("OAuth Client", frappe.db.get_value("OAuth Bearer Token", frappe.get_request_header("Authorization").split(" ")[1], 'client'))

--- a/frappe/patches/v7_0/cleanup_list_settings.py
+++ b/frappe/patches/v7_0/cleanup_list_settings.py
@@ -6,7 +6,7 @@ def execute():
 		for ls in list_settings:
 			if ls and ls.data:
 				data = json.loads(ls.data)
-				if not data.has_key("fields"):
+				if "fields" not in data:
 					continue
 				fields = data["fields"]
 				for field in fields:

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -245,7 +245,7 @@ def get_role_permissions(meta, user=None, verbose=False):
 					perms["apply_user_permissions"][ptype] = 1
 
 		# delete 0 values
-		for key, value in perms.get("apply_user_permissions").items():
+		for key, value in list(perms.get("apply_user_permissions").items()):
 			if not value:
 				del perms["apply_user_permissions"][key]
 

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -12,6 +12,7 @@ from frappe.utils import cstr
 import frappe.utils.scheduler
 import cProfile, pstats
 from six import StringIO
+from six.moves import reload_module
 
 unittest_runner = unittest.TextTestRunner
 
@@ -233,7 +234,7 @@ def get_modules(doctype):
 	try:
 		test_module = load_doctype_module(doctype, module, "test_")
 		if test_module:
-			reload(test_module)
+			reload_module(test_module)
 	except ImportError:
 		test_module = None
 

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -12,7 +12,7 @@ from pyqrcode import create as qrcreate
 from six import StringIO
 from base64 import b64encode, b32encode
 from frappe.utils import get_url, get_datetime, time_diff_in_seconds
-from six import string_types
+from six import iteritems, string_types
 
 class ExpiredLoginException(Exception): pass
 
@@ -68,7 +68,7 @@ def cache_2fa_data(user, token, otp_secret, tmp_id):
 		frappe.cache().expire(tmp_id + '_token', expiry_time)
 	else:
 		expiry_time = 180
-	for k, v in {'_usr': user, '_pwd': pwd, '_otp_secret': otp_secret}.iteritems():
+	for k, v in iteritems({'_usr': user, '_pwd': pwd, '_otp_secret': otp_secret}):
 		frappe.cache().set("{0}{1}".format(tmp_id, k), v)
 		frappe.cache().expire("{0}{1}".format(tmp_id, k), expiry_time)
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -12,7 +12,7 @@ from babel.core import UnknownLocaleError
 from dateutil import parser
 from num2words import num2words
 from six.moves import html_parser as HTMLParser
-from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import quote, urljoin
 from html2text import html2text
 from six import iteritems, text_type, string_types, integer_types
 
@@ -654,7 +654,7 @@ def get_url(uri=None, full_address=False):
 	if frappe.conf.http_port:
 		host_name = host_name + ':' + str(frappe.conf.http_port)
 
-	url = urllib.basejoin(host_name, uri) if uri else host_name
+	url = urljoin(host_name, uri) if uri else host_name
 
 	return url
 

--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
+from six.moves import xrange
 
 def get_monthly_results(goal_doctype, goal_field, date_col, filter_str, aggregation = 'sum'):
 	'''Get monthly aggregation values for given field of doctype'''

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -1,5 +1,5 @@
 import json
-import bleach, bleach_whitelist
+import bleach, bleach_whitelist.bleach_whitelist as bleach_whitelist
 from six import string_types
 
 def sanitize_html(html, linkify=False):

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -109,7 +109,7 @@ def get_encryption_key():
 	from frappe.installer import update_site_config
 
 	if 'encryption_key' not in frappe.local.conf:
-		encryption_key = Fernet.generate_key()
+		encryption_key = Fernet.generate_key().decode()
 		update_site_config('encryption_key', encryption_key)
 		frappe.local.conf.encryption_key = encryption_key
 

--- a/frappe/www/rss.py
+++ b/frappe/www/rss.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import frappe
 import urllib
 from frappe.utils import escape_html, get_request_site_address, now, cstr
-from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import quote, urljoin
 
 no_cache = 1
 base_template_path = "templates/www/rss.xml"
@@ -22,7 +22,7 @@ def get_context(context):
 
 	for blog in blog_list:
 		blog_page = cstr(quote(blog.name.encode("utf-8")))
-		blog.link = urllib.basejoin(host, blog_page)
+		blog.link = urljoin(host, blog_page)
 		blog.content = escape_html(blog.content or "")
 
 	if blog_list:

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.utils import get_request_site_address, get_datetime, nowdate
 from frappe.website.router import get_pages, get_all_page_context_from_doctypes
 from six import iteritems
-from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import quote, urljoin
 
 no_cache = 1
 no_sitemap = 1
@@ -21,13 +21,13 @@ def get_context(context):
 	for route, page in iteritems(get_pages()):
 		if not page.no_sitemap:
 			links.append({
-				"loc": urllib.basejoin(host, quote(page.name.encode("utf-8"))),
+				"loc": urljoin(host, quote(page.name.encode("utf-8"))),
 				"lastmod": nowdate()
 			})
 
 	for route, data in iteritems(get_all_page_context_from_doctypes()):
 		links.append({
-			"loc": urllib.basejoin(host, quote((route or "").encode("utf-8"))),
+			"loc": urljoin(host, quote((route or "").encode("utf-8"))),
 			"lastmod": get_datetime(data.get("modified")).strftime("%Y-%m-%d")
 		})
 

--- a/frappe/www/third_party_apps.py
+++ b/frappe/www/third_party_apps.py
@@ -26,7 +26,7 @@ def get_context(context):
 		client_apps.append(app)
 
 	app = None
-	if (frappe.form_dict.has_key("app")):
+	if "app" in frappe.form_dict:
 		app = frappe.get_doc("OAuth Client", frappe.form_dict.app)
 		app = app.__dict__
 		app["client_secret"] = None


### PR DESCRIPTION
After [Frappe PR #3984](https://github.com/frappe/frappe/pull/3984) and [ERPNext PR #10519](https://github.com/frappe/erpnext/pull/10519)

`bench run-tests` fails without printing test logs

this and [ERPNext PR #10670](https://github.com/frappe/erpnext/pull/10670) fixes that and now `bench run-tests` yields test logs



```
...


E..EEEEEEEE.....F........E..EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.........E
E.......EE.......EEEEEE.....EEEEEEEEEEEEEEEEEEEEE.EEFEEEEEEEEEEE.............
.E....E.E.EEE.....EEEEEEEEEEE........E...E.........EE...FF..F...FFFFFF......E..E..........F
..........FFEEEEEEEF...F.EEEE..EEEEEEE.EE..........EEE..............E..E..EEEEE..EEE..
..E.EEEE.EEEEEEEEEEEEEEEEEEEE.EEEE..E...EEEEEEEEEEEE......................EEE
E.EEEE.E...............EEE..E........E..E.......E...................EEEEEEEEEEF.EEEEEEEEEE
EEEEEE..F.EFEEEEE..EEEE..EEEEEEEEEEEEEEFEEEEEEEE.EEEEEEEEE......E.EE
EEE.EEEEEEEEE.EEEEEEEEE..EEE.EEEEEEE.EEEEEEEE.EEE.E......EE......E.E.......
....................F...EEEEEE...E


...

Ran 661 tests in 272.446s

FAILED (failures=21, errors=327)
```