### PR TITLE
[minor] Increase Query Report Result Area size to 70vh

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -45,7 +45,7 @@ frappe.views.QueryReport = Class.extend({
 		<div class="no-report-area msg-box no-border" style="display: none;"></div>\
 		<div class="chart_area" style="border-bottom: 1px solid #d1d8dd; padding: 0px 5%"></div>\
 		<div class="results" style="display: none;">\
-			<div class="result-area" style="height:400px;"></div>\
+			<div class="result-area" style="height:70vh;"></div>\
 			<button class="btn btn-secondary btn-default btn-xs expand-all hidden" style="margin: 10px;">'+__('Expand All')+'</button>\
 			<button class="btn btn-secondary btn-default btn-xs collapse-all hidden" style="margin: 10px; margin-left: 0px;">'+__('Collapse All')+'</button>\
 			<p class="help-msg alert alert-warning text-center" style="margin: 15px; margin-top: 0px;"></p>\


### PR DESCRIPTION
It would be nice to have dynamic resizing of the Result Area for Query Reports. Though upon checking, this is controlled by a JS Library called Slick. Grid. For now the quickest workaround is to make the area from 400px to 650px to cater more space. 

**400px**

![400](https://user-images.githubusercontent.com/21003054/30093859-ce508e18-92fa-11e7-9ecc-f421513523f4.png)


**650px**

![650](https://user-images.githubusercontent.com/21003054/30093874-dfe89c88-92fa-11e7-97f2-502528e399b3.png)

If anyone can edit this to a more dynamic state would be really great!

