### PR TITLE
[Fix] Item code - integer 

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -389,6 +389,9 @@ class Database:
 		if isinstance(filters, string_types):
 			filters = { "name": filters }
 
+		elif isinstance(filters, integer_types):
+			filters = {"name": frappe.as_unicode(filters)}
+
 		for f in filters:
 			_build_condition(f)
 


### PR DESCRIPTION
Summary:
While creating a new item, item code couldn't be saved as a numeric value.
![anim1](https://user-images.githubusercontent.com/17617465/30159739-4172a128-93e7-11e7-9307-3507f3d8da5f.gif)

Now, it could be saved as a numeric value by converting it into a string type.
![anim](https://user-images.githubusercontent.com/17617465/30159770-6ce48c04-93e7-11e7-9615-7bc383cd47ad.gif)
