### PR TITLE
[Fix] Type conversion in item code

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -8,7 +8,7 @@ import frappe.model
 import frappe.utils
 import json, os
 
-from six import iteritems, string_types
+from six import iteritems, string_types, integer_types
 
 '''
 Handle RESTful requests that are mapped to the `/api/resource` route.
@@ -61,6 +61,10 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False):
 
 	try:
 		filters = json.loads(filters)
+
+		if isinstance(filters, (integer_types, float)):
+			filters = frappe.as_unicode(filters)
+
 	except (TypeError, ValueError):
 		# filters are not passesd, not json
 		pass


### PR DESCRIPTION
Summary: 
While creating a new item, item code cannot be set as a numeric value, json.loads loaded data containing only numerics as int/float.

![anim1](https://user-images.githubusercontent.com/17617465/30162591-fd287e64-93f2-11e7-9dbb-98342e46e634.gif)

Made changes in the client.py file which converts the numeric value to string and sets the item code.

![anim](https://user-images.githubusercontent.com/17617465/30162653-348dbd2e-93f3-11e7-87b8-16052bba5e9c.gif)
