### PR TITLE
[minor] show the child table fields lable in Auto Email Report

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -147,10 +147,13 @@ class Report(Document):
 				limit=limit,
 				user=user)
 
-			meta = frappe.get_meta(self.ref_doctype)
-
-			columns = [meta.get_field(c[0]) or frappe._dict(label=meta.get_label(c[0]), fieldname=c[0])
-				for c in columns]
+			_columns = []
+			for column in columns:
+				meta = frappe.get_meta(column[1])
+				field = [meta.get_field(column[0]) 
+					or frappe._dict(label=meta.get_label(column[0]), fieldname=column[0])]
+				_columns.extend(field)
+			columns = _columns
 
 			out = out + [list(d) for d in result]
 

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -150,8 +150,7 @@ class Report(Document):
 			_columns = []
 			for column in columns:
 				meta = frappe.get_meta(column[1])
-				field = [meta.get_field(column[0]) 
-					or frappe._dict(label=meta.get_label(column[0]), fieldname=column[0])]
+				field = [meta.get_field(column[0]) or frappe._dict(label=meta.get_label(column[0]), fieldname=column[0])]
 				_columns.extend(field)
 			columns = _columns
 

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -103,7 +103,7 @@ class AutoEmailReport(Document):
 
 	@staticmethod
 	def get_spreadsheet_data(columns, data):
-		out = [[df.label for df in columns], ]
+		out = [[_(df.label) for df in columns], ]
 		for row in data:
 			new_row = []
 			out.append(new_row)

--- a/frappe/templates/emails/auto_email_report.html
+++ b/frappe/templates/emails/auto_email_report.html
@@ -20,7 +20,7 @@
 		<tr>
 			{% for col in columns %}
 			<th {{- get_alignment(col) }}>
-				{{- col.label -}}
+				{{- _(col.label) -}}
 			</th>
 			{% endfor %}
 		</tr>


### PR DESCRIPTION
fixes for https://github.com/frappe/frappe/issues/3098, https://github.com/frappe/frappe/issues/3323

`before`
<img width="854" alt="screen shot 2017-09-11 at 5 29 06 pm" src="https://user-images.githubusercontent.com/11224291/30273483-c919e442-9716-11e7-93fa-6ffa813be7a5.png">

`after`
<img width="850" alt="screen shot 2017-09-11 at 5 54 43 pm" src="https://user-images.githubusercontent.com/11224291/30274343-a6378dc2-971a-11e7-86da-e3a650ac8528.png">
