### PR TITLE
[Fix] Accentuated characters are valid email's sender name

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -491,7 +491,9 @@ def check_format(email_id):
 
 def get_name_from_email_string(email_string, email_id, name):
 	name = email_string.replace(email_id, '')
-	name = re.sub('[^A-Za-z0-9 ]+', '', name).strip()
+	name = re.sub('[^A-Za-z0-9\u00C0-\u024F\/\_\' ]+', '', name).strip()
+	if not name:
+		name = email_id
 	return name
 
 def get_installed_apps_info():


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/11695402/30421110-5f6a06ea-9959-11e7-8622-2111e6f41a57.png)
Updated regex for extracting sender's name
![after](https://user-images.githubusercontent.com/11695402/30421136-7745252e-9959-11e7-8acf-a6ef25e2fb26.png)

