### PR TITLE
[minor] don't format Code type fields in listview

### DIFF
--- a/frappe/public/js/frappe/list/list_item_main.html
+++ b/frappe/public/js/frappe/list/list_item_main.html
@@ -32,6 +32,8 @@
             data-filter="{%= col.fieldname %},=,{%= value %}">
         {% if(formatters && formatters[col.fieldname]) { %}
             {{ formatters[col.fieldname](value, col.df, data) }}
+        {% } else if(col.fieldtype == "Code") { %}
+            {{ value }}
         {% } else { %}
             {{ frappe.format(value, col.df, null, data) }}
         {% } %}


### PR DESCRIPTION
fixes for https://github.com/frappe/frappe/issues/2957

`before`

<img width="950" alt="screen shot 2017-09-14 at 4 49 45 pm" src="https://user-images.githubusercontent.com/11224291/30427254-bc6b41de-996c-11e7-84d9-1f690fc4a1c7.png">

`after`

<img width="946" alt="screen shot 2017-09-14 at 4 49 11 pm" src="https://user-images.githubusercontent.com/11224291/30427231-a803bb2c-996c-11e7-9ea5-e3a2bed38e6a.png">
