### PR TITLE
[fix] set default role specified in Portal Settings while signup as website user

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -746,6 +746,11 @@ def sign_up(email, full_name, redirect_to):
 		user.flags.ignore_permissions = True
 		user.insert()
 
+		# set default signup role as per Portal Settings
+		default_role = frappe.db.get_value("Portal Settings", None, "default_role")
+		if default_role:
+			user.add_roles(default_role)
+
 		if redirect_to:
 			frappe.cache().hset('redirect_after_login', user.name, redirect_to)
 

--- a/frappe/website/doctype/portal_settings/portal_settings.js
+++ b/frappe/website/doctype/portal_settings/portal_settings.js
@@ -2,6 +2,16 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Portal Settings', {
+	setup: function(frm){
+		frm.fields_dict["default_role"].get_query = function(doc){
+			return {
+				filters: {
+					"desk_access": 0,
+					"disabled": 0
+				}
+			}
+		}
+	},
 	onload: function(frm) {
 		frm.get_field('menu').grid.only_sortable();
 	},


### PR DESCRIPTION
- Show only non-desk access roles on Portal Settings
- Set to user if `Default Role at Time of Signup` specified in Portal Settings