### PR TITLE
[hotfix] encode traceback for frappe.log_error method

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1330,7 +1330,7 @@ def logger(module=None, with_more_info=True):
 
 def log_error(message=None, title=None):
 	'''Log error to Error Log'''
-	get_doc(dict(doctype='Error Log', error=str(message or get_traceback()),
+	get_doc(dict(doctype='Error Log', error=as_unicode(message or get_traceback()),
 		method=title)).insert(ignore_permissions=True)
 
 def get_desk_link(doctype, name):


### PR DESCRIPTION
fixes for https://github.com/frappe/frappe/issues/4119
Error while logging following error
```
NegativeStockError: São necessárias 2.0 unidades de <a href="#Form/Item/low on stock item" style="font-weight: bold;">Item low on stock item</a> em <a href="#Form/Warehouse/Stores - WPL" style="font-weight: bold;">Armazém Stores - WPL</a> para concluir esta transação.
```
```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 923, in call
    return fn(*args, **newargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 323, in make_invoice
    name_list = submit_invoice(si_doc, name, doc, name_list)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 486, in submit_invoice
    frappe.log_error(frappe.get_traceback())
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 1333, in log_error
    get_doc(dict(doctype='Error Log', error=str(message or get_traceback()),
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe3' in position 3867: ordinal not in range(128)
```