### PR TITLE
[fixes] render extracted jinja title for custom doctypes

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -168,6 +168,9 @@ def build_page(path):
 		frappe.local.path = path
 
 	context = get_context(path)
+	if "{{" in context.title:
+		title_template = context.pop('title')
+		context.title = frappe.render_template(title_template, context)
 
 	if context.source:
 		html = frappe.render_template(context.source, context)


### PR DESCRIPTION
context.title value was `{{ title or (_("{0} List").format(doctype)) }}`
`before`
<img width="511" alt="screen shot 2017-09-15 at 11 40 09 am" src="https://user-images.githubusercontent.com/11224291/30468757-a60598d8-9a0a-11e7-97ea-78068c7fcf10.png">

`after`
<img width="493" alt="screen shot 2017-09-15 at 11 39 48 am" src="https://user-images.githubusercontent.com/11224291/30468763-aa3753b0-9a0a-11e7-83cb-c4737fce322f.png">