### PR TITLE
[minor] don't setup checkbox if the childtable is read_only

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -142,6 +142,8 @@ frappe.ui.form.Grid = Class.extend({
 				grid: this
 			});
 		}
+		// to hide checkbox if grid is not editable
+		this.header_row.toggle_check();
 	},
 	refresh: function(force) {
 		!this.wrapper && this.make();
@@ -170,7 +172,6 @@ frappe.ui.form.Grid = Class.extend({
 		} else {
 			// redraw
 			var _scroll_y = $(document).scrollTop();
-
 			this.make_head();
 
 			if(!this.grid_rows) {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -142,8 +142,6 @@ frappe.ui.form.Grid = Class.extend({
 				grid: this
 			});
 		}
-		// to hide checkbox if grid is not editable
-		this.header_row.toggle_check();
 	},
 	refresh: function(force) {
 		!this.wrapper && this.make();
@@ -173,6 +171,8 @@ frappe.ui.form.Grid = Class.extend({
 			// redraw
 			var _scroll_y = $(document).scrollTop();
 			this.make_head();
+			// to hide checkbox if grid is not editable
+			this.header_row && this.header_row.toggle_check();
 
 			if(!this.grid_rows) {
 				this.grid_rows = [];

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -2,10 +2,10 @@ frappe.ui.form.GridRow = Class.extend({
 	init: function(opts) {
 		this.on_grid_fields_dict = {};
 		this.on_grid_fields = [];
-		this.row_check_html = '<input type="checkbox" class="grid-row-check pull-left">';
 		this.columns = {};
 		this.columns_list = [];
 		$.extend(this, opts);
+		this.row_check_html = '<input type="checkbox" class="grid-row-check pull-left">';
 		this.make();
 	},
 	make: function() {
@@ -121,6 +121,8 @@ frappe.ui.form.GridRow = Class.extend({
 		if(this.grid_form) {
 			this.grid_form.layout && this.grid_form.layout.refresh(this.doc);
 		}
+
+		this.toggle_check();
 	},
 	render_template: function() {
 		this.set_row_index();
@@ -592,4 +594,10 @@ frappe.ui.form.GridRow = Class.extend({
 	toggle_editable: function(fieldname, editable) {
 		this.set_field_property(fieldname, 'read_only', editable ? 0 : 1);
 	},
+	toggle_check: function() {
+		// to hide checkbox if grid is not editable
+		this.wrapper
+			.find('.grid-row-check')
+			.css("display", this.grid.is_editable()? 'block':'none');
+	}
 });


### PR DESCRIPTION
fixes for https://github.com/frappe/frappe/issues/2503

`before`
<img width="727" alt="screen shot 2017-09-15 at 12 48 44 pm" src="https://user-images.githubusercontent.com/11224291/30470913-4de655de-9a14-11e7-95b5-9850ede7b3b0.png">

`after`
<img width="736" alt="screen shot 2017-09-15 at 12 48 19 pm" src="https://user-images.githubusercontent.com/11224291/30470920-5224240a-9a14-11e7-9af8-6ec3f34675f3.png">
