### PR TITLE
[minor] dont show the quick entry dialog if there are no mandatory or bold fields available

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -48,7 +48,8 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 			return false;
 		}
 
-		if (this.too_many_mandatory_fields() || this.has_child_table()) {
+		if (this.too_many_mandatory_fields() || this.has_child_table()
+			|| !this.mandatory.length) {
 			return false;
 		}
 


### PR DESCRIPTION
redirect to form if doctype don't have any mandatory or bold fields

<img width="1027" alt="screen shot 2017-09-15 at 6 03 35 pm" src="https://user-images.githubusercontent.com/11224291/30482336-38440e5c-9a40-11e7-8856-e25563dbac04.png">