### PR TITLE
[minor] reverted code control's background color to white

### DIFF
--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -601,8 +601,7 @@ select.form-control {
 .control-code.bold {
   height: 400px;
   font-family: Monaco, "Courier New", monospace;
-  background-color: black;
-  color: #fffce7;
+  color: black;
   font-size: 12px;
   line-height: 1.7em;
   border: none;

--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -601,10 +601,9 @@ select.form-control {
 .control-code.bold {
   height: 400px;
   font-family: Monaco, "Courier New", monospace;
-  color: black;
+  color: #36414C;
   font-size: 12px;
   line-height: 1.7em;
-  border: none;
 }
 .delivery-status-indicator {
   display: inline-block;

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -749,8 +749,7 @@ select.form-control {
 .control-code, .control-code.bold {
 	height: 400px;
 	font-family: Monaco, "Courier New", monospace;
-	background-color: black;
-	color: @light-yellow;
+	color: black;
 	font-size: 12px;
 	line-height: 1.7em;
 	border: none;

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -749,10 +749,9 @@ select.form-control {
 .control-code, .control-code.bold {
 	height: 400px;
 	font-family: Monaco, "Courier New", monospace;
-	color: black;
+	color: @text-color;
 	font-size: 12px;
 	line-height: 1.7em;
-	border: none;
 }
 
 .delivery-status-indicator {


### PR DESCRIPTION
fixes for https://github.com/frappe/frappe/issues/4080