### PR TITLE
[fix] Make toolbar only after reaching desk

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -26,11 +26,7 @@ frappe.setup = {
 }
 
 frappe.pages['setup-wizard'].on_page_load = function(wrapper) {
-	// setup page ui
-	$(".navbar:first").toggle(false);
-
-	var requires = ["/assets/frappe/css/animate.min.css"].concat(
-		frappe.boot.setup_wizard_requires || []);
+	var requires = (frappe.boot.setup_wizard_requires || []);
 
 	frappe.require(requires, function() {
 		frappe.call({
@@ -38,7 +34,7 @@ frappe.pages['setup-wizard'].on_page_load = function(wrapper) {
 			freeze: true,
 			callback: function(r) {
 				frappe.setup.data.lang = r.message;
-				
+
 				frappe.setup.run_event("before_load");
 				var wizard_settings = {
 					parent: wrapper,
@@ -181,8 +177,8 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 					localStorage.setItem("session_last_route", frappe.setup.welcome_page);
 				}
 				setTimeout(function() {
-					// frappe.ui.toolbar.clear_cache();
-					window.location = "/desk";
+					// Reload
+					window.location.href = '';
 				}, 2000);
 				setTimeout(()=> {
 					$('body').removeClass('setup-state');

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -355,7 +355,7 @@ frappe.Application = Class.extend({
 	},
 	make_nav_bar: function() {
 		// toolbar
-		if(frappe.boot) {
+		if(frappe.boot && !frappe.boot.in_setup_wizard) {
 			frappe.frappe_toolbar = new frappe.ui.toolbar.Toolbar();
 		}
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -163,6 +163,7 @@ def get():
 		# check only when clear cache is done, and don't cache this
 		if frappe.local.request:
 			bootinfo["change_log"] = get_change_log()
+			bootinfo["in_setup_wizard"] = not cint(frappe.db.get_single_value('System Settings', 'setup_complete'))
 			bootinfo["is_first_startup"] = cint(frappe.db.get_single_value('System Settings', 'is_first_startup'))
 
 	bootinfo["metadata_version"] = frappe.cache().get_value("metadata_version")


### PR DESCRIPTION
As all of the toolbar's functionality makes sense post-setup, it is likely better to not create it at all during setup, rather than creating and then simply hiding it.
The toolbar also has listeners attached, some of which may require permissions:
![screen shot 2017-09-22 at 1 12 10 am](https://user-images.githubusercontent.com/5196925/30720101-ceb407e0-9f43-11e7-92d1-2b69e56a795a.png)


Behaviour stays the same:
![toolbar_fix](https://user-images.githubusercontent.com/5196925/30720068-af10e5c0-9f43-11e7-9d53-12d3bc9e671f.gif)