### PR TITLE
Force uploads to be private by default

### DIFF
--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -12,6 +12,9 @@ frappe.upload = {
 
 		// whether to show public/private checkbox or not
 		opts.show_private = !("is_private" in opts);
+		
+		// make private by default
+		opts.is_private = 1;
 
 		var d = null;
 		// create new dialog if no parent given
@@ -195,6 +198,8 @@ frappe.upload = {
 		$(document).on('upload_complete', on_upload);
 
 		function upload_next() {
+			
+			debugger;
 			if(files) {
 				i += 1;
 				var file = files[i];
@@ -237,7 +242,6 @@ frappe.upload = {
 		if (args.file_size) {
 			frappe.upload.validate_max_file_size(args.file_size);
 		}
-
 		if(opts.on_attach) {
 			opts.on_attach(args)
 		} else {

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -14,7 +14,7 @@ frappe.upload = {
 		opts.show_private = !("is_private" in opts);
 		
 		// make private by default
-		if (!("options" in opts) || ("options" in opts && 
+		if (!("options" in opts) || ("options" in opts &&
 			(!opts.options.toLowerCase()=="public" && !opts.options.toLowerCase()=="image"))) {
 			opts.is_private = 1;
 		}

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -14,8 +14,10 @@ frappe.upload = {
 		opts.show_private = !("is_private" in opts);
 		
 		// make private by default
-		opts.is_private = 1;
-
+		if (!("options" in opts) || ("options" in opts && !opts.options.toLowerCase()=="image")) {
+			opts.is_private = 1;
+		}
+		
 		var d = null;
 		// create new dialog if no parent given
 		if(!opts.parent) {
@@ -165,12 +167,12 @@ frappe.upload = {
 					<div class="list-item__content list-item__content--flex-2 ellipsis">
 						<span>${file.name}</span>
 						<span style="margin-top: 1px; margin-left: 5px;"
-							class="fa fa-fw text-warning fa-lock">
+							class="fa fa-fw text-warning ${file.is_private ? 'fa-lock': 'fa-unlock-alt'}">
 						</span>
 					</div>
 					${show_private?
 						`<div class="list-item__content file-public-column ellipsis">
-							<input type="checkbox"/></div>`
+							<input type="checkbox" ${!file.is_private ? 'checked' : ''}/></div>`
 					: ''}
 					<div class="list-item__content list-item__content--activity ellipsis" style="flex: 0 0 32px;">
 					<button class="btn btn-default btn-xs text-muted uploaded-file-remove">

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -162,12 +162,12 @@ frappe.upload = {
 					<div class="list-item__content list-item__content--flex-2 ellipsis">
 						<span>${file.name}</span>
 						<span style="margin-top: 1px; margin-left: 5px;"
-							class="fa fa-fw text-warning ${file.is_private ? 'fa-lock': 'fa-unlock-alt'}">
+							class="fa fa-fw text-warning fa-lock">
 						</span>
 					</div>
 					${show_private?
 						`<div class="list-item__content file-public-column ellipsis">
-							<input type="checkbox" ${!file.is_private ? 'checked' : ''}/></div>`
+							<input type="checkbox"/></div>`
 					: ''}
 					<div class="list-item__content list-item__content--activity ellipsis" style="flex: 0 0 32px;">
 					<button class="btn btn-default btn-xs text-muted uploaded-file-remove">
@@ -252,7 +252,7 @@ frappe.upload = {
 					frappe.upload.upload_to_server(fileobj, args, opts);
 				}, __("Private or Public?"));
 			} else {
-				if ("is_private" in opts) {
+				if (!("is_private" in args) && "is_private" in opts) {
 					args["is_private"] = opts.is_private;
 				}
 

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -14,7 +14,8 @@ frappe.upload = {
 		opts.show_private = !("is_private" in opts);
 		
 		// make private by default
-		if (!("options" in opts) || ("options" in opts && !opts.options.toLowerCase()=="image")) {
+		if (!("options" in opts) || ("options" in opts && 
+			(!opts.options.toLowerCase()=="public" && !opts.options.toLowerCase()=="image"))) {
 			opts.is_private = 1;
 		}
 		

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -198,8 +198,6 @@ frappe.upload = {
 		$(document).on('upload_complete', on_upload);
 
 		function upload_next() {
-			
-			debugger;
 			if(files) {
 				i += 1;
 				var file = files[i];


### PR DESCRIPTION
Uploads should be private by default so that sensitive information doesn't accidentally get shared with the public. 

Demo:
![private_uploads](https://user-images.githubusercontent.com/16806041/30723813-86afb14c-9eee-11e7-84a2-f8baf6040010.gif)