### PR TITLE
Fixed rounding problem in stripe integration (#10645)

### DIFF
--- a/frappe/integrations/doctype/stripe_settings/stripe_settings.py
+++ b/frappe/integrations/doctype/stripe_settings/stripe_settings.py
@@ -7,7 +7,7 @@ import frappe
 from frappe.model.document import Document
 from frappe import _
 from six.moves.urllib.parse import urlencode
-from frappe.utils import get_url, call_hook_method, cint
+from frappe.utils import get_url, call_hook_method, cint, flt
 from frappe.integrations.utils import make_get_request, make_post_request, create_request_log, create_payment_gateway
 
 class StripeSettings(Document):
@@ -62,7 +62,7 @@ class StripeSettings(Document):
 			"Bearer {0}".format(self.get_password(fieldname="secret_key", raise_exception=False))}
 		
 		data = {
-			"amount": cint(self.data.amount)*100,
+			"amount": cint(flt(self.data.amount)*100),
 			"currency": self.data.currency,
 			"source": self.data.stripe_token_id,
 			"description": self.data.description

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -65,8 +65,6 @@ def prepare_options(html, options):
 		# defaults
 		'margin-right': '15mm',
 		'margin-left': '15mm',
-		'margin-top': '15mm',
-                'margin-bottom': '15mm',
 	})
 
 	html, html_options = read_options_from_html(html)
@@ -135,6 +133,13 @@ def prepare_header_footer(soup):
 
 			# {"header-html": "/tmp/frappe-pdf-random.html"}
 			options[html_id] = fname
+
+		else:
+			if html_id == "header-html":
+				options["margin-top"] = "15mm"
+
+			elif html_id == "footer-html":
+				options["margin-bottom"] = "15mm"
 
 	return options
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -65,6 +65,8 @@ def prepare_options(html, options):
 		# defaults
 		'margin-right': '15mm',
 		'margin-left': '15mm',
+		'margin-top': '15mm',
+                'margin-bottom': '15mm',
 	})
 
 	html, html_options = read_options_from_html(html)
@@ -133,13 +135,6 @@ def prepare_header_footer(soup):
 
 			# {"header-html": "/tmp/frappe-pdf-random.html"}
 			options[html_id] = fname
-
-		else:
-			if html_id == "header-html":
-				options["margin-top"] = "15mm"
-
-			elif html_id == "footer-html":
-				options["margin-bottom"] = "15mm"
 
 	return options
 


### PR DESCRIPTION
There is a problem when calculating Stripe amount parameter, because it rounds the original value before the multiplication to remove the decimals.