### PR TITLE
Fixed problem with margin top and bottom overwritten in print format (#3451)

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -65,6 +65,8 @@ def prepare_options(html, options):
 		# defaults
 		'margin-right': '15mm',
 		'margin-left': '15mm',
+		'margin-top': '15mm',
+		'margin-bottom': '15mm',
 	})
 
 	html, html_options = read_options_from_html(html)
@@ -133,13 +135,6 @@ def prepare_header_footer(soup):
 
 			# {"header-html": "/tmp/frappe-pdf-random.html"}
 			options[html_id] = fname
-
-		else:
-			if html_id == "header-html":
-				options["margin-top"] = "15mm"
-
-			elif html_id == "footer-html":
-				options["margin-bottom"] = "15mm"
 
 	return options
 


### PR DESCRIPTION
If you define default margin-top and margin-bottom at initialization time as margin-left and margin-right, then you will not have to overwrite it in prepare_header_footer function, so html options tags will not get overwritten too.

See #3451 for details.