### PR TITLE
Allow workbook pass in make_xlsx

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -12,9 +12,11 @@ from six import StringIO, string_types
 
 
 # return xlsx file object
-def make_xlsx(data, sheet_name):
+def make_xlsx(data, sheet_name, wb=None):
 
-	wb = openpyxl.Workbook(write_only=True)
+	if wb is None:
+		wb = openpyxl.Workbook(write_only=True)
+
 	ws = wb.create_sheet(sheet_name, 0)
 
 	row1 = ws.row_dimensions[1]


### PR DESCRIPTION
Allows the make_xlsx method to be called multiple times for the same workbook (allows multi-sheet workbooks to be created easily).