### PR TITLE
[fix] dropbox upload of unicode filenames

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -146,7 +146,7 @@ def upload_from_folder(path, dropbox_folder, dropbox_client, did_not_upload, err
 def upload_file_to_dropbox(filename, folder, dropbox_client):
 	create_folder_if_not_exists(folder, dropbox_client)
 	chunk_size = 4 * 1024 * 1024
-	file_size = os.path.getsize(filename)
+	file_size = os.path.getsize(encode(filename))
 	mode = (dropbox.files.WriteMode.overwrite)
 
 	f = open(encode(filename), 'rb')


### PR DESCRIPTION
When using Unicode filenames Dropbox backup fails with an error similar to:
UnicodeEncodeError: 'ascii' codec can't encode character u'\u015f' in position 44: ordinal not in range(128)
This commit fixes this issue.