### PR TITLE
[hotfix] send email from sender's email account if From field is selected on communication view

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -287,6 +287,12 @@ def set_incoming_outgoing_accounts(doc):
 	if not doc.outgoing_email_account:
 		doc.outgoing_email_account = frappe.db.get_value("Email Account",
 			{"default_outgoing": 1, "enable_outgoing": 1},
+			["email_id", "always_use_account_email_id_as_sender", "name", "send_unsubscribe_message"],as_dict=True) or frappe._dict()
+
+	if not doc.outgoing_email_account:
+		# if from address is not the default email account
+		doc.outgoing_email_account = frappe.db.get_value("Email Account",
+			{"email_id": doc.sender, "enable_outgoing": 1},
 			["email_id", "always_use_account_email_id_as_sender", "name", "send_unsubscribe_message"], as_dict=True) or frappe._dict()
 
 	if doc.sent_or_received == "Sent":

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -73,14 +73,14 @@ class EMail:
 		self.cc = cc or []
 		self.html_set = False
 
-		self.email_account = email_account or get_outgoing_email_account()
+		self.email_account = email_account or get_outgoing_email_account(sender=sender)
 
 	def set_html(self, message, text_content = None, footer=None, print_html=None,
 		formatted=None, inline_images=None, header=None):
 		"""Attach message in the html portion of multipart/alternative"""
 		if not formatted:
 			formatted = get_formatted_html(self.subject, message, footer, print_html,
-				email_account=self.email_account, header=header)
+				email_account=self.email_account, header=header, sender=self.sender)
 
 		# this is the first html part of a multi-part message,
 		# convert to text well
@@ -234,9 +234,9 @@ class EMail:
 		return self.msg_root.as_string()
 
 def get_formatted_html(subject, message, footer=None, print_html=None,
-		email_account=None, header=None, unsubscribe_link=None):
+		email_account=None, header=None, unsubscribe_link=None, sender=None):
 	if not email_account:
-		email_account = get_outgoing_email_account(False)
+		email_account = get_outgoing_email_account(False, sender=sender)
 
 	rendered_email = frappe.get_template("templates/emails/standard.html").render({
 		"header": get_header(header),

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -64,7 +64,7 @@ def send(recipients=None, sender=None, subject=None, message=None, text_content=
 	if isinstance(send_after, int):
 		send_after = add_days(nowdate(), send_after)
 
-	email_account = get_outgoing_email_account(True, append_to=reference_doctype)
+	email_account = get_outgoing_email_account(True, append_to=reference_doctype, sender=sender)
 	if not sender or sender == "Administrator":
 		sender = email_account.default_sender
 
@@ -401,7 +401,7 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 	try:
 		if not frappe.flags.in_test:
 			if not smtpserver: smtpserver = SMTPServer()
-			smtpserver.setup_email_account(email.reference_doctype)
+			smtpserver.setup_email_account(email.reference_doctype, sender=email.sender)
 
 		for recipient in recipients_list:
 			if recipient.status != "Not Sent":

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -40,9 +40,9 @@ def get_outgoing_email_account(raise_exception_not_set=True, append_to=None, sen
 		outgoing account. If default outgoing account is not found, it will
 		try getting settings from `site_config.json`."""
 
-	full_name, sender_email_id = None, None
+	sender_email_id = None
 	if sender:
-		full_name, sender_email_id = parse_addr(sender) or [None, None]
+		sender_email_id = parse_addr(sender)[1]
 
 	if not getattr(frappe.local, "outgoing_email_account", None):
 		frappe.local.outgoing_email_account = {}


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/10888

If `From` is selected in the Communication View while sending an email then send the email from `From` email account instead of Default Email Account.