### PR TITLE
[FIX] Export Custom DocPerm as a fixture

### DIFF
--- a/frappe/core/doctype/custom_docperm/custom_docperm.json
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.json
@@ -1,5 +1,6 @@
 {
  "allow_copy": 0,
+ "allow_guest_to_view": 0,
  "allow_import": 1,
  "allow_rename": 0,
  "autoname": "hash",
@@ -13,6 +14,7 @@
  "engine": "InnoDB",
  "fields": [
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -23,6 +25,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Role and Level",
@@ -41,6 +44,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -51,6 +55,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Role",
@@ -74,6 +79,7 @@
    "width": "150px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -85,6 +91,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Apply User Permissions",
@@ -103,6 +110,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -114,6 +122,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "If user is the owner",
@@ -132,6 +141,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -142,6 +152,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "length": 0,
@@ -159,6 +170,38 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
+   "allow_on_submit": 0,
+   "bold": 0,
+   "collapsible": 0,
+   "columns": 0,
+   "fieldname": "parent_doctype",
+   "fieldtype": "Link",
+   "hidden": 0,
+   "ignore_user_permissions": 0,
+   "ignore_xss_filter": 0,
+   "in_filter": 0,
+   "in_global_search": 0,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Parent DocType",
+   "length": 0,
+   "no_copy": 0,
+   "options": "DocType",
+   "permlevel": 0,
+   "precision": "",
+   "print_hide": 0,
+   "print_hide_if_no_value": 0,
+   "read_only": 0,
+   "remember_last_selected_value": 0,
+   "report_hide": 0,
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 0,
+   "unique": 0
+  },
+  {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -170,6 +213,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Level",
@@ -192,6 +236,7 @@
    "width": "40px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -204,6 +249,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "User Permission DocTypes",
@@ -222,6 +268,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -232,6 +279,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Permissions",
@@ -250,6 +298,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -261,6 +310,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Read",
@@ -283,6 +333,7 @@
    "width": "32px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -294,6 +345,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Write",
@@ -316,6 +368,7 @@
    "width": "32px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -327,6 +380,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Create",
@@ -349,6 +403,7 @@
    "width": "32px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -360,6 +415,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Delete",
@@ -378,6 +434,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -388,6 +445,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "length": 0,
@@ -405,6 +463,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -415,6 +474,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Submit",
@@ -437,6 +497,7 @@
    "width": "32px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -447,6 +508,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 1,
    "in_standard_filter": 0,
    "label": "Cancel",
@@ -469,6 +531,7 @@
    "width": "32px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -479,6 +542,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Amend",
@@ -501,6 +565,7 @@
    "width": "32px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -511,6 +576,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Additional Permissions",
@@ -529,6 +595,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -540,6 +607,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Report",
@@ -560,6 +628,7 @@
    "width": "32px"
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -571,6 +640,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Export",
@@ -589,6 +659,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -599,6 +670,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Import",
@@ -617,6 +689,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -628,6 +701,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Set User Permissions",
@@ -646,6 +720,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -656,6 +731,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "length": 0,
@@ -673,6 +749,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -684,6 +761,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Share",
@@ -702,6 +780,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -713,6 +792,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Print",
@@ -731,6 +811,7 @@
    "unique": 0
   },
   {
+   "allow_bulk_edit": 0,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -742,6 +823,7 @@
    "ignore_user_permissions": 0,
    "ignore_xss_filter": 0,
    "in_filter": 0,
+   "in_global_search": 0,
    "in_list_view": 0,
    "in_standard_filter": 0,
    "label": "Email",
@@ -760,17 +842,17 @@
    "unique": 0
   }
  ],
+ "has_web_view": 0,
  "hide_heading": 0,
  "hide_toolbar": 0,
  "idx": 0,
  "image_view": 0,
  "in_create": 0,
- "in_dialog": 0,
  "is_submittable": 0,
  "issingle": 0,
  "istable": 0,
  "max_attachments": 0,
- "modified": "2017-01-11 04:21:35.217943",
+ "modified": "2017-09-27 15:22:42.311374",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Custom DocPerm",
@@ -801,6 +883,7 @@
  "quick_entry": 0,
  "read_only": 1,
  "read_only_onload": 0,
+ "show_name_in_global_search": 0,
  "sort_field": "modified",
  "sort_order": "ASC",
  "track_changes": 0,

--- a/frappe/core/doctype/custom_docperm/custom_docperm.py
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.py
@@ -7,4 +7,7 @@ import frappe
 from frappe.model.document import Document
 
 class CustomDocPerm(Document):
-	pass
+	def before_save(self):
+		doctype = self.parent_doctype or self.parent
+		self.parent = doctype
+		self.parent_doctype = doctype

--- a/frappe/core/doctype/custom_docperm/test_custom_docperm.js
+++ b/frappe/core/doctype/custom_docperm/test_custom_docperm.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+// rename this file from _test_[name] to test_[name] to activate
+// and remove above this line
+
+QUnit.test("test: Custom DocPerm", function (assert) {
+	let done = assert.async();
+
+	// number of asserts
+	assert.expect(1);
+
+	frappe.run_serially([
+		// insert a new Custom DocPerm
+		() => frappe.tests.make('Custom DocPerm', [
+			// values to be set
+			{key: 'value'}
+		]),
+		() => {
+			assert.equal(cur_frm.doc.key, 'value');
+		},
+		() => done()
+	]);
+
+});

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -194,3 +194,4 @@ frappe.patches.v8_5.patch_event_colors
 frappe.patches.v8_7.update_email_queue_status
 frappe.patches.v8_10.delete_static_web_page_from_global_search
 frappe.patches.v8_x.add_bgn_xaf_xof_currencies
+frappe.patches.v9_x.set_custom_docperm_parent_doctype

--- a/frappe/patches/v9_x/set_custom_docperm_parent_doctype.py
+++ b/frappe/patches/v9_x/set_custom_docperm_parent_doctype.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+    frappe.reload_doc('core', 'doctype', 'custom_docperm')
+    frappe.db.sql("update `tabCustom DocPerm` set parent_doctype = parent")


### PR DESCRIPTION
Solves this issue 
https://github.com/frappe/frappe/issues/2765

It introduces a new field 'parent_doctype' as @rmehta suggested [here](https://github.com/frappe/frappe/pull/2772#issuecomment-284207570), but instead of changing every use of parent (in permissions.py and permission manager files) to use the new field (which would be error-prone because of the confusion between DocPerm and Custom DocPerm). I thought we can make it gradually, by simply syncing the values of parent and parent_doctype and later we may refactor permission logic to depend on parent_doctype
