### PR TITLE
[minor] display title in user mention instead of docname

### DIFF
--- a/frappe/core/doctype/communication/comment.py
+++ b/frappe/core/doctype/communication/comment.py
@@ -81,7 +81,9 @@ def notify_mentions(doc):
 			return
 
 		sender_fullname = get_fullname(frappe.session.user)
-		parent_doc_label = "{0} {1}".format(_(doc.reference_doctype), doc.reference_name)
+		title_field = frappe.get_meta(doc.reference_doctype).get_title_field()
+		parent_doc_label = "{0}: {1}".format(_(doc.reference_doctype),
+			frappe.db.get_value(doc.reference_doctype, doc.reference_name, title_field))
 		subject = _("{0} mentioned you in a comment").format(sender_fullname)
 
 		recipients = [frappe.db.get_value("User", {"enabled": 1, "username": username, "user_type": "System User"})

--- a/frappe/core/doctype/communication/comment.py
+++ b/frappe/core/doctype/communication/comment.py
@@ -82,8 +82,8 @@ def notify_mentions(doc):
 
 		sender_fullname = get_fullname(frappe.session.user)
 		title_field = frappe.get_meta(doc.reference_doctype).get_title_field()
-		parent_doc_label = "{0}: {1}".format(_(doc.reference_doctype),
-			frappe.db.get_value(doc.reference_doctype, doc.reference_name, title_field))
+		parent_doc_label = "{0}: {1} (#{2})".format(_(doc.reference_doctype),
+			frappe.db.get_value(doc.reference_doctype, doc.reference_name, title_field), doc.reference_name)
 		subject = _("{0} mentioned you in a comment").format(sender_fullname)
 
 		recipients = [frappe.db.get_value("User", {"enabled": 1, "username": username, "user_type": "System User"})

--- a/frappe/core/doctype/communication/comment.py
+++ b/frappe/core/doctype/communication/comment.py
@@ -82,8 +82,16 @@ def notify_mentions(doc):
 
 		sender_fullname = get_fullname(frappe.session.user)
 		title_field = frappe.get_meta(doc.reference_doctype).get_title_field()
-		parent_doc_label = "{0}: {1} (#{2})".format(_(doc.reference_doctype),
-			frappe.db.get_value(doc.reference_doctype, doc.reference_name, title_field), doc.reference_name)
+		title = doc.reference_name if title_field == "name" else \
+			frappe.db.get_value(doc.reference_doctype, doc.reference_name, title_field)
+
+		if title != doc.reference_name:
+			parent_doc_label = "{0}: {1} (#{2})".format(_(doc.reference_doctype),
+				title, doc.reference_name)
+		else:
+			parent_doc_label = "{0}: {1}".format(_(doc.reference_doctype),
+				doc.reference_name)
+
 		subject = _("{0} mentioned you in a comment").format(sender_fullname)
 
 		recipients = [frappe.db.get_value("User", {"enabled": 1, "username": username, "user_type": "System User"})

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -215,7 +215,7 @@ class Meta(Document):
 		title_field = getattr(self, 'title_field', None)
 		if not title_field and self.has_field('title'):
 			title_field = 'title'
-		else:
+		if not title_field:
 			title_field = 'name'
 
 		return title_field


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/4667

`before`
<img width="664" alt="screen shot 2017-09-29 at 6 34 35 pm" src="https://user-images.githubusercontent.com/11224291/31017064-e15a4fc4-a544-11e7-96b3-c20203772143.png">

`after`
<img width="658" alt="screen shot 2017-09-29 at 6 30 10 pm" src="https://user-images.githubusercontent.com/11224291/31016977-843ace36-a544-11e7-83d6-fa11ab81f183.png">
