### PR TITLE
Add function to remove specific custom buttons by label

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -275,9 +275,9 @@ frappe.ui.Page = Class.extend({
 		return $('<li class="divider"></li>').appendTo(this.menu);
 	},
 
-	get_inner_group_button: function(label) {
+	get_inner_group_button: function(label, add_if_not_exists) {
 		var $group = this.inner_toolbar.find('.btn-group[data-label="'+label+'"]');
-		if(!$group.length) {
+		if(!$group.length && add_if_not_exists) {
 			$group = $('<div class="btn-group" data-label="'+label+'" style="margin-left: 10px;">\
 				<button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">\
 				'+label+' <span class="caret"></span></button>\
@@ -287,7 +287,7 @@ frappe.ui.Page = Class.extend({
 	},
 
 	set_inner_btn_group_as_primary: function(label) {
-		this.get_inner_group_button(label).find("button").removeClass("btn-default").addClass("btn-primary");
+		this.get_inner_group_button(label, true).find("button").removeClass("btn-default").addClass("btn-primary");
 	},
 
 	btn_disable_enable: function(btn, response) {
@@ -312,7 +312,7 @@ frappe.ui.Page = Class.extend({
 			me.btn_disable_enable(btn, response);
 		};
 		if(group) {
-			var $group = this.get_inner_group_button(group);
+			var $group = this.get_inner_group_button(group, true);
 			$(this.inner_toolbar).removeClass("hide");
 			return $('<li><a>'+label+'</a></li>')
 				.on('click', _action)
@@ -321,6 +321,19 @@ frappe.ui.Page = Class.extend({
 			return $('<button class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
 				.on("click", _action)
 				.appendTo(this.inner_toolbar.removeClass("hide"));
+		}
+	},
+
+	remove_inner_button: function(label, group) {
+		if(group) {
+			var $group = this.get_inner_group_button(__(group), false);
+			if($group.length) {
+                var $group = this.get_inner_group_button(__(group), false);
+                buttons = $group.find(".dropdown-menu li");
+                buttons.filter(function() { return $.text([this]) === __(label); }).remove();
+            }
+		} else {
+            this.inner_toolbar.find("button").filter(function() { return $.text([this]) === __(label); }).remove();
 		}
 	},
 

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -328,12 +328,11 @@ frappe.ui.Page = Class.extend({
 		if(group) {
 			var $group = this.get_inner_group_button(__(group), false);
 			if($group.length) {
-                var $group = this.get_inner_group_button(__(group), false);
-                buttons = $group.find(".dropdown-menu li");
-                buttons.filter(function() { return $.text([this]) === __(label); }).remove();
-            }
+				var buttons = $group.find(".dropdown-menu li");
+				buttons.filter(function() { return $.text([this]) === __(label); }).remove();
+			}
 		} else {
-            this.inner_toolbar.find("button").filter(function() { return $.text([this]) === __(label); }).remove();
+			this.inner_toolbar.find("button").filter(function() { return $.text([this]) === __(label); }).remove();
 		}
 	},
 

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -275,9 +275,9 @@ frappe.ui.Page = Class.extend({
 		return $('<li class="divider"></li>').appendTo(this.menu);
 	},
 
-	get_inner_group_button: function(label, add_if_not_exists) {
+	get_or_add_inner_group_button: function(label) {
 		var $group = this.inner_toolbar.find('.btn-group[data-label="'+label+'"]');
-		if(!$group.length && add_if_not_exists) {
+		if(!$group.length) {
 			$group = $('<div class="btn-group" data-label="'+label+'" style="margin-left: 10px;">\
 				<button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">\
 				'+label+' <span class="caret"></span></button>\
@@ -286,8 +286,12 @@ frappe.ui.Page = Class.extend({
 		return $group;
 	},
 
+	get_inner_group_button: function(label) {
+		return this.inner_toolbar.find('.btn-group[data-label="'+label+'"]');
+	},
+
 	set_inner_btn_group_as_primary: function(label) {
-		this.get_inner_group_button(label, true).find("button").removeClass("btn-default").addClass("btn-primary");
+		this.get_or_add_inner_group_button(label).find("button").removeClass("btn-default").addClass("btn-primary");
 	},
 
 	btn_disable_enable: function(btn, response) {
@@ -312,7 +316,7 @@ frappe.ui.Page = Class.extend({
 			me.btn_disable_enable(btn, response);
 		};
 		if(group) {
-			var $group = this.get_inner_group_button(group, true);
+			var $group = this.get_or_add_inner_group_button(group);
 			$(this.inner_toolbar).removeClass("hide");
 			return $('<li><a>'+label+'</a></li>')
 				.on('click', _action)
@@ -326,7 +330,7 @@ frappe.ui.Page = Class.extend({
 
 	remove_inner_button: function(label, group) {
 		if(group) {
-			var $group = this.get_inner_group_button(__(group), false);
+			var $group = this.get_inner_group_button(__(group));
 			if($group.length) {
 				var buttons = $group.find(".dropdown-menu li");
 				buttons.filter(function() { return $.text([this]) === __(label); }).remove();

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -4,7 +4,7 @@
 /* Form page structure
 
 	+ this.parent (either FormContainer or Dialog)
-		+ this.wrapper
+ 		+ this.wrapper
 			+ this.toolbar
 			+ this.form_wrapper
 					+ this.head
@@ -927,11 +927,14 @@ _f.Frm.prototype.clear_custom_buttons = function() {
 };
 
 //Remove specific custom button by button Label
-_f.Frm.prototype.remove_custom_buttons = function(buttons) {
+_f.Frm.prototype.remove_custom_button = function(buttons) {
 	if(buttons){
 		for (var i=0; i<buttons.length; i++) {
-			if($.isArray(buttons[i]))
-				this.page.remove_inner_button(buttons[i][0], buttons[i][1]);
+			if($.isArray(buttons[i])){
+			    label = buttons[i][0];
+			    group = buttons[i][1];
+				this.page.remove_inner_button(label, group);
+			}
 		}
 	}
 };

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -4,7 +4,7 @@
 /* Form page structure
 
 	+ this.parent (either FormContainer or Dialog)
- 		+ this.wrapper
+		+ this.wrapper
 			+ this.toolbar
 			+ this.form_wrapper
 					+ this.head
@@ -928,12 +928,12 @@ _f.Frm.prototype.clear_custom_buttons = function() {
 
 //Remove specific custom button by button Label
 _f.Frm.prototype.remove_custom_buttons = function(buttons) {
-    if(buttons){
-        for (var i=0; i<buttons.length; i++) {
-            if($.isArray(buttons[i]))
-                this.page.remove_inner_button(buttons[i][0], buttons[i][1]);
-        }
-    }
+	if(buttons){
+		for (var i=0; i<buttons.length; i++) {
+			if($.isArray(buttons[i]))
+				this.page.remove_inner_button(buttons[i][0], buttons[i][1]);
+		}
+	}
 };
 
 _f.Frm.prototype.add_fetch = function(link_field, src_field, tar_field) {

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -4,7 +4,7 @@
 /* Form page structure
 
 	+ this.parent (either FormContainer or Dialog)
- 		+ this.wrapper
+		+ this.wrapper
 			+ this.toolbar
 			+ this.form_wrapper
 					+ this.head
@@ -931,8 +931,8 @@ _f.Frm.prototype.remove_custom_button = function(buttons) {
 	if(buttons){
 		for (var i=0; i<buttons.length; i++) {
 			if($.isArray(buttons[i])){
-			    label = buttons[i][0];
-			    group = buttons[i][1];
+				var label = buttons[i][0];
+				var group = buttons[i][1];
 				this.page.remove_inner_button(label, group);
 			}
 		}

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -919,10 +919,21 @@ _f.Frm.prototype.add_custom_button = function(label, fn, group) {
 	return btn;
 };
 
+//Remove all custom buttons
 _f.Frm.prototype.clear_custom_buttons = function() {
 	this.page.clear_inner_toolbar();
 	this.page.clear_user_actions();
 	this.custom_buttons = {};
+};
+
+//Remove specific custom button by button Label
+_f.Frm.prototype.remove_custom_buttons = function(buttons) {
+    if(buttons){
+        for (var i=0; i<buttons.length; i++) {
+            if($.isArray(buttons[i]))
+                this.page.remove_inner_button(buttons[i][0], buttons[i][1]);
+        }
+    }
 };
 
 _f.Frm.prototype.add_fetch = function(link_field, src_field, tar_field) {


### PR DESCRIPTION
Function to remove custom button by label

Example : 
1. In Material Request, to remove "Stop" button, can be achieved by calling function as below,
frappe.ui.form.on("Material Request", {
	onload: function(frm) {
		var buttons = [ [ "Stop", "" ] ];
		frm.remove_custom_button(buttons);   
		
		//OR
		//var buttons = [ [ "Stop" ] ]; (since it's not inside group of buttons.)
		//frm.remove_custom_button(buttons);
	}
});

![screenshot from 2017-09-30 10-54-40](https://user-images.githubusercontent.com/9530991/31041801-d885cc82-a5cd-11e7-8fa3-a3c1060b2c0e.png)


2. In Material Request, to remove "Purchase Order" button, can be achieved by calling function as below,
frappe.ui.form.on("Material Request", {
	onload: function(frm) {
		var buttons = [ [ "Purchase Order", "Make" ] ];
		frm.remove_custom_button(buttons);	
	}
});
 
![screenshot from 2017-09-30 10-49-36](https://user-images.githubusercontent.com/9530991/31041754-298a2584-a5cd-11e7-8154-af6124a59dce.png)

3. Remove multiple buttons,
frappe.ui.form.on("Material Request", {
	onload: function(frm) {
		var buttons = [ [ "Purchase Order", "Make" ], [ "Supplier Quotation", "Make" ] ];
		frm.remove_custom_button(buttons);
	}
});

![screenshot from 2017-09-30 10-53-16](https://user-images.githubusercontent.com/9530991/31041785-a069ec02-a5cd-11e7-9bd1-e2e9e478d9c9.png)
