### PR TITLE
[DO NOT MERGE] Added latest babel-preset

### DIFF
--- a/frappe/build.js
+++ b/frappe/build.js
@@ -123,7 +123,7 @@ function pack(output_path, inputs, minify) {
 }
 
 function babelify(content, path, minify) {
-	let presets = ['es2015', 'es2016'];
+	let presets = ['env'];
 	// if(minify) {
 	// 	presets.push('babili'); // new babel minifier
 	// }

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -147,15 +147,16 @@ $.extend(frappe.desktop, {
 		const $icons        = frappe.desktop.wrapper.find('.app-icon');
 		const $notis        = $(frappe.desktop.wrapper.find('.circle').toArray().filter((object) => {
 			// This hack is so bad, I should punch myself.
-			const doctype   = $(object).data('doctype');
+			// Seriously, punch yourself.
+			const text      = $(object).find('.circle-text').html()
 			
-			return doctype;
+			return text
 		}));
 		
 		const clearWiggle   = () => {
 			const $closes   = $cases.find('.module-remove');
 			$closes.hide();
-			$notis.show();
+			 $notis.show();
 
 			$icons.trigger('stopRumble');
 

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -147,10 +147,9 @@ $.extend(frappe.desktop, {
 		const $icons        = frappe.desktop.wrapper.find('.app-icon');
 		const $notis        = $(frappe.desktop.wrapper.find('.circle').toArray().filter((object) => {
 			// This hack is so bad, I should punch myself.
-			// Seriously, punch yourself.
-			const text      = $(object).find('.circle-text').html();
+			const doctype   = $(object).data('doctype');
 			
-			return text;
+			return doctype;
 		}));
 		
 		const clearWiggle   = () => {

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -156,7 +156,7 @@ $.extend(frappe.desktop, {
 		const clearWiggle   = () => {
 			const $closes   = $cases.find('.module-remove');
 			$closes.hide();
-			 $notis.show();
+			$notis.show();
 
 			$icons.trigger('stopRumble');
 

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -150,7 +150,7 @@ $.extend(frappe.desktop, {
 			// Seriously, punch yourself.
 			const text      = $(object).find('.circle-text').html();
 			
-			return text
+			return text;
 		}));
 		
 		const clearWiggle   = () => {

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -148,7 +148,7 @@ $.extend(frappe.desktop, {
 		const $notis        = $(frappe.desktop.wrapper.find('.circle').toArray().filter((object) => {
 			// This hack is so bad, I should punch myself.
 			// Seriously, punch yourself.
-			const text      = $(object).find('.circle-text').html()
+			const text      = $(object).find('.circle-text').html();
 			
 			return text
 		}));


### PR DESCRIPTION
Critical [Issue](https://github.com/frappe/erpnext/issues/10978)

Removed outdated presets and added the latest one for babel (`env`) instead. No more changes required to presets since the `env` preset automatically updates it with the latest one.

This is a current fix, @netchampfaris and I will have the `.babelrc` file attached later. This requires some minor refactor for `frappe/build.js`.

Do not merge since the `package.json` needs to updated within bench. Will ping on the commit, soon.