### PR TITLE
[FIX] new babel-presets

### DIFF
--- a/frappe/build.js
+++ b/frappe/build.js
@@ -123,10 +123,10 @@ function pack(output_path, inputs, minify) {
 }
 
 function babelify(content, path, minify) {
-	let presets = ['es2015', 'es2016'];
-	// if(minify) {
-	// 	presets.push('babili'); // new babel minifier
-	// }
+	let presets = ['env'];
+	if(minify) {
+		presets.push('minify');
+	}
 	try {
 		return babel.transform(content, {
 			presets: presets,

--- a/frappe/build.js
+++ b/frappe/build.js
@@ -124,9 +124,8 @@ function pack(output_path, inputs, minify) {
 
 function babelify(content, path, minify) {
 	let presets = ['env'];
-// 	if(minify) {
-// 		presets.push('minify');
-// 	}
+	// Minification doesn't work when loading Frappe Desk
+	// Avoid for now, trace the error and come back.
 	try {
 		return babel.transform(content, {
 			presets: presets,

--- a/frappe/build.js
+++ b/frappe/build.js
@@ -124,9 +124,9 @@ function pack(output_path, inputs, minify) {
 
 function babelify(content, path, minify) {
 	let presets = ['env'];
-	if(minify) {
-		presets.push('minify');
-	}
+// 	if(minify) {
+// 		presets.push('minify');
+// 	}
 	try {
 		return babel.transform(content, {
 			presets: presets,

--- a/package.json
+++ b/package.json
@@ -14,20 +14,20 @@
   },
   "homepage": "https://frappe.io",
   "dependencies": {
-    "babel-core": "^6.24.1",
-    "babel-preset-babili": "0.0.12",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-es2016": "^6.24.1",
-    "babel-preset-es2017": "^6.24.1",
-    "chokidar": "^1.7.0",
-    "chromedriver": "^2.30.1",
     "cookie": "^0.3.1",
     "express": "^4.15.3",
-    "less": "^2.7.2",
-    "nightwatch": "^0.9.16",
     "redis": "^2.7.1",
     "socket.io": "^2.0.1",
     "superagent": "^3.5.2",
-	"touch": "^3.1.0"
+    "touch": "^3.1.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-minify": "^0.2.0",
+    "chokidar": "^1.7.0",
+    "chromedriver": "^2.32.3",
+    "less": "^2.7.2",
+    "nightwatch": "^0.9.16"
   }
 }


### PR DESCRIPTION
This PR is a fix in reference to the this [issue](https://github.com/frappe/erpnext/issues/10978).

Removed outdated presets and added the latest ones
1. `babel-preset-env` (Autodetects the preset you need to compile ES6
2. `babel-preset-minify` (For minifying, replaced the prior deprecated one - `babeli`)

Although `frappe/build.js` has these presets embedded, I suggest we move to a `.babelrc` file attached with frappe instead. This requires a minor refactor for `frappe/build.js`. (@netchampfaris and I were discussing how we can have module bundlers included as well, all this once we finalize on splitting `frappe.ui`, it's all worth then!)

Also, `package.json` dependencies require a split (development and production). This is currently been done. Thank the lords `bench` merges `package.json` metadata neatly!

No more warnings from `babel` with their 😿 emojis on terminal screens.

Ready to Merge and has been tested.