### PR TITLE
[minor] don't update the parent status if comment is added

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -173,6 +173,11 @@ def update_parent_status(doc):
 	if not parent:
 		return
 
+	# update parent status only if we create the Email communication
+	# ignore in case of only Comment is added
+	if doc.communication_type == "Comment":
+		return
+
 	status_field = parent.meta.get_field("status")
 
 	if status_field:


### PR DESCRIPTION
Parent document status (**Replied**) and **Mins to First Response** should be updated only if the email (Communication) is sent to user and ignore if we are just adding the comment to document