### PR TITLE
Letterhead and title missing in PDF (print and report both) because of unwanted margins

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -64,9 +64,7 @@ def prepare_options(html, options):
 
 		# defaults
 		'margin-right': '15mm',
-		'margin-left': '15mm',
-		'margin-top': '15mm',
-		'margin-bottom': '15mm',
+		'margin-left': '15mm'
 	})
 
 	html, html_options = read_options_from_html(html)


### PR DESCRIPTION
Before (Letterhead and title missing):

<img width="856" alt="screen shot 2017-10-03 at 5 00 40 pm" src="https://user-images.githubusercontent.com/16913064/31123242-b6681bb4-a85c-11e7-894c-fdf7e0009746.png">
 After (With letterhead and the title):
<img width="855" alt="screen shot 2017-10-03 at 5 01 09 pm" src="https://user-images.githubusercontent.com/16913064/31123284-e44c50f4-a85c-11e7-9e78-5688573fba2d.png">

Without letterhead also works fine:
<img width="835" alt="screen shot 2017-10-03 at 5 16 14 pm" src="https://user-images.githubusercontent.com/16913064/31123712-a4dbfd64-a85e-11e7-8387-0dd08bae4842.png">

Following this issue (https://github.com/frappe/frappe/issues/3451). For custom prints I think user should set the margin is custom css instead of hardcoding it here.

Fixed https://github.com/frappe/frappe/issues/4235 and https://github.com/frappe/frappe/issues/4239


For reports:

Before:
<img width="1173" alt="screen shot 2017-10-03 at 5 11 09 pm" src="https://user-images.githubusercontent.com/16913064/31123532-fbba1644-a85d-11e7-804c-aa17fecb6538.png">

After:
<img width="1161" alt="screen shot 2017-10-03 at 5 10 39 pm" src="https://user-images.githubusercontent.com/16913064/31123546-03f834ee-a85e-11e7-9995-c716b4efad33.png">

