### PR TITLE
Empty Child Table Row Should Delete On Save (#4202)

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -63,10 +63,8 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 					return cint(df.in_list_view) === 1;
 				});
 
-				var empty_rows = []
-
 				var is_empty_row = function(cells) {
-					for (i=0; i < cells.length; i++){
+					for (var i=0; i < cells.length; i++){
 						if(locals[doc.doctype][doc.name][cells[i].fieldname]){
 							return false;
 						}

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -41,6 +41,45 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 
 	};
 
+	var remove_empty_rows = function() {
+		/**
+		This function removes empty rows. Note that in this function, a row is considered
+		empty if the fields with `in_list_view: 1` are undefined or falsy because that's
+		what users also consider to be an empty row
+		 */
+		const docs = frappe.model.get_all_docs(frm.doc);
+
+		// we should only worry about table data
+		const tables = docs.filter(function(d){
+			return frappe.model.is_table(d.doctype);
+		});
+
+		tables.map(
+			function(doc){
+				const cells = frappe.meta.docfield_list[doc.doctype] || [];
+
+				const in_list_view_cells = cells.filter(function(df) {
+					return cint(df.in_list_view) === 1;
+				});
+
+				var empty_rows = []
+
+				var is_empty_row = function(cells) {
+					for (i=0; i < cells.length; i++){
+						if(locals[doc.doctype][doc.name][cells[i].fieldname]){
+							return false;
+						}
+					}
+					return true;
+				}
+
+				if (is_empty_row(in_list_view_cells)) {
+					frappe.model.clear_doc(doc.doctype, doc.name);
+				}
+			}
+		);
+	};
+
 	var cancel = function () {
 		var args = {
 			doctype: frm.doc.doctype,

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -18,6 +18,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 	var freeze_message = working_label ? __(working_label) : "";
 
 	var save = function () {
+		remove_empty_rows();
 		check_name(function () {
 			$(frm.wrapper).addClass('validated-form');
 			if (check_mandatory()) {


### PR DESCRIPTION
Fixed #4202  
Admittedly, it's a minor annoyance of ERPNext that empty rows are not deleted automatically. This PR changes that behaviour.

The basic user considers an empty row in a table to be one in which the cells shown on the table are empty of falsy. These will be fields with `in_list_view: 1`. This PR works based on that.

![peek 2017-10-04 05-00](https://user-images.githubusercontent.com/818803/31160292-494c75aa-a8c7-11e7-8105-a06961d08b02.gif)

![peek 2017-10-04 05-01](https://user-images.githubusercontent.com/818803/31160295-4e522130-a8c7-11e7-8d24-02b00230c330.gif)

![peek 2017-10-04 05-11](https://user-images.githubusercontent.com/818803/31160298-53652708-a8c7-11e7-9c04-8ef8e2e557e9.gif)
