### PR TITLE
[Hotfix]Attach field dialog does not display browse button / web link controls (#4246)

### DIFF
--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -14,7 +14,7 @@ frappe.upload = {
 		opts.show_private = !("is_private" in opts);
 		
 		// make private by default
-		if (!("options" in opts) || ("options" in opts &&
+		if (!opts.options || ("options" in opts &&
 			(!opts.options.toLowerCase()=="public" && !opts.options.toLowerCase()=="image"))) {
 			opts.is_private = 1;
 		}


### PR DESCRIPTION
Fixed #4246 
Code makes use of "in operator" which also returns `true` if the value of the key is undefined. This PR changes the case to use dot notation