### PR TITLE
[hotfix] check if doc has valid title value

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -329,7 +329,8 @@ frappe.ui.form.Timeline = Class.extend({
 		if(c.subject && c.communication_type==="Communication") {
 			if(this.frm.doc.subject && !this.frm.doc.subject.includes(c.subject)) {
 				c.show_subject = true;
-			} else if(this.frm.meta.title_field && !!this.frm.doc[this.frm.meta.title_field].includes(c.subject)) {
+			} else if(this.frm.meta.title_field && this.frm.doc[this.frm.meta.title_field]
+				&& !!this.frm.doc[this.frm.meta.title_field].includes(c.subject)) {
 				c.show_subject = true;
 			} else if(!this.frm.doc.name.includes(c.subject)) {
 				c.show_subject = true;


### PR DESCRIPTION
```
form.min.js?ver=1507197398.0:5667 Uncaught (in promise) TypeError: Cannot read property 'includes' of undefined
    at Class.prepare_timeline_item (form.min.js?ver=1507197398.0:5667)
    at Class.render_timeline_item (form.min.js?ver=1507197398.0:5518)
    at form.min.js?ver=1507197398.0:5486
    at Array.forEach (<anonymous>)
    at Class.refresh (form.min.js?ver=1507197398.0:5484)
    at Class.refresh (form.min.js?ver=1507197398.0:5083)
    at HTMLDivElement.<anonymous> (form.min.js?ver=1507197398.0:5062)
    at HTMLDivElement.dispatch (jquery.min.js:3)
    at HTMLDivElement.$event.dispatch (report.min.js?ver=1507197398.0:3036)
    at HTMLDivElement.r.handle (jquery.min.js:3)
```