### PR TITLE
[hotfix] Razorpay Checkout fixes

### DIFF
--- a/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py
+++ b/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py
@@ -83,13 +83,15 @@ class RazorpaySettings(Document):
 			frappe.throw(_("Please select another payment method. Razorpay does not support transactions in currency '{0}'").format(currency))
 
 	def get_payment_url(self, **kwargs):
-		return get_url("./integrations/razorpay_checkout?{0}".format(urlencode(kwargs)))
+		integration_request = create_request_log(kwargs, "Host", "Razorpay")
+		return get_url("./integrations/razorpay_checkout?token={0}".format(integration_request.name))
 
 	def create_request(self, data):
 		self.data = frappe._dict(data)
 
 		try:
-			self.integration_request = create_request_log(self.data, "Host", "Razorpay")
+			self.integration_request = frappe.get_doc("Integration Request", self.data.token)
+			self.integration_request.update_status(self.data, 'Queued')
 			return self.authorize_payment()
 
 		except Exception:

--- a/frappe/templates/includes/integrations/razorpay_checkout.js
+++ b/frappe/templates/includes/integrations/razorpay_checkout.js
@@ -6,7 +6,7 @@ $(document).ready(function(){
 			"name": "{{ title }}",
 			"description": "{{ description }}",
 			"handler": function (response){
-				razorpay.make_payment_log(response, options, "{{ reference_doctype }}", "{{ reference_docname }}");
+				razorpay.make_payment_log(response, options, "{{ reference_doctype }}", "{{ reference_docname }}", "{{ token }}");
 			},
 			"prefill": {
 				"name": "{{ payer_name }}",
@@ -24,7 +24,7 @@ $(document).ready(function(){
 
 frappe.provide('razorpay');
 
-razorpay.make_payment_log = function(response, options, doctype, docname){
+razorpay.make_payment_log = function(response, options, doctype, docname, token){
 	$('.razorpay-loading').addClass('hidden');
 	$('.razorpay-confirming').removeClass('hidden');
 
@@ -36,7 +36,8 @@ razorpay.make_payment_log = function(response, options, doctype, docname){
 			"razorpay_payment_id": response.razorpay_payment_id,
 			"options": options,
 			"reference_doctype": doctype,
-			"reference_docname": docname
+			"reference_docname": docname,
+			"token": token
 		},
 		callback: function(r){
 			if (r.message && r.message.status == 200) {


### PR DESCRIPTION
- Generate token while initiating razorpay payment and accept payment against the token. 
   Do not pass payment arguments in URL, the user can modify payment parameters.