### PR TITLE
[fix] Hide Editable Grid Columns

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -345,47 +345,57 @@ frappe.ui.form.Grid = Class.extend({
 		return data;
 	},
 	set_column_disp: function(fieldname, show) {
-		var fname = "";
-
 		if($.isArray(fieldname)) {
 			var me = this;
 			for(var i=0, l=fieldname.length; i<l; i++) {
-				fname = fieldname[i];
+				var fname = fieldname[i];
 				me.get_docfield(fname).hidden = show ? 0 : 1;
+				set_editable_grid_column_disp(fname, show);
 			}
 		} else {
 			this.get_docfield(fieldname).hidden = show ? 0 : 1;
-			fname = fieldname;
+			set_editable_grid_column_disp(fieldname, show);
 		}
 
+		this.refresh(true);
+	},
+	set_editable_grid_column_disp: function(fieldname, show) {
 		//Hide columns for editable grids
 		if (this.meta.editable_grid) {
 			this.grid_rows.forEach(function(row) {
 				row.columns_list.forEach(function(column) {
 					//Hide the column specified
-					if (column.df.fieldname == fname) {
-						//Show the static area and hide field area if it is not the editable row
-						if (show && (row != frappe.ui.form.editable_row)) {
-							column.static_area.show();
-							column.field_area && column.field_area.toggle(false);
+					if (column.df.fieldname == fieldname) {
+						if (show) {
+							column.df.hidden = false;
+
+							//Show the static area and hide field area if it is not the editable row
+							if  (row != frappe.ui.form.editable_row) {
+								column.static_area.show();
+								column.field_area && column.field_area.toggle(false);
+							}
+							//Hide the static area and show field area if it is the editable row
+							else {
+								column.static_area.hide();
+								column.field_area && column.field_area.toggle(true);
+
+								//Format the editable column appropriately if it is now visible
+								if (column.field) {
+									column.field.refresh();
+									if (column.field.$input) column.field.$input.toggleClass('input-sm', true);
+								}
+							}
 						}
 						else {
-							//Hide the static area but show the field area if it is the editable row
+							column.df.hidden = true;
 							column.static_area.hide();
-							column.field_area && column.field_area.toggle(true);
-
-							//Format the editable column appropriately if it is now visible
-							if (column.field) {
-								column.field.refresh();
-								if (column.field.$input) column.field.$input.toggleClass('input-sm', true);
-							}
 						}
 					}
 				});
 			});
 		}
 
-		this.refresh(true);
+		this.refresh();
 	},
 	toggle_reqd: function(fieldname, reqd) {
 		this.get_docfield(fieldname).reqd = reqd;

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -345,15 +345,17 @@ frappe.ui.form.Grid = Class.extend({
 		return data;
 	},
 	set_column_disp: function(fieldname, show) {
+		var fname = "";
+
 		if($.isArray(fieldname)) {
 			var me = this;
 			for(var i=0, l=fieldname.length; i<l; i++) {
-				var fname = fieldname[i];
+				fname = fieldname[i];
 				me.get_docfield(fname).hidden = show ? 0 : 1;
 			}
 		} else {
 			this.get_docfield(fieldname).hidden = show ? 0 : 1;
-			var fname = fieldname;
+			fname = fieldname;
 		}
 
 		//Hide columns for editable grids

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -357,7 +357,7 @@ frappe.ui.form.Grid = Class.extend({
 		}
 
 		//Hide columns for editable grids
-		if (this.is_editable()) {
+		if (this.meta.editable_grid) {
 			this.grid_rows.forEach(function(row) {
 				row.columns_list.forEach(function(column) {
 					//Hide the column specified

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -353,6 +353,34 @@ frappe.ui.form.Grid = Class.extend({
 			}
 		} else {
 			this.get_docfield(fieldname).hidden = show ? 0 : 1;
+			var fname = fieldname;
+		}
+
+		//Hide columns for editable grids
+		if (this.is_editable()) {
+			this.grid_rows.forEach(function(row) {
+				row.columns_list.forEach(function(column) {
+					//Hide the column specified
+					if (column.df.fieldname == fname) {
+						//Show the static area and hide field area if it is not the editable row
+						if (show && (row != frappe.ui.form.editable_row)) {
+							column.static_area.show();
+							column.field_area && column.field_area.toggle(false);
+						}
+						else {
+							//Hide the static area but show the field area if it is the editable row
+							column.static_area.hide();
+							column.field_area && column.field_area.toggle(true);
+
+							//Format the editable column appropriately if it is now visible
+							if (column.field) {
+								column.field.refresh();
+								if (column.field.$input) column.field.$input.toggleClass('input-sm', true);
+							}
+						}
+					}
+				});
+			});
 		}
 
 		this.refresh(true);

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -350,11 +350,11 @@ frappe.ui.form.Grid = Class.extend({
 			for(var i=0, l=fieldname.length; i<l; i++) {
 				var fname = fieldname[i];
 				me.get_docfield(fname).hidden = show ? 0 : 1;
-				set_editable_grid_column_disp(fname, show);
+				this.set_editable_grid_column_disp(fname, show);
 			}
 		} else {
 			this.get_docfield(fieldname).hidden = show ? 0 : 1;
-			set_editable_grid_column_disp(fieldname, show);
+			this.set_editable_grid_column_disp(fieldname, show);
 		}
 
 		this.refresh(true);

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -308,7 +308,10 @@ frappe.ui.form.GridRow = Class.extend({
 		} else {
 			this.row.toggleClass('editable-row', false);
 			this.columns_list.forEach(function(column) {
-				column.static_area.toggle(true);
+				if (column.df.hidden == false) {
+					column.static_area.toggle(true);
+				}
+
 				column.field_area && column.field_area.toggle(false);
 			});
 			frappe.ui.form.editable_row = null;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -288,7 +288,7 @@ frappe.ui.form.GridRow = Class.extend({
 		// whether grid is editable
 		if(this.grid.allow_on_grid_editing() && this.grid.is_editable() && this.doc && show !== false) {
 
-			// disable other editale row
+			// disable other editable row
 			if(frappe.ui.form.editable_row
 				&& frappe.ui.form.editable_row !== this) {
 				frappe.ui.form.editable_row.toggle_editable_row(false);


### PR DESCRIPTION
This fixes a bug where set_column_disp does not hide editable grid columns.

fixes: https://github.com/frappe/frappe/issues/4254