### PR TITLE
Minor changes to suppport treeview for task

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -59,7 +59,7 @@ def make_tree_args(**kwarg):
 	
 	doctype = kwarg['doctype']
 	parent_field = 'parent_' + doctype.lower().replace(' ', '_')
-	name_field = doctype.lower().replace(' ', '_') + '_name'
+	name_field = kwarg.get('name_field', doctype.lower().replace(' ', '_') + '_name')
 	
 	kwarg.update({
 		name_field: kwarg[name_field],

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -43,6 +43,7 @@ frappe.views.TreeView = Class.extend({
 			this.get_root();
 		}
 
+		this.onload();
 		this.set_menu_item();
 		this.set_primary_action();
 	},
@@ -79,6 +80,10 @@ frappe.views.TreeView = Class.extend({
 		} else {
 			this.body = this.page.main;
 		}
+	},
+	onload: function() {
+		var me = this;
+		this.opts.onload && this.opts.onload(me);
 	},
 	make_filters: function(){
 		var me = this;


### PR DESCRIPTION
Summary:
Root label was not visible if there were no tasks to begin with. added an onload function to make_tree even in absence of data under root.