### PR TITLE
[hotfix] fixed margin for disabled check field

### DIFF
--- a/frappe/public/css/desk.css
+++ b/frappe/public/css/desk.css
@@ -626,6 +626,10 @@ li.user-progress .progress-bar {
 }
 .frappe-rtl .checkbox .disp-area {
   margin-right: -20px;
+  margin-left: 0px;
+}
+.checkbox .disp-area {
+  margin-left: -20px;
 }
 .text-editor {
   height: 400px;

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -484,6 +484,11 @@ li.user-progress {
 
 .frappe-rtl .checkbox .disp-area {
 	margin-right: -20px;
+	margin-left: 0px;
+}
+
+.checkbox .disp-area {
+	margin-left: -20px;
 }
 
 .text-editor {


### PR DESCRIPTION
`before`
<img width="468" alt="screen shot 2017-10-10 at 1 13 21 pm" src="https://user-images.githubusercontent.com/11224291/31374768-e0e50950-adbc-11e7-8636-02fe3be9dcb1.png">

`after`
<img width="468" alt="screen shot 2017-10-10 at 1 13 06 pm" src="https://user-images.githubusercontent.com/11224291/31374766-dedbf4d4-adbc-11e7-943b-0d1882101a38.png">
