### PR TITLE
[hotfix] enable Update button if error occurred after customize form save

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -146,6 +146,7 @@ frappe.customize_form.set_primary_action = function(frm) {
 			return frm.call({
 				doc: frm.doc,
 				freeze: true,
+				btn: frm.page.btn_primary,
 				method: "save_customization",
 				callback: function(r) {
 					if(!r.exc) {


### PR DESCRIPTION
fixes for https://github.com/frappe/frappe/issues/4286

`before`
![before](https://user-images.githubusercontent.com/11224291/31375113-1c0c9b3c-adbe-11e7-99ad-1e278996af18.gif)

`after`
![after](https://user-images.githubusercontent.com/11224291/31375055-f24ba0a4-adbd-11e7-90e8-838206c9278e.gif)