### PR TITLE
Add New Function: `get_party_shipping_address`

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -80,6 +80,7 @@ def get_party_shipping_address(doctype, name):
 	"""
 	Returns an Address name (best guess) for the given doctype and name for which `address_type == 'Shipping'` is true.
 	Where there are multiple matching records, Addresses for which `is_shipping_address = 1` is given priority.
+	If these still do not yield anything, it tries to fall back to a billing address.
 	It returns an empty string if there is no matching record.
 
 	:param doctype: Party Doctype
@@ -93,7 +94,7 @@ def get_party_shipping_address(doctype, name):
 		'dl.link_doctype=%s '
 		'and dl.link_name=%s '
 		'and dl.parenttype="Address" '
-		'and ta.address_type="Shipping" order by ta.is_shipping_address desc limit 1',
+		'order by ta.is_shipping_address, ta.address_type desc limit 1',
 		(doctype, name)
 	)
 	if out:

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -75,6 +75,33 @@ class Address(Document):
 
 		return False
 
+
+def get_party_shipping_address(doctype, name):
+	"""
+	Returns an Address name (best guess) for the given doctype and name for which `address_type == 'Shipping'` is true.
+	Where there are multiple matching records, Addresses for which `is_shipping_address = 1` is given priority.
+	It returns an empty string if there is no matching record.
+
+	:param doctype: Party Doctype
+	:param name: Party name
+	:return: String
+	"""
+	out = frappe.db.sql(
+		'SELECT dl.parent '
+		'from `tabDynamic Link` dl join `tabAddress` ta on dl.parent=ta.name '
+		'where '
+		'dl.link_doctype=%s '
+		'and dl.link_name=%s '
+		'and dl.parenttype="Address" '
+		'and ta.address_type="Shipping" order by ta.is_shipping_address desc limit 1',
+		(doctype, name)
+	)
+	if out:
+		return out[0][0]
+	else:
+		return ''
+
+
 @frappe.whitelist()
 def get_default_address(doctype, name, sort_key='is_primary_address'):
 	'''Returns default Address name for the given doctype, name'''

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -4,7 +4,11 @@
 from __future__ import unicode_literals
 
 import frappe, unittest
-from frappe.contacts.doctype.address.address import get_address_display
+from frappe.contacts.doctype.address.address import get_address_display, get_party_shipping_address
+
+
+test_dependencies = ['Contact']
+
 
 class TestAddress(unittest.TestCase):
 	def test_template_works(self):
@@ -31,3 +35,8 @@ class TestAddress(unittest.TestCase):
 		address = frappe.get_list("Address")[0].name
 		display = get_address_display(frappe.get_doc("Address", address).as_dict())
 		self.assertTrue(display)
+
+	def test_get_party_shipping_address(self):
+		address = get_party_shipping_address('Contact', '_Test Contact For _Test Customer')
+		self.assertIn(address, ['_Test Address 2 Title-Shipping', '_Test Address 3 Title-Shipping'])
+		self.assertEqual(address, '_Test Address 3 Title-Shipping')

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -40,3 +40,7 @@ class TestAddress(unittest.TestCase):
 		address = get_party_shipping_address('Contact', '_Test Contact For _Test Customer')
 		self.assertIn(address, ['_Test Address 2 Title-Shipping', '_Test Address 3 Title-Shipping'])
 		self.assertEqual(address, '_Test Address 3 Title-Shipping')
+
+	def test_get_party_shipping_address_fallback_to_billing(self):
+		address = get_party_shipping_address('Contact', '_Test Contact For _Test Supplier')
+		self.assertEqual(address, '_Test Address 4 Title-Billing')

--- a/frappe/contacts/doctype/address/test_records.json
+++ b/frappe/contacts/doctype/address/test_records.json
@@ -1,0 +1,48 @@
+[
+  {
+    "doctype": "Address",
+    "address_type": "Billing",
+    "address_line1": "Address line 1",
+    "address_title": "_Test Address 1 Title",
+    "city": "Lagos",
+    "Country": "Nigeria",
+    "links": [
+      {
+        "link_doctype": "Contact",
+        "link_name": "_Test Contact For _Test Customer",
+        "doctype": "Dynamic Link"
+      }
+    ]
+  },
+  {
+    "doctype": "Address",
+    "address_type": "Shipping",
+    "address_line1": "Address line 2",
+    "address_title": "_Test Address 2 Title",
+    "city": "Lagos",
+    "Country": "Nigeria",
+    "links": [
+      {
+        "link_doctype": "Contact",
+        "link_name": "_Test Contact For _Test Customer",
+        "doctype": "Dynamic Link"
+      }
+    ]
+  },
+  {
+    "doctype": "Address",
+    "address_type": "Shipping",
+    "address_line1": "Address line 3",
+    "address_title": "_Test Address 3 Title",
+    "city": "Lagos",
+    "Country": "Nigeria",
+    "is_shipping_address": "1",
+    "links": [
+      {
+        "link_doctype": "Contact",
+        "link_name": "_Test Contact For _Test Customer",
+        "doctype": "Dynamic Link"
+      }
+    ]
+  }
+]

--- a/frappe/contacts/doctype/address/test_records.json
+++ b/frappe/contacts/doctype/address/test_records.json
@@ -44,5 +44,21 @@
         "doctype": "Dynamic Link"
       }
     ]
+  },
+  {
+    "doctype": "Address",
+    "address_type": "Billing",
+    "address_line1": "Address line 4",
+    "address_title": "_Test Address 4 Title",
+    "city": "Lagos",
+    "Country": "Nigeria",
+    "is_shipping_address": "1",
+    "links": [
+      {
+        "link_doctype": "Contact",
+        "link_name": "_Test Contact For _Test Supplier",
+        "doctype": "Dynamic Link"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds a new function `get_party_shipping_address` as a solution to frappe/erpnext#11129 as at present, there is no API that can reliably be used to fetch the shipping address for the party. Test case included