### PR TITLE
enable cron like scheduler 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,4 @@ pyqrcode
 pypng
 premailer
 psycopg2
-
+croniter


### PR DESCRIPTION
Added the ability to trigger **cron** like schedule by adding new label `cron` to `scheduler_events` in hooks:
```
scheduler_events = {
	"cron": {
		"15 18 * * *": [
			"frappe.twofactor.delete_all_barcodes_for_users",
			"frappe.oauth.delete_oauth2_data"
		],
		"*/6 * * * *": [
			"frappe.email.queue.flush",
			"frappe.utils.error.collect_error_snapshots"
		]
	},

    ...

    "all": [
        "frappe.email.queue.flush",
        "frappe.email.doctype.email_account.email_account.pull",
        "frappe.email.doctype.email_account.email_account.notify_unreplied",
        "frappe.oauth.delete_oauth2_data",
        "frappe.integrations.doctype.razorpay_settings.razorpay_settings.capture_payment",
        "frappe.twofactor.delete_all_barcodes_for_users"
    ]
}
```

Other than that, looking at the code probably would be possible to use same technique to trigger all the events by transforming label to cron string, kind of: 

```
sobstitutions = {
            "yearly": "0 0 1 1 *",
            "anually": "0 0 1 1 *",
            "monthly": "0 0 1 * *",
            "monthly_long": "0 0 1 * *",
            "weekly": "0 0 * * 0",
            "weekly_long": "0 0 * * 0",
            "daily": "0 0 * * *",
            "daily_long": "0 0 * * *",
            "midnight": "0 0 * * *",
            "hourly": "0 * * * *",
            "hourly_long": "0 * * * *",
            "all": "0/" + str((frappe.get_conf().scheduler_interval or 240) // 60) + " * * * *",
        }
```
and checking cron string so that event is enqueued right after next execution date time as elapsed.


