### PR TITLE
Stop reloading the HTML content after every document change

### DIFF
--- a/frappe/public/js/frappe/form/controls/html.js
+++ b/frappe/public/js/frappe/form/controls/html.js
@@ -2,9 +2,6 @@ frappe.ui.form.ControlHTML = frappe.ui.form.Control.extend({
 	make: function() {
 		this._super();
 		this.disp_area = this.wrapper;
-		$(document).on('change', () => {
-			setTimeout(() => this.refresh_input(), 500);
-		});
 	},
 	refresh_input: function() {
 		var content = this.get_content();


### PR DESCRIPTION
This timer breaks every HTML field we have by reloading the HTML content on every -unrelated- document change.