### PR TITLE
Python 3 compatibility Frappe test fixes

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -6,7 +6,7 @@ globals attached to frappe module
 """
 from __future__ import unicode_literals, print_function
 
-from six import iteritems, text_type, string_types
+from six import iteritems, binary_type, text_type, string_types
 from werkzeug.local import Local, release_local
 import os, sys, importlib, inspect, json
 
@@ -61,7 +61,7 @@ def as_unicode(text, encoding='utf-8'):
 		return text
 	elif text==None:
 		return ''
-	elif isinstance(text, string_types):
+	elif isinstance(text, binary_type):
 		return text_type(text, encoding)
 	else:
 		return text_type(text)

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -322,9 +322,9 @@ def add_attachment(fname, fcontent, content_type=None,
 	# Set the filename parameter
 	if fname:
 		attachment_type = 'inline' if inline else 'attachment'
-		part.add_header(b'Content-Disposition', attachment_type, filename=text_type(fname))
+		part.add_header('Content-Disposition', attachment_type, filename=text_type(fname))
 	if content_id:
-		part.add_header(b'Content-ID', '<{0}>'.format(content_id))
+		part.add_header('Content-ID', '<{0}>'.format(content_id))
 
 	parent.attach(part)
 

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -415,7 +415,7 @@ def get_filecontent_from_path(path):
 		full_path = path
 
 	if os.path.exists(full_path):
-		with open(full_path) as f:
+		with open(full_path, 'rb') as f:
 			filecontent = f.read()
 
 		return filecontent

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -21,9 +21,9 @@ This is the text version of this email
 '''
 
 		img_path = os.path.abspath('assets/frappe/images/favicon.png')
-		with open(img_path) as f:
+		with open(img_path, 'rb') as f:
 			img_content = f.read()
-			img_base64 = base64.b64encode(img_content)
+			img_base64 = base64.b64encode(img_content).decode()
 
 		# email body keeps 76 characters on one line
 		self.img_base64 = fixed_column_width(img_base64, 76)

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -191,7 +191,9 @@ def write_file(content, fname, is_private=0):
 	# create directory (if not exists)
 	frappe.create_folder(file_path)
 	# write the file
-	with open(os.path.join(file_path.encode('utf-8'), fname.encode('utf-8')), 'w+') as f:
+	if isinstance(content, text_type):
+		content = content.encode()
+	with open(os.path.join(file_path.encode('utf-8'), fname.encode('utf-8')), 'wb+') as f:
 		f.write(content)
 
 	return get_files_path(fname, is_private=is_private)


### PR DESCRIPTION
After #4191 `bench run-tests --app frappe` fails with a bunch of errors (fewer than before though), this fixes some of those.

Now I get something like this

```
E...............F.............................................E.........EE........F..........
....................................FEEEE.EEEEEE...............................EE....EEE.E...
....................E.....................................F............EEEEEEEF...F....E..EEE
EEEE..E
----------------------------------------------------------------------
Ran 286 tests in 116.951s

FAILED (failures=6, errors=37)

```

Remaining errors are a result of a very small number of problems and will probably be easy to fix.

**Note :** commits from [ERPNext #10670](https://github.com/frappe/erpnext/pull/10670) (I'll rebase and push soon) are needed to produce these results.

**Note to self:**
These are the possible culprits
```
frappe/sessions.py line 415
frappe/sessions.py line 422
frappe/frappeclient.py line 43
frappe/desk/form/meta.py line 22
frappe/model/document.py line 577
frappe/translate.py line 548
frappe/email/receive.py line 401
frappe/utils/pdf.py line 132
frappe/email/doctype/email_account/test_email_account.py line 114
frappe/tests/test_email.py line 87
frappe/utils/xlsxutils.py line 37
frappe/utils/csvutils.py line 59
frappe/twofactor.py line 323
```