### PR TITLE
 More Python 3 compatibility Frappe test fixes

### DIFF
--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -117,13 +117,13 @@ class TestEvent(unittest.TestCase):
 		ev.insert()
 
 		ev_list = get_events("2014-02-01", "2014-02-01", "Administrator", for_reminder=True)
-		self.assertTrue(filter(lambda e: e.name==ev.name, ev_list))
+		self.assertTrue(list(filter(lambda e: e.name==ev.name, ev_list)))
 
 		ev_list1 = get_events("2015-01-20", "2015-01-20", "Administrator", for_reminder=True)
-		self.assertFalse(filter(lambda e: e.name==ev.name, ev_list1))
+		self.assertFalse(list(filter(lambda e: e.name==ev.name, ev_list1)))
 
 		ev_list2 = get_events("2014-02-20", "2014-02-20", "Administrator", for_reminder=True)
-		self.assertFalse(filter(lambda e: e.name==ev.name, ev_list2))
+		self.assertFalse(list(filter(lambda e: e.name==ev.name, ev_list2)))
 
 		ev_list3 = get_events("2015-02-01", "2015-02-01", "Administrator", for_reminder=True)
-		self.assertTrue(filter(lambda e: e.name==ev.name, ev_list3))
+		self.assertTrue(list(filter(lambda e: e.name==ev.name, ev_list3)))

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -111,7 +111,7 @@ class TestEmailAccount(unittest.TestCase):
 		frappe.sendmail(sender="test_sender@example.com", recipients="test_recipient@example.com",
 			content="test mail 001", subject="test-mail-001", delayed=False)
 
-		sent_mail = email.message_from_string(frappe.flags.sent_mail)
+		sent_mail = email.message_from_string(frappe.flags.sent_mail.decode())
 		self.assertTrue("test-mail-001" in sent_mail.get("Subject"))
 
 	def test_print_format(self):

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -49,7 +49,7 @@ class TestEmail(unittest.TestCase):
 		self.assertTrue('test@example.com' in queue_recipients)
 		self.assertTrue('test1@example.com' in queue_recipients)
 		self.assertEquals(len(queue_recipients), 2)
-		self.assertTrue('Unsubscribe' in frappe.flags.sent_mail)
+		self.assertTrue('Unsubscribe' in frappe.flags.sent_mail.decode())
 
 	def test_cc_header(self):
 		#test if sending with cc's makes it into header
@@ -84,7 +84,7 @@ class TestEmail(unittest.TestCase):
 		self.assertTrue('test@example.com' in queue_recipients)
 		self.assertTrue('test1@example.com' in queue_recipients)
 
-		self.assertTrue('This email was sent to test@example.com and copied to test1@example.com' in frappe.flags.sent_mail)
+		self.assertTrue('This email was sent to test@example.com and copied to test1@example.com' in frappe.flags.sent_mail.decode())
 
 	def test_expose(self):
 		from frappe.utils.verified_command import verify_request
@@ -104,12 +104,12 @@ class TestEmail(unittest.TestCase):
 			where status='Sent'""", as_dict=1)[0].message
 		self.assertTrue('<!--recipient-->' in message)
 
-		email_obj = email.message_from_string(frappe.flags.sent_mail)
+		email_obj = email.message_from_string(frappe.flags.sent_mail.decode())
 		for part in email_obj.walk():
 			content = part.get_payload(decode=True)
 
 			if content:
-				frappe.local.flags.signed_query_string = re.search('(?<=/api/method/frappe.email.queue.unsubscribe\?).*(?=\n)', content).group(0)
+				frappe.local.flags.signed_query_string = re.search('(?<=/api/method/frappe.email.queue.unsubscribe\?).*(?=\n)', content.decode()).group(0)
 				self.assertTrue(verify_request())
 				break
 
@@ -150,7 +150,7 @@ class TestEmail(unittest.TestCase):
 		self.assertFalse('test@example.com' in queue_recipients)
 		self.assertTrue('test1@example.com' in queue_recipients)
 		self.assertEquals(len(queue_recipients), 1)
-		self.assertTrue('Unsubscribe' in frappe.flags.sent_mail)
+		self.assertTrue('Unsubscribe' in frappe.flags.sent_mail.decode())
 
 	def test_email_queue_limit(self):
 		from frappe.email.queue import send, EmailLimitCrossedError

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -9,7 +9,7 @@ import pyotp, os
 from frappe.utils.background_jobs import enqueue
 from jinja2 import Template
 from pyqrcode import create as qrcreate
-from six import StringIO
+from six import BytesIO
 from base64 import b64encode, b32encode
 from frappe.utils import get_url, get_datetime, time_diff_in_seconds
 from six import iteritems, string_types
@@ -318,11 +318,11 @@ def get_qr_svg_code(totp_uri):
 	'''Get SVG code to display Qrcode for OTP.'''
 	url = qrcreate(totp_uri)
 	svg = ''
-	stream = StringIO()
+	stream = BytesIO()
 	try:
 		url.svg(stream, scale=4, background="#eee", module_color="#222")
-		svg = stream.getvalue().replace('\n', '')
-		svg = b64encode(bytes(svg))
+		svg = stream.getvalue().decode().replace('\n', '')
+		svg = b64encode(svg.encode())
 	finally:
 		stream.close()
 	return svg


### PR DESCRIPTION
After #4318 `bench run-tests --app frappe` fails with a bunch of errors (fewer than before though), this fixes some of those.

Now I get something like this

```
E.............................................................E.........EE........F..........
....................................FEEEE.E.EEEE...............................E.......E.....
....................E.....................................F............EEEEEEEF...F....E.....
......
----------------------------------------------------------------------
Ran 286 tests in 115.167s

FAILED (failures=5, errors=25)
```
**Note :** commits from [ERPNext #10670](https://github.com/frappe/erpnext/pull/10670) (I'll rebase and push soon) are needed to produce these results.

**Note to self:**
These are the possible culprits
```
frappe/sessions.py line 415
frappe/sessions.py line 422
frappe/frappeclient.py line 43
frappe/desk/form/meta.py line 22
frappe/model/document.py line 577
frappe/translate.py line 548
frappe/email/receive.py line 401
frappe/utils/pdf.py line 132
frappe/email/doctype/email_account/test_email_account.py line 114
frappe/utils/xlsxutils.py line 37
frappe/utils/csvutils.py line 59
```