### PR TITLE
[hotfix] robots.txt file is considered as static instead of getting context from robots.py

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -80,7 +80,7 @@ def is_static_file(path):
 	if ('.' not in path):
 		return False
 	extn = path.rsplit('.', 1)[-1]
-	if extn in ('html', 'md', 'js', 'xml', 'css'):
+	if extn in ('html', 'md', 'js', 'xml', 'css', 'txt'):
 		return False
 
 	for app in frappe.get_installed_apps():
@@ -100,7 +100,6 @@ def get_static_file_reponse():
 	response = Response(wrap_file(frappe.local.request.environ, f), direct_passthrough=True)
 	response.mimetype = mimetypes.guess_type(frappe.flags.file_path)[0] or b'application/octet-stream'
 	return response
-
 
 def build_response(path, data, http_status_code, headers=None):
 	# build response

--- a/frappe/www/robots.py
+++ b/frappe/www/robots.py
@@ -4,8 +4,8 @@ no_sitemap = 1
 base_template_path = "templates/www/robots.txt"
 
 def get_context(context):
-	robots_txt = (frappe.db.get_single_value('Website Settings', 'robots_txt')
-					or (frappe.local.conf.robots_txt and frappe.read_file(frappe.local.conf.robots_txt))
-					or '')
+	robots_txt = (
+		frappe.db.get_single_value('Website Settings', 'robots_txt') or
+		(frappe.local.conf.robots_txt and frappe.read_file(frappe.local.conf.robots_txt)) or '')
 
 	return { 'robots_txt': robots_txt }


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/11200

<img width="338" alt="screen shot 2017-10-16 at 11 58 24 am" src="https://user-images.githubusercontent.com/11224291/31598088-59a9eea4-b269-11e7-970c-b05dae530637.png">