### PR TITLE
Don't show img tags in kanban card

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -593,7 +593,7 @@ frappe.provide("frappe.views");
 		function make_dom() {
 			var opts = {
 				name: card.name,
-				title: card.title
+				title: remove_img_tags(card.title)
 			};
 			self.$card = $(frappe.render_template('kanban_card', opts))
 				.appendTo(wrapper);
@@ -1115,5 +1115,11 @@ frappe.provide("frappe.views");
 				flag = true;
 		});
 		return flag;
+	}
+
+	function remove_img_tags(html) {
+		const $temp = $(`<div>${html}</div>`)
+		$temp.find('img').remove();
+		return $temp.html();
 	}
 })();


### PR DESCRIPTION
- https://discuss.erpnext.com/t/how-to-make-kanban-view-just-first-text-lines/29428

Before:
![image](https://user-images.githubusercontent.com/9355208/31599261-3c31b496-b26f-11e7-80fe-12b74ea23798.png)


After:
![image](https://user-images.githubusercontent.com/9355208/31599239-2a44ea00-b26f-11e7-84c1-0ccb8cc71f1f.png)
