### PR TITLE
[override] get_dashboard

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -357,13 +357,24 @@ class Meta(Document):
 
 	def get_dashboard_data(self):
 		'''Returns dashboard setup related to this doctype.
-
 		This method will return the `data` property in the
 		`[doctype]_dashboard.py` file in the doctype folder'''
 		data = frappe._dict()
 		try:
 			module = load_doctype_module(self.name, suffix='_dashboard')
-			if hasattr(module, 'get_data'):
+			dashboard_method = frappe.get_hooks('get_dashboard_data').get(self.name)
+
+			if dashboard_method:
+				import importlib
+
+				method_splitted = dashboard_method[0].split('.')
+				last = method_splitted.pop()
+				path = '.'.join(method_splitted)
+
+				m = importlib.import_module(path)
+
+				data = frappe._dict(getattr(m, last)())
+			elif hasattr(module, 'get_data'):
 				data = frappe._dict(module.get_data())
 		except ImportError:
 			pass


### PR DESCRIPTION
This new functionality adds the possibility for developers to override the data, which is provided by *_dashboard.py files in their get_data method, by simply using the hooks.py file.

Requested for example here:
https://discuss.erpnext.com/t/doctypes-dashboard-override-not-whitelisted-methods/27857

# Example in hooks.py

```
override_dashboard_data = {
	"Customer": "mycustommodule.myutils.my_customer_method",
        "Opportunity": "mycustommodule.myutils.my_opportunity_method"
}
```

# Example method

"my_customer_method" method will look for example like following:

```
def my_customer_method():
	return {
		'heatmap': False,
		'heatmap_message': _('Dashboard'),
		'fieldname': 'customer',
		'transactions': [
			{
				'label': _('Important documents'),
				'items': ['CustomDocType1', 'CustomDocType2']
			},
			{
				'label': _("More important stuff"),
				"items": ['CustomDocType3', 'CustomDocType4']
			}
		]
	}


```

