### PR TITLE
Cron like events scheduler

### DIFF
--- a/frappe/docs/user/en/tutorial/task-runner.md
+++ b/frappe/docs/user/en/tutorial/task-runner.md
@@ -1,8 +1,8 @@
 # Scheduled Tasks
 
-Finally, an application also has to send email notifications and do other kind of scheduled tasks. In Frappé, if you have setup the bench, the task / scheduler is setup via Celery using Redis Queue.
+Finally, an application also has to send email notifications and do other kind of scheduled tasks. In Frappé, if you have setup the bench, the task / scheduler is setup via RQ using Redis Queue.
 
-To add a new task handler, go to `hooks.py` and add a new handler. Default handlers are `all`, `daily`, `weekly`, `monthly`. The `all` handler is called every 3 minutes by default.
+To add a new task handler, go to `hooks.py` and add a new handler. Default handlers are `all`, `daily`, `weekly`, `monthly`, `cron`. The `all` handler is called every 4 minutes by default.
 
 	# Scheduled Tasks
 	# ---------------
@@ -11,6 +11,15 @@ To add a new task handler, go to `hooks.py` and add a new handler. Default handl
 		"daily": [
 			"library_management.tasks.daily"
 		],
+		"cron": {
+			"0/10 * * * *": [
+				"library_management.task.run_every_ten_mins"
+			],
+			"15 18 * * *": [
+				"library_management.task.every_day_at_18_15"
+			]
+		}
+			
 	}
 
 Here we can point to a Python function and that function will be executed every day. Let us look what this function looks like:
@@ -21,6 +30,14 @@ Here we can point to a Python function and that function will be executed every 
 	from __future__ import unicode_literals
 	import frappe
 	from frappe.utils import datediff, nowdate, format_date, add_days
+	
+	def every_ten_minutes():
+		# stuff to do every 10 minutes
+		pass
+		
+	def every_day_at_18_15():
+		# stuff to do every day at 6:15pm
+		pass
 
 	def daily():
 		loan_period = frappe.db.get_value("Library Management Settings",

--- a/frappe/tests/test_scheduler.py
+++ b/frappe/tests/test_scheduler.py
@@ -33,7 +33,7 @@ class TestScheduler(TestCase):
 		next_event = last_event + relativedelta(minutes=30)
 
 		enqueue_applicable_events(frappe.local.site, next_event, last_event)
-		self.assertFalse("all" in frappe.flags.ran_schedulers)
+		self.assertFalse("cron" in frappe.flags.ran_schedulers)
 
 		# maintain last_event and next_event on the same day
 		last_event = now_datetime().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -55,7 +55,7 @@ class TestScheduler(TestCase):
 
 		enqueue_applicable_events(frappe.local.site, next_event, last_event)
 		self.assertTrue("all" in frappe.flags.ran_schedulers)
-		self.assertTrue("hourly" in frappe.flags.ran_schedulers)
+		self.assertFalse("hourly" in frappe.flags.ran_schedulers)
 
 
 	def test_restrict_scheduler_events(self):

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -29,9 +29,9 @@ from croniter import croniter
 
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
-SOBSTITUTIONS = {
+cron_map = {
     "yearly": "0 0 1 1 *",
-    "anually": "0 0 1 1 *",
+    "annual": "0 0 1 1 *",
     "monthly": "0 0 1 * *",
     "monthly_long": "0 0 1 * *",
     "weekly": "0 0 * * 0",
@@ -163,7 +163,7 @@ def trigger(site, event, last=None, queued_jobs=(), now=False):
                     frappe.logger(__name__).error('Exception in Trigger Events for Site {0}, Cron String {1}'.format(site, e))
 
         else:
-            if croniter(SOBSTITUTIONS[event], last).get_next(datetime) <= frappe.utils.now_datetime():
+            if croniter(cron_map[event], last).get_next(datetime) <= frappe.utils.now_datetime():
                 events.extend(events_from_hooks)
 
     for handler in events:

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -155,6 +155,7 @@ def trigger(site, event, last=None, queued_jobs=(), now=False):
         events = []
         if event == "cron":
             for e in events_from_hooks:
+                e = cron_map.get(e, e)
                 if croniter.is_valid(e):
                     if croniter(e, last).get_next(datetime) <= frappe.utils.now_datetime():
                         events.extend(events_from_hooks[e])

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,4 @@ pyqrcode
 pypng
 premailer
 psycopg2
-
+croniter


### PR DESCRIPTION
Added the ability to trigger **cron** like schedule by adding new label `cron` to `scheduler_events` in hooks:
```
scheduler_events = {
	"cron": {
		"15 18 * * *": [
			"frappe.twofactor.delete_all_barcodes_for_users",
			"frappe.oauth.delete_oauth2_data"
		],
		"*/6 * * * *": [
			"frappe.email.queue.flush",
			"frappe.utils.error.collect_error_snapshots"
		],
		"annual": [
			"frappe.twofactor.delete_all_barcodes_for_users",
			"frappe.utils.error.collect_error_snapshots"
		]
	},

    ...

    "all": [
        "frappe.email.queue.flush",
        "frappe.email.doctype.email_account.email_account.pull",
        "frappe.email.doctype.email_account.email_account.notify_unreplied",
        "frappe.oauth.delete_oauth2_data",
        "frappe.integrations.doctype.razorpay_settings.razorpay_settings.capture_payment",
    ]
}
```

Changed way to check if events are due to be enqueued; substituting label with corresponding cron string and checking it so that event is enqueued right after next execution date time as elapsed.

Used substitution dict:

```
cron_map = {
            "yearly": "0 0 1 1 *",
            "annual": "0 0 1 1 *",
            "monthly": "0 0 1 * *",
            "monthly_long": "0 0 1 * *",
            "weekly": "0 0 * * 0",
            "weekly_long": "0 0 * * 0",
            "daily": "0 0 * * *",
            "daily_long": "0 0 * * *",
            "midnight": "0 0 * * *",
            "hourly": "0 * * * *",
            "hourly_long": "0 * * * *",
            "all": "0/" + str((frappe.get_conf().scheduler_interval or 240) // 60) + " * * * *",
        }
```

