### PR TITLE
[hotfix] ingore_mandatory fields while saving the sms settings in add_sms_sender_name_as_paramenters patch

### DIFF
--- a/frappe/patches/v9_1/add_sms_sender_name_as_parameters.py
+++ b/frappe/patches/v9_1/add_sms_sender_name_as_parameters.py
@@ -13,4 +13,6 @@ def execute():
 			"parameter": "sender_name",
 			"value": sms_sender_name
 		})
+		sms_settings.flags.ignore_mandatory = True
+		sms_settings.flags.ignore_permissions = True
 		sms_settings.save()


### PR DESCRIPTION
```
Executing frappe.patches.v9_1.add_sms_sender_name_as_parameters in local.site (297e2e2cb00d9aef)
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/commands/site.py", line 217, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_sin
▽
# Copyright (c) 2017, Frappe and Contributors
gle
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/patches/v9_1/add_sms_sender_name_as_parameters.py", line 18, in execute
    sms_settings.save()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/document.py", line 256, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/document.py", line 293, in _save
    self._validate()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/document.py", line 436, in _validate
    self._validate_mandatory()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/document.py", line 655, in _validate_mandatory
    name=self.name))
frappe.exceptions.MandatoryError: [SMS Settings, SMS Settings]: sms_gateway_url, message_parameter, receiver_parameter
```