### PR TITLE
[hotfix] ignore validate_length for single doctypes

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -563,6 +563,10 @@ class BaseDocument(object):
 		if frappe.flags.in_install:
 			return
 
+		if self.meta.issingle:
+			# single doctype value type is mediumtext
+			return
+
 		for fieldname, value in iteritems(self.get_valid_dict()):
 			df = self.meta.get_field(fieldname)
 			if df and df.fieldtype in type_map and type_map[df.fieldtype][0]=="varchar":


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/commands/site.py", line 217, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/patches/v9_1/add_sms_sender_name_as_parameters.py", line 18, in execute
    sms_settings.save()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/document.py", line 256, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/document.py", line 293, in _save
    self._validate()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/document.py", line 439, in _validate
    self._validate_length()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/model/base_document.py", line 579, in _validate_length
    .format(reference, _(df.label), max_length, value), frappe.CharacterLengthExceededError, title=_('Value too big'))
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/__init__.py", line 319, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2017-10-18/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
frappe.exceptions.CharacterLengthExceededError: SMS Settings SMS Settings: 'SMS Gateway URL' ( http://api.textlocal.in/send/?username=&lt;insert_email_id&gt;&amp;hash=&lt;insert_hash_key&gt;&amp;sender=TXTLCL&amp;numbers=91XXXXXX&amp;message=Test_message) will get truncated, as max characters allowed is 140
```