### PR TITLE
Added ability to set JSBarcode options

### DIFF
--- a/frappe/public/js/frappe/form/controls/barcode.js
+++ b/frappe/public/js/frappe/form/controls/barcode.js
@@ -27,8 +27,30 @@ frappe.ui.form.ControlBarcode = frappe.ui.form.ControlData.extend({
 	get_barcode_html(value) {
 		// Get svg
 		const svg = this.barcode_area.find('svg')[0];
-		JsBarcode(svg, value, {height: 40});
+		JsBarcode(svg, value, this.get_options(value));
 		$(svg).attr('data-barcode-value', value);
 		return this.barcode_area.html();
+	},
+
+	get_options(value) {
+		// get JsBarcode options
+		options = JSON.parse('{ "height" : 40 }');
+		if (this.isValidJson(this.df.options)) {
+			options = JSON.parse(this.df.options);
+			if (options.format && options.format === "EAN") {
+				options.format = value.length == 8 ? "EAN8" : "EAN13";
+			}
+		}
+		return options;
+	},
+
+	isValidJson(jsonData) {
+		try {
+			JSON.parse(jsonData);
+			return true;
+		} catch (e) {
+			return false;
+		}
 	}
+
 });

--- a/frappe/public/js/frappe/form/controls/barcode.js
+++ b/frappe/public/js/frappe/form/controls/barcode.js
@@ -34,7 +34,7 @@ frappe.ui.form.ControlBarcode = frappe.ui.form.ControlData.extend({
 
 	get_options(value) {
 		// get JsBarcode options
-		options = JSON.parse('{ "height" : 40 }');
+		let options = JSON.parse('{ "height" : 40 }');
 		if (this.isValidJson(this.df.options)) {
 			options = JSON.parse(this.df.options);
 			if (options.format && options.format === "EAN") {


### PR DESCRIPTION
Field Options can be set as json style, like: 

`{ "format" : "EAN", "height" : 20, "width" : 1 }`

examples: 

<img width="903" alt="schermata 2017-10-19 alle 19 41 45" src="https://user-images.githubusercontent.com/11652845/31786054-6cd7c352-b507-11e7-8667-ec03800b7cfc.png">

<img width="561" alt="schermata 2017-10-19 alle 19 42 25" src="https://user-images.githubusercontent.com/11652845/31786174-ddd317c8-b507-11e7-9bd7-94b49f2b8c67.png">

For EAN type it will automatically recognize if EAN13 or EAN8 based on barcode value length:

<img width="894" alt="schermata 2017-10-19 alle 20 01 29" src="https://user-images.githubusercontent.com/11652845/31786407-a7a1bf8c-b508-11e7-8820-4d89e7593a1e.png">

<img width="459" alt="schermata 2017-10-19 alle 20 03 21" src="https://user-images.githubusercontent.com/11652845/31786410-ad4b52c2-b508-11e7-8f62-5906c9e8f667.png">


if options is not a valid JSON, will fallback to standard options:

<img width="910" alt="schermata 2017-10-19 alle 19 43 44" src="https://user-images.githubusercontent.com/11652845/31786052-6c7d1dc6-b507-11e7-8af3-358e8deb3a4f.png">

<img width="506" alt="schermata 2017-10-19 alle 19 44 09" src="https://user-images.githubusercontent.com/11652845/31786051-6c274d06-b507-11e7-95e1-1085b727bd84.png">

All available options for JSBarcode can be found at: 

https://github.com/lindell/JsBarcode/wiki/Options

