### PR TITLE
[formatdate] Return empty string if no date provided

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -218,7 +218,11 @@ def formatdate(string_date=None, format_string=None):
 		 * mm-dd-yyyy
 		 * dd/mm/yyyy
 	"""
-	date = getdate(string_date) if string_date else now_datetime().date()
+
+	if not string_date:
+		return ''
+
+	date = getdate(string_date)
 	if not format_string:
 		format_string = get_user_format().replace("mm", "MM")
 


### PR DESCRIPTION
Earlier it used to return todays date if date was falsy. This is incorrect behaviour. Reports generated from server side were affected. On the JS side, the Date formatter is correct.