### PR TITLE
[fix] Do not show the Save Button if there is a Workflow without Local Changes and Print Preview is Toggled

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -264,7 +264,10 @@ frappe.ui.form.Toolbar = Class.extend({
 			status = "Submit";
 		} else if (this.can_save()) {
 			if (!this.frm.save_disabled) {
-				status = "Save";
+				//Show the save button if there is no workflow or if there is a workflow and there are changes
+				if (!this.has_workflow() || (this.has_workflow() && this.frm.doc.__unsaved)) {
+					status = "Save";
+				}
 			}
 		} else if (this.can_update()) {
 			status = "Update";

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -265,7 +265,7 @@ frappe.ui.form.Toolbar = Class.extend({
 		} else if (this.can_save()) {
 			if (!this.frm.save_disabled) {
 				//Show the save button if there is no workflow or if there is a workflow and there are changes
-				if (!this.has_workflow() || (this.has_workflow() && this.frm.doc.__unsaved)) {
+				if (this.has_workflow() ? this.frm.doc.__unsaved : true) {
 					status = "Save";
 				}
 			}


### PR DESCRIPTION
The save button is currently shown when there is a workflow and when the print preview is shown and subsequently cleared, even though there were no local changes made.

![workflow_save_button](https://user-images.githubusercontent.com/8383249/31884870-30147132-b821-11e7-921e-475b694c845b.gif)
