### PR TITLE
Make User Permissions importable

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.json
+++ b/frappe/core/doctype/user_permission/user_permission.json
@@ -1,7 +1,7 @@
 {
  "allow_copy": 0, 
  "allow_guest_to_view": 0, 
- "allow_import": 0, 
+ "allow_import": 1, 
  "allow_rename": 0, 
  "beta": 0, 
  "creation": "2017-07-17 14:25:27.881871", 
@@ -148,7 +148,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-07-27 22:55:58.647315", 
+ "modified": "2017-10-24 13:25:33.258794", 
  "modified_by": "Administrator", 
  "module": "Core", 
  "name": "User Permission", 


### PR DESCRIPTION
Unless there was some reason that they weren't made importable on transition into a DocType.