### PR TITLE
[hotfix] delete and sync the child table customization

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -104,8 +104,9 @@ def sync_customizations_for_doctype(data):
 	update_schema = False
 
 	def sync(key, custom_doctype, doctype_fieldname):
-		frappe.db.sql('delete from `tab{0}` where `{1}`=%s'.format(custom_doctype, doctype_fieldname),
-			doctype)
+		doctypes = list(set(map(lambda row: row.get(doctype_fieldname), data[key])))
+		frappe.db.sql('delete from `tab{0}` where `{1}` in ({2})'.format(
+			custom_doctype, doctype_fieldname, ",".join(["'%s'"%dt for dt in doctypes])))
 
 		for d in data[key]:
 			d['doctype'] = custom_doctype

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -106,7 +106,7 @@ def sync_customizations_for_doctype(data):
 	def sync(key, custom_doctype, doctype_fieldname):
 		doctypes = list(set(map(lambda row: row.get(doctype_fieldname), data[key])))
 		frappe.db.sql('delete from `tab{0}` where `{1}` in ({2})'.format(
-			custom_doctype, doctype_fieldname, ",".join(["'%s'"%dt for dt in doctypes])))
+			custom_doctype, doctype_fieldname, ",".join(["'%s'" % dt for dt in doctypes])))
 
 		for d in data[key]:
 			d['doctype'] = custom_doctype


### PR DESCRIPTION
`traceback`

While syncing the customization only parent custom field, property setters are deleted which causes the Integrity Error.

steps to recreate the issue.

Add custom field on Project and Project Task and try to run `bench migrate`

```
dev-bench bench --site hotfix.dev migrate
Migrating hotfix.dev
Updating DocTypes for frappe        : [========================================]
Updating DocTypes for erpnext       : [========================================]
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/commands/site.py", line 217, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/migrate.py", line 36, in migrate
    sync_customizations()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/modules/utils.py", line 96, in sync_customizations
    sync_customizations_for_doctype(data)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/modules/utils.py", line 116, in sync_customizations_for_doctype
    sync('custom_fields', 'Custom Field', 'dt')
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/modules/utils.py", line 113, in sync
    doc.db_insert()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/model/base_document.py", line 310, in db_insert
    raise frappe.DuplicateEntryError(self.doctype, self.name, e)
frappe.exceptions.DuplicateEntryError: (u'Custom Field', u'Project Task-field_on_child_table', IntegrityError(1062, "Duplicate entry 'Project Task-field_on_child_table' for key 'PRIMARY'"))
```