### PR TITLE
UI fixes to Geolocation field

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -1,4 +1,4 @@
-frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlData.extend({
+frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlCode.extend({
 	make_wrapper() {
 		// Create the elements for map area
 		this._super();


### PR DESCRIPTION
One field in section takes up 2 col width instead of 1 col

![1col](https://user-images.githubusercontent.com/1040161/32072190-63c11130-baaf-11e7-9ecc-2df764fbda95.png)

![2col](https://user-images.githubusercontent.com/1040161/32072196-6956c234-baaf-11e7-9797-1b9989517c59.png)
