### PR TITLE
[fix] Workflow does not permit submission, duplication etc.

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -955,8 +955,8 @@ _f.Frm.prototype.validate_form_action = function(action, resolve) {
 	// Allow submit, write, cancel and create permissions for read only documents that are assigned by
 	// workflows if the user already have those permissions. This is to allow for users to
 	// continue through the workflow states and to allow execution of functions like Duplicate.
-	if (!frappe.workflow.is_read_only(this.doctype, this.docname) && (perms["write"] ||
-		perms["create"] || perms["submit"] || perms["cancel"])) {
+	if ((frappe.workflow.is_read_only(this.doctype, this.docname) && (perms["write"] ||
+		perms["create"] || perms["submit"] || perms["cancel"])) || !frappe.workflow.is_read_only(this.doctype, this.docname)) {
 		var allowed_for_workflow = true;
 	}
 


### PR DESCRIPTION
If the user's roles does not contain the "Allow Edit For" role, the workflow prevents the user from performing functions such as Submit, Duplicate etc. even though the user's other roles actually allow them to perform such functions.

Permission Error Message:
![image](https://user-images.githubusercontent.com/8383249/32089465-b854c08a-bb1c-11e7-9aaa-1b4376221ce8.png)

Workflow Setup:
![image](https://user-images.githubusercontent.com/8383249/32089871-1d45947c-bb1f-11e7-9a9d-02b58d3153c0.png)

User has Stock Manager role.

