### PR TITLE
[Fix] List count error if filter contains Child table

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -581,10 +581,24 @@ def get_list(doctype, *args, **kwargs):
 
 @frappe.whitelist()
 def get_count(doctype, filters=None):
-	if filters:
-		filters = json.loads(filters)
-
 	if isinstance(filters, list):
 		filters = frappe.utils.make_filter_dict(filters)
 
 	return frappe.db.count(doctype, filters=filters)
+
+@frappe.whitelist()
+def set_filters(doctype, filters=None):
+    count = []
+    if filters:
+        filters = json.loads(filters)
+
+    for d in filters:
+        filt = []
+        if d[0] != doctype:
+            doctype = d[0]
+        filt.append(d)
+
+        count.append(get_count(doctype, filt))
+    if count:
+        return min(count)
+    return count

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -308,15 +308,7 @@ class DatabaseQuery(object):
 			if f.operator.lower() == 'between' and \
 				(f.fieldname in ('creation', 'modified') or (df and (df.fieldtype=="Date" or df.fieldtype=="Datetime"))):
 
-				from_date = None
-				to_date = None
-				if f.value and isinstance(f.value, (list, tuple)):
-					if len(f.value) >= 1: from_date = f.value[0]
-					if len(f.value) >= 2: to_date = f.value[1]
-
-				value = "'%s' AND '%s'" % (
-					add_to_date(get_datetime(from_date),days=-1).strftime("%Y-%m-%d %H:%M:%S.%f"),
-					get_datetime(to_date).strftime("%Y-%m-%d %H:%M:%S.%f"))
+				value = get_between_date_filter(f.value)
 				fallback = "'0000-00-00 00:00:00'"
 
 			elif df and df.fieldtype=="Date":
@@ -619,5 +611,21 @@ def is_parent_only_filter(doctype, filters):
 		for flt in filters:
 			if doctype not in flt:
 				only_parent_doctype = False
+			if 'Between' in flt:
+				flt[3] = get_between_date_filter(flt[3])
 
 	return only_parent_doctype
+
+def get_between_date_filter(value):
+	from_date = None
+	to_date = None
+
+	if value and isinstance(value, (list, tuple)):
+		if len(value) >= 1: from_date = value[0]
+		if len(value) >= 2: to_date = value[1]
+
+	data = "'%s' AND '%s'" % (
+		add_to_date(get_datetime(from_date),days=-1).strftime("%Y-%m-%d %H:%M:%S.%f"),
+		get_datetime(to_date).strftime("%Y-%m-%d %H:%M:%S.%f"))
+
+	return data

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -609,7 +609,7 @@ def get_count(doctype, filters=None):
 					conditions.append(join_condition)
 
 		return frappe.db.sql_list("""select count(*) from {0}
-			where {1}""".format(','.join(tables), ' and '.join(conditions)), debug=1)
+			where {1}""".format(','.join(tables), ' and '.join(conditions)), debug=0)
 
 def is_parent_only_filter(doctype, filters):
 	#check if filters contains only parent doctype

--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -362,7 +362,7 @@ frappe.views.ListRenderer = Class.extend({
 		const $header_right = this.list_view.list_header.find('.list-item__content--activity');
 
 		frappe.call({
-			method: 'frappe.model.db_query.set_filters',
+			method: 'frappe.model.db_query.get_count',
 			args: {
 				doctype: this.doctype,
 				filters: this.list_view.get_filters_args()

--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -362,13 +362,13 @@ frappe.views.ListRenderer = Class.extend({
 		const $header_right = this.list_view.list_header.find('.list-item__content--activity');
 
 		frappe.call({
-			method: 'frappe.model.db_query.get_count',
+			method: 'frappe.model.db_query.set_filters',
 			args: {
 				doctype: this.doctype,
 				filters: this.list_view.get_filters_args()
 			}
 		}).then(r => {
-			const count = r.message;
+			const count = r.message ? r.message : current_count;
 			const $html = $(`<span>${current_count} of ${count}</span>`);
 
 			$html.css({

--- a/frappe/tests/ui/test_list_count.js
+++ b/frappe/tests/ui/test_list_count.js
@@ -1,0 +1,34 @@
+QUnit.module('Setup');
+
+QUnit.test("Test List Count", function(assert) {
+	assert.expect(3);
+	const done = assert.async();
+
+	frappe.run_serially([
+		() => frappe.set_route('List', 'DocType'),
+		() => frappe.timeout(0.5),
+		() => {
+			let count = $('.list-row-right').text().split(' ')[0];
+			assert.equal(cur_list.data.length, count, "Correct Count");
+		},
+
+		() => frappe.timeout(1),
+		() => cur_list.filter_list.add_filter('Doctype', 'module', '=', 'Desk'),
+		() => frappe.click_button('Refresh'),
+		() => {
+			let count = $('.list-row-right').text().split(' ')[0];
+			assert.equal(cur_list.data.length, count, "Correct Count");
+		},
+
+		() => cur_list.filter_list.clear_filters(),
+		() => frappe.timeout(1),
+		() => {
+			cur_list.filter_list.push_new_filter('DocField', 'fieldname', 'like', 'owner');
+			frappe.click_button('Apply');
+			let count = $('.list-row-right').text().split(' ')[0];
+			assert.equal(cur_list.data.length, count, "Correct Count");
+		},
+
+		done
+	]);
+});

--- a/frappe/tests/ui/tests.txt
+++ b/frappe/tests/ui/tests.txt
@@ -17,3 +17,4 @@ frappe/tests/ui/test_control_html.js
 frappe/tests/ui/test_control_geolocation.js
 frappe/core/doctype/role_profile/test_role_profile.js
 frappe/core/doctype/user/test_user_with_role_profile.js
+frappe/tests/ui/test_list_count.js


### PR DESCRIPTION
Summary:- 
If a column value is used to filter a list, list count throws error as it checked for the column in the parent Doctype.
![child-table-filter](https://user-images.githubusercontent.com/11695402/32103333-862e35f2-bb3d-11e7-8d4e-05500f50e208.gif)
fix:-
![child-table-filter-fix](https://user-images.githubusercontent.com/11695402/32103354-a6863f98-bb3d-11e7-9729-4e03534d69d6.gif)
