### PR TITLE
[hotfix] bring throttling limit from site_config rather than a fixed "60"

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -983,6 +983,5 @@ def throttle_user_creation():
 	if frappe.flags.in_import:
 		return
 
-	# bring creation_throttling_limit from site_config.json key
-	if frappe.db.get_creation_count('User', 60) > frappe.local.conf.get("creation_throttling_limit", 60):
+	if frappe.db.get_creation_count('User', 60) > frappe.local.conf.get("throttle_user_limit", 60):
 		frappe.throw(_('Throttled'))

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -982,5 +982,7 @@ def reset_otp_secret(user):
 def throttle_user_creation():
 	if frappe.flags.in_import:
 		return
-	if frappe.db.get_creation_count('User', 60) > 60:
+
+	# bring creation_throttling_limit from site_config.json key
+	if frappe.db.get_creation_count('User', 60) > frappe.local.conf.get("creation_throttling_limit", 60):
 		frappe.throw(_('Throttled'))


### PR DESCRIPTION
Since the commit of https://github.com/frappe/frappe/commit/d20f9e2895522091607eb551eb5e2aedc14faed3 System is not taken more than 60 new users in a 60 minutes. Error Keeps popping up with every Sign Up attempt:

 File "/frappe/frappe/model/document.py", line 211, in insert
    self.run_method("before_insert")
  File "/frappe/frappe/model/document.py", line 702, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/frappe/frappe/model/document.py", line 964, in composer
    """Raise exception if Table field is empty.""
  File "/frappe/frappe/model/document.py", line 947, in runner
    val1 = doc.get_value(fieldname)
  File "/frappe/frappe/model/document.py", line 696, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/frappe/core/doctype/user/user.py", line 45, in before_insert
  File "/frappe/frappe/core/doctype/user/user.py", line 986, in throttle_user_creation
  File "/frappe/frappe/__init__.py", line 319, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
ValidationError: Throttled

This error prevents new signups till the number is decreased again to less than 60 in the last 60 minutes. To solve that, a new key in site_config to be declared to determine the number of allowed new records, instead of having it a fixed "60" in the code.
Mentioning that the default value would be 60 if site_config has no settings of it
Key is: "creation_throttling_limit"
