### PR TITLE
[hotfix] Not able to export general ledger report's data in excel

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -29,6 +29,10 @@ def make_xlsx(data, sheet_name, wb=None):
 				value = handle_html(item)
 			else:
 				value = item
+
+			if isinstance(value, basestring):
+				value = value.encode('unicode_escape').decode('utf-8')
+
 			clean_row.append(value)
 
 		ws.append(clean_row)


### PR DESCRIPTION
**Error**
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 935, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 169, in export_query
    xlsx_file = make_xlsx(result, "Query Report")
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/utils/xlsxutils.py", line 38, in make_xlsx
    ws.append(clean_row)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/openpyxl/writer/write_only.py", line 236, in append
    self.writer.send(row)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/openpyxl/writer/write_only.py", line 166, in _write_header
    cell.value = value
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/openpyxl/cell/cell.py", line 294, in value
    self._bind_value(value)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/openpyxl/cell/cell.py", line 191, in _bind_value
    value = self.check_string(value)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/openpyxl/cell/cell.py", line 156, in check_string
    raise IllegalCharacterError
IllegalCharacterError
```