### PR TITLE
Enable non JSON api post requests

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -79,7 +79,11 @@ def handle():
 					frappe.local.response.update({"data": doc})
 
 				if frappe.local.request.method=="PUT":
-					data = json.loads(frappe.local.form_dict.data)
+					try:
+						data = json.loads(frappe.local.form_dict.data)
+					except ValueError:
+						data = frappe.local.form_dict
+
 					doc = frappe.get_doc(doctype, name)
 
 					if "flags" in data:
@@ -115,7 +119,7 @@ def handle():
 						data = json.loads(frappe.local.form_dict.data)
 					except ValueError:
 						data = frappe.local.form_dict
-						
+
 					data.update({
 						"doctype": doctype
 					})

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -111,7 +111,11 @@ def handle():
 							doctype, **frappe.local.form_dict)})
 
 				if frappe.local.request.method=="POST":
-					data = json.loads(frappe.local.form_dict.data)
+					try:
+						data = json.loads(frappe.local.form_dict.data)
+					except ValueError:
+						data = frappe.local.form_dict
+						
 					data.update({
 						"doctype": doctype
 					})


### PR DESCRIPTION
Some third party applications, send requests in non json format. This change will enable developers to integrate them.

# Before

Traceback (most recent call last):
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.api.handle()
  File "/home/ubuntu/frappe-bench/apps/frappe/frappe/api.py", line 115, in handle
    data = json.loads(frappe.local.form_dict.data)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded

# Now

Just works and creates the doc as intended.