### PR TITLE
Fix filters dismiss button

### DIFF
--- a/frappe/public/less/list.less
+++ b/frappe/public/less/list.less
@@ -45,12 +45,15 @@
 
 .set-filters .btn-group {
 	margin-right: 10px;
+	white-space: nowrap;
+	font-size: 0;
 }
 
 .set-filters .btn-group .btn-default {
 	background-color: transparent;
 	border: 1px solid @border-color;
 	color: @text-muted;
+	float: none;
 }
 
 .filter-box {


### PR DESCRIPTION
Keep the dismiss button near to the filter

# Before mobile

![image](https://user-images.githubusercontent.com/8351245/32219478-a3fa7cf0-be2e-11e7-8d42-22712b9befdb.png)

# After mobile

![image](https://user-images.githubusercontent.com/8351245/32219494-abaf9408-be2e-11e7-93c6-aa4a46277c32.png)

# Before desktop & after desktop

![image](https://user-images.githubusercontent.com/8351245/32219508-b2c1e638-be2e-11e7-87b6-84e8dd71d6b4.png)

White-space nowrap won't work on floated content. Furthermore we need the font-size: 0 to have no space between the dismiss button and the filter itself.