### PR TITLE
Enable the ability to build custom api responses

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -125,6 +125,21 @@ def handle():
 	else:
 		raise frappe.DoesNotExistError
 
+	try:
+		custom_api_response = frappe.get_hooks('custom_api_responses').get(doctype)
+
+		if custom_api_response:
+			import importlib
+
+		method_splitted = custom_api_response[0].split('.')
+		last = method_splitted.pop()
+		path = '.'.join(method_splitted)
+
+		m = importlib.import_module(path)
+		return getattr(m, last)(frappe.local.response)
+	except Exception:
+		pass
+	
 	return build_response("json")
 
 def validate_oauth():

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -137,7 +137,7 @@ def handle():
 
 		m = importlib.import_module(path)
 		return getattr(m, last)(frappe.local.response)
-	except Exception, e:
+	except Exception:
 		pass
 
 	return build_response("json")

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -137,9 +137,9 @@ def handle():
 
 		m = importlib.import_module(path)
 		return getattr(m, last)(frappe.local.response)
-	except Exception:
+	except Exception, e:
 		pass
-	
+
 	return build_response("json")
 
 def validate_oauth():


### PR DESCRIPTION
Some third party applications, require certain answers. At the moment, Frappe's API replies with a json of the form dict. If you don't have control about how third party applications process your response, you need to have the control about how you build your custom response.

The api still processes the data as usual, but right before the default response is built, it will check for a hook in hooks.py in the custom_api_responses dictionary.

Since it's in a try, catch block, the default response will be sent if something in building the default response, is going wrong.

# hooks.py example

`custom_api_responses = {
	"MyCalls": "mymodule.utils.custom_response"
}`

# Method example

```
def custom_response(response):
	from frappe.utils.response import make_logs
	from werkzeug.wrappers import Response

	make_logs()
	response = Response()
	if frappe.local.response.http_status_code:
			response.status_code = frappe.local.response['http_status_code']
			del frappe.local.response['http_status_code']

	response.mimetype = 'application/xml'
	response.charset = 'utf-8'
	response.data = '<?xml version="1.0" encoding="UTF-8"?><Response attribute="customattribute" />'
	return response
```

Please note the response.data content:

I chose this example, because, even if Frappe would support XML responses out of the box, you simply couldn't build this kind of response by the documents dict data, without having this custom_response feature.