### PR TITLE
[min] removed psutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ pyopenssl
 ndg-httpsclient
 pyasn1
 zxcvbn-python
-psutil
 unittest-xml-reporting
 oauthlib
 PyJWT


### PR DESCRIPTION
not a dependency. `bench` uses, frappe doesn't.