### PR TITLE
Optimize regex to find parent of mail

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -457,8 +457,8 @@ class EmailAccount(Document):
 				# try and match by subject and sender
 				# if sent by same sender with same subject,
 				# append it to old coversation
-				subject = frappe.as_unicode(strip(re.sub("(^\s*(Fw|FW|fwd)[^:]*:|\s*(Re|RE)[^:]*:\s*)*",
-					"", email.subject)))
+				subject = frappe.as_unicode(strip(re.sub("(^\s*(fw|fwd|wg)[^:]*:|\s*(re|aw)[^:]*:\s*)*",
+					"", email.subject, 0, flags=re.IGNORECASE)))
 
 				parent = frappe.db.get_all(self.append_to, filters={
 					self.sender_field: email.from_email,


### PR DESCRIPTION
Made the Regex case insensitive and changed the regex to show only the lowercase (which will save some space). Added the aw and wg for german answer and forwarding.

I will add more languages based on this list https://en.wikipedia.org/wiki/List_of_email_subject_abbreviations after more research.

EDIT: Any concerns about adding a field like that one "E-Mail prefixes" in the Language doctype and using those in the regex?

![image](https://user-images.githubusercontent.com/8351245/32461863-94d1c842-c337-11e7-892a-411ef4f9df49.png)
