### PR TITLE
[minor][hotfix] initialize script property in page.py

### DIFF
--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -97,6 +97,7 @@ class Page(Document):
 	def load_assets(self):
 		from frappe.modules import get_module_path, scrub
 		import os
+		self.script = ''
 
 		page_name = scrub(self.name)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/__init__.py", line 935, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/desk/desk_page.py", line 32, in getpage
    doc = get(page)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/desk/desk_page.py", line 15, in get
    page.load_assets()
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/core/doctype/page/page.py", line 144, in load_assets
    self.script += get_lang_js("page", self.name)
AttributeError: 'Page' object has no attribute 'script'

```