### PR TITLE
Allow developers to choose attachments

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -354,11 +354,14 @@ frappe.views.CommunicationComposer = Class.extend({
 		var fields = this.dialog.fields_dict;
 		var attach = $(fields.select_attachments.wrapper).find(".attach-list").empty();
 
-		if (cur_frm){
+		if (this.attachments.length) {
+			var files = this.attachments;
+		} else if (cur_frm) {
 			var files = cur_frm.get_files();
-		}else {
-			var files = this.attachments
+		} else {
+			var files = [];
 		}
+
 		if(files.length) {
 			$.each(files, function(i, f) {
 				if (!f.file_name) return;


### PR DESCRIPTION
This change allows developers to choose attachments, even if there is a cur_frm object, like so:

```
new frappe.views.CommunicationComposer({
	doc: frm.doc,
	frm: frm,
	subject: "Hello",
	attachments: [
		{
			file_name: "filename.jpg",
			file_url: "/files/filename.jpg",
			is_private: 0,
			name: "a50177b946"
		}
	]
});
```

Without this change the attachments of the document are used instead of the hard coded attachments, which obviously isn't what developers want.