### PR TITLE
Fix More button in timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -126,7 +126,7 @@ frappe.ui.form.Timeline = Class.extend({
 			});
 
 		// more btn
-		if (this.more===undefined && communications.length===20) {
+		if (this.more===undefined && communications.length) {
 			this.more = true;
 		}
 


### PR DESCRIPTION
communications.length, in our case, was 67, which was leading to the fact, that we don't see the more button and were wondering, why we don't see all communications.

Maybe someone can tell, why you was checking for the length of 20.

Without that check, it works.

EDIT: After this change, the more button is displayed once to much (when all 67 communications are loaded). If you click it the last time, the more button disappears. Maybe someone can help with this. 

Still it is better to display the more button once too much, then once too less (or not at all like in the current Frappe version).

Another EDIT:

Even the comments counter on the left top is wrong. Seems like a major issue in communication loading in the timeline. It relies on the wrong numbers:

![image](https://user-images.githubusercontent.com/8351245/32603844-88fe3030-c54b-11e7-8fd7-06fe23a31971.png)

This doc has 67 communications, not 19. When I use the more button (which this PR fixes), the number goes up.