### PR TITLE
Allow users to confirm the message by enter

### DIFF
--- a/frappe/www/message.html
+++ b/frappe/www/message.html
@@ -40,6 +40,8 @@ html, body {
 		if(window.location.hash) {
 			localStorage.setItem('session_last_route', window.location.hash.substr(1));
 		}
+		
+		$('.btn-primary').focus();
 	});
 </script>
 {% endblock %}


### PR DESCRIPTION
Users can confirm the message and proceed by pressing enter, not necessary to use the mouse.

![nov -13-2017 11-28-27](https://user-images.githubusercontent.com/8351245/32721183-f49ecf94-c865-11e7-84e5-bf844156b802.gif)
