### PR TITLE
Allow developers to choose attachments

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -354,7 +354,7 @@ frappe.views.CommunicationComposer = Class.extend({
 		var fields = this.dialog.fields_dict;
 		var attach = $(fields.select_attachments.wrapper).find(".attach-list").empty();
 
-		if (this.attachments.length) {
+		if (undefined !== this.attachments && this.attachments.length) {
 			var files = this.attachments;
 		} else if (cur_frm) {
 			var files = cur_frm.get_files();

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -354,11 +354,14 @@ frappe.views.CommunicationComposer = Class.extend({
 		var fields = this.dialog.fields_dict;
 		var attach = $(fields.select_attachments.wrapper).find(".attach-list").empty();
 
-		if (cur_frm){
+		if (this.attachments.length) {
+			var files = this.attachments;
+		} else if (cur_frm) {
 			var files = cur_frm.get_files();
-		}else {
-			var files = this.attachments
+		} else {
+			var files = [];
 		}
+
 		if(files.length) {
 			$.each(files, function(i, f) {
 				if (!f.file_name) return;

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -354,12 +354,12 @@ frappe.views.CommunicationComposer = Class.extend({
 		var fields = this.dialog.fields_dict;
 		var attach = $(fields.select_attachments.wrapper).find(".attach-list").empty();
 
-		if (undefined !== this.attachments && this.attachments.length) {
-			var files = this.attachments;
-		} else if (cur_frm) {
-			var files = cur_frm.get_files();
-		} else {
-			var files = [];
+		var files = []
+		if (this.attachments && this.attachments.length) {
+			files = files.concat(this.attachments);
+		}
+		if (cur_frm) {
+			files = files.concat(cur_frm.get_files());
 		}
 
 		if(files.length) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -354,7 +354,7 @@ frappe.views.CommunicationComposer = Class.extend({
 		var fields = this.dialog.fields_dict;
 		var attach = $(fields.select_attachments.wrapper).find(".attach-list").empty();
 
-		var files = []
+		var files = [];
 		if (this.attachments && this.attachments.length) {
 			files = files.concat(this.attachments);
 		}


### PR DESCRIPTION
This change allows developers to choose attachments, even if there is a cur_frm object, like so:

```
new frappe.views.CommunicationComposer({
	doc: frm.doc,
	frm: frm,
	subject: "Hello",
	attachments: [
		{
			file_name: "filename.jpg",
			file_url: "/files/filename.jpg",
			is_private: 0,
			name: "a50177b946"
		}
	]
});
```

Without this change the attachments of the document are used instead of the hard coded attachments, which obviously isn't what developers want.

Fixed and manually tested