### PR TITLE
[fix] temporarily freeze html2text to version 2016.9.19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ selenium
 -e git+https://github.com/frappe/python-pdfkit.git#egg=pdfkit
 babel
 ipython
-html2text
+html2text==2016.9.19
 email_reply_parser
 click
 num2words==0.5.5


### PR DESCRIPTION
In version 2017.10.4 of html2text, they haven't considered unicode while formating the string.

Which resulting into,

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/model/document.py", line 256, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/model/document.py", line 290, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/model/document.py", line 809, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/model/document.py", line 702, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/model/document.py", line 964, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/model/document.py", line 947, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/model/document.py", line 696, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-10/apps/erpnext/erpnext/projects/doctype/project/project.py", line 61, in validate
    self.send_welcome_email()
  File "/home/frappe/benches/bench-2017-11-10/apps/erpnext/erpnext/projects/doctype/project/project.py", line 215, in send_welcome_email
    frappe.sendmail(user.user, subject=_("Project Collaboration Invitation"), content=content.format(*messages))
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/__init__.py", line 432, in sendmail
    inline_images=inline_images, header=header)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/email/queue.py", line 75, in send
    text_content = html2text(message)
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/html2text/__init__.py", line 925, in html2text
    return h.handle(html)
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/html2text/__init__.py", line 145, in handle
    self.feed(data)
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/html2text/__init__.py", line 142, in feed
    HTMLParser.HTMLParser.feed(self, data)
  File "/usr/lib64/python2.7/HTMLParser.py", line 114, in feed
    self.goahead(0)
  File "/usr/lib64/python2.7/HTMLParser.py", line 160, in goahead
    k = self.parse_endtag(i)
  File "/usr/lib64/python2.7/HTMLParser.py", line 398, in parse_endtag
    self.handle_endtag(elem)
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/html2text/__init__.py", line 191, in handle_endtag
    self.handle_tag(tag, None, 0)
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/html2text/__init__.py", line 472, in handle_tag
    link_url(self, a['href'], '')
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/html2text/__init__.py", line 442, in link_url
    title=title))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 43-47: ordinal not in range(128)
```


Issue Casue, 
https://github.com/Alir3z4/html2text/pull/190/files
```
 self.o(']({url}{title})'.format(url=escape_md(url), title=title))

eg:
>>> test_string = u'新客户测试3G10'
>>> '{0}'.format(test_string)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-4: ordinal not in range(128)

```
In our case, url is Unicode and html2text trying to format Unicode into a string.


25 days back issue was maked on remo https://github.com/Alir3z4/html2text/issues/188
Also, the potential fix for the issue was raised before 12 days but not yet merged https://github.com/Alir3z4/html2text/pull/190 .

Thus time being downgrading to version 2016.9.19