### PR TITLE
[fix] fix language code for Serbian language

### DIFF
--- a/frappe/geo/languages.json
+++ b/frappe/geo/languages.json
@@ -264,11 +264,11 @@
   "name": "Shqiptar"
  }, 
  {
-  "code": "sr", 
+  "code": "sr-RS", 
   "name": "\u0441\u0440\u043f\u0441\u043a\u0438"
  }, 
  {
-  "code": "sr-SP", 
+  "code": "sr", 
   "name": "Srpski"
  }, 
  {

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -197,3 +197,4 @@ frappe.patches.v8_10.delete_static_web_page_from_global_search
 frappe.patches.v8_x.add_bgn_xaf_xof_currencies
 frappe.patches.v9_1.add_sms_sender_name_as_parameters
 frappe.patches.v9_1.resave_domain_settings
+frappe.patches.v9_1.update_language_code

--- a/frappe/patches/v9_1/update_language_code.py
+++ b/frappe/patches/v9_1/update_language_code.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+	frappe.rename_doc("Language", "sr", 'sr-RS', force=True)
+	frappe.rename_doc("Language", "sr-SP", 'sr', force=True)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/__init__.py", line 935, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 172, in load_messages
    m = get_dict("page", "setup-wizard")
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/translate.py", line 122, in get_dict
    message_dict.update(get_dict_from_hooks(fortype, name))
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/translate.py", line 140, in get_dict_from_hooks
    translated_dict.update(frappe.get_attr(method)())
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/geo/country_info.py", line 34, in get_translated_dict
    locale = Locale.parse(frappe.local.lang, sep="-")
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/babel/core.py", line 331, in parse
    raise UnknownLocaleError(input_id)
UnknownLocaleError: unknown locale u'sr_SP'
```

For fix referred :
- https://en.wikipedia.org/wiki/Serbian_language
- https://musescore.org/en/node/87871, https://github.com/musescore/MuseScore/pull/2292

 