### PR TITLE
[Fix] Title field not set in the quotation if record has been created using data import tool

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -795,9 +795,8 @@ class Document(BaseDocument):
 		- `before_update_after_submit` for **Update after Submit**
 
 		Will also update title_field if set"""
-		self.set_title_field()
-		self.reset_seen()
 
+		self.reset_seen()
 		self._doc_before_save = None
 		if not self.is_new() and getattr(self.meta, 'track_changes', False):
 			self.get_doc_before_save()
@@ -815,6 +814,8 @@ class Document(BaseDocument):
 			self.run_method("before_cancel")
 		elif self._action=="update_after_submit":
 			self.run_method("before_update_after_submit")
+
+		self.set_title_field()
 
 	def run_post_save_methods(self):
 		"""Run standard methods after `INSERT` or `UPDATE`. Standard Methods are:


### PR DESCRIPTION
**Issue**

User has created quotation using data import tool which has not set the title field because customer name(title field) was not added in the csv. After import customer name was showing in the quotation form but not in the title field.

**After Fix**

![quotation_issue](https://user-images.githubusercontent.com/8780500/32768814-71f14efc-c93f-11e7-89d1-3435e7f1a5cf.gif)
