### PR TITLE
Wait for trigger promises to finish before save

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -205,7 +205,11 @@ _f.Frm.prototype.watch_model_updates = function() {
 				&& me.fields_dict[fieldname].refresh(fieldname);
 
 			me.layout.refresh_dependency();
-			return me.script_manager.trigger(fieldname, doc.doctype, doc.name);
+			let object = me.script_manager.trigger(fieldname, doc.doctype, doc.name);
+			if(object instanceof Promise) {
+				me.promises.push(object);
+			}
+			return object;
 		}
 	});
 
@@ -586,6 +590,8 @@ _f.Frm.prototype.setnewdoc = function() {
 	// this.check_doctype_conflict(docname);
 	var me = this;
 
+	this.promises = [];
+
 	// hide any open grid
 	this.script_manager.trigger("before_load", this.doctype, this.docname)
 		.then(() => {
@@ -696,7 +702,9 @@ _f.Frm.prototype.save = function(save_action, callback, btn, on_error) {
 
 		// let any pending js process finish
 		setTimeout(function() {
-			me._save(save_action, callback, btn, on_error, resolve);
+			Promise.all(me.promises).then(() => {
+				me._save(save_action, callback, btn, on_error, resolve);
+			});
 		}, 100);
 	});
 };


### PR DESCRIPTION
Replicated via: WN-SUP28944

If save is clicked before blurring a trigger-calling field, the trigger may or may not finish before the save, resulting in the trigger affected fields not getting updated.

The proposed pattern will require the trigger on the field to return a `Promise`:

![screen shot 2017-11-14 at 2 55 55 pm](https://user-images.githubusercontent.com/5196925/32772611-68d30722-c94c-11e7-971b-fad1b109d826.png)

This will cause save to wait for any leftover triggers (Also needs the freeze screen evidently):

![triggers_on_save](https://user-images.githubusercontent.com/5196925/32772803-09cf3f9c-c94d-11e7-80d7-bd848ee8d986.gif)

