### PR TITLE
[fix] Allow capital letters in bucket name for S3 Backup DocType  

### DIFF
--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -22,7 +22,7 @@ class S3BackupSettings(Document):
 			aws_secret_access_key=self.get_password('secret_access_key'),
 		)
 
-		bucket_lower = str(self.bucket).lower()
+		bucket_lower = str(self.bucket)
 
 		try:
 			conn.list_buckets()


### PR DESCRIPTION
[Fixes #11547](https://github.com/frappe/erpnext/issues/11547)