### PR TITLE
[fix] prepare file list by including all nested files

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -122,26 +122,27 @@ def upload_from_folder(path, dropbox_folder, dropbox_client, did_not_upload, err
 		else:
 			raise
 
-	for filename in os.listdir(path):
-		filename = cstr(filename)
+	for root, directory, files in os.walk(path):
+		for filename in files:
+			filename = cstr(filename)
+			filepath = os.path.join(root, filename)
 
-		if filename in ignore_list:
-			continue
+			if filename in ignore_list:
+				continue
 
-		found = False
-		filepath = os.path.join(path, filename)
-		for file_metadata in response.entries:
-			if (os.path.basename(filepath) == file_metadata.name
-				and os.stat(encode(filepath)).st_size == int(file_metadata.size)):
-				found = True
-				break
+			found = False
+			for file_metadata in response.entries:
+				if (os.path.basename(filepath) == file_metadata.name
+					and os.stat(encode(filepath)).st_size == int(file_metadata.size)):
+					found = True
+					break
 
-		if not found:
-			try:
-				upload_file_to_dropbox(filepath, dropbox_folder, dropbox_client)
-			except Exception:
-				did_not_upload.append(filename)
-				error_log.append(frappe.get_traceback())
+			if not found:
+				try:
+					upload_file_to_dropbox(filepath, dropbox_folder, dropbox_client)
+				except Exception:
+					did_not_upload.append(filepath)
+					error_log.append(frappe.get_traceback())
 
 def upload_file_to_dropbox(filename, folder, dropbox_client):
 	create_folder_if_not_exists(folder, dropbox_client)


### PR DESCRIPTION
```
qextserialport-1.2beta2 - Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 141, in upload_from_folder
    upload_file_to_dropbox(filepath, dropbox_folder, dropbox_client)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 152, in upload_file_to_dropbox
    f = open(encode(filename), 'rb')
IOError: [Errno 21] Is a directory: './sapcon.erpnext.com/private/files/qextserialport-1.2beta2'

MO-X-B_N-75-VF-D18-SCUTE-ELIXIR-0.pdf - Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 141, in upload_from_folder
    upload_file_to_dropbox(filepath, dropbox_folder, dropbox_client)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 152, in upload_file_to_dropbox
    f = open(encode(filename), 'rb')
IOError: [Errno 21] Is a directory: './sapcon.erpnext.com/private/files/Remote_Calibration'

```