### PR TITLE
[fix] increased chunk size to 15 mb while uploading file to dropbox

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -144,8 +144,10 @@ def upload_from_folder(path, dropbox_folder, dropbox_client, did_not_upload, err
 				error_log.append(frappe.get_traceback())
 
 def upload_file_to_dropbox(filename, folder, dropbox_client):
+	"""upload files with chunk of 15 mb to reduce session append calls"""
+
 	create_folder_if_not_exists(folder, dropbox_client)
-	chunk_size = 4 * 1024 * 1024
+	chunk_size = 15 * 1024 * 1024
 	file_size = os.path.getsize(encode(filename))
 	mode = (dropbox.files.WriteMode.overwrite)
 


### PR DESCRIPTION
```
Birth cert.jpeg - Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 141, in upload_from_folder
    upload_file_to_dropbox(filepath, dropbox_folder, dropbox_client)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 157, in upload_file_to_dropbox
    dropbox_client.files_upload(f.read(), path, mode)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/dropbox/base.py", line 1267, in files_upload
    f,
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/dropbox/dropbox.py", line 239, in request
    timeout=timeout)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/dropbox/dropbox.py", line 330, in request_json_string_with_retry
    timeout=timeout)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/dropbox/dropbox.py", line 414, in request_json_string
    timeout=timeout,
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/requests/sessions.py", line 522, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/requests/sessions.py", line 596, in send
    r = adapter.send(request, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/requests/adapters.py", line 423, in send
    timeout=timeout
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 595, in urlopen
    chunked=chunked)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 386, in _make_request
    httplib_response = conn.getresponse(buffering=True)
  File "/usr/lib64/python2.7/httplib.py", line 1089, in getresponse
    response.begin()
  File "/usr/lib64/python2.7/httplib.py", line 444, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python2.7/httplib.py", line 400, in _read_status
    line = self.fp.readline(_MAXLINE + 1)
  File "/usr/lib64/python2.7/socket.py", line 476, in readline
    data = self._sock.recv(self._rbufsize)
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/requests/packages/urllib3/contrib/pyopenssl.py", line 207, in recv
    [self.socket], [], [], self.socket.gettimeout())
  File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/rq/timeouts.py", line 51, in handle_death_penalty
    'value ({0} seconds)'.format(self._timeout))
JobTimeoutException: Job exceeded maximum timeout value (1500 seconds)

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 46, in take_backup_to_dropbox
    if did_not_upload: raise Exception
Exception
```

---

Currently, we are uploading files by splitting it into 4MB chunks. This initiates multiple calls to `chunk_upload` API and thus leads to worker timeout. 

Using large chunks will mean fewer calls to `chunked_upload` and faster overall throughput.

As we allow default max files size up to 10 MB for upload, keeping chunk size to 15 MB to avoid worker timeout.

Ref: https://www.dropbox.com/developers-v1/core/docs#files_put