### PR TITLE
redirection fix for role based redirect using the role_home_page hook

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -136,6 +136,7 @@ class LoginManager:
 		self.validate_hour()
 		self.make_session()
 		self.set_user_info()
+		self.run_trigger('on_after_login')
 
 	def set_user_info(self, resume=False):
 		# set sid again


### PR DESCRIPTION
The main reason for this pull request is to mitigate issues regarding redirection of users/roles from /desk to some other specified place. The post regarding the details of this request can be found at https://discuss.erpnext.com/t/rerouting-system-user-to-page-other-than-desk-on-login/30582, discussed by @rmehta  and I.

Problem: I can't 100% get frappe to allow a redirection of my users based on role, not even with the ```role_home_page``` hook.
Solution: add ```self.run_trigger('on_after_login')``` to the ```post_login``` function inside of ```frappe/auth.py```. This, in conjunction with the ```role_home_page``` hook in a custom application allows a developer to add a definition like the following:
```
def on_after_login(login_manager):
    set_user_info(login_manager)
```
```
def set_user_info(login_manager, resume=False):
	login_manager.info = frappe.db.get_value("User", login_manager.user,
 		["user_type", "first_name", "last_name", "user_image"], as_dict=1)
	if login_manager.info.user_type=="Website User":
		frappe.local.cookie_manager.set_cookie("system_user", "no")
		if not resume:
			frappe.local.response["message"] = "No App"
			frappe.local.response["home_page"] = "/"
	else:
		frappe.local.cookie_manager.set_cookie("system_user", "yes")
		if not resume:
			frappe.local.response['message'] = 'Logged In'
			frappe.local.response["home_page"] = "/"
```

This gave me the ability to reset the user information AFTER frappe routes the user desk, even after checking the ```role_home_page``` hooks. 