### PR TITLE
Removed ignore link validation from the report, add ignore_link_validation in report js file for link field

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -328,10 +328,6 @@ frappe.views.QueryReport = Class.extend({
 						me.trigger_refresh();
 					}
 				}
-
-				// This is specifically done true earlier due to some reason. Please update if anyone finds that.
-				// Done false as the api can be used in the script reports which can break due to invalid links
-				df.ignore_link_validation = false;
 			}
 		});
 


### PR DESCRIPTION
Set ignore_link_validation in the report's js code if you want to skip link validation for the link field

```
{
			"fieldname":"supplier",
			"label": __("Supplier"),
			"fieldtype": "Link",
			"options": "Supplier",
			"ignore_link_validation": true
},
```



