### PR TITLE
Fix search field optic in standard filters

### DIFF
--- a/frappe/public/css/list.css
+++ b/frappe/public/css/list.css
@@ -186,25 +186,6 @@
 .listview-main-section .octicon-heart {
   cursor: pointer;
 }
-.listview-main-section .page-form {
-  padding-left: 17px;
-}
-@media (max-width: 991px) {
-  .listview-main-section .page-form {
-    padding-left: 25px;
-  }
-}
-.listview-main-section .page-form .octicon-search {
-  float: left;
-  padding-top: 7px;
-  margin-left: -4px;
-  margin-right: -4px;
-}
-@media (max-width: 991px) {
-  .listview-main-section .page-form .octicon-search {
-    margin-left: -12px;
-  }
-}
 .like-action.octicon-heart {
   color: #ff5858;
 }

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -35,6 +35,10 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 	set_input_areas: function() {
 		if(this.only_input) {
 			this.input_area = this.wrapper;
+
+			if (this.df.fieldname == 'name') {
+				this.input_area = $('<div class="input-group">').appendTo(this.wrapper);
+			}
 		} else {
 			this.label_area = this.label_span = this.$wrapper.find("label").get(0);
 			this.input_area = this.$wrapper.find(".control-input").get(0);

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -10,6 +10,10 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 			.addClass("input-with-feedback form-control")
 			.prependTo(this.input_area);
 
+		if (this.df.fieldname == 'name') {
+			$('<span class="input-group-addon"><i class="octicon octicon-search text-muted small"></i></span>').prependTo(this.input_area);
+		}
+
 		if (in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image'],
 			this.df.fieldtype)) {
 			this.$input.attr("maxlength", this.df.length || 140);

--- a/frappe/public/js/frappe/ui/base_list.js
+++ b/frappe/public/js/frappe/ui/base_list.js
@@ -186,10 +186,7 @@ frappe.ui.BaseList = Class.extend({
 
 		if (this.meta) {
 			var filter_count = 1;
-			if(this.is_list_view) {
-				$(`<span class="octicon octicon-search text-muted small"></span>`)
-					.prependTo(this.page.page_form);
-			}
+
 			this.page.add_field({
 				fieldtype: 'Data',
 				label: 'ID',

--- a/frappe/public/less/list.less
+++ b/frappe/public/less/list.less
@@ -233,23 +233,6 @@
 	.octicon-heart {
 		cursor: pointer;
 	}
-	.page-form {
-		padding-left: 17px;
-
-		@media (max-width: @screen-sm) {
-			padding-left: 25px;
-		}
-
-		.octicon-search {
-		    float: left;
-		    padding-top: 7px;
-		    margin-left: -4px;
-		    margin-right: -4px;
-			@media (max-width: @screen-sm) {
-				margin-left: -12px;
-			}
-		}
-	}
 }
 
 .like-action.octicon-heart {


### PR DESCRIPTION
At the moment, the way the search icon is placed in the list toolbar / standard filters, is wrong, since we can not have anything outside of cols in the bootstrap grid, where 12 cols result to 100% width. If we put something outside of it, the grid is broken.

This becomes obvious, when we want 6 standard filters, which shouldn't be a problem, since 6*2 cols results in 12 cols.

# Example at the moment

![image](https://user-images.githubusercontent.com/8351245/32996718-84642cbc-cd86-11e7-80c4-0ea0282945ff.png)

As you can see, the filters become messy.

# Example with this fix

![image](https://user-images.githubusercontent.com/8351245/32996728-dce3657e-cd86-11e7-9963-ec411a4ed461.png)

As you can see, it's fixed now. We could even place more than 6 filters and have a clean view.

Another example from ERPNext default:

![image](https://user-images.githubusercontent.com/8351245/33099941-f56859dc-cf12-11e7-8ddc-4fa743e8fdde.png)
