### PR TITLE
[Fix] Desktop icon page not showing for french language

### DIFF
--- a/frappe/core/page/modules_setup/includes/module_icons.html
+++ b/frappe/core/page/modules_setup/includes/module_icons.html
@@ -5,7 +5,7 @@
 	    <label>
 	      <input type="checkbox" data-module="{{ icon.module_name }}" class="module-select"
 					{% if not (icon.hidden if user else icon.blocked) %}checked{% endif %}>
-					{{ _(icon.label or icon.module_name) }}
+					{{ frappe.db.escape(_(icon.label or icon.module_name)) }}
 	    </label>
 	  </div>
 	</div>

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -153,6 +153,7 @@ def get_allowed_functions_for_jenv():
 		out['frappe']["db"] = {
 			"get_value": frappe.db.get_value,
 			"get_default": frappe.db.get_default,
+			"escape": frappe.db.escape,
 		}
 
 	return out


### PR DESCRIPTION
**Issue**
Desktop icon page not opening for french language because Data Import Tool translation in french is Outil d'Importation de Données which contain single quote(')
![screen shot 2017-11-21 at 1 38 05 pm](https://user-images.githubusercontent.com/8780500/33061220-4579b80a-cec1-11e7-95cb-38981bac1e96.png)
![screen shot 2017-11-21 at 1 38 18 pm](https://user-images.githubusercontent.com/8780500/33061221-45a2943c-cec1-11e7-8d4a-9b9ad15011d3.png)


**After Fix**
![screen shot 2017-11-21 at 1 35 51 pm](https://user-images.githubusercontent.com/8780500/33061246-689656b8-cec1-11e7-8015-c61515bcaec4.png)
