### PR TITLE
added FreeOTP as two-factor authentication app

### DIFF
--- a/frappe/www/qrcode.html
+++ b/frappe/www/qrcode.html
@@ -17,7 +17,7 @@
 		</p>
 		<br>
 		<p class='text-muted small'>{{ _("Authentication Apps you can use are: ") }}
-			Google Authenticator, Lastpass Authenticator, Authy and Duo Mobile.
+			FreeOTP, Google Authenticator, Lastpass Authenticator, Authy and Duo Mobile.
 		</p>
 	</div>
 	<div class='col-sm-6' style='padding-top: 15px;'>


### PR DESCRIPTION
FreeOTP (https://freeotp.github.io/) is an open source OTP app available for Android and iOS. It is ad-free and supported by Red Hat.

After successful test with Frappe Framework: v9.1.10 (master), I propose to include this to the list of compatible OTP apps.