### PR TITLE
[Fix] Error in bench migrate after latest merge

### DIFF
--- a/frappe/desk/page/activity/activity.js
+++ b/frappe/desk/page/activity/activity.js
@@ -78,12 +78,12 @@ frappe.pages['activity'].on_page_load = function(wrapper) {
 		}, 'fa fa-th')
 	}
 
-	this.page.add_menu_item(__('Authentication Log'), function() {
+	this.page.add_menu_item(__('Activity Log'), function() {
 		frappe.route_options = {
 			"user": frappe.session.user
 		}
 
-		frappe.set_route('Report', "Authentication Log");
+		frappe.set_route('Report', "Activity Log");
 	}, 'fa fa-th')
 
 	this.page.add_menu_item(__('Show Likes'), function() {

--- a/frappe/patches/v9_1/move_feed_to_activity_log.py
+++ b/frappe/patches/v9_1/move_feed_to_activity_log.py
@@ -8,18 +8,22 @@ def execute():
 	activity_log_fields = frappe.get_meta('Activity Log').fields
 
 	for d in communication_data:
-		communication_doc = frappe.get_doc('Communication', d)
+		try:
+			communication_doc = frappe.get_doc('Communication', d)
 
-		activity_data = {'doctype': 'Activity Log'}
-		for field in activity_log_fields:
-			if communication_doc.get(field.fieldname):
-				activity_data[field.fieldname] = communication_doc.get_value(field.fieldname)
+			activity_data = {'doctype': 'Activity Log'}
+			for field in activity_log_fields:
+				if communication_doc.get(field.fieldname):
+					activity_data[field.fieldname] = communication_doc.get_value(field.fieldname)
 
-		activity_doc = frappe.get_doc(activity_data)
-		activity_doc.insert()
+			activity_doc = frappe.get_doc(activity_data)
+			activity_doc.insert()
 
-		frappe.db.sql("""update `tabActivity Log` set creation = %s,\
-			modified = %s where name = %s""", (communication_doc.creation,communication_doc.modified,activity_doc.name))
+			frappe.db.sql("""update `tabActivity Log` set creation = %s,\
+				modified = %s where name = %s""", (communication_doc.creation,communication_doc.modified,activity_doc.name))
 
-		frappe.db.sql("""delete from `tabCommunication` where name='{0}'""".format(communication_doc.name))
+			frappe.db.sql("""delete from `tabCommunication` where name='{0}'""".format(communication_doc.name))
+
+		except frappe.LinkValidationError:
+			pass
 	frappe.delete_doc("DocType", "Authentication Log")


### PR DESCRIPTION
Summary:
Patch `move_feed_to_activity_log` throws error on bench migrate, added an exception.
Also, improvised the activity page.