### PR TITLE
[fix] show upgrade button on usage page for free users too

### DIFF
--- a/frappe/core/page/usage_info/usage_info.html
+++ b/frappe/core/page/usage_info/usage_info.html
@@ -1,12 +1,14 @@
 <div>
-	{% if limits.expiry %}
+	{% if limits.upgrade_url %}
 	<div class="upgrade-message padding" style="border-bottom: 1px solid #d0d8dc;">
-		<h4>{{ __("You have {0} days left in your subscription", [days_to_expiry]) }}</h4>
+		{% if limits.expiry %}
+			<h4>{{ __("You have {0} days left in your subscription", [days_to_expiry]) }}</h4>
+		{%elif%}
+			<h4>{{ __("You have subscribed for One User Free plan") }}</h4>
+		{% endif %}
 
-		{% if limits.upgrade_url %}
 		<p>Upgrade to a premium plan with more users, storage and priority support.</p>
 		<button class="btn btn-primary btn-sm primary-action">Upgrade</button>
-		{% endif %}
 	</div>
 	{% endif %}
 

--- a/frappe/core/page/usage_info/usage_info.html
+++ b/frappe/core/page/usage_info/usage_info.html
@@ -4,7 +4,7 @@
 		{% if limits.expiry %}
 			<h4>{{ __("You have {0} days left in your subscription", [days_to_expiry]) }}</h4>
 		{%elif%}
-			<h4>{{ __("You have subscribed for One User Free plan") }}</h4>
+			<h4>{{ __("You have subscribed for one user free plan") }}</h4>
 		{% endif %}
 
 		<p>Upgrade to a premium plan with more users, storage and priority support.</p>


### PR DESCRIPTION
No upgrade button for free plan subscription

<img width="1187" alt="screen shot 2017-11-24 at 6 26 22 pm" src="https://user-images.githubusercontent.com/3784093/33211539-069f2328-d145-11e7-8c46-e5947ae3c561.png">
