### PR TITLE
[UI Tests] Added offset and animate parameter to scroll_to, click, and login functions

### DIFF
--- a/frappe/utils/selenium_testdriver.py
+++ b/frappe/utils/selenium_testdriver.py
@@ -63,14 +63,14 @@ class TestDriver(object):
 			self.driver.quit()
 		self.driver = None
 
-	def login(self, wait_for_id="#page-desktop"):
+	def login(self, wait_for_id="#page-desktop", animate=0, scroll_offset=0):
 		if self.logged_in:
 			return
 		self.get('login')
 		self.wait_for("#login_email")
 		self.set_input("#login_email", "Administrator")
 		self.set_input("#login_password", "admin")
-		self.click('.btn-login')
+		self.click('.btn-login', animate=animate, offset=scroll_offset)
 		self.wait_for(wait_for_id)
 		self.logged_in = True
 
@@ -157,8 +157,8 @@ class TestDriver(object):
 	def get_wait(self, timeout=20):
 		return WebDriverWait(self.driver, timeout)
 
-	def scroll_to(self, selector):
-		self.execute_script("frappe.ui.scroll('{0}')".format(selector))
+	def scroll_to(self, selector, animate=0, offset=0):
+		self.execute_script("frappe.ui.scroll('{0}', {1}, {2})".format(selector, animate, offset))
 
 	def set_route(self, *args):
 		self.execute_script('frappe.set_route({0})'\
@@ -166,9 +166,9 @@ class TestDriver(object):
 
 		self.wait_for(xpath='//div[@data-page-route="{0}"]'.format('/'.join(args)), timeout=4)
 
-	def click(self, css_selector, xpath=None, timeout=20):
+	def click(self, css_selector, xpath=None, timeout=20, animate=0, offset=0):
 		element = self.wait_till_clickable(css_selector, xpath, timeout)
-		self.scroll_to(css_selector)
+		self.scroll_to(css_selector, animate, offset)
 		time.sleep(0.5)
 		element.click()
 		return element


### PR DESCRIPTION
Purpose:
- For scenarios where a user might have a fixed banner on their page, simulating a click becomes hard since the element is overlapped by the banner but is inside the viewport of the browser

---

Images:

Without offset:
![image](https://user-images.githubusercontent.com/8912289/33365046-e900b144-d50c-11e7-9595-da19bcd4495e.png)
With offset:
![image](https://user-images.githubusercontent.com/8912289/33365060-f859f5e2-d50c-11e7-891e-7fb8d2c36b44.png)

---

Changes made:
- Added a parameter to control the scroll offset and animation to the `click`, `scroll_to`, and `login` methods