### PR TITLE
XSS vulnerability Fix #11750

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -12,6 +12,7 @@ from werkzeug.local import LocalManager
 from werkzeug.exceptions import HTTPException, NotFound
 from werkzeug.contrib.profiler import ProfilerMiddleware
 from werkzeug.wsgi import SharedDataMiddleware
+import jinja2
 
 import frappe
 import frappe.handler
@@ -121,7 +122,7 @@ def init_request(request):
 	frappe.local.http_request = frappe.auth.HTTPRequest()
 
 def make_form_dict(request):
-	frappe.local.form_dict = frappe._dict({ k:v[0] if isinstance(v, (list, tuple)) else v \
+	frappe.local.form_dict = frappe._dict({ k: str(jinja2.escape(v[0])) if isinstance(v, (list, tuple)) else str(jinja2.escape(v)) \
 		for k, v in iteritems(request.form or request.args) })
 
 	if "_" in frappe.local.form_dict:

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -121,8 +121,16 @@ def init_request(request):
 
 	frappe.local.http_request = frappe.auth.HTTPRequest()
 
+def safe_unicode(x):
+	try:
+		x = x.decode('utf-8')
+	except UnicodeDecodeError as e:
+		pass
+
+	return x
+
 def make_form_dict(request):
-	frappe.local.form_dict = frappe._dict({ k: str(jinja2.escape(v[0])) if isinstance(v, (list, tuple)) else str(jinja2.escape(v)) \
+	frappe.local.form_dict = frappe._dict({ k: safe_unicode(jinja2.escape(v[0])) if isinstance(v, (list, tuple)) else safe_unicode(jinja2.escape(v)) \
 		for k, v in iteritems(request.form or request.args) })
 
 	if "_" in frappe.local.form_dict:


### PR DESCRIPTION
This PR is an attempt to fix Issue [#11750](https://github.com/frappe/erpnext/issues/11750) - XSS on Login Page.

### Diagnosis
`app.py` on response from the server does not sanitise the expected `form_dict`.

### Solution
Using jinja2's escape to sanitise any malicious code from any request via `frappe.call` should have this fixed. This is true since `jinja2` claims to be 100% XSS safe.

### Example
![](http://g.recordit.co/NNAiX8R1nk.gif)