### PR TITLE
[Feature] Modularity to server side tests

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -300,6 +300,7 @@ def console(context):
 @click.command('run-tests')
 @click.option('--app', help="For App")
 @click.option('--doctype', help="For DocType")
+@click.option('--doctype-list', help="For sequential DocType tests, pass path to txt file")
 @click.option('--test', multiple=True, help="Specific test")
 @click.option('--driver', help="For Travis")
 @click.option('--ui-tests', is_flag=True, default=False, help="Run UI Tests")
@@ -308,7 +309,7 @@ def console(context):
 @click.option('--junit-xml-output', help="Destination file path for junit xml report")
 @pass_context
 def run_tests(context, app=None, module=None, doctype=None, test=(),
-	driver=None, profile=False, junit_xml_output=False, ui_tests = False):
+	driver=None, profile=False, junit_xml_output=False, ui_tests = False, doctype_list=None):
 	"Run tests"
 	import frappe.test_runner
 	tests = test
@@ -316,9 +317,9 @@ def run_tests(context, app=None, module=None, doctype=None, test=(),
 	site = get_site(context)
 	frappe.init(site=site)
 
-	ret = frappe.test_runner.main(app, module, doctype, context.verbose, tests=tests,
-		force=context.force, profile=profile, junit_xml_output=junit_xml_output,
-		ui_tests = ui_tests)
+	ret = frappe.test_runner.main(app=app, module=module, doctype=doctype,
+		verbose=context.verbose, tests=tests, force=context.force, profile=profile,
+		junit_xml_output=junit_xml_output, ui_tests = ui_tests, doctype_list=doctype_list)
 	if len(ret.failures) == 0 and len(ret.errors) == 0:
 		ret = 0
 

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -56,7 +56,7 @@ def main(app=None, module=None, doctype=None, verbose=False, tests=(),
 			frappe.get_attr(fn)()
 
 		if doctype_list:
-			ret = run_sequen_doctype_tests(doctype_list, verbose, tests, force, profile)
+			ret = run_doctype_test_list(doctype_list, verbose, tests, force, profile)
 		elif doctype:
 			ret = run_tests_for_doctype(doctype, verbose, tests, force, profile)
 		elif module:
@@ -85,7 +85,7 @@ def set_test_email_config():
 		"admin_password": "admin"
 	})
 
-def run_sequen_doctype_tests(doctype_list, verbose=False, tests=(), force=False, profile=False):
+def run_doctype_test_list(doctype_list, verbose=False, tests=(), force=False, profile=False):
 	# check if doctype file exsts
 	import os
 


### PR DESCRIPTION
- added '--doctype-list' option to run-tests, which takes in a .txt file as input with a list of doctypes to be tested and runs the server side tests for them sequentially