### PR TITLE
[fix] Item group test cases

### DIFF
--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -212,13 +212,13 @@ class NestedSet(Document):
 				raise
 
 	def before_rename(self, olddn, newdn, merge=False, group_fname="is_group"):
-		if merge and self.get(group_fname):
+		if merge and hasattr(self, group_fname):
 			is_group = frappe.db.get_value(self.doctype, newdn, group_fname)
 			if self.get(group_fname) != is_group:
 				frappe.throw(_("Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"), NestedSetInvalidMergeError)
 
 	def after_rename(self, olddn, newdn, merge=False):
-		if(not self.nsm_parent_field):
+		if not self.nsm_parent_field:
 			parent_field = "parent_" + self.doctype.replace(" ", "_").lower()
 		else:
 			parent_field = self.nsm_parent_field


### PR DESCRIPTION
**Issue**

```
ERROR: test_merge_leaves (erpnext.setup.doctype.item_group.test_item_group.TestItem)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/test_item_group.py", line 195, in test_merge_leaves
    self.test_basic_tree(records=records_to_test)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/test_item_group.py", line 22, in test_basic_tree
    ["lft", "rgt", "parent_item_group"])
TypeError: 'NoneType' object is not iterable

======================================================================
ERROR: test_move_group_into_another (erpnext.setup.doctype.item_group.test_item_group.TestItem)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/test_item_group.py", line 90, in test_move_group_into_another
    self.test_basic_tree()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/test_item_group.py", line 22, in test_basic_tree
    ["lft", "rgt", "parent_item_group"])
TypeError: 'NoneType' object is not iterable

```