### PR TITLE
Fixed Currency Precision during Display

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -61,7 +61,7 @@ frappe.form.formatters = {
 			if ( decimals.length < precision ) {
 				// If the value stored in DB is less than expected currency precision.
 				const fraction = frappe.model.get_value(":Currency", currency, "fraction_units") || 100; // brutal, but okay.
-				precision      = cstr(precision).length - 1;
+				precision      = cstr(fraction).length - 1;
 				
 			} else if (decimals.length < 3) {
 				// min precision 2

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -28,7 +28,6 @@ frappe.form.formatters = {
 			// options points to a currency field, but expects precision of float!
 			docfield.precision = precision;
 			return frappe.form.formatters.Currency(value, docfield, options, doc);
-
 		} else {
 			// show 1.000000 as 1
 			if (!(options || {}).always_show_decimals && !is_null(value)) {
@@ -56,16 +55,22 @@ frappe.form.formatters = {
 		if (precision > 2) {
 			let parts = cstr(value).split('.');
 			let decimals = parts.length > 1 ? parts[1] : '';
-			if (decimals.length < 3) {
+
+			// If you ever change the code below, it's going to hurt someone from UAE, a lot.
+
+			if ( decimals.length < precision ) {
+				// If the value stored in DB is less than expected currency precision.
+				const fraction = frappe.model.get_value(":Currency", currency, "fraction_units") || 100; // brutal, but okay.
+				precision      = cstr(precision).length - 1;
+				
+			} else if (decimals.length < 3) {
 				// min precision 2
 				precision = 2;
-			} else if (decimals.length < precision) {
-				// or min decimals
-				precision = decimals.length;
-			}
+			} 
 		}
 		value = (value==null || value==="") ?
 			"" : format_currency(value, currency, precision);
+		
 		if (options && options.only_value) {
 			return value;
 		} else {


### PR DESCRIPTION
This PR addresses the Issue [11856](https://github.com/frappe/erpnext/issues/11856).

#### Gist
Value rounds to 2 even when 3. This is problematic since `Sales Invoice` on print would display `.99` and not `.990` (Hence, the currency exchange value would incur an amount loss).

Example
999.990 **rounded** off to 2, 3 or X digits is 999.99. This, on check would set precision value to decimal length (floating point instead currency precision, previously done by Kanchan, not sure why). And hence would display the same.
![](http://g.recordit.co/qcOdQCV2oA.gif)

#### Fix
A cached fetch to Currency DocType's `fraction_units` field, followed which the precision is set.
Working - Assuming `KWD` (Fraction Units being 1000) and Precision 3.
![](http://g.recordit.co/yyZ5MWb4bn.gif)