### PR TITLE
Fixed Currency Precision during Display

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -65,7 +65,7 @@ frappe.form.formatters = {
 			}
 		}
 		
-		value = value ? "" : format_currency(value, currency, precision);
+		value = (value == null || value == "") ? "" : format_currency(value, currency, precision);
 		
 		if ( options && options.only_value ) {
 			return value;

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -50,24 +50,25 @@ frappe.form.formatters = {
 	Percent: function(value, docfield, options) {
 		return frappe.form.formatters._right(flt(value, 2) + "%", options)
 	},
-	Currency: function(value, docfield, options, doc) {
-		var currency = frappe.meta.get_field_currency(docfield, doc);
+	Currency: function (value, docfield, options, doc) {
+		var currency  = frappe.meta.get_field_currency(docfield, doc);
 		var precision = docfield.precision || cint(frappe.boot.sysdefaults.currency_precision) || 2;
+
+		// If you change anything below, it's going to hurt a company in UAE, a bit.
 		if (precision > 2) {
-			let parts = cstr(value).split('.');
-			let decimals = parts.length > 1 ? parts[1] : '';
-			if (decimals.length < 3) {
-				// min precision 2
-				precision = 2;
-			} else if (decimals.length < precision) {
-				// or min decimals
-				precision = decimals.length;
+			var parts	 = cstr(value).split("."); // should be minimum 2, comes from the DB
+			var decimals = parts.length > 1 ? parts[1] : ""; // parts.length == 2 ???
+			
+			if ( decimals.length < 3 || decimals.length < precision ) {
+				const fraction = frappe.model.get_value(":Currency", currency, "fraction_units") || 100; // if not set, minimum 2.
+				precision      = cstr(fraction).length - 1;
 			}
 		}
-		value = (value==null || value==="") ?
-			"" : format_currency(value, currency, precision);
-		if (options && options.only_value) {
-			return value;
+		
+		value = value ? "" : format_currency(value, currency, precision);
+		
+		if ( options && options.only_value ) {
+			return value
 		} else {
 			return frappe.form.formatters._right(value, options);
 		}

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -68,7 +68,7 @@ frappe.form.formatters = {
 		value = value ? "" : format_currency(value, currency, precision);
 		
 		if ( options && options.only_value ) {
-			return value
+			return value;
 		} else {
 			return frappe.form.formatters._right(value, options);
 		}


### PR DESCRIPTION
This PR addresses the Issue [11856](https://github.com/frappe/erpnext/issues/11856).

#### Gist
Value rounds to 2 even when 3. This is problematic since `Sales Invoice` on print would display `.99` and not `.990` (Hence, the currency exchange value would incur an amount loss).

Example
999.990 **rounded** off to 2, 3 or X digits is 999.99. This, on check would set precision value to decimal length (floating point instead currency precision, previously done by Kanchan, not sure why). And hence would display the same.
![](http://g.recordit.co/qcOdQCV2oA.gif)

#### Fix
A cached fetch to Currency DocType's `fraction_units` field, followed which the precision is set.
Working - Assuming `KWD` (Fraction Units being 1000) and Precision 3.
![](http://g.recordit.co/yyZ5MWb4bn.gif)