### PR TITLE
[Fix] Make new button(+) not working for chinese language

### DIFF
--- a/frappe/public/js/legacy/clientscriptAPI.js
+++ b/frappe/public/js/legacy/clientscriptAPI.js
@@ -482,7 +482,7 @@ _f.Frm.prototype.make_new = function(doctype) {
 	if(this.make_methods && this.make_methods[doctype]) {
 		return this.make_methods[doctype](this);
 	} else if(this.custom_make_buttons && this.custom_make_buttons[doctype]) {
-		this.custom_buttons[this.custom_make_buttons[doctype]].trigger('click');
+		this.custom_buttons[__(this.custom_make_buttons[doctype])].trigger('click');
 	} else {
 		frappe.model.with_doctype(doctype, function() {
 			var new_doc = frappe.model.get_new_doc(doctype);


### PR DESCRIPTION
While making delivery note from sales order, plus button next to deliver note not working for chinese language
![screen shot 2017-12-06 at 2 46 32 pm](https://user-images.githubusercontent.com/8780500/33654099-1715b4c0-da95-11e7-80c7-dc7ef4396869.png)
