### PR TITLE
v8.x.x Prevent duplicate sidebar display in mobile view

### DIFF
--- a/frappe/www/me.html
+++ b/frappe/www/me.html
@@ -34,7 +34,7 @@
 		</div>
 	</div>
 </div>
-<div class="col-xs-12 visible-xs" style="min-height: 400px; padding: 10px 0 0 0">
+<div class="col-xs-12 hide" style="min-height: 400px; padding: 10px 0 0 0">
 	<ul class="list-group">
 		<a class="list-group-item" href="/profile">
             {{ _("Profile") }}


### PR DESCRIPTION
![repeat_sidemenu](https://user-images.githubusercontent.com/17238907/33666038-079154f6-da99-11e7-8708-70cde828d798.png)

On the Portal View, when viewed on mobile, side menu is duplicated, this fixes it.