### PR TITLE
Add is_image util

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -112,7 +112,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 		<img src="{{ doc[df.fieldname] }}" class="signature-img img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype in ("Attach", "Attach Image") and doc[df.fieldname]
-		and (guess_mimetype(doc[df.fieldname])[0] or "").startswith("image/") %}
+		and frappe.utils.is_image(doc[df.fieldname]) %}
 		<img src="{{ doc[df.fieldname] }}" class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
     {% elif df.fieldtype=="HTML" %}

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -511,6 +511,13 @@ def is_html(text):
 			break
 	return out
 
+def is_image(filepath):
+	from mimetypes import guess_type
+
+	# filepath can be https://example.com/bed.jpg?v=129
+	filepath = filepath.split('?')[0]
+	return (guess_type(filepath)[0] or "").startswith("image/")
+
 
 # from Jinja2 code
 _striptags_re = re.compile(r'(<!--.*?-->|<[^>]*>)')


### PR DESCRIPTION
`guess_mimetype` fails if the image url is something like `https://example.com/bed.jpg?v=123`.
This PR introduces a new util method `is_image` and handles this case as well.