### PR TITLE
Encrypted PDF

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1224,7 +1224,7 @@ def format(*args, **kwargs):
 	import frappe.utils.formatters
 	return frappe.utils.formatters.format_value(*args, **kwargs)
 
-def get_print(doctype=None, name=None, print_format=None, style=None, html=None, as_pdf=False, doc=None, output = None, no_letterhead = 0):
+def get_print(doctype=None, name=None, print_format=None, style=None, html=None, as_pdf=False, doc=None, output = None, no_letterhead = 0, password = None):
 	"""Get Print Format for given document.
 
 	:param doctype: DocType of document.
@@ -1246,11 +1246,11 @@ def get_print(doctype=None, name=None, print_format=None, style=None, html=None,
 		html = build_page("printview")
 
 	if as_pdf:
-		return get_pdf(html, output = output)
+		return get_pdf(html, output = output, password = password)
 	else:
 		return html
 
-def attach_print(doctype, name, file_name=None, print_format=None, style=None, html=None, doc=None):
+def attach_print(doctype, name, file_name=None, print_format=None, style=None, html=None, doc=None, password = None):
 	from frappe.utils import scrub_urls
 
 	if not file_name: file_name = name
@@ -1263,7 +1263,7 @@ def attach_print(doctype, name, file_name=None, print_format=None, style=None, h
 	if int(print_settings.send_print_as_pdf or 0):
 		out = {
 			"fname": file_name + ".pdf",
-			"fcontent": get_print(doctype, name, print_format=print_format, style=style, html=html, as_pdf=True, doc=doc)
+			"fcontent": get_print(doctype, name, print_format=print_format, style=style, html=html, as_pdf=True, doc=doc, password = password)
 		}
 	else:
 		out = {

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -18,7 +18,7 @@ def get_pdf(html, options=None, output = None, password = None):
 
 		if password:
 			password = str(password).encode('utf-8')
-			fname_out = os.path.join("/tmp", "encrypted-pdf-{0}.pdf".format(frappe.generate_hash()))
+			fname_out = os.path.join("/tmp", "frappe-pdf-{0}.pdf".format(frappe.generate_hash()))
 			writer = PdfFileWriter()
 			reader = PdfFileReader(file(fname, "rb"))
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -67,11 +67,11 @@ def get_pdf(html, options=None, output = None, password = None):
 
 	return filedata
 
-def append_pdf(input_pdf,output, password = None):
-	if password and input_pdf.isEncrypted:
-		input_pdf.decrypt(password)		
+def append_pdf(input,output, password = None):
+	if password and input.isEncrypted:
+		input.decrypt(password)
 	# Merging multiple pdf files
-	[output.addPage(input_pdf.getPage(page_num)) for page_num in range(input_pdf.numPages)]
+	[output.addPage(input.getPage(page_num)) for page_num in range(input.numPages)]
 
 def prepare_options(html, options):
 	if not options:

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -8,15 +8,32 @@ from frappe import _
 from bs4 import BeautifulSoup
 from PyPDF2 import PdfFileWriter, PdfFileReader
 
-def get_pdf(html, options=None, output = None):
+def get_pdf(html, options=None, output = None, password = None):
 	html = scrub_urls(html)
 	html, options = prepare_options(html, options)
 	fname = os.path.join("/tmp", "frappe-pdf-{0}.pdf".format(frappe.generate_hash()))
 
 	try:
 		pdfkit.from_string(html, fname, options=options or {})
+
+		if password:
+			password = str(password).encode('utf-8')
+			fname_out = os.path.join("/tmp", "encrypted-pdf-{0}.pdf".format(frappe.generate_hash()))
+			writer = PdfFileWriter()
+			input = PdfFileReader(file(fname, "rb"))
+
+			for pagenum in range(input.numPages):
+				writer.addPage(input.getPage(pagenum))
+			
+			output_stream = file(fname_out, "wb")
+			writer.encrypted(password)
+			writer.write(output_stream)
+			output_stream.close()
+			old_fname = fname
+			fname = fname_out
+
 		if output:
-			append_pdf(PdfFileReader(file(fname,"rb")),output)
+			append_pdf(PdfFileReader(file(fname,"rb")),output, password = password)
 		else:
 			with open(fname, "rb") as fileobj:
 				filedata = fileobj.read()
@@ -41,12 +58,19 @@ def get_pdf(html, options=None, output = None):
 		cleanup(fname, options)
 
 	if output:
+		if password:
+			output.encrypt(password)
 		return output
+
+	if password and os.path.exists(old_fname):
+		os.remove(old_fname)
 
 	return filedata
 
-def append_pdf(input,output):
+def append_pdf(input,output, password = None):
 	# Merging multiple pdf files
+	if password and input.isEncrypted:
+		input.decrypt(password)
     [output.addPage(input.getPage(page_num)) for page_num in range(input.numPages)]
 
 def prepare_options(html, options):

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -67,11 +67,12 @@ def get_pdf(html, options=None, output = None, password = None):
 
 	return filedata
 
-def append_pdf(input,output, password = None):
-	# Merging multiple pdf files
-	if password and input.isEncrypted:
+def append_pdf(input,output, password = None):	
+	if password and input.isEncrypted:		
 		input.decrypt(password)
-    [output.addPage(input.getPage(page_num)) for page_num in range(input.numPages)]
+		
+	# Merging multiple pdf files
+	[output.addPage(input.getPage(page_num)) for page_num in range(input.numPages)]
 
 def prepare_options(html, options):
 	if not options:

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -20,10 +20,10 @@ def get_pdf(html, options=None, output = None, password = None):
 			password = str(password).encode('utf-8')
 			fname_out = os.path.join("/tmp", "encrypted-pdf-{0}.pdf".format(frappe.generate_hash()))
 			writer = PdfFileWriter()
-			input = PdfFileReader(file(fname, "rb"))
+			reader = PdfFileReader(file(fname, "rb"))
 
-			for pagenum in range(input.numPages):
-				writer.addPage(input.getPage(pagenum))
+			for pagenum in range(reader.numPages):
+				writer.addPage(reader.getPage(pagenum))
 			
 			output_stream = file(fname_out, "wb")
 			writer.encrypted(password)

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -24,7 +24,7 @@ def get_pdf(html, options=None, output = None, password = None):
 
 			for pagenum in range(reader.numPages):
 				writer.addPage(reader.getPage(pagenum))
-			
+
 			output_stream = file(fname_out, "wb")
 			writer.encrypted(password)
 			writer.write(output_stream)
@@ -67,12 +67,11 @@ def get_pdf(html, options=None, output = None, password = None):
 
 	return filedata
 
-def append_pdf(input,output, password = None):	
-	if password and input.isEncrypted:		
-		input.decrypt(password)
-		
+def append_pdf(input_pdf,output, password = None):
+	if password and input_pdf.isEncrypted:
+		input_pdf.decrypt(password)		
 	# Merging multiple pdf files
-	[output.addPage(input.getPage(page_num)) for page_num in range(input.numPages)]
+	[output.addPage(input_pdf.getPage(page_num)) for page_num in range(input_pdf.numPages)]
 
 def prepare_options(html, options):
 	if not options:


### PR DESCRIPTION
frappe/utils/pdf.py is be able to encrypted pdf (set password for pdf).
so we can set password Salary Slip when send it out.

https://github.com/frappe/erpnext/blob/0f97eda7c9a9d595d9003afeb6dd54a0eb33b2b8/erpnext/hr/doctype/salary_slip/salary_slip.py#L420

email_args = {
				"recipients": [receiver],
				"message": _("Please see attachment"),
				"subject": 'Salary Slip - from {0} to {1}'.format(self.start_date, self.end_date),
				"attachments": [frappe.attach_print(self.doctype, self.name, file_name=self.name, **password = "123456"**)],
				"reference_doctype": self.doctype,
				"reference_name": self.name
				}