### PR TITLE
Note regarding CSRF-Token added to POST request rest api docs.

### DIFF
--- a/frappe/docs/user/en/guides/integration/rest_api.md
+++ b/frappe/docs/user/en/guides/integration/rest_api.md
@@ -210,6 +210,8 @@ _Response:_
 		"parentfield": null
 	  }
 	}
+	
+Note: `POST` requests are to be sent along with `X-Frappe-CSRF-Token:<csrf-token>` header.
 
 #### Read
 


### PR DESCRIPTION
CSRF Token Checks Prohibit POST Rest API Calls for a Logged in User. Note added to keep users aware of this.