### PR TITLE
Combine "Login with LDAP" with normal "Login"

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -43,18 +43,6 @@ def get_ldap_settings():
 		# this will return blank settings
 		return frappe._dict()
 
-@frappe.whitelist(allow_guest=True)
-def login():
-	#### LDAP LOGIN LOGIC #####
-	args = frappe.form_dict
-	user = authenticate_ldap_user(frappe.as_unicode(args.usr), frappe.as_unicode(args.pwd))
-
-	frappe.local.login_manager.user = user.name
-	frappe.local.login_manager.post_login()
-
-	# because of a GET request!
-	frappe.db.commit()
-
 def authenticate_ldap_user(user=None, password=None):
 	dn = None
 	params = {}

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -55,20 +55,6 @@ login.bind_events = function() {
 		login.call(args);
 		return false;
 	});
-
-	$(".btn-ldap-login").on("click", function(){
-		var args = {};
-		args.cmd = "{{ ldap_settings.method }}";
-		args.usr = ($("#login_email").val() || "").trim();
-		args.pwd = $("#login_password").val();
-		args.device = "desktop";
-		if(!args.usr || !args.pwd) {
-			login.set_indicator("{{ _("Both login and password required") }}", 'red');
-			return false;
-		}
-		login.call(args);
-		return false;
-	});
 }
 
 

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -25,11 +25,6 @@
 
 			<button class="btn btn-sm btn-primary btn-block btn-login" type="submit">
 				{{ _("Sign in") }}</button>
-
-			{% if ldap_settings.enabled %}
-			<button class="btn btn-sm btn-default btn-block btn-login btn-ldap-login">
-				{{ _("Login with LDAP") }}</button>
-			{% endif %}
 		</form>
 	</div>
 	<div class='form-footer'>


### PR DESCRIPTION
There was a separate Login with LDAP button when LDAP integration is enabled which will confuse normal user, also block mobile App user using LDAP account.
This enhancement removed Login with LDAP button and related code. Add lines of code letting user can login with LDAP when failed authentication with local database.
Which means when a user perform a login, LoginManager will authenticate the user with local database first, then attempt using LDAP if local authentication failed and LDAP is enabled.