### PR TITLE
Bugfix 4622 (prevent password reset for disabled user)

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -778,6 +778,9 @@ def reset_password(user):
 
 	try:
 		user = frappe.get_doc("User", user)
+		if user.enabled==0:
+			return 'not allowed'
+
 		user.validate_reset_password()
 		user.reset_password(send_email=True)
 

--- a/frappe/www/qrcode.html
+++ b/frappe/www/qrcode.html
@@ -17,7 +17,7 @@
 		</p>
 		<br>
 		<p class='text-muted small'>{{ _("Authentication Apps you can use are: ") }}
-			Google Authenticator, Lastpass Authenticator, Authy and Duo Mobile.
+			FreeOTP, Google Authenticator, Lastpass Authenticator, Authy and Duo Mobile.
 		</p>
 	</div>
 	<div class='col-sm-6' style='padding-top: 15px;'>


### PR DESCRIPTION
This is a bugfix pull request for https://github.com/frappe/frappe/issues/4622

It implements a checkpoint before the password is reset that this will return "not allowed" in case the user is disabled.

Testing both positive (reset disabled --> blocked) and negative (reset enabled --> works) were successful.