### PR TITLE
Reset password not allowed for disabled users

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -769,6 +769,8 @@ def reset_password(user):
 
 	try:
 		user = frappe.get_doc("User", user)
+		if not user.enabled:
+			return 'disabled'
 		user.validate_reset_password()
 		user.reset_password(send_email=True)
 

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -184,6 +184,8 @@ login.login_handlers = (function() {
 					login.set_indicator("{{ _("Not a valid user") }}", 'red');
 				} else if (data.message=='not allowed') {
 					login.set_indicator("{{ _("Not Allowed") }}", 'red');
+				} else if (data.message=='disabled') {
+					login.set_indicator("{{ _("Not Allowed: Disabled User") }}", 'red');
 				} else {
 					login.set_indicator("{{ _("Instructions Emailed") }}", 'green');
 				}


### PR DESCRIPTION
#4622 
Summary:
If a user is disabled and has role such as system manager, he/she was able to reset password and login again, as well as enable his/her account. 
So, added a condition to not allow such users to reset their passwords.

![login](https://user-images.githubusercontent.com/17617465/34003217-c097804c-e11a-11e7-9ea4-766475935101.gif)