### PR TITLE
[FIX] multiple Progress Dialog Render

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -103,9 +103,11 @@ frappe.ui.Dialog = frappe.ui.FieldGroup.extend({
 		// show it
 		this.$wrapper.modal("show");
 		this.primary_action_fulfilled = false;
+		this.is_visible = true;
 	},
 	hide: function(from_event) {
 		this.$wrapper.modal("hide");
+		this.is_visible = false;
 	},
 	get_close_btn: function() {
 		return this.$wrapper.find(".btn-modal-close");

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -235,8 +235,7 @@ frappe.verify_password = function(callback) {
 }
 
 frappe.show_progress = function(title, count, total=100, description) {
-	if(frappe.cur_progress && frappe.cur_progress.title === title
-			&& frappe.cur_progress.$wrapper.is(":visible")) {
+	if(frappe.cur_progress && frappe.cur_progress.title === title && frappe.cur_progress.is_visible) {
 		var dialog = frappe.cur_progress;
 	} else {
 		var dialog = new frappe.ui.Dialog({


### PR DESCRIPTION
This PR attempts to fix the issue of the Progress Dialog rendered multiple times. This is possibly because `frappe.cur_progress.$wrapper.is(":visible")` receives false positives at times during server calls. Using the native Dialog API instead.

##### Before
![](http://g.recordit.co/8q63HHa2al.gif)

##### After
![](http://g.recordit.co/PTTtmgCN0x.gif)