### PR TITLE
[Minor] Remove print statements from translate

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -98,8 +98,6 @@ def get_dict(fortype, name=None):
 	asset_key = fortype + ":" + (name or "-")
 	translation_assets = cache.hget("translation_assets", frappe.local.lang, shared=True) or {}
 
-	print(translation_assets)
-
 	if not asset_key in translation_assets:
 		if fortype=="doctype":
 			messages = get_messages_from_doctype(name)
@@ -123,12 +121,8 @@ def get_dict(fortype, name=None):
 		message_dict = make_dict_from_messages(messages)
 		message_dict.update(get_dict_from_hooks(fortype, name))
 
-		print(message_dict)
-
 		# remove untranslated
 		message_dict = {k:v for k, v in iteritems(message_dict) if k!=v}
-
-		print(message_dict)
 
 		translation_assets[asset_key] = message_dict
 
@@ -170,7 +164,6 @@ def make_dict_from_messages(messages, full_dict=None):
 		if m[1] in full_dict:
 			out[m[1]] = full_dict[m[1]]
 
-	print(out)
 	return out
 
 def get_lang_js(fortype, name):


### PR DESCRIPTION
All the data passing through translation was printed in the console - Client side tests running out of log space since travis console was getting filled with printed data.