### PR TITLE
[Fix] Child doctype custom fields gets deleted on updating parent doctype customization

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -100,14 +100,16 @@ def sync_customizations_for_doctype(data):
 	update_schema = False
 
 	def sync(key, custom_doctype, doctype_fieldname):
-		doctypes = list(set(map(lambda row: row.get(doctype_fieldname), data[key])))
-		frappe.db.sql('delete from `tab{0}` where `{1}` in ({2})'.format(
-			custom_doctype, doctype_fieldname, ",".join(["'%s'" % dt for dt in doctypes])))
+		frappe.db.sql('delete from `tab{0}` where `{1}`=%s'.format(custom_doctype, doctype_fieldname),
+			doctype)
 
 		for d in data[key]:
 			d['doctype'] = custom_doctype
 			doc = frappe.get_doc(d)
-			doc.db_insert()
+			try:
+				doc.db_insert()
+			except:
+				pass
 
 	if data['custom_fields']:
 		sync('custom_fields', 'Custom Field', 'dt')


### PR DESCRIPTION
Possible fix for https://github.com/frappe/frappe/issues/4662