### PR TITLE
[export-fields] export comma separated lines for long values

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -62,6 +62,7 @@ def handle_html(data):
 	obj.body_width = 0
 	value = obj.handle(h)
 	value = ", ".join(value.split('  \n'))
+	value = ", ".join(value.split('\n'))
 	value = ", ".join(value.split('# '))
 	return value
 

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -61,13 +61,9 @@ def handle_html(data):
 	obj.ignore_links = True
 	obj.body_width = 0
 	value = obj.handle(h)
-	value = value.split('\n', 1)
-	value = value[0].split('# ',1)
-	if len(value) < 2:
-		return value[0]
-	else:
-		return value[1]
-
+	value = ", ".join(value.split('  \n'))
+	value = ", ".join(value.split('# '))
+	return value
 
 def read_xlsx_file_from_attached_file(file_id=None, fcontent=None):
 	if file_id:

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -62,7 +62,7 @@ def handle_html(data):
 	obj.body_width = 0
 	value = obj.handle(h)
 	value = ", ".join(value.split('  \n'))
-	value = ", ".join(value.split('\n'))
+	value = " ".join(value.split('\n'))
 	value = ", ".join(value.split('# '))
 	return value
 


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/12085

before:
<img width="867" alt="screen shot 2017-12-21 at 5 07 05 pm" src="https://user-images.githubusercontent.com/5196925/34254997-9780404a-e674-11e7-9f3a-69f8c7adf8de.png">

after:
<img width="739" alt="screen shot 2017-12-21 at 5 26 24 pm" src="https://user-images.githubusercontent.com/5196925/34255001-9b56731a-e674-11e7-9184-51851a6c7529.png">
