### PR TITLE
Listdown doman-activated doctype in Contacts & Address

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -148,7 +148,7 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 	all_doctypes = doctypes + _doctypes
 
 	valid_doctypes = []
-	user_roles = frappe.db.get_all('Has Role', {'parent': frappe.session.user}, 'role', as_list=True)
+	user_roles = frappe.get_roles()
 	for ctype in all_doctypes:
 		if frappe.db.exists('Custom DocPerm', {"parent": ctype[0]}):
 			dtype = 'Custom DocPerm'
@@ -157,7 +157,7 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 
 		valid_doctypes.append(frappe.db.get_all(dtype, {
 			'parent': ctype[0],
-			'role': ('in', [role[0] for role in user_roles])
+			'role': ('in', user_roles)
 		}, 'distinct parent', as_list=True))
 
 	return sorted(valid_doctypes, key=lambda item: item[0])

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -147,10 +147,17 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 
 	all_doctypes = doctypes + _doctypes
 
+	valid_doctypes = []
 	user_roles = frappe.db.get_all('Has Role', {'parent': frappe.session.user}, 'role', as_list=True)
-	valid_doctypes = frappe.db.get_all('DocPerm', {
-			'parent': ('in', [ctype[0] for ctype in all_doctypes]),
+	for ctype in all_doctypes:
+		if frappe.db.exists('Custom DocPerm', {"parent": ctype[0]}):
+			dtype = 'Custom DocPerm'
+		else:
+			dtype = 'DocPerm'
+
+		valid_doctypes.append(frappe.db.get_all(dtype, {
+			'parent': ctype[0],
 			'role': ('in', [role[0] for role in user_roles])
-		}, 'distinct parent', as_list=True)
+		}, 'distinct parent', as_list=True))
 
 	return sorted(valid_doctypes, key=lambda item: item[0])

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -146,4 +146,11 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 		order_by="dt asc", as_list=True)
 
 	all_doctypes = doctypes + _doctypes
-	return sorted(all_doctypes, key=lambda item: item[0])
+
+	user_roles = frappe.db.get_all('Has Role', {'parent': frappe.session.user}, 'role', as_list=True)
+	valid_doctypes = frappe.db.get_all('DocPerm', {
+			'parent': ('in', [ctype[0] for ctype in all_doctypes]),
+			'role': ('in', [role[0] for role in user_roles])
+		}, 'distinct parent', as_list=True)
+
+	return sorted(valid_doctypes, key=lambda item: item[0])


### PR DESCRIPTION
Issue:- Doctype link field showed all the doctype - even the ones that aren't active
Fix:- 
![fix-doctype-listdown](https://user-images.githubusercontent.com/11695402/34293309-559c21f6-e72a-11e7-85d3-5a7c1da636b7.gif)
