### PR TITLE
[fix] Remove dirty call in sync.js

### DIFF
--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -45,7 +45,7 @@ $.extend(frappe.model, {
 				}
 			}
 
-			if(cur_frm && isPlain) cur_frm.dirty();
+
 
 		}
 


### PR DESCRIPTION
Issue: Document Status does not update in Sales Order after Sales Invoice is saved 
Removed if(cur_frm && isPlain) cur_frm.dirty().
Added cur_frm.dirty in erpnext/public/js/utils.js in erpnext.

Before
![si2](https://user-images.githubusercontent.com/6947417/34355296-31945804-ea5a-11e7-89ac-d798054b0be9.gif)

After
![si](https://user-images.githubusercontent.com/6947417/34355236-d3974edc-ea59-11e7-96a0-a47b577a8a13.gif)
