### PR TITLE
Revert checkbox CSS properties to those from v9

### DIFF
--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -895,8 +895,8 @@ li.user-progress {
 
 // custom font awesome checkbox
 input[type="checkbox"] {
+	visibility: hidden;
 	position: relative;
-	left: -999999px;
 
 	&:before {
 		position: absolute;


### PR DESCRIPTION
This PR aims to fix frappe/erpnext/issues/12218

Edit: screencast added
![peek 2017-12-28 12-51](https://user-images.githubusercontent.com/10875796/34400636-74c6392e-ebce-11e7-9a94-30d799beb9a8.gif)
