### PR TITLE
[FIX] remove tag element from list

### DIFF
--- a/frappe/public/js/frappe/ui/tags.js
+++ b/frappe/public/js/frappe/ui/tags.js
@@ -84,7 +84,10 @@ frappe.ui.Tags = class {
 	removeTag(label) {
 		if(this.tagsList.includes(label)) {
 			let $tag = this.$ul.find(`.frappe-tag[data-tag-label="${label}"]`);
-			$tag.remove();
+			
+			// Just don't remove tag, but also the li DOM.
+			$tag.parent('.tags-list-item').remove();
+
 			this.tagsList = this.tagsList.filter(d => d !== label);
 			this.onTagRemove && this.onTagRemove(label);
 		}


### PR DESCRIPTION
This PR is fixes for the newly updated Tag Editor.

tag elements on remove would not remove the corresponding list element.

#### Before
![](http://recordit.co/u7ApXwrWdD.gif)

#### After
![](http://g.recordit.co/YL9IVxO5cf.gif)