### PR TITLE
[Frappe-Chat, Urgent] Get frappe.user namespace on new-site (Before Startup)

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -161,6 +161,3 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 		}
 
 	arg["parenttype"] = "Assignment"
-
-	from frappe.desk.page.chat import chat
-	chat.post(**arg)

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -190,7 +190,7 @@ sounds = [
 
 	# frappe chat sounds
 	{ "name": "chat-message", 	   "src": "/assets/frappe/sounds/chat-message.mp3",      "volume": 0.1 },
-	{ "name": "chat-notification", "src": "/assets/frappe/sounds/chat-noticication.mp3", "volume": 0.1 }
+	{ "name": "chat-notification", "src": "/assets/frappe/sounds/chat-notification.mp3", "volume": 0.1 }
 ]
 
 bot_parsers = [

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -18,6 +18,7 @@
  * frappe.user.first_name("Rahul Malhotra")
  * // returns "Rahul"
  */
+frappe.provide('frappe.user')
 frappe.user.first_name = user => frappe.user.full_name(user).split(" ")[0]
 
 // frappe.ui extensions

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -149,6 +149,3 @@ def notify_assignment(shared_by, doc_type, doc_name, description=None, notify=0)
 				shared_by),
 		'notify': notify
 	}
-
-	from frappe.desk.page.chat import chat
-	chat.post(**arg)


### PR DESCRIPTION
This PR fixes to create new sites that obtain the `frappe.user` namespace for chat. Fails to create new-sites before (Login Errors).