### PR TITLE
[Frappe-Chat, Urgent] Get frappe.user namespace on new-site creation.

### DIFF
--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -18,6 +18,7 @@
  * frappe.user.first_name("Rahul Malhotra")
  * // returns "Rahul"
  */
+frappe.provide('frappe.user')
 frappe.user.first_name = user => frappe.user.full_name(user).split(" ")[0]
 
 // frappe.ui extensions


### PR DESCRIPTION
This PR fixes to create new sites that obtain the frappe.user namespace for chat. Fails to create new-sites before (Login Errors).