### PR TITLE
[fix] consider Not In or In conditions

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -592,8 +592,14 @@ def get_count(doctype, filters=None):
 			if table not in tables:
 				tables.append(table)
 
-			conditions.append('{fieldname} {operator} "{value}"'.format(fieldname=fieldname,
-				operator=f[2], value=f[3]))
+			if isinstance(f[3], (list, tuple)):
+				value = ("({0})").format(", ".join(['"%s"']*len(f[3])))%tuple(f[3])
+
+				conditions.append('{fieldname} {operator} {value}'.format(fieldname=fieldname,
+					operator=f[2], value=value))
+			else:
+				conditions.append('{fieldname} {operator} "{value}"'.format(fieldname=fieldname,
+					operator=f[2], value=f[3]))
 
 			if doctype != f[0]:
 				join_condition = '`tab{child_doctype}`.parent =`tab{doctype}`.name'.format(child_doctype=f[0], doctype=doctype)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/db_query.py", line 604, in get_count
    where {1}""".format(','.join(tables), ' and '.join(conditions)), debug=0)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/database.py", line 232, in sql_list
    return [r[0] for r in self.sql(query, values, debug=debug)]
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/database.py", line 176, in sql
    self._cursor.execute(query)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
ProgrammingError: (1064, u'You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near \'"[u\'Completed\', u\'Closed\']"\' at line 2')
```