### PR TITLE
Fix #4719

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -34,7 +34,7 @@ frappe.ui.Dialog = frappe.ui.FieldGroup.extend({
 
 		// show footer
 		this.action = this.action || { primary: { }, secondary: { } };
-		if(this.primary_action || this.action.primary) {
+		if(this.primary_action || this.action.primary.label) {
 			this.set_primary_action(this.primary_action_label || this.action.primary.label || __("Submit"), this.primary_action || this.action.primary.click);
 		}
 


### PR DESCRIPTION
Empty JS Objects are not falsy valued.

Use `frappe._.is_empty` instead! Very similar to [Lodash's](https://lodash.com/docs/4.17.4#isEmpty)'s implementation. Considers the usecase and purpose.