### PR TITLE
Fix JSON parse failure incase POST with no content is called.

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -123,7 +123,7 @@ def init_request(request):
 def make_form_dict(request):
 	import json
 
-	if request.content_type == 'application/json':
+	if request.content_type == 'application/json' and request.data:
 		args = json.loads(request.data)
 	else:
 		args = request.form or request.args


### PR DESCRIPTION
JSON parse fails incase an empty POST request is made. 