### PR TITLE
Fix indentation which causes error on restore

### DIFF
--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -18,8 +18,8 @@ def restore(name):
 		doc.insert()
 	except frappe.DocstatusTransitionError:
 		frappe.msgprint(_("Cancelled Document restored as Draft"))
-        doc.docstatus = 0
-        doc.insert()
+        	doc.docstatus = 0
+        	doc.insert()
 
 	doc.add_comment('Edit', _('restored {0} as {1}').format(deleted.deleted_name, doc.name))
 


### PR DESCRIPTION
Fixes error message, that document with a specific number already exists, even if it doesn't.