### PR TITLE
Filtering Sales Invoice against Sales Order lists Sales Invoice's items in ROW #12265

### DIFF
--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -38,6 +38,7 @@ frappe.views.ListRenderer = Class.extend({
 
 		// default settings
 		this.order_by = this.order_by || 'modified desc';
+		this.group_by = this.group_by || '';
 		this.filters = this.filters || [];
 		this.page_length = this.page_length || 20;
 	},
@@ -53,6 +54,7 @@ frappe.views.ListRenderer = Class.extend({
 		this.init_user_settings();
 
 		this.order_by = this.user_settings.order_by || this.settings.order_by;
+		this.group_by = this.get_group_by();
 		this.filters = this.user_settings.filters || this.settings.filters;
 		this.page_length = this.settings.page_length;
 
@@ -60,6 +62,16 @@ frappe.views.ListRenderer = Class.extend({
 		if(frappe.model.is_submittable(this.doctype) && (!this.filters || !this.filters.length)) {
 			this.filters = [[this.doctype, "docstatus", "!=", 2]];
 		}
+	},
+
+	/**
+	* Get the name of the column to use in SQL `group by`.
+	* It defaults to 'creation'
+	*/
+	get_group_by: function() {
+		const default_column = this.settings.group_by || 'creation';
+		const group_by = $.format('`tab{0}`.`{1}`', [this.doctype, default_column]);
+		return group_by;
 	},
 	init_user_settings: function () {
 		frappe.provide('frappe.model.user_settings.' + this.doctype + '.' + this.name);

--- a/frappe/public/js/frappe/list/list_renderer.js
+++ b/frappe/public/js/frappe/list/list_renderer.js
@@ -3,9 +3,10 @@
 
 frappe.provide('frappe.views');
 
-// Renders customized list
-// usually based on `in_list_view` property
-
+/**
+* Renders customized list. Usually based on `in_list_view` property.
+* It carries information that is used in frappe.views.ListView
+*/
 frappe.views.ListRenderer = Class.extend({
 	name: 'List',
 	init: function (opts) {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -536,16 +536,22 @@ frappe.views.ListView = frappe.ui.BaseList.extend({
 		})
 	},
 
+	/*
+	* Prepares extra information for the SQL query to fetch
+	* records for the list view.
+	*/
 	get_args: function () {
 		var args = {
 			doctype: this.doctype,
 			fields: this.list_renderer.fields,
 			filters: this.get_filters_args(),
 			order_by: this.get_order_by_args(),
+			group_by: this.list_renderer.group_by,
 			with_comment_count: true
 		}
 		return args;
 	},
+
 	get_filters_args: function() {
 		var filters = [];
 		if(this.filter_list) {

--- a/frappe/public/js/frappe/ui/base_list.js
+++ b/frappe/public/js/frappe/ui/base_list.js
@@ -265,6 +265,10 @@ frappe.ui.BaseList = Class.extend({
 		this.onreset && this.onreset();
 	},
 
+	/*
+	* Uses the value of `frappe.route_options` to automatically set
+	* a filter in a list view.
+	*/
 	set_filters_from_route_options: function ({clear_filters=true} = {}) {
 		var me = this;
 		if(this.filter_list && clear_filters) {
@@ -368,8 +372,12 @@ frappe.ui.BaseList = Class.extend({
 			}
 		}
 	},
+
+	/*
+	* Prepares arguments that will be used to query the database to
+	* return the desired records for the list view
+	*/
 	get_call_args: function () {
-		// load query
 		if (!this.method) {
 			var query = this.get_query && this.get_query() || this.query;
 			query = this.add_limits(query);

--- a/frappe/public/js/frappe/ui/filters/filters.js
+++ b/frappe/public/js/frappe/ui/filters/filters.js
@@ -46,6 +46,9 @@ frappe.ui.FilterList = Class.extend({
 		}
 	},
 
+	/*
+	* Removes all filters.
+	*/
 	clear_filters: function() {
 		$.each(this.filters, function(i, f) { f.remove(true); });
 		if(this.base_list.page.fields_dict) {
@@ -56,6 +59,15 @@ frappe.ui.FilterList = Class.extend({
 		this.filters = [];
 	},
 
+	/*
+	* Adds a new filter.
+	* @param {string} doctype
+	* @param {string} fieldname
+	* @param {string} condition
+	* @param {string} value
+	* @param {string} hidden
+	* @returns {Boolean} - Returns true if filter is added
+	*/
 	add_filter: function(doctype, fieldname, condition, value, hidden) {
 		// adds a new filter, returns true if filter has been added
 


### PR DESCRIPTION
This was reported in frappe/erpnext#12265. Sales order and Purchase Order filters were causing the same document to be listed as many times as the items in the  Sales/Purchase Invoice.

### Before
![screenshot-2018-1-5 sales invoice 1](https://user-images.githubusercontent.com/818803/34597026-71b1122e-f1e4-11e7-857d-3a722db0658c.png)

![screenshot-2018-1-5 purchase invoice](https://user-images.githubusercontent.com/818803/34597036-830b1dc6-f1e4-11e7-8bc9-8fffaf731325.png)

I fixed this by adding group_by information for list_renderers. When the filter concerns a child table, the results will be as is presently. Using `group by` on the creation column, the query will do away with the needless records.

### After
![screenshot-2018-1-5 sales invoice 2](https://user-images.githubusercontent.com/818803/34597205-9a6b2a46-f1e5-11e7-9328-8c623267c568.png)

![screenshot-2018-1-5 babatunde fowler - so-00003](https://user-images.githubusercontent.com/818803/34597275-0ff8a054-f1e6-11e7-9edd-873d9b2b7758.png)

![screenshot-2018-1-5 main one - po-00001-1 2](https://user-images.githubusercontent.com/818803/34597296-217933b6-f1e6-11e7-96e9-85447b980319.png)

![screenshot-2018-1-5 purchase invoice 1](https://user-images.githubusercontent.com/818803/34597348-66e96fec-f1e6-11e7-81e0-e9fa51857be8.png)

Users can modify this behavior also by adding "group_by" to listview_settings.

Also fixes frappe/erpnext#11660
