### PR TITLE
[MIN] Fixes Message Timestamp for Chat

### DIFF
--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1931,9 +1931,7 @@ class extends Component
         }
 
         if ( props.last_message )
-        {
             item.timestamp = frappe.chat.pretty_datetime(props.last_message.creation)
-        }
 
         return (
             h("li", null,

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -949,14 +949,14 @@ frappe.chat.pretty_datetime   = function (date)
 {
     const today    = moment()
     const instance = date.moment
-    
+        
     if ( today.isSame(instance, "d") )
-        return today.format("hh:mm A")
+        return instance.format("hh:mm A")
     else
     if ( today.isSame(instance, "week") )
-        return today.format("dddd")
+        return instance.format("dddd")
     else
-        return today.format("DD/MM/YYYY")
+        return instance.format("DD/MM/YYYY")
 }
 
 // frappe.chat.sound
@@ -1931,7 +1931,9 @@ class extends Component
         }
 
         if ( props.last_message )
+        {
             item.timestamp = frappe.chat.pretty_datetime(props.last_message.creation)
+        }
 
         return (
             h("li", null,

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -34,7 +34,7 @@ frappe.ui.Dialog = frappe.ui.FieldGroup.extend({
 
 		// show footer
 		this.action = this.action || { primary: { }, secondary: { } };
-		if(this.primary_action || this.action.primary.label) {
+		if(this.primary_action || !frappe._.is_empty(this.action.primary)) {
 			this.set_primary_action(this.primary_action_label || this.action.primary.label || __("Submit"), this.primary_action || this.action.primary.click);
 		}
 


### PR DESCRIPTION
What a blunder! Would always return today's timestamp and not it's argument's! #4723 

Also, New API 💃 

```js
frappe.chat.pretty_datetime(frappe.datetime.now()) // Uses moment only.
```

Exactly how Telegram does! :smile:
  
```js
frappe.chat.pretty_datetime(frappe.datetime.now()) // 01:33 PM
frappe.chat.pretty_datetime(yesterday) // Friday
frappe.chat.pretty_datetime(week_ago) // 01/01/2018
```
  
![](http://g.recordit.co/lennmvw08D.gif)