### PR TITLE
Encode doc.name when generating form link.

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -527,7 +527,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	get_form_link(doc) {
-		return '#Form/' + this.doctype + '/' + doc.name;
+		return '#Form/' + this.doctype + '/' + encodeURI(doc.name);
 	}
 
 	get_subject_html(doc) {


### PR DESCRIPTION
This fixes #4773.