### PR TITLE
[Fix] Standard filter for Id in ListView

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -518,10 +518,11 @@ class FilterArea {
 
 		let fields = [
 			{
-				fieldtype: 'Data',
+				fieldtype: 'Link',
 				label: 'ID',
 				condition: 'like',
 				fieldname: 'name',
+				options: this.list_view.doctype,
 				onchange: () => this.refresh_list_view()
 			}
 		];


### PR DESCRIPTION
![fix-standard-filter](https://user-images.githubusercontent.com/11695402/34661640-078bd912-f471-11e7-83e8-41ce4ce96c2f.gif)
Id box was previously left as of 'Data' fieldtype - hence no dropdown