### PR TITLE
change the data field into string if number is given

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -168,7 +168,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 									# added file to attachments list
 									attachments.append(d[fieldname])
 
-								elif fieldtype in ("Link", "Dynamic Link") and d[fieldname]:
+								elif fieldtype in ("Link", "Dynamic Link", "Data") and d[fieldname]:
 									# as fields can be saved in the number format(long type) in data import template
 									d[fieldname] = cstr(d[fieldname])
 


### PR DESCRIPTION
#### Fix for the support issue 

Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/core/doctype/data_import/importer.py", line 385, in upload
    doc.insert()
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/model/document.py", line 212, in insert
    self.set_new_name()
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/model/document.py", line 372, in set_new_name
    set_new_name(self)
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/model/naming.py", line 59, in set_new_name
    doc.name = validate_name(doc.doctype, doc.name, frappe.get_meta(doc.doctype).get_field("name_case"))
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/model/naming.py", line 174, in validate_name
    if name.startswith('New '+doctype):
AttributeError: 'long' object has no attribute 'startswith'
  
  