### PR TITLE
`setup_check` `remove_rows_button` click handler does not refresh parent form #4792

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -106,6 +106,7 @@ frappe.ui.form.Grid = Class.extend({
 
 			tasks.push(() => {
 				if (dirty) me.refresh();
+				if (me.frm) me.frm.refresh();
 			});
 
 			frappe.run_serially(tasks);


### PR DESCRIPTION
![peek 2018-01-08 20-34](https://user-images.githubusercontent.com/818803/34689370-9280b3dc-f4b5-11e7-8014-ade151ea97ba.gif)

 Fixes #4792 