### PR TITLE
Fix line break before Jinja Templating

### DIFF
--- a/frappe/docs/user/en/tutorial/before.md
+++ b/frappe/docs/user/en/tutorial/before.md
@@ -50,6 +50,7 @@ Resources:
 
  1. [Codecademy Tutorial for JavaScript](https://www.codecademy.com/learn/learn-javascript)
  1. [Codecademy Tutorial for jQuery](https://www.codecademy.com/learn/jquery)
+
 ---
 
 #### 5. Jinja Templating


### PR DESCRIPTION
Rendered version was not showing correctly, the bullet point `Codecademy Tutorial for jQuery` was showing as a header.