### PR TITLE
Hotfix naming escape

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -199,11 +199,14 @@ def _set_amended_name(doc):
 
 def append_number_if_name_exists(doctype, name, fieldname='name', separator='-'):
 	if frappe.db.exists(doctype, name):
+		# should be escaped 2 times since
+		# python string will parse the first escape
+		escaped_name = re.escape(re.escape(name))
 		last = frappe.db.sql("""select name from `tab{doctype}`
 			where {fieldname} regexp '^{name}{separator}[[:digit:]]+'
 			order by length({fieldname}) desc,
 				{fieldname} desc limit 1""".format(doctype=doctype,
-					name=name, fieldname=fieldname, separator=separator))
+					name=escaped_name, fieldname=fieldname, separator=separator), debug=1)
 
 		if last:
 			count = str(cint(last[0][0].rsplit("-", 1)[1]) + 1)

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -206,7 +206,7 @@ def append_number_if_name_exists(doctype, name, fieldname='name', separator='-')
 			where {fieldname} regexp '^{name}{separator}[[:digit:]]+'
 			order by length({fieldname}) desc,
 				{fieldname} desc limit 1""".format(doctype=doctype,
-					name=escaped_name, fieldname=fieldname, separator=separator), debug=1)
+					name=escaped_name, fieldname=fieldname, separator=separator))
 
 		if last:
 			count = str(cint(last[0][0].rsplit("-", 1)[1]) + 1)


### PR DESCRIPTION
File `~/frappe-bench/apps/frappe/frappe/model/naming.py method: append_number_if_name_exists`
If Item Template name is like **Hammo Base (1** , the regex in the sql query breaks.