### PR TITLE
`add_dropdown_item` should only add unique labels

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -247,6 +247,14 @@ frappe.ui.Page = Class.extend({
 
 	//-- Generic --//
 
+	/*
+	* Add label to given drop down menu. If label, is already contained in the drop
+	* down menu, it will be ignored.
+	* @param {string} label - Text for the drop down menu
+	* @param {function} click - function to be called when `label` is clicked
+	* @param {Boolean} standard
+	* @param {object} parent - DOM object representing the parent of the drop down item lists
+	*/
 	add_dropdown_item: function(label, click, standard, parent) {
 		const is_already_added = () => {
 			let found_lists = $(parent).find('li > a.grey-link:contains(' + label + ')');

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -248,10 +248,17 @@ frappe.ui.Page = Class.extend({
 	//-- Generic --//
 
 	add_dropdown_item: function(label, click, standard, parent) {
+		const is_already_added = () => {
+			let found_lists = $(parent).find('li > a.grey-link:contains(' + label + ')');
+			return found_lists.length > 0;
+		}
+
 		parent.parent().removeClass("hide");
 
 		var $li = $('<li><a class="grey-link">'+ label +'</a><li>'),
 			$link = $li.find("a").on("click", click);
+
+		if (is_already_added()) return;
 
 		if(standard===true) {
 			$li.appendTo(parent);


### PR DESCRIPTION
Close frappe/erpnext#12405

This PR makes `add_dropdown_item` ensure that all the links in a drop down are unique. For example:

### Before
![peek 2018-01-12 21-15](https://user-images.githubusercontent.com/818803/34893632-66400d1e-f7de-11e7-8de5-a7a4ba6feaf0.gif)

### After
![peek 2018-01-12 21-12](https://user-images.githubusercontent.com/818803/34893637-6d58a782-f7de-11e7-95a5-df494610127c.gif)
