### PR TITLE
Remove CSSMin

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -13,8 +13,6 @@ Build the `public` folders and setup languages
 """
 
 import os, frappe, json, shutil, re
-# from cssmin import cssmin
-
 
 app_paths = None
 def setup():
@@ -177,10 +175,6 @@ def pack(target, sources, no_compress, verbose):
 		except Exception:
 			print("--Error in:" + f + "--")
 			print(frappe.get_traceback())
-
-	if not no_compress and outtype == 'css':
-		pass
-		#outtxt = cssmin(outtxt)
 
 	with open(target, 'w') as f:
 		f.write(outtxt.encode("utf-8"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 boto3
 chardet
-cssmin
 dropbox==7.3.1
 gunicorn
 httplib2


### PR DESCRIPTION
Not used. Comes in good time with Webpack integration to have build.py cleaned up too!