### PR TITLE
fix documentation image link

### DIFF
--- a/frappe/docs/user/en/bench/guides/settings-limits.md
+++ b/frappe/docs/user/en/bench/guides/settings-limits.md
@@ -36,4 +36,4 @@ Example:
 
 You can check your usage by opening the "Usage Info" page from the toolbar / AwesomeBar. A limit will only show up on the page if it has been set.
 
-<img class="screenshot" alt="Doctype Saved" src="/docs/assets/img/usage_info.png">
+<img class="screenshot" alt="Doctype Saved" src="/assets/frappe_docs/assets/img/usage_info.png">

--- a/frappe/docs/user/en/guides/app-development/adding-custom-button-to-form.md
+++ b/frappe/docs/user/en/guides/app-development/adding-custom-button-to-form.md
@@ -24,7 +24,7 @@ We should edit `frappe\core\doctype\user\user.js`
 
 You should be seeing a button on user form as shown below,
 
-<img class="screenshot" alt="Custom Button" src="/docs/assets/img/app-development/add_custom_button.png">
+<img class="screenshot" alt="Custom Button" src="/assets/frappe_docs/assets/img/app-development/add_custom_button.png">
 
 
 <!-- markdown -->

--- a/frappe/docs/user/en/guides/app-development/dialogs-types.md
+++ b/frappe/docs/user/en/guides/app-development/dialogs-types.md
@@ -4,7 +4,7 @@ Frappé provides a group of standard dialogs that are very useful while coding.
 
 ## Alert Dialog
 
-<img class="screenshot" src="/docs/assets/img/app-development/show-alert.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/app-development/show-alert.png">
 
 Alert Dialog is used for showing non-obstructive messages.
 
@@ -21,7 +21,7 @@ It has 2 parameters:
 
 ## Prompt Dialog
 
-<img class="screenshot" src="/docs/assets/img/app-development/prompt.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/app-development/prompt.png">
 
 Prompt Dialog is used for collecting data from users.
 
@@ -47,7 +47,7 @@ It has 4 parameters:
 ---
 ## Confirm Dialog
 
-<img class="screenshot" src="/docs/assets/img/app-development/confirm-dialog.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/app-development/confirm-dialog.png">
 
 Confirm Dialog is used to get a confirmation from the user before executing an action.
 
@@ -73,7 +73,7 @@ It has 3 arguments:
 
 ## Message Print
 
-<img class="screenshot" src="/docs/assets/img/app-development/msgprint.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/app-development/msgprint.png">
 
 Message Print is used for showing information to users.
 
@@ -96,7 +96,7 @@ It has 2 arguments:
 
 ### Custom Dialog
 
-<img class="screenshot" src="/docs/assets/img/app-development/dialog.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/app-development/dialog.png">
 
 You can extend and build your own custom dialogs using `frappe.ui.Dialog`
 

--- a/frappe/docs/user/en/guides/app-development/exporting-customizations.md
+++ b/frappe/docs/user/en/guides/app-development/exporting-customizations.md
@@ -4,12 +4,12 @@ A common use case is to extend a DocType via Custom Fields and Property Setters 
 
 You will see a button for **Export Customizations**
 
-<img class="screenshot" src="/docs/assets/img/app-development/export-custom-1.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/app-development/export-custom-1.png">
 
 Here you can select the module and whether you want these particular customizations to be synced after every update.
 
 The customizations will be exported to a new folder `custom` in the module folder of your app. The customizations will be saved by the name of the DocType
 
-<img class="screenshot" src="/docs/assets/img/app-development/export-custom-2.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/app-development/export-custom-2.png">
 
 When you do `bench update` or `bench migrate` these customizations will be synced to the app.

--- a/frappe/docs/user/en/guides/app-development/fetch-custom-field-value-from-master-to-all-related-transactions.md
+++ b/frappe/docs/user/en/guides/app-development/fetch-custom-field-value-from-master-to-all-related-transactions.md
@@ -5,11 +5,11 @@ Let's say, there is a custom field "VAT Number" in Supplier, which should be fet
 #### Steps:
 
 1. Create a Custom Field **VAT Number** for *Supplier* document with *Field Type* as **Data**.    
-    <img class="screenshot" src="/docs/assets/img/add-vat-number-in-supplier.png">
+    <img class="screenshot" src="/assets/frappe_docs/assets/img/add-vat-number-in-supplier.png">
 
 1. Create another Custom Field **VAT Number** for *Purchase Order* document, but in this case with *Field Type* as **Read Only** or check **Read Only** checkbox. Set the **Options** as `supplier.vat_number`.    
-    <img class="screenshot" src="/docs/assets/img/add-vat-number-in-purchase-order.png">
+    <img class="screenshot" src="/assets/frappe_docs/assets/img/add-vat-number-in-purchase-order.png">
 
 1. Go to the user menu and click "Reload".
 1. Now, on selection of Supplier in a new Purchase Order, **VAT Number** will be fetched automatically from the selected Supplier.    
-    <img class="screenshot" src="/docs/assets/img/vat-number-fetched.png">
+    <img class="screenshot" src="/assets/frappe_docs/assets/img/vat-number-fetched.png">

--- a/frappe/docs/user/en/guides/app-development/generating-docs.md
+++ b/frappe/docs/user/en/guides/app-development/generating-docs.md
@@ -50,7 +50,7 @@ While linking make sure you add `/docs` to all your links.
 
 You can add images in the `/docs/assets` folder. You can add links to the images as follows:
 
-    {% raw %}<img src="/docs/assets/img/my-img/gif" class="screenshot">{% endraw %}
+    {% raw %}<img src="/assets/frappe_docs/assets/img/my-img/gif" class="screenshot">{% endraw %}
 
 ---
 

--- a/frappe/docs/user/en/guides/automated-testing/qunit-testing.md
+++ b/frappe/docs/user/en/guides/automated-testing/qunit-testing.md
@@ -12,7 +12,7 @@ To run your files, you can use the **Test Runner**. The **Test Runner** gives a 
 
 In the CI, all QUnit tests are run by the **Test Runner** using `frappe/tests/test_test_runner.py`
 
-<img src="/docs/assets/img/app-development/test-runner.png" class="screenshot">
+<img src="/assets/frappe_docs/assets/img/app-development/test-runner.png" class="screenshot">
 
 ### Running Tests
 

--- a/frappe/docs/user/en/guides/data/using-data-migration-tool.md
+++ b/frappe/docs/user/en/guides/data/using-data-migration-tool.md
@@ -11,7 +11,7 @@ A Data Migration Plan encapsulates a set of mappings.
 
 Let's make a new *Data Migration Plan*. Set the plan name as 'Atlas Sync'. We also need to add mappings in the mappings child table.
 
-<img class="screenshot" alt="New Data Migration Plan" src="/docs/assets/img/data-migration/new-data-migration-plan.png">
+<img class="screenshot" alt="New Data Migration Plan" src="/assets/frappe_docs/assets/img/data-migration/new-data-migration-plan.png">
 
 
 ### Data Migration Mapping
@@ -27,7 +27,7 @@ To define a mapping, we need to put in some values that define the structure of 
 1. Mapping Type: A Mapping can be of type 'Push' or 'Pull', depending on whether the data is to be mapped remotely or locally. It can also be 'Sync', which will perform both push and pull operations in a single cycle.
 1. Page Length: This defines the batch size of the sync.
 
-<img class="screenshot" alt="New Data Migration Mapping" src="/docs/assets/img/data-migration/new-data-migration-mapping.png">
+<img class="screenshot" alt="New Data Migration Mapping" src="/assets/frappe_docs/assets/img/data-migration/new-data-migration-mapping.png">
 
 #### Specifying field mappings:
 
@@ -35,11 +35,11 @@ The most basic form of a field mapping would be to specify fieldnames of the rem
 
 Let's add the field mappings and save:
 
-<img class="screenshot" alt="Add fields in Data Migration Mapping" src="/docs/assets/img/data-migration/new-data-migration-mapping-fields.png">
+<img class="screenshot" alt="Add fields in Data Migration Mapping" src="/assets/frappe_docs/assets/img/data-migration/new-data-migration-mapping-fields.png">
 
 We can now add the 'Item to Atlas Item' mapping to our Data Migration Plan and save it.
 
-<img class="screenshot" alt="Save Atlas Sync Plan" src="/docs/assets/img/data-migration/atlas-sync-plan.png">
+<img class="screenshot" alt="Save Atlas Sync Plan" src="/assets/frappe_docs/assets/img/data-migration/atlas-sync-plan.png">
 
 #### Additional layer of control with pre and post process:
 
@@ -47,24 +47,24 @@ Migrating data frequently involves more steps in addition to one-to-one mapping.
 
 In our case, an `item_to_atlas_item` module is created under the `data_migration_mapping` directory in `Integrations` (module for the 'Atlas Sync' plan).
 
-<img class="screenshot" alt="Mapping __init__.py" src="/docs/assets/img/data-migration/mapping-init-py.png">
+<img class="screenshot" alt="Mapping __init__.py" src="/assets/frappe_docs/assets/img/data-migration/mapping-init-py.png">
 
 You can implement the `pre_process` (receives the source doc) and `post_process` (receives both source and target docs, as well as any additional arguments) methods, to extend the mapping process. Here's what some operations could look like:
 
-<img class="screenshot" alt="Pre and Post Process" src="/docs/assets/img/data-migration/mapping-pre-and-post-process.png">
+<img class="screenshot" alt="Pre and Post Process" src="/assets/frappe_docs/assets/img/data-migration/mapping-pre-and-post-process.png">
 
 ### Data Migration Connector
 Now, to connect to the remote source, we need to create a *Data Migration Connector*.
 
-<img class="screenshot" alt="New Data Migration Connector" src="/docs/assets/img/data-migration/new-connector.png">
+<img class="screenshot" alt="New Data Migration Connector" src="/assets/frappe_docs/assets/img/data-migration/new-connector.png">
 
 We only have two connector types right now, let's add another Connector Type in the Data Migration Connector DocType.
 
-<img class="screenshot" alt="Add Connector Type in Data Migration Connector" src="/docs/assets/img/data-migration/add-connector-type.png">
+<img class="screenshot" alt="Add Connector Type in Data Migration Connector" src="/assets/frappe_docs/assets/img/data-migration/add-connector-type.png">
 
 Now, let's create a new Data Migration Connector.
 
-<img class="screenshot" alt="Atlas Connector" src="/docs/assets/img/data-migration/atlas-connector.png">
+<img class="screenshot" alt="Atlas Connector" src="/assets/frappe_docs/assets/img/data-migration/atlas-connector.png">
 
 As you can see we chose the Connector Type as Atlas. We also added the hostname, username and password for our Atlas instance so that we can authenticate.
 
@@ -74,18 +74,18 @@ Create a new file called `atlas_connection.py` in `frappe/data_migration/doctype
 
 We just have to implement the `insert`, `update` and `delete` methods for our atlas connector. We also need to write the code to connect to our Atlas instance in the `__init__` method. Just see `frappe_connection.py` for reference.
 
-<img class="screenshot" alt="Atlas Connection file" src="/docs/assets/img/data-migration/atlas-connection-py.png">
+<img class="screenshot" alt="Atlas Connection file" src="/assets/frappe_docs/assets/img/data-migration/atlas-connection-py.png">
 
 After creating the Atlas Connector, we also need to import it into `data_migration_connector.py`
 
-<img class="screenshot" alt="Edit Connector file" src="/docs/assets/img/data-migration/edit-connector-py.png">
+<img class="screenshot" alt="Edit Connector file" src="/assets/frappe_docs/assets/img/data-migration/edit-connector-py.png">
 
 ### Data Migration Run
 Now that we have our connector, the last thing to do is to create a new *Data Migration Run*.
 
 A Data Migration Run takes a Data Migration Plan and Data Migration Connector and execute the plan according to our configuration. It takes care of queueing, batching, delta updates and more.
 
-<img class="screenshot" alt="Data Migration Run" src="/docs/assets/img/data-migration/data-migration-run.png">
+<img class="screenshot" alt="Data Migration Run" src="/assets/frappe_docs/assets/img/data-migration/data-migration-run.png">
 
 Just click Run. It will now push our Items to the remote Atlas instance and you can see the progress which updates in realtime.
 

--- a/frappe/docs/user/en/guides/deployment/how-to-enable-social-logins.md
+++ b/frappe/docs/user/en/guides/deployment/how-to-enable-social-logins.md
@@ -5,7 +5,7 @@ Use Facebook, Google or GitHub authentication to login to Frappé, and your user
 The system uses the **Email Address** supplied by these services to **match with an existing user** in Frappé. If no such user is found, **a new user is created** of the default type **Website User**, if Signup is not disabled in Website Settings. Any System Manager can later change the user type from **Website User** to **System User**, so that the user can access the Desktop.
 
 #### Login screen with Social Logins enabled
-<img class="screenshot" alt="Login screen with Social Logins enabled" src="/docs/assets/img/social-logins.png">
+<img class="screenshot" alt="Login screen with Social Logins enabled" src="/assets/frappe_docs/assets/img/social-logins.png">
 
 To enable these signups, you need to have **Client ID** and **Client Secret** from these authentication services for your Frappé site. The Client ID and Client Secret are to be set in Website > Setup > Social Login Keys. Here are the steps to obtain these credentials.
 

--- a/frappe/docs/user/en/guides/integration/how_to_setup_oauth.md
+++ b/frappe/docs/user/en/guides/integration/how_to_setup_oauth.md
@@ -26,7 +26,7 @@ Go to
 
 > Setup > Integrations > OAuth Provider Settings
 
-<img class="screenshot" src="/docs/assets/img/oauth_provider_settings.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/oauth_provider_settings.png">
 
 ### Add Primary Server
 
@@ -40,7 +40,7 @@ As a System Manager go to
 
 > Setup > Integrations > OAuth Client
 
-<img class="screenshot" src="/docs/assets/img/oauth2_client_app.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/oauth2_client_app.png">
 
 To add a client fill in the following details
 

--- a/frappe/docs/user/en/guides/integration/openid_connect_and_frappe_social_login.md
+++ b/frappe/docs/user/en/guides/integration/openid_connect_and_frappe_social_login.md
@@ -40,33 +40,33 @@ Now you will see Frappé icon on the login page. Click on this icon to login wit
 ### Part 1 : on Frappé Identity Provider (IDP)
 
 Login to IDP
-<img class="screenshot" src="/docs/assets/img/00-login-to-idp.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/00-login-to-idp.png">
 
 Add OAuth Client on IDP
-<img class="screenshot" src="/docs/assets/img/01-add-oauth-client-on-idp.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/01-add-oauth-client-on-idp.png">
 
 Set Server URL on IDP
-<img class="screenshot" src="/docs/assets/img/02-set-server-url-on-idp.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/02-set-server-url-on-idp.png">
 
 ### Part 2 : on Frappé App Server
 
 Set `Frappé Client ID`  and `Frappé Client Secret` on App server (refer the client set on IDP)
-<img class="screenshot" src="/docs/assets/img/03-set-clientid-client-secret-server-on-app-server.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/03-set-clientid-client-secret-server-on-app-server.png">
 
 **Note**: Frappé Server URL is the main server where identities from your organization are stored.
 
 Login Screen on App Server (login with frappe)
-<img class="screenshot" src="/docs/assets/img/04-login-screen-on-app-server.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/04-login-screen-on-app-server.png">
 
 ### Part 3 : Redirected on IDP 
 
 login with user on IDP
-<img class="screenshot" src="/docs/assets/img/05-login-with-user-on-idp.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/05-login-with-user-on-idp.png">
 
 Confirm Access on IDP
-<img class="screenshot" src="/docs/assets/img/06-confirm-grant-access-on-idp.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/06-confirm-grant-access-on-idp.png">
 
 ### Part 4 : Back on App Server
 
 Logged in on app server with ID from IDP
-<img class="screenshot" src="/docs/assets/img/07-logged-in-as-website-user-with-id-from-idp.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/07-logged-in-as-website-user-with-id-from-idp.png">

--- a/frappe/docs/user/en/guides/integration/social_login_key.md
+++ b/frappe/docs/user/en/guides/integration/social_login_key.md
@@ -10,7 +10,7 @@ To add Social Login Key go to
 
 Social Login Key
 
-<img class="screenshot" src="/docs/assets/img/social_login_key.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/social_login_key.png">
 
 1. Select the Social Login Provider or select "Custom"
 2. If required for provider enter "Base URL"

--- a/frappe/docs/user/en/guides/integration/using_oauth.md
+++ b/frappe/docs/user/en/guides/integration/using_oauth.md
@@ -20,7 +20,7 @@ redirect_uri = <redirect uri from OAuth Client>
 
 #### Confirmation Dialog
 
-<img class="screenshot" src="/docs/assets/img/oauth_confirmation_page.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/oauth_confirmation_page.png">
 
 Click 'Allow' to receive authorization code in redirect uri.
 

--- a/frappe/docs/user/en/guides/integration/webhooks.md
+++ b/frappe/docs/user/en/guides/integration/webhooks.md
@@ -10,7 +10,7 @@ To add Webhook go to
 
 Webhook
 
-<img class="screenshot" src="/docs/assets/img/webhook.png">
+<img class="screenshot" src="/assets/frappe_docs/assets/img/webhook.png">
 
 1. Select the DocType for which hook needs to be triggered e.g. Note
 2. Select the DocEvent for which hook needs to be triggered e.g. on_trash

--- a/frappe/docs/user/en/guides/portal-development/generators.md
+++ b/frappe/docs/user/en/guides/portal-development/generators.md
@@ -22,7 +22,7 @@ We added `published`, `route` in the DocType
 
 **Note:** The field `route` is mandatory
 
-<img class="screenshot" alt="Generator fields" src="/docs/assets/img/generators.png">
+<img class="screenshot" alt="Generator fields" src="/assets/frappe_docs/assets/img/generators.png">
 
 #### 2. Added Website Generator to Hooks
 

--- a/frappe/docs/user/en/guides/portal-development/portal-roles.md
+++ b/frappe/docs/user/en/guides/portal-development/portal-roles.md
@@ -8,7 +8,7 @@ Roles can be assigned to Website Users and they will see menu based on their rol
 1. Each Portal Menu Item can have a role associated with it. If that role is set, then only those users having that role can see that menu item
 1. Rules can be set for default roles that will be set on default users on hooks
 
-<img class="screenshot" alt="Portal Settings" src="/docs/assets/img/portals/portal-settings.png">
+<img class="screenshot" alt="Portal Settings" src="/assets/frappe_docs/assets/img/portals/portal-settings.png">
 
 #### Rules for Default Role
 

--- a/frappe/docs/user/en/guides/portal-development/web-forms.md
+++ b/frappe/docs/user/en/guides/portal-development/web-forms.md
@@ -2,7 +2,7 @@
 
 Web Forms are a powerful way to add forms to your website. Web forms are powerful and scriptable and from Version 7.1+ they also include tables, paging and other utilities
 
-<img class="screenshot" alt="Web Form" src="/docs/assets/img/portals/sample-web-form.png">
+<img class="screenshot" alt="Web Form" src="/assets/frappe_docs/assets/img/portals/sample-web-form.png">
 
 ### Standard Web Forms
 

--- a/frappe/docs/user/en/guides/reports-and-printing/how-to-make-query-report.md
+++ b/frappe/docs/user/en/guides/reports-and-printing/how-to-make-query-report.md
@@ -8,7 +8,7 @@ To create a new Query Report:
 
 ### 1. Create a new Report
 
-<img class="screenshot" alt="Query Report" src="/docs/assets/img/query-report.png">
+<img class="screenshot" alt="Query Report" src="/assets/frappe_docs/assets/img/query-report.png">
 
 1. Set type as "Query Report"
 1. Set the reference DocType - Users that have access to the reference DocType will have access to the report
@@ -37,7 +37,7 @@ You can define complex queries such as:
 
 ### 3. Check the Report
 
-<img class="screenshot" alt="Query Report" src="/docs/assets/img/query-report-out.png">
+<img class="screenshot" alt="Query Report" src="/assets/frappe_docs/assets/img/query-report-out.png">
 
 ### 4. Advanced (adding filters)
 

--- a/frappe/docs/user/en/guides/reports-and-printing/how-to-make-script-reports.md
+++ b/frappe/docs/user/en/guides/reports-and-printing/how-to-make-script-reports.md
@@ -10,7 +10,7 @@ Since these reports give you unrestricted access via Python scripts, they can on
 
 ### 1. Create a new Report
 
-<img class="screenshot" alt="Script Report" src="/docs/assets/img/script-report.png">
+<img class="screenshot" alt="Script Report" src="/assets/frappe_docs/assets/img/script-report.png">
 
 1. Set Report Type as "Script Report"
 1. Set "Is Standard" as "Yes"

--- a/frappe/docs/user/en/guides/reports-and-printing/print-format-for-reports.md
+++ b/frappe/docs/user/en/guides/reports-and-printing/print-format-for-reports.md
@@ -58,7 +58,7 @@ Here is how the General Ledger Report is built:
 
 Here is what the report looks like:
 
-<img class="screenshot" alt="General Ledger" src="/docs/assets/img/general-ledger.png">
+<img class="screenshot" alt="General Ledger" src="/assets/frappe_docs/assets/img/general-ledger.png">
 
 ##### Comments:
 

--- a/frappe/docs/user/en/tutorial/controllers.md
+++ b/frappe/docs/user/en/tutorial/controllers.md
@@ -48,7 +48,7 @@ In this script:
 
 Check if your validations work by creating new records
 
-<img class="screenshot" alt="Transaction" src="/docs/assets/img/lib_trans.png">
+<img class="screenshot" alt="Transaction" src="/assets/frappe_docs/assets/img/lib_trans.png">
 
 #### Debugging
 

--- a/frappe/docs/user/en/tutorial/doctypes.md
+++ b/frappe/docs/user/en/tutorial/doctypes.md
@@ -6,7 +6,7 @@ To create a new **DocType**, go to:
 
 > Developer > Documents > Doctype > New
 
-<img class="screenshot" alt="New Doctype" src="/docs/assets/img/doctype_new.png">
+<img class="screenshot" alt="New Doctype" src="/assets/frappe_docs/assets/img/doctype_new.png">
 
 In the DocType, first the Module, which in our case is **Library Management**
 
@@ -25,7 +25,7 @@ Fields are much more than database columns, they can be:
 
 Let us add the fields of the Article.
 
-<img class="screenshot" alt="Adding Fields" src="/docs/assets/img/doctype_adding_field.png">
+<img class="screenshot" alt="Adding Fields" src="/assets/frappe_docs/assets/img/doctype_adding_field.png">
 
 When you add fields, you need to enter the **Type**. **Label** is optional for Section Break and Column Break. **Name** (`fieldname`) is the name of the database table column and also the property of the controller. This has to be *code friendly*, i.e. it has to have small cases are _ instead of " ". If you leave the Fieldname blank, it will be automatically set when you save it.
 
@@ -47,7 +47,7 @@ We can add the following fields:
 
 After adding the fields, hit done and add a new row in the Permission Rules section. For now, let us give Read, Write, Create, Delete and Report access to **Librarian**. Frappé has a finely grained Role based permission model. You can also change permissions later using the **Role Permissions Manager** from **Setup**.
 
-<img class="screenshot" alt="Adding Permissions" src="/docs/assets/img/doctype_adding_permission.png">
+<img class="screenshot" alt="Adding Permissions" src="/assets/frappe_docs/assets/img/doctype_adding_permission.png">
 
 #### Saving
 

--- a/frappe/docs/user/en/tutorial/naming-and-linking.md
+++ b/frappe/docs/user/en/tutorial/naming-and-linking.md
@@ -4,7 +4,7 @@ Then let us create the other DocType and save it too:
 
 1. Library Member (First Name, Last Name, Email Address, Phone, Address)
 
-<img class="screenshot" alt="Doctype Saved" src="/docs/assets/img/naming_doctype.png">
+<img class="screenshot" alt="Doctype Saved" src="/assets/frappe_docs/assets/img/naming_doctype.png">
 
 
 #### Naming of DocTypes
@@ -20,7 +20,7 @@ This can be set by entering the **Autoname** field. For controller, leave blank.
 
 > **Search Fields**: A DocType may be named on a series but it still needs to be searched by name. In our case, the Article will be searched by the title or the author name. So this can be entered in search field.
 
-<img class="screenshot" alt="Autonaming and Search Field" src="/docs/assets/img/autoname_and_search_field.png">
+<img class="screenshot" alt="Autonaming and Search Field" src="/assets/frappe_docs/assets/img/autoname_and_search_field.png">
 
 #### Link and Select Fields
 
@@ -30,11 +30,11 @@ In our example, in the Library Transaction DocType, we have to link both the Lib
 
 **Note:** Remeber that Link fields are not automatically set as Foreign Keys in the MariaDB database, because that will implicitly index the column. This may not be optimum hence the Foreign Key validation is done by the Framework.
 
-<img class="screenshot" alt="Link Field" src="/docs/assets/img/link_field.png">
+<img class="screenshot" alt="Link Field" src="/assets/frappe_docs/assets/img/link_field.png">
 
 For select fields, as we mentioned earlier, add the various options in the **Options** input box, each option on a new row.
 
-<img class="screenshot" alt="Select Field" src="/docs/assets/img/select_field.png">
+<img class="screenshot" alt="Select Field" src="/assets/frappe_docs/assets/img/select_field.png">
 
 Similary complete making the other models.
 
@@ -44,7 +44,7 @@ A standard pattern is when you select an ID, say **Library Member** in **Library
 
 To do this, we can use Read Only fields and in options, we can set the the name of the link and the fieldname of the property we want to fetch. For this example in **Member First Name** we can set `library_member.first_name`
 
-<img class="screenshot" alt="Fetch values" src="/docs/assets/img/fetch.png">
+<img class="screenshot" alt="Fetch values" src="/assets/frappe_docs/assets/img/fetch.png">
 
 ### Complete the Models
 
@@ -52,19 +52,19 @@ In the same way, you can complete all the models so that the final fields look l
 
 #### Article
 
-<img class="screenshot" alt="Article" src="/docs/assets/img/doctype_article.png">
+<img class="screenshot" alt="Article" src="/assets/frappe_docs/assets/img/doctype_article.png">
 
 #### Library Member
 
-<img class="screenshot" alt="Library Member" src="/docs/assets/img/doctype_lib_member.png">
+<img class="screenshot" alt="Library Member" src="/assets/frappe_docs/assets/img/doctype_lib_member.png">
 
 #### Library Membership
 
-<img class="screenshot" alt="Library Membership" src="/docs/assets/img/doctype_lib_membership.png">
+<img class="screenshot" alt="Library Membership" src="/assets/frappe_docs/assets/img/doctype_lib_membership.png">
 
 #### Library Transaction
 
-<img class="screenshot" alt="Library Transaction" src="/docs/assets/img/doctype_lib_trans.png">
+<img class="screenshot" alt="Library Transaction" src="/assets/frappe_docs/assets/img/doctype_lib_trans.png">
 
 > Make sure to give permissions to **Librarian** on each DocType
 

--- a/frappe/docs/user/en/tutorial/reports.md
+++ b/frappe/docs/user/en/tutorial/reports.md
@@ -2,6 +2,6 @@
 
 You can also click on the Reports text on the sidebar (left) to see tabulated records
 
-<img class="screenshot" alt="Report" src="/docs/assets/img/report.png">
+<img class="screenshot" alt="Report" src="/assets/frappe_docs/assets/img/report.png">
 
 {next}

--- a/frappe/docs/user/en/tutorial/roles.md
+++ b/frappe/docs/user/en/tutorial/roles.md
@@ -9,6 +9,6 @@ To create a new Role, go to:
 
 > Setup > Users > Role > New
 
-<img class="screenshot" alt="Adding Roles" src="/docs/assets/img/roles_creation.png">
+<img class="screenshot" alt="Adding Roles" src="/assets/frappe_docs/assets/img/roles_creation.png">
 
 {next}

--- a/frappe/docs/user/en/tutorial/single-doctypes.md
+++ b/frappe/docs/user/en/tutorial/single-doctypes.md
@@ -4,6 +4,6 @@ A application will usually have a Settings page. In our application, we can defi
 
 To create an new Single DocType, mark the **Is Single** property as checked.
 
-<img class="screenshot" alt="Single Doctypes" src="/docs/assets/img/tab_single.png">
+<img class="screenshot" alt="Single Doctypes" src="/assets/frappe_docs/assets/img/tab_single.png">
 
 {next}

--- a/frappe/docs/user/en/tutorial/start.md
+++ b/frappe/docs/user/en/tutorial/start.md
@@ -14,7 +14,7 @@ To start the development server, run `bench start`
 
 You can now open your browser and go to `http://localhost:8000`. You should see this login page if all goes well:
 
-<img class="screenshot" alt="Login Screen" src="/docs/assets/img/login.png">
+<img class="screenshot" alt="Login Screen" src="/assets/frappe_docs/assets/img/login.png">
 
 Now login with : 
 
@@ -24,7 +24,7 @@ Password : **Use the password that was created during installation**
 
 When you login, you should see the "Desk" home page
 
-<img class="screenshot" alt="Desk" src="/docs/assets/img/desk.png">
+<img class="screenshot" alt="Desk" src="/assets/frappe_docs/assets/img/desk.png">
 
 As you can see, the Frappé basic system comes with several pre-loaded applications like To Do, File Manager etc. These apps can integrated in your app workflow as we progress.
 

--- a/frappe/docs/user/en/tutorial/users-and-records.md
+++ b/frappe/docs/user/en/tutorial/users-and-records.md
@@ -12,7 +12,7 @@ Create a new User and set the name and first name and new password.
 
 Also give the Librarian and Library Member Roles to this user
 
-<img class="screenshot" alt="Add User Roles" src="/docs/assets/img/add_user_roles.png">
+<img class="screenshot" alt="Add User Roles" src="/assets/frappe_docs/assets/img/add_user_roles.png">
 
 Now logout and login using the new user id and password.
 
@@ -20,36 +20,36 @@ Now logout and login using the new user id and password.
 
 You will now see an icon for the Library Management module. Click on that icon and you will see the Module page:
 
-<img class="screenshot" alt="Library Management Module" src="/docs/assets/img/lib_management_module.png">
+<img class="screenshot" alt="Library Management Module" src="/assets/frappe_docs/assets/img/lib_management_module.png">
 
 Here you can see the DocTypes that we have created for the application. Let us start creating a few records.
 
 First let us create a new Article:
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article_blank.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article_blank.png">
 
 Here you will see that the DocType you had created has been rendered as a form. The validations and other rules will also apply as designed. Let us fill out one Article.
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article.png">
 
 You can also add an image.
 
-<img class="screenshot" alt="Attach Image" src="/docs/assets/img/attach_image.gif">
+<img class="screenshot" alt="Attach Image" src="/assets/frappe_docs/assets/img/attach_image.gif">
 
 Now let us create a new member:
 
-<img class="screenshot" alt="New Library Member" src="/docs/assets/img/new_member.png">
+<img class="screenshot" alt="New Library Member" src="/assets/frappe_docs/assets/img/new_member.png">
 
 After this, let us create a new membership record for the member.
 
 Here if you remember we had set the values of Member First Name and Member Last Name to be directly fetched from the Member records and as soon as you will select the member id, the names will be updated.
 
-<img class="screenshot" alt="New Library Membership" src="/docs/assets/img/new_lib_membership.png">
+<img class="screenshot" alt="New Library Membership" src="/assets/frappe_docs/assets/img/new_lib_membership.png">
 
 As you can see that the date is formatted as year-month-day which is a system format. To set / change date, time and number formats, go to
 
 > Setup > Settings > System Settings
 
-<img class="screenshot" alt="System Settings" src="/docs/assets/img/system_settings.png">
+<img class="screenshot" alt="System Settings" src="/assets/frappe_docs/assets/img/system_settings.png">
 
 {next}

--- a/frappe/docs/user/en/tutorial/web-views.md
+++ b/frappe/docs/user/en/tutorial/web-views.md
@@ -16,11 +16,11 @@ Let us look at the standard Web Views:
 
 If you are logged in as the test user, go to `/article` and you should see the list of articles:
 
-<img class="screenshot" alt="web list" src="/docs/assets/img/web-list.png">
+<img class="screenshot" alt="web list" src="/assets/frappe_docs/assets/img/web-list.png">
 
 Click on one article and you will see the default web view
 
-<img class="screenshot" alt="web view" src="/docs/assets/img/web-view.png">
+<img class="screenshot" alt="web view" src="/assets/frappe_docs/assets/img/web-view.png">
 
 Now if you want to make a better list view for the article, drop a file called `row_template.html` in the
 `library_management/templates/includes/list/` folder. Here is an example file:
@@ -46,7 +46,7 @@ Here, you will get all the properties of the article in the `doc` object.
 
 The updated list view looks like this!
 
-<img class="screenshot" alt="new web list" src="/docs/assets/img/web-list-new.png">
+<img class="screenshot" alt="new web list" src="/assets/frappe_docs/assets/img/web-list-new.png">
 
 #### Home Page
 

--- a/frappe/docs/user/es/bench/guides/settings-limits.md
+++ b/frappe/docs/user/es/bench/guides/settings-limits.md
@@ -36,4 +36,4 @@ Ejemplo:
 
 Puedes verificar el uso abriendo la página de "Usage Info" ubicada en el toolbar / AwesomeBar. Un límite solo va a mostrarse en la página si ha sido configurado.
 
-<img class="screenshot" alt="Doctype Saved" src="/docs/assets/img/usage_info.png">
+<img class="screenshot" alt="Doctype Saved" src="/assets/frappe_docs/assets/img/usage_info.png">

--- a/frappe/docs/user/es/tutorial/controllers.md
+++ b/frappe/docs/user/es/tutorial/controllers.md
@@ -48,7 +48,7 @@ En este script:
 
 Verifica si sus validaciones funcionan creando nuevos registros.
 
-<img class="screenshot" alt="Transaction" src="/docs/assets/img/lib_trans.png">
+<img class="screenshot" alt="Transaction" src="/assets/frappe_docs/assets/img/lib_trans.png">
 
 #### Depurando
 

--- a/frappe/docs/user/es/tutorial/doctypes.md
+++ b/frappe/docs/user/es/tutorial/doctypes.md
@@ -6,7 +6,7 @@ Para crear un nuevo **DocType**, ir a:
 
 > Developer > Documents > Doctype > New
 
-<img class="screenshot" alt="New Doctype" src="/docs/assets/img/doctype_new.png">
+<img class="screenshot" alt="New Doctype" src="/assets/frappe_docs/assets/img/doctype_new.png">
 
 En el DocType, primero el módulo, lo que en nuestro caso es **Library Management**
 
@@ -26,7 +26,7 @@ Fields are much more than database columns, they can be:
 
 Vamos a agregar los campos de el Article.
 
-<img class="screenshot" alt="Adding Fields" src="/docs/assets/img/doctype_adding_field.png">
+<img class="screenshot" alt="Adding Fields" src="/assets/frappe_docs/assets/img/doctype_adding_field.png">
 
 Cuando agredas los campos, necesitas llenar el campo **Type**. **Label** es opcional para los Section Break y Column Break. **Name** (`fieldname`) es el nombre de la columna en la tabla de la base de datos y tambien el nombre de la propiedad para el controlador. Esto tiene que ser *code friendly*, i.e. Necesitas poner _ en lugar de " ". Si dejas en blanco este campo, se va a llenar automáticamente al momento de guardar.
 
@@ -48,7 +48,7 @@ Podemos agregar los siguientes campos:
 
 Despues de agregar los campos, dar click en hecho y agrega una nueva fila en la sección de Permission Roles. Por ahora, vamos a darle accesos Lectura, Escritura, Creación y Reportes al Role **Librarian**. Frappé cuenta con un sistema basados en el modelo de Roles finamente granulado. Puedes cambiar los permisos más adealante usando el **Role Permissions Manager** desde **Setup**.
 
-<img class="screenshot" alt="Adding Permissions" src="/docs/assets/img/doctype_adding_permission.png">
+<img class="screenshot" alt="Adding Permissions" src="/assets/frappe_docs/assets/img/doctype_adding_permission.png">
 
 #### Guardando
 

--- a/frappe/docs/user/es/tutorial/naming-and-linking.md
+++ b/frappe/docs/user/es/tutorial/naming-and-linking.md
@@ -4,7 +4,7 @@ Vamos a crear otro DocType y guardarlo:
 
 1. Library Member (First Name, Last Name, Email Address, Phone, Address)
 
-<img class="screenshot" alt="Doctype Saved" src="/docs/assets/img/naming_doctype.png">
+<img class="screenshot" alt="Doctype Saved" src="/assets/frappe_docs/assets/img/naming_doctype.png">
 
 
 #### Nombrando DocTypes
@@ -20,7 +20,7 @@ Esto puede ser seteado a traves del campo **Autoname**. Para el controlador, dej
 
 > **Search Fields**: Un DocType puede ser nombrado por serie pero seguir teniendo la necesidad de ser buscado por nombre. En nuestro caso, el Article va ser buscado por el título o el nombre del autor. Por lo que vamos a poner esos campos en el campo de search.
 
-<img class="screenshot" alt="Autonaming and Search Field" src="/docs/assets/img/autoname_and_search_field.png">
+<img class="screenshot" alt="Autonaming and Search Field" src="/assets/frappe_docs/assets/img/autoname_and_search_field.png">
 
 #### Campo de Enlace y Campo Select
 
@@ -30,11 +30,11 @@ En nuestro ejemplo, en el DocType de Library Transaction,tenemos que enlazar los
 
 **Nota:** Recuerda que los campos de Enlace no son automáticamente establecidos como claves foraneas en la base de datos MariaDB, porque esto crearía un indice en la columna. Las validaciones de claves foraneas son realizadas por el Framework.
 
-<img class="screenshot" alt="Link Field" src="/docs/assets/img/link_field.png">
+<img class="screenshot" alt="Link Field" src="/assets/frappe_docs/assets/img/link_field.png">
 
 Por campos de tipo Select, como mencionamos antes, agrega varias opciones en la caja de texto **Options**, cada una en una nueva linea.
 
-<img class="screenshot" alt="Select Field" src="/docs/assets/img/select_field.png">
+<img class="screenshot" alt="Select Field" src="/assets/frappe_docs/assets/img/select_field.png">
 
 De manera similar continua haciendo los otros modelos.
 
@@ -44,7 +44,7 @@ Un patrón estandar es que cuando seleccionas un ID, dice **Library Member** en 
 
 Para hacer esto, podemos usar campos de solo lectura y en opciones, podemos especificar el nombre del link (enlace) y el campo o propiedad que deseas obtener. Para este ejempo en **Member First Name** podemos especificar `library_member.first_name`.
 
-<img class="screenshot" alt="Fetch values" src="/docs/assets/img/fetch.png">
+<img class="screenshot" alt="Fetch values" src="/assets/frappe_docs/assets/img/fetch.png">
 
 ### Completar los modelos
 
@@ -52,19 +52,19 @@ En la misma forma, puedes completar todos los modelos, todos los campos deben ve
 
 #### Article
 
-<img class="screenshot" alt="Article" src="/docs/assets/img/doctype_article.png">
+<img class="screenshot" alt="Article" src="/assets/frappe_docs/assets/img/doctype_article.png">
 
 #### Library Member
 
-<img class="screenshot" alt="Library Member" src="/docs/assets/img/doctype_lib_member.png">
+<img class="screenshot" alt="Library Member" src="/assets/frappe_docs/assets/img/doctype_lib_member.png">
 
 #### Library Membership
 
-<img class="screenshot" alt="Library Membership" src="/docs/assets/img/doctype_lib_membership.png">
+<img class="screenshot" alt="Library Membership" src="/assets/frappe_docs/assets/img/doctype_lib_membership.png">
 
 #### Library Transaction
 
-<img class="screenshot" alt="Library Transaction" src="/docs/assets/img/doctype_lib_trans.png">
+<img class="screenshot" alt="Library Transaction" src="/assets/frappe_docs/assets/img/doctype_lib_trans.png">
 
 > Asegurate de dar permiso a **Librarian** en cada DocType
 

--- a/frappe/docs/user/es/tutorial/reports.md
+++ b/frappe/docs/user/es/tutorial/reports.md
@@ -2,6 +2,6 @@
 
 Puedes dar click en el texto que dice Reportes en el panel lateral izquierdo para ver los registros de manera tabulada.
 
-<img class="screenshot" alt="Report" src="/docs/assets/img/report.png">
+<img class="screenshot" alt="Report" src="/assets/frappe_docs/assets/img/report.png">
 
 {next}

--- a/frappe/docs/user/es/tutorial/roles.md
+++ b/frappe/docs/user/es/tutorial/roles.md
@@ -9,6 +9,6 @@ Para crear un nuevo Role, ir a:
 
 > Setup > Users > Role > New
 
-<img class="screenshot" alt="Adding Roles" src="/docs/assets/img/roles_creation.png">
+<img class="screenshot" alt="Adding Roles" src="/assets/frappe_docs/assets/img/roles_creation.png">
 
 {next}

--- a/frappe/docs/user/es/tutorial/single-doctypes.md
+++ b/frappe/docs/user/es/tutorial/single-doctypes.md
@@ -4,6 +4,6 @@ Una aplicación normalmente va a tener una página de configuración. En nuestra
 
 Para crear un Single DocType, marca el checkbox **Is Single**.
 
-<img class="screenshot" alt="Single Doctypes" src="/docs/assets/img/tab_single.png">
+<img class="screenshot" alt="Single Doctypes" src="/assets/frappe_docs/assets/img/tab_single.png">
 
 {next}

--- a/frappe/docs/user/es/tutorial/start.md
+++ b/frappe/docs/user/es/tutorial/start.md
@@ -14,7 +14,7 @@ Para iniciar el servidor de desarrollo, ejecuta `bench start`.
 
 Ahora abre tu navegador y ve a la dirección `http://localhost:8000`. Deberías ver la páagina de inicio de sesión si todo salió bien.:
 
-<img class="screenshot" alt="Login Screen" src="/docs/assets/img/login.png">
+<img class="screenshot" alt="Login Screen" src="/assets/frappe_docs/assets/img/login.png">
 
 Ahora accede con :
 
@@ -24,7 +24,7 @@ Password : **Usa la contraseña que creaste durante la instalación**
 
 Cuando accedas, deberías poder ver la página de inicio (Desk).
 
-<img class="screenshot" alt="Desk" src="/docs/assets/img/desk.png">
+<img class="screenshot" alt="Desk" src="/assets/frappe_docs/assets/img/desk.png">
 
 Como puedes ver, el sistema básico de Frappé viene con algunas aplicaciones preinstaladas como To Do, File Manager etc. Estas aplicaciones pueden integrarse en el flujo de trabajo de su aplicació a medida que avancemos.
 

--- a/frappe/docs/user/es/tutorial/users-and-records.md
+++ b/frappe/docs/user/es/tutorial/users-and-records.md
@@ -12,7 +12,7 @@ Crea un nuevo Usuario y llena los campos de nombre, primer nombre y nueva contra
 
 Luego dale los Roles de Librarian y de Library Member a este usuario.
 
-<img class="screenshot" alt="Add User Roles" src="/docs/assets/img/add_user_roles.png">
+<img class="screenshot" alt="Add User Roles" src="/assets/frappe_docs/assets/img/add_user_roles.png">
 
 Ahora cierra sesión y accede usando las credenciales del nuevo usuario.
 
@@ -20,36 +20,36 @@ Ahora cierra sesión y accede usando las credenciales del nuevo usuario.
 
 Debes ver un ícono del módulo de Library Management. Dar click en el ícono para entrar a la página del módulo:
 
-<img class="screenshot" alt="Library Management Module" src="/docs/assets/img/lib_management_module.png">
+<img class="screenshot" alt="Library Management Module" src="/assets/frappe_docs/assets/img/lib_management_module.png">
 
 Aquí puedes ver los DocTypes que fueron creados para la aplicación. Vamos a comenzar a crear nuevos registros.
 
 Primero vamos a crear un nuevo Article:
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article_blank.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article_blank.png">
 
 Aquí vas a ver que los DocTypes que haz creado han sido renderizados como un formulario. Las validaciones y las otras restricciones también están aplicadas según se diseñaron. Vamos a llenar los datos de un Article.
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article.png">
 
 Puedes agregar una imagen si deseas.
 
-<img class="screenshot" alt="Attach Image" src="/docs/assets/img/attach_image.gif">
+<img class="screenshot" alt="Attach Image" src="/assets/frappe_docs/assets/img/attach_image.gif">
 
 Ahora vamos a crear un nuevo miembro:
 
-<img class="screenshot" alt="New Library Member" src="/docs/assets/img/new_member.png">
+<img class="screenshot" alt="New Library Member" src="/assets/frappe_docs/assets/img/new_member.png">
 
 Despues de esto, crearemos una nueva membresía (membership) para el miembro.
 
 Si recuerdas, aquí hemos específicado los valores del nombre y apellido del miembro directamente desde el registro del miembro tan pronto selecciones el miembro id, los nombres serán actualizados.
 
-<img class="screenshot" alt="New Library Membership" src="/docs/assets/img/new_lib_membership.png">
+<img class="screenshot" alt="New Library Membership" src="/assets/frappe_docs/assets/img/new_lib_membership.png">
 
 Como puedes ver la fecha tiene un formato de año-mes-día lo cual es una fecha del sistema. Para seleccionar o cambiar la fecha, tiempo y formatos de números, ir a:
 
 > Setup > Settings > System Settings
 
-<img class="screenshot" alt="System Settings" src="/docs/assets/img/system_settings.png">
+<img class="screenshot" alt="System Settings" src="/assets/frappe_docs/assets/img/system_settings.png">
 
 {next}

--- a/frappe/docs/user/es/tutorial/web-views.md
+++ b/frappe/docs/user/es/tutorial/web-views.md
@@ -16,11 +16,11 @@ Vamos a ver las Vistas web estandar:
 
 Si estas logueado como el usuario de prueba, ve a `/article` y deberías ver la lista de artículos.
 
-<img class="screenshot" alt="web list" src="/docs/assets/img/web-list.png">
+<img class="screenshot" alt="web list" src="/assets/frappe_docs/assets/img/web-list.png">
 
 Da click en uno de los artículos y vas a ver una vista web por defecto
 
-<img class="screenshot" alt="web view" src="/docs/assets/img/web-view.png">
+<img class="screenshot" alt="web view" src="/assets/frappe_docs/assets/img/web-view.png">
 
 Si deseas hacer una mejor vista para la lista de artículos, crea un archivo llamado `row_template.html` en el directorio `library_management/templates/includes/list/`.
  Aquí hay un archivo de ejemplo:
@@ -45,7 +45,7 @@ Aquí, vas a tener todas las propiedades de un artículo en el objeto `doc`.
 
 La lista actualizada debe lucir de esta manera!
 
-<img class="screenshot" alt="new web list" src="/docs/assets/img/web-list-new.png">
+<img class="screenshot" alt="new web list" src="/assets/frappe_docs/assets/img/web-list-new.png">
 
 #### Página de Inicio
 

--- a/frappe/docs/user/fr/tutorial/controllers.md
+++ b/frappe/docs/user/fr/tutorial/controllers.md
@@ -50,7 +50,7 @@ Dans ce script:
 
 Vérifiez vos validations en créant de nouveaux enregistrements.
 
-<img class="screenshot" alt="Transaction" src="/docs/assets/img/lib_trans.png">
+<img class="screenshot" alt="Transaction" src="/assets/frappe_docs/assets/img/lib_trans.png">
 
 #### Debogage
 

--- a/frappe/docs/user/fr/tutorial/doctypes.md
+++ b/frappe/docs/user/fr/tutorial/doctypes.md
@@ -6,7 +6,7 @@ Pour créer un nouveau **DocType**, rendez-vous sur:
 
 > Developer > Documents > Doctype > New
 
-<img class="screenshot" alt="New Doctype" src="/docs/assets/img/doctype_new.png">
+<img class="screenshot" alt="New Doctype" src="/assets/frappe_docs/assets/img/doctype_new.png">
 
 Dans un premier temps, saisissez le module, dans notre cas, **Library Managment**
 
@@ -25,7 +25,7 @@ Les champs sont bien plus que des colonnes d'une base de données, ils peuvent �
 
 Ajoutons des champs pour l'article.
 
-<img class="screenshot" alt="Adding Fields" src="/docs/assets/img/doctype_adding_field.png">
+<img class="screenshot" alt="Adding Fields" src="/assets/frappe_docs/assets/img/doctype_adding_field.png">
 
 Quand vous ajoutez des champs, vous devez entrer le **Type**. Le **Label** est optionnel pour les retours de sections et de colonnes. 
 Le **Name** (`fieldname`) ets le nom de la colonne dans la base de données et aussi la propriété du controleur. Les définitions
@@ -54,7 +54,7 @@ ajoutons les droits le lecture, écriture, création et suppression au modèle *
 permissions sur les modèles. Vous pouvez aussi changer les permissions plus tard en utilisant le gestionnaire de permissions
 dans la configuration.
 
-<img class="screenshot" alt="Adding Permissions" src="/docs/assets/img/doctype_adding_permission.png">
+<img class="screenshot" alt="Adding Permissions" src="/assets/frappe_docs/assets/img/doctype_adding_permission.png">
 
 #### Sauvegarde
 

--- a/frappe/docs/user/fr/tutorial/naming-and-linking.md
+++ b/frappe/docs/user/fr/tutorial/naming-and-linking.md
@@ -4,7 +4,7 @@ Définissons un nouveau **DocType**:
 
 1. Library Member (First Name, Last Name, Email Address, Phone, Address)
 
-<img class="screenshot" alt="Doctype Saved" src="/docs/assets/img/naming_doctype.png">
+<img class="screenshot" alt="Doctype Saved" src="/assets/frappe_docs/assets/img/naming_doctype.png">
 
 
 #### Le nommage des DocTypes
@@ -21,7 +21,7 @@ Cela peut être configuré par le champs **Autoname**. Pour le controleur, laiss
 > **Search Fields**: Un **DocType** peut être nommé sur la base d'une serie mais nous devons toujours pouvoir le chercher par un nom. 
 Dans notre cas, l'arcicle peut etre cherché par un titre ou par l'auteur. Remplissons donc le champs **Search Fields**.
 
-<img class="screenshot" alt="Autonaming and Search Field" src="/docs/assets/img/autoname_and_search_field.png">
+<img class="screenshot" alt="Autonaming and Search Field" src="/assets/frappe_docs/assets/img/autoname_and_search_field.png">
 
 #### Relation et champs select
 
@@ -34,12 +34,12 @@ Dans notre exemple, pour le **doctype** `Library Transaction`, nous avons un lie
 d'indexer la colonne. Cela pourrait ne pas être optimum, c'est pour cela que la validation de la clé étrangère est faite 
 par le framework.
 
-<img class="screenshot" alt="Link Field" src="/docs/assets/img/link_field.png">
+<img class="screenshot" alt="Link Field" src="/assets/frappe_docs/assets/img/link_field.png">
 
 Pour les champs **select**, comme mentionné plus tôt, ajoutez chacune des options dans le champs **Options**, chaque 
 option sur une nouvelle ligne.
 
-<img class="screenshot" alt="Select Field" src="/docs/assets/img/select_field.png">
+<img class="screenshot" alt="Select Field" src="/assets/frappe_docs/assets/img/select_field.png">
 
 faites de même pour les autres modèles.
 
@@ -52,7 +52,7 @@ Pour cela, nous pouvons utiliser des champs en lecture seules et, dans les optio
 et le nom du champs de la propriété que nous voulons parcourir. Dans cet exemple, dans **Member First Name** nous pouvons 
 définir `library_member.first_name`
 
-<img class="screenshot" alt="Fetch values" src="/docs/assets/img/fetch.png">
+<img class="screenshot" alt="Fetch values" src="/assets/frappe_docs/assets/img/fetch.png">
 
 ### Completer les Modeles
 
@@ -60,19 +60,19 @@ De la même facon, vous pouvez compléter les autres modèles pour qu'au final l
 
 #### Article
 
-<img class="screenshot" alt="Article" src="/docs/assets/img/doctype_article.png">
+<img class="screenshot" alt="Article" src="/assets/frappe_docs/assets/img/doctype_article.png">
 
 #### Library Member
 
-<img class="screenshot" alt="Library Member" src="/docs/assets/img/doctype_lib_member.png">
+<img class="screenshot" alt="Library Member" src="/assets/frappe_docs/assets/img/doctype_lib_member.png">
 
 #### Library Membership
 
-<img class="screenshot" alt="Library Membership" src="/docs/assets/img/doctype_lib_membership.png">
+<img class="screenshot" alt="Library Membership" src="/assets/frappe_docs/assets/img/doctype_lib_membership.png">
 
 #### Library Transaction
 
-<img class="screenshot" alt="Library Transaction" src="/docs/assets/img/doctype_lib_trans.png">
+<img class="screenshot" alt="Library Transaction" src="/assets/frappe_docs/assets/img/doctype_lib_trans.png">
 
 > Vérifiez que le modèles **Librarian** aient les permissions sur chaque **DocType**.
 

--- a/frappe/docs/user/fr/tutorial/reports.md
+++ b/frappe/docs/user/fr/tutorial/reports.md
@@ -2,6 +2,6 @@
 
 Vous pouvez aussi cliquer sur le texte "Rapports" dans la barre latérale de gauche pour voir vos données dans un tableau.
 
-<img class="screenshot" alt="Report" src="/docs/assets/img/report.png">
+<img class="screenshot" alt="Report" src="/assets/frappe_docs/assets/img/report.png">
 
 {next}

--- a/frappe/docs/user/fr/tutorial/roles.md
+++ b/frappe/docs/user/fr/tutorial/roles.md
@@ -10,6 +10,6 @@ Pour créer un nouveau rôle, se rendre sur:
 
 > Setup > Users > Role > New
 
-<img class="screenshot" alt="Adding Roles" src="/docs/assets/img/roles_creation.png">
+<img class="screenshot" alt="Adding Roles" src="/assets/frappe_docs/assets/img/roles_creation.png">
 
 {next}

--- a/frappe/docs/user/fr/tutorial/single-doctypes.md
+++ b/frappe/docs/user/fr/tutorial/single-doctypes.md
@@ -7,6 +7,6 @@ d'une classe. Appelons le **Library Managment Settings**.
 
 Pour créer un DocType de type **Single** cochez la case **Is Single**.
 
-<img class="screenshot" alt="Single Doctypes" src="/docs/assets/img/tab_single.png">
+<img class="screenshot" alt="Single Doctypes" src="/assets/frappe_docs/assets/img/tab_single.png">
 
 {suite}

--- a/frappe/docs/user/fr/tutorial/start.md
+++ b/frappe/docs/user/fr/tutorial/start.md
@@ -14,7 +14,7 @@ Pour démarrer le serveur de développement, lancez la commande `bench start`
 
 Vous pouvez maintenant ouvrir votre navigateur et vous rendre sur `http://localhost:8000`. Si tout se passe bien vous devriez voir:
 
-<img class="screenshot" alt="Login Screen" src="/docs/assets/img/login.png">
+<img class="screenshot" alt="Login Screen" src="/assets/frappe_docs/assets/img/login.png">
 
 Maintenant, connectez vous avec les identifiants suivants: 
 
@@ -24,7 +24,7 @@ Mot de passe: **Le mot de passe que vous avez définis pendant l'installation**
 
 Une fois connecté, vous devriez voir le `Desk`, c'est à dire la page d'accueil
 
-<img class="screenshot" alt="Desk" src="/docs/assets/img/desk.png">
+<img class="screenshot" alt="Desk" src="/assets/frappe_docs/assets/img/desk.png">
 
 Comme vous pouvez le voir, Frappé fournit quelques applications comme un To Do, un gestionnaire de fichiers etc. Ces applications
 peuvent être intégrées par la suite.

--- a/frappe/docs/user/fr/tutorial/users-and-records.md
+++ b/frappe/docs/user/fr/tutorial/users-and-records.md
@@ -12,7 +12,7 @@ Afin de créer des enregistrements, nous avons tout d'abord besoin de créer un 
 Saisissez un nom, un prénom ainsi qu'un mot de passe à votre utilisateur pour le créer et donnez lui les rôles  `Librarian`
  et `Library Member`.
 
-<img class="screenshot" alt="Add User Roles" src="/docs/assets/img/add_user_roles.png">
+<img class="screenshot" alt="Add User Roles" src="/assets/frappe_docs/assets/img/add_user_roles.png">
 
 Maintenant déconnectez-vous puis connectez-vous avec l'utilisateur que vous venez de créer.
 
@@ -21,39 +21,39 @@ Maintenant déconnectez-vous puis connectez-vous avec l'utilisateur que vous ven
 Vous allez désormais voir une icone pour notre module de gestion de librairie. Cliquez sur cette icone et vous apercevrez
 la page du module:
 
-<img class="screenshot" alt="Library Management Module" src="/docs/assets/img/lib_management_module.png">
+<img class="screenshot" alt="Library Management Module" src="/assets/frappe_docs/assets/img/lib_management_module.png">
 
 Vous pouvez donc voir les **DocTypes** que nous avons créés pour l'application. Créons quelques enregistrements.
 
 Définissons un nouvel Article:
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article_blank.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article_blank.png">
 
 Le **DocType** que vous avons définis est transformé en formulaire. Les règles de validation seront appliquées selon nos
 définitions. Remplissons le formulaire pour créer notre premier article.
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article.png">
 
 Vous pouvez aussi ajouter une image.
 
-<img class="screenshot" alt="Attach Image" src="/docs/assets/img/attach_image.gif">
+<img class="screenshot" alt="Attach Image" src="/assets/frappe_docs/assets/img/attach_image.gif">
 
 Maintenant créons un nouveau membre.
 
-<img class="screenshot" alt="New Library Member" src="/docs/assets/img/new_member.png">
+<img class="screenshot" alt="New Library Member" src="/assets/frappe_docs/assets/img/new_member.png">
 
 Après cela, définissons un nouvel abonnement pour ce membre.
 
 Ici, si vous vous souvenez, nous avons définis que les noms et prénoms doivent automatiquement être renseignés dès que nous
 avons selectionné l'ID du membre.
 
-<img class="screenshot" alt="New Library Membership" src="/docs/assets/img/new_lib_membership.png">
+<img class="screenshot" alt="New Library Membership" src="/assets/frappe_docs/assets/img/new_lib_membership.png">
 
 Comme vous pouvez le voir, la date est formattée en années-mois-jour qui est le format du système. Pour configurer / changer 
 le format de la date et de l'heure, rendez-vous sur:
 
 > Setup > Settings > System Settings
 
-<img class="screenshot" alt="System Settings" src="/docs/assets/img/system_settings.png">
+<img class="screenshot" alt="System Settings" src="/assets/frappe_docs/assets/img/system_settings.png">
 
 {suite}

--- a/frappe/docs/user/fr/tutorial/web-views.md
+++ b/frappe/docs/user/fr/tutorial/web-views.md
@@ -20,11 +20,11 @@ Jettons un oeil aux vues standards:
 
 Si vous êtes connecté avec votre utilisateur de test, rendez-vous sur`/article` et vous devriez voir la liste des articles:
 
-<img class="screenshot" alt="web list" src="/docs/assets/img/web-list.png">
+<img class="screenshot" alt="web list" src="/assets/frappe_docs/assets/img/web-list.png">
 
 Cliquez sur un article et vous devriez voir une vue par défaut.
 
-<img class="screenshot" alt="web view" src="/docs/assets/img/web-view.png">
+<img class="screenshot" alt="web view" src="/assets/frappe_docs/assets/img/web-view.png">
 
 Maintenant, si vous voulez une meilleur liste pour vos articles, créez un fichier appelé `row_template.html` dans le
 repertoire `library_management/templates/includes/list/`. Voici un exemple du contenu de ce fichier:
@@ -50,7 +50,7 @@ Ici, vous aurez toutes les propriétés d'un article dans l'object `doc`.
 
 La mise à jour de la liste ressemble à ca !
 
-<img class="screenshot" alt="new web list" src="/docs/assets/img/web-list-new.png">
+<img class="screenshot" alt="new web list" src="/assets/frappe_docs/assets/img/web-list-new.png">
 
 #### La page d'accueil
 

--- a/frappe/docs/user/pt/tutorial/controllers.md
+++ b/frappe/docs/user/pt/tutorial/controllers.md
@@ -48,7 +48,7 @@ Nesse script:
 
 Verifique se suas validações funcionaram, criando de novos registros.
 
-<img class="screenshot" alt="Transaction" src="/docs/assets/img/lib_trans.png">
+<img class="screenshot" alt="Transaction" src="/assets/frappe_docs/assets/img/lib_trans.png">
 
 #### Debugging
 

--- a/frappe/docs/user/pt/tutorial/doctypes.md
+++ b/frappe/docs/user/pt/tutorial/doctypes.md
@@ -6,7 +6,7 @@ Para criar um novo **DocType**, vá para:
 
 > Developer > Documents > Doctype > New
 
-<img class="screenshot" alt="New Doctype" src="/docs/assets/img/doctype_new.png">
+<img class="screenshot" alt="New Doctype" src="/assets/frappe_docs/assets/img/doctype_new.png">
 
 No DocType, criamos o módulo, que no nosso caso é **Library Managment**
 
@@ -25,7 +25,7 @@ Os campos são muito mais do que colunas de banco de dados, eles podem ser:
 
 Vamos adicionar os campos do artigo.
 
-<img class="screenshot" alt="Adding Fields" src="/docs/assets/img/doctype_adding_field.png">
+<img class="screenshot" alt="Adding Fields" src="/assets/frappe_docs/assets/img/doctype_adding_field.png">
 
 Quando você adiciona campos, você precisa digitar o **Type**. **Label** é opcional para quebra de seção e quebra de coluna. **Name** (`fieldname`) é o nome da coluna da tabela de banco de dados e também a propriedade do controlador. Isso tem que ser um *código amigável*, ou seja, ele tem que ter caracteres minusculos e _ em vez de "". Se você deixar o nome do campo em branco, ele será ajustado automaticamente quando você salvá-lo.
 
@@ -47,7 +47,7 @@ Nós podemos adicionar os seguintes campos:
 
 Depois de adicionar os campos, finalize e adicione uma nova linha na seção Regras de permissão. Por enquanto, vamos dar permissão de Read, Write, Create, Delete and Report, a **Librarian**. Frappé tem uma Role baseado nas permissões do modelo. Você também pode alterar as permissões posteriormente usando o **Role Permissions Manager** do **Setup**.
 
-<img class="screenshot" alt="Adding Permissions" src="/docs/assets/img/doctype_adding_permission.png">
+<img class="screenshot" alt="Adding Permissions" src="/assets/frappe_docs/assets/img/doctype_adding_permission.png">
 
 #### Salvando
 

--- a/frappe/docs/user/pt/tutorial/naming-and-linking.md
+++ b/frappe/docs/user/pt/tutorial/naming-and-linking.md
@@ -4,7 +4,7 @@ Em seguida, vamos criar outro DocType e salva-lo também:
 
 1. Library Member (First Name, Last Name, Email Address, Phone, Address)
 
-<img class="screenshot" alt="Doctype Saved" src="/docs/assets/img/naming_doctype.png">
+<img class="screenshot" alt="Doctype Saved" src="/assets/frappe_docs/assets/img/naming_doctype.png">
 
 
 #### Nomeação de DocTypes
@@ -20,7 +20,7 @@ Isso pode ser definido através do preenchimento do campo **Autoname**. Para o c
 
 > **Search Fields**: A DocType pode ser nomeado em uma série, mas ele ainda precisa ser pesquisado por nome. No nosso caso, o artigo será procurado pelo título ou o nome do autor. Portanto, este pode ser inserido no campo de pesquisa.
 
-<img class="screenshot" alt="Autonaming and Search Field" src="/docs/assets/img/autoname_and_search_field.png">
+<img class="screenshot" alt="Autonaming and Search Field" src="/assets/frappe_docs/assets/img/autoname_and_search_field.png">
 
 #### Vinculando e selecionando campos
 
@@ -30,11 +30,11 @@ No nosso exemplo, na Library Transaction DocType, temos que ligar o Membro da Bi
 
 **Observação:** Lembre-se que os campos link não são automaticamente configurados como chaves estrangeiras no banco de dados MariaDB, porque isso vai implicitamente indexar a coluna. Isto pode não ser ideal, mas, a validação de chave estrangeira é feito pelo Framework.
 
-<img class="screenshot" alt="Link Field" src="/docs/assets/img/link_field.png">
+<img class="screenshot" alt="Link Field" src="/assets/frappe_docs/assets/img/link_field.png">
 
 Para campos de multipla escolha, como mencionamos anteriormente, adicione as várias opções na caixa de entrada **Options**, cada opção em uma nova linha.
 
-<img class="screenshot" alt="Select Field" src="/docs/assets/img/select_field.png">
+<img class="screenshot" alt="Select Field" src="/assets/frappe_docs/assets/img/select_field.png">
 
 Fazer o mesmo para outros modelos.
 
@@ -44,7 +44,7 @@ Um modelo padrão é quando você seleciona um ID, **Library Member** na **Libra
 
 Para fazer isso, podemos usar campos de somente leitura e de opções, podemos definir o nome do link e o nome do campo da propriedade que deseja buscar. Para este exemplo no **Member First Name** podemos definir `library_member.first_name`
 
-<img class="screenshot" alt="Fetch values" src="/docs/assets/img/fetch.png">
+<img class="screenshot" alt="Fetch values" src="/assets/frappe_docs/assets/img/fetch.png">
 
 ### Complete os modelos
 
@@ -52,19 +52,19 @@ Da mesma forma, você pode completar todos os modelos de modo que os campos fina
 
 #### Article
 
-<img class="screenshot" alt="Article" src="/docs/assets/img/doctype_article.png">
+<img class="screenshot" alt="Article" src="/assets/frappe_docs/assets/img/doctype_article.png">
 
 #### Library Member
 
-<img class="screenshot" alt="Library Member" src="/docs/assets/img/doctype_lib_member.png">
+<img class="screenshot" alt="Library Member" src="/assets/frappe_docs/assets/img/doctype_lib_member.png">
 
 #### Library Membership
 
-<img class="screenshot" alt="Library Membership" src="/docs/assets/img/doctype_lib_membership.png">
+<img class="screenshot" alt="Library Membership" src="/assets/frappe_docs/assets/img/doctype_lib_membership.png">
 
 #### Library Transaction
 
-<img class="screenshot" alt="Library Transaction" src="/docs/assets/img/doctype_lib_trans.png">
+<img class="screenshot" alt="Library Transaction" src="/assets/frappe_docs/assets/img/doctype_lib_trans.png">
 
 > Lembre-se de dar permissões para **Librarian** em cada DocType
 

--- a/frappe/docs/user/pt/tutorial/reports.md
+++ b/frappe/docs/user/pt/tutorial/reports.md
@@ -2,6 +2,6 @@
 
 Você também pode clicar sobre o texto Relatórios na barra lateral (esquerda) para ver os registros tabulados
 
-<img class="screenshot" alt="Report" src="/docs/assets/img/report.png">
+<img class="screenshot" alt="Report" src="/assets/frappe_docs/assets/img/report.png">
 
 {next}

--- a/frappe/docs/user/pt/tutorial/roles.md
+++ b/frappe/docs/user/pt/tutorial/roles.md
@@ -9,6 +9,6 @@ Para criar um novo roles, vá para:
 
 > Setup > Users > Role > New
 
-<img class="screenshot" alt="Adding Roles" src="/docs/assets/img/roles_creation.png">
+<img class="screenshot" alt="Adding Roles" src="/assets/frappe_docs/assets/img/roles_creation.png">
 
 {next}

--- a/frappe/docs/user/pt/tutorial/single-doctypes.md
+++ b/frappe/docs/user/pt/tutorial/single-doctypes.md
@@ -4,6 +4,6 @@ A aplicação irá normalmente têm uma página de configurações. Em nossa apl
 
 Para criar um DocType Single, marque a propriedade **Is Single** como verdadeira.
 
-<img class="screenshot" alt="Single Doctypes" src="/docs/assets/img/tab_single.png">
+<img class="screenshot" alt="Single Doctypes" src="/assets/frappe_docs/assets/img/tab_single.png">
 
 {next}

--- a/frappe/docs/user/pt/tutorial/start.md
+++ b/frappe/docs/user/pt/tutorial/start.md
@@ -14,7 +14,7 @@ Para iniciar o servidor de desenvolvimento, digite `bench start`
 
 Agora você pode abrir o seu navegador e ir para `http://localhost:8000`. Você deve ver esta página de login, se tudo correu bem:
 
-<img class="screenshot" alt="Login Screen" src="/docs/assets/img/login.png">
+<img class="screenshot" alt="Login Screen" src="/assets/frappe_docs/assets/img/login.png">
 
 Agora logue com :
 
@@ -24,7 +24,7 @@ Senha : **Use a senha que foi criada durante a instalação**
 
 Quando voce logar, voce deverá ver o "Desk" da pagine home
 
-<img class="screenshot" alt="Desk" src="/docs/assets/img/desk.png">
+<img class="screenshot" alt="Desk" src="/assets/frappe_docs/assets/img/desk.png">
 
 Como você pode ver, o básico do sistema Frappé vem com vários aplicativos pré-carregados como coisas a fazer, o Gerenciador de arquivos etc. Esses aplicativos podem ser integrados no fluxo de trabalho do app à medida que progredimos.
 

--- a/frappe/docs/user/pt/tutorial/users-and-records.md
+++ b/frappe/docs/user/pt/tutorial/users-and-records.md
@@ -12,7 +12,7 @@ Crie um novo usuário e definá o nome, o primeiro nome e uma nova senha.
 
 Também de as roles de Librarian e Library Member para este usuario
 
-<img class="screenshot" alt="Add User Roles" src="/docs/assets/img/add_user_roles.png">
+<img class="screenshot" alt="Add User Roles" src="/assets/frappe_docs/assets/img/add_user_roles.png">
 
 Agora saia e se autentique usando o novo ID de usuário e senha.
 
@@ -20,36 +20,36 @@ Agora saia e se autentique usando o novo ID de usuário e senha.
 
 Você vai ver agora um ícone para o módulo de Library Management. Clique nesse ícone e você verá a página do modelo:
 
-<img class="screenshot" alt="Library Management Module" src="/docs/assets/img/lib_management_module.png">
+<img class="screenshot" alt="Library Management Module" src="/assets/frappe_docs/assets/img/lib_management_module.png">
 
 Aqui você pode ver os doctypes que criamos para a aplicação. Vamos começar a criar alguns registros.
 
 Primeiro, vamos criar um novo artigo:
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article_blank.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article_blank.png">
 
 Aqui você vai ver que o DocType que você tinha criado foi processado como um formulário. As validações e outras regras também serão aplicadas conforme projetado. Vamos preencher um artigo.
 
-<img class="screenshot" alt="New Article" src="/docs/assets/img/new_article.png">
+<img class="screenshot" alt="New Article" src="/assets/frappe_docs/assets/img/new_article.png">
 
 Você também pode adicionar uma imagem.
 
-<img class="screenshot" alt="Attach Image" src="/docs/assets/img/attach_image.gif">
+<img class="screenshot" alt="Attach Image" src="/assets/frappe_docs/assets/img/attach_image.gif">
 
 Agora vamos criar um novo membro:
 
-<img class="screenshot" alt="New Library Member" src="/docs/assets/img/new_member.png">
+<img class="screenshot" alt="New Library Member" src="/assets/frappe_docs/assets/img/new_member.png">
 
 Depois disso, vamos criar um novo registro de membership para o membro.
 
 Aqui se você se lembra, nós tinhamos definido os valores do primeiro e do ultimo nome do membro para ser diretamente obtido a partir dos registros de membros e, logo que você selecionar o ID de membro, os nomes serão atualizados.
 
-<img class="screenshot" alt="New Library Membership" src="/docs/assets/img/new_lib_membership.png">
+<img class="screenshot" alt="New Library Membership" src="/assets/frappe_docs/assets/img/new_lib_membership.png">
 
 Como você pode ver que a data é formatada como ano-mês-dia, que é um formato de sistema. Para definir/mudar a data, hora e número de formatos, acesse
 
 > Setup > Settings > System Settings
 
-<img class="screenshot" alt="System Settings" src="/docs/assets/img/system_settings.png">
+<img class="screenshot" alt="System Settings" src="/assets/frappe_docs/assets/img/system_settings.png">
 
 {next}

--- a/frappe/docs/user/pt/tutorial/web-views.md
+++ b/frappe/docs/user/pt/tutorial/web-views.md
@@ -16,11 +16,11 @@ Vamos dar uma olhada na standard Web Views:
 
 Se você estiver logado como usuário de teste, vá para `/article` e você deverá ver a lista de artigos:
 
-<img class="screenshot" alt="web list" src="/docs/assets/img/web-list.png">
+<img class="screenshot" alt="web list" src="/assets/frappe_docs/assets/img/web-list.png">
 
 Clique em um artigo e você vai ver uma Web View padrão
 
-<img class="screenshot" alt="web view" src="/docs/assets/img/web-view.png">
+<img class="screenshot" alt="web view" src="/assets/frappe_docs/assets/img/web-view.png">
 
 Agora, se você quiser fazer uma List View melhor para o artigo, crie um arquivo chamado `row_template.html` na pasta
 `library_management/templates/includes/list/`. Aqui está um exemplo de arquivo:
@@ -46,7 +46,7 @@ Aqui, você vai ter todas as propriedades do artigo no objeto `doc`.
 
 A List View atualizada se parece com isso!
 
-<img class="screenshot" alt="new web list" src="/docs/assets/img/web-list-new.png">
+<img class="screenshot" alt="new web list" src="/assets/frappe_docs/assets/img/web-list-new.png">
 
 #### Home Page
 


### PR DESCRIPTION
Change image links from ".../docs/assets/img/..."  to  ".../assets/frappe_docs/assets/img/..."  to fix broken image links in documentation

![screenshot from 2018-01-15 17-46-06](https://user-images.githubusercontent.com/23179734/34953036-05387bf6-fa1c-11e7-8bbb-8d7d19120253.png)