### PR TITLE
[fix] slideshow private images validation

### DIFF
--- a/frappe/website/doctype/website_slideshow/website_slideshow.py
+++ b/frappe/website/doctype/website_slideshow/website_slideshow.py
@@ -21,9 +21,10 @@ class WebsiteSlideshow(Document):
 	def validate_images(self):
 		''' atleast one image file should be public for slideshow '''
 		files = map(lambda row: row.image, self.slideshow_items)
-		result = frappe.get_all("File", filters={ "file_url":("in", files) }, fields="is_private")
-		if any([file.is_private for file in result]):
-			frappe.throw(_("All Images attached to Website Slideshow should be public"))
+		if files:
+			result = frappe.get_all("File", filters={ "file_url":("in", files) }, fields="is_private")
+			if any([file.is_private for file in result]):
+				frappe.throw(_("All Images attached to Website Slideshow should be public"))
 
 def get_slideshow(doc):
 	if not doc.slideshow:


### PR DESCRIPTION
`in` condition in db filters behaves as such if passed an empty list.
<img width="560" alt="screen shot 2018-01-15 at 8 34 34 pm" src="https://user-images.githubusercontent.com/5196925/34949367-ea603a98-fa35-11e7-96c2-732ee3afbea9.png">

