### PR TITLE
Prevent Duplicate Buttons In `add_inner_button`

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -338,6 +338,15 @@ frappe.ui.Page = Class.extend({
 		}
 	},
 
+	/*
+	* Add button to button group. If there exists another button with the same label,
+	* `add_inner_button` will not add the new button to the button group even if the callback
+	* function is different.
+	*
+	* @param {string} label - Label of the button to be added to the group
+	* @param {object} action - function to be called when button is clicked
+	* @param {string} group - Label of the group button
+	*/
 	add_inner_button: function(label, action, group) {
 		var me = this;
 		let _action = function() {

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -281,6 +281,21 @@ frappe.ui.Page = Class.extend({
 		return $link;
 	},
 
+	/*
+	* Check if there already exists a button with a specified label in a specified button group
+	* @param {object} parent - This should be the `ul` of the button group.
+	* @param {string} selector - CSS Selector of the button to be searched for. By default, it is `li`.
+	* @param {string} label - Label of the button
+	*/
+	is_in_group_button_dropdown: function(parent, selector, label){
+		if (!selector) selector = 'li';
+
+		if (!label || !parent) return false;
+
+		const result = $(parent).find(`${selector}:contains('${label}')`);
+		return result.length > 0;
+	},
+
 	clear_btn_group: function(parent) {
 		parent.empty();
 		parent.parent().addClass("hide");
@@ -333,9 +348,13 @@ frappe.ui.Page = Class.extend({
 		if(group) {
 			var $group = this.get_or_add_inner_group_button(group);
 			$(this.inner_toolbar).removeClass("hide");
-			return $('<li><a>'+label+'</a></li>')
-				.on('click', _action)
-				.appendTo($group.find(".dropdown-menu"));
+
+			if (!this.is_in_group_button_dropdown($group.find(".dropdown-menu"), 'li', label)) {
+				return $('<li><a>'+label+'</a></li>')
+					.on('click', _action)
+					.appendTo($group.find(".dropdown-menu"));
+			}
+
 		} else {
 			return $('<button class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
 				.on("click", _action)

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -290,7 +290,6 @@ frappe.ui.Page = Class.extend({
 		if (!label || !parent) return false;
 
 		const result = $(parent).find(`${selector}:contains('${label}')`);
-		console.log('items - ', result);
 		return result.length > 0;
 	},
 

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -256,17 +256,14 @@ frappe.ui.Page = Class.extend({
 	* @param {object} parent - DOM object representing the parent of the drop down item lists
 	*/
 	add_dropdown_item: function(label, click, standard, parent) {
-		const is_already_added = () => {
-			let found_lists = $(parent).find('li > a.grey-link:contains(' + label + ')');
-			return found_lists.length > 0;
-		}
+		let item_selector = 'li > a.grey-link';
 
 		parent.parent().removeClass("hide");
 
 		var $li = $('<li><a class="grey-link">'+ label +'</a><li>'),
 			$link = $li.find("a").on("click", click);
 
-		if (is_already_added()) return;
+		if (this.is_in_group_button_dropdown(parent, `${item_selector}:contains('${label}')`, label)) return;
 
 		if(standard===true) {
 			$li.appendTo(parent);
@@ -293,6 +290,7 @@ frappe.ui.Page = Class.extend({
 		if (!label || !parent) return false;
 
 		const result = $(parent).find(`${selector}:contains('${label}')`);
+		console.log('items - ', result);
 		return result.length > 0;
 	},
 


### PR DESCRIPTION
Closes: frappe/erpnext#12508

This PR prevents multiple buttons with the same label in button groups. It works similar to #4818 so I have modified `add_dropdown_item` for DRY purposes.

Result of the fix is seen as below:
### Before
![peek 2018-01-17 13-09](https://user-images.githubusercontent.com/818803/35042395-c96c9c42-fb88-11e7-9dcf-a6c1f5c5367a.gif)

### After
![peek 2018-01-17 12-57](https://user-images.githubusercontent.com/818803/35042425-e858f8a8-fb88-11e7-867d-505b11a97394.gif)

### #4818 behavior is still as expected
![peek 2018-01-17 12-53](https://user-images.githubusercontent.com/818803/35042440-02433846-fb89-11e7-9ca9-a21b232d39e7.gif)
