### PR TITLE
Python 3 compatibility Frappe installation fixes

### DIFF
--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -18,8 +18,8 @@ def restore(name):
 		doc.insert()
 	except frappe.DocstatusTransitionError:
 		frappe.msgprint(_("Cancelled Document restored as Draft"))
-        	doc.docstatus = 0
-        	doc.insert()
+		doc.docstatus = 0
+		doc.insert()
 
 	doc.add_comment('Edit', _('restored {0} as {1}').format(deleted.deleted_name, doc.name))
 

--- a/frappe/database.py
+++ b/frappe/database.py
@@ -16,6 +16,7 @@ from frappe.utils import now, get_datetime, cstr
 from frappe import _
 from frappe.model.utils.link_count import flush_local_link_count
 from frappe.utils.background_jobs import execute_job, get_queue
+from frappe import as_unicode
 
 # imports - compatibility imports
 from six import (
@@ -886,10 +887,8 @@ class Database:
 
 	def escape(self, s, percent=True):
 		"""Excape quotes and percent in given string."""
-		if isinstance(s, text_type):
-			s = (s or "").encode("utf-8")
-
-		s = text_type(pymysql.escape_string(s), "utf-8").replace("`", "\\`")
+		# pymysql expects unicode argument to escape_string with Python 3
+		s = as_unicode(pymysql.escape_string(as_unicode(s)), "utf-8").replace("`", "\\`")
 
 		# NOTE separating % escape, because % escape should only be done when using LIKE operator
 		# or when you use python format string to generate query that already has a %s

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 import os
 import os.path
 import frappe
@@ -122,11 +122,11 @@ def upload_file_to_s3(filename, folder, conn, bucket):
 
 	destpath = os.path.join(folder, os.path.basename(filename))
 	try:
-		print "Uploading file:", filename
+		print("Uploading file:", filename)
 		conn.upload_file(filename, bucket, destpath)
 
 	except Exception as e:
-		print "Error uploading: %s" % (e)
+		print("Error uploading: %s" % (e))
 
 
 def delete_old_backups(limit, bucket):
@@ -147,7 +147,7 @@ def delete_old_backups(limit, bucket):
 	oldest_backup = sorted(all_backups)[0]
 
 	if len(all_backups) > backup_limit:
-		print "Deleting Backup: {0}".format(oldest_backup)
+		print("Deleting Backup: {0}".format(oldest_backup))
 		for obj in bucket.objects.filter(Prefix=oldest_backup):
 			# delete all keys that are inside the oldest_backup
 			s3.Object(bucket.name, obj.key).delete()


### PR DESCRIPTION
After #4272, #4761 and #4280 `bench init` fails on Python 3, this fixes that.
