### PR TITLE
Description improvement for Google Cloud installs.

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -839,7 +839,7 @@
    "collapsible": 0, 
    "columns": 0, 
    "depends_on": "eval:!doc.domain && doc.enable_outgoing", 
-   "description": "If non standard port (e.g. 587)", 
+   "description": "If non standard port (e.g. 587). If on Google Cloud, try port 2525.", 
    "fieldname": "smtp_port", 
    "fieldtype": "Data", 
    "hidden": 0, 


### PR DESCRIPTION
Google Cloud allows port 587 for smtp.gmail.com and 2525 for other services such as SparkPost and Mailgun. Took a long time to figure this out.