### PR TITLE
Corrected warning message in make_asset_dirs in build.py

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -101,7 +101,7 @@ def make_asset_dirs(make_copy=False, restore=False):
 							shutil.rmtree(target)
 					os.symlink(source, target)
 			else:
-				warnings.warn('Source {source} does not exists.'.format(source = source))
+				warnings.warn('Source {source} does not exist.'.format(source = source))
 
 def build(no_compress=False, verbose=False):
 	assets_path = os.path.join(frappe.local.sites_path, "assets")


### PR DESCRIPTION
Changed "does not exists." to "does not exist."