### PR TITLE
[fix]Search results list has too much gap between results

### DIFF
--- a/frappe/public/css/list.css
+++ b/frappe/public/css/list.css
@@ -1,7 +1,7 @@
 .result,
 .no-result,
 .freeze {
-  min-height: calc(100vh - 284px);
+  min-height: max-content;
 }
 .freeze-row .level-left,
 .freeze-row .level-right,


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/6947417/35274290-8e444830-0061-11e8-86f6-c49b88418536.gif)

after:
![after](https://user-images.githubusercontent.com/6947417/35274297-94bca536-0061-11e8-9d9c-01518a148446.gif)
