### PR TITLE
[fix] check for exact label match to avoid duplication

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -263,7 +263,7 @@ frappe.ui.Page = Class.extend({
 		var $li = $('<li><a class="grey-link">'+ label +'</a><li>'),
 			$link = $li.find("a").on("click", click);
 
-		if (this.is_in_group_button_dropdown(parent, `${item_selector}:contains('${label}')`, label)) return;
+		if (this.is_in_group_button_dropdown(parent, item_selector, label)) return;
 
 		if(standard===true) {
 			$li.appendTo(parent);
@@ -289,7 +289,10 @@ frappe.ui.Page = Class.extend({
 
 		if (!label || !parent) return false;
 
-		const result = $(parent).find(`${selector}:contains('${label}')`);
+		const result = $(parent).find(`${selector}:contains('${label}')`)
+			.filter(function() {
+				return $(this).text() === label;
+			});
 		return result.length > 0;
 	},
 


### PR DESCRIPTION
### Before
<img width="1171" alt="screen shot 2018-01-24 at 7 26 35 pm" src="https://user-images.githubusercontent.com/3784093/35336161-853a7ad4-013d-11e8-924a-ce417f4abe70.png">

### After
<img width="1111" alt="screen shot 2018-01-24 at 7 25 54 pm" src="https://user-images.githubusercontent.com/3784093/35336168-8b46f7d6-013d-11e8-8dc0-a7b89e37520a.png">
