### PR TITLE
Query Reports No Longer Printing #12671

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -197,6 +197,7 @@ frappe.views.QueryReport = Class.extend({
 				content: content,
 				title: __(this.report_name),
 				print_settings: this.print_settings,
+				columns: this.columns
 			});
 		} else {
 			frappe.render_grid({


### PR DESCRIPTION
Reference: frappe/erpnext#12671.

Query reports were no longer printing.

### Before
![peek 2018-01-29 06-47](https://user-images.githubusercontent.com/818803/35495272-6a3164a6-04c0-11e8-949e-84a2daa34254.gif)

### After
![peek 2018-01-29 06-35](https://user-images.githubusercontent.com/818803/35495279-6f524504-04c0-11e8-8837-28603e6e8134.gif)
