### PR TITLE
Auto Email report limit can be set in site_config

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -12,7 +12,7 @@ from frappe.utils import now, global_date_format, format_time
 from frappe.utils.xlsxutils import make_xlsx
 from frappe.utils.csvutils import to_csv
 
-max_reports_per_user = 3
+max_reports_per_user = frappe.local.conf.max_reports_per_user or 3
 
 class AutoEmailReport(Document):
 	def autoname(self):


### PR DESCRIPTION
- Resolves #4934
- Set max_reports_per_user in site_config to an integer