### PR TITLE
Don't hide checkboxes in grid row after submission

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -171,8 +171,6 @@ frappe.ui.form.Grid = Class.extend({
 			// redraw
 			var _scroll_y = $(document).scrollTop();
 			this.make_head();
-			// to hide checkbox if grid is not editable
-			this.header_row && this.header_row.toggle_check();
 
 			if(!this.grid_rows) {
 				this.grid_rows = [];

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -121,8 +121,6 @@ frappe.ui.form.GridRow = Class.extend({
 		if(this.grid_form) {
 			this.grid_form.layout && this.grid_form.layout.refresh(this.doc);
 		}
-
-		this.toggle_check();
 	},
 	render_template: function() {
 		this.set_row_index();
@@ -596,11 +594,5 @@ frappe.ui.form.GridRow = Class.extend({
 	},
 	toggle_editable: function(fieldname, editable) {
 		this.set_field_property(fieldname, 'read_only', editable ? 0 : 1);
-	},
-	toggle_check: function() {
-		// to hide checkbox if grid is not editable
-		this.wrapper
-			.find('.grid-row-check')
-			.css("display", this.grid.is_editable()? 'block':'none');
 	}
 });


### PR DESCRIPTION
Reverts #4133

Check boxes in the Item table helps user to create a next transaction for the selected items only.

Issues: Once document is submitted, the check-boxes get's hidden. Hence user has to fetch all the items in the next transactions and delete items there.

To be fixed: In the child table, check boxes should be visible after the update as well.

Before:
<img width="926" alt="screen shot 2018-02-01 at 3 42 48 pm" src="https://user-images.githubusercontent.com/836784/35673121-9c119ea2-0766-11e8-9b64-48ddac3b5721.png">


After:
<img width="926" alt="screen shot 2018-02-01 at 3 40 01 pm" src="https://user-images.githubusercontent.com/836784/35673130-a1cc620a-0766-11e8-8e25-f29fa3596d61.png">
