### PR TITLE
[Fix] Link formatter, Indicator not showing in the item link field for stock entry

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -511,6 +511,10 @@ frappe.ui.form.Grid = Class.extend({
 					df.colsize = colsize;
 				}
 
+				if(df.fieldtype == 'Link' && !df.formatter) {
+					df.formatter = frappe.meta.docfield_map[df.parent][df.fieldname].formatter;
+				}
+
 				total_colsize += df.colsize;
 				if(total_colsize > 11)
 					return false;

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -510,9 +510,13 @@ frappe.ui.form.Grid = Class.extend({
 					}
 					df.colsize = colsize;
 				}
-
-				if(df.fieldtype == 'Link' && !df.formatter) {
-					df.formatter = frappe.meta.docfield_map[df.parent][df.fieldname].formatter;
+				
+				// attach formatter on refresh
+				if (df.fieldtype == 'Link' && !df.formatter) {
+					const docfield = frappe.meta.docfield_map[df.parent][df.fieldname];
+					if (docfield && docfield.formatter) {
+						df.formatter = docfield.formatter;
+					}
 				}
 
 				total_colsize += df.colsize;

--- a/frappe/public/js/legacy/client_script_helpers.js
+++ b/frappe/public/js/legacy/client_script_helpers.js
@@ -433,7 +433,7 @@ _f.Frm.prototype.set_indicator_formatter = function(fieldname, get_color, get_te
 		})
 	}
 
-	frappe.meta.get_docfield(doctype, fieldname, this.doc.name).formatter =
+	frappe.meta.docfield_map[doctype][fieldname].formatter =
 		function(value, df, options, doc) {
 			if(value) {
 				return repl('<a class="indicator %(color)s" href="#Form/%(doctype)s/%(name)s">%(label)s</a>', {


### PR DESCRIPTION
**Issue**
No color indicator showing in the item link
![screenshot-2018-1-19 manufacture - ste-e 00261](https://user-images.githubusercontent.com/8780500/35779419-a6c58334-09f2-11e8-8b04-d37f2cdef724.png)

**After Fix**
![fix_indicator_se_issue](https://user-images.githubusercontent.com/8780500/35799211-092a50de-0a8b-11e8-9c65-cf7f93ce733d.gif)



Fixed https://github.com/frappe/erpnext/issues/12413