### PR TITLE
[Fix] Visibility of close icon

### DIFF
--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -724,6 +724,7 @@ body[data-route^="Form/Communication"] textarea[data-fieldname="subject"] {
 }
 .frappe-control[data-fieldtype="Attach"] .attached-file .close {
   position: absolute;
+  opacity: 1;
   top: 0;
   right: 0;
 }


### PR DESCRIPTION
[#12756](https://github.com/frappe/erpnext/issues/12756)
![visibility_close](https://user-images.githubusercontent.com/17617465/35792775-c259ecf2-0a74-11e8-8f88-c1507c88332e.png)
