### PR TITLE
[Fix] Visibility of close icon

### DIFF
--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -724,6 +724,7 @@ body[data-route^="Form/Communication"] textarea[data-fieldname="subject"] {
 }
 .frappe-control[data-fieldtype="Attach"] .attached-file .close {
   position: absolute;
+  opacity: 1;
   top: 0;
   right: 0;
 }

--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -723,8 +723,8 @@ body[data-route^="Form/Communication"] textarea[data-fieldname="subject"] {
   margin-top: 5px;
 }
 .frappe-control[data-fieldtype="Attach"] .attached-file .close {
+  margin-right: -7px;
   position: absolute;
-  opacity: 1;
   top: 0;
   right: 0;
 }


### PR DESCRIPTION
[#12756](https://github.com/frappe/erpnext/issues/12756)
![closemargin](https://user-images.githubusercontent.com/17617465/35805952-cff4aaee-0aa3-11e8-960c-100da0fdf0a2.png)

