### PR TITLE
[fix] set doc.name as doc.__newname for prompt autoname

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -37,7 +37,8 @@ def set_new_name(doc):
 	else:
 		doc.run_method("autoname")
 
-	if not doc.name and autoname:
+		# to check doc.name in autoname.
+	if autoname:
 		if autoname.startswith('field:'):
 			fieldname = autoname[6:]
 			doc.name = (doc.get(fieldname) or "").strip()
@@ -50,6 +51,7 @@ def set_new_name(doc):
 			doc.name = make_autoname(autoname)
 		elif autoname.lower()=='prompt':
 			# set from __newname in save.py
+			doc.name = doc.__newname
 			if not doc.name:
 				frappe.throw(_("Name not set via prompt"))
 


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/12817

Before:
![1](https://user-images.githubusercontent.com/6947417/35955968-d1f46f5c-0cb8-11e8-9cf9-a97895e2ec5f.gif)

after:
![2](https://user-images.githubusercontent.com/6947417/35955982-dd1bbc5a-0cb8-11e8-88d8-88ea40dd08b9.gif)
