### PR TITLE
Responsive iframe

### DIFF
--- a/frappe/public/css/website.css
+++ b/frappe/public/css/website.css
@@ -1049,3 +1049,19 @@ li.footer-child-item {
 .post-description {
   margin: 15px 0;
 }
+.embed-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+}
+.embed-container iframe,
+.embed-container object,
+.embed-container embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/frappe/public/css/website.css
+++ b/frappe/public/css/website.css
@@ -1049,6 +1049,7 @@ li.footer-child-item {
 .post-description {
   margin: 15px 0;
 }
+/* added to make iframe responsive */
 .embed-container {
   position: relative;
   padding-bottom: 56.25%;

--- a/frappe/public/less/website.less
+++ b/frappe/public/less/website.less
@@ -766,3 +766,18 @@ margin-bottom: 3em;
 .post-description {
     margin: 15px 0;
 }
+
+.embed-container { 
+    position: relative; 
+    padding-bottom: 56.25%; 
+    height: 0; 
+    overflow: hidden; 
+    max-width: 100%; } 
+    
+.embed-container iframe, .embed-container object, .embed-container embed { 
+    position: absolute; 
+    top: 0; 
+    left: 0; 
+    width: 100%; 
+    height: 100%; 
+}

--- a/frappe/public/less/website.less
+++ b/frappe/public/less/website.less
@@ -767,6 +767,7 @@ margin-bottom: 3em;
     margin: 15px 0;
 }
 
+/* added to make iframe responsive */
 .embed-container { 
     position: relative; 
     padding-bottom: 56.25%; 


### PR DESCRIPTION
Currently, anything embedded in iframe in Frappe (blogs, docs) is not responsive at all. I've added css to make it more responsive.

**Note :iframe to be put inside ** : `<div class="embed-container"> </div>`

Screenshots:

Before:
![screen shot 2018-02-14 at 1 14 15 pm](https://user-images.githubusercontent.com/33246109/36192769-117e7a4e-1189-11e8-8f65-8cf1507fc5cc.png)

![screen shot 2018-02-14 at 1 15 19 pm](https://user-images.githubusercontent.com/33246109/36194935-a8174546-1191-11e8-902d-04b1cff08bee.png)


After:
![screen shot 2018-02-14 at 1 13 03 pm](https://user-images.githubusercontent.com/33246109/36192773-169f5d90-1189-11e8-9587-113bec8c8562.png)

![screen shot 2018-02-14 at 2 15 50 pm](https://user-images.githubusercontent.com/33246109/36194943-b0af00d6-1191-11e8-850b-987097a91664.png)




