### PR TITLE
handle IndexError for form_dict

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -128,8 +128,11 @@ def make_form_dict(request):
 	else:
 		args = request.form or request.args
 
-	frappe.local.form_dict = frappe._dict({ k:v[0] if isinstance(v, (list, tuple)) else v \
-		for k, v in iteritems(args) })
+	try:
+		frappe.local.form_dict = frappe._dict({ k:v[0] if isinstance(v, (list, tuple)) else v \
+			for k, v in iteritems(args) })
+	except IndexError:
+		frappe.local.form_dict = frappe._dict(args)
 
 	if "_" in frappe.local.form_dict:
 		# _ is passed by $.ajax so that the request is not cached by the browser. So, remove _ from form_dict


### PR DESCRIPTION
woocommerce request body has empty lists. it is causing IndexError while creating form_dict from args.
woocommerce request body
```
{
	u'code': u'onemore',
	u'date_modified_gmt': u'2018-02-15T07:56:45',
	u'maximum_amount': u'0.00',
	u'email_restrictions': [],
	u'individual_use': False,
	u'date_expires_gmt': u'2018-02-28T00:00:00',
	u'limit_usage_to_x_items': None,
	u'id': 12,
	u'free_shipping': True,
	u'discount_type': u'percent',
	u'usage_count': 0,
	u'minimum_amount': u'0.00',
	u'description': u'abcboom',
	u'used_by': [],
	u'exclude_sale_items': False,
	u'excluded_product_categories': [],
	u'date_expires': u'2018-02-28T00:00:00',
	u'meta_data': [],
	u'product_categories': [],
	u'date_created': u'2018-02-13T15:50:10',
	u'excluded_product_ids': [],
	u'usage_limit': None,
	u'date_modified': u'2018-02-15T07:56:45',
	u'date_created_gmt': u'2018-02-13T15:50:10',
	u'amount': u'10.00',
	u'product_ids': [],
	u'usage_limit_per_user': None
}
```
Related to https://github.com/frappe/erpnext/issues/12873