### PR TITLE
[fix] remove ifnull from get_max_email_uid fields

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -714,10 +714,10 @@ def get_max_email_uid(email_account):
 		"communication_medium": "Email",
 		"sent_or_received": "Received",
 		"email_account": email_account
-	}, fields=["ifnull(max(uid), 0) as uid"])
+	}, fields=["max(uid) as uid"])
 
 	if not result:
 		return 1
 	else:
-		max_uid = int(result[0].get("uid", 0)) + 1
+		max_uid = cint(result[0].get("uid", 0)) + 1
 		return max_uid


### PR DESCRIPTION
```
 File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/utils/background_jobs.py", line 95, in execute_job
    method(**kwargs)
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 704, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 247, in receive
    email_sync_rule = self.build_email_sync_rule()
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 586, in build_email_sync_rule
    max_uid = get_max_email_uid(self.name)
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 717, in get_max_email_uid
    }, fields=["ifnull(max(uid), 0) as uid"])
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/database.py", line 562, in get_all
    return frappe.get_all(*args, **kwargs)
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/__init__.py", line 1177, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/__init__.py", line 1150, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/model/db_query.py", line 88, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/model/db_query.py", line 100, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/model/db_query.py", line 116, in prepare_args
    self.sanitize_fields()
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/model/db_query.py", line 209, in sanitize_fields
    _raise_exception()
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/model/db_query.py", line 200, in _raise_exception
    frappe.throw(_('Cannot use sub-query or function in fields'), frappe.DataError)
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/__init__.py", line 323, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2018-02-15/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
DataError: Cannot use sub-query or function in fields
```