### PR TITLE
Allow dynamic link in route options

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -61,7 +61,7 @@ $.extend(frappe.model, {
 		if(frappe.route_options && !doc.parent) {
 			$.each(frappe.route_options, function(fieldname, value) {
 				var df = frappe.meta.has_field(doctype, fieldname);
-				if(df && in_list(['Link', 'Data', 'Select'], df.fieldtype) && !df.no_copy) {
+				if(df && in_list(['Link', 'Data', 'Select', 'Dynamic Link'], df.fieldtype) && !df.no_copy) {
 					doc[fieldname]=value;
 				}
 			});


### PR DESCRIPTION
We have used dynamic link in route options in the creation of [quality inspection](https://github.com/frappe/erpnext/blob/develop/erpnext/public/js/controllers/transaction.js#L193), but as dynamic link was not allowed, it's not working
