### PR TITLE
Skip files with bad file names when syncing help files

### DIFF
--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -237,7 +237,7 @@ class HelpDatabase(object):
 
 			# files not in index.txt
 			for f in os.listdir(path):
-				if not os.path.isdir(os.path.join(path, f)):
+				if not os.path.isdir(os.path.join(path, f)) and len(f.rsplit('.', 1)) == 2:
 					name, extn = f.rsplit('.', 1)
 					if name not in files \
 						and name != 'index' and extn in ('md', 'html'):


### PR DESCRIPTION
User can mistakenly give a bad file name like `filename`, `filename.md.html`, etc. Such files should be skipped by `make_index` function when syncing help files.

For example, if user forgets to add extension to file name you get
```(python)
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/tunde/bench-repo/dev/env/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/tunde/bench-repo/dev/env/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/tunde/bench-repo/dev/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tunde/bench-repo/dev/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tunde/bench-repo/dev/env/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/tunde/bench-repo/dev/env/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/tunde/bench-repo/dev/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/migrate.py", line 65, in migrate
    frappe.utils.help.sync()
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/utils/help.py", line 28, in sync
    help_db.build_index()
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/utils/help.py", line 224, in build_index
    self.make_index(data[0], data[1], data[2])
  File "/home/tunde/bench-repo/dev/apps/frappe/frappe/utils/help.py", line 242, in make_index
    name, extn = f.rsplit('.', 1)
ValueError: need more than 1 value to unpack
```