### PR TITLE
added yarn.lock to .gitignore to fix issue #5034

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ frappe/docs/current
 node_modules
 .kdev4/
 *.kdev4
-
+yarn.lock
 
 # Not Recommended, but will remove once webpack ready
 package-lock.json


### PR DESCRIPTION
This is to resolve the issue #5034 which requires a git reset after each yarn execution by adding the yarn.lock file (which is a local trace) to the ignore list.