### PR TITLE
[Fix] Adding Desktop Icons error

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/modules_select.js
+++ b/frappe/public/js/frappe/ui/toolbar/modules_select.js
@@ -63,7 +63,7 @@ frappe.ui.toolbar.ModulesSelect = class {
 									const user = r.message.user;
 									resolve(icons.map(icon => {
 										const uncheck = user ? icon.hidden : icon.blocked;
-										return { label: icon.value, value: icon.value, checked:!uncheck };
+										return { label: icon.value, value: icon.module_name, checked:!uncheck };
 									}));
 								}
 							});


### PR DESCRIPTION
Issue:- https://github.com/frappe/frappe/issues/5033
![add-icon-issue](https://user-images.githubusercontent.com/11695402/36413461-86d72a2e-1644-11e8-80d0-2d16b75cb4f2.gif)

Fix:-
![add-icon-fix](https://user-images.githubusercontent.com/11695402/36413462-884d97b2-1644-11e8-9855-73f3f92ffa82.gif)

Error arises when label and module_name of the icon aren't the same (for Tools, Developer, Human Resources )