### PR TITLE
[Hotfix] Expand All button configurable in treeview

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -29,6 +29,7 @@ frappe.views.TreeView = Class.extend({
 
 		this.opts = {};
 		this.opts.get_tree_root = true;
+		this.opts.show_expand_all = true;
 		$.extend(this.opts, opts);
 		this.doctype = opts.doctype;
 		this.args = {doctype: me.doctype};
@@ -70,9 +71,11 @@ frappe.views.TreeView = Class.extend({
 			"padding-bottom": "25px"
 		});
 
-		this.page.add_inner_button(__('Expand All'), function() {
-			me.tree.rootnode.load_all();
-		});
+		if(this.opts.show_expand_all) {
+			this.page.add_inner_button(__('Expand All'), function() {
+				me.tree.rootnode.load_all();
+			});
+		}
 
 		if(this.opts.view_template) {
 			var row = $('<div class="row"><div>').appendTo(this.page.main);


### PR DESCRIPTION
"Expand All" button configurable
Use case - In BOM, at a time there is only one bom node while its child nodes are that of items, hence expand_all would't work since it iterates recursively in the nodes finding expandable nodes of the same doctype. So need to disable the visibility of expand_al button for BOM

linked to - [ERPNext #13015](https://github.com/frappe/erpnext/pull/13015)