### PR TITLE
[Fix] Refresh only if timeline exists

### DIFF
--- a/frappe/public/js/frappe/form/footer/attachments.js
+++ b/frappe/public/js/frappe/form/footer/attachments.js
@@ -140,7 +140,7 @@ frappe.ui.form.Attachments = Class.extend({
 				}
 				me.remove_fileid(fileid);
 				me.frm.get_docinfo().communications.push(r.message);
-				me.frm.timeline.refresh();
+				me.frm.timeline && me.frm.timeline.refresh();
 				if (callback) callback();
 			}
 		});


### PR DESCRIPTION
Issue:
Error on rename tool
![refresh-rename-error](https://user-images.githubusercontent.com/17617465/36478426-aa92485e-172a-11e8-86e1-4687f757db27.gif)

Fix:
![refresh-rename-fix](https://user-images.githubusercontent.com/17617465/36478427-aac4b050-172a-11e8-9528-98ed6123fd07.gif)
