### PR TITLE
Commonification of number feature in trees

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -1012,8 +1012,8 @@ _f.Frm.prototype.show_update_number_field = function() {
 	var me = this;
 	
 	if(!this.doc.__islocal && (frappe.get_meta(me.doctype).fields.filter(function(fld) {
-			return (fld.fieldname == "lft" || fld.fieldname == "rgt" || fld.fieldname == frappe.scrub(me.doctype+" number"));
-		}).length == 3)) {
+		return (fld.fieldname == "lft" || fld.fieldname == "rgt" || fld.fieldname == frappe.scrub(me.doctype+" number"));
+	}).length == 3)) {
 		this.add_custom_button(__('Update ' + me.doctype + ' Number'), function() {
 			var d = new frappe.ui.Dialog({
 				title: __('Update ' + me.doctype + ' Number'),

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -1008,14 +1008,13 @@ _f.Frm.prototype.scroll_to_element = function() {
 	}
 };
 _f.Frm.prototype.show_update_number_field = function() {
-	 
-	 var me = this;
 	
-	if(!this.doc.__islocal && (frappe.get_meta(me.doctype).fields.filter(function(fld){ 
-  		return (fld.fieldname == "lft" || fld.fieldname == "rgt" || fld.fieldname == frappe.scrub(me.doctype+" number"))}).length == 3)) {		
-		this.add_custom_button(__('Update '+me.doctype+' Number'), function () {
+	var me = this;
+	
+	if(!this.doc.__islocal && (frappe.get_meta(me.doctype).fields.filter(function(fld){ return (fld.fieldname == "lft" || fld.fieldname == "rgt" || fld.fieldname == frappe.scrub(me.doctype+" number"));}).length == 3)) {		
+		this.add_custom_button(__('Update ' + me.doctype + ' Number'), function() {
 			var d = new frappe.ui.Dialog({
-				title: __('Update '+me.doctype+' Number'),
+				title: __('Update ' + me.doctype + ' Number'),
 				fields: [
 					{
 						"label": me.doctype+' Number',

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -466,6 +466,7 @@ _f.Frm.prototype.refresh = function(docname) {
 
 		this.show_if_needs_refresh();
 	}
+	
 };
 
 _f.Frm.prototype.show_if_needs_refresh = function() {
@@ -498,6 +499,8 @@ _f.Frm.prototype.render_form = function(is_a_different_doc) {
 		// header must be refreshed before client methods
 		// because add_custom_button
 		this.refresh_header(is_a_different_doc);
+
+		this.show_update_number_field();
 
 		// call trigger
 		this.script_manager.trigger("refresh");
@@ -920,6 +923,7 @@ _f.Frm.prototype.set_footnote = function(txt) {
 
 _f.Frm.prototype.add_custom_button = function(label, fn, group) {
 	// temp! old parameter used to be icon
+	// console.log("label:"+label+" fn:"+fn+" group:"+group);
 	if(group && group.indexOf("fa fa-")!==-1) group = null;
 	var btn = this.page.add_inner_button(label, fn, group);
 	this.custom_buttons[label] = btn;
@@ -1003,3 +1007,56 @@ _f.Frm.prototype.scroll_to_element = function() {
 		}
 	}
 };
+_f.Frm.prototype.show_update_number_field = function() {
+	 
+	 var me = this;
+	
+	if(!this.doc.__islocal && (frappe.get_meta(me.doctype).fields.filter(function(fld){ 
+  		return (fld.fieldname == "lft" || fld.fieldname == "rgt" || fld.fieldname == frappe.scrub(me.doctype+" number"))}).length == 3)) {		
+		this.add_custom_button(__('Update '+me.doctype+' Number'), function () {
+			var d = new frappe.ui.Dialog({
+				title: __('Update '+me.doctype+' Number'),
+				fields: [
+					{
+						"label": me.doctype+' Number',
+						"fieldname": frappe.scrub(me.doctype+" number"),
+						"fieldtype": "Data",
+						"reqd": 1
+					}
+				],
+				primary_action: function() {
+		
+					var data = d.get_values();
+					if(data[frappe.scrub(me.doctype+" number")] === me.doc[frappe.scrub(me.doctype+" number")]) {
+						d.hide();
+						return;
+					}
+
+					frappe.call({
+						method: "frappe.utils.nestedset.update_number_field",
+						args: {
+							doctype_name: me.doc.doctype,
+							name: me.doc.name,
+							field_name: d.fields[0].fieldname,
+							field_value: data[frappe.scrub(me.doctype+" number")]
+						},
+						callback: function(r) {
+							if(!r.exc) {
+								if(r.message) {
+									frappe.set_route("Form", me.doctype, r.message);
+								} else {
+									me.set_value(frappe.scrub(me.doctype+" number"), data[frappe.scrub(me.doctype+" number")]);
+								}
+								d.hide();
+							}
+						}
+					});
+				},
+				primary_action_label: __('Update')
+			});
+			d.show();
+		});
+	}
+	
+};
+

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -1011,14 +1011,16 @@ _f.Frm.prototype.show_update_number_field = function() {
 	
 	var me = this;
 	
-	if(!this.doc.__islocal && (frappe.get_meta(me.doctype).fields.filter(function(fld){ return (fld.fieldname == "lft" || fld.fieldname == "rgt" || fld.fieldname == frappe.scrub(me.doctype+" number"));}).length == 3)) {		
+	if(!this.doc.__islocal && (frappe.get_meta(me.doctype).fields.filter(function(fld) {
+			return (fld.fieldname == "lft" || fld.fieldname == "rgt" || fld.fieldname == frappe.scrub(me.doctype+" number"));
+		}).length == 3)) {
 		this.add_custom_button(__('Update ' + me.doctype + ' Number'), function() {
 			var d = new frappe.ui.Dialog({
 				title: __('Update ' + me.doctype + ' Number'),
 				fields: [
 					{
 						"label": me.doctype+' Number',
-						"fieldname": frappe.scrub(me.doctype+" number"),
+						"fieldname": frappe.scrub(me.doctype+" Number"),
 						"fieldtype": "Data",
 						"reqd": 1
 					}

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -13,8 +13,8 @@
 from __future__ import unicode_literals
 
 import frappe
-from frappe import _ 
-from frappe.model.document import Document 
+from frappe import _
+from frappe.model.document import Document
 from frappe.utils import now,cstr
 
 class NestedSetRecursionError(frappe.ValidationError): pass
@@ -220,7 +220,7 @@ class NestedSet(Document):
 	def after_rename(self, olddn, newdn, merge=False):
 		if not merge:
 			new_tree_node = frappe.db.get_value(self.doctype, newdn, [frappe.scrub(self.doctype)+"_name", frappe.scrub(self.doctype)+"_number"], as_dict=1)
-			
+
 			# exclude company abbr
 			new_parts = newdn.split(" - ")[:-1]
 			# update node number and remove from parts
@@ -300,7 +300,7 @@ def validate_field_number(doctype_name, name, field_value, company, field_name):
 @frappe.whitelist()
 def update_number_field(doctype_name, name, field_name, field_value):
 
-	field_key = frappe.scrub(doctype_name)+"_name" 
+	field_key = frappe.scrub(doctype_name)+"_name"
 	doc_details = frappe.db.get_value(doctype_name, name, [field_key, "company"], as_dict=True)
 
 	validate_field_number(doctype_name, name, field_value, doc_details.company, field_name)

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -13,9 +13,9 @@
 from __future__ import unicode_literals
 
 import frappe
-from frappe import _
-from frappe.model.document import Document
-from frappe.utils import now
+from frappe import _ 
+from frappe.model.document import Document 
+from frappe.utils import now,cstr
 
 class NestedSetRecursionError(frappe.ValidationError): pass
 class NestedSetMultipleRootsError(frappe.ValidationError): pass
@@ -218,6 +218,25 @@ class NestedSet(Document):
 				frappe.throw(_("Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"), NestedSetInvalidMergeError)
 
 	def after_rename(self, olddn, newdn, merge=False):
+		if not merge:
+			new_tree_node = frappe.db.get_value(self.doctype, newdn, [frappe.scrub(self.doctype)+"_name", frappe.scrub(self.doctype)+"_number"], as_dict=1)
+			
+			# exclude company abbr
+			new_parts = newdn.split(" - ")[:-1]
+			# update node number and remove from parts
+			if new_parts[0][0].isdigit():
+				# if  node number is separate by space, split using space
+				if len(new_parts) == 1:
+					new_parts = newdn.split("-")
+				if new_tree_node[frappe.scrub(self.doctype)+"_number"] != new_parts[0]:
+					self.db_set(frappe.scrub(self.doctype)+"_number", new_parts[0])
+				new_parts = new_parts[1:]
+
+			# update node name
+			node_name = " - ".join(new_parts)
+			if new_tree_node[frappe.scrub(self.doctype)+"_name"] != node_name:
+				self.db_set(frappe.scrub(self.doctype)+"_name", node_name)
+
 		if not self.nsm_parent_field:
 			parent_field = "parent_" + self.doctype.replace(" ", "_").lower()
 		else:
@@ -258,3 +277,46 @@ def get_ancestors_of(doctype, name):
 	result = frappe.db.sql_list("""select name from `tab{0}`
 		where lft<%s and rgt>%s order by lft desc""".format(doctype), (lft, rgt))
 	return result or []
+
+def get_doc_name_autoname(field_value, doc_title, company):
+	# first validate if company exists
+	company = frappe.db.get_value("Company", company, ["abbr", "name"], as_dict=True)
+	if not company:
+		frappe.throw(_('Company {0} does not exist').format(company))
+
+	parts = [doc_title.strip(), company.abbr]
+	if cstr(field_value).strip():
+		parts.insert(0, cstr(field_value).strip())
+	return ' - '.join(parts)
+
+def validate_field_number(doctype_name, name, field_value, company, field_name):
+	if field_value:
+		doctype_with_same_number = frappe.db.get_value(doctype_name,
+			{field_name: field_value, "company": company, "name": ["!=", name]})
+		if doctype_with_same_number:
+			frappe.throw(_("{0} Number {1} already used in account {2}")
+				.format(doctype_name, field_value, doctype_with_same_number))
+
+@frappe.whitelist()
+def update_number_field(doctype_name, name, field_name, field_value):
+
+	field_key = frappe.scrub(doctype_name)+"_name" 
+	doc_details = frappe.db.get_value(doctype_name, name, [field_key, "company"], as_dict=True)
+
+	validate_field_number(doctype_name, name, field_value, doc_details.company, field_name)
+
+	frappe.db.set_value(doctype_name, name, field_name, field_value)
+
+	doc_title = doc_details[field_key]
+	if doc_title[0].isdigit():
+		separator = " - " if " - " in doc_title else " "
+		doc_title = doc_title.split(separator, 1)[1]
+
+	frappe.db.set_value(doctype_name, name, field_key, doc_title)
+
+	new_name = get_doc_name_autoname(field_value, doc_title, doc_details.company)
+
+	if name != new_name:
+		frappe.rename_doc(doctype_name, name, new_name)
+		return new_name
+	


### PR DESCRIPTION
A proposed solution for commonification of number feature in trees which also solves https://github.com/frappe/erpnext/pull/11291 and works fine for existing Account number feature in Account Tree.

**Brief:** 
Updated nestedset.py and form.js in such a way that if you add a field with the naming convention _" Doctype + Number "_  in every tree that has _'lft'_ and _'rgt'_ fields in it, it will be able to show an additional button to add/update the number.

**Cost Center and Warehouse Tree:**
![tree1](https://user-images.githubusercontent.com/33081409/36545442-e46a2648-180e-11e8-8f99-07595acc3ebe.gif)

**Account Tree:**
![tree2](https://user-images.githubusercontent.com/33081409/36545474-f4d01204-180e-11e8-8ef4-70f859de6587.gif)
