### PR TITLE
[minor] Hide add new row button if cannot_add_rows is enabled in df

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -234,7 +234,7 @@ frappe.ui.form.Grid = Class.extend({
 			this.wrapper.find(".grid-footer").toggle(true);
 
 			// show, hide buttons to add rows
-			if(this.cannot_add_rows) {
+			if(this.cannot_add_rows || (this.df && this.df.cannot_add_rows)) {
 				// add 'hide' to buttons
 				this.wrapper.find(".grid-add-row, .grid-add-multiple-rows")
 					.addClass('hide');


### PR DESCRIPTION
**Before**
![screen shot 2018-02-28 at 1 47 40 am](https://user-images.githubusercontent.com/8780500/36752798-2bc05084-1c2a-11e8-8b01-42d624bb7c1e.png)

**After**
![screen shot 2018-02-28 at 1 48 05 am](https://user-images.githubusercontent.com/8780500/36752722-eb777372-1c29-11e8-858c-16a893dba8ef.png)


