### PR TITLE
global clear cache fix

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -52,7 +52,7 @@ def clear_cache(user=None):
 def clear_global_cache():
 	frappe.model.meta.clear_cache()
 	frappe.cache().delete_value(["app_hooks", "installed_apps",
-		"app_modules", "module_app", "notification_config", 'system_settings'
+		"app_modules", "module_app", "notification_config", 'system_settings',
 		'scheduler_events', 'time_zone', 'webhooks', 'active_domains', 'active_modules'])
 	frappe.setup_module_map()
 


### PR DESCRIPTION
A comma was missing from the list of keys for the deletion of cache in clear_global_cache().
This used to skip the deletion of cached values of `system_settings` & `scheduler_events` due to the concatenation of `system_settings` & `scheduler_events` to `system_settingsscheduler_events`.