### PR TITLE
smtplib login expects strings for username and password

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -191,8 +191,7 @@ class SMTPServer:
 				self._sess.ehlo()
 
 			if self.login and self.password:
-				ret = self._sess.login((self.login or "").encode('utf-8'),
-					(self.password or "").encode('utf-8'))
+				ret = self._sess.login((self.login or ""), (self.password or ""))
 
 				# check if logged correctly
 				if ret[0]!=235:

--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -98,7 +98,7 @@ def get_static_file_response():
 		raise NotFound
 
 	response = Response(wrap_file(frappe.local.request.environ, f), direct_passthrough=True)
-	response.mimetype = mimetypes.guess_type(frappe.flags.file_path)[0] or b'application/octet-stream'
+	response.mimetype = mimetypes.guess_type(frappe.flags.file_path)[0] or 'application/octet-stream'
 	return response
 
 def build_response(path, data, http_status_code, headers=None):


### PR DESCRIPTION
It seems like there could be a considerable number of hidden gotcha's ever since the transition from Python 2.7 to Python 3.5.