### PR TITLE
[Minor] Allow Column-Break & Section-Break without label from Customize form

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -14,6 +14,8 @@ class CustomField(Document):
 		self.name = self.dt + "-" + self.fieldname
 
 	def set_fieldname(self):
+		if self.fieldtype in ["Section Break", "Column Break"]:
+			self.fieldname = self.fieldtype.lower().replace(" ","_") + "_" + str(self.idx)
 		if not self.fieldname:
 			if not self.label:
 				frappe.throw(_("Label is mandatory"))


### PR DESCRIPTION
Issue:- https://github.com/frappe/frappe/issues/5122
![issue-customize](https://user-images.githubusercontent.com/11695402/37075077-088ceb50-21f6-11e8-9274-3db8f42092a5.gif)

Fix:- 
![fix-customize](https://user-images.githubusercontent.com/11695402/37075078-0a04af2c-21f6-11e8-9db7-6d318214eb29.gif)

