### PR TITLE
[hotfix] checkbox alignment

### DIFF
--- a/frappe/public/css/desk.css
+++ b/frappe/public/css/desk.css
@@ -970,6 +970,15 @@ li.user-progress .progress-bar {
 .note-editor.note-frame .note-editing-area .note-editable {
   color: #36414C;
 }
+.checkbox label {
+  padding-left: 0px;
+}
+.checkbox input[type=checkbox] {
+  margin-right: 5px;
+  margin-left: 0px;
+  position: relative;
+  height: 12px;
+}
 input[type="checkbox"] {
   position: relative;
   height: 16px;

--- a/frappe/public/css/form.css
+++ b/frappe/public/css/form.css
@@ -537,8 +537,9 @@ h6.uppercase,
 }
 .disabled-check {
   color: #f5f7fa;
-  margin-right: 3px;
+  margin-right: 5px;
   margin-bottom: -2px;
+  margin-left: 20px;
 }
 .like-disabled-input.for-description {
   font-weight: normal;
@@ -723,7 +724,6 @@ body[data-route^="Form/Communication"] textarea[data-fieldname="subject"] {
   margin-top: 5px;
 }
 .frappe-control[data-fieldtype="Attach"] .attached-file .close {
-  margin-right: -7px;
   position: absolute;
   top: 0;
   right: 0;

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -894,6 +894,17 @@ li.user-progress {
 	color: @text-color;
 }
 
+.checkbox label {
+	padding-left: 0px;
+}
+
+.checkbox input[type=checkbox] {
+	margin-right: 5px;
+	margin-left: 0px;
+	position: relative;
+	height: 12px;
+}
+
 // custom font awesome checkbox
 input[type="checkbox"] {
 	position: relative;

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -671,8 +671,9 @@ h6.uppercase, .h6.uppercase {
 
 .disabled-check {
 	color: @navbar-bg;
-	margin-right: 3px;
+	margin-right: 5px;
 	margin-bottom: -2px;
+	margin-left: 20px;
 }
 
 .like-disabled-input.for-description {


### PR DESCRIPTION
Seems, there was a bit of separate style handling for active and inactive checboxes 

Firefox:

<img width="874" alt="screen shot 2018-03-08 at 12 56 20 pm" src="https://user-images.githubusercontent.com/5196925/37138668-03cffffe-22d1-11e8-98df-8226ceef4815.png">
<img width="996" alt="screen shot 2018-03-08 at 12 56 35 pm" src="https://user-images.githubusercontent.com/5196925/37138670-052011dc-22d1-11e8-9777-3f685c6a7dde.png">


Chrome:
<img width="939" alt="screen shot 2018-03-08 at 12 56 51 pm" src="https://user-images.githubusercontent.com/5196925/37138675-08901164-22d1-11e8-9125-b0e232127523.png">
<img width="939" alt="screen shot 2018-03-08 at 12 59 07 pm" src="https://user-images.githubusercontent.com/5196925/37138677-0a09d8ea-22d1-11e8-8a81-85f434ab2dbd.png">
