### PR TITLE
Moving after_install to occur after fixtures and customizations install

### DIFF
--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -299,7 +299,7 @@ $.extend(frappe.desktop, {
 				// sum all doctypes for a module
 				for (var j=0, k=module_doctypes.length; j < k; j++) {
 					var doctype = module_doctypes[j];
-					var count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
+					let count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
 					count = typeof count == "string" ? parseInt(count) : count;
 					sum += count;
 				}
@@ -308,7 +308,7 @@ $.extend(frappe.desktop, {
 			if(frappe.boot.notification_info.open_count_doctype
 				&& frappe.boot.notification_info.open_count_doctype[module.module_name]!=null) {
 				// notification count explicitly for doctype
-				var count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
+				let count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
 				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}
@@ -316,7 +316,7 @@ $.extend(frappe.desktop, {
 			if(frappe.boot.notification_info.open_count_module
 				&& frappe.boot.notification_info.open_count_module[module.module_name]!=null) {
 				// notification count explicitly for module
-				var count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
+				let count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
 				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -300,7 +300,7 @@ $.extend(frappe.desktop, {
 				for (var j=0, k=module_doctypes.length; j < k; j++) {
 					var doctype = module_doctypes[j];
 					var count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
-					var count = typeof count == "string" ? parseInt(count) : count;
+					count = typeof count == "string" ? parseInt(count) : count;
 					sum += count;
 				}
 			}
@@ -309,7 +309,7 @@ $.extend(frappe.desktop, {
 				&& frappe.boot.notification_info.open_count_doctype[module.module_name]!=null) {
 				// notification count explicitly for doctype
 				var count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
-				var count = typeof count == "string" ? parseInt(count) : count;
+				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}
 			
@@ -317,7 +317,7 @@ $.extend(frappe.desktop, {
 				&& frappe.boot.notification_info.open_count_module[module.module_name]!=null) {
 				// notification count explicitly for module
 				var count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
-				var count = typeof count == "string" ? parseInt(count) : count;
+				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}
 

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -294,23 +294,31 @@ $.extend(frappe.desktop, {
 			var module_doctypes = frappe.boot.notification_info.module_doctypes[module.module_name];
 
 			var sum = 0;
-			if(module_doctypes) {
-				if(frappe.boot.notification_info.open_count_doctype) {
-					// sum all doctypes for a module
-					for (var j=0, k=module_doctypes.length; j < k; j++) {
-						var doctype = module_doctypes[j];
-						sum += (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
-					}
+			
+			if(module_doctypes && frappe.boot.notification_info.open_count_doctype) {
+				// sum all doctypes for a module
+				for (var j=0, k=module_doctypes.length; j < k; j++) {
+					var doctype = module_doctypes[j];
+					var count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
+					var count = typeof count == "string" ? parseInt(count) : count;
+					sum += count;
 				}
-			} else if(frappe.boot.notification_info.open_count_doctype
+			}
+			
+			if(frappe.boot.notification_info.open_count_doctype
 				&& frappe.boot.notification_info.open_count_doctype[module.module_name]!=null) {
 				// notification count explicitly for doctype
-				sum = frappe.boot.notification_info.open_count_doctype[module.module_name];
-
-			} else if(frappe.boot.notification_info.open_count_module
+				var count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
+				var count = typeof count == "string" ? parseInt(count) : count;
+				sum += count;
+			}
+			
+			if(frappe.boot.notification_info.open_count_module
 				&& frappe.boot.notification_info.open_count_module[module.module_name]!=null) {
 				// notification count explicitly for module
-				sum = frappe.boot.notification_info.open_count_module[module.module_name];
+				var count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
+				var count = typeof count == "string" ? parseInt(count) : count;
+				sum += count;
 			}
 
 			// if module found

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -153,7 +153,7 @@ def install_app(name, verbose=False, set_as_patched=True):
 
 	sync_fixtures(name)
 	sync_customizations(name)
-    
+
 	for after_install in app_hooks.after_install or []:
 		frappe.get_attr(after_install)()
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -151,11 +151,11 @@ def install_app(name, verbose=False, set_as_patched=True):
 	if set_as_patched:
 		set_all_patches_as_completed(name)
 
-	for after_install in app_hooks.after_install or []:
-		frappe.get_attr(after_install)()
-
 	sync_fixtures(name)
 	sync_customizations(name)
+    
+	for after_install in app_hooks.after_install or []:
+		frappe.get_attr(after_install)()
 
 	frappe.flags.in_install = False
 

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -535,7 +535,10 @@ frappe.get_module = function(m, default_module) {
 	if (!module.link) module.link = "";
 
 	if (!module._id) {
-		module._id = module.link.toLowerCase().replace("/", "-").replace(' ', '-');
+		// links can have complex values that range beyond simple plain text names, and so do not make for robust IDs.
+		// an example from python: "link": r"javascript:eval('window.open(\'timetracking\', \'_self\')')"
+		// this snippet allows a module to open a custom html page in the same window.
+		module._id = module.module_name.toLowerCase();
 	}
 
 


### PR DESCRIPTION
"after_install" was being called prior to fixtures that a module depends on gets installed, which makes after_install incapable of working with those doctypes. This is particularly frustrating because there is not an "after_install_with_fixtures_and_customizations" hook...