### PR TITLE
Adding sync_hook, and fixing notifications for 'for_module'.

### DIFF
--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -299,7 +299,7 @@ $.extend(frappe.desktop, {
 				// sum all doctypes for a module
 				for (var j=0, k=module_doctypes.length; j < k; j++) {
 					var doctype = module_doctypes[j];
-					var count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
+					let count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
 					count = typeof count == "string" ? parseInt(count) : count;
 					sum += count;
 				}
@@ -308,7 +308,7 @@ $.extend(frappe.desktop, {
 			if(frappe.boot.notification_info.open_count_doctype
 				&& frappe.boot.notification_info.open_count_doctype[module.module_name]!=null) {
 				// notification count explicitly for doctype
-				var count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
+				let count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
 				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}
@@ -316,7 +316,7 @@ $.extend(frappe.desktop, {
 			if(frappe.boot.notification_info.open_count_module
 				&& frappe.boot.notification_info.open_count_module[module.module_name]!=null) {
 				// notification count explicitly for module
-				var count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
+				let count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
 				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -300,7 +300,7 @@ $.extend(frappe.desktop, {
 				for (var j=0, k=module_doctypes.length; j < k; j++) {
 					var doctype = module_doctypes[j];
 					var count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
-					var count = typeof count == "string" ? parseInt(count) : count;
+					count = typeof count == "string" ? parseInt(count) : count;
 					sum += count;
 				}
 			}
@@ -309,7 +309,7 @@ $.extend(frappe.desktop, {
 				&& frappe.boot.notification_info.open_count_doctype[module.module_name]!=null) {
 				// notification count explicitly for doctype
 				var count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
-				var count = typeof count == "string" ? parseInt(count) : count;
+				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}
 			
@@ -317,7 +317,7 @@ $.extend(frappe.desktop, {
 				&& frappe.boot.notification_info.open_count_module[module.module_name]!=null) {
 				// notification count explicitly for module
 				var count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
-				var count = typeof count == "string" ? parseInt(count) : count;
+				count = typeof count == "string" ? parseInt(count) : count;
 				sum += count;
 			}
 

--- a/frappe/core/page/desktop/desktop.js
+++ b/frappe/core/page/desktop/desktop.js
@@ -294,23 +294,31 @@ $.extend(frappe.desktop, {
 			var module_doctypes = frappe.boot.notification_info.module_doctypes[module.module_name];
 
 			var sum = 0;
-			if(module_doctypes) {
-				if(frappe.boot.notification_info.open_count_doctype) {
-					// sum all doctypes for a module
-					for (var j=0, k=module_doctypes.length; j < k; j++) {
-						var doctype = module_doctypes[j];
-						sum += (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
-					}
+			
+			if(module_doctypes && frappe.boot.notification_info.open_count_doctype) {
+				// sum all doctypes for a module
+				for (var j=0, k=module_doctypes.length; j < k; j++) {
+					var doctype = module_doctypes[j];
+					var count = (frappe.boot.notification_info.open_count_doctype[doctype] || 0);
+					var count = typeof count == "string" ? parseInt(count) : count;
+					sum += count;
 				}
-			} else if(frappe.boot.notification_info.open_count_doctype
+			}
+			
+			if(frappe.boot.notification_info.open_count_doctype
 				&& frappe.boot.notification_info.open_count_doctype[module.module_name]!=null) {
 				// notification count explicitly for doctype
-				sum = frappe.boot.notification_info.open_count_doctype[module.module_name];
-
-			} else if(frappe.boot.notification_info.open_count_module
+				var count = frappe.boot.notification_info.open_count_doctype[module.module_name] || 0;
+				var count = typeof count == "string" ? parseInt(count) : count;
+				sum += count;
+			}
+			
+			if(frappe.boot.notification_info.open_count_module
 				&& frappe.boot.notification_info.open_count_module[module.module_name]!=null) {
 				// notification count explicitly for module
-				sum = frappe.boot.notification_info.open_count_module[module.module_name];
+				var count = frappe.boot.notification_info.open_count_module[module.module_name] || 0;
+				var count = typeof count == "string" ? parseInt(count) : count;
+				sum += count;
 			}
 
 			// if module found

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -153,7 +153,7 @@ def install_app(name, verbose=False, set_as_patched=True):
 
 	sync_fixtures(name)
 	sync_customizations(name)
-    
+
 	for after_install in app_hooks.after_install or []:
 		frappe.get_attr(after_install)()
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -151,11 +151,11 @@ def install_app(name, verbose=False, set_as_patched=True):
 	if set_as_patched:
 		set_all_patches_as_completed(name)
 
-	for after_install in app_hooks.after_install or []:
-		frappe.get_attr(after_install)()
-
 	sync_fixtures(name)
 	sync_customizations(name)
+    
+	for after_install in app_hooks.after_install or []:
+		frappe.get_attr(after_install)()
 
 	frappe.flags.in_install = False
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -158,7 +158,7 @@ def install_app(name, verbose=False, set_as_patched=True):
 	sync_customizations(name)
 
 	for after_sync in app_hooks.after_sync or []:
-		frappe.get_attr(after_sync)()
+		frappe.get_attr(after_sync)() #
 
 	frappe.flags.in_install = False
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -151,11 +151,14 @@ def install_app(name, verbose=False, set_as_patched=True):
 	if set_as_patched:
 		set_all_patches_as_completed(name)
 
+	for after_install in app_hooks.after_install or []:
+		frappe.get_attr(after_install)()
+
 	sync_fixtures(name)
 	sync_customizations(name)
 
-	for after_install in app_hooks.after_install or []:
-		frappe.get_attr(after_install)()
+	for after_sync in app_hooks.after_sync or []:
+		frappe.get_attr(after_sync)()
 
 	frappe.flags.in_install = False
 
@@ -361,10 +364,10 @@ def check_if_ready_for_barracuda():
 		if mariadb_variables.get(key) != value:
 			site = frappe.local.site
 			msg = ("Creation of your site - {x} failed because MariaDB is not properly {sep}"
-			       "configured to use the Barracuda storage engine. {sep}"
-			       "Please add the settings below to MariaDB's my.cnf, restart MariaDB then {sep}"
-			       "run `bench new-site {x}` again.{sep2}"
-			       "").format(x=site, sep2="\n"*2, sep="\n")
+				   "configured to use the Barracuda storage engine. {sep}"
+				   "Please add the settings below to MariaDB's my.cnf, restart MariaDB then {sep}"
+				   "run `bench new-site {x}` again.{sep2}"
+				   "").format(x=site, sep2="\n"*2, sep="\n")
 
 			print_db_config(msg, expected_config_for_barracuda)
 			raise frappe.exceptions.ImproperDBConfigurationError(

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -535,7 +535,10 @@ frappe.get_module = function(m, default_module) {
 	if (!module.link) module.link = "";
 
 	if (!module._id) {
-		module._id = module.link.toLowerCase().replace("/", "-").replace(' ', '-');
+		// links can have complex values that range beyond simple plain text names, and so do not make for robust IDs.
+		// an example from python: "link": r"javascript:eval('window.open(\'timetracking\', \'_self\')')"
+		// this snippet allows a module to open a custom html page in the same window.
+		module._id = module.module_name.toLowerCase();
 	}
 
 


### PR DESCRIPTION
Related to: https://github.com/frappe/frappe/pull/5156

The "after_install" hook was being called before "sync_fixtures" and "sync_customizations". "after_sync" has been added per request from @rmehta 

Notifications using "from_module" designation previously did not work. There's two reasons for this. First, the calculation for summing notifications was exclusively choosing the notifications counts from doctype, and not using the total sum to include modules. Second, the default "_id" for a module was being automatically set to the "link" of a module. This is an issue because module links can actually contain JS (which allow them to open there pages in the same window, for example). Because of this, they do not make for good identifiers. This fix uses the toLowerCase of the module_name as the default module _id.