### PR TITLE
[ Fix ] Gantt view issue

### DIFF
--- a/frappe/public/js/frappe/views/gantt/gantt_view.js
+++ b/frappe/public/js/frappe/views/gantt/gantt_view.js
@@ -7,7 +7,11 @@ frappe.views.GanttView = class GanttView extends frappe.views.ListView {
 		this.view_name = 'Gantt';
 		this.page_title = this.page_title + ' ' + __('Gantt');
 		this.calendar_settings = frappe.views.calendar[this.doctype] || {};
-		this.order_by = this.view_user_settings.order_by || this.calendar_settings.field_map.start + ' asc';
+		if(this.calendar_settings.order_by) {
+			this.order_by = this.calendar_settings.order_by + ' asc';
+		} else {
+			this.order_by = this.view_user_settings.order_by || this.calendar_settings.field_map.start + ' asc';
+		}
 	}
 
 	setup_view() {


### PR DESCRIPTION
Make order_by configurable.

Right now it either picks it up from user_settings or from the field_map start.
But in case of Course Schedule, the `start` is set as something that is not its docfield and hence the gantt-view fails to render throwing an error in order_by clause.

related to - https://github.com/frappe/erpnext/pull/13338