### PR TITLE
Minor fix in autonaming

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -47,7 +47,7 @@ def set_new_name(doc):
 		if autoname.startswith("naming_series:"):
 			set_name_by_naming_series(doc)
 		elif "#" in autoname:
-			doc.name = make_autoname(autoname)
+			doc.name = make_autoname(autoname, doc=doc)
 		elif autoname.lower()=='prompt':
 			# set from __newname in save.py
 			if not doc.name:


### PR DESCRIPTION
If naming series of Sales Order is like "SO-.customer_name.-.####", now it will pick customer_name from the form.

<img width="1176" alt="screen shot 2018-03-22 at 12 18 55 pm" src="https://user-images.githubusercontent.com/836784/37755400-509a709e-2dcb-11e8-96f8-61a48ff9d098.png">
