### PR TITLE
[Hotfix] File upload fix

### DIFF
--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -297,6 +297,7 @@ frappe.upload = {
 			upload_with_filedata();
 			return;
 		} else {
+			args.file_size = fileobj.size;
 			frappe.call({
 				method: 'frappe.utils.file_manager.validate_filename',
 				async: false,

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -300,32 +300,34 @@ frappe.upload = {
 			args.file_size = fileobj.size;
 			frappe.call({
 				method: 'frappe.utils.file_manager.validate_filename',
-				async: false,
 				args: {"filename": args.filename},
 				callback: function(r) {
 					args.filename = r.message;
+					upload_through_socketio();
 				}
 			});
 		}
 
-		frappe.socketio.uploader.start({
-			file: fileobj,
-			filename: args.filename,
-			is_private: args.is_private,
-			fallback: () => {
-				// if fails, use old filereader
-				upload_with_filedata();
-			},
-			callback: (data) => {
-				args.file_url = data.file_url;
-				frappe.upload._upload_file(fileobj, args, opts);
-			},
-			on_progress: (percent_complete) => {
-				let increment = (flt(percent_complete) / frappe.upload.total_files);
-				frappe.show_progress(__('Uploading'),
-					start_complete + increment);
-			}
-		});
+		var upload_through_socketio = function() {
+			frappe.socketio.uploader.start({
+				file: fileobj,
+				filename: args.filename,
+				is_private: args.is_private,
+				fallback: () => {
+					// if fails, use old filereader
+					upload_with_filedata();
+				},
+				callback: (data) => {
+					args.file_url = data.file_url;
+					frappe.upload._upload_file(fileobj, args, opts);
+				},
+				on_progress: (percent_complete) => {
+					let increment = (flt(percent_complete) / frappe.upload.total_files);
+					frappe.show_progress(__('Uploading'),
+						start_complete + increment);
+				}
+			});
+		}
 	},
 
 	upload_to_server: function(file, args, opts) {

--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -296,6 +296,15 @@ frappe.upload = {
 		if (opts.no_socketio || frappe.flags.no_socketio || file_not_big_enough) {
 			upload_with_filedata();
 			return;
+		} else {
+			frappe.call({
+				method: 'frappe.utils.file_manager.validate_filename',
+				async: false,
+				args: {"filename": args.filename},
+				callback: function(r) {
+					args.filename = r.message;
+				}
+			});
 		}
 
 		frappe.socketio.uploader.start({

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -84,6 +84,7 @@ def save_url(file_url, filename, dt, dn, folder, is_private, df=None):
 	# 	return None, None
 
 	file_url = unquote(file_url)
+	file_size = frappe.form_dict.file_size
 
 	f = frappe.get_doc({
 		"doctype": "File",
@@ -93,6 +94,7 @@ def save_url(file_url, filename, dt, dn, folder, is_private, df=None):
 		"attached_to_name": dn,
 		"attached_to_field": df,
 		"folder": folder,
+		"file_size": file_size,
 		"is_private": is_private
 	})
 	f.flags.ignore_permissions = True

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -392,3 +392,8 @@ def get_random_filename(extn=None, content_type=None):
 		extn = mimetypes.guess_extension(content_type)
 
 	return random_string(7) + (extn or "")
+
+@frappe.whitelist()
+def validate_filename(filename):
+	fname = get_file_name(filename, hashlib.md5(filename).hexdigest()[-6:])
+	return fname


### PR DESCRIPTION
If the file had same name, the previous file was getting overridden with the newer ones ( incase of files that were being saved through socketio ).

Issue:- 
![file-upload-issue](https://user-images.githubusercontent.com/11695402/37768634-51722c4a-2df4-11e8-9cf6-da6c9698a28b.gif)

Fix:-
![file-upload-fix](https://user-images.githubusercontent.com/11695402/37768767-c6cc1cd0-2df4-11e8-98b2-0db1c7443e38.gif)

Validate filename before starting the socketio process - append hash if filename already exist.

