### PR TITLE
Addition of a filter for last sync timestamp

### DIFF
--- a/frappe/data_migration/doctype/data_migration_run/data_migration_run.py
+++ b/frappe/data_migration/doctype/data_migration_run/data_migration_run.py
@@ -77,6 +77,7 @@ class DataMigrationRun(Document):
 	def get_last_modified_condition(self):
 		last_run_timestamp = frappe.db.get_value('Data Migration Run', dict(
 			data_migration_plan=self.data_migration_plan,
+			data_migration_connector=self.data_migration_connector,
 			name=('!=', self.name)
 		), 'modified')
 		if last_run_timestamp:


### PR DESCRIPTION
Hi,

This is a small request to allow more flexibility with the data migration tool.

In some cases, we might want to use the same plan but different connectors to sync different user accounts. This is for example the case in the [Google Calendar](https://github.com/DOKOS-IO/gcalendar) integration I am currently developing (and trying to stabilize before pushing to the core as fast as I can ^^).

In such cases, we want the system to fetch the same data again to be inserted in all accounts (IDs can be inserted too in some APIs like the Google Calendar API, so we can have a unique "gcalendar_sync_id" for example).

Thank you!

