### PR TITLE
Error Popup Cannot use sub-query or function in fields - Project doctype 

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -203,8 +203,7 @@ class DatabaseQuery(object):
 				field_lower = field.lower()
 				tab_name = re.search(r'`.*?`', field_lower)
 				if tab_name:
-					#remove table name from comparison, quoted name only with ``
-					#example: table (project update in erpnext) contains the update blacklist! 
+					#remove table name from comparison (quoted name only with ` `)
 					field_lower = field_lower.replace(tab_name.group(0),"")
 				if any(keyword in field_lower for keyword in blacklisted_keywords):
 					_raise_exception()

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -200,12 +200,19 @@ class DatabaseQuery(object):
 
 		for field in self.fields:
 			if regex.match(field):
-				if any(keyword in field.lower() for keyword in blacklisted_keywords):
+				field_lower = field.lower()
+				tab_name = re.search(r'`.*?`', field_lower)
+				if tab_name:
+					#remove table name from comparison, quoted name only with ``
+					#example: table (project update in erpnext) contains the update blacklist! 
+					field_lower = field_lower.replace(tab_name.group(0),"")
+				if any(keyword in field_lower for keyword in blacklisted_keywords):
 					_raise_exception()
 
-				if any("{0}(".format(keyword) in field.lower() \
+				if any("{0}(".format(keyword) in field_lower \
 					for keyword in blacklisted_functions):
 					_raise_exception()
+
 
 	def extract_tables(self):
 		"""extract tables from fields"""

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -54,7 +54,7 @@ frappe.search.AwesomeBar = Class.extend({
 			// if(txt && txt.length > 1) {
 			// 	me.global.get_awesome_bar_options(txt.toLowerCase(), me);
 			// }
-
+			txt = __(txt);
 			var $this = $(this);
 			clearTimeout($this.data('timeout'));
 

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -110,7 +110,7 @@ frappe.search.utils = {
 		var firstKeyword = keywords.split(" ")[0];
 		if(firstKeyword.toLowerCase() === __("new")) {
 			frappe.boot.user.can_create.forEach(function (item) {
-				var level = me.fuzzy_search(keywords.substr(4), item);
+				var level = me.fuzzy_search(__(keywords).substr(4), item);
 				if(level) {
 					out.push({
 						type: "New",
@@ -142,7 +142,7 @@ frappe.search.utils = {
 			}
 		};
 		frappe.boot.user.can_read.forEach(function (item) {
-			level = me.fuzzy_search(keywords, item);
+			level = me.fuzzy_search(__(keywords), item);
 			if (level) {
 				target = item;
 				if (in_list(frappe.boot.single_types, item)) {
@@ -181,7 +181,7 @@ frappe.search.utils = {
 		var out = [];
 		var route;
 		Object.keys(frappe.boot.user.all_reports).forEach(function(item) {
-			var level = me.fuzzy_search(keywords, item);
+			var level = me.fuzzy_search(__(keywords), item);
 			if(level > 0) {
 				var report = frappe.boot.user.all_reports[item];
 				if(report.report_type == "Report Builder")
@@ -209,7 +209,7 @@ frappe.search.utils = {
 			p.name = name;
 		});
 		Object.keys(this.pages).forEach(function(item) {
-			var level = me.fuzzy_search(keywords, item);
+			var level = me.fuzzy_search(__(keywords), item);
 			if(level) {
 				var page = me.pages[item];
 				out.push({
@@ -227,7 +227,7 @@ frappe.search.utils = {
 			out.push({
 				type: "Calendar",
 				value: __("Open {0}", [__(target)]),
-				index: me.fuzzy_search(keywords, 'Calendar'),
+				index: me.fuzzy_search(__(keywords), 'Calendar'),
 				match: target,
 				route: ['List', 'Event', target],
 			});
@@ -236,7 +236,7 @@ frappe.search.utils = {
 			out.push({
 				type: "Inbox",
 				value: __("Open {0}", [__('Email Inbox')]),
-				index: me.fuzzy_search(keywords, 'email inbox'),
+				index: me.fuzzy_search(__(keywords), 'email inbox'),
 				match: target,
 				route: ['List', 'Communication', 'Inbox'],
 			});
@@ -248,7 +248,7 @@ frappe.search.utils = {
 		var me = this;
 		var out = [];
 		Object.keys(frappe.modules).forEach(function(item) {
-			var level = me.fuzzy_search(keywords, item);
+			var level = me.fuzzy_search(__(keywords), item);
 			if(level > 0) {
 				var module = frappe.modules[item];
 				if (module._doctype) return;


### PR DESCRIPTION
This problem is originally from erpnext but the source of the problem is from frappe
when an sql query is made through frappe, it checks the whole text for blacklisted keywords

The problem here is that table name can be quoted Like `Project Update`, and any thing within these quotes won't be a problem, so I modified the code a bit to accept ONLY quoted table names.

another solution would be to change the doctype `Project Update` in ERPNext Repo to another name Like `Project News` or whatever, But this won't solve future problems if a table was named the same way.
Hope I added something!

Before edit:
![before](https://user-images.githubusercontent.com/9443874/37894471-af6353aa-30de-11e8-8d0d-a0923205e464.png)

After Edit:
![after](https://user-images.githubusercontent.com/9443874/37894493-b92fca94-30de-11e8-8338-397bef19c384.png)

