### PR TITLE
Raise exception while deleting an item which is a product bundle

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -193,13 +193,20 @@ def check_if_doc_is_linked(doc, method="Delete"):
 					# don't check for communication and todo!
 					continue
 
-				if item and (link_dt != doc.doctype or ((item.parent or item.name) != doc.name)) \
-						and ((method=="Delete" and item.docstatus<2) or (method=="Cancel" and item.docstatus==1)):
-					# raise exception only if
-					# linked to an non-cancelled doc when deleting
-					# or linked to a submitted doc when cancelling
+				if not item:
+					continue
+				elif not ((method=="Delete" and item.docstatus<2) or (method=="Cancel" and item.docstatus==1)):
+					# don't raise exception if not
+					# linked to a non-cancelled doc when deleting or to a submitted doc when cancelling
+					continue
+				elif not (link_dt != doc.doctype or ((item.parent or item.name) != doc.name)):
+						# don't raise exception if not
+						# linked to same item or doc having same name as the item
+					continue
+				else:
 					reference_docname = item.parent or item.name
 					raise_link_exists_exception(doc, linked_doctype, reference_docname)
+
 		else:
 			if frappe.db.get_value(link_dt, None, link_field) == doc.name:
 				raise_link_exists_exception(doc, link_dt, link_dt)

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -195,13 +195,13 @@ def check_if_doc_is_linked(doc, method="Delete"):
 
 				if not item:
 					continue
-				elif not ((method=="Delete" and item.docstatus<2) or (method=="Cancel" and item.docstatus==1)):
+				elif (method != "Delete" or item.docstatus == 2) and (method != "Cancel" or item.docstatus != 1):
 					# don't raise exception if not
 					# linked to a non-cancelled doc when deleting or to a submitted doc when cancelling
 					continue
-				elif not (link_dt != doc.doctype or ((item.parent or item.name) != doc.name)):
-						# don't raise exception if not
-						# linked to same item or doc having same name as the item
+				elif link_dt == doc.doctype and (item.parent or item.name) == doc.name:
+					# don't raise exception if not
+					# linked to same item or doc having same name as the item
 					continue
 				else:
 					reference_docname = item.parent or item.name

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -193,7 +193,7 @@ def check_if_doc_is_linked(doc, method="Delete"):
 					# don't check for communication and todo!
 					continue
 
-				if item and ((item.parent or item.name) != doc.name) \
+				if item and (link_dt != doc.doctype or ((item.parent or item.name) != doc.name)) \
 						and ((method=="Delete" and item.docstatus<2) or (method=="Cancel" and item.docstatus==1)):
 					# raise exception only if
 					# linked to an non-cancelled doc when deleting


### PR DESCRIPTION
Exception is not raised while deleting an item which is also a product bundle item as the docname of product bundle is same as the item name. So, also check if the doctype being deleted is not same as the linked doctype.
Issue:
![delete-product-bundle-item-fix](https://user-images.githubusercontent.com/17617465/37951085-c950682c-31b8-11e8-948f-3f03160f7657.gif)
Fix:
![delete-product-bundle-item-issue](https://user-images.githubusercontent.com/17617465/37951094-d1ca8e1a-31b8-11e8-85a6-7f38442fd6d5.gif)

Closes: frappe/erpnext#13027