### PR TITLE
Notifications

### DIFF
--- a/frappe/async.py
+++ b/frappe/async.py
@@ -89,6 +89,8 @@ def publish_realtime(event=None, message=None, room=None,
 			room = get_user_room(user)
 		elif doctype and docname:
 			room = get_doc_room(doctype, docname)
+		else:
+			room = get_site_room()
 	else:
 		# frappe.chat
 		room = get_chat_room(room)

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -172,8 +172,11 @@ def clear_notifications(user=None):
 		else:
 			cache.delete_key("notification_count:" + name)
 
+	frappe.publish_realtime('clear_notifications')
+
 def delete_notification_count_for(doctype):
 	frappe.cache().delete_key("notification_count:" + doctype)
+	frappe.publish_realtime('clear_notifications')
 
 def clear_doctype_notifications(doc, method=None, *args, **kwargs):
 	config = get_notification_config()

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -222,9 +222,16 @@ frappe.Application = Class.extend({
 
 	start_notification_updates: function() {
 		var me = this;
-		setInterval(function() {
+
+		// refresh_notifications will be called only once during a 1 second window
+		this.refresh_notifications = frappe.utils.debounce(this.refresh_notifications.bind(this), 1000);
+
+		// kickoff
+		this.refresh_notifications();
+
+		frappe.realtime.on('clear_notifications', () => {
 			me.refresh_notifications();
-		}, 30000);
+		});
 
 		// first time loaded in boot
 		$(document).trigger("notification-update");
@@ -237,7 +244,7 @@ frappe.Application = Class.extend({
 
 	refresh_notifications: function() {
 		var me = this;
-		if(frappe.session_alive && frappe.boot && !(frappe.boot.home_page !== 'setup-wizard')) {
+		if(frappe.session_alive && frappe.boot && frappe.boot.home_page !== 'setup-wizard') {
 			return frappe.call({
 				method: "frappe.desk.notifications.get_notifications",
 				callback: function(r) {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -130,8 +130,13 @@ frappe.ui.Filter = class {
 
 		// set value can be asynchronous, so update_filter_tag should happen after field is set
 		this._filter_value_set = Promise.resolve();
+
+		if (['in', 'not in'].includes(condition) && Array.isArray(value)) {
+			value = value.join(',');
+		}
+
 		if(value) {
-			this._filter_value_set = this.field.set_value(value.trim());
+			this._filter_value_set = this.field.set_value((value + '').trim());
 		}
 		return this._filter_value_set;
 	}

--- a/frappe/public/js/frappe/ui/toolbar/notifications.js
+++ b/frappe/public/js/frappe/ui/toolbar/notifications.js
@@ -110,8 +110,6 @@ frappe.ui.notifications = {
 		}
 		let route = frappe.get_route();
 		if(route[0]==="List" && route[1]===doctype) {
-			frappe.pages["List/" + doctype].list_view.refresh();
-		} else {
 			frappe.set_route("List", doctype);
 		}
 	},


### PR DESCRIPTION
- Publish realtime message when notifications are cleared
- Refresh notifications on client on clear_notifications event
- refresh_notfications will be called only once in a 1 second window
- No more 30 sec polling

![notifications-via-socketio](https://user-images.githubusercontent.com/9355208/37991528-0a934a0c-3227-11e8-9572-6db035e47b27.gif)

Fixes: https://github.com/frappe/erpnext/issues/12321