### PR TITLE
pdf.py does not handle output properly if ContentNotFoundError is thrown

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -29,8 +29,11 @@ def get_pdf(html, options=None, output = None):
 
 			# allow pdfs with missing images if file got created
 			if os.path.exists(fname):
-				with open(fname, "rb") as fileobj:
-					filedata = fileobj.read()
+				if output:
+                        		append_pdf(PdfFileReader(file(fname,"rb")),output)
+                		else:
+                        		with open(fname, "rb") as fileobj:
+                                		filedata = fileobj.read()
 
 			else:
 				frappe.throw(_("PDF generation failed because of broken image links"))


### PR DESCRIPTION
If wkhtmltopdf throws a ContentNotFoundError exception (even though there is content) or other catchable exceptions the output keyword is not updated properly as it is in the try: section if no exception is thrown.   This causes the PDF being returned to be empty, empty PdfFileWriter() created in print_format.py line 26. This causes issues like https://github.com/frappe/erpnext/issues/13124 to occur where the viewer.js throws an error due to a bad pdf file.  The ContentNotFoundError exception is happening due to a bad header image link being used when multi printing. 

The whole get_pdf() function should be rebuilt to test for ContentNotFoundError and other errors from wkhtmltopdf and then use a secondary try/catch to check for any other IOErrors related to being able to read the PDF back in from the file.  Right now this is not DRY since I basically copy and pasted lines 18 - 22 under line 31 so that if there is an error but the file exists the output will still be appended properly. Of course this also means that if there is an exception thrown while trying to read the PDF or append there is nothing to catch it. 