### PR TITLE
[ Fix ] Duplicate filename upload

### DIFF
--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -397,6 +397,7 @@ def get_random_filename(extn=None, content_type=None):
 
 @frappe.whitelist()
 def validate_filename(filename):
-	hash_ = get_content_hash(filename)
-	fname = get_file_name(filename, hash_[-6:])
+	from frappe.utils import now_datetime
+	timestamp = now_datetime().strftime(" %Y-%m-%d %H:%M:%S")
+	fname = get_file_name(filename, timestamp)
 	return fname


### PR DESCRIPTION
Append now_time instead of filename hash to the file's name incase of duplicate name