### PR TITLE
[Fix] Letterhead not disaplying in PDF, if salary slip print sent auto from the system

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1250,7 +1250,7 @@ def get_print(doctype=None, name=None, print_format=None, style=None, html=None,
 	else:
 		return html
 
-def attach_print(doctype, name, file_name=None, print_format=None, style=None, html=None, doc=None, lang=None, print_letterhead=False):
+def attach_print(doctype, name, file_name=None, print_format=None, style=None, html=None, doc=None, lang=None, print_letterhead=True):
 	from frappe.utils import scrub_urls
 
 	if not file_name: file_name = name


### PR DESCRIPTION
**Issue**
Salary Slips automatically emailed to employees after successful submission via Payroll Entry do not contain the Letterhead! Emailing the salary slips individually from the system however works fine

Fixed https://github.com/frappe/erpnext/issues/13440