### PR TITLE
Check number format only if precision missing

### DIFF
--- a/frappe/tests/test_fmt_money.py
+++ b/frappe/tests/test_fmt_money.py
@@ -84,6 +84,17 @@ class TestFmtMoney(unittest.TestCase):
 		self.assertEqual(fmt_money(1000000000.2718272637), "1,000,000,000.2718")
 		frappe.db.set_default("currency_precision", "")
 
+	def test_currency_precision_de_format(self):
+		frappe.db.set_default("currency_precision", "4")
+		frappe.db.set_default("number_format", "#.###,##")
+		self.assertEqual(fmt_money(100), "100,00")
+		self.assertEqual(fmt_money(1000), "1.000,00")
+		self.assertEqual(fmt_money(10000), "10.000,00")
+		self.assertEqual(fmt_money(100000), "100.000,00")
+		self.assertEqual(fmt_money(100.23), "100,23")
+		self.assertEqual(fmt_money(1000.456), "1.000,456")
+		frappe.db.set_default("currency_precision", "")
+
 if __name__=="__main__":
 	frappe.connect()
 	unittest.main()

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -374,8 +374,8 @@ def fmt_money(amount, precision=None, currency=None):
 
 	if decimal_str:
 		decimals_after = str(round(amount % 1, precision))
-		parts = decimals_after.split(decimal_str)
-		parts = parts[1] if len(parts) > 1 else ''
+		parts = decimals_after.split('.')
+		parts = parts[1] if len(parts) > 1 else parts[0]
 		decimals = parts
 		if precision > 2:
 			if len(decimals) < 3:

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -372,6 +372,9 @@ def fmt_money(amount, precision=None, currency=None):
 	# 40,000.00000 -> 40,000.00
 	# 40,000.23000 -> 40,000.23
 
+	if isinstance(amount, string_types):
+		amount = flt(amount, precision)
+
 	if decimal_str:
 		decimals_after = str(round(amount % 1, precision))
 		parts = decimals_after.split('.')


### PR DESCRIPTION
Field precision should have a priority.
Should go into this loop only if precision is number_format_precision
https://github.com/frappe/frappe/blob/develop/frappe/utils/data.py#L375
 
Fixed https://github.com/frappe/erpnext/issues/13477