### PR TITLE
Fixed Issue #5376 and #4248

### DIFF
--- a/frappe/desk/page/activity/activity.js
+++ b/frappe/desk/page/activity/activity.js
@@ -190,7 +190,13 @@ frappe.activity.render_heatmap = function(page) {
 					data: {}
 				});
 
-				heatmap.update(r.message);
+				let heatmapData = {};						
+				const object = r.message;
+				for (const [key, value] of Object.entries(object)) {
+					heatmapData[(parseInt(key) - 79200)] = value;
+				}
+
+				heatmap.update(heatmapData);
 			}
 		}
 	})

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -273,7 +273,12 @@ frappe.ui.form.Dashboard = Class.extend({
 			},
 			callback: function(r) {
 				if(r.message.timeline_data) {
-					me.update_heatmap(r.message.timeline_data);
+					let heatmapData = {};						
+					const object = r.message.timeline_data;
+					for (const [key, value] of Object.entries(object)) {
+						heatmapData[(parseInt(key) - 79200)] = value;
+					}
+					me.update_heatmap(heatmapData);
 				}
 
 				// update badges


### PR DESCRIPTION
Hi All

I was able to fix the issue #4248 (Heatmap doesnt work for Doctypes of ERPNext) and #5376 (Heatmap doesnt work for Activity Log).
There were two causes:
* The dict key was not an integer, it was a float
* The timestamp was shifted 79200 into the future

This PR solves the problem that the marks on the heatmap are not displayed. The possibility to change the style of the heatmap is not fulfilled...

With this PR, the PR #5372 will be obsolet.