### PR TITLE
Update order_by in search.py

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -91,7 +91,7 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 			# In order_by, `idx` gets second priority, because it stores link count
 			from frappe.model.db_query import get_order_by
 			order_by_based_on_meta = get_order_by(doctype, meta)
-			order_by = "if(_relevance, _relevance, 99999), `tab{0}`.idx desc, {1}".format(doctype, order_by_based_on_meta)
+			order_by = "if(_relevance, _relevance, 99999), {0}, `tab{1}`.idx desc".format(order_by_based_on_meta, doctype)
 
 			values = frappe.get_list(doctype,
 				filters=filters, fields=formatted_fields,


### PR DESCRIPTION
Attending to the comment "In order_by, `idx` gets second priority, because it stores link count" i changed the order in the SQL statement in the order_by variable so the order_by based on meta is before the order_by idx