### PR TITLE
[urgent] syntax fix

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -761,8 +761,7 @@ def validate_permissions(doctype, for_remove=False):
 			d.set("import", 0)
 			d.set("export", 0)
 
-		for ptype, label in (
-			("set_user_permissions", _("Set User Permissions"))):
+		for ptype, label in [["set_user_permissions", _("Set User Permissions")]]:
 			if d.get(ptype):
 				d.set(ptype, 0)
 				frappe.msgprint(_("{0} cannot be set for Single types").format(label))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 943, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 256, in save
    return self._save(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 290, in _save
    self.run_before_save_methods()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 859, in run_before_save_methods
    self.run_method("validate")
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 755, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 1029, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 1012, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 749, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 69, in validate
    validate_permissions(self)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 790, in validate_permissions
    remove_rights_for_single(d)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 765, in remove_rights_for_single
    ("set_user_permissions", _("Set User Permissions"))):
ValueError: too many values to unpack

```