### PR TITLE
check chat profile exists the right way

### DIFF
--- a/frappe/chat/doctype/chat_profile/chat_profile.py
+++ b/frappe/chat/doctype/chat_profile/chat_profile.py
@@ -76,7 +76,13 @@ def create(user, exists_ok = False, fields = None):
 
     exists_ok, fields = safe_json_loads(exists_ok, fields)
 
-    if frappe.db.exists('Chat Profile', user):
+    result = frappe.db.sql("""
+        SELECT *
+        FROM `tabChat Profile`
+        WHERE user = "{user}"
+    """.format(user = user))
+
+    if result:
         if not exists_ok:
             frappe.throw(_('Chat Profile for User {user} exists.'.format(user = user)))
     else:


### PR DESCRIPTION
Fixes "Duplicate Chat Profile Not found error" on erpnext.org