### PR TITLE
Handle Tables Names that contain blacklisted sql keyword

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -200,10 +200,15 @@ class DatabaseQuery(object):
 
 		for field in self.fields:
 			if regex.match(field):
-				if any(keyword in field.lower() for keyword in blacklisted_keywords):
+				field_lower = field.lower()
+				table_name = re.search(r'`.*?`', field_lower)
+				if table_name:
+					field_lower = field_lower.replace(table_name.group(0),"")
+					# remove quoted table name from sanitizing
+				if any(keyword in field_lower for keyword in blacklisted_keywords):
 					_raise_exception()
 
-				if any("{0}(".format(keyword) in field.lower() \
+				if any("{0}(".format(keyword) in field_lower \
 					for keyword in blacklisted_functions):
 					_raise_exception()
 


### PR DESCRIPTION
Fix: https://github.com/frappe/erpnext/issues/13381
Fix: https://github.com/frappe/erpnext/issues/13057

This problem is originally from erpnext table  `Project Update`  but its best solved through frappe,
when an sql query is made through frappe, it checks the whole text for blacklisted keywords

Usually when we write an sql statement, table name can be quoted Like `Project Update`, and anything within these quotes won't make a problem as sql injection or whatever since it will be considered a string with no functionality, so I modified the code a bit to accept table names that contains blacklisted sql keyword but ONLY if it was quoted.

Another approach would be to change the doctype `Project Update` in ERPNext Repo to another name Like `Project News` or whatever, But this won't solve future problems if a table was named the same way.
Hope I added something!

Before edit:
![before](https://user-images.githubusercontent.com/9443874/37894471-af6353aa-30de-11e8-8d0d-a0923205e464.png)

After Edit:
![after](https://user-images.githubusercontent.com/9443874/37894493-b92fca94-30de-11e8-8338-397bef19c384.png)

