### PR TITLE
check track changes attribute with getattr

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -902,7 +902,7 @@ class Document(BaseDocument):
 
 		update_global_search(self)
 
-		if self.meta.track_changes and self._doc_before_save and not self.flags.ignore_version:
+		if getattr(self.meta, 'track_changes', False) and self._doc_before_save and not self.flags.ignore_version:
 			self.save_version()
 
 		if (self.doctype, self.name) in frappe.flags.currently_saving:


### PR DESCRIPTION
```
$ bench migrate
Migrating test_site
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 69, in execute_patch
    block_user(True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 118, in block_user
    frappe.db.set_global('__session_status', block and 'stop' or None)
  File "/home/travis/frappe-bench/apps/frappe/frappe/database.py", line 756, in set_global
    self.set_default(key, val, user)
  File "/home/travis/frappe-bench/apps/frappe/frappe/database.py", line 764, in set_default
    frappe.defaults.set_default(key, val, parent, parenttype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/defaults.py", line 109, in set_default
    add_default(key, value, parent)
  File "/home/travis/frappe-bench/apps/frappe/frappe/defaults.py", line 120, in add_default
    d.insert(ignore_permissions=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 245, in insert
    self.run_post_save_methods()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 905, in run_post_save_methods
    if self.meta.track_changes and self._doc_before_save and not self.flags.ignore_version:
AttributeError: 'Meta' object has no attribute 'track_changes'
```