### PR TITLE
patch fixes

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -7,7 +7,7 @@ frappe.patches.v8_0.drop_in_dialog #2017-09-22
 frappe.patches.v7_2.remove_in_filter
 execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'docfield', force=True) #2018-02-20
-execute:frappe.reload_doc('core', 'doctype', 'docperm') #2018-04-10
+execute:frappe.reload_doc('core', 'doctype', 'docperm') #2017-03-03
 execute:frappe.reload_doc('core', 'doctype', 'module_def') #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'version') #2017-04-01
 execute:frappe.reload_doc('core', 'doctype', 'activity_log')
@@ -17,7 +17,7 @@ frappe.patches.v7_0.re_route #2016-06-27
 frappe.patches.v8_0.drop_is_custom_from_docperm
 frappe.patches.v8_0.update_records_in_global_search #11-05-2017
 frappe.patches.v8_0.update_published_in_global_search
-execute:frappe.reload_doc('core', 'doctype', 'custom_docperm') #2018-04-10
+execute:frappe.reload_doc('core', 'doctype', 'custom_docperm')
 execute:frappe.reload_doc('core', 'doctype', 'deleted_document')
 execute:frappe.reload_doc('core', 'doctype', 'domain_settings')
 frappe.patches.v8_0.rename_page_role_to_has_role #2017-03-16

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -7,7 +7,7 @@ frappe.patches.v8_0.drop_in_dialog #2017-09-22
 frappe.patches.v7_2.remove_in_filter
 execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'docfield', force=True) #2018-02-20
-execute:frappe.reload_doc('core', 'doctype', 'docperm') #2017-03-03
+execute:frappe.reload_doc('core', 'doctype', 'docperm') #2018-04-10
 execute:frappe.reload_doc('core', 'doctype', 'module_def') #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'version') #2017-04-01
 execute:frappe.reload_doc('core', 'doctype', 'activity_log')
@@ -17,7 +17,7 @@ frappe.patches.v7_0.re_route #2016-06-27
 frappe.patches.v8_0.drop_is_custom_from_docperm
 frappe.patches.v8_0.update_records_in_global_search #11-05-2017
 frappe.patches.v8_0.update_published_in_global_search
-execute:frappe.reload_doc('core', 'doctype', 'custom_docperm')
+execute:frappe.reload_doc('core', 'doctype', 'custom_docperm') #2018-04-10
 execute:frappe.reload_doc('core', 'doctype', 'deleted_document')
 execute:frappe.reload_doc('core', 'doctype', 'domain_settings')
 frappe.patches.v8_0.rename_page_role_to_has_role #2017-03-16
@@ -163,6 +163,7 @@ frappe.patches.v7_1.set_backup_limit
 frappe.patches.v7_2.set_doctype_engine
 frappe.patches.v7_2.merge_knowledge_base
 frappe.patches.v7_0.update_report_builder_json
+frappe.patches.v11_0.drop_column_apply_user_permissions
 frappe.patches.v7_2.set_in_standard_filter_property #1
 frappe.patches.v8_0.drop_unwanted_indexes
 execute:frappe.db.sql("update tabCommunication set communication_date = creation where time(communication_date) = 0")
@@ -205,4 +206,3 @@ frappe.patches.v10_0.refactor_social_login_keys
 frappe.patches.v10_0.enable_chat_by_default_within_system_settings
 frappe.patches.v10_0.remove_custom_field_for_disabled_domain
 execute:frappe.delete_doc("Page", "chat")
-frappe.patches.v11_0.drop_column_apply_user_permissions

--- a/frappe/patches/v10_0/refactor_social_login_keys.py
+++ b/frappe/patches/v10_0/refactor_social_login_keys.py
@@ -60,9 +60,7 @@ def run_patch():
 	frappe.reload_doc("core", "doctype", "user", force=True)
 	frappe.reload_doc("core", "doctype", "user_social_login", force=True)
 
-	users = frappe.get_all("User",
-		fields=["name", "frappe_userid", "fb_userid", "fb_username", "github_userid", "github_username", "google_userid", "modified_by"],
-		filters={"name":("not in", ["Administrator", "Guest"])})
+	users = frappe.get_all("User", fields=["*"], filters={"name":("not in", ["Administrator", "Guest"])})
 
 	for user in users:
 		idx = 0

--- a/frappe/patches/v11_0/drop_column_apply_user_permissions.py
+++ b/frappe/patches/v11_0/drop_column_apply_user_permissions.py
@@ -1,10 +1,13 @@
 import frappe
 
 def execute():
-    column = 'apply_user_permissions'
-    to_remove = ['DocPerm', 'Custom DocPerm']
+	column = 'apply_user_permissions'
+	to_remove = ['DocPerm', 'Custom DocPerm']
 
-    for doctype in to_remove:
-        if column in frappe.db.get_table_columns(doctype):
-            frappe.db.sql("alter table `tab{0}` drop column {1}".format(doctype, column))
+	for doctype in to_remove:
+		if column in frappe.db.get_table_columns(doctype):
+			frappe.db.sql("alter table `tab{0}` drop column {1}".format(doctype, column))
+
+	frappe.reload_doc('core', 'doctype', 'docperm', force=True)
+	frappe.reload_doc('core', 'doctype', 'custom_docperm', force=True)
 


### PR DESCRIPTION
```

Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/patches/v7_2/set_in_standard_filter_property.py", line 13, in execute
    frappe.reload_doctype(doctype.name, force=True)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 687, in reload_doctype
    force=force, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 699, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/utils.py", line 155, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 19, in import_files
    reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 24, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 58, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 132, in import_doc
    doc.insert()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 237, in insert
    d.db_insert()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/base_document.py", line 303, in db_insert
    ), list(d.values()))
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/database.py", line 195, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.IntegrityError: (1048, u"Column 'apply_user_permissions' cannot be null")
```
-----------------------------

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/patches/v10_0/refactor_social_login_keys.py", line 7, in execute
    run_patch()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/patches/v10_0/refactor_social_login_keys.py", line 65, in run_patch
    filters={"name":("not in", ["Administrator", "Guest"])})
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 1181, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 1154, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/db_query.py", line 87, in execute
    result = self.build_and_run()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/db_query.py", line 111, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/database.py", line 205, in sql
    self._cursor.execute(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, u"Unknown column 'frappe_userid' in 'field list'")
```


