### PR TITLE
[fix][minor] Fix logical error in event repeat condition check

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -27,7 +27,7 @@ class Event(Document):
 			# this scenario doesn't make sense i.e. it starts and ends at the same second!
 			self.ends_on = None
 
-		if getdate(self.starts_on) == getdate(self.ends_on) and self.repeat_on == "Every Day":
+		if getdate(self.starts_on) != getdate(self.ends_on) and self.repeat_on == "Every Day":
 			frappe.msgprint(frappe._("Every day events should finish on the same day."), raise_exception=True)
 
 def get_permission_query_conditions(user):


### PR DESCRIPTION
Without this fix you can only create Every Day repeating events that are not ending on the same day.
The condition is doing the total opposite check, if you are trying to create a repeating event with the same day end you get the following error: "Every day events should finish on the same day."