### PR TITLE
[Fix] build_match_conditions() takes at least 2 arguments (1 given)

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -341,7 +341,10 @@ def get_match_cond(doctype):
 	cond = DatabaseQuery(doctype).build_match_conditions()
 	return ((' and ' + cond) if cond else "").replace("%", "%%")
 
-def build_match_conditions(doctype, user, as_condition=True):
+def build_match_conditions(doctype, user=None, as_condition=True):
+	if not user:
+		user = frappe.session.user
+
 	match_conditions =  DatabaseQuery(doctype, user=user).build_match_conditions(as_condition=as_condition)
 	if as_condition:
 		return match_conditions.replace("%", "%%")


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/desk/search.py", line 14, in search_link
    search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/desk/search.py", line 39, in search_widget
    searchfield, start, page_length, filters)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/desk/search.py", line 35, in search_widget
    searchfield, start, page_length, filters, as_dict=as_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/selling/doctype/customer/customer.py", line 188, in get_customer_list
    match_conditions = build_match_conditions("Customer")
TypeError: build_match_conditions() takes at least 2 arguments (1 given)
```
Fixed https://github.com/frappe/erpnext/issues/13626