### PR TITLE
[fix] added ignore_in_install flag to accommodate Gcal custom field

### DIFF
--- a/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.py
+++ b/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.py
@@ -30,6 +30,7 @@ class DataMigrationPlan(Document):
 				create_init_py(get_module_path(self.module), dt, dn)
 
 	def make_custom_fields_for_mappings(self):
+		frappe.flags.ignore_in_install = True
 		label = self.name + ' ID'
 		fieldname = frappe.scrub(label)
 
@@ -51,6 +52,7 @@ class DataMigrationPlan(Document):
 
 		# Create custom field in Deleted Document
 		create_custom_field('Deleted Document', df)
+		frappe.flags.ignore_in_install = False
 
 	def pre_process_doc(self, mapping_name, doc):
 		module = self.get_mapping_module(mapping_name)

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -108,6 +108,8 @@ def get_root_connection(root_login='root', root_password=None):
 
 def install_app(name, verbose=False, set_as_patched=True):
 	frappe.flags.in_install = name
+	frappe.flags.ignore_in_install = False
+
 	frappe.clear_cache()
 	app_hooks = frappe.get_hooks(app_name=name)
 	installed_apps = frappe.get_installed_apps()

--- a/frappe/model/db_schema.py
+++ b/frappe/model/db_schema.py
@@ -230,7 +230,7 @@ class DbTable:
 					'fieldtype': 'Text'
 				})
 
-		if not frappe.flags.in_install_db and frappe.flags.in_install != "frappe":
+		if not frappe.flags.in_install_db and (frappe.flags.in_install != "frappe" or frappe.flags.ignore_in_install):
 			custom_fl = frappe.db.sql("""\
 				SELECT * FROM `tabCustom Field`
 				WHERE dt = %s AND docstatus < 2""", (self.doctype,), as_dict=1)


### PR DESCRIPTION
```
$ bench run-tests
WARNING	Property: Unknown Property name. [11:3: overflow-wrap]
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/utils.py", line 356, in run_tests
    ui_tests = ui_tests, doctype_list_path = doctype_list_path)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 68, in main
    ret = run_all_tests(app, verbose, profile, ui_tests)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 110, in run_all_tests
    test_suite, ui_tests)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 238, in _add_test
    make_test_records(doctype, verbose)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 253, in make_test_records
    make_test_records_for_doctype(options, verbose, force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 301, in make_test_records_for_doctype
    frappe.local.test_objects[doctype] += make_test_objects(doctype, test_module.test_records, verbose, force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 352, in make_test_objects
    d.insert()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 231, in insert
    self.db_insert()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/base_document.py", line 303, in db_insert
    ), list(d.values()))
  File "/home/travis/frappe-bench/apps/frappe/frappe/database.py", line 195, in sql
    self._cursor.execute(query, values)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, u"Unknown column 'gcalendar_sync_id' in 'field list'")
```