### PR TITLE
Update link translation tag

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager_help.html
+++ b/frappe/core/page/permission_manager/permission_manager_help.html
@@ -24,7 +24,7 @@
 		<li>{%= __("Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document.") %}</li>
 		<li>{%= __("If a Role does not have access at Level 0, then higher levels are meaningless.") %}</li>
 		<li>{%= __("Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.") %}</li>
-		<li>{%= __("You can use Customize Form to set levels on fields.") %} <a href="#Form/Customize Form">Setup > Customize Form</a></li>
+		<li>{%= __("You can use Customize Form to set levels on fields.") %} <a href="#Form/Customize Form">{%= __("Setup > Customize Form") %}</a></li>
 	</ol>
     <hr>
 	<h4>{%= __("User Permissions") %}:</h4>


### PR DESCRIPTION
Missing translation tag causing the link is not translated.