### PR TITLE
Check for list_renderer before accessing settings

### DIFF
--- a/frappe/core/doctype/file/file_list.js
+++ b/frappe/core/doctype/file/file_list.js
@@ -38,12 +38,15 @@ frappe.listview_settings['File'] = {
 
 		doclist.breadcrumb = $('<ol class="breadcrumb for-file-list"></ol>')
 			.insertBefore(doclist.filter_area);
-		doclist.list_renderer.settings.setup_menu(doclist);
-		doclist.list_renderer.settings.setup_dragdrop(doclist);
+		
+		if (typeof doclist.list_renderer !== "undefined") {
+			doclist.list_renderer.settings.setup_menu(doclist);
+			doclist.list_renderer.settings.setup_dragdrop(doclist);
 
-		doclist.$page.on("click", ".list-row-checkbox", function(event) {
-			doclist.list_renderer.settings.add_menu_item_copy(doclist);
-		});
+			doclist.$page.on("click", ".list-row-checkbox", function(event) {
+				doclist.list_renderer.settings.add_menu_item_copy(doclist);
+			});
+		}
 	},
 	list_view_doc:function(doclist){
 		$(doclist.wrapper).on("click", 'button[list_view_doc="'+doclist.doctype+'"]', function() {

--- a/frappe/core/doctype/file/file_list.js
+++ b/frappe/core/doctype/file/file_list.js
@@ -39,7 +39,7 @@ frappe.listview_settings['File'] = {
 		doclist.breadcrumb = $('<ol class="breadcrumb for-file-list"></ol>')
 			.insertBefore(doclist.filter_area);
 		
-		if (typeof doclist.list_renderer !== "undefined") {
+		if (doclist.list_renderer) {
 			doclist.list_renderer.settings.setup_menu(doclist);
 			doclist.list_renderer.settings.setup_dragdrop(doclist);
 


### PR DESCRIPTION
In the master version of frappe, in the first attempt of calling the file manager (when onload is called) the report doesn't build, because in the report view, there is no such attribute list_renderer available.

In that change we check if the list renderer is not undefined and only setup the menu, drag and drop and copy function, when the list_renderer object is available.

This problem might not occur in the developer versions (datatables), but many people still work with the master version and need a working file manager report.