### PR TITLE
added handler for decimal object in response

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -20,6 +20,7 @@ from frappe.core.doctype.file.file import check_file_permission
 from frappe.website.render import render
 from frappe.utils import cint
 from six import text_type
+import decimal
 
 def report_error(status_code):
 	'''Build error. Show traceback in developer mode'''
@@ -105,6 +106,9 @@ def json_handler(obj):
 	# serialize date
 	if isinstance(obj, (datetime.date, datetime.timedelta, datetime.datetime)):
 		return text_type(obj)
+
+	elif isinstance(obj, decimal.Decimal):
+		return float(obj)
 
 	elif isinstance(obj, LocalProxy):
 		return text_type(obj)


### PR DESCRIPTION
fixes the issue caused when changing passwords. 
it was caused to version error in `python-zxcvbn` returning, a decimal object instead of a string from version `4.4.24` onwards