### PR TITLE
hide user-progress and help for mobile view

### DIFF
--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -391,6 +391,10 @@ li.user-progress {
 	li.user-progress .progress-chart {
 		width: 25px;
 	}
+
+	li.user-progress {
+		display: none;
+	}
 }
 
 .msg-box {

--- a/frappe/public/less/navbar.less
+++ b/frappe/public/less/navbar.less
@@ -143,6 +143,9 @@
 			padding: 12px;
 		}
 	}
+	.dropdown-help {
+		display: none !important;
+	}
 }
 
 .navbar-new-comments {


### PR DESCRIPTION
Before :- 
<img width="324" alt="screen shot 2018-04-26 at 12 15 08 pm" src="https://user-images.githubusercontent.com/11695402/39289979-a8e82c5a-494b-11e8-8f30-19c28ce7ef77.png">

After :- 
<img width="319" alt="screen shot 2018-04-26 at 12 13 10 pm" src="https://user-images.githubusercontent.com/11695402/39289989-b141e328-494b-11e8-81e4-5b2c2d75d224.png">

