### PR TITLE
Resolved Duplicate Fieldname error for Section Break and Custom field…

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -69,7 +69,12 @@ def import_file_by_path(path, ignore_links=False, overwrite=False, submit=False,
 
 def export_json(doctype, path, filters=None, or_filters=None, name=None):
 	def post_process(out):
-		del_keys = ('parent', 'parentfield', 'parenttype', 'modified_by', 'creation', 'owner', 'idx')
+		del_keys = None
+		if doctype == "Custom Field":
+			del_keys = ('parent', 'parentfield', 'parenttype', 'modified_by', 'creation', 'owner')
+		else:
+			del_keys = ('parent', 'parentfield', 'parenttype', 'modified_by', 'creation', 'owner', 'idx')
+			
 		for doc in out:
 			for key in del_keys:
 				if key in doc:

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -18,7 +18,10 @@ class CustomField(Document):
 			label = self.label
 			if not label:
 				if self.fieldtype in ["Section Break", "Column Break"]:
-					label = self.fieldtype + "_" + str(self.idx)
+					if self.idx:
+						label = self.fieldtype + "_" + str(self.idx)
+					else:
+						label = self.fieldtype + "-" + self.get_field_idx()
 				else:
 					frappe.throw(_("Label is mandatory"))
 
@@ -80,6 +83,17 @@ class CustomField(Document):
 		if self.fieldname == self.insert_after:
 			frappe.throw(_("Insert After cannot be set as {0}").format(meta.get_label(self.insert_after)))
 
+	def get_field_idx(self):
+		meta = frappe.get_meta(self.dt, cached=False)
+		fields = meta.get_fields()
+		idx = 0
+		for f in fields:
+			if f.fieldname == self.insert_after:
+				idx = cint(f.idx) + 1
+		return idx
+		 
+				
+		
 @frappe.whitelist()
 def get_fields_label(doctype=None):
 	return [{"value": df.fieldname or "", "label": _(df.label or "")}


### PR DESCRIPTION
1. There is no idx fieldtype while exporting Custom Field to json file due to which it's was throwing duplicate error for section break and column break fieldtype while importing(If custom Section Break/Custom Field exists in field list more than once).
> Fixed: I modified the code to add idx fieldtype value if doctype is custom field while exporting to json file.

2.  While importing custom field json/csv it's also changing Index of Form while displaying fields in Main Form
> Fixed: I modfied the custom field doctype.py to get exact field index while autoname.

