### PR TITLE
[Minor] Restoring default role permissions for Custom doctype

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -111,6 +111,5 @@ def get_users_with_role(role):
 @frappe.whitelist()
 def get_standard_permissions(doctype):
 	frappe.only_for("System Manager")
-	module = frappe.db.get_value("DocType", doctype, "module")
-	path = get_file_path(module, "DocType", doctype)
-	return read_doc_from_file(path).get("permissions")
+	doc = frappe.get_doc('DocType', doctype)
+	return [p.as_dict() for p in doc.permissions]


### PR DESCRIPTION
Issue:- 
![perm-issue](https://user-images.githubusercontent.com/11695402/39358819-188645a8-4a35-11e8-8bdb-895016c94842.gif)

Fix:-
![perm-fix](https://user-images.githubusercontent.com/11695402/39358814-172b51bc-4a35-11e8-8074-96744d59e9a9.gif)

Restoring Role permissions for custom doctype caused error because default permissions was trying to load from json file of the doctype while custom doctypes dont have any json file.