### PR TITLE
Use email instead of user name for building exclude list from thread_notify

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -359,7 +359,7 @@ def get_cc(doc, recipients=None, fetched_from_email_account=False):
 	if cc:
 		# exclude unfollows, recipients and unsubscribes
 		exclude = [] #added to remove account check
-		exclude += [d[0] for d in frappe.db.get_all("User", ["name"], {"thread_notify": 0}, as_list=True)]
+		exclude += [d[0] for d in frappe.db.get_all("User", ["email"], {"thread_notify": 0}, as_list=True)]
 		exclude += [(parse_addr(email)[1] or "").lower() for email in recipients]
 
 		if fetched_from_email_account:
@@ -380,7 +380,7 @@ def get_bcc(doc, recipients=None, fetched_from_email_account=False):
 
 	if bcc:
 		exclude = []
-		exclude += [d[0] for d in frappe.db.get_all("User", ["name"], {"thread_notify": 0}, as_list=True)]
+		exclude += [d[0] for d in frappe.db.get_all("User", ["email"], {"thread_notify": 0}, as_list=True)]
 		exclude += [(parse_addr(email)[1] or "").lower() for email in recipients]
 
 		if fetched_from_email_account:

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -53,12 +53,18 @@ def get_fullname(user=None):
 
 	return frappe.local.fullnames.get(user)
 
+def get_email_address(user=None):
+	"""get the email address of the user from User"""
+	if not user:
+		user = frappe.session.user
+
+	return frappe.db.get_value("User", user, ["email"], as_dict=True).get("email")
+
 def get_formatted_email(user):
 	"""get Email Address of user formatted as: `John Doe <johndoe@example.com>`"""
-	if user == "Administrator":
-		return user
 	fullname = get_fullname(user)
-	return formataddr((fullname, user))
+	mail = get_email_address(user)
+	return formataddr((fullname, mail))
 
 def extract_email_id(email):
 	"""fetch only the email part of the Email Address"""


### PR DESCRIPTION
Related issue: https://github.com/frappe/frappe/issues/5501

I know there has been another change to exclude the Administrator from the mail list, but this change is still necessary to make this work really reliable, as we shouldn't rely on the fact, that the name is a valid email address.

EDIT: By the way, the problem is still not solved with this change, but I consider it to be the only correct way of handling this.

Edit again: Now it works as expected even for Administrator user.