### PR TITLE
remove bs3 js from the frappe-web.min.js and include that in base.html

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -10,7 +10,6 @@
 	"js/frappe-web.min.js": [
 		"public/js/frappe/class.js",
 		"public/js/frappe/polyfill.js",
-		"public/js/lib/bootstrap.min.js",
 		"public/js/lib/md5.min.js",
 		"public/js/frappe/provide.js",
 		"public/js/frappe/format.js",

--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -82,6 +82,8 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.4/socket.io.slim.js"></script>
 	<script type="text/javascript"
 		src="/assets/js/frappe-web.min.js"></script>
+	<script type="text/javascript"
+		src="/assets/frappe/js/lib/bootstrap.min.js"></script>
 	{% endblock %}
     {%- if js_globals is defined %}
     <script>


### PR DESCRIPTION
Since bs3 js is conflicting with the bs4 hence keep bs3 js in the base template which can be overridden.