### PR TITLE
Double encode url issue

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -176,7 +176,7 @@ frappe.views.TreeView = Class.extend({
 					return !node.is_root && me.can_read;
 				},
 				click: function(node) {
-					frappe.set_route("Form", me.doctype, encodeURIComponent(node.label));
+					frappe.set_route("Form", me.doctype, node.label);
 				}
 			},
 			{


### PR DESCRIPTION
**Issue**
![issue_set_route](https://user-images.githubusercontent.com/8780500/39518853-1e362f36-4e22-11e8-850d-2a52a3eac8ce.gif)

**After Fix**
![after_fix](https://user-images.githubusercontent.com/8780500/39518971-8b81bc68-4e22-11e8-94fd-8ddd5c98d610.gif)

We're encoding url in the frappe.set_route method