### PR TITLE
dark magic to revive travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_script:
   - bench reinstall --yes
   - bench setup-help
   - bench scheduler disable
+  - sed -i 's/9000/9001/g' sites/common_site_config.json
   - bench start &
   - sleep 10
 


### PR DESCRIPTION
It seems that some process inside travis is using port no 9000. Hence
adding this line in the travis.yml to change common_site_config.json and
use port no 9001 for socket_io