### PR TITLE
Rebuild help for docs which have been renamed

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -390,6 +390,8 @@ def bulk_rename(doctype, rows=None, via_console = False):
 			else:
 				rename_log.append(msg)
 
+	frappe.enqueue('frappe.utils.global_search.rebuild_for_doctype', doctype=doctype)
+
 	if not via_console:
 		return rename_log
 


### PR DESCRIPTION
After execution of a bulk rename, the help cache for the particular
doctype didn't used to change. Added this fix to ensure the help is
rebuilt for the particular doctype whose docs have been renamed