### PR TITLE
JWT response does not contain email attribute for Office 365

### DIFF
--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -133,7 +133,9 @@ def get_info_via_oauth(provider, code, decoder=None, id_token=False):
 
 	if id_token:
 		parsed_access = json.loads(session.access_token_response.text)
+
 		token = parsed_access['id_token']
+
 		info = jwt.decode(token, flow.client_secret, verify=False)
 	else:
 		api_endpoint = oauth2_providers[provider].get("api_endpoint")
@@ -177,7 +179,7 @@ def login_oauth_user(data=None, provider=None, state=None, email_id=None, key=No
 		frappe.respond_as_web_page(_("Invalid Request"), _("Invalid Token"), http_status_code=417)
 		return
 
-	user = data["email"]
+	user = get_email(data)
 
 	if not user:
 		frappe.respond_as_web_page(_("Invalid Request"), _("Please ensure that your profile has an email address"))
@@ -224,10 +226,10 @@ def update_oauth_user(user, data, provider):
 			"doctype":"User",
 			"first_name": get_first_name(data),
 			"last_name": get_last_name(data),
-			"email": data["email"],
+			"email": get_email(data),
 			"gender": (data.get("gender") or "").title(),
 			"enabled": 1,
-			"new_password": frappe.generate_hash(data["email"]),
+			"new_password": frappe.generate_hash(get_email(data)),
 			"location": data.get("location"),
 			"user_type": "Website User",
 			"user_image": data.get("picture") or data.get("avatar_url")
@@ -276,6 +278,9 @@ def get_first_name(data):
 
 def get_last_name(data):
 	return data.get("last_name") or data.get("family_name")
+
+def get_email(data):
+	return data.get("email") or data.get("upn") or data.get("unique_name")
 
 def redirect_post_login(desk_user):
 	# redirect!


### PR DESCRIPTION
using unique_name or upn instead

sample token 

{"upn": "john.doe@test.com", "family_name": "Doe", "sub": "VdfnM-y6Y4xvIvWZdr84stP1PcBNYxVliFoRyfgLNAR8", "uti": "qVGmfXLzsEWc4JaKGVUCAA", "ver": "1.0", "aud": "76aa7459-4822-4a80-f1e6-6d15341ff809", "iss": "https://sts.windows.net/10drfef10-3abf-4792-b0e1-717d9c327807/", "oid": "62464ba4-3gbe-414d-afe6-def6ba90f158", "ipaddr": "143.93.197.13", "unique_name": "john.doe@test.com", "given_name": "John", "exp": 1525426960, "tid": "10d6ff10-3ax0-4792-b0e1-717d9c327807", "iat": 1525423060, "amr": ["pwd", "mfa"], "nbf": 1525423060, "name": "john Doe" }