### PR TITLE
Make #5200 Python 3 Compatible

### DIFF
--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 import string
 import frappe
+import six
 from frappe import _
 from frappe.utils import cstr, encode
 from cryptography.fernet import Fernet, InvalidToken
@@ -21,7 +22,10 @@ class LegacyPassword(pbkdf2_sha256):
 		# it is possible that we will generate a false positive if the users password happens to be 40 hex chars proceeded
 		# by an * char, but this seems highly unlikely
 		if not (secret[0] == "*" and len(secret) == 41 and all(c in string.hexdigits for c in secret[1:])):
-			secret = mysql41.hash(secret + self.salt)
+			if six.PY3:
+				secret = mysql41.hash(secret + self.salt.decode())
+			else:
+				secret = mysql41.hash(secret + self.salt)
 		return super(LegacyPassword, self)._calc_checksum(secret)
 
 


### PR DESCRIPTION
Fixes #5526 

The problem identified is that `self.salt` is a `byte` so this PR tries to convert it to a `str`.