### PR TITLE
[fix] set no_copy property for workflow state field

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -201,3 +201,4 @@ frappe.patches.v9_1.revert_domain_settings
 frappe.patches.v9_1.move_feed_to_activity_log
 execute:frappe.delete_doc('Page', 'data-import-tool', ignore_missing=True)
 frappe.patches.v10_0.reload_countries_and_currencies
+frappe.patches.v10_0.set_no_copy_to_workflow_state

--- a/frappe/patches/v10_0/set_no_copy_to_workflow_state.py
+++ b/frappe/patches/v10_0/set_no_copy_to_workflow_state.py
@@ -1,0 +1,10 @@
+import frappe
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+def execute():
+	for dt in frappe.get_all("Workflow", fields=['name', 'document_type', 'workflow_state_field']):
+		custom_field_name = "{0}-{1}".format(dt.document_type, dt.workflow_state_field)
+
+		custom_field = frappe.get_doc("Custom Field", custom_field_name)
+		custom_field.no_copy = 1
+		custom_field.save()

--- a/frappe/patches/v10_0/set_no_copy_to_workflow_state.py
+++ b/frappe/patches/v10_0/set_no_copy_to_workflow_state.py
@@ -1,10 +1,11 @@
 import frappe
-from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
 def execute():
 	for dt in frappe.get_all("Workflow", fields=['name', 'document_type', 'workflow_state_field']):
-		custom_field_name = "{0}-{1}".format(dt.document_type, dt.workflow_state_field)
+		fieldname = frappe.db.get_value("Custom Field", filters={'dt': dt.document_type,
+			'fieldname': dt.workflow_state_field})
 
-		custom_field = frappe.get_doc("Custom Field", custom_field_name)
-		custom_field.no_copy = 1
-		custom_field.save()
+		if fieldname:
+			custom_field = frappe.get_doc("Custom Field", fieldname)
+			custom_field.no_copy = 1
+			custom_field.save()

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -31,6 +31,7 @@ class Workflow(Document):
 				"label": self.workflow_state_field.replace("_", " ").title(),
 				"hidden": 1,
 				"allow_on_submit": 1,
+				"no_copy": 1,
 				"fieldtype": "Link",
 				"options": "Workflow State",
 			}).save()


### PR DESCRIPTION
If a workflow is enabled for documents, then while pulling details from other documents the system copies workflow status too.

Thus set `no_copy` property, while creating `workflow_state` field. 

Also added patch, to update existing fields.

---
### Issue

![workflow_issue_2](https://user-images.githubusercontent.com/3784093/39670744-102e6fde-5129-11e8-9e94-9ff8b8d66506.gif)

### Fix

![workflow_issue_1](https://user-images.githubusercontent.com/3784093/39670748-1ca39244-5129-11e8-9be5-86a41daf7cb4.gif)


