### PR TITLE
escape new line char while creating boilerplate for app

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -272,7 +272,7 @@ from setuptools import setup, find_packages
 import re, ast
 
 with open('requirements.txt') as f:
-	install_requires = f.read().strip().split('\n')
+	install_requires = f.read().strip().split('\\n')
 
 # get version from __version__ variable in {app_name}/__init__.py
 _version_re = re.compile(r'__version__\s+=\s+(.*)')


### PR DESCRIPTION
```
➜  frappe-bench ./env/bin/pip install -e ./apps/wit_education_app_1 --no-cache-dir 
Obtaining file:///Users/saurabh/project/frappe-bench/apps/wit_education_app_1
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/saurabh/project/frappe-bench/apps/wit_education_app_1/setup.py", line 6, in <module>
        install_requires = f.read().strip().split('')
    ValueError: empty separator
    
    ----------------------------------------
```