### PR TITLE
fix python3 issue reading pdf

### DIFF
--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -303,12 +303,13 @@ def get_file(fname):
 			content = f.read()
 	else:
 		with io.open(encode(file_path), mode='rb') as f:
+			content = f.read()
 			try:
 				# for plain text files
-				content = f.read().decode()
+				content = content.decode()
 			except UnicodeDecodeError:
 				# for .png, .jpg, etc
-				content = f.read()
+				pass
 
 	return [file_path.rsplit("/", 1)[-1], content]
 


### PR DESCRIPTION
File types other than plain text files weren't sent properly in email. The initial implementation of try except used to destroy the file object in the try statement, and hence we were getting a blank string in the except block. The fix involves reading the file object separately before trying to decode it.