### PR TITLE
Show fieldname as tooltip for all users if developer_mode=1

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -14,8 +14,7 @@ frappe.ui.form.Control = Class.extend({
 		this.make();
 
 		// if developer_mode=1, show fieldname as tooltip
-		if(frappe.boot.user && frappe.boot.user.name==="Administrator" &&
-			frappe.boot.developer_mode===1 && this.$wrapper) {
+		if(frappe.boot.user && frappe.boot.developer_mode===1 && this.$wrapper) {
 			this.$wrapper.attr("title", __(this.df.fieldname));
 		}
 


### PR DESCRIPTION
If `developer_mode = 1`, all users should be able to see the fieldname as tooltip and not only the Administrator. As some use cases require logging in as a user and not as an Administrator for testing purposes.