### PR TITLE
Python 3 fixes for PR bot

### DIFF
--- a/frappe/utils/setup_docs.py
+++ b/frappe/utils/setup_docs.py
@@ -167,7 +167,7 @@ class setup_docs(object):
 			html = frappe.render_template("templates/autodoc/license.html",
 				context = self.app_context)
 
-		with open(os.path.join(self.docs_path, "license.html"), "w") as license_file:
+		with open(os.path.join(self.docs_path, "license.html"), "wb") as license_file:
 			license_file.write(html.encode("utf-8"))
 
 		# contents
@@ -215,7 +215,7 @@ class setup_docs(object):
 
 				if not os.path.exists(module_doc_path):
 					print("Writing " + module_doc_path)
-					with open(module_doc_path, "w") as f:
+					with open(module_doc_path, "wb") as f:
 						context = {"name": self.app + "." + module_name}
 						context.update(self.app_context)
 						context['full_module_name'] = self.app + '.' + full_module_name
@@ -276,7 +276,7 @@ class setup_docs(object):
 
 				print("Writing " + model_path)
 
-				with open(model_path, "w") as f:
+				with open(model_path, "wb") as f:
 					context = {"doctype": doctype_real_name}
 					context.update(self.app_context)
 					f.write(frappe.render_template("templates/autodoc/doctype.html",
@@ -303,5 +303,5 @@ edit_link = '''
 def add_breadcrumbs_tag(path):
 	with open(path, 'r') as f:
 		content = frappe.as_unicode(f.read())
-	with open(path, 'w') as f:
+	with open(path, 'wb') as f:
 		f.write(('<!-- add-breadcrumbs -->\n' + content).encode('utf-8'))

--- a/frappe/www/qrcode.py
+++ b/frappe/www/qrcode.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import frappe
 from frappe import _
-from urlparse import parse_qs
+from six.moves.urllib.parse import parse_qs
 from frappe.twofactor import get_qr_svg_code
 
 def get_context(context):


### PR DESCRIPTION
In python 2 writing to file can be done by reading the file as 'w' or
'wb', however, in python 3 if we're writing 'utf-8' encoded stuff to a
file, it needs to be opened using the 'wb' argument. 'b' here stands for
binary.