### PR TITLE
Show fieldname as tooltip for all users if developer_mode=1

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -14,8 +14,7 @@ frappe.ui.form.Control = Class.extend({
 		this.make();
 
 		// if developer_mode=1, show fieldname as tooltip
-		if(frappe.boot.user && frappe.boot.user.name==="Administrator" &&
-			frappe.boot.developer_mode===1 && this.$wrapper) {
+		if(frappe.boot.user && frappe.boot.developer_mode===1 && this.$wrapper) {
 			this.$wrapper.attr("title", __(this.df.fieldname));
 		}
 


### PR DESCRIPTION
Fieldnames as tooltip should be visible for all users, as some use cases require users **not** being Administrator for testing and developing purposes.