### PR TITLE
Replace frappe.db.sql to frappe.get_list to apply permissions

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -38,17 +38,17 @@ def get_all_nodes(doctype, parent, tree_method, **filters):
 @frappe.whitelist()
 def get_children(doctype, parent='', **filters):
 	parent_field = 'parent_' + doctype.lower().replace(' ', '_')
+	filters=[['docstatus', '<' ,'2']]
+	doctype_meta = frappe.get_meta(doctype)
+	if doctype_meta.get(parent_field) : filters.append([parent_field,'=', parent])
+	data = frappe.get_list(doctype, fields=[
+		'name as value',
+		'{0} as title'.format(doctype_meta.get('title_field') or 'name'),
+		'is_group as expandable'],
+		filters=filters,
+		order_by='name')
 
-	return frappe.db.sql("""select name as value, `{title_field}` as title,
-		is_group as expandable
-		from `tab{ctype}`
-		where docstatus < 2
-		and ifnull(`{parent_field}`,'') = %s
-		order by name""".format(
-			ctype = frappe.db.escape(doctype),
-			parent_field = frappe.db.escape(parent_field),
-			title_field = frappe.get_meta(doctype).title_field or 'name'),
-		parent, as_dict=1)
+	return data
 
 @frappe.whitelist()
 def add_node():

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -148,7 +148,7 @@ def get_role_permissions(doctype_meta, user=None, verbose=False):
 		)
 
 		roles = frappe.get_roles(user)
-		
+
 		def is_perm_applicable(perm):
 			return perm.role in roles and cint(perm.permlevel)==0
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -147,8 +147,9 @@ def get_role_permissions(doctype_meta, user=None, verbose=False):
 			if_owner={}
 		)
 
+		roles = frappe.get_roles(user)
+		
 		def is_perm_applicable(perm):
-			roles = frappe.get_roles(user)
 			return perm.role in roles and cint(perm.permlevel)==0
 
 		def has_permission_without_if_owner_enabled(ptype):


### PR DESCRIPTION
 `get_children` method in `treeview.py` used `frappe.db.sql` to get data, which had no permission check.
Now its replaced with` frappe.get_list` which will check permission based on the session user.

fixes 3rd issue in https://github.com/frappe/frappe/issues/5545