### PR TITLE
Allow everything for Admin

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -12,11 +12,7 @@ class Role(Document):
 			frappe.throw(frappe._("Standard roles cannot be renamed"))
 
 	def after_insert(self):
-		# Add role to Administrator
-		if frappe.flags.in_install != "frappe":
-			user = frappe.get_doc("User", "Administrator")
-			user.flags.ignore_permissions = True
-			user.add_roles(self.name)
+		frappe.cache().hdel('roles', 'Administrator')
 
 	def validate(self):
 		if self.disabled:


### PR DESCRIPTION
- Return all available role if the user is an admin
   >This will allow admin to access doctype even if the doctype
      has docperm with only disabled roles
- No longer need to add the role for admin on every new role creation 