### PR TITLE
[fix] Button duplication on page trigger: refresh

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -375,16 +375,15 @@ frappe.ui.Page = Class.extend({
 			$(this.inner_toolbar).removeClass("hide");
 
 			if (!this.is_in_group_button_dropdown($group.find(".dropdown-menu"), 'li', label)) {
-				return $('<li><a>'+label+'</a></li>')
+				return $('<li><a data-label="'+label+'">'+label+'</a></li>')
 					.on('click', _action)
 					.appendTo($group.find(".dropdown-menu"));
 			}
 
 		} else {
-			var button = this.inner_toolbar.find('button')
-				.filter((i, btn) =>  label.includes($(btn).text()));
+			var button = this.inner_toolbar.find('button[data-label="'+label+'"]');
 			if( button.length == 0 ) {
-				return $('<button class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
+				return $('<button data-label="'+label+'" class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
 					.on("click", _action)
 					.appendTo(this.inner_toolbar.removeClass("hide"));
 			} else {
@@ -403,16 +402,12 @@ frappe.ui.Page = Class.extend({
 		if (group) {
 			var $group = this.get_inner_group_button(__(group));
 			if($group.length) {
-				$group.find('.dropdown-menu li a')
-					.filter((i, btn) => label.includes($(btn).text()))
-					.remove();
+				$group.find('.dropdown-menu li a[data-label="'+label+'"]').remove();
 			}
 			if ($group.find('.dropdown-menu li a').length === 0) $group.remove();
 		} else {
 
-			this.inner_toolbar.find('button')
-				.filter((i, btn) =>  label.includes($(btn).text()))
-				.remove();
+			this.inner_toolbar.find('button[data-label="'+label+'"]').remove();
 		}
 	},
 

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -381,9 +381,15 @@ frappe.ui.Page = Class.extend({
 			}
 
 		} else {
-			return $('<button class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
-				.on("click", _action)
-				.appendTo(this.inner_toolbar.removeClass("hide"));
+			var button = this.inner_toolbar.find('button')
+				.filter((i, btn) =>  label.includes($(btn).text()));
+			if( button.length == 0 ) {
+				return $('<button class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
+					.on("click", _action)
+					.appendTo(this.inner_toolbar.removeClass("hide"));
+			} else {
+				return button;
+			}
 		}
 	},
 

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -322,9 +322,9 @@ frappe.ui.Page = Class.extend({
 	},
 
 	get_or_add_inner_group_button: function(label) {
-		var $group = this.inner_toolbar.find('.btn-group[data-label="'+label+'"]');
+		var $group = this.inner_toolbar.find('.btn-group[data-label="'+encodeURIComponent(label)+'"]');
 		if(!$group.length) {
-			$group = $('<div class="btn-group" data-label="'+label+'" style="margin-left: 10px;">\
+			$group = $('<div class="btn-group" data-label="'+encodeURIComponent(label)+'" style="margin-left: 10px;">\
 				<button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">\
 				'+label+' <span class="caret"></span></button>\
 				<ul class="dropdown-menu" style="margin-top: -8px;"></ul></div>').appendTo(this.inner_toolbar);
@@ -333,7 +333,7 @@ frappe.ui.Page = Class.extend({
 	},
 
 	get_inner_group_button: function(label) {
-		return this.inner_toolbar.find('.btn-group[data-label="'+label+'"]');
+		return this.inner_toolbar.find('.btn-group[data-label="'+encodeURIComponent(label)+'"]');
 	},
 
 	set_inner_btn_group_as_primary: function(label) {
@@ -381,7 +381,7 @@ frappe.ui.Page = Class.extend({
 			}
 
 		} else {
-			var button = this.inner_toolbar.find('button[data-label="'+label+'"]');
+			var button = this.inner_toolbar.find('button[data-label="'+encodeURIComponent(label)+'"]');
 			if( button.length == 0 ) {
 				return $('<button data-label="'+encodeURIComponent(label)+'" class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
 					.on("click", _action)
@@ -402,12 +402,12 @@ frappe.ui.Page = Class.extend({
 		if (group) {
 			var $group = this.get_inner_group_button(__(group));
 			if($group.length) {
-				$group.find('.dropdown-menu li a[data-label="'+label+'"]').remove();
+				$group.find('.dropdown-menu li a[data-label="'+encodeURIComponent(label)+'"]').remove();
 			}
 			if ($group.find('.dropdown-menu li a').length === 0) $group.remove();
 		} else {
 
-			this.inner_toolbar.find('button[data-label="'+label+'"]').remove();
+			this.inner_toolbar.find('button[data-label="'+encodeURIComponent(label)+'"]').remove();
 		}
 	},
 

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -375,7 +375,7 @@ frappe.ui.Page = Class.extend({
 			$(this.inner_toolbar).removeClass("hide");
 
 			if (!this.is_in_group_button_dropdown($group.find(".dropdown-menu"), 'li', label)) {
-				return $('<li><a data-label="'+label+'">'+label+'</a></li>')
+				return $('<li><a data-label="'+encodeURIComponent(label)+'">'+label+'</a></li>')
 					.on('click', _action)
 					.appendTo($group.find(".dropdown-menu"));
 			}
@@ -383,7 +383,7 @@ frappe.ui.Page = Class.extend({
 		} else {
 			var button = this.inner_toolbar.find('button[data-label="'+label+'"]');
 			if( button.length == 0 ) {
-				return $('<button data-label="'+label+'" class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
+				return $('<button data-label="'+encodeURIComponent(label)+'" class="btn btn-default btn-xs" style="margin-left: 10px;">'+__(label)+'</btn>')
 					.on("click", _action)
 					.appendTo(this.inner_toolbar.removeClass("hide"));
 			} else {

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -934,7 +934,9 @@ _f.Frm.prototype.add_custom_button = function(label, fn, group) {
 	// temp! old parameter used to be icon
 	if(group && group.indexOf("fa fa-")!==-1) group = null;
 	var btn = this.page.add_inner_button(label, fn, group);
-	this.custom_buttons[label] = btn;
+	if(btn) {
+		this.custom_buttons[label] = btn;
+	}
 	return btn;
 };
 


### PR DESCRIPTION
## Issue
Buttons were duplicated if there was a programmatic trigger to refresh the page.
![image](https://user-images.githubusercontent.com/8912289/40159025-15b98de0-59c5-11e8-9652-4dae894301ed.png)

### Expected behavior
When a form is refreshed in any way, all document buttons should only appear once.
### Actual behavior
When a `refresh` is triggered on a page programmatically, instead of keeping a single instance of a button, duplicates are being created.
### Solution
Check if the button exists or not before creating it, and just return the button instance if it already exists.