### PR TITLE
[Minor] Patch fix for migration

### DIFF
--- a/frappe/patches/v7_2/remove_in_filter.py
+++ b/frappe/patches/v7_2/remove_in_filter.py
@@ -3,3 +3,4 @@ import frappe
 def execute():
 	if frappe.db.has_column('DocField', 'in_filter'):
 		frappe.db.sql('alter table tabDocField drop column in_filter')
+	frappe.clear_cache(doctype="DocField")

--- a/frappe/patches/v8_0/drop_in_dialog.py
+++ b/frappe/patches/v8_0/drop_in_dialog.py
@@ -3,3 +3,4 @@ import frappe
 def execute():
 	if frappe.db.has_column('DocType', 'in_dialog'):
 		frappe.db.sql('alter table tabDocType drop column in_dialog')
+	frappe.clear_cache(doctype="DocType")


### PR DESCRIPTION
Migrating from v7 runs into error after dropping the field from DocType and DocField.

Clearing meta_cache for these doctypes fixes the migration issue.