### PR TITLE
Account for documents with integer names so they can be deleted.

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -12,7 +12,7 @@ from frappe.utils.password import delete_all_passwords_for
 from frappe import _
 from frappe.model.naming import revert_series_if_last
 from frappe.utils.global_search import delete_for_document
-from six import string_types
+from six import string_types, integer_types
 
 def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reload=False,
 	ignore_permissions=False, flags=None, ignore_on_trash=False, ignore_missing=True):
@@ -27,7 +27,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 		name = frappe.form_dict.get('dn')
 
 	names = name
-	if isinstance(name, string_types):
+	if isinstance(name, string_types) or isinstance(name, integer_types):
 		names = [name]
 
 	for name in names or []:


### PR DESCRIPTION
**Issue:**
- Documents with names that are only numbers are not deleted when using the list view bulk action button.

**Reproduce**
- Create a doctype with autoname set to a field of 'Data' type but uses numbers as IDs such as: 344, 53234, etc.
- Go to list view and selected checkbox for 1 or more documents
- Use 'Action' button to 'Delete' these items

**Expected Results:**
- items should be deleted

**Observed Results:**
- items are not deleted and no error message are shown to user. However, the browser console shows a error stating that .bold() is not available when trying to send cannot delete message to the user.

- Even though ID field used is of 'Data' type, once the delete_doc() is called the name becomes integer type and fails to be deleted since the integer cannot be enumerated (line 33 of delete_doc.py).

