### PR TITLE
fix for $(..).dropdown is not a fucntion

### DIFF
--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -405,7 +405,9 @@ $(document).ready(function() {
 
 $(document).on("page-change", function() {
 	$(document).trigger("apply_permissions");
-	$('.dropdown-toggle').dropdown();
+	$(document).ready(function(){
+		$(".dropdown-toggle").dropdown();
+	});	
 
 	//multilevel dropdown fix
 	$('.dropdown-menu .dropdown-submenu .dropdown-toggle').on('click', function(e) {


### PR DESCRIPTION
the dropdown function doesn't seem to work before the document is ready on the foundation website for some reason 