### PR TITLE
[Minor] Patch fix for older user_settings

### DIFF
--- a/frappe/patches/v11_0/update_list_user_settings.py
+++ b/frappe/patches/v11_0/update_list_user_settings.py
@@ -15,10 +15,12 @@ def execute():
 		# traverse through each doctype's settings for a user
 		for d in settings:
 			data = json.loads(d['data'])
-			if data and ('List' in data) and ('order_by' in data['List']):
+			if data and ('List' in data) and ('order_by' in data['List']) and data['List']['order_by']:
 				# convert order_by to sort_order & sort_by and delete order_by
 				order_by = data['List']['order_by']
-				order_by = order_by.replace('`', '').split('.')[1]
+				if '`' in order_by and '.' in order_by:
+					order_by = order_by.replace('`', '').split('.')[1]
+
 				data['List']['sort_by'], data['List']['sort_order'] = order_by.split(' ')
 				data['List'].pop('order_by')
 				update_user_settings(d['doctype'], json.dumps(data), for_update=True)


### PR DESCRIPTION
Older user_settings has - ``` modified desc ``` instead of ``` `tabDocType`.`modified` desc ```

Also only update if order_by has value in it. Some user have order_by set as blank