### PR TITLE
Add Custom Jinja methods from hooks.py

### DIFF
--- a/frappe/docs/user/en/guides/basics/hooks.md
+++ b/frappe/docs/user/en/guides/basics/hooks.md
@@ -275,3 +275,21 @@ Example,
 			"erpnext.setup.doctype.backup_manager.backup_manager.take_backups_daily"
 		],
 	}
+
+### Jinja Customization
+
+Fetch custom methods and filters that are to be available globally in jinja environment.
+
+* `methods`
+* `filters`
+
+Example,
+
+	jenv = {
+		"methods": [
+			"method_name:dotted.path.to.method_definition"
+		],
+		"filters": [
+			"filter_name:dotted.path.to.filter_function"
+		]
+	}

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -156,6 +156,12 @@ def get_allowed_functions_for_jenv():
 			"escape": frappe.db.escape,
 		}
 
+	# load jenv methods from hooks.py
+	for app in frappe.get_installed_apps():
+		for jenv_method in frappe.get_hooks(app_name=app).get('jenv', {"methods": []})["methods"]:
+			method_name, method_definition = jenv_method.split(":")
+			out[method_name] = frappe.get_attr(method_definition)
+
 	return out
 
 def get_jloader():
@@ -205,6 +211,6 @@ def set_filters(jenv):
 
 	# load jenv_filters from hooks.py
 	for app in frappe.get_installed_apps():
-		for jenv_filter in (frappe.get_hooks(app_name=app).jenv_filter or []):
+		for jenv_filter in frappe.get_hooks(app_name=app).get('jenv', {"filters": []})["filters"]:
 			filter_name, filter_function = jenv_filter.split(":")
 			jenv.filters[filter_name] = frappe.get_attr(filter_function)


### PR DESCRIPTION
Option to add custom methods and filters to jinja environment from hooks.py.

Changed jenv_filter to jenv = { "filters": []}
This is done to keep in par with all other hooks definition and added methods to it.

Example for it is updated in the documentation of hooks.
