### PR TITLE
[query-perf-log] Add execution time for debug opt in frappe.db.sql

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -10,6 +10,7 @@ import datetime
 import frappe
 import frappe.defaults
 import frappe.async
+from time import time
 import re
 import frappe.model.meta
 from frappe.utils import now, get_datetime, cstr, cast_fieldtype
@@ -172,6 +173,8 @@ class Database:
 
 		# execute
 		try:
+			time_start = time()
+
 			if values!=():
 				if isinstance(values, dict):
 					values = dict(values)
@@ -203,6 +206,12 @@ class Database:
 					frappe.log(">>>>")
 
 				self._cursor.execute(query)
+
+			if debug:
+				frappe.errprint("\n--- query stats start ---\n")
+				time_end = time()
+				frappe.errprint(("Execution time: {0} sec").format(round(time_end - time_start, 2)))
+				frappe.errprint("\n--- query stats end ---\n")
 
 		except Exception as e:
 			if ignore_ddl and e.args[0] in (ER.BAD_FIELD_ERROR, ER.NO_SUCH_TABLE,

--- a/frappe/database.py
+++ b/frappe/database.py
@@ -173,7 +173,8 @@ class Database:
 
 		# execute
 		try:
-			time_start = time()
+			if debug:
+				time_start = time()
 
 			if values!=():
 				if isinstance(values, dict):


### PR DESCRIPTION
Although hardcore optimization will mostly be carried out in the MariaDB console itself, we could go for some extra info in the `debug=True` query logs, the option is pretty cool for at-a-glance info.

<img width="540" alt="screen shot 2018-05-22 at 9 50 50 pm" src="https://user-images.githubusercontent.com/5196925/40375799-43539f4a-5e0a-11e8-8821-b2db1dc4ec51.png">

Added this while optimizing https://github.com/frappe/erpnext/pull/14185

Use of `frappe.errprint` (similar to it being used for the query explain logs) seems out of place, any other util?

-----------------------------------------------------
### Premise
For those who may not know, 

`frappe.db.sql()` features a `debug` option:

<img width="528" alt="screen shot 2018-05-22 at 10 23 37 pm" src="https://user-images.githubusercontent.com/5196925/40377557-ce1648ae-5e0e-11e8-915a-5715bf4ec637.png">

which prints the query text, table info, format, to help you check where things may have messed up if they did:

<img width="796" alt="screen shot 2018-05-22 at 9 56 04 pm" src="https://user-images.githubusercontent.com/5196925/40377613-ec50b732-5e0e-11e8-80e1-7cd60617527a.png">

This PR is to add an approximate execution time as well to that info.