### PR TITLE
Jinja Customization from hooks.py bug fix

### DIFF
--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -156,12 +156,9 @@ def get_allowed_functions_for_jenv():
 			"escape": frappe.db.escape,
 		}
 
-	if getattr(frappe.local, "site", None):
-		# load jenv methods from hooks.py
-		for app in frappe.get_installed_apps():
-			for jenv_method in frappe.get_hooks(app_name=app).get('jenv', {"methods": []})["methods"]:
-				method_name, method_definition = jenv_method.split(":")
-				out[method_name] = frappe.get_attr(method_definition)
+	# load jenv methods from hooks.py
+	for method_name, method_definition in get_jenv_customization("methods"):
+		out[method_name] = frappe.get_attr(method_definition)
 
 	return out
 
@@ -211,7 +208,14 @@ def set_filters(jenv):
 	if frappe.flags.in_setup_help: return
 
 	# load jenv_filters from hooks.py
+	for filter_name, filter_function in get_jenv_customization("filters"):
+		jenv.filters[filter_name] = frappe.get_attr(filter_function)
+
+def get_jenv_customization(customizable_type):
+	import frappe
 	for app in frappe.get_installed_apps():
-		for jenv_filter in frappe.get_hooks(app_name=app).get('jenv', {"filters": []})["filters"]:
-			filter_name, filter_function = jenv_filter.split(":")
-			jenv.filters[filter_name] = frappe.get_attr(filter_function)
+		for jenv_customizable, jenv_customizable_definition in frappe.get_hooks(app_name=app).get("jenv", {}).items():
+			if customizable_type == jenv_customizable:
+				for data in jenv_customizable_definition:
+					split_data = data.split(":")
+					yield split_data[0], split_data[1]

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -213,9 +213,11 @@ def set_filters(jenv):
 
 def get_jenv_customization(customizable_type):
 	import frappe
-	for app in frappe.get_installed_apps():
-		for jenv_customizable, jenv_customizable_definition in frappe.get_hooks(app_name=app).get("jenv", {}).items():
-			if customizable_type == jenv_customizable:
-				for data in jenv_customizable_definition:
-					split_data = data.split(":")
-					yield split_data[0], split_data[1]
+
+	if getattr(frappe.local, "site", None):
+		for app in frappe.get_installed_apps():
+			for jenv_customizable, jenv_customizable_definition in frappe.get_hooks(app_name=app).get("jenv", {}).items():
+				if customizable_type == jenv_customizable:
+					for data in jenv_customizable_definition:
+						split_data = data.split(":")
+						yield split_data[0], split_data[1]


### PR DESCRIPTION
Customization options required jenv to include filters and methods mandatorily. Missing any of the options throws a key not found error. This is being fixed to accept customizations optionally from hooks.py.