### PR TITLE
[fix] cached timestamp in frappe.model.with_doctype()

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -99,7 +99,7 @@ $.extend(frappe.model, {
 			var cached_timestamp = null;
 			if(localStorage["_doctype:" + doctype]) {
 				let cached_docs = JSON.parse(localStorage["_doctype:" + doctype]);
-				let cached_doc = cached_docs.filter(doc => doc.name === doctype);
+				let cached_doc = cached_docs.filter(doc => doc.name === doctype)[0];
 				if(cached_doc) {
 					cached_timestamp = cached_doc.modified;
 				}

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -98,8 +98,11 @@ $.extend(frappe.model, {
 		} else {
 			var cached_timestamp = null;
 			if(localStorage["_doctype:" + doctype]) {
-				var cached_doc = JSON.parse(localStorage["_doctype:" + doctype]);
-				cached_timestamp = cached_doc.modified;
+				let cached_docs = JSON.parse(localStorage["_doctype:" + doctype]);
+				let cached_doc = cached_docs.filter(doc => doc.name === doctype);
+				if(cached_doc) {
+					cached_timestamp = cached_doc.modified;
+				}
 			}
 			return frappe.call({
 				method:'frappe.desk.form.load.getdoctype',


### PR DESCRIPTION
`localStorage` stores meta info of all relevant doctypes for a doctype in an array. We have to pick the one we're requesting in `with_doctype()`.

<img width="423" alt="screen shot 2018-05-25 at 3 26 15 pm" src="https://user-images.githubusercontent.com/5196925/40538694-ff3bfc3a-602f-11e8-9a74-ca441d3817f4.png">
