### PR TITLE
Update country_info.json

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -817,6 +817,7 @@
  },
  "Ethiopia": {
   "code": "et",
+  "currency": "ETB",
   "currency_fraction": "Santim",
   "currency_fraction_units": 100,
   "currency_name": "Ethiopian Birr",


### PR DESCRIPTION
when setting up ERPNext for the first time the currency "ETB" doesn't appear on the country, currency and timezone selection page. I think this solves that. And I am not sure if that inserts this particular currency into the `tabCurrency` table out of the box.

Thanks