### PR TITLE
Consider default print language when sending mail

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -285,11 +285,11 @@ frappe.views.CommunicationComposer = Class.extend({
 		return frappe.last_edited_communication[this.doc][this.key];
 	},
 
-	selected_format: function () {
+	selected_format: function() {
 		return this.dialog.fields_dict.select_print_format.input.value || this.frm.meta.default_print_format || "Standard";
 	},
 
-	get_print_format: function (format) {
+	get_print_format: function(format) {
 		if (!format) {
 			format = this.selected_format();
 		}

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -310,10 +310,10 @@ frappe.views.CommunicationComposer = Class.extend({
 		this.lang_code = doc.language
 
 		if (this.get_print_format().default_print_language) {
-			default_print_language_code = this.get_print_format().default_print_language;
+			var default_print_language_code = this.get_print_format().default_print_language;
 			me.lang_code = default_print_language_code;
 		} else {
-			default_print_language_code = null;
+			var default_print_language_code = null;
 		}
 
 		//On selection of language retrieve language code

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -295,9 +295,9 @@ frappe.views.CommunicationComposer = Class.extend({
 		}
 
 		if (locals["Print Format"] && locals["Print Format"][format]) {
-			return locals["Print Format"][format]
+			return locals["Print Format"][format];
 		} else {
-			return {}
+			return {};
 		}
 	},
 

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -285,6 +285,22 @@ frappe.views.CommunicationComposer = Class.extend({
 		return frappe.last_edited_communication[this.doc][this.key];
 	},
 
+	selected_format: function () {
+		return this.dialog.fields_dict.select_print_format.input.value || this.frm.meta.default_print_format || "Standard";
+	},
+
+	get_print_format: function (format) {
+		if (!format) {
+			format = this.selected_format();
+		}
+
+		if (locals["Print Format"] && locals["Print Format"][format]) {
+			return locals["Print Format"][format]
+		} else {
+			return {}
+		}
+	},
+
 	setup_print_language: function() {
 		var me = this;
 		var doc = this.doc || cur_frm.doc;
@@ -292,6 +308,13 @@ frappe.views.CommunicationComposer = Class.extend({
 
 		//Load default print language from doctype
 		this.lang_code = doc.language
+
+		if (this.get_print_format().default_print_language) {
+			default_print_language_code = this.get_print_format().default_print_language;
+			me.lang_code = default_print_language_code;
+		} else {
+			default_print_language_code = null;
+		}
 
 		//On selection of language retrieve language code
 		$(fields.language_sel.input).change(function(){
@@ -301,8 +324,13 @@ frappe.views.CommunicationComposer = Class.extend({
 		// Load all languages in the select field language_sel
 		$(fields.language_sel.input)
 			.empty()
-			.add_options(frappe.get_languages())
-			.val(doc.language)
+			.add_options(frappe.get_languages());
+
+		if (default_print_language_code) {
+			$(fields.language_sel.input).val(default_print_language_code);
+		} else {
+			$(fields.language_sel.input).val(doc.language);
+		}
 	},
 
 	setup_print: function() {


### PR DESCRIPTION
As users are allowed to define a default print language for a print format, this change is bringing support for that feature to the Communication Composer / Mail Form.

Related to https://github.com/frappe/frappe/pull/4777

Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [x] Changes to Existing Features
- [x] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

**Please don't be intimidated by the long list of options you've fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

