### PR TITLE
Enable doc.get_formatted() in Standard Reply

### DIFF
--- a/frappe/email/doctype/standard_reply/standard_reply.py
+++ b/frappe/email/doctype/standard_reply/standard_reply.py
@@ -18,7 +18,7 @@ def get_standard_reply(template_name, doc):
 		doc = json.loads(doc)
 
 	the_doc = frappe.get_doc(doc.get('doctype'), doc.get('name'))
-	
+
 	doc.update({'doc': the_doc})
 	
 	standard_reply = frappe.get_doc("Standard Reply", template_name)

--- a/frappe/email/doctype/standard_reply/standard_reply.py
+++ b/frappe/email/doctype/standard_reply/standard_reply.py
@@ -17,6 +17,10 @@ def get_standard_reply(template_name, doc):
 	if isinstance(doc, string_types):
 		doc = json.loads(doc)
 
+	the_doc = frappe.get_doc(doc.get('doctype'), doc.get('name'))
+	
+	doc.update({'doc': the_doc})
+	
 	standard_reply = frappe.get_doc("Standard Reply", template_name)
 	return {"subject" : frappe.render_template(standard_reply.subject, doc), 
 			"message" : frappe.render_template(standard_reply.response, doc)}


### PR DESCRIPTION
Enables the ability to use for example doc.get_formatted('due_date') in standard reply

Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [x] Changes to Existing Features
- [ ] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

**Please don't be intimidated by the long list of options you've fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

