### PR TITLE
Check if subject is default when sending mail

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -207,7 +207,7 @@ frappe.views.CommunicationComposer = Class.extend({
 				}
 
 				content_field.set_value(content.join(''));
-				if(subject === "") {
+				if(subject === "" || subject == __(me.frm.meta.name) + ': ' + me.frm.docname) {
 					subject_field.set_value(reply.subject);
 				}
 


### PR DESCRIPTION
When sending an e mail by a standard reply / email template, using the Communication Composer, the code checks if subject is empty. It should check as well, if the subject is in the default format, because otherwise the subject of the Standard Reply / E Mail Template will never be used.

Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [x] Changes to Existing Features
- [ ] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

**Please don't be intimidated by the long list of options you've fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

