### PR TITLE
[navbar] Reduce items in-between space

### DIFF
--- a/frappe/public/less/navbar.less
+++ b/frappe/public/less/navbar.less
@@ -1,19 +1,38 @@
 @import "variables.less";
 @import "mixins.less";
 
-.navbar .dropdown-toggle {
-	padding-top: 8px;
-	padding-bottom: 8px;
-}
-
 .navbar-fixed-top {
 	left: 0px;
 	right: 0px;
 }
 
-.navbar a {
-	font-size: 12px;
-	font-weight: bold;
+.navbar {
+	a {
+		font-size: 12px;
+		font-weight: bold;
+	}
+
+	.dropdown-toggle {
+		padding-top: 8px;
+		padding-bottom: 8px;
+	}
+
+	// instead of changes within BS3 itself
+	.nav > li > a {
+		padding: 10px 10px;
+	}
+
+	.navbar-search-icon {
+		color: @navbar-default-color;
+		font-size: inherit;
+		position: relative;
+		right: 24px;
+		top: 1px;
+	}
+
+	.badge {
+		font-weight: normal;
+	}
 }
 
 .navbar-icon-home {
@@ -179,18 +198,6 @@
 #navbar-search {
 	width: 100%;
 	background-color: rgba(255, 255, 255, 0.9);
-}
-
-.navbar .navbar-search-icon {
-	color: @navbar-default-color;
-	font-size: inherit;
-	position: relative;
-	right: 24px;
-	top: 1px;
-}
-
-.navbar .badge {
-	font-weight: normal;
 }
 
 #navbar-search-results {


### PR DESCRIPTION
Salvaging some real estate.

**Before:**
<img width="1029" alt="screen shot 2018-06-04 at 12 06 36 pm" src="https://user-images.githubusercontent.com/5196925/40902321-4a8caa04-67f1-11e8-8b6a-7fed516bc3ba.png">

**After:**
<img width="1029" alt="screen shot 2018-06-04 at 12 06 56 pm" src="https://user-images.githubusercontent.com/5196925/40902324-4daaa18c-67f1-11e8-92c2-179a10968106.png">

Smaller screen behaviour stays the same:
<img width="504" alt="screen shot 2018-06-04 at 12 16 46 pm" src="https://user-images.githubusercontent.com/5196925/40902443-a3f20e68-67f1-11e8-8267-7f15843b019e.png">
