### PR TITLE
[Minor] Fix filter query for get_children in treeview

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -38,7 +38,7 @@ def get_all_nodes(doctype, parent, tree_method, **filters):
 @frappe.whitelist()
 def get_children(doctype, parent='', **filters):
 	parent_field = 'parent_' + doctype.lower().replace(' ', '_')
-	filters=[['ifnull(`{0}`,'')'.format(parent_field), '=', parent],
+	filters=[['ifnull(`{0}`,"")'.format(parent_field), '=', parent],
 		['docstatus', '<' ,'2']]
 
 	doctype_meta = frappe.get_meta(doctype)


### PR DESCRIPTION
<img width="1005" alt="screen shot 2018-06-04 at 5 20 21 pm" src="https://user-images.githubusercontent.com/17617465/40916017-ca53b1ea-681b-11e8-883d-87c46205a2d6.png">

Now:
<img width="986" alt="screen shot 2018-06-04 at 5 19 22 pm" src="https://user-images.githubusercontent.com/17617465/40916016-ca261406-681b-11e8-96e5-5aa3fd043889.png">