### PR TITLE
[fix] Incorrect email account as sender

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -54,7 +54,23 @@ def get_outgoing_email_account(raise_exception_not_set=True, append_to=None, sen
 
 		if append_to:
 			# append_to is only valid when enable_incoming is checked
-			email_account = _get_email_account({"enable_outgoing": 1, "enable_incoming": 1, "append_to": append_to})
+
+			# in case of multiple Email Accounts with same append_to
+			# narrow it down based on email_id
+			email_account = _get_email_account({
+				"enable_outgoing": 1,
+				"enable_incoming": 1,
+				"append_to": append_to,
+				"email_id": sender_email_id
+			})
+
+			# else find the first Email Account with append_to
+			if not email_account:
+				email_account = _get_email_account({
+					"enable_outgoing": 1,
+					"enable_incoming": 1,
+					"append_to": append_to
+				})
 
 		if not email_account and sender_email_id:
 			# check if the sender has email account with enable_outgoing


### PR DESCRIPTION
If there are multiple Email Accounts with the same append_to,
then the first one is fetched which is incorrect if there is an
Email Account for the current user.

Now it is first filtered by email_id, if not found falls back to old
behaviour.