### PR TITLE
Minor fix

### DIFF
--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -149,12 +149,14 @@ frappe.ui.Tree = class {
 		if(!deep) {
 			frappe.run_serially([
 				() => {return this.get_nodes(value, is_root);},
-				(data_set) => { this.render_node_children(node, data_set); }
+				(data_set) => { this.render_node_children(node, data_set); },
+				() => { this.set_selected_node(node); }
 			]);
 		} else {
 			frappe.run_serially([
 				() => {return this.get_all_nodes(value, is_root);},
-				(data_list) => { this.render_children_of_all_nodes(data_list); }
+				(data_list) => { this.render_children_of_all_nodes(data_list); },
+				() => { this.set_selected_node(node); }
 			]);
 		}
 	}

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -194,11 +194,7 @@ class NestedSet(Document):
 			frappe.throw(_("Root {0} cannot be deleted").format(_(self.doctype)))
 
 		# cannot delete non-empty group
-		has_children = frappe.db.sql("""select count(name) from `tab{doctype}`
-			where `{nsm_parent_field}`=%s""".format(doctype=self.doctype, nsm_parent_field=self.nsm_parent_field),
-			(self.name,))[0][0]
-		if has_children:
-			frappe.throw(_("Cannot delete {0} as it has child nodes").format(self.name), NestedSetChildExistsError)
+		self.validate_if_child_exists()
 
 		self.set(self.nsm_parent_field, "")
 
@@ -210,6 +206,13 @@ class NestedSet(Document):
 				frappe.message_log.pop()
 			else:
 				raise
+
+	def validate_if_child_exists(self):
+		has_children = frappe.db.sql("""select count(name) from `tab{doctype}`
+			where `{nsm_parent_field}`=%s""".format(doctype=self.doctype, nsm_parent_field=self.nsm_parent_field),
+			(self.name,))[0][0]
+		if has_children:
+			frappe.throw(_("Cannot delete {0} as it has child nodes").format(self.name), NestedSetChildExistsError)
 
 	def before_rename(self, olddn, newdn, merge=False, group_fname="is_group"):
 		if merge and hasattr(self, group_fname):
@@ -237,7 +240,7 @@ class NestedSet(Document):
 				frappe.throw(_("""Multiple root nodes not allowed."""), NestedSetMultipleRootsError)
 
 	def validate_ledger(self, group_identifier="is_group"):
-		if self.get(group_identifier) == "No":
+		if hasattr(self, group_identifier) and not bool(self.get(group_identifier)):
 			if frappe.db.sql("""select name from `tab{0}` where {1}=%s and docstatus!=2"""
 				.format(self.doctype, self.nsm_parent_field), (self.name)):
 				frappe.throw(_("{0} {1} cannot be a leaf node as it has children").format(_(self.doctype), self.name))


### PR DESCRIPTION
Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):

In Nestedset, changing the parent's is_group on and off didn't throw any error. Toggling group off shouldn't be allowed for group node as it gives wrong interpretation if viewed in tree.

In Tree view, after a node is added, expand all node function is ran which changed the variable 'selected_node' for every group node and gets set at the last node it expanded. Hence adding another node right after placed it in the wrong group.

- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 
NestedSet Issue -
![nestedset-issue](https://user-images.githubusercontent.com/11695402/41089480-87b77f92-6a5f-11e8-8cc8-721ce5cb3a0a.gif)

Treeview Issue - 
![tree-issue](https://user-images.githubusercontent.com/11695402/41089482-89bd7a58-6a5f-11e8-8f75-804f5d3bbce2.gif)

Treeview Fix -
![tree-fix](https://user-images.githubusercontent.com/11695402/41089489-8b2e151e-6a5f-11e8-9740-8cab8c8abf58.gif)


**Please don't be intimidated by the long list of options you've to fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

