### PR TITLE
[Fix] dropbox client setup

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -101,12 +101,12 @@ def backup_to_dropbox(upload_db_backup=True):
 		dropbox_settings['access_token'] = access_token['oauth2_token']
 		set_dropbox_access_token(access_token['oauth2_token'])
 
+	dropbox_client = dropbox.Dropbox(dropbox_settings['access_token'])
+
 	if not upload_db_backup:
-		dropbox_client = dropbox.Dropbox(dropbox_settings['access_token'])
 		backup = new_backup(ignore_files=True)
 		filename = os.path.join(get_backups_path(), os.path.basename(backup.backup_path_db))
 		upload_file_to_dropbox(filename, "/database", dropbox_client)
-
 
 	# upload files to files folder
 	did_not_upload = []


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 47, in take_backup_to_dropbox
    did_not_upload, error_log = backup_to_dropbox(upload_db_backup)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 115, in backup_to_dropbox
    upload_from_folder(get_files_path(), 0, "/files", dropbox_client, did_not_upload, error_log)
UnboundLocalError: local variable 'dropbox_client' referenced before assignment
```

https://discuss.erpnext.com/t/dropbox-backup-not-working-after-i-bench-updated/37191