### PR TITLE
 Automatically create unique index on autoname field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -203,10 +203,10 @@ class DocType(Document):
 				frappe.throw(_("Invalid fieldname '{0}' in autoname".format(field)))
 			else:
   				for df in self.fields:
-    				if(df.fieldname == field):
-      					df.search_index = 1
-      					df.unique = 1
-					break
+    					if df.fieldname == field:
+      						df.search_index = 1
+	      					df.unique = 1
+						break
 
 		if autoname and (not autoname.startswith('field:')) \
 			and (not autoname.startswith('eval:')) \

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -202,10 +202,10 @@ class DocType(Document):
 			if not field or field not in [ df.fieldname for df in self.fields ]:
 				frappe.throw(_("Invalid fieldname '{0}' in autoname".format(field)))
 			else:
-  				for df in self.fields:
-    					if df.fieldname == field:
-      						df.search_index = 1
-	      					df.unique = 1
+				for df in self.fields:
+					if df.fieldname == field:
+						df.search_index = 1
+						df.unique = 1
 						break
 
 		if autoname and (not autoname.startswith('field:')) \

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -196,11 +196,17 @@ class DocType(Document):
 			self.autoname = "naming_series:"
 
 		# validate field name if autoname field:fieldname is used
-
+		# Create unique index on autoname field automatically.
 		if autoname and autoname.startswith('field:'):
 			field = autoname.split(":")[1]
 			if not field or field not in [ df.fieldname for df in self.fields ]:
 				frappe.throw(_("Invalid fieldname '{0}' in autoname".format(field)))
+			else:
+  				for df in self.fields:
+    				if(df.fieldname == field):
+      					df.search_index = 1
+      					df.unique = 1
+					break
 
 		if autoname and (not autoname.startswith('field:')) \
 			and (not autoname.startswith('eval:')) \


### PR DESCRIPTION
Refer https://discuss.erpnext.com/t/frappe-performance-convention-gap-index-not-used/37438 

When a new doctype is created with autoname as "field:<Some field>, then this PR will automatically mark that field as indexed

e.g. first_name field is set as autoname field - 
<img width="1186" alt="screen shot 2018-06-11 at 7 53 20 pm" src="https://user-images.githubusercontent.com/8121864/41237521-4b8cc194-6db1-11e8-91cb-214cb04a19e2.png">

Then it will be automatically marked as 'indexed' - 

<img width="577" alt="screen shot 2018-06-11 at 7 55 01 pm" src="https://user-images.githubusercontent.com/8121864/41237539-5bd34f46-6db1-11e8-8b23-3cc1cedc897b.png">
