### PR TITLE
Fix bug with smtplib and crammd5 servers that prevents email sending

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -171,7 +171,7 @@ class SMTPServer:
 		if self.email_account:
 			self.server = self.email_account.smtp_server
 			self.login = getattr(self.email_account, "login_id", None) or self.email_account.email_id
-			self.password = frappe.safe_decode(self.email_account.password)
+			self.password = str(self.email_account.password)
 			self.port = self.email_account.smtp_port
 			self.use_tls = self.email_account.use_tls
 			self.sender = self.email_account.email_id

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -169,10 +169,9 @@ class SMTPServer:
 	def setup_email_account(self, append_to=None, sender=None):
 		self.email_account = get_outgoing_email_account(raise_exception_not_set=False, append_to=append_to, sender=sender)
 		if self.email_account:
-			account_password = self.email_account.password
 			self.server = self.email_account.smtp_server
 			self.login = getattr(self.email_account, "login_id", None) or self.email_account.email_id
-			self.password = frappe.safe_encode(account_password)
+			self.password = frappe.safe_encode(self.email_account.password)
 			self.port = self.email_account.smtp_port
 			self.use_tls = self.email_account.use_tls
 			self.sender = self.email_account.email_id

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -171,7 +171,7 @@ class SMTPServer:
 		if self.email_account:
 			self.server = self.email_account.smtp_server
 			self.login = getattr(self.email_account, "login_id", None) or self.email_account.email_id
-			self.password = str(self.email_account.password)
+			self.password = frappe.safe_decode(self.email_account.password)
 			self.port = self.email_account.smtp_port
 			self.use_tls = self.email_account.use_tls
 			self.sender = self.email_account.email_id

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -169,9 +169,10 @@ class SMTPServer:
 	def setup_email_account(self, append_to=None, sender=None):
 		self.email_account = get_outgoing_email_account(raise_exception_not_set=False, append_to=append_to, sender=sender)
 		if self.email_account:
+			account_password = self.email_account.password
 			self.server = self.email_account.smtp_server
 			self.login = getattr(self.email_account, "login_id", None) or self.email_account.email_id
-			self.password = str(self.email_account.password)
+			self.password = frappe.safe_encode(account_password, 'ascii')
 			self.port = self.email_account.smtp_port
 			self.use_tls = self.email_account.use_tls
 			self.sender = self.email_account.email_id

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -172,7 +172,7 @@ class SMTPServer:
 			account_password = self.email_account.password
 			self.server = self.email_account.smtp_server
 			self.login = getattr(self.email_account, "login_id", None) or self.email_account.email_id
-			self.password = frappe.safe_encode(account_password, 'ascii')
+			self.password = frappe.safe_encode(account_password)
 			self.port = self.email_account.smtp_port
 			self.use_tls = self.email_account.use_tls
 			self.sender = self.email_account.email_id

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -171,7 +171,7 @@ class SMTPServer:
 		if self.email_account:
 			self.server = self.email_account.smtp_server
 			self.login = getattr(self.email_account, "login_id", None) or self.email_account.email_id
-			self.password = self.email_account.password
+			self.password = str(self.email_account.password)
 			self.port = self.email_account.smtp_port
 			self.use_tls = self.email_account.use_tls
 			self.sender = self.email_account.email_id


### PR DESCRIPTION
This Is a fix for my issue https://github.com/frappe/frappe/issues/5496. 
After researching it for months I've established that it's the password that is sent as Unicode but should be plain ASCII that's causing the problem. 

I've found many other references to the same issue in multiple projects and the common factor was smtplib and the password sent as Unicode so I tried it and it fixed my issue.  

https://github.com/stephenmcd/mezzanine/issues/899
https://github.com/posativ/isso/issues/126

