### PR TITLE
clear toolbar & button before loading a new report

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -355,6 +355,9 @@ frappe.ui.form.GridRow = Class.extend({
 
 		// sync get_query
 		field.get_query = this.grid.get_field(df.fieldname).get_query;
+		field.df.onchange = function() {
+			me.grid.grid_rows[this.doc.idx-1].refresh_field(this.df.fieldname);
+		};
 		field.refresh();
 		if(field.$input) {
 			field.$input

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -76,6 +76,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	load_report() {
+		this.page.clear_inner_toolbar();
 		this.route = frappe.get_route();
 		this.page_name = frappe.get_route_str();
 		this.report_name = this.route[1];


### PR DESCRIPTION
Issue - Once any button is added in query report and the page gets cached, it starts appearing for all reports. Fixed it by clearing toolbar before a report is loaded.

![issue-qr](https://user-images.githubusercontent.com/11695402/41699858-7e85a144-7543-11e8-8357-3b649be01ea5.gif)


Issue - https://github.com/frappe/frappe/issues/5643
![issue-ref](https://user-images.githubusercontent.com/11695402/41704077-e13676ba-7552-11e8-97c6-626730755f09.gif)

Fix-
![fix-ref](https://user-images.githubusercontent.com/11695402/41704079-e2c28c58-7552-11e8-92c6-17656f60bd38.gif)
