### PR TITLE
[style] max-width class to fulfill ellipsis usage requirement

### DIFF
--- a/frappe/public/less/common.less
+++ b/frappe/public/less/common.less
@@ -280,3 +280,9 @@ a.no-decoration& {
 .ellipsis {
 	.text-ellipsis();
 }
+
+/* Given that the element that text-ellipsis is applied to,
+	should have a max width for it to work */
+.ellipsis-width {
+	max-width: 200px;
+}


### PR DESCRIPTION
fixes frappe/erpnext#13077
with https://github.com/frappe/erpnext/pull/14629

<img width="848" alt="screen shot 2018-06-21 at 10 40 25 pm" src="https://user-images.githubusercontent.com/5196925/41734521-db1a5fa6-75a4-11e8-886d-301e7669733f.png">