### PR TITLE
[build-docs][context] look for _sidebar.json in parent directories

### DIFF
--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -127,7 +127,7 @@ def load_sidebar(context, sidebar_json_path):
 
 def get_sidebar_json_path(path):
 	'''Look for a _sidebar.json going upwards from given path'''
-	if path == '/' or not path:
+	if os.path.split(path)[1] == 'www' or path == '/' or not path:
 		return ''
 
 	sidebar_json_path = os.path.join(path, '_sidebar.json')

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -120,6 +120,22 @@ def build_context(context):
 
 	return context
 
+def load_sidebar(context, sidebar_json_path):
+	with open(sidebar_json_path, 'r') as sidebarfile:
+		context.sidebar_items = json.loads(sidebarfile.read())
+		context.show_sidebar = 1
+
+def get_sidebar_json_path(path):
+	'''Look for a _sidebar.json going upwards from given path'''
+	if path == '/' or not path:
+		return ''
+
+	sidebar_json_path = os.path.join(path, '_sidebar.json')
+	if os.path.exists(sidebar_json_path):
+		return sidebar_json_path
+	else:
+		return get_sidebar_json_path(os.path.split(path)[0])
+
 def add_sidebar_and_breadcrumbs(context):
 	'''Add sidebar and breadcrumbs to context'''
 	from frappe.website.router import get_page_info_from_template
@@ -128,11 +144,9 @@ def add_sidebar_and_breadcrumbs(context):
 		add_sidebar_data(context)
 	else:
 		if context.basepath:
-			sidebar_json_path = os.path.join(context.basepath, '_sidebar.json')
-			if os.path.exists(sidebar_json_path):
-				with open(sidebar_json_path, 'r') as sidebarfile:
-					context.sidebar_items = json.loads(sidebarfile.read())
-					context.show_sidebar = 1
+			sidebar_json_path = get_sidebar_json_path(context.basepath)
+			if sidebar_json_path:
+				load_sidebar(context, sidebar_json_path)
 
 	if context.add_breadcrumbs and not context.parents:
 		if context.basepath:

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -154,9 +154,11 @@ def add_sidebar_and_breadcrumbs(context):
 		add_sidebar_data(context)
 	else:
 		if context.basepath:
+			hooks = frappe.get_hooks('look_for_sidebar_json')
+			look_for_sidebar_json = hooks[0] if hooks else 0
 			sidebar_json_path = get_sidebar_json_path(
 				context.basepath,
-				frappe.get_hooks('look_for_sidebar_json')[0]
+				look_for_sidebar_json
 			)
 			if sidebar_json_path:
 				load_sidebar(context, sidebar_json_path)

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -125,8 +125,15 @@ def load_sidebar(context, sidebar_json_path):
 		context.sidebar_items = json.loads(sidebarfile.read())
 		context.show_sidebar = 1
 
-def get_sidebar_json_path(path):
-	'''Look for a _sidebar.json going upwards from given path'''
+def get_sidebar_json_path(path, look_for=False):
+	'''
+		Get _sidebar.json path from directory path
+
+		:param path: path of the current diretory
+		:param look_for: if True, look for _sidebar.json going upwards from given path
+
+		:return: _sidebar.json path
+	'''
 	if os.path.split(path)[1] == 'www' or path == '/' or not path:
 		return ''
 
@@ -134,7 +141,10 @@ def get_sidebar_json_path(path):
 	if os.path.exists(sidebar_json_path):
 		return sidebar_json_path
 	else:
-		return get_sidebar_json_path(os.path.split(path)[0])
+		if look_for:
+			return get_sidebar_json_path(os.path.split(path)[0], look_for)
+		else:
+			return ''
 
 def add_sidebar_and_breadcrumbs(context):
 	'''Add sidebar and breadcrumbs to context'''
@@ -144,7 +154,10 @@ def add_sidebar_and_breadcrumbs(context):
 		add_sidebar_data(context)
 	else:
 		if context.basepath:
-			sidebar_json_path = get_sidebar_json_path(context.basepath)
+			sidebar_json_path = get_sidebar_json_path(
+				context.basepath,
+				frappe.get_hooks('look_for_sidebar_json')[0]
+			)
 			if sidebar_json_path:
 				load_sidebar(context, sidebar_json_path)
 


### PR DESCRIPTION
Adds ability to skip _sidebar.json for the child if the parent directory has it. Will replicate the same sidebar across child directories, if not overridden.

Turned out useful for: https://github.com/erpnext/foundation/pull/219

Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [x] Changes to Existing Features
- [ ] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

**Please don't be intimidated by the long list of options you've to fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 
