### PR TITLE
Remove hardcoded roles for editing users

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -193,13 +193,13 @@ frappe.ui.form.on('User', {
 })
 
 function has_access_to_edit_user() {
-	return has_common(frappe.user_roles, get_roles_for_editing_user())
+	return has_common(frappe.user_roles, get_roles_for_editing_user());
 }
 
 function get_roles_for_editing_user() {
 	return frappe.get_meta('User').permissions
 		.filter(perm => perm.permlevel >= 1 && perm.write)
-		.map(perm => perm.role) || ['System Manager']
+		.map(perm => perm.role) || ['System Manager'];
 }
 
 frappe.ModuleEditor = Class.extend({

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -38,7 +38,7 @@ frappe.ui.form.on('User', {
 	},
 
 	onload: function(frm) {
-		frm.can_edit_roles = has_common(frappe.user_roles, ["Administrator", "System Manager"]);
+		frm.can_edit_roles = has_access_to_edit_user();
 
 		if(frm.can_edit_roles && !frm.is_new()) {
 			if(!frm.roles_editor) {
@@ -75,7 +75,7 @@ frappe.ui.form.on('User', {
 				frappe.frappe_toolbar.modules_select.show(doc.name);
 			}, null, "btn-default")
 
-			if(has_common(frappe.user_roles, ["Administrator", "System Manager"])) {
+			if(has_access_to_edit_user()) {
 
 				frm.add_custom_button(__("Set User Permissions"), function() {
 					frappe.route_options = {
@@ -155,7 +155,7 @@ frappe.ui.form.on('User', {
 	},
 	enabled: function(frm) {
 		var doc = frm.doc;
-		if(!frm.is_new() && has_common(frappe.user_roles, ["Administrator", "System Manager"])) {
+		if(!frm.is_new() && has_access_to_edit_user()) {
 			frm.toggle_display(['sb1', 'sb3', 'modules_access'], doc.enabled);
 			frm.set_df_property('enabled', 'read_only', 0);
 		}
@@ -192,6 +192,15 @@ frappe.ui.form.on('User', {
 	}
 })
 
+function has_access_to_edit_user() {
+	return has_common(frappe.user_roles, get_roles_for_editing_user())
+}
+
+function get_roles_for_editing_user() {
+	return frappe.get_meta('User').permissions
+		.filter(perm => perm.permlevel >= 1 && perm.write)
+		.map(perm => perm.role) || ['System Manager']
+}
 
 frappe.ModuleEditor = Class.extend({
 	init: function(frm, wrapper) {


### PR DESCRIPTION
- Allow 'User setting' changes if the user has a role which has `write` access with `permlevel >= 1` for User doctype

Fixes https://github.com/frappe/erpnext/issues/14178
