### PR TITLE
[Fix] Email address searching in receipt fails if some contacts does not have email address

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -89,7 +89,7 @@ def get_cached_contacts(txt):
 	if not txt:
 		return contacts
 
-	match = [d for d in contacts if (txt in d.value or txt in d.description)]
+	match = [d for d in contacts if (d.value and (txt in d.value or txt in d.description))]
 	return match
 
 def update_contact_cache(contacts):


### PR DESCRIPTION
Issue:
While searching for email, if any contact similar to search does not have email address it throws error.

![re](https://user-images.githubusercontent.com/16913064/41959833-b4af4ad2-7a0b-11e8-984b-d5479b74f144.gif)

After Fix:
![re fix](https://user-images.githubusercontent.com/16913064/41959835-b6560dc6-7a0b-11e8-884b-1f8fd76147c2.gif)




