### PR TITLE
[Fix] Defaults doesn't comply with user permission fix

### DIFF
--- a/frappe/public/js/frappe/defaults.js
+++ b/frappe/public/js/frappe/defaults.js
@@ -8,6 +8,9 @@ frappe.defaults = {
 		if(!d && frappe.defaults.is_a_user_permission_key(key))
 			d = defaults[frappe.model.scrub(key)];
 		if($.isArray(d)) d = d[0];
+		if(frappe.defaults.not_in_user_permission(key, d)) {
+			return;
+		}
 		return d;
 	},
 	get_user_defaults: function(key) {
@@ -23,6 +26,13 @@ frappe.defaults = {
 			}
 		}
 		if(!$.isArray(d)) d = [d];
+
+		// filter out values which are not permitted to the user
+		d.filter(item => {
+			if(!frappe.defaults.not_in_user_permission(key, item)) {
+				return item;
+			}
+		});
 		return d;
 	},
 	get_global_default: function(key) {
@@ -63,6 +73,10 @@ frappe.defaults = {
 			}
 		}
 
+		if(frappe.defaults.not_in_user_permission(key, value)) {
+			return;
+		}
+
 		if(value) {
 			try {
 				return JSON.parse(value)
@@ -74,6 +88,11 @@ frappe.defaults = {
 
 	is_a_user_permission_key: function(key) {
 		return key.indexOf(":")===-1 && key !== frappe.model.scrub(key);
+	},
+
+	not_in_user_permission: function(key, value) {
+		let user_permission = this.get_user_permissions()[frappe.model.unscrub(key)];
+		return user_permission && !user_permission["docs"].includes(value);
 	},
 
 	get_user_permissions: function() {

--- a/frappe/tests/test_defaults.py
+++ b/frappe/tests/test_defaults.py
@@ -47,3 +47,26 @@ class TestDefaults(unittest.TestCase):
 
 		clear_default("key6", value="value6")
 		self.assertEqual(get_user_default("key6"), None)
+
+	def test_user_permission_on_defaults(self):
+		self.assertEqual(get_global_default("language"), "en")
+		self.assertEqual(get_user_default("language"), "en")
+		self.assertEqual(get_user_default_as_list("language"), ["en"])
+
+		old_user = frappe.session.user
+		user = 'test@example.com'
+		frappe.set_user(user)
+
+		perm_doc = frappe.get_doc(dict(
+			doctype='User Permission',
+			user=frappe.session.user,
+			allow="Language",
+			for_value="en-GB",
+		)).insert(ignore_permissions = True)
+
+		self.assertEqual(get_global_default("language"), None)
+		self.assertEqual(get_user_default("language"), None)
+		self.assertEqual(get_user_default_as_list("language"), [])
+
+		frappe.delete_doc('User Permission', perm_doc.name)
+		frappe.set_user(old_user)


### PR DESCRIPTION
Issue:- https://github.com/frappe/erpnext/issues/14442
![issue-defaults](https://user-images.githubusercontent.com/11695402/41967490-5a92a120-7a1f-11e8-8df5-b26a1781da67.gif)

Fix:-
![fix-defaults](https://user-images.githubusercontent.com/11695402/41967496-5babdeaa-7a1f-11e8-944a-0e293a9d74dd.gif)

Getting defaults like lets say Company from global defaults, if user is restricted to some other company, still he is able to see default Company at first until explicitly removed from the field since mostly defaults are set in the field's default.

Added an extra check before returning the value and return only if user has permission over it.
