### PR TITLE
Auto Repeat Enhancement

### DIFF
--- a/frappe/desk/doctype/auto_repeat/auto_repeat.js
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat.js
@@ -79,6 +79,34 @@ frappe.ui.form.on('Auto Repeat', {
 				}
 			}
 		});
+	},
+
+	template: function(frm) {
+		if (frm.doc.template) {
+			frappe.model.with_doc("Email Template", frm.doc.template, () => {
+				let email_template = frappe.get_doc("Email Template", frm.doc.template);
+				frm.set_value("subject", email_template.subject);
+				frm.set_value("message", email_template.response);
+				frm.refresh_field("subject");
+				frm.refresh_field("message");
+			});
+		}
+	},
+
+	get_contacts: function(frm) {
+		frappe.call({
+			method: "frappe.desk.doctype.auto_repeat.auto_repeat.get_contacts",
+			args: {
+				reference_doctype: frm.doc.reference_doctype,
+				reference_name: frm.doc.reference_document
+			},
+			callback: function(r) {
+				if(r.message) {
+					frm.set_value("recipients", r.message.join());
+					frm.refresh_field("recipients");
+				}
+			}
+		});
 	}
 });
 

--- a/frappe/desk/doctype/auto_repeat/auto_repeat.json
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat.json
@@ -15,6 +15,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -45,6 +46,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -77,6 +79,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -109,6 +112,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -141,6 +145,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -171,6 +176,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -203,6 +209,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 1, 
    "bold": 0, 
    "collapsible": 0, 
@@ -234,6 +241,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -265,6 +273,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 1, 
    "bold": 0, 
    "collapsible": 0, 
@@ -296,6 +305,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -326,6 +336,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -358,6 +369,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -388,6 +400,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 1, 
    "bold": 0, 
    "collapsible": 0, 
@@ -420,6 +433,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -451,6 +465,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -482,6 +497,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -514,6 +530,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 1, 
@@ -545,6 +562,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -576,6 +594,41 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
+   "depends_on": "eval: doc.notify_by_email", 
+   "fieldname": "template", 
+   "fieldtype": "Link", 
+   "hidden": 0, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "label": "Template", 
+   "length": 0, 
+   "no_copy": 0, 
+   "options": "Email Template", 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 0, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 0, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "translatable": 0, 
+   "unique": 0
+  }, 
+  {
+   "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -609,6 +662,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -639,6 +693,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -671,6 +726,40 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
+   "depends_on": "eval: doc.notify_by_email", 
+   "fieldname": "get_contacts", 
+   "fieldtype": "Button", 
+   "hidden": 0, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "label": "Get Contacts", 
+   "length": 0, 
+   "no_copy": 0, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 0, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 0, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "translatable": 0, 
+   "unique": 0
+  }, 
+  {
+   "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -704,6 +793,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 1, 
@@ -736,6 +826,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -768,6 +859,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 1, 
@@ -799,6 +891,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -831,6 +924,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -871,7 +965,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-05-30 17:47:41.965193", 
+ "modified": "2018-06-27 19:28:27.704807", 
  "modified_by": "Administrator", 
  "module": "Desk", 
  "name": "Auto Repeat", 
@@ -880,7 +974,6 @@
  "permissions": [
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 1, 
    "create": 1, 
    "delete": 1, 
@@ -900,7 +993,6 @@
   }, 
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 1, 
    "create": 1, 
    "delete": 1, 
@@ -920,7 +1012,6 @@
   }, 
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 1, 
    "create": 1, 
    "delete": 1, 

--- a/frappe/desk/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat.py
@@ -336,3 +336,38 @@ def auto_repeat_doctype_query(doctype, txt, searchfield, start, page_len, filter
 			'start': start,
 			'page_len': page_len
 		})
+
+@frappe.whitelist()
+def get_contacts(reference_doctype, reference_name):
+	docfields = frappe.get_meta(reference_doctype).fields
+
+	contact_fields = []
+	for field in docfields:
+		if field.fieldtype == "Link" and field.options == "Contact":
+			contact_fields.append(field.fieldname)
+
+	if contact_fields:
+		contacts = []
+		for contact_field in contact_fields:
+			contacts.append(frappe.db.get_value(reference_doctype, reference_name, contact_field))
+	else:
+		return []
+
+	if contacts:
+		emails = []
+		for contact in contacts:
+			emails.append(frappe.db.get_value("Contact", contact, "email_id"))
+
+		return emails
+	else:
+		return []
+
+
+@frappe.whitelist()
+def update_reference(docname, reference):
+	try:
+		frappe.db.set_value("Auto Repeat", docname, "reference_document", reference)
+		return "success"
+	except Exception as e:
+		raise e
+		return "error"


### PR DESCRIPTION
Hi,

This PR adds a few enhancements and User Experience improvements to the Auto Repeat (former Subscription) document:

1. Allow fetching the subject and email message from an existing Email Template (former Standard Reply).
It avoids having to rewrite a message each time you create an auto-repeat document

2. Addition of a button to fetch any contact email address from the reference document.

3. Addition of a method to update the reference document.
After using "Auto Repeat" a lot, one of the main issue is that one needs to create a new document anytime anything is changed compared to the initial reference.
With this option (Added in sales invoices to start with) you can simply update your auto repeat document without having to create a new one.

![image](https://user-images.githubusercontent.com/4903591/41992232-2b0a265c-7a48-11e8-8068-a13d790228dc.png)

