### PR TITLE
[NEEDS DISCUSSION] check if connection exists before sending mail

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -351,6 +351,8 @@ def flush(from_test=False):
 			break
 
 		if email:
+			if not smtpserver.is_connected():
+				smtpserver = SMTPServer()
 			send_one(email, smtpserver, auto_commit, from_test=from_test)
 
 		# NOTE: removing commit here because we pass auto_commit

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -230,3 +230,10 @@ class SMTPServer:
 		except smtplib.SMTPException:
 			frappe.msgprint(_('Unable to send emails at this time'))
 			raise
+
+	def is_connected(self):
+		try:
+			status = self.sess.noop()[0]
+		except:  # smtplib.SMTPServerDisconnected
+			status = -1
+		return True if status == 250 else False


### PR DESCRIPTION
**NEEDS DISCUSSION BEFORE MERGING**

Issue:
Emails weren't being sent due to ( smtplib.SMTPServerDisconnected )

Possible Reason:
Emails were sent before a Connection could be established

Possible Fix: 
Checking if the connection exists. It serves 2 purposes:
1. Generates a time delay
2. If session doesn't exist, it creates one