### PR TITLE
Doctype links in foreign language

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -4,7 +4,9 @@
 from __future__ import unicode_literals
 import frappe
 
+from frappe import _
 import functools
+import re
 
 def load_address_and_contact(doc, key=None):
 	"""Loads address list and contact list in `__onload`"""
@@ -128,24 +130,28 @@ def delete_contact_and_address(doctype, docname):
 def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	if not txt: txt = ""
 
-	txt = txt.lower()
-	txt = "%%%s%%" % (txt)
+	#txt = txt.lower()
+	#txt = "%%%s%%" % (txt)
 
-	filters.update({
-		"parent": ("like", txt)
-	})
+	#filters.update({
+	#	"parent": ("like", txt)
+	#})
 
 	doctypes = frappe.db.get_all("DocField", filters=filters, fields=["parent"],
 		distinct=True, as_list=True)
 
-	filters.pop("parent")
+	doctypes = filter(lambda x: re.search(txt+".*", _(x[0]), re.IGNORECASE), doctypes)
+
+	#filters.pop("parent")
 	filters.update({
 		"dt": ("not in", [d[0] for d in doctypes]),
-		"dt": ("like", txt),
+		#"dt": ("like", txt),
 	})
 
 	_doctypes = frappe.db.get_all("Custom Field", filters=filters, fields=["dt"],
 		as_list=True)
+	
+	_doctypes = filter(lambda x: re.search(txt+".*", _(x[0]), re.IGNORECASE), _doctypes)
 
 	all_doctypes = [d[0] for d in doctypes + _doctypes]
 	valid_doctypes = []

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -130,28 +130,19 @@ def delete_contact_and_address(doctype, docname):
 def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	if not txt: txt = ""
 
-	#txt = txt.lower()
-	#txt = "%%%s%%" % (txt)
-
-	#filters.update({
-	#	"parent": ("like", txt)
-	#})
-
 	doctypes = frappe.db.get_all("DocField", filters=filters, fields=["parent"],
 		distinct=True, as_list=True)
 
-	doctypes = filter(lambda x: re.search(txt+".*", _(x[0]), re.IGNORECASE), doctypes)
+	doctypes = tuple([d for d in doctypes if re.search(txt+".*", _(d[0]), re.IGNORECASE)])
 
-	#filters.pop("parent")
 	filters.update({
-		"dt": ("not in", [d[0] for d in doctypes]),
-		#"dt": ("like", txt),
+		"dt": ("not in", [d[0] for d in doctypes])
 	})
 
 	_doctypes = frappe.db.get_all("Custom Field", filters=filters, fields=["dt"],
 		as_list=True)
 	
-	_doctypes = filter(lambda x: re.search(txt+".*", _(x[0]), re.IGNORECASE), _doctypes)
+	_doctypes = tuple([d for d in _doctypes if re.search(txt+".*", _(d[0]), re.IGNORECASE)])
 
 	all_doctypes = [d[0] for d in doctypes + _doctypes]
 	valid_doctypes = []

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -141,7 +141,7 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 
 	_doctypes = frappe.db.get_all("Custom Field", filters=filters, fields=["dt"],
 		as_list=True)
-	
+
 	_doctypes = tuple([d for d in _doctypes if re.search(txt+".*", _(d[0]), re.IGNORECASE)])
 
 	all_doctypes = [d[0] for d in doctypes + _doctypes]

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -10,7 +10,7 @@ from frappe import _
 from six import string_types
 import re
 
-UNTRANSLATED_DOCTYPES = ["DocType", "Roles"]
+UNTRANSLATED_DOCTYPES = ["DocType", "Role"]
 
 def sanitize_searchfield(searchfield):
 	blacklisted_keywords = ['select', 'delete', 'drop', 'update', 'case', 'and', 'or', 'like']

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -144,6 +144,7 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 				ignore_permissions = ignore_permissions,
 				as_list=not as_dict)
 
+
 			# remove _relevance from results
 			if as_dict:
 				for r in values:

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -12,7 +12,6 @@ import re
 
 UNTRANSLATED_DOCTYPES = ["DocType", "Roles"]
 
-
 def sanitize_searchfield(searchfield):
 	blacklisted_keywords = ['select', 'delete', 'drop', 'update', 'case', 'and', 'or', 'like']
 

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -10,6 +10,8 @@ from frappe import _
 from six import string_types
 import re
 
+UNTRANSLATED_DOCTYPES = ["DocType", "Roles"]
+
 
 def sanitize_searchfield(searchfield):
 	blacklisted_keywords = ['select', 'delete', 'drop', 'update', 'case', 'and', 'or', 'like']
@@ -109,8 +111,8 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 
 				for f in search_fields:
 					fmeta = meta.get_field(f.strip())
-					if f == "name" or (fmeta and fmeta.fieldtype in ["Data", "Text", "Small Text", "Long Text",
-						"Link", "Select", "Read Only", "Text Editor"]):
+					if (doctype not in UNTRANSLATED_DOCTYPES) and (f == "name" or (fmeta and fmeta.fieldtype in ["Data", "Text", "Small Text", "Long Text",
+						"Link", "Select", "Read Only", "Text Editor"])):
 							or_filters.append([doctype, f.strip(), "like", "%{0}%".format(txt)])
 
 			if meta.get("fields", {"fieldname":"enabled", "fieldtype":"Check"}):
@@ -143,6 +145,9 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 				order_by=order_by,
 				ignore_permissions = ignore_permissions,
 				as_list=not as_dict)
+
+			if doctype in UNTRANSLATED_DOCTYPES:
+				values = tuple([v for v in list(values) if re.search(txt+".*", (_(v.name) if as_dict else _(v[0])), re.IGNORECASE)])
 
 			# remove _relevance from results
 			if as_dict:

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -144,7 +144,6 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 				ignore_permissions = ignore_permissions,
 				as_list=not as_dict)
 
-
 			# remove _relevance from results
 			if as_dict:
 				for r in values:

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -138,6 +138,9 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 
 			ignore_permissions = True if doctype == "DocType" else (cint(ignore_user_permissions) and has_permission(doctype))
 
+			if doctype in UNTRANSLATED_DOCTYPES:
+				page_length = None
+
 			values = frappe.get_list(doctype,
 				filters=filters, fields=formatted_fields,
 				or_filters = or_filters, limit_start = start,

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -62,6 +62,7 @@ class TestSearch(unittest.TestCase):
 		frappe.local.lang = 'en'
 		search_widget(doctype="DocType", txt="suppl", page_length=30)
 		output = frappe.response["values"]
+		print(output)
 
 		result = [['found' for x in y if x=="Supplier"] for y in output]
 		self.assertTrue(['found'] in result)
@@ -69,6 +70,7 @@ class TestSearch(unittest.TestCase):
 		frappe.local.lang = 'fr'
 		search_widget(doctype="DocType", txt="fourn", page_length=30)
 		output = frappe.response["values"]
+		print(output)
 
 		result = [['found' for x in y if x=="Supplier"] for y in output]
 		self.assertTrue(['found'] in result)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import unittest
 import frappe
 from frappe.desk.search import search_link
-from frappe.contacts.address_and_contact import filter_dynamic_link_doctypes
 from frappe.desk.search import search_widget
 
 class TestSearch(unittest.TestCase):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -62,7 +62,6 @@ class TestSearch(unittest.TestCase):
 		frappe.local.lang = 'en'
 		search_widget(doctype="DocType", txt="suppl", page_length=30)
 		output = frappe.response["values"]
-		print(output)
 
 		result = [['found' for x in y if x=="Supplier"] for y in output]
 		self.assertTrue(['found'] in result)
@@ -70,7 +69,6 @@ class TestSearch(unittest.TestCase):
 		frappe.local.lang = 'fr'
 		search_widget(doctype="DocType", txt="fourn", page_length=30)
 		output = frappe.response["values"]
-		print(output)
 
 		result = [['found' for x in y if x=="Supplier"] for y in output]
 		self.assertTrue(['found'] in result)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -39,22 +39,14 @@ class TestSearch(unittest.TestCase):
 		self.assertRaises(frappe.DataError,
 			search_link, 'DocType', 'Customer', query=None, filters=None,
 			page_length=20, searchfield=';')
-	
-	#Search for the word "clie", part of the word "client" (customer) in french.
-	def test_contact_search_in_foreign_language(self):
-		frappe.local.lang = 'fr'
-		output = filter_dynamic_link_doctypes("DocType", "clie", "name", 0, 20, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
 
-		result = [['found' for x in y if x=="Customer"] for y in output]
-		self.assertTrue(['found'] in result)
-
-	#Search for the word "fourn", part of the word "fournisseur" (supplier) in french.
+	#Search for the word "pay", part of the word "pays" (country) in french.
 	def test_link_search_in_foreign_language(self):
 		frappe.local.lang = 'fr'
-		search_widget(doctype="DocType", txt="fourn", page_length=20)
+		search_widget(doctype="DocType", txt="pay", page_length=20)
 		output = frappe.response["values"]
 
-		result = [['found' for x in y if x=="Supplier"] for y in output]
+		result = [['found' for x in y if x=="Country"] for y in output]
 		self.assertTrue(['found'] in result)
 
 	def tearDown(self):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -8,7 +8,6 @@ from frappe.desk.search import search_link
 from frappe.contacts.address_and_contact import filter_dynamic_link_doctypes
 from frappe.desk.search import search_widget
 
-
 class TestSearch(unittest.TestCase):
 	def test_search_field_sanitizer(self):
 		# pass
@@ -44,14 +43,8 @@ class TestSearch(unittest.TestCase):
 	#First search for the word "cust" and get "Customer" as result.
 	#Then search for the word "clie", part of the word "client" (customer) in french.
 	def test_contact_search_in_foreign_language(self):
-		frappe.local.lang = 'en'
-		output = filter_dynamic_link_doctypes("DocType", "cust", "name", 0, 30, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
-
-		result = [['found' for x in y if x=="Customer"] for y in output]
-		self.assertTrue(['found'] in result)
-
 		frappe.local.lang = 'fr'
-		output = filter_dynamic_link_doctypes("DocType", "clie", "name", 0, 30, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
+		output = filter_dynamic_link_doctypes("DocType", "clie", "name", 0, 20, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
 
 		result = [['found' for x in y if x=="Customer"] for y in output]
 		self.assertTrue(['found'] in result)
@@ -59,15 +52,8 @@ class TestSearch(unittest.TestCase):
 	#First search for the word "suppl" and get "Supplier" as result.
 	#Then search for the word "fourn", part of the word "fournisseur" (supplier) in french.
 	def test_link_search_in_foreign_language(self):
-		frappe.local.lang = 'en'
-		search_widget(doctype="DocType", txt="suppl", page_length=30)
-		output = frappe.response["values"]
-
-		result = [['found' for x in y if x=="Supplier"] for y in output]
-		self.assertTrue(['found'] in result)
-
 		frappe.local.lang = 'fr'
-		search_widget(doctype="DocType", txt="fourn", page_length=30)
+		search_widget(doctype="DocType", txt="fourn", page_length=20)
 		output = frappe.response["values"]
 
 		result = [['found' for x in y if x=="Supplier"] for y in output]

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -40,8 +40,7 @@ class TestSearch(unittest.TestCase):
 			search_link, 'DocType', 'Customer', query=None, filters=None,
 			page_length=20, searchfield=';')
 	
-	#First search for the word "cust" and get "Customer" as result.
-	#Then search for the word "clie", part of the word "client" (customer) in french.
+	#Search for the word "clie", part of the word "client" (customer) in french.
 	def test_contact_search_in_foreign_language(self):
 		frappe.local.lang = 'fr'
 		output = filter_dynamic_link_doctypes("DocType", "clie", "name", 0, 20, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
@@ -49,8 +48,7 @@ class TestSearch(unittest.TestCase):
 		result = [['found' for x in y if x=="Customer"] for y in output]
 		self.assertTrue(['found'] in result)
 
-	#First search for the word "suppl" and get "Supplier" as result.
-	#Then search for the word "fourn", part of the word "fournisseur" (supplier) in french.
+	#Search for the word "fourn", part of the word "fournisseur" (supplier) in french.
 	def test_link_search_in_foreign_language(self):
 		frappe.local.lang = 'fr'
 		search_widget(doctype="DocType", txt="fourn", page_length=20)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -1,10 +1,12 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+
+# Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
 import unittest
 import frappe
 from frappe.desk.search import search_link
+from frappe.contacts.address_and_contact import filter_dynamic_link_doctypes
 
 
 class TestSearch(unittest.TestCase):
@@ -38,3 +40,38 @@ class TestSearch(unittest.TestCase):
 		self.assertRaises(frappe.DataError,
 			search_link, 'DocType', 'Customer', query=None, filters=None,
 			page_length=20, searchfield=';')
+	
+	#First search for the word "cust" and get "Customer" as result.
+	#Then search for the word "clie", part of the word "client" (customer) in french.
+	def test_contact_search_in_foreign_language(self):
+		frappe.local.lang = 'en'
+		output = filter_dynamic_link_doctypes("DocType", "cust", "name", 0, 30, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
+
+		result = [['found' for x in y if x=="Customer"] for y in output]
+		self.assertTrue(['found'] in result)
+
+		frappe.local.lang = 'fr'
+		output = filter_dynamic_link_doctypes("DocType", "clie", "name", 0, 30, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
+
+		result = [['found' for x in y if x=="Customer"] for y in output]
+		self.assertTrue(['found'] in result)
+
+	#First search for the word "suppl" and get "Supplier" as result.
+	#Then search for the word "fourn", part of the word "fournisseur" (supplier) in french.
+	def test_link_search_in_foreign_language(self):
+		frappe.local.lang = 'en'
+		search_widget(doctype="DocType", txt="suppl", page_length=30)
+		output = frappe.response["values"]
+
+		result = [['found' for x in y if x=="Supplier"] for y in output]
+		self.assertTrue(['found'] in result)
+
+		frappe.local.lang = 'fr'
+		search_widget(doctype="DocType", txt="fourn", page_length=30)
+		output = frappe.response["values"]
+
+		result = [['found' for x in y if x=="Supplier"] for y in output]
+		self.assertTrue(['found'] in result)
+
+	def tearDown(self):
+		frappe.local.lang = 'en'

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
@@ -7,6 +6,7 @@ import unittest
 import frappe
 from frappe.desk.search import search_link
 from frappe.contacts.address_and_contact import filter_dynamic_link_doctypes
+from frappe.desk.search import search_widget
 
 
 class TestSearch(unittest.TestCase):


### PR DESCRIPTION
Hi,

This PR aims at solving a big issue for users of ERPNext and Frappe in a foreign language.

As described here: https://github.com/frappe/frappe/issues/4849, when searching for a doctype, the system doesn't take into account the translated name as it performs a direct query in the database.

It is fine for all normal documents (unless I missed it) since their name can be in a foreign language, but Doctypes are registered in English. You can imagine that it can be a big issues for people who don't speak well english and don't know how the doctype is named in English.

Thanks in advance for your help !
