### PR TITLE
Check if permission needs to be ignored in link fields

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -136,7 +136,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			if (!me.$input.cache[doctype]) {
 				me.$input.cache[doctype] = {};
 			}
-
+			
 			var term = e.target.value;
 
 			if (me.$input.cache[doctype][term]!=null) {
@@ -147,6 +147,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			var args = {
 				'txt': term,
 				'doctype': doctype,
+				'ignore_user_permissions': me.df.ignore_user_permissions
 			};
 
 			me.set_custom_query(args);


### PR DESCRIPTION
- Check if permission needs to be ignored in link fields
case - if user permission is ignored for the link field then user permission should not be applied for the options in the link field.