### PR TITLE
[Bug Fix] Data import from non EN language template failed

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -39,6 +39,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 
 	# for translations
 	if user:
+		frappe.cache().hdel("lang", user)
 		frappe.set_user_lang(user)
 
 	if data_import_doc and isinstance(data_import_doc, string_types):
@@ -196,7 +197,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 		else:
 			doc = frappe._dict(zip(columns, rows[start_idx][1:]))
 			doc['doctype'] = doctype
-			return doc
+			return doc, [], None
 
 	# used in testing whether a row is empty or parent row or child row
 	# checked only 3 first columns since first two columns can be blank for example the case of

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -116,7 +116,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 		dt = None
 		for i, d in enumerate(doctype_row[1:]):
 			if d not in ("~", "-"):
-				if d and doctype_row[i] in (None, '' ,'~', '-', 'DocType:'):
+				if d and doctype_row[i] in (None, '' ,'~', '-', _("DocType") + ":"):
 					dt, parentfield = d, None
 					# xls format truncates the row, so it may not have more columns
 					if len(doctype_row) > i+2:


### PR DESCRIPTION
Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.
here the discussion thread https://discuss.erpnext.com/t/problem-importing-supplier-when-language-is-simplified-chinese-zh/37856

how to reproduce the error
1. logon by the user with language as EN
2. change the user language to other language such as ZH, wait till the system auto refresh to ZH language
3. go to item, data import-> download template with data for mandatory fields only
4. update the downloaded template file， there will be the following errors in the traceback.
  Please do not change the rows above
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/data_import/importer.py", line 294, in upload
    doctype = get_header_row(get_data_keys_definition().main_table)[1]
IndexError: list index out of range
5.Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/data_import/importer.py", line 368, in upload
    doc, attachments, last_error_row_idx = get_doc(row_idx)
ValueError: too many values to unpack

