### PR TITLE
Remove !important rules so that custom css in Print Format can override

### DIFF
--- a/frappe/public/css/bootstrap.css
+++ b/frappe/public/css/bootstrap.css
@@ -193,9 +193,9 @@ th {
   *,
   *:before,
   *:after {
-    color: #000 !important;
+    color: #000;
+    background: transparent;
     text-shadow: none !important;
-    background: transparent !important;
     -webkit-box-shadow: none !important;
             box-shadow: none !important;
   }
@@ -254,11 +254,11 @@ th {
   }
   .table td,
   .table th {
-    background-color: #fff !important;
+    background-color: #fff;
   }
   .table-bordered th,
   .table-bordered td {
-    border: 1px solid #ddd !important;
+    border: 1px solid #ddd;
   }
 }
 @font-face {


### PR DESCRIPTION
Cherry picked from `develop` branch https://github.com/frappe/frappe/pull/5235