### PR TITLE
[fix]email error due to incorrect smtp server auth

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -340,8 +340,6 @@ def flush(from_test=False):
 		msgprint(_("Emails are muted"))
 		from_test = True
 
-	smtpserver = SMTPServer()
-
 	make_cache_queue()
 
 	for i in range(cache.llen('cache_email_queue')):
@@ -350,7 +348,15 @@ def flush(from_test=False):
 		if cint(frappe.defaults.get_defaults().get("hold_queue"))==1:
 			break
 
+		smtpserver_dict = frappe._dict()
+
 		if email:
+			sender = frappe.get_value("Email Queue", email, "sender") 
+			smtpserver = smtpserver_dict.get(sender)
+			if not smtpserver:
+				smtpserver = SMTPServer()
+				smtpserver_dict[sender] = smtpserver
+
 			send_one(email, smtpserver, auto_commit, from_test=from_test)
 
 		# NOTE: removing commit here because we pass auto_commit


### PR DESCRIPTION
- A dict of smtpserver objects is created for every sender
- A smtp server object is created if not present for the given sender
- smtpserver object is picked based on the sender of the mail
