### PR TITLE
[Enhance] Global search multi key words to pin point search result

### DIFF
--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -50,8 +50,12 @@ class TestGlobalSearch(unittest.TestCase):
 		self.assertTrue('After Mulder awakens from his coma, he realizes his duty to prevent alien colonization. ' in results[0].content)
 
 		results = global_search.search('extraterrestrial')
-		self.assertTrue('Carter explored themes of extraterrestrial involvement in ancient mass extinctions in this episode, the third in a trilogy.' in results[0].content)
-
+		self.assertTrue('Carter explored themes of extraterrestrial involvement in ancient mass extinctions in this episode, the third in a trilogy.' in results[0].content)                
+		results = global_search.search('awakens & duty & alien')
+		self.assertTrue('After Mulder awakens from his coma, he realizes his duty to prevent alien colonization. ' in results[0].content)
+		results = global_search.search('awakens & duty & otherterm')
+		self.assertTrue(!results[0].content)
+		
 	def test_update_doc(self):
 		self.insert_test_events()
 		test_subject = 'testing global search'

--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -50,7 +50,7 @@ class TestGlobalSearch(unittest.TestCase):
 		self.assertTrue('After Mulder awakens from his coma, he realizes his duty to prevent alien colonization. ' in results[0].content)
 
 		results = global_search.search('extraterrestrial')
-		self.assertTrue('Carter explored themes of extraterrestrial involvement in ancient mass extinctions in this episode, the third in a trilogy.' in results[0].content)                
+		self.assertTrue('Carter explored themes of extraterrestrial involvement in ancient mass extinctions in this episode, the third in a trilogy.' in results[0].content)
 		results = global_search.search('awakens & duty & alien')
 		self.assertTrue('After Mulder awakens from his coma, he realizes his duty to prevent alien colonization. ' in results[0].content)
 

--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -53,7 +53,7 @@ class TestGlobalSearch(unittest.TestCase):
 		self.assertTrue('Carter explored themes of extraterrestrial involvement in ancient mass extinctions in this episode, the third in a trilogy.' in results[0].content)                
 		results = global_search.search('awakens & duty & alien')
 		self.assertTrue('After Mulder awakens from his coma, he realizes his duty to prevent alien colonization. ' in results[0].content)
-		
+
 	def test_update_doc(self):
 		self.insert_test_events()
 		test_subject = 'testing global search'

--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -53,8 +53,6 @@ class TestGlobalSearch(unittest.TestCase):
 		self.assertTrue('Carter explored themes of extraterrestrial involvement in ancient mass extinctions in this episode, the third in a trilogy.' in results[0].content)                
 		results = global_search.search('awakens & duty & alien')
 		self.assertTrue('After Mulder awakens from his coma, he realizes his duty to prevent alien colonization. ' in results[0].content)
-		results = global_search.search('awakens & duty & otherterm')
-		self.assertTrue(!results[0].content)
 		
 	def test_update_doc(self):
 		self.insert_test_events()

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -342,27 +342,34 @@ def search(text, start=0, limit=20, doctype=""):
 	:param limit: number of results to return, default 20
 	:return: Array of result objects
 	"""
-
-	text = "+" + text + "*"
-	if not doctype:
-		results = frappe.db.sql('''
-			select
-				doctype, name, content
-			from
-				__global_search
-			where
-				match(content) against (%s IN BOOLEAN MODE)
-			limit {start}, {limit}'''.format(start=start, limit=limit), text+"*", as_dict=True)
-	else:
-		results = frappe.db.sql('''
-			select
-				doctype, name, content
-			from
-				__global_search
-			where
-				doctype = %s AND
-				match(content) against (%s IN BOOLEAN MODE)
-			limit {start}, {limit}'''.format(start=start, limit=limit), (doctype, text), as_dict=True)
+	results = []
+	texts = text.split('&')
+	for text in texts:
+		text = "+" + text + "*"
+		if not doctype:
+			result = frappe.db.sql('''
+				select
+					doctype, name, content
+				from
+					__global_search
+				where
+					match(content) against (%s IN BOOLEAN MODE)
+				limit {start}, {limit}'''.format(start=start, limit=limit), text+"*", as_dict=True)
+		else:
+			result = frappe.db.sql('''
+				select
+					doctype, name, content
+				from
+					__global_search
+				where
+					doctype = %s AND
+					match(content) against (%s IN BOOLEAN MODE)
+				limit {start}, {limit}'''.format(start=start, limit=limit), (doctype, text), as_dict=True)
+		tmp_result=[]
+		for i in result:
+			if i in results or not results:
+				tmp_result.append(i)
+		results = tmp_result
 
 	for r in results:
 		try:
@@ -384,15 +391,25 @@ def web_search(text, start=0, limit=20):
 	:return: Array of result objects
 	"""
 
-	text = "+" + text + "*"
-	results = frappe.db.sql('''
-		select
-			doctype, name, content, title, route
-		from
-			__global_search
-		where
-			published = 1 and
-			match(content) against (%s IN BOOLEAN MODE)
-		limit {start}, {limit}'''.format(start=start, limit=limit),
-		text, as_dict=True)
+	results = []
+	texts = text.split('&')
+	for text in texts:	
+		text = "+" + text + "*"
+		result = frappe.db.sql('''
+			select
+				doctype, name, content, title, route
+			from
+				__global_search
+			where
+				published = 1 and
+				match(content) against (%s IN BOOLEAN MODE)
+			limit {start}, {limit}'''.format(start=start, limit=limit),
+			text, as_dict=True)
+
+		tmp_result=[]
+		for i in result:
+			if i in results or not results:
+				tmp_result.append(i)
+		results = tmp_result
+
 	return results

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -393,7 +393,7 @@ def web_search(text, start=0, limit=20):
 
 	results = []
 	texts = text.split('&')
-	for text in texts:	
+	for text in texts:
 		text = "+" + text + "*"
 		result = frappe.db.sql('''
 			select


### PR DESCRIPTION
Motivation:
The current global search is a very powerful and killer feature which enable universally searching the whole ERP system by simple key words, it is more a kind of internal Google. so far so good, per my observation and study the forum discussion about global search, I identified an important missing feature, that is it only support search by single key word or using as default an OR logic to combine all the user input search text separated by space. for example if we have similar items with names as 
apple ipad, apple iphone,  sumsung ipad, sumsung phone etc, there is no way to pin point the specific item, because using either single key word or multi key words separated by space will result more results than expected, the other similar cases is that some times it is needed to search orders by the item names included in it or by all the tags assigned to it,  the current global search can not handle this important use case.
![global_search_and](https://user-images.githubusercontent.com/12823863/42354406-3244e166-80f9-11e8-8e9e-f98f883db280.gif)

Solution by this pull request
the user can use the AND operator (&) in the search text, e.g 'apple & ipad', then in the backend, two separate search into the global search help table will be executed, one for each search term, here apple and ipad respectively, then the 2 search results will be checked, only these records which exist in both search result (the AND logic) will be finally returned to the user(front end). it is quite straight forward. for more details, check the code.

support the user to use and operator (&) in the search text, to search target document by combined multi search term(key words separated by &, thus we can search purchase order by vendor name, the items purchased all together!

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.