### PR TITLE
Rearrange user-permission-replication patch 

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -18,6 +18,7 @@ frappe.patches.v8_0.drop_is_custom_from_docperm
 frappe.patches.v8_0.update_records_in_global_search #11-05-2017
 frappe.patches.v8_0.update_published_in_global_search
 execute:frappe.reload_doc('core', 'doctype', 'custom_docperm')
+frappe.patches.v11_0.replicate_old_user_permissions
 frappe.patches.v11_0.drop_column_apply_user_permissions
 execute:frappe.reload_doc('core', 'doctype', 'activity_log')
 execute:frappe.reload_doc('core', 'doctype', 'deleted_document')
@@ -218,5 +219,4 @@ frappe.patches.v11_0.update_list_user_settings
 frappe.patches.v11_0.rename_workflow_action_to_workflow_action_master #13-06-2018
 frappe.patches.v11_0.rename_email_alert_to_notification #13-06-2018
 frappe.patches.v11_0.delete_duplicate_user_permissions
-frappe.patches.v11_0.replicate_old_user_permissions
 frappe.patches.v11_0.get_docs_apps_if_not_present


### PR DESCRIPTION
Run `replicate_old_user_permissions` patch before dropping apply_user_permission column 
as the patch is dependent on `apply_user_permission` column