### PR TITLE
Convert doc field value to string type before using

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-from frappe.utils import now_datetime, cint
+from frappe.utils import now_datetime, cint, cstr
 import re
 from six import string_types
 
@@ -258,7 +258,7 @@ def _field_autoname(autoname, doc, skip_slicing=None):
 	`autoname` field starts with 'field:'
 	"""
 	fieldname = autoname if skip_slicing else autoname[6:]
-	name = (doc.get(fieldname) or '').strip()
+	name = (cstr(doc.get(fieldname)) or '').strip()
 	return name
 
 


### PR DESCRIPTION
The auto naming of documents doesn't take into account if one of the field(s) is not of the type String, as a result, it throws an error.

To solve the issue convert the value retrieved into a String before moving forward.