### PR TITLE
[Minor] Patch fix

### DIFF
--- a/frappe/patches/v11_0/copy_fetch_data_from_options.py
+++ b/frappe/patches/v11_0/copy_fetch_data_from_options.py
@@ -27,4 +27,5 @@ def execute():
 		set property="fetch_from"
 		where property="options" and value like '%.%'
 		and property_type in ('Data', 'Read Only', 'Text', 'Small Text', 'Text Editor', 'Code', 'Link', 'Check')
+		and field_name!='naming_series'
 	''')


### PR DESCRIPTION
Patch for fetch_from should avoid naming_series in Property Setter as `options` in naming_series can contain '.' followed by hash which does not mean its fetching value from somewhere.

https://github.com/frappe/erpnext/issues/14828