### PR TITLE
[Fix] Not able to save item

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -256,9 +256,10 @@ def update_global_search(doc):
 		if hasattr(doc, 'is_website_published') and doc.meta.allow_guest_to_view:
 			published = 1 if doc.is_website_published() else 0
 
+		title = doc.get_title()
 		frappe.flags.update_global_search.append(
 			dict(doctype=doc.doctype, name=doc.name, content=' ||| '.join(content or ''),
-				published=published, title=doc.get_title()[:int(varchar_len)], route=doc.get('route')))
+				published=published, title=title[:int(varchar_len)] if title else doc.name, route=doc.get('route')))
 
 		enqueue_global_search()
 


### PR DESCRIPTION
Issue
Set manufacturer_part_no in title field of the item and while saving item not set the manufacturer_part_no
![screen shot 2018-07-09 at 2 07 33 pm](https://user-images.githubusercontent.com/8780500/42439797-746f4be6-8381-11e8-9ae4-2f3573ee4953.png)


Then while saving item getting below error

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/client.py", line 143, in insert
    doc = frappe.get_doc(doc).insert()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 248, in insert
    self.run_post_save_methods()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 906, in run_post_save_methods
    update_global_search(self)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/utils/global_search.py", line 261, in update_global_search
    published=published, title=doc.get_title()[:int(varchar_len)], route=doc.get('route')))
TypeError: 'NoneType' object has no attribute '__getitem__'

14:03:26.989 
```