### PR TITLE
Allow multiple values to be passed as arguments to rpush and lpush

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -121,11 +121,11 @@ class RedisWrapper(redis.Redis):
 			except redis.exceptions.ConnectionError:
 				pass
 
-	def lpush(self, key, value):
-		super(redis.Redis, self).lpush(self.make_key(key), value)
+	def lpush(self, key, *values):
+		super(redis.Redis, self).lpush(self.make_key(key), *values)
 
-	def rpush(self, key, value):
-		super(redis.Redis, self).rpush(self.make_key(key), value)
+	def rpush(self, key, *values):
+		super(redis.Redis, self).rpush(self.make_key(key), *values)
 
 	def lpop(self, key):
 		return super(redis.Redis, self).lpop(self.make_key(key))


### PR DESCRIPTION
Minor change to redis wrapper

Allow usage of following patterns
```
values = [1,2,3,4]
cache.lpush('some-queue', *values)
```
or
```
cache.lpush('some-queue', 1, 2, 3, 4)
```


instead of forced loop like
```
values = [1,2,3,4]
for v in values:
    cache.lpush('some-queue', v)
```
