### PR TITLE
Set pager in mariadb console

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -312,6 +312,7 @@ def mariadb(context):
 		'-p'+frappe.conf.db_password,
 		frappe.conf.db_name,
 		'-h', frappe.conf.db_host or "localhost",
+		'--pager=less -SFX',
 		"-A"])
 
 @click.command('console')


### PR DESCRIPTION
Use `less` as a pager in `bench mariadb`. (Only for output larger than size of the terminal)