### PR TITLE
Add patch to skip user perm check for doctype

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -220,3 +220,4 @@ frappe.patches.v11_0.rename_workflow_action_to_workflow_action_master #13-06-201
 frappe.patches.v11_0.rename_email_alert_to_notification #13-06-2018
 frappe.patches.v11_0.delete_duplicate_user_permissions
 frappe.patches.v11_0.get_docs_apps_if_not_present
+frappe.patches.v11_0.skip_user_permission_check_for_department

--- a/frappe/patches/v11_0/skip_user_permission_check_for_department.py
+++ b/frappe/patches/v11_0/skip_user_permission_check_for_department.py
@@ -1,0 +1,23 @@
+import frappe
+
+# Skips user permission check for doctypes where department link field was recently added
+# https://github.com/frappe/erpnext/pull/14121
+
+def execute():
+    user_permissions = frappe.get_all("User Permission", filters=[['allow', '=', 'Department']], fields=['name', 'skip_for_doctype'])
+
+    for perm in user_permissions:
+        skip_for_doctype = perm.get('skip_for_doctype')
+        doctypes_to_skip = ['Appraisal', 'Retention Bonus', 'Compensatory Leave Request', 'Additional Salary Component', 'Shift Request',
+            'Leave Allocation', 'Shift Assignment', 'Expense Claim', 'Instructor', 'Salary Slip', 'Employee Tax Exemption Proof Submission',
+            'Attendance', 'Training Feedback', 'Employee Incentive', 'Employee Tax Exemption Declaration', 'Training Result Employee',
+            'Travel Request', 'Leave Application', 'Employee Advance', 'Activity Cost', 'Salary Structure Assignment','Training Event Employee',
+            'Timesheet', 'Employee Transfer', 'Sales Person', 'Employee Benefit Application', 'Attendance Request',
+            'Payroll Employee Detail', 'Employee Promotion', 'Leave Encashment', 'Employee Benefit Claim']
+
+        skip_for_doctype = skip_for_doctype.split('\n') + doctypes_to_skip
+        skip_for_doctype = set(skip_for_doctype) # to remove duplicates
+        skip_for_doctype = '\n'.join(skip_for_doctype) # convert back to string
+
+        frappe.set_value('User Permission', perm.name, 'skip_for_doctype', skip_for_doctype)
+


### PR DESCRIPTION
- Skip user permission check for doctypes where
department link field was recently added