### PR TITLE
Possibility to go to file manager from sidebard

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -265,7 +265,7 @@
 		"public/js/frappe/form/user_image.js",
 		"public/js/frappe/form/share.js",
 		"public/js/frappe/form/form_viewers.js",
-
+		"public/js/frappe/form/footer/attachment.html",
 		"public/js/frappe/form/footer/form_footer.html",
 		"public/js/frappe/form/footer/timeline.html",
 		"public/js/frappe/form/footer/timeline_item.html",

--- a/frappe/public/js/frappe/form/footer/attachment.html
+++ b/frappe/public/js/frappe/form/footer/attachment.html
@@ -1,0 +1,10 @@
+<li class="attachment-row">
+	<a class="close">&times;</a>
+	<a href="{{ file_path }}">
+		<i class="{{ icon }} fa-fw text-warning"></i>
+	</a>
+	<a href="{{ file_url }}" target="_blank" title="{{ file_name }}" class="ellipsis" style="max-width: calc(100% - 43px);">
+		<span>{{ file_name }}</span>
+	</a>
+</li>
+

--- a/frappe/public/js/frappe/form/footer/attachments.js
+++ b/frappe/public/js/frappe/form/footer/attachments.js
@@ -62,23 +62,13 @@ frappe.ui.form.Attachments = Class.extend({
 		}
 
 		var me = this;
-		var lock_icon = repl('<a href="%(file_path)s"><i class="%(icon)s fa-fw text-warning"></i></a> ', { 
-			file_path: '/desk#Form/File/' + fileid,
-			icon: attachment.is_private ? 'fa fa-lock' : 'fa fa-unlock-alt'
-		})
 
-		var $attach = $(repl('<li class="attachment-row">\
-				<a class="close">&times;</a>\
-				%(lock_icon)s\
-				<a href="%(file_url)s" target="_blank" title="%(file_name)s" \
-					class="ellipsis" style="max-width: calc(100% - 43px);">\
-					<span>%(file_name)s</span></a>\
-			</li>', {
-				lock_icon: lock_icon,
-				file_name: file_name,
-				file_url: frappe.urllib.get_full_url(file_url)
-			}))
-			.insertAfter(this.attachments_label.addClass("has-attachments"));
+		var $attach = $(frappe.render_template("attachment", { 
+			"file_path": "/desk#Form/File/" + fileid,
+			"icon": attachment.is_private ? "fa fa-lock" : "fa fa-unlock-alt",
+			"file_name": file_name,
+			"file_url": frappe.urllib.get_full_url(file_url)
+		})).insertAfter(this.attachments_label.addClass("has-attachments"));			
 
 		var $close =
 			$attach.find(".close")

--- a/frappe/public/js/frappe/form/footer/attachments.js
+++ b/frappe/public/js/frappe/form/footer/attachments.js
@@ -62,6 +62,11 @@ frappe.ui.form.Attachments = Class.extend({
 		}
 
 		var me = this;
+		var lock_icon = repl('<a href="%(file_path)s"><i class="%(icon)s fa-fw text-warning"></i></a> ', { 
+			file_path: '/desk#Form/File/' + fileid,
+			icon: attachment.is_private ? 'fa fa-lock' : 'fa fa-unlock-alt'
+		})
+
 		var $attach = $(repl('<li class="attachment-row">\
 				<a class="close">&times;</a>\
 				%(lock_icon)s\
@@ -69,7 +74,7 @@ frappe.ui.form.Attachments = Class.extend({
 					class="ellipsis" style="max-width: calc(100% - 43px);">\
 					<span>%(file_name)s</span></a>\
 			</li>', {
-				lock_icon: attachment.is_private ? '<i class="fa fa-lock fa-fw text-warning"></i> ': "",
+				lock_icon: lock_icon,
 				file_name: file_name,
 				file_url: frappe.urllib.get_full_url(file_url)
 			}))


### PR DESCRIPTION
Hi,

This is small PR to provide the possibility to go the file manager directly from the sidebar without changing the current UX.

I have just added a link in the lock icon and an unlock icon for unlocked files.
![image](https://user-images.githubusercontent.com/4903591/42580613-3f929e7c-852b-11e8-8c77-8d4e02289da0.png)


When clicking on the lock (or unlock icon) you are redirected immediately to the file manager:
![image](https://user-images.githubusercontent.com/4903591/42580662-559d48a2-852b-11e8-9138-7e06176ca9e1.png)


I have set the unlock icon in orange to be consistent with the existing UI, but maybe I could change it to another color to differentiate it ? Let me know your decision.

Thanks in advance for your help.