### PR TITLE
Fix comment mentions

### DIFF
--- a/frappe/core/doctype/communication/comment.py
+++ b/frappe/core/doctype/communication/comment.py
@@ -94,9 +94,8 @@ def notify_mentions(doc):
 
 		subject = _("{0} mentioned you in a comment").format(sender_fullname)
 
-		recipients = [frappe.db.get_value("User", {"enabled": 1, "username": username, "user_type": "System User"})
-			for username in mentions]
-
+		recipients = [frappe.db.get_value("User", {"enabled": 1, "name": name, "user_type": "System User"})
+			for name in mentions]
 		frappe.sendmail(
 			recipients=recipients,
 			sender=frappe.session.user,

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -12,6 +12,7 @@ from frappe.limits import update_limits, clear_limit
 from frappe.utils import get_url
 from frappe.core.doctype.user.user import get_total_users
 from frappe.core.doctype.user.user import MaxUsersReachedError, test_password_strength
+from frappe.core.doctype.user.user import extract_mentions
 
 test_records = frappe.get_test_records('User')
 
@@ -255,3 +256,11 @@ class TestUser(unittest.TestCase):
 		# Score 4; should pass
 		result = test_password_strength("Eastern_43A1W")
 		self.assertEqual(result['feedback']['password_policy_validation_passed'], True)
+
+	def test_comment_mentions(self):
+		user_name = "@test.comment@example.com"
+		self.assertEqual(extract_mentions(user_name)[0], "test.comment@example.com")
+		user_name = "Testing comment, @test-user please check."
+		self.assertEqual(extract_mentions(user_name)[0], "test-user")
+		user_name = "Testing comment, @test.user@example.com please check."
+		self.assertEqual(extract_mentions(user_name)[0], "test.user@example.com")

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -899,9 +899,9 @@ def notify_admin_access_to_system_manager(login_manager=None):
 		)
 
 def extract_mentions(txt):
-	"""Find all instances of @username in the string.
+	"""Find all instances of @name in the string.
 	The mentions will be separated by non-word characters or may appear at the start of the string"""
-	return re.findall(r'(?:[^\w]|^)@([\w]*)', txt)
+	return re.findall(r'(?:[^\w\.\-\@]|^)@([\w\.\-\@]*)', txt)
 
 
 def handle_password_test_fail(result):

--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -17,7 +17,7 @@ frappe.ui.form.Timeline = Class.extend({
 
 		this.comment_area = new frappe.ui.CommentArea({
 			parent: this.wrapper.find('.timeline-head'),
-			mentions: this.get_usernames_for_mentions(),
+			mentions: this.get_names_for_mentions(),
 			on_submit: (val) => {
 				val && this.insert_comment(
 					"Comment", val, this.comment_area.button);
@@ -99,7 +99,7 @@ frappe.ui.form.Timeline = Class.extend({
 
 		this.editing_area = new frappe.ui.CommentArea({
 			parent: this.$editing_area,
-			mentions: this.get_usernames_for_mentions(),
+			mentions: this.get_names_for_mentions(),
 			no_wrapper: true
 		});
 
@@ -653,11 +653,11 @@ frappe.ui.form.Timeline = Class.extend({
 		return last_email;
 	},
 
-	get_usernames_for_mentions: function() {
+	get_names_for_mentions: function() {
 		var valid_users = Object.keys(frappe.boot.user_info)
 			.filter(user => !["Administrator", "Guest"].includes(user));
 
-		return valid_users.map(user => frappe.boot.user_info[user].username || frappe.boot.user_info[user].name);
+		return valid_users.map(user => frappe.boot.user_info[user].name);
 	},
 
 	setup_comment_like: function() {


### PR DESCRIPTION
- Currently, on mentioning a user using `@` in comments, it shows usernames and names in the dropdown.
- If in a comment, name is selected using `@`, the currently written regex function truncates it and only allows numbers, alphabets and _ but it could be an email address as well, hence, an error occurs in the email queue.
- So modified the mentions function to only show names instead of usernames, regex function to allow email ids.