### PR TITLE
[fix] frappe.query_report should be null if report is not initialized

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -168,17 +168,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		} else {
 			this.page.show_form();
 		}
-
-		// set the field 'query_report_filters_by_name' first
-		// as they can be used in
-		// setting/triggering the filters
-		this.set_filters_by_name();
-	}
-
-	set_filters_by_name() {
-		for (var i in this.filters) {
-			frappe.query_report_filters_by_name[this.filters[i].df.fieldname] = this.filters[i];
-		}
 	}
 
 	set_route_filters() {
@@ -202,7 +191,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	clear_filters() {
 		this.page.clear_fields();
-		frappe.query_report_filters_by_name = {};
 	}
 
 	refresh() {
@@ -610,3 +598,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		return this.get_filter_values;
 	}
 };
+
+Object.defineProperty(frappe, 'query_report_filters_by_name', {
+	get() {
+		if (!frappe.query_report.filters) return null;
+		return frappe.query_report.filters.reduce((f, acc) => {
+			acc[f.df.fieldname] = f;
+			return acc;
+		}, {});
+	}
+});


### PR DESCRIPTION
Make `frappe.query_report_filters_by_name` as a computed property, so that it always has the current reports filters, no need to clear it and set it everytime.

Fixes: https://github.com/frappe/erpnext/issues/14892