### PR TITLE
Query Report: deprecated query_report_filters_by_name

### DIFF
--- a/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js
+++ b/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js
@@ -15,7 +15,7 @@ frappe.query_reports["Addresses And Contacts"] = {
 			"label": __("Entity Name"),
 			"fieldtype": "Dynamic Link",
 			"get_options": function() {
-				let reference_doctype = frappe.query_report_filters_by_name.reference_doctype.get_value();
+				let reference_doctype = frappe.query_report.get_filter_value('reference_doctype');
 				if(!reference_doctype) {
 					frappe.throw(__("Please select Entity Type first"));
 				}

--- a/frappe/core/report/feedback_ratings/feedback_ratings.js
+++ b/frappe/core/report/feedback_ratings/feedback_ratings.js
@@ -21,14 +21,14 @@ frappe.query_reports["Feedback Ratings"] = {
 			"label": __("Document ID"),
 			"fieldtype": "Dynamic Link",
 			"get_options": function() {
-				var document_type = frappe.query_report_filters_by_name.document_type.get_value();
+				var document_type = frappe.query_report.get_filter_value('document_type');
 				if(!document_type) {
 					frappe.throw(__("Please select Document Type first"));
 				}
 				return document_type;
 			}
 		},
-		{ 
+		{
 			"fieldname":"from_date",
 			"label": __("From Date"),
 			"fieldtype": "Date",

--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js
@@ -20,7 +20,7 @@ frappe.query_reports["Permitted Documents For User"] = {
 				return {
 					"query": "frappe.core.report.permitted_documents_for_user.permitted_documents_for_user.query_doctypes",
 					"filters": {
-						"user": frappe.query_report_filters_by_name.user.get_value()
+						"user": frappe.query_report.get_filter_value('user')
 					}
 				}
 			}

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -63,9 +63,10 @@ def generate_report_result(report, filters=None, user=None):
 			# The JOB:
 			try:
 				res = frappe.get_attr(method_name)(frappe._dict(filters))
-			except Exception:
-				frappe.db.set_value('Report', report.name, 'prepared_report', 1)
-				frappe.throw("The report to too long to load. Please reload the page to generate it in background.")
+			except Exception as e:
+				raise e
+				# frappe.db.set_value('Report', report.name, 'prepared_report', 1)
+				# frappe.throw("The report to too long to load. Please reload the page to generate it in background.")
 
 			columns, result = res[0], res[1]
 			if len(res) > 2:

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -63,10 +63,9 @@ def generate_report_result(report, filters=None, user=None):
 			# The JOB:
 			try:
 				res = frappe.get_attr(method_name)(frappe._dict(filters))
-			except Exception as e:
-				raise e
-				# frappe.db.set_value('Report', report.name, 'prepared_report', 1)
-				# frappe.throw("The report to too long to load. Please reload the page to generate it in background.")
+			except Exception:
+				frappe.db.set_value('Report', report.name, 'prepared_report', 1)
+				frappe.throw("The report to too long to load. Please reload the page to generate it in background.")
 
 			columns, result = res[0], res[1]
 			if len(res) > 2:

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -93,13 +93,11 @@ frappe.ui.form.on('Auto Email Report', {
 							this.hide();
 							frm.set_value('filters', JSON.stringify(values));
 							frm.trigger('show_filters');
-							frappe.query_report_filters_by_name = null;
 						}
 					}
 				});
 				dialog.show();
 				dialog.set_values(filters);
-				frappe.query_report_filters_by_name = dialog.fields_dict;
 			})
 		}
 	}


### PR DESCRIPTION
Deprecate `frappe.query_report_filters_by_name`. If you try to use it, you always get null and a deprecation message in the console:
![image](https://user-images.githubusercontent.com/9355208/42813289-1ab0a902-89de-11e8-9c9d-4f24f121df74.png)

Also, removed all usages of it from `frappe` and `erpnext`.
![image](https://user-images.githubusercontent.com/9355208/42813249-f2dd99e4-89dd-11e8-8778-956fb2c54efc.png)

The new API can be used as follows:
```js

// get filter value
frappe.query_report.get_filter_value('company')

// set filter value
frappe.query_report.set_filter_value('company', 'Gadget Technologies')

// set multiple values
frappe.query_report.set_filter_value({
  from_date: start_date,
  to_date: end_date
});

```