### PR TITLE
Allow Braintree custom confirmation page through hooks

### DIFF
--- a/frappe/integrations/doctype/braintree_settings/braintree_settings.py
+++ b/frappe/integrations/doctype/braintree_settings/braintree_settings.py
@@ -102,6 +102,9 @@ class BraintreeSettings(Document):
 				try:
 					custom_redirect_to = frappe.get_doc(self.data.reference_doctype,
 						self.data.reference_docname).run_method("on_payment_authorized", self.flags.status_changed_to)
+					braintree_success_page = frappe.get_hooks('braintree_success_page')
+					if braintree_success_page:
+						custom_redirect_to = frappe.get_attr(braintree_success_page[-1])(self.data)
 				except Exception:
 					frappe.log_error(frappe.get_traceback())
 


### PR DESCRIPTION
Hi,

This small PR gives the possibility to implement custom confirmation pages on the portal for Braintree.

It appears that the default behavior of ERPNext is not suitable for every companies. In fact this particular page is very important in the payment flow and companies like to be able to completely customize it.

It doesn't change the standard behavior in case people prefer to use the redirection chosen in the payment cart.

Thanks in advance.