### PR TITLE
[Fix] Not able to login

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -208,7 +208,7 @@ class LoginManager:
 	def check_if_enabled(self, user):
 		"""raise exception if user not enabled"""
 		doc = frappe.get_doc("System Settings")
-		if doc.allow_consecutive_login_attempts > 0:
+		if cint(doc.allow_consecutive_login_attempts) > 0:
 			check_consecutive_login_attempts(user, doc)
 
 		if user=='Administrator': return


### PR DESCRIPTION
**Issue**
```
website.js:150 Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 59, in application
    init_request(request)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 121, in init_request
    frappe.local.http_request = frappe.auth.HTTPRequest()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/auth.py", line 51, in __init__
    frappe.local.login_manager = LoginManager()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/auth.py", line 105, in __init__
    if self.login()==False: return
  File "/home/frappe/frappe-bench/apps/frappe/frappe/auth.py", line 126, in login
    self.authenticate(user=user, pwd=pwd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/auth.py", line 209, in authenticate
    self.check_if_enabled(user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/auth.py", line 215, in check_if_enabled
    if doc.allow_consecutive_login_attempts > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```