### PR TITLE
Make start and end date as mandatory

### DIFF
--- a/frappe/desk/doctype/calendar_view/calendar_view.json
+++ b/frappe/desk/doctype/calendar_view/calendar_view.json
@@ -42,6 +42,7 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -72,6 +73,7 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -99,9 +101,10 @@
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
-   "reqd": 0, 
+   "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -129,9 +132,10 @@
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
-   "reqd": 0, 
+   "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }
  ], 
@@ -145,7 +149,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-11-14 14:14:11.544811", 
+ "modified": "2018-07-20 08:23:23.737254", 
  "modified_by": "Administrator", 
  "module": "Desk", 
  "name": "Calendar View", 


### PR DESCRIPTION
Error due to calendar view if start and end date are blank.

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/desk/calendar.py", line 46, in get_events
    return frappe.get_list(doctype, fields=fields, filters=filters)
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/__init__.py", line 1150, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/model/db_query.py", line 88, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/model/db_query.py", line 100, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/model/db_query.py", line 116, in prepare_args
    self.sanitize_fields()
  File "/home/frappe/benches/bench-2018-07-19/apps/frappe/frappe/model/db_query.py", line 204, in sanitize_fields
    if sub_query_regex.match(field):
TypeError: expected string or buffer
```