### PR TITLE
refactored code to add support in filters to get descendant or ancest…

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -45,8 +45,8 @@ def get_bootinfo():
 	bootinfo.all_domains = [d.get("name") for d in frappe.get_all("Domain")]
 
 	bootinfo.module_app = frappe.local.module_app
-	bootinfo.single_types = frappe.db.sql_list("""select name from tabDocType
-		where issingle=1""")
+	bootinfo.single_types = [d.name for d in frappe.get_all('DocType', {'issingle': 1})]
+	bootinfo.nested_set_doctypes = [d.parent for d in frappe.get_all('DocField', {'fieldname': 'lft'}, ['parent'])]
 	add_home_page(bootinfo, doclist)
 	bootinfo.page_info = get_allowed_pages()
 	load_translations(bootinfo)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -328,7 +328,7 @@ class DatabaseQuery(object):
 		can_be_null = True
 
 		# prepare in condition
-		if f.operator.lower() in ('ancestors of', 'descendants of'):
+		if f.operator.lower() in ('ancestors of', 'descendants of', 'not ancestors of', 'not descendants of'):
 			values = f.value or ''
 
 			# TODO: handle list and tuple
@@ -344,7 +344,7 @@ class DatabaseQuery(object):
 			lft, rgt = frappe.db.get_value(ref_doctype, f.value, ["lft", "rgt"])
 
 			# Get descendants elements of a DocType with a tree structure
-			if f.operator.lower() in ('descendants of') :
+			if f.operator.lower() in ('descendants of', 'not descendants of') :
 				result = frappe.db.sql_list("""select name from `tab{0}`
 					where lft>%s and rgt<%s order by lft asc""".format(ref_doctype), (lft, rgt))
 			else :
@@ -357,7 +357,8 @@ class DatabaseQuery(object):
 			value = '("{0}")'.format('", "'.join(value))
 			# changing operator to IN as the above code fetches all the parent / child values and convert into tuple
 			# which can be directly used with IN operator to query.
-			f.operator = 'in'
+			f.operator = 'not in' if f.operator.lower() in ('not ancestors of', 'not descendants of') else 'in'
+
 
 		elif f.operator.lower() in ('in', 'not in'):
 			values = f.value or ''

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -343,12 +343,12 @@ class DatabaseQuery(object):
 			result=[]
 			lft, rgt = frappe.db.get_value(ref_doctype, f.value, ["lft", "rgt"])
 
+			# Get descendants elements of a DocType with a tree structure
 			if f.operator.lower() in ('descendants of') :
-				"""Get descendants elements of a DocType with a tree structure"""
 				result = frappe.db.sql_list("""select name from `tab{0}`
 					where lft>%s and rgt<%s order by lft asc""".format(ref_doctype), (lft, rgt))
 			else :
-				"""Get ancestor elements of a DocType with a tree structure"""
+				# Get ancestor elements of a DocType with a tree structure
 				result = frappe.db.sql_list("""select name from `tab{0}`
 					where lft<%s and rgt>%s order by lft desc""".format(ref_doctype), (lft, rgt))
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -328,7 +328,38 @@ class DatabaseQuery(object):
 		can_be_null = True
 
 		# prepare in condition
-		if f.operator.lower() in ('in', 'not in'):
+		if f.operator.lower() in ('ancestors of', 'descendants of'):
+			values = f.value or ''
+
+			# TODO: handle list and tuple
+			# if not isinstance(values, (list, tuple)):
+			# 	values = values.split(",")
+
+			ref_doctype = f.doctype
+
+			if frappe.get_meta(f.doctype).get_field(f.fieldname) is not None :
+				ref_doctype = frappe.get_meta(f.doctype).get_field(f.fieldname).options
+
+			result=[]
+			lft, rgt = frappe.db.get_value(ref_doctype, f.value, ["lft", "rgt"])
+
+			if f.operator.lower() in ('descendants of') :
+				"""Get descendants elements of a DocType with a tree structure"""
+				result = frappe.db.sql_list("""select name from `tab{0}`
+					where lft>%s and rgt<%s order by lft asc""".format(ref_doctype), (lft, rgt))
+			else :
+				"""Get ancestor elements of a DocType with a tree structure"""
+				result = frappe.db.sql_list("""select name from `tab{0}`
+					where lft<%s and rgt>%s order by lft desc""".format(ref_doctype), (lft, rgt))
+
+			fallback = "''"
+			value = (frappe.db.escape((v or '').strip(), percent=False) for v in result)
+			value = '("{0}")'.format('", "'.join(value))
+			# changing operator to IN as the above code fetches all the parent / child values and convert into tuple
+			# which can be directly used with IN operator to query.
+			f.operator = 'in'
+
+		elif f.operator.lower() in ('in', 'not in'):
 			values = f.value or ''
 			if not isinstance(values, (list, tuple)):
 				values = values.split(",")

--- a/frappe/public/js/frappe/ui/filters/edit_filter.html
+++ b/frappe/public/js/frappe/ui/filters/edit_filter.html
@@ -15,7 +15,9 @@
 				<option value="<=">{%= __("<=") %}</option>
 				<option value="Between">{%= __("Between") %}</option>
 				<option value="descendants of">Descendants Of</option>
+				<option value="not descendants of">Not Descendants Of</option>
 				<option value="ancestors of">Ancestors Of</option>
+				<option value="not ancestors of">Not Ancestors Of</option>
 			</select>
 		</div>
 		<div class="col-sm-6 col-xs-12">

--- a/frappe/public/js/frappe/ui/filters/edit_filter.html
+++ b/frappe/public/js/frappe/ui/filters/edit_filter.html
@@ -14,10 +14,10 @@
 				<option value=">=">{%= __(">=") %}</option>
 				<option value="<=">{%= __("<=") %}</option>
 				<option value="Between">{%= __("Between") %}</option>
-				<option value="descendants of">Descendants Of</option>
-				<option value="not descendants of">Not Descendants Of</option>
-				<option value="ancestors of">Ancestors Of</option>
-				<option value="not ancestors of">Not Ancestors Of</option>
+				<option value="descendants of">{%= __("Descendants Of") %}</option>
+				<option value="not descendants of">{%= __("Not Descendants Of") %}</option>
+				<option value="ancestors of">{%= __("Ancestors Of") %}</option>
+				<option value="not ancestors of">{%= __("Not Ancestors Of") %}</option>
 			</select>
 		</div>
 		<div class="col-sm-6 col-xs-12">

--- a/frappe/public/js/frappe/ui/filters/edit_filter.html
+++ b/frappe/public/js/frappe/ui/filters/edit_filter.html
@@ -14,6 +14,8 @@
 				<option value=">=">{%= __(">=") %}</option>
 				<option value="<=">{%= __("<=") %}</option>
 				<option value="Between">{%= __("Between") %}</option>
+				<option value="descendants of">Descendants Of</option>
+				<option value="ancestors of">Ancestors Of</option>
 			</select>
 		</div>
 		<div class="col-sm-6 col-xs-12">

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -296,7 +296,14 @@ frappe.ui.Filter = class {
 	hide_nested_set_conditions(df) {
 		if ( !( df.fieldtype == "Link" && frappe.boot.nested_set_doctypes.includes(df.options))) {
 			this.filter_edit_area.find(`.condition option[value="descendants of"]`).hide();
+			this.filter_edit_area.find(`.condition option[value="not descendants of"]`).hide();
 			this.filter_edit_area.find(`.condition option[value="ancestors of"]`).hide();
+			this.filter_edit_area.find(`.condition option[value="not ancestors of"]`).hide();
+		}else {
+			this.filter_edit_area.find(`.condition option[value="descendants of"]`).show();
+			this.filter_edit_area.find(`.condition option[value="not descendants of"]`).show();
+			this.filter_edit_area.find(`.condition option[value="ancestors of"]`).show();
+			this.filter_edit_area.find(`.condition option[value="not ancestors of"]`).show();
 		}
 	}
 };
@@ -383,7 +390,7 @@ frappe.ui.filter_utils = {
 		} else if(['Text','Small Text','Text Editor','Code','Tag','Comments',
 			'Dynamic Link','Read Only','Assign'].indexOf(df.fieldtype)!=-1) {
 			df.fieldtype = 'Data';
-		} else if(df.fieldtype=='Link' && ['=', '!=', 'descendants of', 'ancestors of'].indexOf(condition)==-1) {
+		} else if(df.fieldtype=='Link' && ['=', '!=', 'descendants of', 'ancestors of', 'not descendants of', 'not ancestors of'].indexOf(condition)==-1) {
 			df.fieldtype = 'Data';
 		}
 		if(df.fieldtype==="Data" && (df.options || "").toLowerCase()==="email") {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -295,8 +295,8 @@ frappe.ui.Filter = class {
 
 	hide_nested_set_conditions(df) {
 		if ( !( df.fieldtype == "Link" && frappe.boot.nested_set_doctypes.includes(df.options))) {
-			this.filter_edit_area.find(`.condition option[value="descendants of"]`).hide()
-			this.filter_edit_area.find(`.condition option[value="ancestors of"]`).hide()
+			this.filter_edit_area.find(`.condition option[value="descendants of"]`).hide();
+			this.filter_edit_area.find(`.condition option[value="ancestors of"]`).hide();
 		}
 	}
 };

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -17,7 +17,9 @@ frappe.ui.Filter = class {
 			["<", "<"],
 			[">=", ">="],
 			["<=", "<="],
-			["Between", __("Between")]
+			["Between", __("Between")],
+			["descendants of", __("Descendants Of")],
+			["ancestors of", __("Ancestors Of")]
 		];
 		this.invalid_condition_map = {
 			Date: ['like', 'not like'],
@@ -185,7 +187,7 @@ frappe.ui.Filter = class {
 	make_field(df, old_fieldtype) {
 		let old_text = this.field ? this.field.get_value() : null;
 		this.hide_invalid_conditions(df.fieldtype, df.original_type);
-
+		this.hide_nested_set_conditions(df);
 		let field_area = this.filter_edit_area.find('.filter-field').empty().get(0);
 		let f = frappe.ui.form.make_control({
 			df: df,
@@ -216,7 +218,6 @@ frappe.ui.Filter = class {
 			this.hidden
 		];
 	}
-
 	get_selected_value() {
 		return this.utils.get_selected_value(this.field, this.get_condition());
 	}
@@ -229,6 +230,7 @@ frappe.ui.Filter = class {
 		let $condition_field = this.filter_edit_area.find('.condition');
 		$condition_field.val(condition);
 		if(trigger_change) $condition_field.change();
+
 	}
 
 	make_tag() {
@@ -288,6 +290,13 @@ frappe.ui.Filter = class {
 			this.filter_edit_area.find(`.condition option[value="${condition[0]}"]`).toggle(
 				!invalid_conditions.includes(condition[0])
 			);
+		}
+	}
+
+	hide_nested_set_conditions(df) {
+		if ( !( df.fieldtype == "Link" && frappe.boot.nested_set_doctypes.includes(df.options))) {
+			this.filter_edit_area.find(`.condition option[value="descendants of"]`).hide()
+			this.filter_edit_area.find(`.condition option[value="ancestors of"]`).hide()
 		}
 	}
 };
@@ -374,7 +383,7 @@ frappe.ui.filter_utils = {
 		} else if(['Text','Small Text','Text Editor','Code','Tag','Comments',
 			'Dynamic Link','Read Only','Assign'].indexOf(df.fieldtype)!=-1) {
 			df.fieldtype = 'Data';
-		} else if(df.fieldtype=='Link' && ['=', '!='].indexOf(condition)==-1) {
+		} else if(df.fieldtype=='Link' && ['=', '!=', 'descendants of', 'ancestors of'].indexOf(condition)==-1) {
 			df.fieldtype = 'Data';
 		}
 		if(df.fieldtype==="Data" && (df.options || "").toLowerCase()==="email") {

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -816,7 +816,8 @@ def get_filter(doctype, f):
 		# if operator is missing
 		f.operator = "="
 
-	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "between", "descendants of", "ancestors of")
+	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in",
+		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of")
 	if f.operator.lower() not in valid_operators:
 		frappe.throw(frappe._("Operator must be one of {0}").format(", ".join(valid_operators)))
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -816,7 +816,7 @@ def get_filter(doctype, f):
 		# if operator is missing
 		f.operator = "="
 
-	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "between")
+	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "between", "descendants of", "ancestors of")
 	if f.operator.lower() not in valid_operators:
 		frappe.throw(frappe._("Operator must be one of {0}").format(", ".join(valid_operators)))
 


### PR DESCRIPTION
This features adds two new filters `descendants of` and `ancestors of` which allow users to filter data to get all child or parents for a selected value.

It can used form UI as well as backend.

For example: 
Customer Group 
![cgroup](https://user-images.githubusercontent.com/13943539/43011614-a7171c48-8c61-11e8-8a3d-94c068f00812.png)

So now if I have to check all sales order whose parent is foobar I can simply do

From UI:

![filter](https://user-images.githubusercontent.com/13943539/43011738-f4e12df6-8c61-11e8-9754-d38aebf6afef.png)

From backend:

```

ex: frappe.get_all('Sales Order', {'customer_group': ('descendants of', 'foobar')})
```
Output: 
![screenshot from 2018-07-20 21-10-25](https://user-images.githubusercontent.com/13943539/43011537-69765c1e-8c61-11e8-9e1b-55613ef21e6f.png)
