### PR TITLE
[Enhance] Add items to dashboard through client-side scripting

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -7,6 +7,7 @@ import frappe
 from frappe.utils import time_diff_in_seconds, now, now_datetime, DATETIME_FORMAT
 from dateutil.relativedelta import relativedelta
 from six import string_types
+import json
 
 @frappe.whitelist()
 def get_notifications():
@@ -232,7 +233,7 @@ def get_filters_for(doctype):
 	return config.get('for_doctype').get(doctype, {})
 
 @frappe.whitelist()
-def get_open_count(doctype, name):
+def get_open_count(doctype, name, items=None):
 	'''Get open count for given transactions and filters
 
 	:param doctype: Reference DocType
@@ -246,9 +247,12 @@ def get_open_count(doctype, name):
 	links = meta.get_dashboard_data()
 
 	# compile all items in a list
-	items = []
-	for group in links.transactions:
-		items.extend(group.get('items'))
+	if not items:
+		for group in links.transactions:
+			items.extend(group.get('items'))
+
+	if not isinstance(items, list):
+		items = json.loads(items)
 
 	out = []
 	for d in items:

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -195,8 +195,6 @@ frappe.ui.form.Dashboard = Class.extend({
 			});
 
 			this.filter_permissions();
-			this.render_links();
-			this.set_open_count();
 		}
 	},
 

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -166,6 +166,40 @@ frappe.ui.form.Dashboard = Class.extend({
 		this.filter_permissions();
 	},
 
+	add_transactions: function(opts) {
+		// add additional data on dashboard
+		let group_added = [];
+
+		if(!Array.isArray(opts)) opts=[opts];
+
+		if(!this.data) {
+			this.init_data();
+		}
+
+		if(this.data && (this.data.transactions || []).length) {
+			// check if label already exists, add items to it
+			this.data.transactions.map(group => {
+				opts.map(d => {
+					if(d.label == group.label) {
+						group_added.push(d.label);
+						group.items.push(...d.items);
+					}
+				});
+			});
+
+			// if label not already present, add new label and items under it
+			opts.map(d => {
+				if(!group_added.includes(d.label)) {
+					this.data.transactions.push(d);
+				}
+			});
+
+			this.filter_permissions();
+			this.render_links();
+			this.set_open_count();
+		}
+	},
+
 	filter_permissions: function() {
 		// filter out transactions for which the user
 		// does not have permission
@@ -263,13 +297,13 @@ frappe.ui.form.Dashboard = Class.extend({
 		});
 
 		var method = this.data.method || 'frappe.desk.notifications.get_open_count';
-
 		frappe.call({
 			type: "GET",
 			method: method,
 			args: {
 				doctype: this.frm.doctype,
 				name: this.frm.doc.name,
+				items: items
 			},
 			callback: function(r) {
 				if(r.message.timeline_data) {


### PR DESCRIPTION
![dashboard](https://user-images.githubusercontent.com/11695402/43122672-83a8aebc-8f3f-11e8-8bd2-eec49637c6a1.gif)

format is same as adding stuff in '_dashboard.py' file

```
# for Item DocType
this.frm.dashboard.add_transactions([
	{
		'items': [
			'Sales Invoice',
			'Bin'
		],
		'label': 'Sell'
	},
	{
		'items': [
			'Stock Entry',
			'Bin'
		],
		'label': 'Buying'
	}
]);
```