### PR TITLE
Fix comment mentions to avoid html tags

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -260,6 +260,8 @@ class TestUser(unittest.TestCase):
 	def test_comment_mentions(self):
 		user_name = "@test.comment@example.com"
 		self.assertEqual(extract_mentions(user_name)[0], "test.comment@example.com")
+		user_name = "@test.comment@test-example.com"
+		self.assertEqual(extract_mentions(user_name)[0], "test.comment@test-example.com")
 		user_name = "Testing comment, @test-user please check."
 		self.assertEqual(extract_mentions(user_name)[0], "test-user")
 		user_name = "Testing comment, @test.user@example.com please check."

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -901,6 +901,7 @@ def notify_admin_access_to_system_manager(login_manager=None):
 def extract_mentions(txt):
 	"""Find all instances of @name in the string.
 	The mentions will be separated by non-word characters or may appear at the start of the string"""
+	txt = re.sub(r'(<[a-zA-Z\/][^>]*>)', '', txt)
 	return re.findall(r'(?:[^\w\.\-\@]|^)@([\w\.\-\@]*)', txt)
 
 


### PR DESCRIPTION
Apparently, if a comment mention email is something like `@example@ss-india.com`, it gets interpreted as `@example@ss<a href="http://-india.com">-india.com` and fails in the email queue. So added a regex function to replace html tags before extracting.