### PR TITLE
[python3] let PdfFileReader handle file opening

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -16,7 +16,7 @@ def get_pdf(html, options=None, output = None):
 	try:
 		pdfkit.from_string(html, fname, options=options or {})
 		if output:
-			append_pdf(PdfFileReader(file(fname,"rb")),output)
+			append_pdf(PdfFileReader(fname),output)
 		else:
 			with open(fname, "rb") as fileobj:
 				filedata = fileobj.read()


### PR DESCRIPTION
In Python 3, file() is deprecated. 
PdfFileReader can internally handle file opening and closing, so file() is no longer necessary.

See description of stream parameter here:
https://pythonhosted.org/PyPDF2/PdfFileReader.html#PyPDF2.PdfFileReader

Alternatively, open() can be used.