### PR TITLE
using regex instead of soup to parse pdf page margins

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -88,7 +88,7 @@ def read_options_from_html(html):
 	options.update(prepare_header_footer(soup))
 
 	toggle_visible_pdf(soup)
-	
+
 	# use regex instead of soup-parser
 	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size"):
 		try:

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -7,6 +7,7 @@ from frappe.utils import scrub_urls
 from frappe import _
 from bs4 import BeautifulSoup
 from PyPDF2 import PdfFileWriter, PdfFileReader
+import re
 
 def get_pdf(html, options=None, output = None):
 	html = scrub_urls(html)
@@ -87,13 +88,14 @@ def read_options_from_html(html):
 	options.update(prepare_header_footer(soup))
 
 	toggle_visible_pdf(soup)
-
-	# extract pdfkit options from html
-	for html_id in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size"):
+	
+	# use regex instead of soup-parser
+	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size"):
 		try:
-			tag = soup.find(id=html_id)
-			if tag and tag.contents:
-				options[html_id] = tag.contents
+			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
+			match = pattern.findall(html)
+			if match:
+				options[attr] = str(match[-1][3]).strip()
 		except:
 			pass
 


### PR DESCRIPTION
`cherry-pick` from develop, related to #4972