### PR TITLE
Handle broken images

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -201,6 +201,12 @@ frappe.dom = {
 	},
 	is_touchscreen: function() {
 		return ('ontouchstart' in window)
+	},
+	handle_broken_images(container) {
+		$(container).find('img').on('error', (e) => {
+			const $img = $(e.currentTarget);
+			$img.addClass('no-image');
+		});
 	}
 }
 

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -1144,3 +1144,36 @@ input[type="checkbox"] {
 	}
 
 }
+
+/* broken image styling */
+
+img.no-image {
+	position: relative;
+	height: 100%;
+	width: 100%;
+}
+
+img.no-image:before {
+	content: " ";
+	display: block;
+	position: absolute;
+	left: 0;
+	height: calc(100%);
+	width: 100%;
+	background-color: @light-bg;
+}
+
+img.no-image:after {
+	content: "\f1c5";
+	display: block;
+	font-style: normal;
+	font-family: FontAwesome;
+	color: @text-muted;
+
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	left: 0;
+	width: 100%;
+	text-align: center;
+}

--- a/frappe/public/less/flex.less
+++ b/frappe/public/less/flex.less
@@ -2,6 +2,10 @@
     display: flex;
 }
 
+.flex-column {
+    flex-direction: column;
+}
+
 .justify-center {
     justify-content: center;
 }


### PR DESCRIPTION
#### Handle broken images gracefully

![image](https://user-images.githubusercontent.com/9355208/43313520-e2d88270-91ad-11e8-9cae-47b4765243da.png)

This method will add a class to images which had it's `src` set but the image was not loaded due to any reason.

Usage:

```js

// after your render function
// pass the $wrapper where your img elements are rendered
frappe.dom.handle_broken_images($wrapper);

```