### PR TITLE
[email] smtp connection per sender

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -2,7 +2,6 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-from six.moves import range
 import frappe
 from six.moves import html_parser as HTMLParser
 import smtplib, quopri, json
@@ -332,7 +331,6 @@ def return_unsubscribed_page(email, doctype, name):
 def flush(from_test=False):
 	"""flush email queue, every time: called from scheduler"""
 	# additional check
-	cache = frappe.cache()
 	check_email_limit([])
 
 	auto_commit = not from_test
@@ -340,34 +338,27 @@ def flush(from_test=False):
 		msgprint(_("Emails are muted"))
 		from_test = True
 
-	make_cache_queue()
-
 	smtpserver_dict = frappe._dict()
 
-	for i in range(cache.llen('cache_email_queue')):
-		email = cache.lpop('cache_email_queue')
+	for email in get_queue():
 
 		if cint(frappe.defaults.get_defaults().get("hold_queue"))==1:
 			break
 
-		if email:
-			sender = frappe.db.get_value("Email Queue", email, "sender")
-			smtpserver = smtpserver_dict.get(sender)
+		if email.name:
+			smtpserver = smtpserver_dict.get(email.sender)
 			if not smtpserver:
 				smtpserver = SMTPServer()
-				smtpserver_dict[sender] = smtpserver
+				smtpserver_dict[email.sender] = smtpserver
 
-			send_one(email, smtpserver, auto_commit, from_test=from_test)
+			send_one(email.name, smtpserver, auto_commit, from_test=from_test)
 
 		# NOTE: removing commit here because we pass auto_commit
 		# finally:
 		# 	frappe.db.commit()
-def make_cache_queue():
-	'''cache values in queue before sendign'''
-	cache = frappe.cache()
-
-	emails = frappe.db.sql('''select
-			name
+def get_queue():
+	return frappe.db.sql('''select
+			name, sender
 		from
 			`tabEmail Queue`
 		where
@@ -375,12 +366,8 @@ def make_cache_queue():
 			(send_after is null or send_after < %(now)s)
 		order
 			by priority desc, creation asc
-		limit 500''', { 'now': now_datetime() })
+		limit 500''', { 'now': now_datetime() }, as_dict=True)
 
-	# reset value
-	cache.delete_value('cache_email_queue')
-	for e in emails:
-		cache.rpush('cache_email_queue', e[0])
 
 def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=False):
 	'''Send Email Queue with given smtpserver'''

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -340,9 +340,9 @@ def flush(from_test=False):
 		msgprint(_("Emails are muted"))
 		from_test = True
 
-	smtpserver = SMTPServer()
-
 	make_cache_queue()
+
+	smtpserver_dict = frappe._dict()
 
 	for i in range(cache.llen('cache_email_queue')):
 		email = cache.lpop('cache_email_queue')
@@ -351,6 +351,12 @@ def flush(from_test=False):
 			break
 
 		if email:
+			sender = frappe.db.get_value("Email Queue", email, "sender")
+			smtpserver = smtpserver_dict.get(sender)
+			if not smtpserver:
+				smtpserver = SMTPServer()
+				smtpserver_dict[sender] = smtpserver
+
 			send_one(email, smtpserver, auto_commit, from_test=from_test)
 
 		# NOTE: removing commit here because we pass auto_commit


### PR DESCRIPTION
[fix]email error due to incorrect smtp server auth  …
- A dict of smtpserver objects is created for every sender
- A smtp server object is created if not present for the given sender
- smtpserver object is picked based on the sender of the mail

[fix]remove cache from queue.py

The PR was sent in `develop`, should've gone into `hotfix`