### PR TITLE
Extract traceback from failed FrappeClient request and frappe.throw it

### DIFF
--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -286,7 +286,16 @@ class FrappeClient(object):
 			raise
 
 		if rjson and ("exc" in rjson) and rjson["exc"]:
-			raise FrappeException(rjson["exc"])
+			exc = None
+			try:
+				exc = json.loads(rjson["exc"])[0]
+			except Exception:
+				pass
+
+			if exc:
+				frappe.throw(exc, exc=FrappeException, title="FrappeClient request failed")
+			else:
+				raise FrappeException(rjson["exc"])
 		if 'message' in rjson:
 			return rjson['message']
 		elif 'data' in rjson:

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -286,16 +286,13 @@ class FrappeClient(object):
 			raise
 
 		if rjson and ("exc" in rjson) and rjson["exc"]:
-			exc = None
 			try:
 				exc = json.loads(rjson["exc"])[0]
+				exc = 'FrappeClient Request Failed\n\n' + exc
 			except Exception:
-				pass
+				exc = rjson["exc"]
 
-			if exc:
-				frappe.throw(exc, exc=FrappeException, title="FrappeClient request failed")
-			else:
-				raise FrappeException(rjson["exc"])
+			raise FrappeException(exc)
 		if 'message' in rjson:
 			return rjson['message']
 		elif 'data' in rjson:


### PR DESCRIPTION
Failed requests from FrappeClient may contain traceback from the requested Frappe Server. In this PR, we extract that traceback for easier debugging of remote requests.

![image](https://user-images.githubusercontent.com/9355208/43506557-12e0e06a-9588-11e8-88f6-92f9dafef05f.png)

