### PR TITLE
[Bug] Auto email report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -108,6 +108,7 @@ class AutoEmailReport(Document):
 			new_row = []
 			out.append(new_row)
 			for df in columns:
+				if not row.get(df.fieldname): continue
 				new_row.append(frappe.format(row[df.fieldname], df, row))
 
 		return out


### PR DESCRIPTION
```
Traceback (most recent call last): File "/home/frappe/benches/bench-2018-07-
31/apps/frappe/frappe/app.py", line 62, in application response = frappe.handler.handle() File 
"/home/frappe/benches/bench-2018-07-31/apps/frappe/frappe/handler.py", line 22, in handle data = 
execute_cmd(cmd) File "/home/frappe/benches/bench-2018-07-31/apps/frappe/frappe/handler.py", 
line 53, in execute_cmd return frappe.call(method, **frappe.form_dict) File 
"/home/frappe/benches/bench-2018-07-31/apps/frappe/frappe/__init__.py", line 939, in call return fn(*args, **newargs) File "/home/frappe/benches/bench-2018-07-
31/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 167, in send_now 
auto_email_report.send() File "/home/frappe/benches/bench-2018-07-
31/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 122, in send data = 
self.get_report_content() File "/home/frappe/benches/bench-2018-07-
31/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 75, in
 get_report_content spreadsheet_data = self.get_spreadsheet_data(columns, data) File 
"/home/frappe/benches/bench-2018-07-
31/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 111, in 
get_spreadsheet_data new_row.append(frappe.format(row[df.fieldname], df, row)) KeyError: u'account'

```