### PR TITLE
Print the doctype name when migrations break

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -224,7 +224,11 @@ class DocType(Document):
 		"""Update database schema, make controller templates if `custom` is not set and clear cache."""
 		from frappe.model.db_schema import updatedb
 		self.delete_duplicate_custom_fields()
-		updatedb(self.name, self)
+		try:
+			updatedb(self.name, self)
+		except Exception as e:
+			print("\n\nThere was an issue while migrating the DocType: {}\n".format(self.name))
+			raise e
 
 		self.change_modified_of_parent()
 		make_module_and_roles(self)


### PR DESCRIPTION
Before:
```
➜  frappe-bench bench --site site.name migrate
Migrating site.name
Updating DocTypes for frappe        : [========================================]
Updating DocTypes for erpnext: [==========                              ]
There was an issue while migrating the DocType: Issue

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
...
```

After:
```
➜  frappe-bench bench --site site.name migrate
Migrating site.name
Updating DocTypes for frappe        : [========================================]
Updating DocTypes for erpnext: [==========                              ]

There was an issue while migrating the DocType: Issue

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
...
```

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.