### PR TITLE
Add utility frappe.utils.md_to_html

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -434,8 +434,7 @@ def sendmail(recipients=[], sender="", subject="No Subject", message="No Message
 	message = content or message
 
 	if as_markdown:
-		from markdown2 import markdown
-		message = markdown(message)
+		message = frappe.utils.md_to_html(message)
 
 	if not delayed:
 		now = True

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -11,7 +11,6 @@ from frappe.core.doctype.role.role import get_emails_from_role
 from frappe.utils import validate_email_add, nowdate, parse_val, is_html
 from frappe.utils.jinja import validate_template
 from frappe.modules.utils import export_module_json, get_doc_module
-from markdown2 import markdown
 from six import string_types
 from frappe.integrations.doctype.slack_webhook_url.slack_webhook_url import send_slack_message
 
@@ -225,7 +224,7 @@ def get_context(context):
 		self.message = self.get_template()
 
 		if not is_html(self.message):
-			self.message = markdown(self.message)
+			self.message = frappe.utils.md_to_html(self.message)
 
 @frappe.whitelist()
 def get_documents_for_today(notification):

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -6,7 +6,6 @@
 from __future__ import unicode_literals, print_function
 from werkzeug.test import Client
 import os, re, sys, json, hashlib, requests, traceback
-from markdown2 import markdown as _markdown
 from .html_utils import sanitize_html
 import frappe
 from frappe.utils.identicon import Identicon
@@ -442,7 +441,7 @@ def watch(path, handler=None, debug=True):
 	observer.join()
 
 def markdown(text, sanitize=True, linkify=True):
-	html = _markdown(text)
+	html = frappe.utils.md_to_html(text)
 
 	if sanitize:
 		html = html.replace("<!-- markdown -->", "")

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -943,6 +943,7 @@ def md_to_html(markdown_text):
 		'fenced-code-blocks': None,
 		'tables': None,
 		'header-ids': None,
+		'highlightjs-lang': None,
 		'html-classes': {
 			'table': 'table table-bordered'
 		}

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -938,10 +938,19 @@ def to_markdown(html):
 
 	return text
 
-def to_html(markdown_text):
+def md_to_html(markdown_text):
+	extras = {
+		'fenced-code-blocks': None,
+		'tables': None,
+		'header-ids': None,
+		'html-classes': {
+			'table': 'table table-bordered'
+		}
+	}
+
 	html = None
 	try:
-		html = markdown(markdown_text)
+		html = markdown(markdown_text, extras=extras)
 	except MarkdownError:
 		pass
 

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -10,7 +10,6 @@ from frappe.model.db_schema import DbManager
 from frappe.installer import get_root_connection
 from frappe.database import Database
 import os, subprocess
-from markdown2 import markdown
 from bs4 import BeautifulSoup
 import jinja2.exceptions
 
@@ -182,7 +181,7 @@ class HelpDatabase(object):
 
 									relpath = self.get_out_path(fpath)
 									relpath = relpath.replace("user", app)
-									content = markdown(content)
+									content = frappe.utils.md_to_html(content)
 									title = self.make_title(basepath, fname, content)
 									intro = self.make_intro(content)
 									content = self.make_content(content, fpath, relpath, app)

--- a/frappe/website/js/syntax_highlight.js
+++ b/frappe/website/js/syntax_highlight.js
@@ -1,0 +1,18 @@
+const hljs = require('highlight.js/lib/highlight');
+
+hljs.registerLanguage('javascript', require('highlight.js/lib/languages/javascript'));
+hljs.registerLanguage('python', require('highlight.js/lib/languages/python'));
+hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'));
+hljs.registerLanguage('django', require('highlight.js/lib/languages/django'));
+hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'));
+hljs.registerLanguage('css', require('highlight.js/lib/languages/css'));
+hljs.registerLanguage('markdown', require('highlight.js/lib/languages/markdown'));
+hljs.registerLanguage('diff', require('highlight.js/lib/languages/diff'));
+hljs.registerLanguage('json', require('highlight.js/lib/languages/json'));
+hljs.registerLanguage('less', require('highlight.js/lib/languages/less'));
+hljs.registerLanguage('nginx', require('highlight.js/lib/languages/nginx'));
+hljs.registerLanguage('scss', require('highlight.js/lib/languages/scss'));
+hljs.registerLanguage('shell', require('highlight.js/lib/languages/shell'));
+hljs.registerLanguage('sql', require('highlight.js/lib/languages/sql'));
+
+module.exports = hljs;

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -2,7 +2,7 @@
 // MIT License. See license.txt
 /* eslint-disable no-console */
 
-import hljs from 'highlight.js';
+import hljs from './syntax_highlight';
 
 frappe.provide("website");
 frappe.provide("frappe.awesome_bar_path");
@@ -265,9 +265,7 @@ $.extend(frappe, {
 	},
 
 	highlight_code_blocks: function() {
-		$('pre code').each(function(i, block) {
-			hljs.highlightBlock(block);
-		});
+		hljs.initHighlighting();
 	},
 	bind_filters: function() {
 		// set in select

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -223,13 +223,12 @@ def get_page_info(path, app, start, basepath=None, app_path=None, fname=None):
 
 def setup_source(page_info):
 	'''Get the HTML source of the template'''
-	from markdown2 import markdown
 	jenv = frappe.get_jenv()
 	source = jenv.loader.get_source(jenv, page_info.template)[0]
 	html = ''
 
 	if page_info.template.endswith('.md'):
-		source = markdown(source, extras=["fenced-code-blocks"])
+		source = frappe.utils.md_to_html(source)
 
 		if not page_info.show_sidebar:
 			source = '<div class="from-markdown">' + source + '</div>'

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -8,7 +8,6 @@ from frappe import _
 
 from frappe.modules import get_doc_path
 from frappe.utils import cint, strip_html
-from markdown2 import markdown
 from six import string_types
 
 no_cache = 1
@@ -169,7 +168,7 @@ def convert_markdown(doc, meta):
 		if field.fieldtype=='Text Editor':
 			value = doc.get(field.fieldname)
 			if value and '<!-- markdown -->' in value:
-				doc.set(field.fieldname, markdown(value))
+				doc.set(field.fieldname, frappe.utils.md_to_html(value))
 
 @frappe.whitelist()
 def get_html_and_style(doc, name=None, print_format=None, meta=None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chardet
 dropbox==7.3.1
 gunicorn
 jinja2
-markdown2
+markdown2==2.3.5
 PyMySQL
 maxminddb-geolite2
 python-dateutil


### PR DESCRIPTION
- Replace all occurences of manual imports with this utility
- Also enable extras
  - fenced-code-blocks
  - tables with class 'table table-bordered'
  - header-ids

Better syntax highlighting
- Update markdown2 to 2.3.5
- Only load syntax files for languages we support
- Enable highlightjs-lang extra to add class to code blocks

![image](https://user-images.githubusercontent.com/9355208/43686916-dc3fbc32-98ea-11e8-8ee0-876d4d628fd0.png)
