### PR TITLE
[injection][fix] prevent jinja exec in search title

### DIFF
--- a/frappe/templates/includes/search_template.html
+++ b/frappe/templates/includes/search_template.html
@@ -1,4 +1,4 @@
-<h1>{{ title }}</h1>
+<h1>{{ title }}: "{{ query }}"</h1>
 
 {%- macro search_results_section(results, title, has_more) -%}
 	<div class='search-result col-sm-6'>

--- a/frappe/www/search.py
+++ b/frappe/www/search.py
@@ -10,7 +10,8 @@ def get_context(context):
 	context.no_cache = 1
 	if frappe.form_dict.q:
 		query = str(utils.escape(sanitize_html(frappe.form_dict.q)))
-		context.title = _('Search Results for "{0}"').format(query)
+		context.title = _('Search Results for ')
+		context.query = query
 		context.route = '/search'
 		context.update(get_search_results(query))
 	else:


### PR DESCRIPTION
Also: https://github.com/frappe/erpnext/pull/15094

Looks like this also has to be fixed in Hotfix.

Before: 
<img width="1668" alt="rce_screen1" src="https://user-images.githubusercontent.com/5196925/43701616-77ce6ac0-9974-11e8-89cd-c79f160ee7d1.png">


After:
<img width="612" alt="screen shot 2018-08-06 at 12 23 46 pm" src="https://user-images.githubusercontent.com/5196925/43701598-6ad06b84-9974-11e8-9a64-16beb68ae94b.png">