### PR TITLE
fix(email html): Allow pre and code tags in email html

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -21,7 +21,7 @@ def clean_email_html(html):
 
 	return bleach.clean(clean_script_and_style(html),
 		tags=['div', 'p', 'br', 'ul', 'ol', 'li', 'b', 'i', 'em', 'a',
-			'table', 'thead', 'tbody', 'td', 'tr', 'th',
+			'table', 'thead', 'tbody', 'td', 'tr', 'th', 'pre', 'code',
 			'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'button', 'img'],
 		attributes=['border', 'colspan', 'rowspan',
 			'src', 'href', 'style', 'id'],


### PR DESCRIPTION
`pre` and `code` tags are safe and should be allowed in email html

![image](https://user-images.githubusercontent.com/9355208/43701699-b51acb9e-9974-11e8-86f6-4e509f380d16.png)
