### PR TITLE
[hotfix] prevent jinja exec in search title

### DIFF
--- a/frappe/www/search.html
+++ b/frappe/www/search.html
@@ -1,7 +1,7 @@
 {% extends "templates/web.html" %}
 
 {% block page_content %}
-<h1>{{ title }}</h1>
+<h1>{{ title }}: "{{ query }}"</h1>
 
 <div>
 	<form action='/search'>

--- a/frappe/www/search.py
+++ b/frappe/www/search.py
@@ -10,7 +10,8 @@ def get_context(context):
 	context.no_cache = 1
 	if frappe.form_dict.q:
 		query = str(utils.escape(sanitize_html(frappe.form_dict.q)))
-		context.title = _('Search Results for "{0}"').format(query)
+		context.title = _('Search Results for')
+		context.query = query
 		context.update(get_search_results(query))
 	else:
 		context.title = _('Search')


### PR DESCRIPTION
Same as: https://github.com/frappe/frappe/pull/5928, but on hotfix due to a different template implementation.