### PR TITLE
[frappe-client] raise an exception for error codes

### DIFF
--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -282,6 +282,8 @@ class FrappeClient(object):
 		return params
 
 	def post_process(self, response):
+		response.raise_for_status()
+
 		try:
 			rjson = response.json()
 		except ValueError:


### PR DESCRIPTION
Using `requests` built-in `raise_for_status()` for error codes (4xx or 5xx).