### PR TITLE
[handler] Raise exceptions in request in dev_mode

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -40,10 +40,11 @@ def execute_cmd(cmd, from_async=False):
 
 	try:
 		method = get_attr(cmd)
-	except SyntaxError as e: # syntax error throws method not found
-		raise e
-	except:
-		frappe.respond_as_web_page(title='Invalid Method', html='Method not found',
+	except Exception as e:
+		if frappe.local.conf.developer_mode:
+			raise e
+		else:
+			frappe.respond_as_web_page(title='Invalid Method', html='Method not found',
 			indicator_color='red', http_status_code=404)
 		return
 
@@ -106,7 +107,7 @@ def run_custom_method(doctype, name, custom_method):
 @frappe.whitelist()
 def uploadfile():
 	ret = None
-	
+
 	try:
 		if frappe.form_dict.get('from_form'):
 			try:


### PR DESCRIPTION
We just had the feature [Raise on Syntax Error](https://github.com/frappe/frappe/commit/c4fac7a09c86f9103892a6cafad8f734e60d8780#diff-ce6d074582812c78df4b58a2057c8b06) contributed. Not examining, I vaguely relied on it and wasted time because it didn't manage to catch an `ImportError`. By reasoning, we may add to it to the mix as `except (SyntaxError, ImportError) as e`, but we start to see a pattern.

In a development environment, if we can make room for `SyntaxError`s, we should probably be catching _all_ errors while executing requests, because we need them.

**In Production, we fall back to the 404 HTML page in case of any failure.**

### Results (in developer mode):

#### Syntax Error:
<img width="864" alt="screen shot 2018-08-08 at 8 22 07 pm" src="https://user-images.githubusercontent.com/5196925/43845144-ef255c70-9b48-11e8-8867-80f7e74f90ce.png">


#### Import Error:
<img width="808" alt="screen shot 2018-08-08 at 8 08 26 pm" src="https://user-images.githubusercontent.com/5196925/43845150-f299ddc2-9b48-11e8-92ba-085bfdbe93cc.png">


#### Method Not Found:
<img width="843" alt="screen shot 2018-08-08 at 8 07 06 pm" src="https://user-images.githubusercontent.com/5196925/43845142-ec29f81e-9b48-11e8-95d0-c16fd1dfe60a.png">


#### Restricted Method:
<img width="839" alt="screen shot 2018-08-08 at 8 06 41 pm" src="https://user-images.githubusercontent.com/5196925/43845113-dc3e4afe-9b48-11e8-93c5-e5775f853f55.png">
