### PR TITLE
Print format builder translations

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -2,7 +2,7 @@
     {% if(field.print_hide) { %}style="background-color: #F7FAFC; color: #8D99A6;"
         title="{{ __("Hidden") }}"{% } %}
     data-fieldname="{%= field.fieldname %}"
-    data-label="{{ field.label }}"
+    data-label="{{ __(field.label) }}"
 
 	{% if field.align %}data-align="{{ field.align }}"{% endif %}
     data-fieldtype="{%= field.fieldtype %}"
@@ -25,7 +25,7 @@
 				data-custom-html-id={{ field.custom_html_id }}{% endif %}>
 			{{ field.options || me.get_no_content() }}</div>
     {% } else { %}
-        <span class="field-label">{{ field.label }}</span>
+        <span class="field-label">{{ __(field.label) }}</span>
         {% if(field.fieldtype==="Table") { %}
             <span> ({%= __("Table") %})</span>
             <a class="pull-right select-columns btn btn-default btn-xs">

--- a/frappe/printing/page/print_format_builder/print_format_builder_layout.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_layout.html
@@ -19,6 +19,6 @@
 	</div>
 	<div class="print-format-builder-add-section text-muted text-center">
 		<span class="octicon octicon-plus"></span>
-		<a class="grey">Add a new section</a>
+		<a class="grey">{%= __("Add a new section") %}</a>
 	</div>
 </div>

--- a/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html
@@ -10,7 +10,7 @@
             <span class="btn btn-xs field-label
                 {%= (f.fieldtype==="Custom HTML") ? "btn-info" : "btn-default" %}"
                 style="cursor: grab; display: inline-block">
-                {%= f.label %}
+                {%= __(f.label) %}
             </span>
         </div>
         {% } %}


### PR DESCRIPTION
Hi,

This PR makes a few elements translatable in the print builder.

1. Sidebar fields:
![image](https://user-images.githubusercontent.com/4903591/43970604-6887b1d6-9cce-11e8-9259-6200bda4052f.png)

2. Column fields:
![image](https://user-images.githubusercontent.com/4903591/43970626-77779134-9cce-11e8-9f1c-4e9589d42ce5.png)

3. Add a new section field:
![image](https://user-images.githubusercontent.com/4903591/43970675-9fe4afda-9cce-11e8-8314-de3fe7ba92e2.png)



Thanks