### PR TITLE
Update frappe-datatable to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "awesomplete": "^1.1.2",
     "cookie": "^0.3.1",
     "express": "^4.16.2",
-    "frappe-datatable": "^1.1.6",
+    "frappe-datatable": "^1.2.0",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.2.0",
     "highlight.js": "^9.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,9 +954,9 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
-frappe-datatable@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.1.6.tgz#6c0de348ff728facb9b5ea4bba03103745969ede"
+frappe-datatable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.2.0.tgz#d715eeb009c13a15f5e1b8aebc305284497c19e3"
   dependencies:
     clusterize.js "^0.18.0"
     lodash "^4.17.5"


### PR DESCRIPTION
More about the new filters here: https://github.com/frappe/datatable/commit/cdb276abfd7a37290102661dfd3e9bbc108d9880

![report-advanced-filters](https://user-images.githubusercontent.com/9355208/44078393-fbce455c-9fc3-11e8-835a-a918f2f1382b.gif)
