### PR TITLE
[csv-utils] don't decode when you've encoded special chars

### DIFF
--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -50,13 +50,12 @@ def read_csv_content(fcontent, ignore_encoding=False):
 				continue
 
 		if not decoded:
-			frappe.msgprint(_("Unknown file encoding. Tried utf-8, windows-1250, windows-1252."),
-				raise_exception=True)
+			frappe.throw(_("Unknown file encoding. Tried utf-8, windows-1250, windows-1252."))
 
 	fcontent = fcontent.encode("utf-8")
 	content  = [ ]
 	for line in fcontent.splitlines(True):
-		content.append(frappe.safe_decode(line))
+		content.append(line)
 
 	try:
 		rows = []
@@ -77,8 +76,7 @@ def read_csv_content(fcontent, ignore_encoding=False):
 		return rows
 
 	except Exception:
-		frappe.msgprint(_("Not a valid Comma Separated Value (CSV File)"))
-		raise
+		frappe.throw(_("Not a valid Comma Separated Value (CSV File)"))
 
 @frappe.whitelist()
 def send_csv_to_client(args):

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -50,7 +50,7 @@ def read_csv_content(fcontent, ignore_encoding=False):
 				continue
 
 		if not decoded:
-			frappe.throw(_("Unknown file encoding. Tried utf-8, windows-1250, windows-1252."))
+			frappe.msgprint(_("Unknown file encoding. Tried utf-8, windows-1250, windows-1252."), raise_exception=True)
 
 	fcontent = fcontent.encode("utf-8")
 	content  = [ ]
@@ -76,7 +76,8 @@ def read_csv_content(fcontent, ignore_encoding=False):
 		return rows
 
 	except Exception:
-		frappe.throw(_("Not a valid Comma Separated Value (CSV File)"))
+		frappe.msgprint(_("Not a valid Comma Separated Value (CSV File)"))
+		raise
 
 @frappe.whitelist()
 def send_csv_to_client(args):


### PR DESCRIPTION
Not sure why this was done; decoding right after encoding takes care of problematic strings.

Doing so gives an encoding error, and ultimately a CSV parsing error:

<img width="1042" alt="screen shot 2018-08-14 at 4 15 02 pm" src="https://user-images.githubusercontent.com/5196925/44087367-42081f2a-9fdd-11e8-8612-57a7a55602b7.png">
