### PR TITLE
[Fix] Download report not working

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -260,10 +260,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	add_prepared_report_buttons(doc) {
 		if(doc){
 			this.page.add_inner_button(__("Download Report"), function (){
-				frappe.call({
-					method:"frappe.core.doctype.prepared_report.prepared_report.download_attachment",
-					args: {"dn": doc.name}
-				});
+				window.open(
+					frappe.urllib.get_full_url(
+						"/api/method/frappe.core.doctype.prepared_report.prepared_report.download_attachment?"
+						+"dn="+encodeURIComponent(doc.name)));
 			});
 
 			this.show_status(__(`

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -371,13 +371,13 @@ def download_file(file_url):
 	"""
 	file_doc = frappe.get_doc("File", {"file_url":file_url})
 	file_doc.check_permission("read")
+	path = os.path.join(get_files_path(), os.path.basename(file_url))
 
-	with open(getattr(frappe.local, "site_path", None) + file_url, "rb") as fileobj:
+	with open(path, "rb") as fileobj:
 		filedata = fileobj.read()
-	frappe.local.response.filename = file_url[file_url.rfind("/")+1:]
+	frappe.local.response.filename = os.path.basename(file_url)
 	frappe.local.response.filecontent = filedata
 	frappe.local.response.type = "download"
-
 
 def extract_images_from_doc(doc, fieldname):
 	content = doc.get(fieldname)


### PR DESCRIPTION

![screen shot 2018-08-16 at 6 23 06 pm](https://user-images.githubusercontent.com/8780500/44209556-804a3480-a181-11e8-9e4d-39b8592d1bb9.png)
On click of download report, getting below error

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 91, in download_attachment
    download_file(attachment.file_url)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/utils/file_manager.py", line 375, in download_file
    with open(getattr(frappe.local, "site_path", None) + file_url, "rb") as fileobj:
IOError: [Errno 2] No such file or directory: u'./beta_site_test/files/2018-54-16-15:8.csv'
```