### PR TITLE
[Fix] Prepared report is not able to export

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -161,7 +161,10 @@ def run(report_name, filters=None, user=None):
 
 	if report.prepared_report:
 		if filters:
-			dn = json.loads(filters).get("prepared_report_name")
+			if isinstance(filters, string_types):
+				filters = json.loads(filters)
+
+			dn = filters.get("prepared_report_name")
 		else:
 			dn = ""
 		return get_prepared_report_result(report, filters, dn)
@@ -187,16 +190,12 @@ def get_prepared_report_result(report, filters, dn=""):
 			"result": data[1:]
 		}
 
-	return {
+	latest_report_data.update({
 		"prepared_report": True,
-		"data": latest_report_data,
 		"doc": doc
-		# "message": message,
-		# "chart": chart,
-		# "data_to_be_printed": data_to_be_printed,
-		# "status": status
-	}
+	})
 
+	return latest_report_data
 
 @frappe.whitelist()
 def export_query():

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -245,7 +245,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			if (data.prepared_report){
 				this.prepared_report = true;
 				this.add_prepared_report_buttons(data.doc);
-				data = data.data;
 			}
 			this.toggle_message(false);
 			if (data.result && data.result.length) {
@@ -567,7 +566,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 				frappe.tools.downloadify(out, null, this.report_name);
 			} else {
-				const filters = this.get_filter_values(true);
+				let filters = this.get_filter_values(true);
+				if (frappe.urllib.get_dict("prepared_report_name")) {
+					filters = Object.assign(frappe.urllib.get_dict("prepared_report_name"), filters);
+				}
 
 				const args = {
 					cmd: 'frappe.desk.query_report.export_query',


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 224, in export_query
    data = run(report_name, filters)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 164, in run
    dn = json.loads(filters).get("prepared_report_name")
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: expected string or buffer
```

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 230, in export_query
    columns = get_columns_dict(data.columns)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 453, in get_columns_dict
    for idx, col in enumerate(columns):
TypeError: 'NoneType' object is not iterable
```