### PR TITLE
[fix]: use is_async in background jobs instead of async

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1422,7 +1422,7 @@ def enqueue(*args, **kwargs):
 		:param queue: (optional) should be either long, default or short
 		:param timeout: (optional) should be set according to the functions
 		:param event: this is passed to enable clearing of jobs from queues
-		:param async: (optional) if async=False, the method is executed immediately, else via a worker
+		:param is_async: (optional) if is_async=False, the method is executed immediately, else via a worker
 		:param job_name: (optional) can be used to name an enqueue call, which can be used to prevent duplicate calls
 		:param kwargs: keyword arguments to be passed to the method
 	'''

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1019,7 +1019,7 @@ def reset_otp_secret(user):
 			'delayed':False,
 			'retry':3
 		}
-		enqueue(method=frappe.sendmail, queue='short', timeout=300, event=None, async=True, job_name=None, now=False, **email_args)
+		enqueue(method=frappe.sendmail, queue='short', timeout=300, event=None, is_async=True, job_name=None, now=False, **email_args)
 		return frappe.msgprint(_("OTP Secret has been reset. Re-registration will be required on next login."))
 	else:
 		return frappe.throw(_("OTP secret can only be reset by the Administrator."))

--- a/frappe/database.py
+++ b/frappe/database.py
@@ -975,7 +975,7 @@ class Database:
 def enqueue_jobs_after_commit():
 	if frappe.flags.enqueue_after_commit and len(frappe.flags.enqueue_after_commit) > 0:
 		for job in frappe.flags.enqueue_after_commit:
-			q = get_queue(job.get("queue"), async=job.get("async"))
+			q = get_queue(job.get("queue"), is_async=job.get("is_async"))
 			q.enqueue_call(execute_job, timeout=job.get("timeout"),
 							kwargs=job.get("queue_args"))
 		frappe.flags.enqueue_after_commit = []

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -80,7 +80,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 					doc.run_method('on_change')
 
 				frappe.enqueue('frappe.model.delete_doc.delete_dynamic_links', doctype=doc.doctype, name=doc.name,
-					async=False if frappe.flags.in_test else True)
+					is_async=False if frappe.flags.in_test else True)
 
 				# check if links exist
 				if not force:
@@ -324,4 +324,3 @@ def insert_feed(doc):
 		"subject": "{0} {1}".format(_(doc.doctype), doc.name),
 		"full_name": get_fullname(doc.owner)
 	}).insert(ignore_permissions=True)
-

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -288,7 +288,7 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 		'use_post': ss.use_post
 	}
 	enqueue(method=send_request, queue='short', timeout=300, event=None,
-		async=True, job_name=None, now=False, **sms_args)
+		is_async=True, job_name=None, now=False, **sms_args)
 	return True
 
 def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, message=None):
@@ -315,7 +315,7 @@ def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, mess
 	}
 
 	enqueue(method=frappe.sendmail, queue='short', timeout=300, event=None,
-		async=True, job_name=None, now=False, **email_args)
+		is_async=True, job_name=None, now=False, **email_args)
 	return True
 
 def get_qr_svg_code(totp_uri):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -24,7 +24,7 @@ queue_timeout = {
 redis_connection = None
 
 def enqueue(method, queue='default', timeout=300, event=None,
-	async=True, job_name=None, now=False, enqueue_after_commit=False, **kwargs):
+	is_async=True, job_name=None, now=False, enqueue_after_commit=False, **kwargs):
 	'''
 		Enqueue method to be executed using a background worker
 
@@ -32,15 +32,20 @@ def enqueue(method, queue='default', timeout=300, event=None,
 		:param queue: should be either long, default or short
 		:param timeout: should be set according to the functions
 		:param event: this is passed to enable clearing of jobs from queues
-		:param async: if async=False, the method is executed immediately, else via a worker
+		:param is_async: if is_async=False, the method is executed immediately, else via a worker
 		:param job_name: can be used to name an enqueue call, which can be used to prevent duplicate calls
 		:param now: if now=True, the method is executed via frappe.call
 		:param kwargs: keyword arguments to be passed to the method
 	'''
+	# To handle older implementations
+	if 'async' in kwargs:
+		is_async = True
+		del kwargs['async']
+
 	if now or frappe.flags.in_migrate:
 		return frappe.call(method, **kwargs)
 
-	q = get_queue(queue, async=async)
+	q = get_queue(queue, is_async=is_async)
 	if not timeout:
 		timeout = queue_timeout.get(queue) or 300
 	queue_args = {
@@ -49,7 +54,7 @@ def enqueue(method, queue='default', timeout=300, event=None,
 		"method": method,
 		"event": event,
 		"job_name": job_name or cstr(method),
-		"async": async,
+		"is_async": is_async,
 		"kwargs": kwargs
 	}
 	if enqueue_after_commit:
@@ -58,7 +63,7 @@ def enqueue(method, queue='default', timeout=300, event=None,
 
 		frappe.flags.enqueue_after_commit.append({
 			"queue": queue,
-			"async": async,
+			"is_async": is_async,
 			"timeout": timeout,
 			"queue_args":queue_args
 		})
@@ -76,11 +81,11 @@ def enqueue_doc(doctype, name=None, method=None, queue='default', timeout=300,
 def run_doc_method(doctype, name, doc_method, **kwargs):
 	getattr(frappe.get_doc(doctype, name), doc_method)(**kwargs)
 
-def execute_job(site, method, event, job_name, kwargs, user=None, async=True, retry=0):
+def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True, retry=0):
 	'''Executes job in a worker, performs commit/rollback and logs if there is any error'''
 	from frappe.utils.scheduler import log
 
-	if async:
+	if is_async:
 		frappe.connect(site)
 		if os.environ.get('CI'):
 			frappe.flags.in_test = True
@@ -110,7 +115,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, async=True, re
 			time.sleep(retry+1)
 
 			return execute_job(site, method, event, job_name, kwargs,
-				async=async, retry=retry+1)
+				is_async=is_async, retry=retry+1)
 
 		else:
 			log(method_name, message=repr(locals()))
@@ -125,7 +130,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, async=True, re
 		frappe.db.commit()
 
 	finally:
-		if async:
+		if is_async:
 			frappe.destroy()
 
 def start_worker(queue=None, quiet = False):
@@ -193,11 +198,11 @@ def get_queue_list(queue_list=None):
 	else:
 		return default_queue_list
 
-def get_queue(queue, async=True):
+def get_queue(queue, is_async=True):
 	'''Returns a Queue object tied to a redis connection'''
 	validate_queue(queue)
 
-	return Queue(queue, connection=get_redis_conn(), async=async)
+	return Queue(queue, connection=get_redis_conn(), is_async=is_async)
 
 def validate_queue(queue, default_queue_list=None):
 	if not default_queue_list:


### PR DESCRIPTION
With python 3.7, async and await are now reserved keywords, hence, cannot be used as variables/parameters. This PR changes background jobs to accept "is_async" parameter instead of "async" param. 

This is also backward compatible as "async" will still be checked in keyword args, and if present, will be set to "is_async" is_async instead.

Further migration also requires upgrading dropbox-sdk to version 9+, as it also has similar flaw.