### PR TITLE
[Minor] Background job failing

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -202,7 +202,7 @@ def get_queue(queue, is_async=True):
 	'''Returns a Queue object tied to a redis connection'''
 	validate_queue(queue)
 
-	return Queue(queue, connection=get_redis_conn(), is_async=is_async)
+	return Queue(queue, connection=get_redis_conn(), async=is_async)
 
 def validate_queue(queue, default_queue_list=None):
 	if not default_queue_list:


### PR DESCRIPTION
```
12:30:06 worker_long.1    |     exec code in run_globals
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
12:30:06 worker_long.1    |     main()
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
12:30:06 worker_long.1    |     click.Group(commands=commands)(prog_name='bench')
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
12:30:06 worker_long.1    |     return self.main(*args, **kwargs)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
12:30:06 worker_long.1    |     rv = self.invoke(ctx)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
12:30:06 worker_long.1    |     return _process_result(sub_ctx.command.invoke(sub_ctx))
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
12:30:06 worker_long.1    |     return _process_result(sub_ctx.command.invoke(sub_ctx))
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
12:30:06 worker_long.1    |     return ctx.invoke(self.callback, **ctx.params)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
12:30:06 worker_long.1    |     return callback(*args, **kwargs)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/apps/frappe/frappe/commands/scheduler.py", line 158, in start_worker
12:30:06 worker_long.1    |     start_worker(queue, quiet = quiet)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 150, in start_worker
12:30:06 worker_long.1    |     Worker(queues, name=get_worker_name(queue)).work(logging_level = logging_level)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/rq/worker.py", line 504, in work
12:30:06 worker_long.1    |     self.register_death()
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/rq/worker.py", line 302, in register_death
12:30:06 worker_long.1    |     p.execute()
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/client.py", line 2894, in execute
12:30:06 worker_long.1    |     return execute(conn, stack, raise_on_error)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/client.py", line 2749, in _execute_transaction
12:30:06 worker_long.1    |     connection.send_packed_command(all_cmds)
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 585, in send_packed_command
12:30:06 worker_long.1    |     self.connect()
12:30:06 worker_long.1    |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 489, in connect
12:30:06 worker_long.1    |     raise ConnectionError(self._error_message(e))
12:30:06 worker_long.1    | redis.exceptions.ConnectionError: Error 61 connecting to localhost:11000. Connection refused.
12:30:06 worker_short.1   |     return execute(conn, stack, raise_on_error)
12:30:06 worker_short.1   |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/client.py", line 2749, in _execute_transaction
12:30:06 worker_short.1   |     connection.send_packed_command(all_cmds)
12:30:06 worker_short.1   |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 585, in send_packed_command
12:30:06 worker_short.1   |     self.connect()
12:30:06 worker_short.1   |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 489, in connect
12:30:06 worker_short.1   |     raise ConnectionError(self._error_message(e))
12:30:06 worker_short.1   | redis.exceptions.ConnectionError: Error 61 connecting to localhost:11000. Connection refused.
12:30:06 worker_default.1 | Traceback (most recent call last):
12:30:06 worker_default.1 |   File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
12:30:06 worker_default.1 |     "__main__", fname, loader, pkg_name)
12:30:06 worker_default.1 |   File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
12:30:06 worker_default.1 |     exec code in run_globals
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
12:30:06 worker_default.1 |     main()
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
12:30:06 worker_default.1 |     click.Group(commands=commands)(prog_name='bench')
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
12:30:06 worker_default.1 |     return self.main(*args, **kwargs)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
12:30:06 worker_default.1 |     rv = self.invoke(ctx)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
12:30:06 worker_default.1 |     return _process_result(sub_ctx.command.invoke(sub_ctx))
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
12:30:06 worker_default.1 |     return _process_result(sub_ctx.command.invoke(sub_ctx))
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
12:30:06 worker_default.1 |     return ctx.invoke(self.callback, **ctx.params)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
12:30:06 worker_default.1 |     return callback(*args, **kwargs)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/apps/frappe/frappe/commands/scheduler.py", line 158, in start_worker
12:30:06 worker_default.1 |     start_worker(queue, quiet = quiet)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 150, in start_worker
12:30:06 worker_default.1 |     Worker(queues, name=get_worker_name(queue)).work(logging_level = logging_level)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/rq/worker.py", line 504, in work
12:30:06 worker_default.1 |     self.register_death()
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/rq/worker.py", line 302, in register_death
12:30:06 worker_default.1 |     p.execute()
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/client.py", line 2894, in execute
12:30:06 worker_default.1 |     return execute(conn, stack, raise_on_error)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/client.py", line 2749, in _execute_transaction
12:30:06 worker_default.1 |     connection.send_packed_command(all_cmds)
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 585, in send_packed_command
12:30:06 worker_default.1 |     self.connect()
12:30:06 worker_default.1 |   File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/redis/connection.py", line 489, in connect
12:30:06 worker_default.1 |     raise ConnectionError(self._error_message(e))
12:30:06 worker_default.1 | redis.exceptions.ConnectionError: Error 61 connecting to localhost:11000. Connection refused.
12:30:07 system           | worker_long.1 stopped (rc=1)
12:30:07 system           | worker_short.1 stopped (rc=1)
12:30:07 system           | worker_default.1 stopped (rc=1)
12:30:07 system           | web.1 stopped (rc=0)
```

`Queue` class from `rq` library takes argument as 'async'