### PR TITLE
[Fix] Ascii code issue while downloading report

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -46,6 +46,8 @@ def make_xlsx(data, sheet_name, wb=None):
 
 def handle_html(data):
 	# return if no html tags found
+	data = frappe.as_unicode(data)
+
 	if '<' not in data:
 		return data
 	if '>' not in data:


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 248, in export_query
    xlsx_file = make_xlsx(result, "Query Report")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/xlsxutils.py", line 30, in make_xlsx
    value = handle_html(item)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/xlsxutils.py", line 49, in handle_html
    if '<' not in data:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 35: ordinal not in range(128)
```