### PR TITLE
[fix]: decorate get_sidebar_stats with frappe.read_only

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -233,6 +233,7 @@ def delete_items():
 	return failed
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_sidebar_stats(stats, doctype, filters=[]):
 	cat_tags = frappe.db.sql("""select tag.parent as category, tag.tag_name as tag
 		from `tabTag Doc Category` as docCat


### PR DESCRIPTION
This PR redirects get_sidebar_stats to read_only replica in order to reduce overhead on transactional server due to potentially heavy "select _user_tags, count(*) from <doctype> group by _user_tags" query.