### PR TITLE
remove docstatus filter for non submittable doctypes

### DIFF
--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -131,7 +131,7 @@ frappe.ui.FieldSelect = Class.extend({
 
 	add_field_option(df) {
 		if (df.fieldname == 'docstatus' && !frappe.model.is_submittable(this.doctype))
-      			return;
+			return;
 
 		var me = this;
 		var label, table;

--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -130,8 +130,8 @@ frappe.ui.FieldSelect = Class.extend({
 	},
 
 	add_field_option(df) {
-    if (df.fieldname == 'docstatus' && !frappe.model.is_submittable(this.doctype))
-      return;
+		if (df.fieldname == 'docstatus' && !frappe.model.is_submittable(this.doctype))
+      			return;
 
 		var me = this;
 		var label, table;

--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -130,6 +130,9 @@ frappe.ui.FieldSelect = Class.extend({
 	},
 
 	add_field_option(df) {
+    if (df.fieldname == 'docstatus' && !frappe.model.is_submittable(this.doctype))
+      return;
+
 		var me = this;
 		var label, table;
 		if(me.doctype && df.parent==me.doctype) {


### PR DESCRIPTION
"Document Status" filter on non-submittable doctypes results in full table scan. Tables with huge number of records e.g. tabVersion results in 'Request Time out' for other transactional requests. 

**Steps to reproduce the issue -** 
Go to 'Version List' and add 'Document Stauts' = 'Submitted' filter.

