### PR TITLE
[webform] get_all options for link fields regardless of user/creator

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -548,12 +548,10 @@ def get_in_list_view_fields(doctype):
 def get_link_options(web_form_name, doctype):
 	web_form_doc = frappe.get_doc("Web Form", web_form_name)
 	doctype_validated = False
-	limited_to_user   = False
 	if web_form_doc.login_required:
 		# check if frappe session user is not guest or admin
 		if frappe.session.user != 'Guest':
 			doctype_validated = True
-			limited_to_user   = True
 	else:
 		for field in web_form_doc.web_form_fields:
 			if field.options == doctype:
@@ -561,10 +559,7 @@ def get_link_options(web_form_name, doctype):
 				break
 
 	if doctype_validated:
-		if limited_to_user:
-			return "\n".join([doc.name for doc in frappe.get_all(doctype, filters = {"owner":frappe.session.user})])
-		else:
-			return "\n".join([doc.name for doc in frappe.get_all(doctype)])
+		return "\n".join([doc.name for doc in frappe.get_all(doctype)])
 
 	else:
 		raise frappe.PermissionError('Not Allowed, {0}'.format(doctype))


### PR DESCRIPTION
In most cases, webform link fields are for the sole purpose of selecting harmless static option names.  

<img width="840" alt="screen shot 2018-08-27 at 7 30 04 pm" src="https://user-images.githubusercontent.com/5196925/44664111-f37c6200-aa2f-11e8-86be-745d25787db1.png">
