### PR TITLE
[Minor] Quick entry fix

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -45,7 +45,9 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 		} else {
 			// prepare a list of mandatory and bold fields
 			this.mandatory = $.map(fields,
-				function(d) { return ((d.reqd || d.bold || d.allow_in_quick_entry) && !d.read_only) ? $.extend({}, d) : null; });
+				function(d) { return ((d.reqd || d.bold || d.allow_in_quick_entry)
+					&& !d.read_only && d.fieldtype!="Table") ? $.extend({}, d) : null;
+				});
 		}
 		this.meta = frappe.get_meta(this.doctype);
 		if (!this.doc) {


### PR DESCRIPTION
quick_entry dialog fails to open if mandatory field is of type "Table"

![qe](https://user-images.githubusercontent.com/11695402/44841386-d4184b80-ac60-11e8-9257-4dc30837049c.gif)
