### PR TITLE
On assignment notification is not sent to the assigned user

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -180,7 +180,7 @@ def _notify(args):
 		frappe.sendmail(\
 			recipients=contact,
 			sender= frappe.db.get_value("User", frappe.session.user, "email"),
-			subject=_("New Message from {0}").format(get_fullname(frappe.session.user)),
+			subject=_("New message from {0}").format(get_fullname(frappe.session.user)),
 			template="new_message",
 			args={
 				"from": get_fullname(frappe.session.user),

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -163,4 +163,30 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 			'notify': notify
 		}
 
-	arg["parenttype"] = "Assignment"
+	if arg and arg.get("notify"):
+		_notify(arg)
+
+def _notify(args):
+	from frappe.utils import get_fullname, get_url
+
+	args = frappe._dict(args)
+	contact = args.contact
+	txt = args.txt
+
+	try:
+		if not isinstance(contact, list):
+			contact = [frappe.db.get_value("User", contact, "email") or contact]
+
+		frappe.sendmail(\
+			recipients=contact,
+			sender= frappe.db.get_value("User", frappe.session.user, "email"),
+			subject=_("New Message from {0}").format(get_fullname(frappe.session.user)),
+			template="new_message",
+			args={
+				"from": get_fullname(frappe.session.user),
+				"message": txt,
+				"link": get_url()
+			},
+			header=[_('New Message'), 'orange'])
+	except frappe.OutgoingEmailError:
+		pass


### PR DESCRIPTION
Previously there was chat.post method(to send email) which was deprecated and therefore it's not working
https://github.com/frappe/frappe/commit/e28d49772404d903baded000d964b069c9945a01#diff-2b190148dcc78d2da3dbe6236d565cd2
