### PR TITLE
feat: Add dashboard.show_progress

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -118,8 +118,7 @@ frappe.ui.form.Dashboard = Class.extend({
 		if (title){
 			this._progress_map[title].remove();
 			delete this._progress_map[title];
-		}
-		else {
+		} else {
 			this._progress_map = {};
 			this.progress_area.empty();
 		}

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -109,8 +109,10 @@ frappe.ui.form.Dashboard = Class.extend({
 		}
 
 		progress_chart.find('.progress-bar').each((i, progress_bar) => {
-			const width = percent[i].width;
-			$(progress_bar).css('width', width);
+			const { progress_class, width } = percent[i];
+			$(progress_bar).css('width', width)
+				.removeClass('progress-bar-danger progress-bar-success')
+				.addClass(progress_class);
 		});
 	},
 

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -90,6 +90,28 @@ frappe.ui.form.Dashboard = Class.extend({
 		}
 
 		this.show();
+
+		return progress_chart;
+	},
+
+	show_progress: function(title, percent, message) {
+		this._progress_map = this._progress_map || {};
+
+		if (!this._progress_map[title]) {
+			const progress_chart = this.add_progress(title, percent, message);
+			this._progress_map[title] = progress_chart;
+		}
+
+		let progress_chart = this._progress_map[title];
+
+		if (!$.isArray(percent)) {
+			percent = this.format_percent(title, percent);
+		}
+
+		progress_chart.find('.progress-bar').each((i, progress_bar) => {
+			const width = percent[i].width;
+			$(progress_bar).css('width', width);
+		});
 	},
 
 	format_percent: function(title, percent) {

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -85,9 +85,8 @@ frappe.ui.form.Dashboard = Class.extend({
 				title="%(title)s"></div>', opts)).appendTo(progress);
 		});
 
-		if(message) {
-			$('<p class="text-muted small">' + message + '</p>').appendTo(this.progress_area);
-		}
+		if (!message) message = '';
+		$(`<p class="progress-message text-muted small">${message}</p>`).appendTo(progress_chart);
 
 		this.show();
 
@@ -96,24 +95,34 @@ frappe.ui.form.Dashboard = Class.extend({
 
 	show_progress: function(title, percent, message) {
 		this._progress_map = this._progress_map || {};
-
 		if (!this._progress_map[title]) {
 			const progress_chart = this.add_progress(title, percent, message);
 			this._progress_map[title] = progress_chart;
 		}
-
 		let progress_chart = this._progress_map[title];
-
 		if (!$.isArray(percent)) {
 			percent = this.format_percent(title, percent);
 		}
-
 		progress_chart.find('.progress-bar').each((i, progress_bar) => {
 			const { progress_class, width } = percent[i];
 			$(progress_bar).css('width', width)
 				.removeClass('progress-bar-danger progress-bar-success')
 				.addClass(progress_class);
 		});
+
+		if (!message) message = '';
+		progress_chart.find('.progress-message').text(message);
+	},
+
+	hide_progress: function(title) {
+		if (title){
+			this._progress_map[title].remove();
+			delete this._progress_map[title];
+		}
+		else {
+			this._progress_map = {};
+			this.progress_area.empty();
+		}
 	},
 
 	format_percent: function(title, percent) {


### PR DESCRIPTION
- maps progress bars with titles
- updates existing progress bars if it exists

`dashboard.add_progress` only adds a new progress every time it is called.
`dashboard.show_progress` adds if there doesn't exist a progress bar with that title, else updates it.


