### PR TITLE
[child-records] set name in new child records before setting password

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -289,6 +289,8 @@ class Document(BaseDocument):
 		self.set_docstatus()
 		self.check_if_latest()
 		self.set_parent_in_children()
+		self.set_name_in_children()
+
 		self.validate_higher_perm_levels()
 		self._validate_links()
 		self.run_before_save_methods()
@@ -680,6 +682,12 @@ class Document(BaseDocument):
 		for d in self.get_all_children():
 			d.parent = self.name
 			d.parenttype = self.doctype
+
+	def set_name_in_children(self):
+		# Set name for any new children
+		for d in self.get_all_children():
+			if not d.name:
+				set_new_name(d)
 
 	def validate_update_after_submit(self):
 		if self.flags.ignore_validate_update_after_submit:


### PR DESCRIPTION
`set_encrypted_password()` requires that the document object have the `name` field set. The following issue crops up in the case when child records have a `password` field.

As opposed to `insert()`, when `_save()` is called on the parent document, `set_encrypted_password()` assumes that `name` is set for the doc _and_ the child docs (as the doc is being saved, not inserted). Therefore, any newly appended child records do not have `name` set when it is called, resulting in the attached trace.

This PR does something similar to what `insert()` does but only for new child records.

```
Traceback (most recent call last):
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/erpnext/erpnext/hub_node/api.py", line 38, in register_user
    settings.add_hub_user(frappe.session.user)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/erpnext/erpnext/hub_node/doctype/marketplace_settings/marketplace_settings.py", line 68, in add_hub_user
    self.save()
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 302, in _save
    self._validate()
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 463, in _validate
    d._save_passwords()
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 640, in _save_passwords
    set_encrypted_password(self.doctype, self.name, new_password, df.fieldname)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/utils/password.py", line 56, in set_encrypted_password
    { 'doctype': doctype, 'name': name, 'fieldname': fieldname, 'pwd': encrypt(pwd) })
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/database.py", line 199, in sql
    self._cursor.execute(query, values)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 166, in execute
    result = self._query(query)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 856, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1057, in _read_query_result
    result.read()
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1340, in read
    first_packet = self.connection._read_packet()
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1014, in _read_packet
    packet.check_error()
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 393, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
IntegrityError: (1048, u"Column 'name' cannot be null")
```