### PR TITLE
Show names in dropdown, but send mails to email set in user's master

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -677,7 +677,7 @@ frappe.ui.form.Timeline = Class.extend({
 		var valid_users = Object.keys(frappe.boot.user_info)
 			.filter(user => !["Administrator", "Guest"].includes(user));
 
-		return valid_users.map(user => frappe.boot.user_info[user].email);
+		return valid_users.map(user => frappe.boot.user_info[user].name);
 	},
 
 	setup_comment_like: function() {


### PR DESCRIPTION
In comment mentions, if a user's email has been changed, it sends mail to the user's name, ie. the email set while creating the user. After this fix, it will send emails to the email id currently set in the User's master and show user's name in the dropdown.