### PR TITLE
feature(coverage): Add test coverage to frappe travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,16 @@ python:
 
 services:
   - mysql
- 
+
 install:
   - sudo rm /etc/apt/sources.list.d/mongodb*.list
   - sudo rm /etc/apt/sources.list.d/docker.list
   - sudo apt-get install hhvm && rm -rf /home/travis/.kiex/
   - sudo apt-get purge -y mysql-common mysql-server mysql-client
   - nvm install v8.10.0
-  
+
+  - pip install python-coveralls
+
   - wget https://raw.githubusercontent.com/frappe/bench/master/playbooks/install.py
 
   - sudo python install.py --develop --user travis --without-bench-setup
@@ -41,4 +43,7 @@ before_script:
   - sleep 10
 
 script:
-  - bench run-tests
+  - bench run-tests --coverage
+
+after_script:
+  - coveralls -b apps/frappe -d ../../sites/.coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ google-auth-httplib2
 google-auth-oauthlib
 faker
 stripe
+coverage


### PR DESCRIPTION
Time to measure test coverage. Isn't perfect, but good enough to get started.

Uses Coveralls.io integration. Test coverage is generated during Travis-ci build, using coverage.py

See [Coveralls UI](https://coveralls.io/github/frappe/frappe) to get an idea about the report.