### PR TITLE
[New Feature] Table field now support copy & paste from Excel directly

### DIFF
--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -20,6 +20,74 @@ frappe.ui.form.ControlTable = frappe.ui.form.Control.extend({
 			$('<p class="text-muted small">' + __(this.df.description) + '</p>')
 				.appendTo(this.wrapper);
 		}
+		this.$wrapper.on('paste',':text', function(e) {
+			var cur_table_field =$(e.target).closest('div [data-fieldtype="Table"]').data('fieldname');
+			var cur_field = $(e.target).data('fieldname');
+			var cur_grid= cur_frm.get_field(cur_table_field).grid;
+			var cur_grid_rows = cur_grid.grid_rows;
+			var cur_doctype = cur_grid.doctype;
+			var cur_row_docname =$(e.target).closest('div .grid-row').data('name');
+			var row_idx = locals[cur_doctype][cur_row_docname].idx;
+			var clipboardData, pastedData;
+			// Get pasted data via clipboard API
+			clipboardData = event.clipboardData || window.clipboardData || event.originalEvent.clipboardData;
+			pastedData = clipboardData.getData('Text');
+			if (!pastedData) return;
+			var data = frappe.utils.csv_to_array(pastedData,'\t');
+			if (data.length === 1 & data[0].length === 1) return;
+			if (data.length > 100){
+				data = data.slice(0, 100);
+				frappe.msgprint('for performance, only the first 100 rows processed!');
+			}
+			var fieldnames = [];
+			var get_field = function(name_or_label){
+				var fieldname;
+				$.each(cur_grid.meta.fields,(ci,field)=>{
+					name_or_label = name_or_label.toLowerCase()
+					if (field.fieldname.toLowerCase() === name_or_label ||
+						(field.label && field.label.toLowerCase() === name_or_label)){
+						  fieldname = field.fieldname;
+						  return false;
+						}
+				});
+				return fieldname;
+			}
+			if (get_field(data[0][0])){ // for raw data with column header
+				$.each(data[0], (ci, column)=>{fieldnames.push(get_field(column));});
+				data.shift();
+			}
+			else{ // no column header, map to the existing visible columns
+				var visible_columns = cur_grid_rows[0].get_visible_columns();
+				var find;
+				$.each(visible_columns, (ci, column)=>{
+					if (column.fieldname === cur_field) find = true;
+					find && fieldnames.push(column.fieldname);
+				})
+			}
+			$.each(data, function(i, row) {
+				var blank_row = true;
+				$.each(row, function(ci, value) {
+					if(value) {
+						blank_row = false;
+						return false;
+					}
+				});
+				if(!blank_row) {
+					if (row_idx > cur_frm.doc[cur_table_field].length){
+						cur_grid.add_new_row();
+					}
+					var cur_row = cur_grid_rows[row_idx - 1];
+					row_idx ++;
+					var row_name = cur_row.doc.name;
+					$.each(row, function(ci, value) {
+						if (fieldnames[ci]) frappe.model.set_value(cur_doctype, row_name, fieldnames[ci], value);
+					});
+					frappe.show_progress(__('Processing'), i, data.length);
+				}
+			});
+			frappe.hide_progress();
+			return false; // Prevent the default handler from running.
+		})		
 	},
 	refresh_input: function() {
 		this.grid.refresh();


### PR DESCRIPTION
How it works
1. Prepare the source data in Excel or text editor with each column separated by tab, 
    case 1. first line as column header, both field name and label supported
    case 2. no column header, the data will directly map to the visible columns
2. Drag to select the records , and copy (ctrl + C)
3. Make sure the child table is in edit mode(if needed click the Add Row button), place the cursor to the target input field of the child table, paste (ctrl + V)
![copypaste](https://user-images.githubusercontent.com/12823863/45279472-d0f44980-b503-11e8-842c-121869d300c1.gif)

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.