### PR TITLE
Permlevel 1 fields are not visible to the users after submission of the document

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -113,6 +113,7 @@ $.extend(frappe.perm, {
 				var permlevel = cint(p.permlevel);
 				if(!perm[permlevel]) {
 					perm[permlevel] = {};
+					perm[permlevel]["permlevel"] = permlevel
 				}
 
 				$.each(frappe.perm.rights, function(i, key) {


### PR DESCRIPTION
**Issue**

User has set the permlevel 1 for the fields rate and amount, he can able to see those fields when the document state is in draft but on submission it's not displaying

**Before Fix**
![screen shot 2018-09-11 at 6 42 11 pm](https://user-images.githubusercontent.com/8780500/45362511-a46b2b00-b5f2-11e8-9e5b-aa861399aab4.png)


**After Fix**
![screen shot 2018-09-11 at 6 41 46 pm](https://user-images.githubusercontent.com/8780500/45362514-a7661b80-b5f2-11e8-930a-333ce8c26548.png)

```
_f.Frm.prototype.set_read_only = function() {
	var perm = [];
	var docperms = frappe.perm.get_perm(this.doc.doctype);
	for (var i=0, l=docperms.length; i<l; i++) {
		var p = docperms[i];
               // In the below code permlevel is blank and therefore system uses the zero and removed the 1
		perm[p.permlevel || 0] = {read:1, print:1, cancel:1};
	}
	this.perm = perm;
}

```
https://github.com/frappe/frappe/blob/develop/frappe/public/js/legacy/client_script_helpers.js#L377