### PR TITLE
fix(Int control): Skip evaluating numbers with commas

### DIFF
--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -20,7 +20,11 @@ frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
 			});
 	},
 	eval_expression: function(value) {
-		if (typeof value==='string' && value.match(/^[0-9+-/* ]+$/)) {
+		if (typeof value==='string'
+			&& value.match(/^[0-9+-/* ]+$/)
+			// strings with commas are evaluated incorrectly
+			// for e.g 47,186.00 -> 186
+			&& !value.includes(',')) {
 			try {
 				return eval(value);
 			} catch (e) {


### PR DESCRIPTION
strings with commas are evaluated incorrectly
for e.g 47,186.00 -> 186