### PR TITLE
fix: check CSRF Token for PUT and DELETE methods as well

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -64,7 +64,7 @@ class HTTPRequest:
 		check_session_stopped()
 
 	def validate_csrf_token(self):
-		if frappe.local.request and frappe.local.request.method=="POST":
+		if frappe.local.request and frappe.local.request.method in ("POST", "PUT", "DELETE"):
 			if not frappe.local.session: return
 			if not frappe.local.session.data.csrf_token \
 				or frappe.local.session.data.device=="mobile" \


### PR DESCRIPTION
PUT and DELETE requests were not being checked for CSRF Token. Hence sending a request from another tab, without adding CSRF, using method PUT, one was able to bypass CSRF check.