### PR TITLE
[FIX] Slideshow images should be a list

### DIFF
--- a/frappe/website/doctype/website_slideshow/website_slideshow.py
+++ b/frappe/website/doctype/website_slideshow/website_slideshow.py
@@ -22,7 +22,7 @@ class WebsiteSlideshow(Document):
 		''' atleast one image file should be public for slideshow '''
 		files = map(lambda row: row.image, self.slideshow_items)
 		if files:
-			result = frappe.get_all("File", filters={ "file_url":("in", files) }, fields="is_private")
+			result = frappe.get_all("File", filters={ "file_url":("in", list(files)) }, fields="is_private")
 			if any([file.is_private for file in result]):
 				frappe.throw(_("All Images attached to Website Slideshow should be public"))
 


### PR DESCRIPTION
…ng passed

Files should be passed as a list. Here it is being passed as a map object.

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.