### PR TITLE
fix(translations): Replace translations by keyword with indexed version

### DIFF
--- a/frappe/chat/doctype/chat_profile/chat_profile.py
+++ b/frappe/chat/doctype/chat_profile/chat_profile.py
@@ -84,7 +84,7 @@ def create(user, exists_ok = False, fields = None):
 
     if result:
         if not exists_ok:
-            frappe.throw(_('Chat Profile for User {user} exists.'.format(user = user)))
+            frappe.throw(_('Chat Profile for User {0} exists.').format(user))
     else:
         dprof      = frappe.new_doc('Chat Profile')
         dprof.user = user

--- a/frappe/chat/doctype/chat_room/chat_room.py
+++ b/frappe/chat/doctype/chat_room/chat_room.py
@@ -33,7 +33,7 @@ def is_direct(owner, other, bidirectional = False):
 	exists = len(get_room(owner, other)) == 1
 	if bidirectional:
 		exists = exists or len(get_room(other, owner)) == 1
-	
+
 	return exists
 
 def get_chat_room_user_set(users, filter_ = None):
@@ -56,19 +56,17 @@ class ChatRoom(Document):
 
 		if self.type == "Direct":
 			if len(self.users) != 1:
-				frappe.throw(_('{type} room must have atmost one user.'.format(type = self.type)))
+				frappe.throw(_('{0} room must have atmost one user.').format(self.type))
 
 			other = squashify(self.users)
 
 			if self.is_new():
 				if is_direct(self.owner, other.user, bidirectional = True):
-					frappe.throw(_('Direct room with {other} already exists.'.format(
-						other = other.user
-					)))
+					frappe.throw(_('Direct room with {0} already exists.').format(other.user))
 
 		if self.type == "Group" and not self.room_name:
 			frappe.throw(_('Group name cannot be empty.'))
-	
+
 	def before_save(self):
 		if not self.is_new():
 			self.get_doc_before_save()
@@ -83,12 +81,12 @@ class ChatRoom(Document):
 				update = { }
 				for changed in diff.changed:
 					field, old, new = changed
-					
+
 					if field == 'last_message':
 						new = chat_message.get(new)
 
 					update.update({ field: new })
-				
+
 				if diff.added or diff.removed:
 					update.update(dict(users = [u.user for u in self.users]))
 
@@ -121,7 +119,7 @@ def get(user, rooms = None, fields = None, filters = None):
 
 	default = ['name', 'type', 'room_name', 'creation', 'owner', 'avatar']
 	handle  = ['users', 'last_message']
-	
+
 	param   = [f for f in fields if f not in handle]
 
 	rooms   = frappe.get_all('Chat Room',
@@ -151,7 +149,7 @@ def get(user, rooms = None, fields = None, filters = None):
 				rooms[i]['last_message'] = None
 
 	rooms = squashify(dictify(rooms))
-	
+
 	return rooms
 
 @frappe.whitelist(allow_guest = True)
@@ -177,7 +175,7 @@ def create(kind, owner, users = None, name = None):
 		room.type 	   = kind
 		room.owner	   = owner
 		room.room_name = name
-		
+
 	dusers = [ ]
 
 	if kind != 'Visitor':
@@ -198,7 +196,7 @@ def create(kind, owner, users = None, name = None):
 		for user in dsettings.chat_operators:
 			if user.user not in users:
 				room.append('users', user)
-			
+
 	room.save(ignore_permissions = True)
 
 	room  = get(owner, rooms = room.name)
@@ -218,5 +216,5 @@ def history(room, user, fields = None, limit = 10, start = None, end = None):
 
 	mess   = chat_message.history(room, limit = limit, start = start, end = end)
 	mess   = squashify(mess)
-	
+
 	return dictify(mess)

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -98,7 +98,7 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 @frappe.whitelist()
 def get_single_value(doctype, field):
 	if not frappe.has_permission(doctype):
-		frappe.throw(_("No permission for {doctype}".format(doctype = doctype)), frappe.PermissionError)
+		frappe.throw(_("No permission for {0}").format(doctype), frappe.PermissionError)
 	value = frappe.db.get_single_value(doctype, field)
 	return value
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -687,9 +687,8 @@ def setup_user_email_inbox(email_account, awaiting_password, email_id, enable_ou
 				"awaiting_password": awaiting_password or 0
 			})
 	else:
-		frappe.msgprint(_("Enabled email inbox for user {users}".format(
-			users=" and ".join([frappe.bold(user.get("name")) for user in user_names])
-		)))
+		users = " and ".join([frappe.bold(user.get("name")) for user in user_names])
+		frappe.msgprint(_("Enabled email inbox for user {0}").format(users))
 
 	ask_pass_update()
 


### PR DESCRIPTION
Keywords in the translation also gets translated which results in an error because python cannot find the key

Example:
```
_("This is a {test}").format(test="hello")

"This is a {test}" gets translated to "यह एक {परीक्षण} है" which throws an error because python cannot find the key
```
