### PR TITLE
[Fix] Case sensitive for the doctype name in the options

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -464,6 +464,9 @@ def validate_fields(meta):
 				options = frappe.db.get_value("DocType", d.options, "name")
 				if not options:
 					frappe.throw(_("Options must be a valid DocType for field {0} in row {1}").format(d.label, d.idx))
+				elif not (options == d.options):
+					frappe.throw(_("Options {0} must be the same as doctype name {1} for the field {2}")
+						.format(d.options, options, d.label))
 				else:
 					# fix case
 					d.options = options


### PR DESCRIPTION
Validate if the value of the options is not the same as doctype name for the fieldtype link and table

![screen shot 2018-09-19 at 4 38 37 pm](https://user-images.githubusercontent.com/8780500/45749978-fe8b7200-bc2a-11e8-8de9-cc9016507772.png)
