### PR TITLE
fix(filters): Allow filter on same field multiple times

### DIFF
--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -144,11 +144,6 @@ frappe.ui.FieldSelect = Class.extend({
 			table = df.parent;
 		}
 
-		// check if this option should be added
-		if (this.filter_options && this.filter_options(table, df.fieldname) === false) {
-			return;
-		}
-
 		if(frappe.model.no_value_type.indexOf(df.fieldtype) == -1 &&
 			!(me.fields_by_name[df.parent] && me.fields_by_name[df.parent][df.fieldname])) {
 			this.options.push({

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -48,9 +48,6 @@ frappe.ui.Filter = class {
 			filter_fields: this.filter_fields,
 			select: (doctype, fieldname) => {
 				this.set_field(doctype, fieldname);
-			},
-			filter_options: (doctype, fieldname) => {
-				return this.filter_items(doctype, fieldname);
 			}
 		});
 

--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -21,10 +21,10 @@ frappe.ui.FilterGroup = class {
 		let promises = [];
 
 		for (const filter of filters) {
-			promises.push(this.add_filter(...filter));
+			promises.push(() => this.add_filter(...filter));
 		}
 
-		return Promise.all(promises);
+		return frappe.run_serially(promises);
 	}
 
 	add_filter(doctype, fieldname, condition, value, hidden) {


### PR DESCRIPTION
This is a valid use case. There can be multiple filters applied on the same field.

![image](https://user-images.githubusercontent.com/9355208/45752754-29c68f00-bc34-11e8-9e75-ae9802b318c2.png)
