### PR TITLE
[depends-on] can be a function with passed doc or a Boolean

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -495,7 +495,13 @@ frappe.ui.form.Layout = Class.extend({
 
 		var parent = this.frm ? this.frm.doc : null;
 
-		if(expression.substr(0,5)=='eval:') {
+		if(typeof(expression) === 'boolean') {
+			out = expression;
+
+		} else if(typeof(expression) === 'function') {
+			out = expression(doc);
+			
+		} else if(expression.substr(0,5)=='eval:') {
 			try {
 				out = eval(expression.substr(5));
 			} catch(e) {


### PR DESCRIPTION
- the function will receive the doc object
- 'eval' was well-intentioned to be set by database values
- but when used programmatically, should be better
