### PR TITLE
fix: call read only db methods in db.js with GET instead of POST

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -17,6 +17,7 @@ frappe.db = {
 			frappe.call({
 				method: 'frappe.model.db_query.get_list',
 				args: args,
+				type: 'GET',
 				callback: function(r) {
 					resolve(r.message);
 				}
@@ -33,6 +34,7 @@ frappe.db = {
 	get_value: function(doctype, filters, fieldname, callback) {
 		return frappe.call({
 			method: "frappe.client.get_value",
+			type: 'GET',
 			args: {
 				doctype: doctype,
 				fieldname: fieldname,
@@ -45,8 +47,11 @@ frappe.db = {
 	},
 	get_single_value: (doctype, field) => {
 		return new Promise(resolve => {
-			frappe.call('frappe.client.get_single_value', { doctype, field })
-				.then(r => resolve(r ? r.message : null));
+			frappe.call({
+				method: 'frappe.client.get_single_value',
+				args: { doctype, field },
+				type: 'GET',
+			}).then(r => resolve(r ? r.message : null));
 		});
 	},
 	set_value: function(doctype, docname, fieldname, value, callback) {
@@ -67,6 +72,7 @@ frappe.db = {
 		return new Promise((resolve, reject) => {
 			frappe.call({
 				method: "frappe.client.get",
+				type: 'GET',
 				args: { doctype, name, filters },
 				callback: r => resolve(r.message)
 			}).fail(reject);
@@ -84,11 +90,11 @@ frappe.db = {
 	},
 	count: function(doctype, args={}) {
 		return new Promise(resolve => {
-			frappe.call(
-				'frappe.client.get_count',
-				Object.assign(args, { doctype }),
-				r => resolve(r.message)
-			);
+			frappe.call({
+				method: 'frappe.client.get_count',
+				type: 'GET',
+				args: Object.assign(args, { doctype })
+			}).then(r => resolve(r.message));
 		});
 	}
 };


### PR DESCRIPTION
Read only methods in db.js were getting called by POST requests. Following standard convention, converted them to GET calls.