### PR TITLE
fix(setup_global_help): allow utf-8 in filename

### DIFF
--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -245,7 +245,7 @@ class HelpDatabase(object):
 
 			links_html = "<ol class='index-links'>"
 			for line in files:
-				fpath = os.path.join(os.path.dirname(original_path), line)
+				fpath = os.path.join(os.path.dirname(frappe.safe_decode(original_path)), frappe.safe_decode(line))
 
 				title = self.db.sql('select title from help where path like %s',
 					os.path.join(fpath, 'index') + '%')


### PR DESCRIPTION
- fixed issue with setting up global help. Setting up global help used
to fail when the filenames were in any language other than english, due
to improper encoding. Used frappe.safe_decode to solve the issue
