### PR TITLE
Validation fix

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -310,7 +310,6 @@ class BaseDocument(object):
 						self.db_insert()
 						return
 
-					frappe.msgprint(_("Duplicate name {0} {1}").format(self.doctype, self.name))
 					raise frappe.DuplicateEntryError(self.doctype, self.name, e)
 
 				elif "Duplicate" in cstr(e.args[1]):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -454,13 +454,12 @@ class Document(BaseDocument):
 			d._extract_images_from_text_editor()
 			d._sanitize_content()
 			d._save_passwords()
-
-		self.validate_set_only_once()
-
 		if self.is_new():
 			# don't set fields like _assign, _comments for new doc
 			for fieldname in optional_fields:
 				self.set(fieldname, None)
+		else:
+			self.validate_set_only_once()
 
 	def validate_set_only_once(self):
 		'''Validate that fields are not changed if not in insert'''


### PR DESCRIPTION
- Validate set_only_once only on doc update
- Remove redundant error message
<img width="635" alt="screen shot 2018-09-25 at 4 57 02 pm" src="https://user-images.githubusercontent.com/13928957/46011695-596a1100-c0e4-11e8-98ac-358a891c1fda.png">
<img width="622" alt="screen shot 2018-09-25 at 4 57 23 pm" src="https://user-images.githubusercontent.com/13928957/46011711-6555d300-c0e4-11e8-9560-1a3acc8c0a75.png">
