### PR TITLE
Get text from link formatter in indicator formatter function

### DIFF
--- a/frappe/public/js/legacy/client_script_helpers.js
+++ b/frappe/public/js/legacy/client_script_helpers.js
@@ -446,11 +446,20 @@ _f.Frm.prototype.set_indicator_formatter = function(fieldname, get_color, get_te
 	frappe.meta.docfield_map[doctype][fieldname].formatter =
 		function(value, df, options, doc) {
 			if(value) {
+				var label;
+				if(get_text) {
+					label = get_text(doc);
+				} else if(frappe.form.link_formatters[df.options]) {
+					label = frappe.form.link_formatters[df.options](value, doc);
+				} else {
+					label = value;
+				}
+
 				return repl('<a class="indicator %(color)s" href="#Form/%(doctype)s/%(name)s">%(label)s</a>', {
 					color: get_color(doc || {}),
 					doctype: df.options,
 					name: value,
-					label: get_text ? get_text(doc) : value
+					label: label
 				});
 			} else {
 				return '';


### PR DESCRIPTION
### Problem

When an Indicator Formatter is set on a Link field the Link Formatter isn't used to format the text. For example the items in Quotation are properly formatted, however, Items in Sales Order are not properly formatted: Item Name is not appended in the Item Code link field.

Quotation (Item without Indicator Formatter):
![image](https://user-images.githubusercontent.com/328330/46051013-98ce4700-c150-11e8-8966-c19688154ce2.png)
Sales Order (Item WITH Indicator Formatter):
![image](https://user-images.githubusercontent.com/328330/46051033-a97ebd00-c150-11e8-8d67-570d3fdde16f.png)

### Solution

Purchase Order (Item WITH Indicator Formatter):
![image](https://user-images.githubusercontent.com/328330/46051145-2d38a980-c151-11e8-930a-b6a0e7f62ac2.png)
