### PR TITLE
[Fix] Not able to send the email, if file is attached

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -753,7 +753,7 @@ def has_permission(doc, ptype=None, user=None):
 		if doc.attached_to_doctype == 'Communication':			
 			try:
 				ref_doctype, ref_name = frappe.db.get_value('Communication', doc.attached_to_name, ['reference_doctype', 'reference_name'])
-			except (frappe.DoesNotExistError, Exception):
+			except (frappe.DoesNotExistError, TypeError):
 				ref_doctype = ref_name = None
 
 			if ref_doctype and ref_name:

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -753,7 +753,7 @@ def has_permission(doc, ptype=None, user=None):
 		if doc.attached_to_doctype == 'Communication':			
 			try:
 				ref_doctype, ref_name = frappe.db.get_value('Communication', doc.attached_to_name, ['reference_doctype', 'reference_name'])
-			except frappe.DoesNotExistError:
+			except (frappe.DoesNotExistError, Exception):
 				ref_doctype = ref_name = None
 
 			if ref_doctype and ref_name:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 70, in make
    comm.insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 222, in insert
    self._validate()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 456, in _validate
    self._extract_images_from_text_editor()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 780, in _extract_images_from_text_editor
    extract_images_from_doc(self, df.fieldname)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 830, in extract_images_from_doc
    content = extract_images_from_html(doc, content)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 871, in extract_images_from_html
    content = re.sub('<img[^>]*src\s*=\s*["\'](?=data:)(.*?)["\']', _save_file, content)
  File "/home/frappe/frappe-bench/env/lib64/python3.6/re.py", line 191, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 863, in _save_file
    _file.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 259, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 282, in _save
    self.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 209, in insert
    self.check_permission("create")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 170, in check_permission
    if not self.has_permission(permtype):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 180, in has_permission
    return frappe.has_permission(self.doctype, permtype, self, verbose=verbose)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 561, in has_permission
    out = frappe.permissions.has_permission(doctype, ptype, doc=doc, verbose=verbose, user=user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 54, in has_permission
    perm = get_doc_permissions(doc, user=user, ptype=ptype).get(ptype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 103, in get_doc_permissions
    if has_controller_permissions(doc, ptype, user=user) == False :
  File "/home/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 251, in has_controller_permissions
    controller_permission = frappe.call(frappe.get_attr(method), doc=doc, ptype=ptype, user=user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 755, in has_permission
    ref_doctype, ref_name = frappe.db.get_value('Communication', doc.attached_to_name, ['reference_doctype', 'reference_name'])
TypeError: 'NoneType' object is not iterable
```