### PR TITLE
[Minor] Doctype and name in title on mention notification email

### DIFF
--- a/frappe/core/doctype/communication/comment.py
+++ b/frappe/core/doctype/communication/comment.py
@@ -92,7 +92,7 @@ def notify_mentions(doc):
 			parent_doc_label = "{0}: {1}".format(_(doc.reference_doctype),
 				doc.reference_name)
 
-		subject = _("{0} mentioned you in a comment").format(sender_fullname)
+		subject = _("{0} mentioned you in a comment in {1}").format(sender_fullname, parent_doc_label)
 
 		recipients = [frappe.db.get_value("User", {"enabled": 1, "name": name, "user_type": "System User"}, "email")
 			for name in mentions]


### PR DESCRIPTION
Currently the email title just says **Kanchan Chauhan mentioned you in a comment** which is not very helpful. 
Added Doctype and name in the email title so as to have first hand information where you have been mentioned.
<img width="499" alt="screen shot 2018-09-27 at 11 15 37 am" src="https://user-images.githubusercontent.com/16913064/46125532-2724f480-c247-11e8-82e4-32ada07565d9.png">
