### PR TITLE
Submit the attendance if it's in draft mode

### DIFF
--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -140,6 +140,8 @@ def import_doc(d, doctype, overwrite, row_idx, submit=False, ignore_links=False)
 			doc.update(d)
 			if d.get("docstatus") == 1:
 				doc.update_after_submit()
+			elif d.get("docstatus") == 0 and submit:
+				doc.submit()
 			else:
 				doc.save()
 			return 'Updated row (#%d) %s' % (row_idx + 1, getlink(doctype, d['name']))


### PR DESCRIPTION
If User has created attendance in draft and later on he is updating the attendance from the data import tool then submit the draft mode attendance, previously system was creating the new attendance. So one remains in submit and one in draft