### PR TITLE
[Fix] Permlevel 1 with read permission fields are not disaplying in the form

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -566,7 +566,7 @@ class Document(BaseDocument):
 		if not df:
 			df = self.meta.get_field(fieldname)
 
-		return df.permlevel in self.get_permlevel_access()
+		return df.permlevel in self.get_permlevel_access(permission_type)
 
 	def get_permissions(self):
 		if self.meta.istable:


### PR DESCRIPTION
- Set permlevel 1 for field Lead Came From in doctype Lead
- For role Purchase User, given read permission for permelevel 1 using role permission manager
- Now purchase user can able to see the field Lead Came From with readonly, but when user check the print it's not displaying