### PR TITLE
Pass Werkzeug/WSGI middleware bytestrings, not unicode.

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -219,11 +219,11 @@ def serve(port=8000, profile=False, site=None, sites_path='.'):
 
 	if not os.environ.get('NO_STATICS'):
 		application = SharedDataMiddleware(application, {
-			'/assets': os.path.join(sites_path, 'assets'),
+			b'/assets': str(os.path.join(sites_path, 'assets'))
 		})
 
 		application = StaticDataMiddleware(application, {
-			'/files': os.path.abspath(sites_path)
+			b'/files': str(os.path.abspath(sites_path))
 		})
 
 	application.debug = True

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -219,12 +219,11 @@ def serve(port=8000, profile=False, site=None, sites_path='.'):
 
 	if not os.environ.get('NO_STATICS'):
 		application = SharedDataMiddleware(application, {
-			b'/assets': os.path.join(
-				sites_path, 'assets').encode('ascii')
+			str('/assets'): str(os.path.join(sites_path, 'assets'))
 		})
 
 		application = StaticDataMiddleware(application, {
-			b'/files': os.path.abspath(sites_path).encode('ascii')
+			str('/files'): str(os.path.abspath(sites_path))
 		})
 
 	application.debug = True

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -219,11 +219,12 @@ def serve(port=8000, profile=False, site=None, sites_path='.'):
 
 	if not os.environ.get('NO_STATICS'):
 		application = SharedDataMiddleware(application, {
-			b'/assets': str(os.path.join(sites_path, 'assets'))
+			b'/assets': os.path.join(
+				sites_path, 'assets').encode('ascii')
 		})
 
 		application = StaticDataMiddleware(application, {
-			b'/files': str(os.path.abspath(sites_path))
+			b'/files': os.path.abspath(sites_path).encode('ascii')
 		})
 
 	application.debug = True


### PR DESCRIPTION
This fixes a bug that prevents website routing to non-ascii routes, such as will be automatically created by items with non-ascii characters in their names.

Werkzeug/WSGI actually does careful decoding of URLs passed to it which ensure they are in the correct format internally. However, using a non-ascii URL was causing a unicode error and exceptions.

In app.py, unicode_literals is in effect. SharedDataMiddleware and StaticDataMiddleware instances are created to deal with files in 'assets' and 'files', respectively. The paths passed need to be bytestrings; however, due to the use of unicode, these were passed as unicode. This was causing a later exception when using a (unicode) string method on the decoded URL string. By explicitly passing bytestrings, this is avoided and everything works as expected.

Example: Create a new instance of Frappe. Add an item with (for example) a degree symbol in the name. Make it appear on the website. The degree symbol will appear in the auto-generated route. Following that route will result in a WSGI exception debugging page. After the fix, the item page appears as expected.

I subsequently tried doing HTML encoding at the time of setting the route (inside WebsiteGenerator), but weirdly it was not working with 'encoded' routes (they were giving a 404 error). Presumably it doesn't like % signs or something?