### PR TITLE
[Fix] In-app documentation

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -84,7 +84,16 @@ def make_asset_dirs(make_copy=False, restore=False):
 
 		symlinks = []
 		symlinks.append([os.path.join(app_base_path, 'public'), os.path.join(assets_path, app_name)])
-		symlinks.append([os.path.join(app_base_path, 'docs'), os.path.join(assets_path, app_name + '_docs')])
+
+		app_doc_path = None
+		if os.path.isdir(os.path.join(app_base_path, 'docs')):
+			app_doc_path = os.path.join(app_base_path, 'docs')
+
+		elif os.path.isdir(os.path.join(app_base_path, 'www', 'docs')):
+			app_doc_path = os.path.join(app_base_path, 'www', 'docs')
+
+		if app_doc_path:
+			symlinks.append([app_doc_path, os.path.join(assets_path, app_name + '_docs')])
 
 		for source, target in symlinks:
 			source = os.path.abspath(source)

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -166,8 +166,8 @@ class HelpDatabase(object):
 				docs_app=docs_app, web_folder=web_folder)
 			if os.path.exists(docs_folder):
 				app_name = getattr(frappe.get_module(app), '__title__', None) or app.title()
-				doc_contents += '<li><a data-path="/{docs_app}/index">{app_name}</a></li>'.format(
-					docs_app=docs_app, app_name=app_name)
+				doc_contents += '<li><a data-path="/{app}/index">{app_name}</a></li>'.format(
+					app=app, app_name=app_name)
 
 				for basepath, folders, files in os.walk(docs_folder):
 					files = self.reorder_files(files)

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -177,14 +177,14 @@ class HelpDatabase(object):
 							with io.open(fpath, 'r', encoding = 'utf-8') as f:
 								try:
 									content = frappe.render_template(f.read(),
-										{'docs_base_url': '/assets/{app}_docs'.format(app=app)})
+										{'docs_base_url': '/assets/{docs_app}_docs'.format(docs_app=docs_app)})
 
 									relpath = self.get_out_path(fpath)
 									relpath = relpath.replace("user", app)
 									content = frappe.utils.md_to_html(content)
 									title = self.make_title(basepath, fname, content)
 									intro = self.make_intro(content)
-									content = self.make_content(content, fpath, relpath, app)
+									content = self.make_content(content, fpath, relpath, app, docs_app)
 									self.db.sql('''insert into help(path, content, title, intro, full_path)
 										values (%s, %s, %s, %s, %s)''', (relpath, content, title, intro, fpath))
 								except jinja2.exceptions.TemplateSyntaxError:
@@ -212,7 +212,7 @@ class HelpDatabase(object):
 			intro = "Help Video: " + intro
 		return intro
 
-	def make_content(self, html, path, relpath, app_name):
+	def make_content(self, html, path, relpath, app_name, doc_app):
 		if '<h1>' in html:
 			html = html.split('</h1>', 1)[1]
 
@@ -222,7 +222,7 @@ class HelpDatabase(object):
 		soup = BeautifulSoup(html, 'html.parser')
 
 		self.fix_links(soup, app_name)
-		self.fix_images(soup, app_name)
+		self.fix_images(soup, doc_app)
 
 		parent = self.get_parent(relpath)
 		if parent:


### PR DESCRIPTION
Hi,

While working on staging-fixes branch I realized that the In-app documentation is not working anymore.

You can see the  apps but not the content when you click on it:
![image](https://user-images.githubusercontent.com/4903591/46363970-c9444280-c674-11e8-962a-cdafba3a3667.png)

It comes from the fact that the system is looking for a path like "/frappe_io/index" whereas the relative paths are registered as "/frappe/index" (or similar) in the system.

I'm therefore proposing this PR which corrects the behavior inside Frappe:

![image](https://user-images.githubusercontent.com/4903591/46364191-630bef80-c675-11e8-8eb0-705160ae2abb.png)


**Just a warning**: I don't know if there can be any impact on the documentation generated on Frappe's or ERPnext's website.


Thank you!