### PR TITLE
fix create_custom_field to accept all parameters of df

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -105,15 +105,11 @@ def create_custom_field(doctype, df, ignore_validate=False):
 		custom_field = frappe.get_doc({
 			"doctype":"Custom Field",
 			"dt": doctype,
-			"permlevel": df.permlevel or 0,
-			"label": df.label,
-			"fieldname": df.fieldname,
-			"fieldtype": df.fieldtype or 'Data',
-			"options": df.options,
-			"insert_after": df.insert_after,
-			"print_hide": df.print_hide,
-			"hidden": df.hidden or 0
+			"permlevel": 0,
+			"fieldtype": 'Data',
+			"hidden": 0
 		})
+		custom_field.update(df)
 		custom_field.flags.ignore_validate = ignore_validate
 		custom_field.insert()
 


### PR DESCRIPTION
Previously, parameters like fetch_from and depends_on were not accepted by create_custom_field, this caused issues.

Code:

![screenshot from 2018-10-03 11-46-02](https://user-images.githubusercontent.com/16315650/46393326-51bcf480-c702-11e8-9a50-544c2c9827fc.png)

Before:

![screenshot from 2018-10-03 11-55-43](https://user-images.githubusercontent.com/16315650/46393529-474f2a80-c703-11e8-8b11-4ff0e545ee0c.png)


After:

![screenshot from 2018-10-03 11-50-58](https://user-images.githubusercontent.com/16315650/46393375-9ba5da80-c702-11e8-8f2f-270dad3cd94b.png)
