### PR TITLE
Allow img src having data protocol

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -33,7 +33,7 @@ def clean_email_html(html):
 			'font-size', 'font-weight', 'font-family', 'text-decoration',
 			'line-height', 'text-align', 'vertical-align'
 		],
-		protocols=['cid', 'http', 'https', 'mailto'],
+		protocols=['cid', 'http', 'https', 'mailto', 'data'],
 		strip=True, strip_comments=True)
 
 def clean_script_and_style(html):


### PR DESCRIPTION

<img width="851" alt="screen shot 2018-10-03 at 4 06 55 pm" src="https://user-images.githubusercontent.com/17617465/46405614-67441580-c726-11e8-89c0-1703f9c3a465.png">


Whenever an image (present on a local machine / clipboard) is pasted in a comment, its not rendered in the comments as the `bleach.clean` function strips the src attribute having data protocol.