### PR TITLE
[GCalendar Integration] All days events and incremental sync

### DIFF
--- a/frappe/data_migration/doctype/data_migration_connector/connectors/calendar_connector.py
+++ b/frappe/data_migration/doctype/data_migration_connector/connectors/calendar_connector.py
@@ -6,7 +6,7 @@ import google.oauth2.credentials
 from googleapiclient.errors import HttpError
 import time
 from datetime import datetime
-from frappe.utils import add_days
+from frappe.utils import add_days, add_years
 
 class CalendarConnector(BaseConnection):
 	def __init__(self, connector):
@@ -98,8 +98,17 @@ class CalendarConnector(BaseConnection):
 	def get_events(self, remote_objectname, filters, page_length):
 		page_token = None
 		results = []
+		events = {"items": []}
 		while True:
-			events = self.gcalendar.events().list(calendarId=self.account.gcalendar_id, maxResults=page_length, singleEvents=False, showDeleted=True).execute()
+			try:
+				events = self.gcalendar.events().list(calendarId=self.account.gcalendar_id, maxResults=page_length, 
+					singleEvents=False, showDeleted=True, syncToken=self.account.next_sync_token or None).execute()
+			except HttpError as err:
+				if err.resp.status in [410]:
+					events = self.gcalendar.events().list(calendarId=self.account.gcalendar_id, maxResults=page_length, 
+						singleEvents=False, showDeleted=True, timeMin=add_years(None, -1).strftime('%Y-%m-%dT%H:%M:%SZ')).execute()
+				else:
+					frappe.log_error(err.resp, "GCalendar Events Fetch Error")
 			for event in events['items']:
 				event.update({'account': self.account.name})
 				event.update({'calendar_tz': events['timeZone']})
@@ -107,6 +116,8 @@ class CalendarConnector(BaseConnection):
 
 			page_token = events.get('nextPageToken')
 			if not page_token:
+				if events.get('nextSyncToken'):
+					frappe.db.set_value("GCalendar Account", self.connector.username, "next_sync_token", events.get('nextSyncToken'))
 				break
 		return list(results)
 
@@ -176,26 +187,26 @@ class CalendarConnector(BaseConnection):
 			doc.end_datetime = doc.start_datetime
 		if doc.all_day == 1:
 			return {
-						'start': {
-							'date': doc.start_datetime.date().isoformat(),
-							'timeZone': timezone,
-						},
-						'end': {
-							'date': doc.start_datetime.date().isoformat(),
-							'timeZone': timezone,
-						}
-					}
+				'start': {
+					'date': doc.start_datetime.date().isoformat(),
+					'timeZone': timezone,
+				},
+				'end': {
+					'date': add_days(doc.end_datetime.date(), 1).isoformat(),
+					'timeZone': timezone,
+				}
+			}
 		else:
 			return {
-						'start': {
-							'dateTime': doc.start_datetime.isoformat(),
-							'timeZone': timezone,
-						},
-						'end': {
-							'dateTime': doc.end_datetime.isoformat(),
-							'timeZone': timezone,
-						}
-					}
+				'start': {
+					'dateTime': doc.start_datetime.isoformat(),
+					'timeZone': timezone,
+				},
+				'end': {
+					'dateTime': doc.end_datetime.isoformat(),
+					'timeZone': timezone,
+				}
+			}
 
 	def return_recurrence(self, doctype, doc):
 		e = frappe.get_doc(doctype, doc.name)

--- a/frappe/data_migration/doctype/data_migration_connector/connectors/calendar_connector.py
+++ b/frappe/data_migration/doctype/data_migration_connector/connectors/calendar_connector.py
@@ -101,11 +101,11 @@ class CalendarConnector(BaseConnection):
 		events = {"items": []}
 		while True:
 			try:
-				events = self.gcalendar.events().list(calendarId=self.account.gcalendar_id, maxResults=page_length, 
+				events = self.gcalendar.events().list(calendarId=self.account.gcalendar_id, maxResults=page_length,
 					singleEvents=False, showDeleted=True, syncToken=self.account.next_sync_token or None).execute()
 			except HttpError as err:
 				if err.resp.status in [410]:
-					events = self.gcalendar.events().list(calendarId=self.account.gcalendar_id, maxResults=page_length, 
+					events = self.gcalendar.events().list(calendarId=self.account.gcalendar_id, maxResults=page_length,
 						singleEvents=False, showDeleted=True, timeMin=add_years(None, -1).strftime('%Y-%m-%dT%H:%M:%SZ')).execute()
 				else:
 					frappe.log_error(err.resp, "GCalendar Events Fetch Error")

--- a/frappe/integrations/data_migration_mapping/gcalendar_to_event/__init__.py
+++ b/frappe/integrations/data_migration_mapping/gcalendar_to_event/__init__.py
@@ -4,6 +4,7 @@ import frappe
 from datetime import datetime
 from dateutil.parser import parse
 from pytz import timezone
+from frappe.utils import add_days
 
 
 def pre_process(events):
@@ -17,7 +18,7 @@ def pre_process(events):
 		if 'date' in events["start"]:
 			datevar = 'date'
 			start_dt = parse(events["start"]['date'])
-			end_dt = parse(events["end"]['date'])
+			end_dt = add_days(parse(events["end"]['date']), -1)
 		elif 'dateTime' in events["start"]:
 			datevar = 'dateTime'
 			start_dt = parse(events["start"]['dateTime'])

--- a/frappe/integrations/doctype/gcalendar_account/gcalendar_account.json
+++ b/frappe/integrations/doctype/gcalendar_account/gcalendar_account.json
@@ -1,5 +1,6 @@
 {
  "allow_copy": 0, 
+ "allow_events_in_timeline": 0, 
  "allow_guest_to_view": 0, 
  "allow_import": 0, 
  "allow_rename": 0, 
@@ -15,6 +16,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -47,6 +49,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -75,10 +78,11 @@
    "search_index": 0, 
    "set_only_once": 0, 
    "translatable": 0, 
-   "unique": 0
+   "unique": 1
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -111,6 +115,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -143,6 +148,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -175,6 +181,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -205,6 +212,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -236,6 +244,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -267,6 +276,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -297,6 +307,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -328,6 +339,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -359,6 +371,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -389,6 +402,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -417,6 +431,38 @@
    "set_only_once": 0, 
    "translatable": 0, 
    "unique": 0
+  }, 
+  {
+   "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
+   "fieldname": "next_sync_token", 
+   "fieldtype": "Data", 
+   "hidden": 1, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "label": "Next Sync Token", 
+   "length": 0, 
+   "no_copy": 0, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 0, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 0, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "translatable": 0, 
+   "unique": 0
   }
  ], 
  "has_web_view": 0, 
@@ -429,7 +475,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-03-23 19:29:46.887501", 
+ "modified": "2018-10-04 13:32:27.673907", 
  "modified_by": "Administrator", 
  "module": "Integrations", 
  "name": "GCalendar Account", 
@@ -438,7 +484,6 @@
  "permissions": [
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 0, 
    "create": 1, 
    "delete": 1, 
@@ -458,7 +503,6 @@
   }, 
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 0, 
    "create": 1, 
    "delete": 1, 
@@ -484,5 +528,6 @@
  "sort_field": "modified", 
  "sort_order": "DESC", 
  "track_changes": 1, 
- "track_seen": 0
+ "track_seen": 0, 
+ "track_views": 0
 }


### PR DESCRIPTION
Hi,

This PR has two goals:

1. Correct the synchronization of all day events.
In Google Calendar (and RFC5545) the end date in not inclusive for an all day event, whereas in Frappe, the end date is inclusive (The sync was only partly working for all day events until now).
It means that we should send the end date +1 day to GCalendar and register the end date -1 received from Google Calendar.
I guess it's something to keep in mind for a future CalDav integration, since it relies also on the same RFC specifications.


2. Make an incremental synchronization of the calendar using the next_sync_token provided by GCalendar.
This should lower the sync time and the server overload a lot.

Thanks in advance for your review.

Best regards,

Charles-Henri