### PR TITLE
fix(): ignore empty fields in security settings

### DIFF
--- a/frappe/patches/v10_0/enhance_security.py
+++ b/frappe/patches/v10_0/enhance_security.py
@@ -29,4 +29,5 @@ def execute():
 	if cint(doc.allow_consecutive_login_attempts) <= 3:
 		doc.allow_consecutive_login_attempts = 3
 
+	doc.flags.ignore_mandatory = True
 	doc.save()


### PR DESCRIPTION
- migration used to break on newly created sites which did not have any
fields filled
