### PR TITLE
[Hotfix] [Permission] Fix custom docperm check in get_valid_perm 

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -41,12 +41,13 @@ $.extend(frappe.perm, {
 		var perm = [{ read: 0, apply_user_permissions: {} }];
 
 		var meta = frappe.get_doc("DocType", doctype);
-		if (!meta) {
-			return perm;
-		}
 
 		if (frappe.session.user === "Administrator" || frappe.user_roles.includes("Administrator")) {
 			perm[0].read = 1;
+		}
+
+		if (!meta) {
+			return perm;
 		}
 
 		frappe.perm.build_role_permissions(perm, meta);


### PR DESCRIPTION
Previously to get valid perm we just used to check all the custom docperms available for the user's role and apply standard perms for missing doctypes.
But there might be some doctypes with custom docperms which might not match any of user's role.
Such doctype's perms should not be replaced by standard docperm.
This PR fixes that.

