### PR TITLE
Run report on explicit click instead of automatic refresh on load.

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -50,7 +50,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		// Setup buttons
 		this.primary_action = null;
 		this.secondary_action = {
-			label: __('Refresh'),
+			label: __('Run Report'),
 			action: () => this.refresh()
 		};
 
@@ -81,7 +81,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.load_report();
 		} else {
 			// same report
-			this.refresh_report();
+			// this.refresh_report();
 		}
 	}
 
@@ -117,7 +117,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.set_route_filters(),
 			() => this.report_settings.onload && this.report_settings.onload(this),
 			() => this.get_user_settings(),
-			() => this.refresh()
+			// () => this.refresh()
 		]);
 	}
 
@@ -176,7 +176,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						this.reset_report_view();
 					}
 					else if (!this._no_refresh) {
-						this.refresh();
+						// this.refresh();
 					}
 				}
 			};
@@ -339,7 +339,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			treeView: this.tree_report,
 			layout: 'fixed'
 		};
-		
+
 		if (this.report_settings.get_datatable_options) {
 			datatable_options = this.report_settings.get_datatable_options(datatable_options);
 		}
@@ -762,7 +762,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	get_menu_items() {
 		return [
 			{
-				label: __('Refresh'),
+				label: __('Run Report'),
 				action: () => this.refresh(),
 				class: 'visible-xs'
 			},
@@ -855,7 +855,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	toggle_loading(flag) {
-		this.toggle_message(flag, __('Loading') + '...');
+		this.toggle_message(flag, __('Please click Run Report button to load report') + '...');
 	}
 
 


### PR DESCRIPTION
Currently when report view is loaded, report is executed immediately without waiting for user to specify the required filters. 

In case the report is backed by a complex query and fetches lot of data, it ends up executing multiple duplicate queries while user enters the required filters. One query is fired when report is loaded, and each entry in the filter causes another request. 

We have seen our database server hogging down because of these multiple duplicate queries. While auto loading may be good for small size databases, it is surely not good for large size databases like ours. 

This PR changes this behaviour of the report view. User will have to explicitly click on the 'Run Report' button to execute it. 

This saves lot of unnecessary server and db calls.  The report view looks like below  - 

![image](https://user-images.githubusercontent.com/8121864/46548257-23027200-c8ec-11e8-8aa0-73c7674e69fa.png)
