### PR TITLE
fix(Query Report): Abort last ajax request in refresh

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -235,15 +235,22 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			filters = Object.assign(filters || {}, obj);
 		}
 
-		return new Promise(resolve => frappe.call({
-			method: 'frappe.desk.query_report.run',
-			type: 'GET',
-			args: {
-				report_name: this.report_name,
-				filters: filters,
-			},
-			callback: resolve
-		})).then(r => {
+		// only one refresh at a time
+		if (this.last_ajax) {
+			this.last_ajax.abort();
+		}
+
+		return new Promise(resolve => {
+			this.last_ajax = frappe.call({
+				method: 'frappe.desk.query_report.run',
+				type: 'GET',
+				args: {
+					report_name: this.report_name,
+					filters: filters,
+				},
+				callback: resolve
+			})
+		}).then(r => {
 			let data = r.message;
 
 			this.hide_status();
@@ -339,7 +346,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			treeView: this.tree_report,
 			layout: 'fixed'
 		};
-		
+
 		if (this.report_settings.get_datatable_options) {
 			datatable_options = this.report_settings.get_datatable_options(datatable_options);
 		}


### PR DESCRIPTION
- If there are two ajax requests and the 1st one takes longer than the
2nd, it's data overrides the report later


