### PR TITLE
feature(debugger): Allow VS Code python debugger to work

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -213,7 +213,7 @@ def after_request(rollback):
 
 application = local_manager.make_middleware(application)
 
-def serve(port=8000, profile=False, site=None, sites_path='.'):
+def serve(port=8000, profile=False, no_reload=False, no_threading=False, site=None, sites_path='.'):
 	global application, _site, _sites_path
 	_site = site
 	_sites_path = sites_path
@@ -243,7 +243,7 @@ def serve(port=8000, profile=False, site=None, sites_path='.'):
 		log.setLevel(logging.ERROR)
 
 	run_simple('0.0.0.0', int(port), application,
-		use_reloader=not in_test_env,
+		use_reloader=False if in_test_env else not no_reload,
 		use_debugger=not in_test_env,
 		use_evalex=not in_test_env,
-		threaded=True)
+		threaded=not no_threading)

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -460,8 +460,10 @@ def run_setup_wizard_ui_test(context, app=None, profile=False):
 @click.command('serve')
 @click.option('--port', default=8000)
 @click.option('--profile', is_flag=True, default=False)
+@click.option('--noreload', "no_reload", is_flag=True, default=False)
+@click.option('--nothreading', "no_threading", is_flag=True, default=False)
 @pass_context
-def serve(context, port=None, profile=False, sites_path='.', site=None):
+def serve(context, port=None, profile=False, no_reload=False, no_threading=False, sites_path='.', site=None):
 	"Start development web server"
 	import frappe.app
 
@@ -470,7 +472,7 @@ def serve(context, port=None, profile=False, sites_path='.', site=None):
 	else:
 		site = context.sites[0]
 
-	frappe.app.serve(port=port, profile=profile, site=site, sites_path='.')
+	frappe.app.serve(port=port, profile=profile, no_reload=no_reload, no_threading=no_threading, site=site, sites_path='.')
 
 @click.command('request')
 @click.option('--args', help='arguments like `?cmd=test&key=value` or `/api/request/method?..`')


### PR DESCRIPTION
![screen shot 2018-10-08 at 12 52 10 pm](https://user-images.githubusercontent.com/8528887/46596236-6aaa1900-caf9-11e8-8fe7-88e9be48ba24.png)

This PR enables [Visual Studio Code Debugging feature](https://code.visualstudio.com/docs/editor/debugging).

Checklist for proper functioning.

- [ ] Update `Procfile`
- [ ] Get Visual Studio Code (duh!)
- [ ] Install [Python Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
- [ ] Update `launch.json`
- [ ] Start Debugging

### Caveats

1. Disables Auto Reload Feature (However You can achieve the same results by manual reload (⌘⇧F5))
2. Disables Werkzeug Multithreading

### How To

#### 1. Update `Procfile`
**Caution: This modifies the behaviour of `bench start`**

Comment out a line (prepend # to it) from the `Procfile` (located in the bench directory) that looks like this.
```
web: bench serve --port 8000
```
We will run this process from VS code instead of running it with `bench start`.


#### 2. Update `launch.json`
Add a configuration to your `launch.json` in VS Code that should look something like this (This more or less does exactly what the removed line from Procfile does).

```
{
    "name": "Bench",
    "type": "python",
    "request": "launch",
    "program": "${workspaceFolder}/frappe/frappe/utils/bench_helper.py",
    "args": [
        "frappe", "serve", "--port", "8000", "--noreload", "--nothreading"
    ],
    "pythonPath": "${workspaceFolder}/../env/bin/python",
    "cwd": "${workspaceFolder}/../sites",
    "env": {
        "DEV_SERVER": "1"
    }
}
```

Paths mentioned in given configuration assumes that you have `apps` directory as your workspace directory (The directory you open `code` with). `workspaceFolder` is a vs code variable that points to (if it's not obvious from its name) workspace directory.

You are not forced to use `apps` as your workspace directory, however do remember to change `workspaceFolder`, `pythonPath` and `cwd` accordingly.

#### 3. Execute `bench start`

This should be kept running as usual.

#### 4. Start debugging
VS Code -> Debug Panel (⌘⇧D) -> Start Debugging or With a keyboard shortcut(⌘⇧F5).

### Explanation

#### 1. `program` and `args`

```
"program": "${workspaceFolder}/frappe/frappe/utils/bench_helper.py",
"args": ["frappe", "serve", "--port", "8000", "--noreload", "--nothreading"],
```
Does exact same thing as `bench serve --port 8000 --noreload --nothreading` which is same as
```
cd sites
../env/bin/python ../apps/frappe/frappe/utils/bench_helper.py frappe serve  --port 8000 --noreload --nothreading
```

`--noreload` diasbles werkezeug's autoreload fetaure and `--nothreading` disables multithreading.

#### 2. `cwd`
```
"cwd": "${workspaceFolder}/../sites",
```
Above command must be executed from `sites` directory.

#### 3. `env`
```
"env": {
    "DEV_SERVER": "1"
}
```
`bench start` creates an environment variable `DEV_SERVER` and set it to `1`. Socket.io doesn't work correctly without this (long story).

Running only `bench serve` doesn't set this variable so you need to explicitly set it.

### Details

Currently, frappe runs with `use_reloader=True` and `threaded=True`, VS Code Debugger for some reason doesn't play well with these features, [Django and Flask](https://code.visualstudio.com/docs/python/debugging#_debugging-specific-app-types) also have this problem.
