### PR TITLE
Fixes #6220 Link Type Filter triggers double refresh of Report 

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -318,6 +318,11 @@ frappe.views.QueryReport = Class.extend({
 				if(df.get_query) f.get_query = df.get_query;
 				if(df.on_change) f.on_change = df.on_change;
 				df.onchange = () => {
+					if (me.previous_filters 
+						&& (JSON.stringify(me.previous_filters) == JSON.stringify(me.get_values()))) {
+						return;
+					}
+					me.previous_filters = me.get_values();
 					if(!me.flags.filters_set) {
 						// don't trigger change while setting filters
 						return;


### PR DESCRIPTION
Fix for Link Type Filter triggers double refresh of Report when Link Field looses focus.

![fixed](https://user-images.githubusercontent.com/37295029/46658994-a1ebf900-cbd1-11e8-9f09-bfc0b2f46f71.gif)
