### PR TITLE
Fixes #6220 Link Type Filter triggers double refresh of Report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -169,6 +169,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			if (df.on_change) f.on_change = df.on_change;
 
 			df.onchange = () => {
+				if (this.previous_filters 
+					&& (JSON.stringify(this.previous_filters) == JSON.stringify(this.get_filter_values()))) {
+					return;
+				}
+				this.previous_filters = this.get_filter_values();
 				if (f.on_change) {
 					f.on_change(this);
 				} else {


### PR DESCRIPTION
Link Type Filter triggers double refresh of Report when Link Field looses focus

![fixed-staging](https://user-images.githubusercontent.com/37295029/46660849-93074580-cbd5-11e8-983d-c2c46bc01d90.gif)
