### PR TITLE
[UX] Display zero amounts

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -23,8 +23,8 @@ frappe.form.formatters = {
 	},
 	Float: function(value, docfield, options, doc) {
 		// don't allow 0 precision for Floats, hence or'ing with null
-		var precision = docfield.precision 
-			|| cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) 
+		var precision = docfield.precision
+			|| cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision)
 			|| null;
 		if (docfield.options && docfield.options.trim()) {
 			// options points to a currency field, but expects precision of float!
@@ -67,7 +67,7 @@ frappe.form.formatters = {
 			}
 		}
 
-		value = (value == null || value == "") ? "" : format_currency(value, currency, precision);
+		value = (value == null || value === "") ? "" : format_currency(value, currency, precision);
 
 		if ( options && options.only_value ) {
 			return value;


### PR DESCRIPTION
A change made in a [previous PR](https://github.com/frappe/frappe/pull/4579/files) rendered zero-values in documents as an empty string.

<hr>

**Before**

![image](https://user-images.githubusercontent.com/13396535/46664794-a8816d00-cbdf-11e8-9787-4f5ff057a2ae.png)

<hr>

**After**

![image](https://user-images.githubusercontent.com/13396535/46664761-8c7dcb80-cbdf-11e8-9a26-8b9e47503176.png)