### PR TITLE
[fix] file: permission issue on email attachment

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -542,7 +542,7 @@ class File(NestedSet):
 			if has_permission(self, 'read'):
 				return True
 
-		raise frappe.PermissionError
+			raise frappe.PermissionError
 
 	def get_extension(self):
 		'''returns split filename and extension'''
@@ -741,7 +741,7 @@ def remove_all(dt, dn, from_delete=False):
 	except Exception as e:
 		if e.args[0]!=1054: raise # (temp till for patched)
 
-      
+
 def has_permission(doc, ptype=None, user=None):
 	permission = True
 


### PR DESCRIPTION
fixed a file permission issue where 'private' email attachments were not viewable by anyone (including the uploader).