### PR TITLE
Improve Braintree checkout UX

### DIFF
--- a/frappe/templates/includes/integrations/braintree_checkout.js
+++ b/frappe/templates/includes/integrations/braintree_checkout.js
@@ -42,6 +42,14 @@ $(document).ready(function() {
 				})
 			});
 		});
+
+		instance.on('paymentMethodRequestable', function (event) {
+			button.removeAttribute('disabled');
+		});
+
+		instance.on('noPaymentMethodRequestable', function () {
+			button.setAttribute('disabled', true);
+		});
 	});
 
 })

--- a/frappe/templates/pages/integrations/braintree_checkout.html
+++ b/frappe/templates/pages/integrations/braintree_checkout.html
@@ -26,7 +26,7 @@
 				</div>
 			</section>
 
-			<button class="btn btn-primary" type="submit" id="submit-button"><span>{{ _("Pay") }} {{ amount }} {{ currency }}</span></button>
+			<button class="btn btn-primary" type="submit" id="submit-button" disabled><span>{{ _("Pay") }} {{ amount }} {{ currency }}</span></button>
 		</form>
 
 	</div>


### PR DESCRIPTION
Hi,

This is small PR to improve Braintree's payment page UX.

Until the card details are registered, the button is disabled:
![image](https://user-images.githubusercontent.com/4903591/46796121-25c9f080-cd4c-11e8-9075-6ab0718dbe0b.png)

![image](https://user-images.githubusercontent.com/4903591/46796134-2f535880-cd4c-11e8-95a7-6f217f2c9106.png)


Thank you