### PR TITLE
[Fix] local variable 'send_email' referenced before assignment

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -798,9 +798,12 @@ def sign_up(email, full_name, redirect_to):
 			return 2, _("Please ask your administrator to verify your sign-up")
 
 @frappe.whitelist(allow_guest=True)
-def reset_password(user):
+def reset_password(user, send_email=False):
 	if user=="Administrator":
 		return 'not allowed'
+	
+	if send_email and send_email=='false':
+		send_email = false
 
 	try:
 		user = frappe.get_doc("User", user)
@@ -808,7 +811,7 @@ def reset_password(user):
 			return 'disabled'
 
 		user.validate_reset_password()
-		user.reset_password(send_email=True)
+		user.reset_password(send_email=send_email)
 
 		return frappe.msgprint(_("Password reset instructions have been sent to your email"))
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -798,7 +798,7 @@ def sign_up(email, full_name, redirect_to):
 			return 2, _("Please ask your administrator to verify your sign-up")
 
 @frappe.whitelist(allow_guest=True)
-def reset_password(user, send_email=False):
+def reset_password(user, send_email=True):
 	if user=="Administrator":
 		return 'not allowed'
 	

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -802,9 +802,6 @@ def reset_password(user):
 	if user=="Administrator":
 		return 'not allowed'
 
-	if isinstance(send_email, string_types):
-		if send_email=='false': send_email = False
-
 	try:
 		user = frappe.get_doc("User", user)
 		if not user.enabled:


### PR DESCRIPTION
Reset password not working because of below issue
```
Traceback (most recent call last):
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/core/doctype/user/user.py", line 805, in reset_password
    if isinstance(send_email, string_types):
UnboundLocalError: local variable 'send_email' referenced before assignment
```