### PR TITLE
[Bug Fix] get_value for child table does not work js

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -31,14 +31,15 @@ frappe.db = {
 			});
 		});
 	},
-	get_value: function(doctype, filters, fieldname, callback) {
+	get_value: function(doctype, filters, fieldname, callback, parent_doc) {
 		return frappe.call({
 			method: "frappe.client.get_value",
 			type: 'GET',
 			args: {
 				doctype: doctype,
 				fieldname: fieldname,
-				filters: filters
+				filters: filters,
+				parent: parent_doc
 			},
 			callback: function(r) {
 				callback && callback(r.message);


### PR DESCRIPTION
Issue: `check_parent_permission` was implemented but the parameter was not added to the function itself hence even if parent had permissions, get_value did not work for child table.

<img width="842" alt="screen shot 2018-10-15 at 7 24 44 pm" src="https://user-images.githubusercontent.com/16913064/46955215-0a464900-d0b0-11e8-809d-52ddba66e56b.png">

Fix: Added `parent` parameter. Had to use parent_doc since parent is kind of a reserved word.
Usage: frappe.db.get_value(`childtable doctype `, {`filters`}, `fieldname`,`parent`,  (r) => {})