### PR TITLE
[Fix] Report Addresses And Contacts not working

### DIFF
--- a/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py
+++ b/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py
@@ -91,7 +91,7 @@ def get_party_details(party_type, party_list, doctype, party_details):
 
 	records = frappe.get_list(doctype, filters=filters, fields=fields, as_list=True)
 	for d in records:
-		details = party_details.get(d[0])
+		details = party_details.get(d[0]) or {}
 		details.setdefault(frappe.scrub(doctype), []).append(d[1:])
 
 	return party_details


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py", line 16, in execute
    columns, data = get_columns(filters), get_data(filters)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py", line 42, in get_data
    return get_party_addresses_and_contact(party_type, party)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py", line 59, in get_party_addresses_and_contact
    party_details = get_party_details(party_type, party_list, "Address", party_details)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py", line 95, in get_party_details
    details.setdefault(frappe.scrub(doctype), []).append(d[1:])
AttributeError: 'NoneType' object has no attribute 'setdefault'
```