### PR TITLE
[Fix] multiple user permissions messages are coming even if permissions are set

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -89,6 +89,9 @@ def has_permission(doctype, ptype="read", doc=None, verbose=False, user=None):
 	if not perm:
 		perm = false_if_not_shared()
 
+	if perm and frappe.message_log:
+		frappe.message_log.pop()
+
 	if verbose: print("Final Permission: {0}".format(perm))
 	return perm
 


### PR DESCRIPTION
User permissions messages are coming even if permissions are set

![image150e33](https://user-images.githubusercontent.com/8780500/47200294-2b9a8400-d393-11e8-8ae2-26aa5af3ebfc.png)
