### PR TITLE
[Fix] Invalid date format message in quick entry for date field

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -24,7 +24,13 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			// set default
 			$.each(this.fields_list, function(i, field) {
 				if (field.df["default"]) {
-					field.set_input(field.df["default"]);
+					let def_value = field.df["default"];
+
+					if (def_value == 'Today' && field.df["fieldtype"] == 'Date') {
+						def_value = frappe.datetime.get_today();
+					}
+
+					field.set_input(def_value);
 					// if default and has depends_on, render its fields.
 					me.refresh_dependency();
 				}


### PR DESCRIPTION
If date field added in quick entry then getting below message
![screen shot 2018-10-17 at 7 47 37 pm](https://user-images.githubusercontent.com/8780500/47092896-a2c20200-d245-11e8-9da6-16040536a550.png)
