### PR TITLE
Update in-app Docs Generation 

### DIFF
--- a/frappe/config/docs.py
+++ b/frappe/config/docs.py
@@ -2,5 +2,5 @@
 
 from __future__ import unicode_literals
 
-source_link = "https://github.com/frappe/frappe"
+source_link = "https://github.com/frappe/frappe_io"
 docs_base_url = "/docs"

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -15,6 +15,8 @@ develop_version = '10.x.x-develop'
 
 app_email = "info@frappe.io"
 
+docs_app = "frappe_io"
+
 before_install = "frappe.utils.install.before_install"
 after_install = "frappe.utils.install.after_install"
 

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -38,7 +38,7 @@ def get_help_content(path):
 def get_improve_page_html(app_name, target):
 	docs_config = frappe.get_module(app_name + ".config.docs")
 	source_link = docs_config.source_link
-	branch = getattr(docs_config, "branch", "develop")
+	branch = getattr(docs_config, "branch", "master")
 	html = '''<div class="page-container">
 				<div class="page-content">
 				<div class="edit-container text-center">
@@ -186,6 +186,10 @@ class HelpDatabase(object):
 			html = html.replace('{next}', '')
 
 		target = path.split('/', 3)[-1]
+
+		if app_name != doc_app:
+    		target = target.replace(app_name, doc_app + '/www')
+		app_name = path.split('/', 3)[2]
 		html += get_improve_page_html(app_name, target)
 
 		soup = BeautifulSoup(html, 'html.parser')

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -182,7 +182,7 @@ class HelpDatabase(object):
 			intro = "Help Video: " + intro
 		return intro
 
-	def make_content(self, html, path, relpath):
+	def make_content(self, html, path, relpath, app_name, doc_app):
 		if '<h1>' in html:
 			html = html.split('</h1>', 1)[1]
 
@@ -190,13 +190,12 @@ class HelpDatabase(object):
 			html = html.replace('{next}', '')
 
 		target = path.split('/', 3)[-1]
-		app_name = path.split('/', 3)[2]
 		html += get_improve_page_html(app_name, target)
 
 		soup = BeautifulSoup(html, 'html.parser')
 
 		self.fix_links(soup, app_name)
-		self.fix_images(soup, app_name)
+		self.fix_images(soup, doc_app)
 
 		parent = self.get_parent(relpath)
 		if parent:

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -195,7 +195,7 @@ class HelpDatabase(object):
 		soup = BeautifulSoup(html, 'html.parser')
 
 		self.fix_links(soup, app_name)
-		self.fix_images(soup, doc_app)
+		self.fix_images(soup, app_name)
 
 		parent = self.get_parent(relpath)
 		if parent:

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -188,7 +188,7 @@ class HelpDatabase(object):
 		target = path.split('/', 3)[-1]
 
 		if app_name != doc_app:
-    		target = target.replace(app_name, doc_app + '/www')
+			target = target.replace(app_name, doc_app + '/www')
 		app_name = path.split('/', 3)[2]
 		html += get_improve_page_html(app_name, target)
 

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -128,12 +128,8 @@ class HelpDatabase(object):
 			# Expect handling of cloning docs apps in bench
 			docs_app = frappe.get_hooks('docs_app', app, app)[0]
 
-			web_folder = 'www/' if docs_app != app else ''
-
-			docs_folder = '../apps/{docs_app}/{docs_app}/{web_folder}docs/user'.format(
-				docs_app=docs_app, web_folder=web_folder)
-			self.out_base_path = '../apps/{docs_app}/{docs_app}/{web_folder}docs'.format(
-				docs_app=docs_app, web_folder=web_folder)
+			docs_folder = '../apps/{app}/{app}/docs/user'.format(app=app)
+			self.out_base_path = '../apps/{app}/{app}/docs'.format(app=app)
 			if os.path.exists(docs_folder):
 				app_name = getattr(frappe.get_module(app), '__title__', None) or app.title()
 				doc_contents += '<li><a data-path="/{app}/index">{app_name}</a></li>'.format(
@@ -147,7 +143,7 @@ class HelpDatabase(object):
 							with io.open(fpath, 'r', encoding = 'utf-8') as f:
 								try:
 									content = frappe.render_template(f.read(),
-										{'docs_base_url': '/assets/{docs_app}_docs'.format(docs_app=docs_app)})
+										{'docs_base_url': '/assets/{app}_docs'.format(app=app)})
 
 									relpath = self.get_out_path(fpath)
 									relpath = relpath.replace("user", app)

--- a/frappe/utils/help.py
+++ b/frappe/utils/help.py
@@ -307,14 +307,3 @@ class HelpDatabase(object):
 		if pos:
 			files[0], files[pos] = files[pos], files[0]
 		return files
-
-def setup_apps_for_docs(app):
-	docs_app = frappe.get_hooks('docs_app', app, app)[0]
-
-	if docs_app and not os.path.exists(frappe.get_app_path(app)):
-		print("Getting {docs_app} required by {app}".format(docs_app=docs_app, app=app))
-		subprocess.check_output(['bench', 'get-app', docs_app], cwd = '..')
-	else:
-		if docs_app:
-			print("{docs_app} required by {app} already present".format(docs_app=docs_app, app=app))
-


### PR DESCRIPTION
Currently, in v10, the docs still point to ERPNext develop branch, before it being moved to erpnext.org app.

Co-authored-by: Shreya Shah <shreyashah115@gmail.com>

Related PR in ERPNext:

https://github.com/frappe/erpnext/pull/15739

![docs-link](https://user-images.githubusercontent.com/33246109/47209359-cbfda200-d3ad-11e8-8b00-f60d1aff130d.gif)
