### PR TITLE
Primary key in tabSeries

### DIFF
--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -173,7 +173,8 @@ CREATE TABLE `tabDocType` (
 DROP TABLE IF EXISTS `tabSeries`;
 CREATE TABLE `tabSeries` (
   `name` varchar(100) DEFAULT NULL,
-  `current` int(10) NOT NULL DEFAULT 0
+  `current` int(10) NOT NULL DEFAULT 0,
+  PRIMARY KEY(`name`)
 ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED CHARACTER SET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/frappe/database/postgres/framework_postgres.sql
+++ b/frappe/database/postgres/framework_postgres.sql
@@ -173,10 +173,9 @@ CREATE TABLE "tabDocType" (
 DROP TABLE IF EXISTS "tabSeries";
 CREATE TABLE "tabSeries" (
   "name" varchar(100) DEFAULT NULL,
-  "current" bigint NOT NULL DEFAULT 0
+  "current" bigint NOT NULL DEFAULT 0,
+  PRIMARY KEY ("name")
 ) ;
-
-create index on "tabSeries" ("name");
 
 --
 -- Table structure for table "tabSessions"
@@ -276,4 +275,3 @@ CREATE TABLE "tabDefaultValue" (
 
 create index on "tabDefaultValue" ("parent");
 create index on "tabDefaultValue" ("parent", "defkey");
-

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -229,3 +229,4 @@ frappe.patches.v10_0.modify_smallest_currency_fraction
 frappe.patches.v10_0.enhance_security
 frappe.patches.v11_0.multiple_references_in_events
 frappe.patches.v11_0.set_allow_self_approval_in_workflow
+execute:frappe.db.sql('ALTER table `tabSeries` ADD PRIMARY KEY IF NOT EXISTS (name)')

--- a/frappe/patches/v11_0/set_primary_key_in_tabseries.py
+++ b/frappe/patches/v11_0/set_primary_key_in_tabseries.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+import frappe
+
+def execute():
+	frappe.db.sql('ALTER table `tabSeries` add PRIMARY KEY (name)')

--- a/frappe/patches/v11_0/set_primary_key_in_tabseries.py
+++ b/frappe/patches/v11_0/set_primary_key_in_tabseries.py
@@ -1,7 +1,0 @@
-# Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
-# MIT License. See license.txt
-
-import frappe
-
-def execute():
-	frappe.db.sql('ALTER table `tabSeries` add PRIMARY KEY (name)')


### PR DESCRIPTION
Add primary key on name for tabSeries
This is added as any search on tabSeries requires table level locks as it is performing a non unique search.