### PR TITLE
PDF allow parsing header-spacing option from custom print format

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -93,7 +93,7 @@ def read_options_from_html(html):
 	toggle_visible_pdf(soup)
 
 	# use regex instead of soup-parser
-	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size"):
+	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size", "header-spacing"):
 		try:
 			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
 			match = pattern.findall(html)


### PR DESCRIPTION
Added header-spacing in read_options_from_html in pdf.py

I had a lot of trouble trying to get the headers and footers in the PDF to show up correctly. So this option is really useful for setting space between header and content

Additional Stuff: In my case I had to use header-spacing in negative (like header-spacing: -15mm) because somehow wkhtmltopdf would somehow add an margin and unexpected and unwanted below the header.