### PR TITLE
Link user permissions fix

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -3,12 +3,13 @@
 
 # Search
 from __future__ import unicode_literals
+import re
+from frappe import _
 import frappe, json
+from six import string_types
 from frappe.utils import cstr, unique, cint
 from frappe.permissions import has_permission
-from frappe import _
-from six import string_types
-import re
+from frappe.core.doctype.user_permission.user_permission import get_user_permissions
 
 UNTRANSLATED_DOCTYPES = ["DocType", "Role"]
 
@@ -143,11 +144,10 @@ def search_widget(doctype, txt, query=None, searchfield=None, reference_doctype=
 
 			ignore_permissions = True if doctype == "DocType" else (cint(ignore_user_permissions) and has_permission(doctype))
 
-			from frappe.core.doctype.user_permission.user_permission import get_user_permissions
-			user_permissions = get_user_permissions()
 
 			# ignore_permission if reference doctype is in skip_for_doctype of user permission
 			if not ignore_permissions and reference_doctype:
+				user_permissions = get_user_permissions()
 				if reference_doctype in user_permissions.get(doctype, {}).get("skip_for_doctype", []):
 					ignore_permissions = True
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -147,6 +147,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			var args = {
 				'txt': term,
 				'doctype': doctype,
+				'reference_doctype': me.doctype,
 				'ignore_user_permissions': me.df.ignore_user_permissions
 			};
 


### PR DESCRIPTION
Previously user permission was getting applied on link fields even if it was ignored in advanced control for some doctype.

This PR aims to fix that.