### PR TITLE
Added frappe.get_cached_doc in available jinja methods

### DIFF
--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -115,6 +115,7 @@ def get_allowed_functions_for_jenv():
 			"get_hooks": frappe.get_hooks,
 			"get_meta": frappe.get_meta,
 			"get_doc": frappe.get_doc,
+			"get_cached_doc": frappe.get_cached_doc,
 			"get_list": frappe.get_list,
 			"get_all": frappe.get_all,
 			'get_system_settings': frappe.get_system_settings,


### PR DESCRIPTION
Added frappe.get_cached_doc in available jinja methods.
This would be helpful for looking for some extra values in master docs like Item or Item Group and so on. 