### PR TITLE
[fix] Email Group Total Subscribers update on deletion of email group member

### DIFF
--- a/frappe/email/doctype/email_group_member/email_group_member.py
+++ b/frappe/email/doctype/email_group_member/email_group_member.py
@@ -7,7 +7,12 @@ import frappe
 from frappe.model.document import Document
 
 class EmailGroupMember(Document):
-	pass
+	def on_trash(self):
+		email_group = frappe.get_doc("Email Group",self.email_group)
+		total_subscribers = frappe.db.sql("""select count(*) from `tabEmail Group Member`
+			where email_group=%s and name <> %s""", (self.email_group, self.name))[0][0]
+		email_group.total_subscribers = total_subscribers
+		email_group.db_update()
 
 def after_doctype_insert():
 	frappe.db.add_unique("Email Group Member", ("email_group", "email"))

--- a/frappe/email/doctype/email_group_member/email_group_member.py
+++ b/frappe/email/doctype/email_group_member/email_group_member.py
@@ -7,6 +7,10 @@ import frappe
 from frappe.model.document import Document
 
 class EmailGroupMember(Document):
+	def after_insert(self):
+		email_group = frappe.get_doc("Email Group", self.email_group)
+		email_group.update_total_subscribers()
+
 	def on_trash(self):
 		email_group = frappe.get_doc("Email Group",self.email_group)
 		total_subscribers = frappe.db.sql("""select count(*) from `tabEmail Group Member`

--- a/frappe/email/doctype/email_group_member/test_email_group_member.py
+++ b/frappe/email/doctype/email_group_member/test_email_group_member.py
@@ -9,4 +9,25 @@ import unittest
 # test_records = frappe.get_test_records('Email Group Member')
 
 class TestEmailGroupMember(unittest.TestCase):
-	pass
+	def setUp(self):
+		frappe.delete_doc_if_exists("Email Group", "_Test Email Group")
+		frappe.get_doc({
+			"doctype": "Email Group",
+			"title": "_Test Email Group",
+			"total_subscribers": 0
+		}).insert(ignore_permissions=True)
+
+		frappe.db.sql("delete from `tabEmail Group Member` where email_group = '_Test Email Group'")
+		for email in ["test1@example.com", "test2@example.com"]:
+			frappe.get_doc({
+				"doctype": "Email Group Member",
+				"email_group": "_Test Email Group",
+				"email": email,
+				"unsubscribed": 0
+			}).insert(ignore_permissions=True)
+
+	def test_total_subscribers(self):
+		email_group_mem = frappe.db.get_value("Email Group Member", {"email": "test1@example.com"}, "name")
+		frappe.delete_doc('Email Group Member', email_group_mem)
+		total_subscribers = frappe.db.get_value("Email Group", "_Test Email Group", "total_subscribers")
+		self.assertEquals(total_subscribers, 1)


### PR DESCRIPTION
On deletion of Email Group Member/Subscribers, Email Group total subscribers count didn't update.
Issue Reference - [11639](https://github.com/frappe/frappe/issues/19158)

**Total Subscribers on Email Group**

![image](https://user-images.githubusercontent.com/14306547/47427775-fb961b00-d7ae-11e8-83a4-48c80cfcf8df.png)

**In Actual**

![image](https://user-images.githubusercontent.com/14306547/47427800-0d77be00-d7af-11e8-9a5d-978db4083506.png)

**After Fix**

![image](https://user-images.githubusercontent.com/14306547/47428321-8a576780-d7b0-11e8-9213-4f761a7e01db.png)



