### PR TITLE
Revert series count after doc deletion

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -170,13 +170,13 @@ def getseries(key, digits, doctype=''):
 def revert_series_if_last(key, name):
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
-		if '.' in prefix:
-			prefix = parse_naming_series(prefix.split('.'))
-
 		if "#" not in hashes:
 			return
 	else:
 		prefix = key
+
+	if '.' in prefix:
+		prefix = parse_naming_series(prefix.split('.'))
 
 	count = cint(name.replace(prefix, ""))
 	current = frappe.db.sql("select `current` from `tabSeries` where name=%s for update", (prefix,))


### PR DESCRIPTION
If the naming_series is something like `SA-INV-.YYYY.-`, it fails in the first condition of the function as it doesn't have `#` in it, and hence, the `YYYY` doesn't get parsed as well, therefore the prefix is not generated and the series doesn't revert back even after document deletion.
 