### PR TITLE
Added msgprint for 502 for xhr requests

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -177,7 +177,7 @@ frappe.request.call = function(opts) {
 			opts.error_callback && opts.error_callback();
 		},
 		502: function(xhr) {
-			frappe.msgprint("Internal Server Error");
+			frappe.msgprint(__("Internal Server Error"));
 		}
 	};
 

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -175,6 +175,9 @@ frappe.request.call = function(opts) {
 		504: function(xhr) {
 			frappe.msgprint(__("Request Timed Out"))
 			opts.error_callback && opts.error_callback();
+		},
+		502: function(xhr) {
+			frappe.msgprint("Internal Server Error");
 		}
 	};
 


### PR DESCRIPTION
Added msgprint for 502 error so that its not suppressed silently if it happens after the UI loads.

Counter part of below error when it happens in XHR requests.
![image](https://user-images.githubusercontent.com/37295029/47492329-60fb1200-d86a-11e8-9814-38d9c61a5c69.png)
