### PR TITLE
Docker Auto Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# Frappe Bench
+FROM alpine:latest
+MAINTAINER developers@frappe.io
+
+USER root
+ENV LANG C.UTF-8
+
+COPY docker-entrypoint.sh usr/local/bin/docker-entrypoint.sh
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+
+RUN apk add --update --no-cache \
+  build-base \
+  libffi-dev \
+  git \
+  su-exec \
+  nodejs \
+  yarn \
+  python-dev \
+  py-pip \
+  jpeg-dev \
+  zlib-dev \
+  libxslt-dev \
+  libxml2-dev \
+  postgresql-dev \
+  gcc \
+  python3-dev \
+  musl-dev \
+  mysql-client
+
+RUN pip install --upgrade setuptools pip && rm -rf ~/.cache/pip
+RUN mkdir -p /home/frappe && adduser -h /home/frappe -D frappe
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN cd /tmp \
+  && wget -c https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz \
+  && tar xvf wkhtmltox-0.12.3_linux-generic-amd64.tar.xz \
+  && cp wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf \
+  && chmod o+x /usr/local/bin/wkhtmltopdf
+
+RUN git clone https://github.com/revant/bench.git /home/frappe/.bench -b docker \
+  && pip install -e /home/frappe/.bench \
+  && chown -R frappe:frappe /home/frappe
+
+USER frappe
+RUN cd /home/frappe \
+  && bench init frappe-bench --in-docker \
+  && cd frappe-bench
+
+WORKDIR /home/frappe/frappe-bench
+
+VOLUME /home/frappe/frappe-bench/sites
+
+EXPOSE 8000
+EXPOSE 9000
+EXPOSE 6787
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN cd /tmp \
   && cp wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf \
   && chmod o+x /usr/local/bin/wkhtmltopdf
 
-RUN git clone https://github.com/revant/bench.git /home/frappe/.bench -b docker \
+RUN git clone https://github.com/frappe/bench.git /home/frappe/.bench -b master \
   && pip install -e /home/frappe/.bench \
   && chown -R frappe:frappe /home/frappe
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+function checkEnv() {
+  if [[ -z "$DB_HOST" ]]; then
+    echo "DB_HOST is not set"
+    exit 1
+  fi
+  if [[ -z "$DB_PASSWORD" ]]; then
+    echo "DB_PASSWORD is not set"
+    exit 1
+  fi
+  if [[ -z "$ADMIN_PASSWORD" ]]; then
+    echo "ADMIN_PASSWORD is not set"
+    exit 1
+  fi
+  if [[ -z "$REDIS_QUEUE" ]]; then
+    echo "REDIS_QUEUE is not set"
+    exit 1
+  fi
+  if [[ -z "$REDIS_SOCKETIO" ]]; then
+    echo "REDIS_SOCKETIO is not set"
+    exit 1
+  fi
+  if [[ -z "$REDIS_CACHE" ]]; then
+    echo "REDIS_CACHE is not set"
+    exit 1
+  fi
+}
+
+function checkConnection() {
+  # Wait for mariadb
+  dockerize -wait tcp://$DB_HOST:3306 -timeout 30s
+
+  # Wait for all redis
+  dockerize -wait tcp://$REDIS_QUEUE:11000 -timeout 30s
+  dockerize -wait tcp://$REDIS_SOCKETIO:12000 -timeout 30s
+  dockerize -wait tcp://$REDIS_CACHE:13000 -timeout 30s
+}
+
+function configureBench() {
+  # set common config
+  bench config set-common-config -c db_host $DB_HOST
+  bench config set-common-config -c redis_queue "redis://$REDIS_QUEUE:11000"
+  bench config set-common-config -c redis_socketio "redis://$REDIS_SOCKETIO:12000"
+  bench config set-common-config -c redis_cache "redis://$REDIS_CACHE:13000"
+
+  # set procfile
+  rm Procfile
+  bench setup procfile
+  tail -n +4 Procfile > Procfile.1
+  mv Procfile.1 Procfile
+}
+
+if [ "$1" = 'new-site' ]; then
+  # Validate if DB_HOST is set.
+  checkEnv
+  # Validate DB Connection
+  checkConnection
+  # configure bench
+  configureBench
+
+  bench new-site --mariadb-root-password $DB_PASSWORD --admin-password $ADMIN_PASSWORD "$2"
+fi
+
+if [ "$1" = 'start' ]; then
+  # Validate if DB_HOST is set.
+  checkEnv
+  # Validate DB Connection
+  checkConnection
+  # configure bench
+  configureBench
+  
+  bench start
+fi
+
+if [ "$1" = 'migrate' ]; then
+  # Validate if DB_HOST is set.
+  checkEnv
+  # Validate DB Connection
+  checkConnection
+  # configure bench
+  configureBench
+
+  bench --site "$2" migrate
+fi
+
+exec "$@"


### PR DESCRIPTION
Sequence for merging : 

- [ ] wkhtmltopdf not working

1. Merge this https://github.com/frappe/bench/pull/735 into frappe/bench/master. This will allow bench to be run under docker environment
2. Go to docker hub and create an automated build for branches. (use suitable naming convention)
  - develop = frappe:edge
  - staging = frappe:beta
  - master = frappe:latest
3. Merge this request into develop branch and it will create frappe:edge build
 
Notes  : 

- Only frappe is installed in this image
- No site is installed in this image
- Site can be created after initialising the container
- Sites directory will be available in docker volume or mounted volume
- ERPNext build will be incremental and will be based on this image.
- This results into successful build.Live image from my fork here https://hub.docker.com/r/revantnandgaonkar/frappe/tags/
- Build manages the secrets through environment variables
- docker-entrypoint.sh can be extended as per need in consequent PRs

For custom apps :

If any custom apps need to build docker images they can follow the same pattern
i.e. frappe image + custom app image or frappe image + erpnext image + custom app image.
