### PR TITLE
[Feature]: Autoincrement

### DIFF
--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -307,7 +307,7 @@ class DataExporter:
 		d = doc.copy()
 		meta = frappe.get_meta(dt)
 		if self.all_doctypes:
-			d.name = '"'+ d.name+'"'
+			d.name = '"{}"'.format(d.name)
 
 		if len(rows) < rowidx + 1:
 			rows.append([""] * (len(self.columns) + 1))

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -546,7 +546,7 @@
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
-   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>", 
+   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li><li><b>autoincrement</b> uses database auto increment feature</li></ol>", 
    "fieldname": "autoname", 
    "fieldtype": "Data", 
    "hidden": 0, 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -45,7 +45,6 @@ class DocType(Document):
 		self.check_developer_mode()
 		self.validate_autoname()
 		self.validate_name()
-		# self.validate_child_table_autoincrement()
 
 		if self.issingle:
 			self.allow_import = 0
@@ -63,6 +62,9 @@ class DocType(Document):
 		self.validate_series()
 		self.validate_document_type()
 		validate_fields(self)
+
+		if self.autoname == "autoincrement":
+			self.allow_rename = 0
 
 		if self.istable:
 			# no permission records for child table
@@ -160,15 +162,6 @@ class DocType(Document):
 		if not self.is_new():
 			if (self.get("autoname") == "autoincrement" and self.get_doc_before_save().get("autoname") != "autoincrement") or (self.get("autoname") != "autoincrement" and self.get_doc_before_save().get("autoname") == "autoincrement"):
 				frappe.throw("Can not change autoname <b>{0}</b> to <b>{1}</b>".format(self.get_doc_before_save().get("autoname"), self.get("autoname")))
-
-	def validate_child_table_autoincrement(self):
-		errors = []
-		if self.autoname == "autoincrement":
-			error_fields = self.get('fields', {'fieldtype': 'Table'})
-			for row in error_fields:
-				errors.append("Autoincrement naming does not support child table, please rectify row {0}".format(row.idx))
-		if errors:
-			frappe.throw(errors)
 
 	def validate_document_type(self):
 		if self.document_type=="Transaction":

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -122,7 +122,7 @@ class TestDocType(unittest.TestCase):
 
 		doc = self.new_doctype("Test Auto Increment", autoname="autoincrement")
 		doc.insert()
-		tab_desc = frappe.db.sql("DESC `tabTest Auto Increment`", as_dict=1)
+		tab_desc = frappe.db.get_table_columns_description("tabTest Auto Increment")
 		for row in tab_desc:
 			if row.Field == "name":
 				self.assertTrue(row.Extra == "auto_increment")
@@ -172,7 +172,7 @@ class TestDocType(unittest.TestCase):
 
 		doc = self.new_doctype("Test Naming Series", autoname="AUTO-INC-.######")
 		doc.insert()
-		tab_desc = frappe.db.sql("DESC `tabTest Naming Series`", as_dict=1)
+		tab_desc = frappe.db.get_table_columns_description("tabTest Naming Series")
 		for row in tab_desc:
 			if row.Field == "name":
 				self.assertFalse(row.Extra == "auto_increment")

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -282,3 +282,6 @@ class MariaDBDatabase(Database):
 
 	def get_database_list(self, target):
 		return [d[0] for d in self.sql("SHOW DATABASES;")]
+
+	def get_last_insert_id(self):
+		return frappe.db.sql("SELECT last_insert_id() as name;", as_dict=1)[0].name

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -8,6 +8,10 @@ class MariaDBTable(DBTable):
 	def create(self):
 		add_text = ''
 
+		name_str = "name varchar({varchar_len}) not null primary key,".format(varchar_len=frappe.db.VARCHAR_LEN)
+		if self.meta.autoname and self.meta.autoname == "autoincrement":
+			name_str = "name BIGINT not null AUTO_INCREMENT primary key,"
+
 		# columns
 		column_defs = self.get_column_definitions()
 		if column_defs: add_text += ',\n'.join(column_defs) + ',\n'
@@ -18,7 +22,7 @@ class MariaDBTable(DBTable):
 
 		# create table
 		frappe.db.sql("""create table `%s` (
-			name varchar({varchar_len}) not null primary key,
+			{name_str}
 			creation datetime(6),
 			modified datetime(6),
 			modified_by varchar({varchar_len}),
@@ -33,10 +37,11 @@ class MariaDBTable(DBTable):
 			ENGINE={engine}
 			ROW_FORMAT=COMPRESSED
 			CHARACTER SET=utf8mb4
-			COLLATE=utf8mb4_unicode_ci""".format(varchar_len=frappe.db.VARCHAR_LEN,
+			COLLATE=utf8mb4_unicode_ci""".format(name_str=name_str, varchar_len=frappe.db.VARCHAR_LEN,
 				engine=self.meta.get("engine") or 'InnoDB') % (self.table_name, add_text))
 
 	def alter(self):
+
 		for col in self.columns.values():
 			col.build_for_alter_table(self.current_columns.get(col.fieldname.lower()))
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -293,6 +293,10 @@ class PostgresDatabase(Database):
 	def get_database_list(self, target):
 		return [d[0] for d in self.sql("SELECT datname FROM pg_database;")]
 
+	def get_last_insert_id(self):
+		return frappe.db.sql("SELECT LASTVAL() as name;", as_dict=1)[0].name
+
+
 def modify_query(query):
 	""""Modifies query according to the requirements of postgres"""
 	# replace ` with " for definitions

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -7,6 +7,10 @@ class PostgresTable(DBTable):
 	def create(self):
 		add_text = ''
 
+		name_str = "name varchar({varchar_len}) not null primary key,".format(varchar_len=frappe.db.VARCHAR_LEN)
+		if self.meta.autoname and self.meta.autoname == "autoincrement":
+			name_str = "name SERIAL not null primary key,"
+
 		# columns
 		column_defs = self.get_column_definitions()
 		if column_defs: add_text += ',\n'.join(column_defs)
@@ -16,7 +20,7 @@ class PostgresTable(DBTable):
 		# TODO: set docstatus length
 		# create table
 		frappe.db.sql("""create table `%s` (
-			name varchar({varchar_len}) not null primary key,
+			{name_str}
 			creation timestamp(6),
 			modified timestamp(6),
 			modified_by varchar({varchar_len}),
@@ -26,7 +30,7 @@ class PostgresTable(DBTable):
 			parentfield varchar({varchar_len}),
 			parenttype varchar({varchar_len}),
 			idx bigint not null default '0',
-			%s)""".format(varchar_len=frappe.db.VARCHAR_LEN) % (self.table_name, add_text))
+			%s)""".format(name_str=name_str, varchar_len=frappe.db.VARCHAR_LEN) % (self.table_name, add_text))
 
 		frappe.db.commit()
 

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -335,5 +335,3 @@ def add_column(doctype, column_name, fieldtype, precision=None):
 	frappe.db.commit()
 	frappe.db.sql("alter table `tab%s` add column %s %s" % (doctype,
 		column_name, get_definition(fieldtype, precision)))
-
-

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -311,7 +311,7 @@ class BaseDocument(object):
 					values = ", ".join(["%s"] * len(columns))
 				), list(d.values()))
 			if self.meta.autoname == "autoincrement":
-				self.name = frappe.db.sql("SELECT last_insert_id() as name;", as_dict=1)[0].name
+				self.name = frappe.db.get_last_insert_id()
 		except Exception as e:
 			if frappe.db.is_primary_key_violation(e):
 				if self.meta.autoname=="hash":

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -302,8 +302,15 @@ class BaseDocument(object):
 
 		d = self.get_valid_dict(convert_dates_to_str=True)
 
-		columns = list(d)
 		try:
+			# For Postgres, autoincrement name column with NOT NULL constraint
+			# requires the value to be either DEFAULT or that the column should be omitted
+
+			# Omit name column from column list
+			if not self.name and frappe.conf.db_type == 'postgres':
+				d.pop("name", None)
+
+			columns = list(d)
 			frappe.db.sql("""INSERT INTO `tab{doctype}` ({columns})
 					VALUES ({values})""".format(
 					doctype = self.doctype,

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -317,8 +317,8 @@ class BaseDocument(object):
 				if self.meta.autoname=="hash":
 					# hash collision? try again
 					self.name = None
-					return self.db_insert()
-					# return
+					self.db_insert()
+					return
 
 				frappe.msgprint(_("Duplicate name {0} {1}").format(self.doctype, self.name))
 				raise frappe.DuplicateEntryError(self.doctype, self.name, e)
@@ -331,7 +331,6 @@ class BaseDocument(object):
 				raise
 
 		self.set("__islocal", False)
-		return self
 
 	def db_update(self):
 		if self.get("__islocal") or not self.name:

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -126,7 +126,7 @@ def update_naming_series(doc):
 			and getattr(doc, "naming_series", None):
 			revert_series_if_last(doc.naming_series, doc.name)
 
-		elif doc.meta.autoname.split(":")[0] not in ("Prompt", "field", "hash"):
+		elif doc.meta.autoname.split(":")[0] not in ("Prompt", "field", "hash", "autoincrement"):
 			revert_series_if_last(doc.meta.autoname, doc.name)
 
 def delete_from_table(doctype, name, ignore_doctypes, doc):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -237,6 +237,8 @@ class Document(BaseDocument):
 
 		# children
 		for d in self.get_all_children():
+			d.parent = self.name
+			d.parenttype = self.doctype
 			d.db_insert()
 
 		self.run_method("after_insert")
@@ -763,10 +765,7 @@ class Document(BaseDocument):
 			value = self.get(df.fieldname)
 			if isinstance(value, list):
 				ret.extend(value)
-			if ret and self.meta.autoname == "autoincrement":
-				for row in ret:
-					row.parent = self.name
-					row.parenttype = self.doctype
+
 		return ret
 
 	def run_method(self, method, *args, **kwargs):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -763,6 +763,10 @@ class Document(BaseDocument):
 			value = self.get(df.fieldname)
 			if isinstance(value, list):
 				ret.extend(value)
+			if ret and self.meta.autoname == "autoincrement":
+				for row in ret:
+					row.parent = self.name
+					row.parenttype = self.doctype
 		return ret
 
 	def run_method(self, method, *args, **kwargs):

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -250,6 +250,10 @@ def append_number_if_name_exists(doctype, value, fieldname='name', separator='-'
 
 
 def _set_amended_name(doc):
+
+	if frappe.get_meta(doc.doctype).autoname == "autoincrement":
+		return None
+
 	am_id = 1
 	am_prefix = doc.amended_from
 	if frappe.db.get_value(doc.doctype, doc.amended_from, "amended_from"):

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -48,7 +48,7 @@ def set_new_name(doc):
 		frappe.throw(_("{0} is required").format(doc.meta.get_label(fieldname)))
 
 	# at this point, we fall back to name generation with the hash option
-	if not doc.name or autoname == 'hash':
+	if (not doc.name and autoname != "autoincrement" ) or autoname == 'hash':
 		doc.name = make_autoname('hash', doc.doctype)
 
 	doc.name = validate_name(
@@ -75,6 +75,8 @@ def set_name_from_naming_options(autoname, doc):
 		doc.name = _format_autoname(autoname, doc)
 	elif '#' in autoname:
 		doc.name = make_autoname(autoname, doc=doc)
+	elif _autoname.startswith('autoincrement'):
+		doc.name = None
 
 def set_name_by_naming_series(doc):
 	"""Sets name by the `naming_series` property"""
@@ -196,6 +198,8 @@ def get_default_naming_series(doctype):
 
 
 def validate_name(doctype, name, case=None, merge=False):
+	if not name and frappe.get_meta(doctype).autoname == "autoincrement":
+		return
 	if not name:
 		return 'No Name Specified for %s' % doctype
 	if name.startswith('New '+doctype):

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -373,7 +373,10 @@ frappe.views.BaseList = class BaseList {
 	prepare_data(r) {
 		let data = r.message || {};
 		data = !Array.isArray(data) ? frappe.utils.dict(data.keys, data.values) : data;
-
+		data = data.map(doc => {
+			doc.name = cstr(doc.name)
+			return doc
+		})
 		if (this.start === 0) {
 			this.data = data;
 		} else {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -625,7 +625,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return this.settings.get_form_link(doc);
 		}
 
-		const docname = doc.name.match(/[%'"]/)
+		const docname = cstr(doc.name).match(/[%'"]/)
 			? encodeURIComponent(doc.name)
 			: doc.name;
 
@@ -636,7 +636,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		let user = frappe.session.user;
 		let subject_field = this.columns[0].df;
 		let value = doc[subject_field.fieldname] || doc.name;
-		let subject = strip_html(value);
+		let subject = strip_html(cstr(value));
 		let escaped_subject = frappe.utils.escape_html(subject);
 
 		const liked_by = JSON.parse(doc._liked_by || '[]');

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -836,6 +836,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						// this doc was changed and should not be visible
 						// in the listview according to filters applied
 						// let's remove it manually
+						this.data = this.data.map(doc => {
+							doc.name = cstr(doc.name)
+							return doc
+						})
 						this.data = this.data.filter(d => d.name !== name);
 						this.render();
 						return;

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -10,7 +10,7 @@ import os
 import time
 import redis
 from io import FileIO
-from frappe.utils import get_site_path
+from frappe.utils import get_site_path, cstr
 from frappe import conf
 
 END_LINE = '<!-- frappe: end-file -->'
@@ -188,7 +188,7 @@ def get_user_info(sid):
 	}
 
 def get_doc_room(doctype, docname):
-	return ''.join([frappe.local.site, ':doc:', doctype, '/', docname])
+	return ''.join([frappe.local.site, ':doc:', doctype, '/', cstr(docname)])
 
 def get_user_room(user):
 	return ''.join([frappe.local.site, ':user:', user])


### PR DESCRIPTION
Autoincrement, is a new feature which allow user to configure doctype to have auto increment numbering. This helps in performance for doctypes which does not need sequencing, best suit can be
1. child table
2. error log
3. email queue
etc.

It uses database auto increment feature to set the name.

what is done
1. create new doctype with autoincrement.
2. curd operation

what is pending.
1. add code to migrate old data.

Performance improvement:
3 times faster then naming series.

Test details:
Created a simple doctype student with 4 attributes
Name, Age, Gender and Standard.

created a Jmeter script with 200 User and each post 5 request.
![config](https://user-images.githubusercontent.com/13943539/47613086-1ec21280-daae-11e8-9b63-8a814713f47b.png)

Naming Series result:
![naming series](https://user-images.githubusercontent.com/13943539/47613084-19fd5e80-daae-11e8-94b9-63a7e211d84c.png)

Autoincrement result:
![auto](https://user-images.githubusercontent.com/13943539/47613097-40bb9500-daae-11e8-95d8-8b6201b18608.png)
 

