### PR TITLE
Increase search results limit

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -357,7 +357,7 @@ frappe.search.SearchDialog = Class.extend({
 			no_results_status: (keyword) => __("<p>No results found for '" + keyword + "' in Global Search</p>"),
 
 			get_results: function(keywords, callback) {
-				var start = 0, limit = 100;
+				var start = 0, limit = 1000;
 				var results = frappe.search.utils.get_nav_results(keywords);
 				frappe.search.utils.get_global_results(keywords, start, limit)
 					.then(function(global_results) {


### PR DESCRIPTION
Reported on support.

Suppose a user is searching for some customer named 'Test Customer', the search result shows all the documents having the given text 'Test Customer' from `__globalsearch` but as it is limited to only 100 results, it fails to display the Customer master.