### PR TITLE
fix: Dont refresh list if filters are being edited

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -659,6 +659,12 @@ class FilterArea {
 			on_change: () => this.refresh_list_view()
 		});
 	}
+
+	is_being_edited() {
+		// returns true if user is currently editing filters
+		return this.filter_list &&
+			this.filter_list.wrapper.find('.filter-box:visible').length > 0;
+	}
 }
 
 // utility function to validate view modes

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -784,6 +784,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	setup_realtime_updates() {
 		frappe.realtime.on('list_update', data => {
+			if (this.filter_area.is_being_edited()) {
+				return;
+			}
+
 			const { doctype, name } = data;
 			if (doctype !== this.doctype) return;
 


### PR DESCRIPTION
If you were in the middle of adding or editing filters, the list would refresh if there is an update event triggered by the server. Now, we prevent this behaviour for better UX.

![list-filters-ux](https://user-images.githubusercontent.com/9355208/47717746-9a69be00-dc6c-11e8-964c-76b9f0546f55.gif)
