### PR TITLE
fix(filters): dont validate email in filters

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -85,6 +85,9 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 		return val==null ? "" : val;
 	},
 	validate: function(v) {
+		if(this.df.is_filter) {
+			return v;
+		}
 		if(this.df.options == 'Phone') {
 			if(v+''=='') {
 				return '';

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -162,7 +162,9 @@ frappe.ui.Filter = class {
 		let df = copy_dict(original_docfield);
 
 		// filter field shouldn't be read only or hidden
-		df.read_only = 0; df.hidden = 0;
+		df.read_only = 0;
+		df.hidden = 0;
+		df.is_filter = true;
 
 		let c = condition ? condition : this.utils.get_default_condition(df);
 		this.set_condition(c);

--- a/frappe/templates/includes/list/filters.js
+++ b/frappe/templates/includes/list/filters.js
@@ -20,6 +20,7 @@ function setup_list_filters() {
 					fieldtype: df.fieldtype,
 					label: df.label,
 					options: df.options,
+					is_filter: true,
 					change: (e) => {
 						const query_params = Object.assign(frappe.utils.get_query_params(), {
 							[df.fieldname]: f.get_value()


### PR DESCRIPTION
Added a flag `is_filter` in control definition and skipped validation if this flag is true