### PR TITLE
Fix conditional statement

### DIFF
--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -28,7 +28,7 @@ def two_factor_is_enabled(user=None):
 	enabled = int(frappe.db.get_value('System Settings', None, 'enable_two_factor_auth') or 0)
 	if enabled:
 		bypass_two_factor_auth = int(frappe.db.get_value('System Settings', None, 'bypass_2fa_for_retricted_ip_users') or 0)
-		if bypass_two_factor_auth:
+		if bypass_two_factor_auth and user:
 			user_doc = frappe.get_doc("User", user)
 			restrict_ip_list = user_doc.get_restricted_ip_list() #can be None or one or more than one ip address
 			if restrict_ip_list:


### PR DESCRIPTION
In our systems after setting up the two factor the following error occur:
```
Title
frappe.twofactor.delete_all_barcodes_for_users
Error
{'retry': 0, 'log': <function log at 0x7f5119429398>, 'site': u'erp.eso-electronic.com', 'event': u'all', 'method_name': u'frappe.twofactor.delete_all_barcodes_for_users', 'method': <function delete_all_barcodes_for_users at 0x7f51193f6d70>, 'user': u'Administrator', 'kwargs': {}, 'async': True, 'job_name': u'frappe.twofactor.delete_all_barcodes_for_users'}
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 98, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/twofactor.py", line 376, in delete_all_barcodes_for_users
    if not two_factor_is_enabled():
  File "/home/frappe/frappe-bench/apps/frappe/frappe/twofactor.py", line 32, in two_factor_is_enabled
    user_doc = frappe.get_doc("User", user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 666, in get_doc
    return frappe.model.document.get_doc(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 69, in get_doc
    return controller(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 104, in __init__
    self.load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 141, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 338, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 324, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 297, in _raise_exception
    raise raise_exception(msg)
DoesNotExistError: User None not found
```

This is because `two_factor_is_enabled` function has as default argument `User=None`.
As a result 
```
	enabled = int(frappe.db.get_value('System Settings', None, 'enable_two_factor_auth') or 0)
	if enabled:
		bypass_two_factor_auth = int(frappe.db.get_value('System Settings', None, 'bypass_2fa_for_retricted_ip_users') or 0)
		if bypass_two_factor_auth:
                       ---> True with User None , next line breaks
                   	user_doc = frappe.get_doc("User", user)

``
