### PR TITLE
[Enhance] Duplicate row below a selected row in grid Table

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -470,7 +470,9 @@ export default class Grid {
 		if(this.is_editable()) {
 			if(this.frm) {
 				var d = frappe.model.add_child(this.frm.doc, this.df.options, this.df.fieldname, idx);
-				d = this.duplicate_row(d, copy_doc);
+				if(copy_doc) {
+					d = this.duplicate_row(d, copy_doc);
+				}
 				d.__unedited = true;
 				this.frm.script_manager.trigger(this.df.fieldname + "_add", d.doctype, d.name);
 				this.refresh();
@@ -498,14 +500,12 @@ export default class Grid {
 	}
 
 	duplicate_row(d, copy_doc) {
-		if(copy_doc) {
-			$.each(copy_doc, function(key, value) {
-				if(!["creation", "modified", "modified_by", "idx", "owner",
-					"parent", "doctype", "name", "parentield"].includes(key)) {
-					d[key] = value;
-				}
-			});
-		}
+		$.each(copy_doc, function(key, value) {
+			if(!["creation", "modified", "modified_by", "idx", "owner",
+				"parent", "doctype", "name", "parentield"].includes(key)) {
+				d[key] = value;
+			}
+		});
 
 		return d;
 	}

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -466,10 +466,11 @@ export default class Grid {
 			this.grid_rows_by_docname[doc.name].refresh_field(fieldname, value);
 		}
 	}
-	add_new_row(idx, callback, show) {
+	add_new_row(idx, callback, show, copy_doc) {
 		if(this.is_editable()) {
 			if(this.frm) {
 				var d = frappe.model.add_child(this.frm.doc, this.df.options, this.df.fieldname, idx);
+				d = this.duplicate_row(d, copy_doc);
 				d.__unedited = true;
 				this.frm.script_manager.trigger(this.df.fieldname + "_add", d.doctype, d.name);
 				this.refresh();
@@ -494,6 +495,19 @@ export default class Grid {
 
 			return d;
 		}
+	}
+
+	duplicate_row(d, copy_doc) {
+		if(copy_doc) {
+			$.each(copy_doc, function(key, value) {
+				if(!["creation", "modified", "modified_by", "idx", "owner",
+					"parent", "doctype", "name", "parentield"].includes(key)) {
+					d[key] = value;
+				}
+			});
+		}
+
+		return d;
 	}
 
 	set_focus_on_row(idx) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -111,11 +111,12 @@ export default class GridRow {
 			}
 		}
 	}
-	insert(show, below) {
+	insert(show, below, duplicate) {
 		var idx = this.doc.idx;
+		var copy_doc = duplicate ? this.doc : null;
 		if(below) idx ++;
 		this.toggle_view(false);
-		this.grid.add_new_row(idx, null, show);
+		this.grid.add_new_row(idx, null, show, copy_doc);
 	}
 	refresh() {
 		if(this.frm && this.doc) {

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -50,6 +50,12 @@ export default class GridRowForm {
 					<button class="btn btn-default btn-xs pull-right grid-insert-row-below hidden-xs"
 						style="margin-left: 7px;">
 						${ __("Insert Below") }</button>
+					<button class="btn btn-default btn-xs pull-right grid-duplicate-row hidden-xs"
+						style="margin-left: 7px;">
+						${ __("Duplicate Above") }</button>
+					<button class="btn btn-default btn-xs pull-right grid-duplicate-row-below hidden-xs"
+						style="margin-left: 7px;">
+						${ __("Duplicate Below") }</button>
 					<button class="btn btn-danger btn-xs pull-right grid-delete-row">
 						<i class="octicon octicon-trashcan"
 							style="padding-bottom: 2px; margin-top: 1px;"></i>
@@ -88,6 +94,14 @@ export default class GridRowForm {
 		this.wrapper.find(".grid-insert-row-below")
 			.on('click', function() {
 				me.row.insert(true, true); return false;
+			});
+		this.wrapper.find(".grid-duplicate-row")
+			.on('click', function() {
+				me.row.insert(true, false, true); return false;
+			});
+		this.wrapper.find(".grid-duplicate-row-below")
+			.on('click', function() {
+				me.row.insert(true, true, true); return false;
 			});
 		this.wrapper.find(".grid-append-row")
 			.on('click', function() {

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -52,10 +52,7 @@ export default class GridRowForm {
 						${ __("Insert Below") }</button>
 					<button class="btn btn-default btn-xs pull-right grid-duplicate-row hidden-xs"
 						style="margin-left: 7px;">
-						${ __("Duplicate Above") }</button>
-					<button class="btn btn-default btn-xs pull-right grid-duplicate-row-below hidden-xs"
-						style="margin-left: 7px;">
-						${ __("Duplicate Below") }</button>
+						${ __("Duplicate") }</button>
 					<button class="btn btn-danger btn-xs pull-right grid-delete-row">
 						<i class="octicon octicon-trashcan"
 							style="padding-bottom: 2px; margin-top: 1px;"></i>
@@ -96,10 +93,6 @@ export default class GridRowForm {
 				me.row.insert(true, true); return false;
 			});
 		this.wrapper.find(".grid-duplicate-row")
-			.on('click', function() {
-				me.row.insert(true, false, true); return false;
-			});
-		this.wrapper.find(".grid-duplicate-row-below")
 			.on('click', function() {
 				me.row.insert(true, true, true); return false;
 			});


### PR DESCRIPTION
![duplicate-rows](https://user-images.githubusercontent.com/11695402/47851577-0f6cfd00-ddff-11e8-887e-453d41803319.gif)

### Updated
![image](https://user-images.githubusercontent.com/11695402/47852183-f6654b80-de00-11e8-9e30-aaade20e9ad2.png)


- Just like `Insert Above` & `Insert Below`, `Duplicate Above` & `Duplicate Below` button added.
- `add_new_row` function of grid takes additional parameter i.e., doc object of currently selected row, and iterates through it to copy value to new row being inserted.
- control shifts to newly created row.
- initially had 2 buttons to add duplicate row above or below, later someone pointed it out that we can already drag rows up or down - so makes sense keep 1 button ( `Duplicate` as seen in the screenshot ) to duplicate row and add it below the selected row which can then be dragged to desired location easily as such.