### PR TITLE
fix(Quill): Add data-row attr to whitelist

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -158,7 +158,7 @@ acceptable_attributes = [
 	'step', 'style', 'summary', 'suppress', 'tabindex', 'target',
 	'template', 'title', 'toppadding', 'type', 'unselectable', 'usemap',
 	'urn', 'valign', 'value', 'variable', 'volume', 'vspace', 'vrml',
-	'width', 'wrap', 'xml:lang'
+	'width', 'wrap', 'xml:lang', 'data-row'
 ]
 
 mathml_attributes = [


### PR DESCRIPTION
- data-row attribute is added by Quill for retaining table structure


