### PR TITLE
Fix reroute bug

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -116,7 +116,7 @@ frappe.get_raw_route_str = function(route) {
 }
 
 frappe.get_route_str = function(route) {
-	var rawRoute = frappe.get_raw_route_str()
+	var rawRoute = frappe.get_raw_route_str(route);
 	route = $.map(rawRoute.split('/'), frappe._decode_str).join('/');
 
 	return route;


### PR DESCRIPTION
Before, 'window.history.back()' was getting executed for all reroutes,
instead of rerouting to the route specified by
frappe.re_route[window.location.hash].

This fix causes 'window.history.back()' to only execute for the special
case where a document is renamed and then the back button is pressed
(as intended). All other reroutes will forward to the appropriate route
specified in frappe.re_route.