### PR TITLE
Fix permission error while import

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -320,7 +320,7 @@ class Meta(Document):
 
 	def set_custom_permissions(self):
 		'''Reset `permissions` with Custom DocPerm if exists'''
-		if frappe.flags.in_patch or frappe.flags.in_import or frappe.flags.in_install:
+		if frappe.flags.in_patch or frappe.flags.in_install:
 			return
 
 		if not self.istable and self.name not in ('DocType', 'DocField', 'DocPerm',


### PR DESCRIPTION
Custom permission should apply while import
or else import of doctype with custom roles fails
