### PR TITLE
Bredcrumb issue in the file

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -38,9 +38,10 @@ class File(NestedSet):
 		self.set_folder_name()
 
 	def get_name_based_on_parent_folder(self):
-		path = get_breadcrumbs(self.folder)
-		folder_name = frappe.get_value("File", self.folder, "file_name")
-		return "/".join([d.file_name for d in path] + [folder_name, self.file_name])
+		if self.folder:
+			path = get_breadcrumbs(self.folder)
+			folder_name = frappe.get_value("File", self.folder, "file_name")
+			return "/".join([d.file_name for d in path] + [folder_name, self.file_name])
 
 	def autoname(self):
 		"""Set name for folder"""


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
TypeError: get_breadcrumbs() takes exactly 1 argument (0 given)
```