### PR TITLE
Fix #6341

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -289,16 +289,15 @@ class DocType(Document):
 		clear_linked_doctype_cache()
 
 	def delete_duplicate_custom_fields(self):
-		if not (frappe.db.table_exists(self.name) and frappe.db.table_exists("Custom Field")):
-			return
-
-		fields = [d.fieldname for d in self.fields if d.fieldtype in data_fieldtypes]
-
-		frappe.db.sql('''delete from
-				`tabCustom Field`
-			where
-				 dt = {0} and fieldname in ({1})
-		'''.format('%s', ', '.join(['%s'] * len(fields))), tuple([self.name] + fields), as_dict=True)
+                if not (frappe.db.table_exists(self.name) and frappe.db.table_exists("Custom Field")):
+                        return
+                fields = [d.fieldname for d in self.fields if d.fieldtype in type_map]
+                if len(fields) < 0:
+                        frappe.db.sql('''delete from
+                                        `tabCustom Field`
+                                where
+                                         dt = {0} and fieldname in ({1})
+                        '''.format('%s', ', '.join(['%s'] * len(fields))), tuple([self.name] + fields), as_dict=True)
 
 	def sync_global_search(self):
 		'''If global search settings are changed, rebuild search properties for this table'''

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -15,7 +15,7 @@ from frappe.model.document import Document
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.desk.notifications import delete_notification_count_for
 from frappe.modules import make_boilerplate, get_doc_path
-from frappe.database.schema import validate_column_name, validate_column_length
+from frappe.database.schema import validate_column_name, validate_column_length, type_map
 from frappe.model.docfield import supports_translation
 import frappe.website.render
 


### PR DESCRIPTION
Fixes #6341 where in rare cases, `delete_duplicate_custom_fields()` throws a ProgrammingError when it's trying to populate with empty custom fields, and trying to find and delete duplicates.