### PR TITLE
Allow Selecting Page Orientation for Report Print View

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -299,17 +299,13 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head) {
 		depends_on: "with_letter_head",
 		options: $.map(frappe.boot.letter_heads, function (i, d) { return d }),
 		default: letter_head || default_letter_head
+	}, {
+		fieldtype: "Select",
+		fieldname: "orientation",
+		label: __("Orientation"),
+		options: "Landscape\nPortrait",
+		default: "Landscape"
 	}];
-
-	if (pdf) {
-		columns.push({
-			fieldtype: "Select",
-			fieldname: "orientation",
-			label: __("Orientation"),
-			options: "Landscape\nPortrait",
-			default: "Landscape"
-		})
-	}
 
 	frappe.prompt(columns, function (data) {
 		var data = $.extend(print_settings, data);

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -664,12 +664,14 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	print_report(print_settings) {
 		const custom_format = this.report_settings.html_format || null;
 		const filters_html = this.get_filters_html_for_print();
+		const landscape = print_settings.orientation == 'Landscape';
 
 		frappe.render_grid({
 			template: custom_format,
 			title: __(this.report_name),
 			subtitle: filters_html,
 			print_settings: print_settings,
+			landscape: landscape,
 			filters: this.get_filter_values(),
 			data: custom_format ? this.data : this.get_data_for_print(),
 			columns: custom_format ? this.columns : this.get_columns_for_print(),

--- a/frappe/public/js/lib/microtemplate.js
+++ b/frappe/public/js/lib/microtemplate.js
@@ -96,10 +96,12 @@ frappe.render_grid = function(opts) {
 	}
 
 	// show landscape view if columns more than 10
-	if (opts.columns && opts.columns.length > 10) {
-		opts.landscape = true;
-	} else {
-		opts.landscape = false;
+	if (opts.landscape == null) {
+		if(opts.columns && opts.columns.length > 10) {
+			opts.landscape = true;
+		} else {
+			opts.landscape = false;
+		}
 	}
 
 	// render content


### PR DESCRIPTION
This pull request allows the user to select the orientation when printing reports. For some reason this feature was there but not allowed to the user

**Print options dialog window:**
![image](https://user-images.githubusercontent.com/328330/47950909-6dbeea80-df7b-11e8-9cf9-009a0ff7d554.png)

**General Ledger report in portrait mode:**
![portraitreport](https://user-images.githubusercontent.com/328330/47950941-e160f780-df7b-11e8-91d7-0f537b9f89fe.png)
