### PR TITLE
Disable smart shrinking for wkhtmltopdf and more options readable from template

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -62,6 +62,7 @@ def prepare_options(html, options):
 		'background': None,
 		'images': None,
 		'quiet': None,
+		'disable-smart-shrinking': None,
 		# 'no-outline': None,
 		'encoding': "UTF-8",
 		#'load-error-handling': 'ignore',
@@ -93,7 +94,10 @@ def read_options_from_html(html):
 	toggle_visible_pdf(soup)
 
 	# use regex instead of soup-parser
-	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size", "header-spacing"):
+	for attr in [
+		"margin-top", "margin-bottom", "margin-left", "margin-right", "header-spacing",
+		"page-size", "page-width", "page-height", "orientation"
+	]:
 		try:
 			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
 			match = pattern.findall(html)


### PR DESCRIPTION
I noticed that font size produced in PDF is smaller than it is in HTML. I found this link which fixed this problem: https://stackoverflow.com/questions/40478343/page-size-in-pdf-generated-by-wkhtmltopdf-is-25-smaller-than-expected/40478446

I installed wkhtmltopdf 0.12.5 from their debian package from https://wkhtmltopdf.org/downloads.html

Additionally I included some more page options that can be parsed from the template.