### PR TITLE
fix(email): Email status changes to Read

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -276,10 +276,7 @@ def get_unsubscribe_message(unsubscribe_message, expose_recipients):
 			target="_blank">{0}</a>'''.format(_('Unsubscribe'))
 		unsubscribe_html = _("{0} to stop receiving emails of this type").format(unsubscribe_link)
 
-	html = """<div class="email-pixel">
-			<!--email open check-->
-		</div>
-		<div class="email-unsubscribe">
+	html = """<div class="email-unsubscribe">
 			<!--cc message-->
 			<div>
 				{0}

--- a/frappe/public/js/frappe/form/footer/timeline_item.html
+++ b/frappe/public/js/frappe/form/footer/timeline_item.html
@@ -67,7 +67,7 @@
 									var indicator_class = "green";
 								} else if (data.delivery_status === "Sending") {
 									var indicator_class = "orange";
-								} else if (in_list("Opened", "Read", data.delivery_status)) {
+								} else if (in_list(["Opened", "Read"], data.delivery_status)) {
 									var indicator_class = "blue";
 								} else {
 									var indicator_class = "red";

--- a/frappe/templates/emails/email_footer.html
+++ b/frappe/templates/emails/email_footer.html
@@ -17,6 +17,10 @@
 
 	<!--unsubscribe link here-->
 
+	<div class="email-pixel">
+		<!--email open check-->
+	</div>
+
 	<!-- default_mail_footer -->
 	{% if default_mail_footer %}
 	<div class="default-mail-footer">


### PR DESCRIPTION
The email recieved template was in unsubscribe email. Hence it
didn't used to function in case the emails were sent from DocTypes
like Issue, wherein the unsubscribe email template is not used.
Moved it to email_footer template.
