### PR TITLE
fix(Quill): Add all quill attributes that are required to render it

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -158,7 +158,9 @@ acceptable_attributes = [
 	'step', 'style', 'summary', 'suppress', 'tabindex', 'target',
 	'template', 'title', 'toppadding', 'type', 'unselectable', 'usemap',
 	'urn', 'valign', 'value', 'variable', 'volume', 'vspace', 'vrml',
-	'width', 'wrap', 'xml:lang', 'data-row'
+	'width', 'wrap', 'xml:lang', 'data-row', 'data-list', 'data-language',
+	'data-value', 'role', 'frameborder', 'allowfullscreen', 'spellcheck',
+	'data-mode', 'data-gramm', 'data-placeholder'
 ]
 
 mathml_attributes = [


### PR DESCRIPTION
Quill attaches some data attributes on it's content, which is required for proper rendering. The server side is very strict in cleaning out html, so the attributes have to be added to the whitelist.