### PR TITLE
[Fix] User listview is not working becaause full name field is hidden

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -1,5 +1,6 @@
 {
  "allow_copy": 0, 
+ "allow_events_in_timeline": 0, 
  "allow_guest_to_view": 0, 
  "allow_import": 1, 
  "allow_rename": 1, 
@@ -252,7 +253,7 @@
    "columns": 0, 
    "fieldname": "full_name", 
    "fieldtype": "Data", 
-   "hidden": 1, 
+   "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
    "in_filter": 0, 
@@ -266,7 +267,7 @@
    "precision": "", 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
-   "read_only": 0, 
+   "read_only": 1, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
    "reqd": 0, 
@@ -2206,7 +2207,7 @@
  "istable": 0, 
  "max_attachments": 5, 
  "menu_index": 0, 
- "modified": "2018-09-28 16:34:06.215199", 
+ "modified": "2018-11-06 12:41:33.864058", 
  "modified_by": "Administrator", 
  "module": "Core", 
  "name": "User", 
@@ -2259,5 +2260,6 @@
  "sort_order": "DESC", 
  "title_field": "full_name", 
  "track_changes": 1, 
- "track_seen": 0
+ "track_seen": 0, 
+ "track_views": 0
 }


### PR DESCRIPTION
User has set the filter on the standard field Full Name and later on he refreshed the page and getting below error.
![screen shot 2018-11-06 at 11 48 25 am](https://user-images.githubusercontent.com/8780500/48048561-ed3dfb00-e1c1-11e8-96ed-571a8c4e490f.png)


Recently we have added the feature that if field is hidden then it will not added in the filter, so to fix this issue I have disabled hidden property for the field Full Name and enabled read only property

**After fix**
![image](https://user-images.githubusercontent.com/8780500/48048607-13fc3180-e1c2-11e8-83b3-a1215bfe46ac.png)
