### PR TITLE
Symlink node_modules in app public

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -77,13 +77,15 @@ def make_asset_dirs(make_copy=False, restore=False):
 		if not os.path.exists(dir_path):
 			os.makedirs(dir_path)
 
-	# symlink app/public > assets/app
 	for app_name in frappe.get_all_apps(True):
 		pymodule = frappe.get_module(app_name)
 		app_base_path = os.path.abspath(os.path.dirname(pymodule.__file__))
 
 		symlinks = []
+		# app/public > assets/app
 		symlinks.append([os.path.join(app_base_path, 'public'), os.path.join(assets_path, app_name)])
+		# app/node_modules > assets/app/node_modules
+		symlinks.append([os.path.join(app_base_path, '..', 'node_modules'), os.path.join(assets_path, app_name, 'node_modules')])
 
 		app_doc_path = None
 		if os.path.isdir(os.path.join(app_base_path, 'docs')):

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -65,9 +65,9 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 
 	load_lib() {
 		if (frappe.boot.developer_mode) {
-			this.root_lib_path = '/assets/frappe/js/lib/ace-builds/src-noconflict/';
+			this.root_lib_path = '/assets/frappe/node_modules/ace-builds/src-noconflict/';
 		} else {
-			this.root_lib_path = '/assets/frappe/js/lib/ace-builds/src-min-noconflict/';
+			this.root_lib_path = '/assets/frappe/node_modules/ace-builds/src-min-noconflict/';
 		}
 
 		this.library_loaded = new Promise(resolve => {


### PR DESCRIPTION
Ace Editor loads assets incrementally as required, so the whole `ace-builds` folder need to be exposed via the web server. Better to use the `node_modules` directory instead of copying it to the libs folder. The files doesn't need to be checked into `git` too. We can use other libraries on demand with this structure.