### PR TITLE
fix: Email Reply Chain

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -16,6 +16,24 @@ Table.create = (value) => {
 }
 Quill.register(Table, true);
 
+// hidden blot
+const Block = Quill.import('blots/block');
+class HiddenBlock extends Block {
+	static create(value) {
+		const node = super.create(value);
+		node.setAttribute('data-comment', value);
+		node.classList.add('hidden');
+		return node;
+	}
+
+	static formats(node) {
+		return node.getAttribute('data-comment');
+	}
+}
+HiddenBlock.blotName = 'hiddenblot';
+HiddenBlock.tagName = 'DIV';
+Quill.register(HiddenBlock, true);
+
 // image uploader
 const Uploader = Quill.import('modules/uploader');
 Uploader.DEFAULTS.mimetypes.push('image/gif');

--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -336,7 +336,7 @@ frappe.ui.form.Timeline = class Timeline {
 			});
 		} else {
 			if(c.communication_type=="Communication" && c.communication_medium=="Email") {
-				c.content = c.content.split("<!-- original-reply -->")[0];
+				c.content = c.content.split('<div data-comment="original-reply">')[0];
 				c.content = frappe.utils.strip_original_content(c.content);
 
 				c.original_content = c.content;

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -657,7 +657,7 @@ frappe.views.CommunicationComposer = Class.extend({
 			var communication_date = last_email.communication_date || last_email.creation;
 			content = '<div><br></div>'
 				+ reply
-				+ "<br><!-- original-reply --><br>"
+				+ "<div data-comment='original-reply'></div>"
 				+ '<blockquote>' +
 					'<p>' + __("On {0}, {1} wrote:",
 					[frappe.datetime.global_date_format(communication_date) , last_email.sender]) + '</p>' +

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -160,7 +160,7 @@ acceptable_attributes = [
 	'urn', 'valign', 'value', 'variable', 'volume', 'vspace', 'vrml',
 	'width', 'wrap', 'xml:lang', 'data-row', 'data-list', 'data-language',
 	'data-value', 'role', 'frameborder', 'allowfullscreen', 'spellcheck',
-	'data-mode', 'data-gramm', 'data-placeholder'
+	'data-mode', 'data-gramm', 'data-placeholder', 'data-comment'
 ]
 
 mathml_attributes = [


### PR DESCRIPTION
Previous email is appended to the next reply, but was not rendered by splitting it with a hardcoded comment string. Since Quill does not support comments, created a new HiddenBlock for it.

![email-reply-chain](https://user-images.githubusercontent.com/9355208/48117751-280e6480-e290-11e8-8f91-784db4ebfe0e.gif)
