### PR TITLE
Use full-width container for desk [desk-sidebar] [2018-code-sprint]

### DIFF
--- a/frappe/core/page/desktop/desktop_list_view.html
+++ b/frappe/core/page/desktop/desktop_list_view.html
@@ -1,4 +1,4 @@
-<div class="container page-body">
+<div class="container-fluid container-margin-10 page-body">
     <div class="row">
         <div class="layout-main-section">
             <div class="page-content desktop-list" style="margin-top: 40px;">

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -1,5 +1,5 @@
 <div class="page-head">
-	<div class="container">
+	<div class="container-fluid container-margin-10">
 		<div class="row">
 			<div class="col-md-7 col-sm-8 col-xs-6 page-title">
 				<!-- title -->
@@ -46,7 +46,7 @@
 		</div>
 	</div>
 </div>
-<div class="container page-body">
+<div class="container-fluid container-margin-10 page-body">
 	<div class="page-toolbar hide">
 		<div class="container">
 		</div>

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -1,5 +1,5 @@
 <div class="navbar navbar-default navbar-fixed-top" role="navigation">
-	<div class="container">
+	<div class="container-fluid container-margin-10">
 		<div class="navbar-header navbar-desk">
 			<a class="navbar-brand toggle-sidebar visible-xs visible-sm">
 				<i class="octicon octicon-three-bars"></i>

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -45,6 +45,13 @@ a[disabled="disabled"] {
 	margin-top: 3px;
 }
 
+@media (min-width: 768px) {
+	.container-margin-10 {
+		margin-right: 10px;
+		margin-left: 10px;
+	}
+}
+
 /* alert */
 
 

--- a/frappe/public/less/desktop.less
+++ b/frappe/public/less/desktop.less
@@ -18,11 +18,6 @@ body[data-route=""] .navbar-default, body[data-route="desktop"] .navbar-default 
 	overflow: auto;
 }
 
-.container-margin-10 {
-	margin-right: 10px;
-	margin-left: 10px;
-}
-
 .case-wrapper {
 	position: relative;
 	margin: 0px;

--- a/frappe/public/less/desktop.less
+++ b/frappe/public/less/desktop.less
@@ -18,6 +18,11 @@ body[data-route=""] .navbar-default, body[data-route="desktop"] .navbar-default 
 	overflow: auto;
 }
 
+.container-margin-10 {
+	margin-right: 10px;
+	margin-left: 10px;
+}
+
 .case-wrapper {
 	position: relative;
 	margin: 0px;
@@ -341,4 +346,3 @@ body[data-route="desktop"] .navbar-set-desktop-icons {
 	}
 
 }
-

--- a/frappe/public/less/mobile.less
+++ b/frappe/public/less/mobile.less
@@ -70,12 +70,11 @@ body {
 		padding: 8px 0px !important;
 	}
 
-	.navbar > .container > .navbar-header {
+	.navbar > .container-fluid > .navbar-header {
 		float: left;
-		width: 80%;
 	}
 
-	.navbar > .container > .navbar-right {
+	.navbar > .container-fluid > .navbar-right {
 		float: right;
 	}
 


### PR DESCRIPTION
This change makes Desk full-width by changing the page wrapper from a
bootstrap 'container' to a 'container-fluid'. Moving from an elastic
layout to a fluid, full-width layout creates a more responsive user
experience that takes advantage of all available screen real estate. The
additional space also provides opportunity for new features and view
elements, such as the Desk Sidebar that @joshreeder, @agritheory, and
myself will be working to get pulled in in the ensuing weeks.

Related issues:
https://github.com/frappe/erpnext/issues/14147
https://github.com/frappe/erpnext/issues/6436

Related discussion:
https://discuss.erpnext.com/t/why-not-use-the-full-width/34746/5
https://discuss.erpnext.com/t/app-erpnext-full-size-view-for-all-e-g-reports-gant-charts-etc/34910

I haven't been able to successfully run the UI tests locally yet. I posted a question about it here: https://discuss.erpnext.com/t/error-when-running-bench-run-ui-tests/42470

Here are some screenshots comparing Desk in a 'container' to Desk in a 'container-fluid':

## Desk (container vs. container-fluid)

### .container
<img width="1391" alt="desktop" src="https://user-images.githubusercontent.com/7940033/48160003-fe573c80-e293-11e8-95a9-92ba53dada79.png">

### .container-fluid
<img width="1391" alt="desktop - fw" src="https://user-images.githubusercontent.com/7940033/48160032-0d3def00-e294-11e8-95a6-03f8e30deefb.png">

## Other pages using a full-width container

### Document page
<img width="1391" alt="document - fw" src="https://user-images.githubusercontent.com/7940033/48160122-46765f00-e294-11e8-92a1-d3e15eb1f813.png">

### List View
<img width="1391" alt="list veiw - fw" src="https://user-images.githubusercontent.com/7940033/48160188-6c036880-e294-11e8-83e0-f63661562972.png">

### Report
<img width="1391" alt="report - fw" src="https://user-images.githubusercontent.com/7940033/48160224-83425600-e294-11e8-9c38-83207efb7d16.png">




