### PR TITLE
removed meta dependency when Link field options is [Select]

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -58,9 +58,7 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 	page_length=10, filters=None, filter_fields=None, as_dict=False):
 	if isinstance(filters, string_types):
 		filters = json.loads(filters)
-
-	meta = frappe.get_meta(doctype)
-
+	
 	if searchfield:
 		sanitize_searchfield(searchfield)
 
@@ -78,6 +76,8 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 		search_widget(doctype, txt, standard_queries[doctype][0],
 			searchfield, start, page_length, filters)
 	else:
+		meta = frappe.get_meta(doctype)
+
 		if query:
 			frappe.throw(_("This query style is discontinued"))
 			# custom query


### PR DESCRIPTION

Removed the dependency of pre-loaded meta  if Link field options are [Select](Even no validation is required), 
It's not required to get doctype meta when user need to call custom query function on using get_query.

Why I did it:
I am try to get the data from two different tables, which only possible through custom get_query  by setting the link field options are to [Select].
Otherwise it's throwing errors:
 >> **"[Select] doctype doesn't exists"**  if option are set to [Select]
>> invalid link while saving the form if options are set to particular doctype(because data is coming from two different doctypes).