### PR TITLE
Revert feature, listView filter shows hidden field

### DIFF
--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -118,7 +118,7 @@ frappe.ui.FieldSelect = Class.extend({
 
 		// child tables
 		$.each(me.table_fields, function(i, table_df) {
-			if(table_df.options && !table_df.hidden) {
+			if(table_df.options) {
 				var child_table_fields = [].concat(frappe.meta.docfield_list[table_df.options]);
 				$.each(frappe.utils.sort(child_table_fields, "label", "string"), function(i, df) {
 					// show fields where user has read access and if report hide flag is not set
@@ -145,7 +145,7 @@ frappe.ui.FieldSelect = Class.extend({
 		}
 
 		if(frappe.model.no_value_type.indexOf(df.fieldtype) == -1 &&
-			!(me.fields_by_name[df.parent] && me.fields_by_name[df.parent][df.fieldname]) && !df.hidden) {
+			!(me.fields_by_name[df.parent] && me.fields_by_name[df.parent][df.fieldname])) {
 			this.options.push({
 				label: label,
 				value: table + "." + df.fieldname,


### PR DESCRIPTION
Because of the feature, user is facing lot of problems. There are many standard fields which we have kept as hidden and through code we used those fields to apply filter on the list. For example in the sales order item prevdoc_docname is the hidden field and we uses this field to keep the quotation reference. Now when user clicks on the sales order link from the quotation's dashboard, system throwing below error
![image](https://user-images.githubusercontent.com/8780500/48249159-1b207b00-e420-11e8-9c07-571b2f3325ea.png)

Same error is coming for the field full_name in the user form.

The feature should be like user should not be able to filter the hidden fields manually from the list view but from the code it should allow 