### PR TITLE
Refactor frappe.db.insert (clientside)

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -80,9 +80,7 @@ frappe.db = {
 		});
 	},
 	insert: function(doc) {
-		return new Promise(resolve => {
-			frappe.call('frappe.client.insert', { doc }, r => resolve(r.message));
-		});
+		return frappe.xcall('frappe.client.insert', { doc });
 	},
 	delete_doc: function(doctype, name) {
 		return new Promise(resolve => {


### PR DESCRIPTION
Previously, fail condition was not handled properly due to which `.catch()` was not working as expected.
Now instead of adding `.fail()` to handle failure condition, use `frappe.xcall` which returns a proper Promise object.
