### PR TITLE
fix(Quill Editor): Set HTML using Quill's API

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -172,7 +172,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 			return;
 		}
 
-		this.quill.root.innerHTML = value;
+		this.quill.clipboard.dangerouslyPasteHTML(value);
 	},
 
 	get_input_value() {


### PR DESCRIPTION
Directly setting the innerHTML worked in cases where the incoming HTML was parsed correctly by Quill's Delta format. If it was not the case, then Quill detects that change as an external change and the doc is set as dirty.

