### PR TITLE
Adding Products Settings for Website in the Website module

### DIFF
--- a/frappe/config/website.py
+++ b/frappe/config/website.py
@@ -86,6 +86,11 @@ def get_data():
 					"type": "doctype",
 					"name": "Portal Settings",
 					"label": _("Portal Settings"),
+				},
+				{
+					"type": "doctype",
+					"name": "Products Settings",
+					"label": _("Products Settings"),
 				}
 			]
 		},


### PR DESCRIPTION
Added the Products Settings DocType (already existing in core Frappe) to the menu for Website Module.
Previously user had to manually enter the name in the Awesome bar.
![ezgif-3-d69c1b0dc4a2](https://user-images.githubusercontent.com/16600935/48283672-c92d2480-e422-11e8-961e-0e91ef9acb27.gif)

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.