### PR TITLE
(fix) data-import: UnicodeEncodeError on data import in python2

### DIFF
--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -76,6 +76,6 @@ def format_value(value, df=None, doc=None, currency=None, translated=False):
 
 	elif df.get("fieldtype") in ("Text", "Small Text"):
 		if not re.search("(\<br|\<div|\<p)", value):
-			return value.replace("\n", "<br>")
+			return frappe.safe_decode(value).replace("\n", "<br>")
 
 	return value

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -290,7 +290,7 @@ def get_formatted_value(value, field):
 
 	if getattr(field, 'fieldtype', None) in ["Text", "Text Editor"]:
 		h = HTMLParser()
-		value = h.unescape(value)
+		value = h.unescape(frappe.safe_decode(value))
 		value = (re.subn(r'<[\s]*(script|style).*?</\1>(?s)', '', text_type(value))[0])
 		value = ' '.join(value.split())
 	return field.label + " : " + strip_html_tags(text_type(value))


### PR DESCRIPTION
fixes the error:

`UnicodeEncodeError: 'ascii' codec can't encode character u'\xWHATEVER' in position WHATEVER: ordinal not in range(128)`