### PR TITLE
fix: set is_patch flag before running patch

### DIFF
--- a/frappe/patches/v11_0/sync_user_permission_doctype_before_migrate.py
+++ b/frappe/patches/v11_0/sync_user_permission_doctype_before_migrate.py
@@ -1,5 +1,6 @@
 import frappe
 
 def execute():
+	frappe.flags.in_patch = True
 	frappe.reload_doc('core', 'doctype', 'user_permission')
 	frappe.db.commit()


### PR DESCRIPTION
set frappe.flags.in_patch to True before running the
sync_user_permission_doctype_before_migrate patch via hooks
