### PR TITLE
[Fix] Website Chat

### DIFF
--- a/frappe/chat/doctype/chat_room/chat_room.py
+++ b/frappe/chat/doctype/chat_room/chat_room.py
@@ -195,7 +195,10 @@ def create(kind, owner, users = None, name = None):
 
 		for user in dsettings.chat_operators:
 			if user.user not in users:
-				room.append('users', user)
+				# appending user to room.users will remove the user from chat_operators
+				# this is undesirable, create a new Chat Room User instead
+				chat_room_user = {"doctype": "Chat Room User", "user": user.user}
+				room.append('users', chat_room_user)
 
 	room.save(ignore_permissions = True)
 

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -421,7 +421,9 @@ frappe.ready(function() {
 		callback: (r) => {
 			if (r.message) {
 				frappe.require('/assets/js/moment-bundle.min.js', () => {
-					frappe.require('/assets/js/chat.js');
+					frappe.require('/assets/js/chat.js', () => {
+						frappe.chat.setup();
+					});
 				});
 			}
 		}


### PR DESCRIPTION
Chat button is now being rendered as intended on website pages for anonymous users.

Also, Chat Operators table (from Website Settings DocType) isn't accidentally being purged anymore. (There probably wasn't a reason to notice this before)

This will probably need some more work to be usable.

### To Do

- [ ] Show welcome chat message to visitors.
- [ ] Don't create a chat room for every visitor. 
- [ ] Put Chat Operators in created chat room only after visitor sends a message. 