### PR TITLE
fix(Quill): Set HTML without triggering a focus

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -171,7 +171,9 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 			return;
 		}
 
-		this.quill.clipboard.dangerouslyPasteHTML(value);
+		// set html without triggering a focus
+		const delta = this.quill.clipboard.convert({ html: value, text: '' });
+		this.quill.setContents(delta);
 	},
 
 	get_input_value() {


### PR DESCRIPTION
When loading a new form or existing one, the Text Editor is being focused resulting in incorrect scroll position of the form.

This change quietly sets the html without triggering a focus.