### PR TITLE
fix: Fail bench build in CI environment

### DIFF
--- a/rollup/build.js
+++ b/rollup/build.js
@@ -63,7 +63,13 @@ function build_assets(app) {
 function build(inputOptions, outputOptions) {
 	return rollup.rollup(inputOptions)
 		.then(bundle => bundle.write(outputOptions))
-		.catch(err => log(chalk.red(err)));
+		.catch(err => {
+			log(chalk.red(err));
+			// Kill process to fail in a CI environment
+			if (process.env.CI) {
+				process.kill(process.pid)
+			}
+		});
 }
 
 function concatenate_files() {


### PR DESCRIPTION
`bench build` should fail the test in travis, so that code with syntax errors are caught.

![image](https://user-images.githubusercontent.com/9355208/48490908-6eddfa80-e84c-11e8-8184-9d84544da45a.png)
