### PR TITLE
Make vue globally available to avoid redundant import

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -18,6 +18,9 @@
 	"js/chat.js": [
 		"public/js/frappe/chat.js"
 	],
+	"js/frappe-vue.min.js": [
+		"public/js/frappe_vue.js"
+	],
 	"js/frappe-web.min.js": [
 		"public/js/frappe/class.js",
 		"public/js/frappe/polyfill.js",

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
 /* eslint-disable no-console */
+
 frappe.start_app = function() {
 	if(!frappe.Application)
 		return;

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -1,22 +1,12 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
 /* eslint-disable no-console */
-import Vue from 'vue/dist/vue.js';
-
 frappe.start_app = function() {
 	if(!frappe.Application)
 		return;
 	frappe.assets.check();
 	frappe.provide('frappe.app');
 	frappe.app = new frappe.Application();
-};
-
-frappe.setup_vue = () => {
-	if (!window.Vue) {
-		Vue.prototype.__ = window.__;
-		Vue.prototype.frappe = window.frappe;
-		window.Vue = Vue;
-	}
 };
 
 $(document).ready(function() {

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -18,7 +18,6 @@ $(document).ready(function() {
 		});
 	}
 	frappe.start_app();
-	frappe.setup_vue();
 });
 
 frappe.Application = Class.extend({

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
 /* eslint-disable no-console */
+import Vue from 'vue/dist/vue.js';
 
 frappe.start_app = function() {
 	if(!frappe.Application)
@@ -8,6 +9,14 @@ frappe.start_app = function() {
 	frappe.assets.check();
 	frappe.provide('frappe.app');
 	frappe.app = new frappe.Application();
+};
+
+frappe.setup_vue = () => {
+	if (!window.Vue) {
+		Vue.prototype.__ = window.__;
+		Vue.prototype.frappe = window.frappe;
+		window.Vue = Vue;
+	}
 };
 
 $(document).ready(function() {
@@ -19,6 +28,7 @@ $(document).ready(function() {
 		});
 	}
 	frappe.start_app();
+	frappe.setup_vue();
 });
 
 frappe.Application = Class.extend({

--- a/frappe/public/js/frappe/social/social_home.js
+++ b/frappe/public/js/frappe/social/social_home.js
@@ -12,7 +12,7 @@ frappe.social.Home = class SocialHome {
 	}
 	make_body() {
 		this.$social_container = this.$parent.find('.layout-main');
-		frappe.require('assets/js/frappe-vue.min.js', () => {
+		frappe.require('/assets/js/frappe-vue.min.js', () => {
 			new Vue({
 				el: this.$social_container[0],
 				render: h => h(Home)

--- a/frappe/public/js/frappe/social/social_home.js
+++ b/frappe/public/js/frappe/social/social_home.js
@@ -12,10 +12,11 @@ frappe.social.Home = class SocialHome {
 	}
 	make_body() {
 		this.$social_container = this.$parent.find('.layout-main');
-
-		new Vue({
-			el: this.$social_container[0],
-			render: h => h(Home)
+		frappe.require('assets/js/frappe-vue.js', () => {
+			new Vue({
+				el: this.$social_container[0],
+				render: h => h(Home)
+			});
 		});
 	}
 	setup_header() {

--- a/frappe/public/js/frappe/social/social_home.js
+++ b/frappe/public/js/frappe/social/social_home.js
@@ -12,7 +12,7 @@ frappe.social.Home = class SocialHome {
 	}
 	make_body() {
 		this.$social_container = this.$parent.find('.layout-main');
-		frappe.require('assets/js/frappe-vue.js', () => {
+		frappe.require('assets/js/frappe-vue.min.js', () => {
 			new Vue({
 				el: this.$social_container[0],
 				render: h => h(Home)

--- a/frappe/public/js/frappe/social/social_home.js
+++ b/frappe/public/js/frappe/social/social_home.js
@@ -1,7 +1,5 @@
-import Vue from 'vue/dist/vue.js';
 import Home from './Home.vue';
 
-Vue.prototype.__ = window.__;
 frappe.provide('frappe.social');
 
 frappe.social.Home = class SocialHome {

--- a/frappe/public/js/frappe_vue.js
+++ b/frappe/public/js/frappe_vue.js
@@ -1,0 +1,7 @@
+import Vue from 'vue/dist/vue.js';
+
+if (!window.Vue) {
+	Vue.prototype.__ = window.__;
+	Vue.prototype.frappe = window.frappe;
+	window.Vue = Vue;
+}


### PR DESCRIPTION
Require vue on demand. 
Since it vue already gets imported while build process, it avoids redundant imports. 