### PR TITLE
redis: freeze requirement to 2.10.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ werkzeug
 semantic_version
 rauth>=0.6.2
 requests
-redis
+redis==2.10.6
 selenium
 babel
 ipython


### PR DESCRIPTION
the new redis 3.0.0 update has breaking changes, so we freeze the version to 2.10.6 for now.