### PR TITLE
fix(prepared-report): Prepared Report Enhancements

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.js
+++ b/frappe/core/doctype/prepared_report/prepared_report.js
@@ -15,7 +15,7 @@ frappe.ui.form.on('Prepared Report', {
 			<tbody></tbody>
 		</table>`);
 
-		const filters = JSON.parse(JSON.parse(frm.doc.filters));
+		const filters = JSON.parse(frm.doc.filters);
 
 		Object.keys(filters).forEach(key => {
 			const filter_row = $(`<tr>

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -44,7 +44,7 @@ def run_background(instance):
 
 	frappe.publish_realtime(
 		'report_generated',
-		{"report_name": instance.report_name},
+		{"report_name": instance.report_name, "name": instance.name},
 		user=frappe.session.user
 	)
 

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -13,8 +13,8 @@ from frappe.utils.background_jobs import enqueue
 from frappe.desk.query_report import generate_report_result
 from frappe.utils.file_manager import save_file, remove_all
 from frappe.desk.form.load import get_attachments
-from frappe.utils.file_manager import download_file
-from frappe.utils import gzip_compress
+from frappe.utils.file_manager import get_file
+from frappe.utils import gzip_compress, gzip_decompress
 
 class PreparedReport(Document):
 
@@ -69,4 +69,6 @@ def create_json_gz_file(data, dt, dn):
 @frappe.whitelist()
 def download_attachment(dn):
 	attachment = get_attachments("Prepared Report", dn)[0]
-	download_file(attachment.file_url)
+	frappe.local.response.filename = attachment.file_name[:-2]
+	frappe.local.response.filecontent = gzip_decompress(get_file(attachment.name)[1])
+	frappe.local.response.type = "binary"

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -35,7 +35,7 @@ class PreparedReport(Document):
 
 def run_background(instance):
 	report = frappe.get_doc("Report", instance.ref_report_doctype)
-	result = generate_report_result(report, filters=json.loads(instance.filters), user=instance.owner)
+	result = generate_report_result(report, filters=instance.filters, user=instance.owner)
 	create_json_gz_file(result['result'], 'Prepared Report', instance.name)
 
 	instance.status = "Completed"

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -5,7 +5,6 @@
 
 from __future__ import unicode_literals
 import base64
-import gzip
 import json
 
 import frappe
@@ -15,7 +14,7 @@ from frappe.desk.query_report import generate_report_result
 from frappe.utils.file_manager import save_file, remove_all
 from frappe.desk.form.load import get_attachments
 from frappe.utils.file_manager import download_file
-
+from frappe.utils import gzip_compress
 
 class PreparedReport(Document):
 
@@ -57,7 +56,7 @@ def create_json_gz_file(data, dt, dn):
 	encoded_content = frappe.safe_encode(json.dumps(data))
 
 	# GZip compression seems to reduce storage requirements by 80-90%
-	compressed_content = gzip.compress(encoded_content)
+	compressed_content = gzip_compress(encoded_content)
 	save_file(
 		fname=json_filename,
 		content=compressed_content,

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -53,7 +53,7 @@ def create_json_gz_file(data, dt, dn):
 	# Storing data in CSV file causes information loss
 	# Reports like P&L Statement were completely unsuable because of this
 	json_filename = '{0}.json.gz'.format(frappe.utils.data.format_datetime(frappe.utils.now(), "Y-m-d-H:M"))
-	encoded_content = frappe.safe_encode(json.dumps(data))
+	encoded_content = frappe.safe_encode(frappe.as_json(data))
 
 	# GZip compression seems to reduce storage requirements by 80-90%
 	compressed_content = gzip_compress(encoded_content)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -111,6 +111,7 @@ def background_enqueue_run(report_name, filters=None, user=None):
 	track_instance.insert(ignore_permissions=True)
 	frappe.db.commit()
 	return {
+		"name": track_instance.name,
 		"redirect_url": get_url_to_form("Prepared Report", track_instance.name)
 	}
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -167,6 +167,7 @@ def run(report_name, filters=None, user=None):
 				filters = json.loads(filters)
 
 			dn = filters.get("prepared_report_name")
+			filters.pop("prepared_report_name", None)
 		else:
 			dn = ""
 		result = get_prepared_report_result(report, filters, dn, user)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import frappe
 import os, json, datetime
-import gzip
 
 from frappe import _
 from frappe.modules import scrub, get_module_path
@@ -17,6 +16,7 @@ from frappe.permissions import get_role_permissions
 from six import string_types, iteritems
 from datetime import timedelta
 from frappe.utils.file_manager import get_file
+from frappe.utils import gzip_decompress
 
 def get_report_doc(report_name):
 	doc = frappe.get_doc("Report", report_name)
@@ -194,7 +194,7 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 		# Prepared Report data is stored in a GZip compressed JSON file
 		attached_file_name = frappe.db.get_value("File", {"attached_to_doctype": doc.doctype, "attached_to_name":doc.name}, "name")
 		compressed_content = get_file(attached_file_name)[1]
-		uncompressed_content = gzip.decompress(compressed_content)
+		uncompressed_content = gzip_decompress(compressed_content)
 		data = json.loads(uncompressed_content)
 		if data:
 			latest_report_data = {

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -169,7 +169,7 @@ def run(report_name, filters=None, user=None):
 			dn = filters.get("prepared_report_name")
 		else:
 			dn = ""
-		result = get_prepared_report_result(report, filters, dn)
+		result = get_prepared_report_result(report, filters, dn, user)
 	else:
 		result = generate_report_result(report, filters, user)
 
@@ -178,9 +178,10 @@ def run(report_name, filters=None, user=None):
 	return result
 
 
-def get_prepared_report_result(report, filters, dn=""):
+def get_prepared_report_result(report, filters, dn="", user=None):
 	latest_report_data = {}
-	doc_list = frappe.get_all("Prepared Report", filters={"status": "Completed", "report_name": report.name})
+	# Only look for completed prepared reports with given filters.
+	doc_list = frappe.get_all("Prepared Report", filters={"status": "Completed", "report_name": report.name, "filters": json.dumps(filters), "owner": user})
 	doc = None
 	if len(doc_list):
 		if dn:

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -100,7 +100,7 @@ def background_enqueue_run(report_name, filters=None, user=None):
 		frappe.get_doc({
 			"doctype": "Prepared Report",
 			"report_name": report_name,
-			# This looks like an insanity but, without this it'd be very hard to find Prepared Reports matvhing given condition
+			# This looks like an insanity but, without this it'd be very hard to find Prepared Reports matching given condition
 			# We're ensuring that spacing is consistent. e.g. JS seems to put no spaces after ":", Python on the other hand does.
 			"filters": json.dumps(json.loads(filters)),
 			"ref_report_doctype": report_name,

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -200,7 +200,7 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 		if data:
 			latest_report_data = {
 				"columns": json.loads(doc.columns) if doc.columns else data[0],
-				"result": data[1:]
+				"result": data
 			}
 
 	latest_report_data.update({

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -100,7 +100,9 @@ def background_enqueue_run(report_name, filters=None, user=None):
 		frappe.get_doc({
 			"doctype": "Prepared Report",
 			"report_name": report_name,
-			"filters": json.dumps(filters),
+			# This looks like an insanity but, without this it'd be very hard to find Prepared Reports matvhing given condition
+			# We're ensuring that spacing is consistent. e.g. JS seems to put no spaces after ":", Python on the other hand does.
+			"filters": json.dumps(json.loads(filters)),
 			"ref_report_doctype": report_name,
 			"report_type": report.report_type,
 			"query": report.query,

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -231,3 +231,4 @@ frappe.patches.v10_0.enhance_security
 frappe.patches.v11_0.multiple_references_in_events
 frappe.patches.v11_0.set_allow_self_approval_in_workflow
 frappe.patches.v11_0.migrate_report_settings_for_new_listview
+frappe.patches.v11_0.delete_all_prepared_reports

--- a/frappe/patches/v11_0/delete_all_prepared_reports.py
+++ b/frappe/patches/v11_0/delete_all_prepared_reports.py
@@ -1,0 +1,6 @@
+import frappe
+
+def execute():
+	prepared_reports = frappe.get_all("Prepared Report")
+	for report in prepared_reports:
+		frappe.delete_doc("Prepared Report", report.name)

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -64,7 +64,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		frappe.realtime.on("report_generated", (data) => {
 			if(data.report_name) {
 				let alert_message = `Report ${this.report_name} generated.
-					<a target='_blank' href="#query-report/${this.report_name}">View</a>`;
+					<a target='_blank' href="#query-report/${this.report_name}/?prepared_report_name=${data.name}">View</a>`;
 				frappe.show_alert({message: alert_message, indicator: 'orange'});
 			}
 		});

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -375,7 +375,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			})).then(r => {
 				const data = r.message;
 				// Rememeber the name of Prepared Report doc
-				this.prepared_report_doc_name = data.name
+				this.prepared_report_doc_name = data.name;
 				let alert_message = `Report initiated. You can track its status
 					<a class='text-info' target='_blank' href=${data.redirect_url}>here</a>`;
 				frappe.show_alert({message: alert_message, indicator: 'orange'});

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -63,9 +63,17 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	setup_events() {
 		frappe.realtime.on("report_generated", (data) => {
 			if(data.report_name) {
-				let alert_message = `Report ${this.report_name} generated.
-					<a target='_blank' href="#query-report/${this.report_name}/?prepared_report_name=${data.name}">View</a>`;
-				frappe.show_alert({message: alert_message, indicator: 'orange'});
+				this.prepared_report_action = "Rebuild";
+				// If generated report and currently active Prepared Report has same fiters
+				// then refresh the Prepared Report
+				// Otherwise show alert with the link to the Prepared Report
+				if(data.name == this.prepared_report_doc_name) {
+					this.refresh();
+				} else {
+					let alert_message = `Report ${this.report_name} generated.
+						<a target='_blank' href="#query-report/${this.report_name}/?prepared_report_name=${data.name}">View</a>`;
+					frappe.show_alert({message: alert_message, indicator: 'orange'});
+				}
 			}
 		});
 	}
@@ -93,6 +101,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.page_title = __(this.report_name);
 		this.menu_items = this.get_menu_items();
 		this.datatable = null;
+		this.prepared_report_action = "New";
 
 		frappe.run_serially([
 			() => this.get_report_doc(),
@@ -273,7 +282,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				// If query_string contains prepared_report_name then set filters
 				// to match the mentioned prepared report doc and disable editing
 				if(query_params.prepared_report_name) {
-					this.render_prepared_report_doc = true;
+					this.prepared_report_action = "Edit";
 					const filters_from_report = JSON.parse(data.doc.filters);
 					Object.values(this.filters).forEach(function(field) {
 						if (filters_from_report[field.fieldname]) {
@@ -311,25 +320,38 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						+"dn="+encodeURIComponent(doc.name)));
 			});
 
-			this.show_status(__(`
-				<span class="indicator orange">This report was <a href=#Form/Prepared%20Report/${doc.name}>generated</a>
-				on ${frappe.datetime.convert_to_user_tz(doc.report_end_time)}.
-				<a href=#List/Prepared%20Report>See all past reports</a>.</span>
-			`));
+			const part1 = __('This report was generated {0}.', [frappe.datetime.comment_when(doc.report_end_time)]);
+			const part2 = __('To get the updated report, click on {0}.', [__('Rebuild')]);
+			const part3 = __('See all past reports.');
+
+			this.show_status(`
+				<span class="indicator orange">
+					${part1}
+					${part2}
+					<a href="#List/Prepared%20Report?report_name=${this.report_name}">${part3}</a>
+				</span>
+			`);
 		};
 
-		// if query_string has prepared_report_name then change primary action to create
-		// a new prepared report
-		if(this.render_prepared_report_doc) {
+		// Three cases
+		// 1. First time with given filters, no data.
+		// 2. Showing data from specific report
+		// 3. Showing data from an old report without specific report name
+		if(this.prepared_report_action == "New") {
 			this.page.set_primary_action(
-				__("New"),
+				__("Generate New Report"),
 				() => {
-					this.render_prepared_report_doc = false;
-					frappe.set_route(frappe.get_route());
-					this.add_prepared_report_buttons();
+					this.generate_background_report();
 				}
 			);
-		} else {
+		} else if(this.prepared_report_action == "Edit") {
+			this.page.set_primary_action(
+				__("Edit"),
+				() => {
+					frappe.set_route(frappe.get_route());
+				}
+			);
+		} else if(this.prepared_report_action == "Rebuild"){
 			this.page.set_primary_action(
 				__("Rebuild"),
 				this.generate_background_report.bind(this)
@@ -352,6 +374,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				callback: resolve
 			})).then(r => {
 				const data = r.message;
+				// Rememeber the name of Prepared Report doc
+				this.prepared_report_doc_name = data.name
 				let alert_message = `Report initiated. You can track its status
 					<a class='text-info' target='_blank' href=${data.redirect_url}>here</a>`;
 				frappe.show_alert({message: alert_message, indicator: 'orange'});
@@ -923,6 +947,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	reset_report_view() {
 		this.hide_status();
 		this.toggle_nothing_to_show(true);
+		this.refresh();
 	}
 
 	toggle_loading(flag) {
@@ -937,6 +962,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				Please set the appropriate filters and then generate a new one.`);
 		}
 		this.toggle_message(flag, message);
+		if(flag){
+			this.prepared_report_action = "New";
+		}
+		this.add_prepared_report_buttons();
 	}
 
 	toggle_message(flag, message) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -266,15 +266,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 			this.hide_status();
 
-			if (data.prepared_report){
+			if (data.prepared_report) {
 				this.prepared_report = true;
-				var query_string = frappe.utils.get_query_string(frappe.get_route_str())
-				var query_params = frappe.utils.get_query_params(query_string)
+				const query_string = frappe.utils.get_query_string(frappe.get_route_str());
+				const query_params = frappe.utils.get_query_params(query_string);
 				// If query_string contains prepared_report_name then set filters
 				// to match the mentioned prepared report doc and disable editing
 				if(query_params.prepared_report_name) {
-					this.render_prepared_report_doc = true
-					var filters_from_report = JSON.parse(data.doc.filters);
+					this.render_prepared_report_doc = true;
+					const filters_from_report = JSON.parse(data.doc.filters);
 					Object.values(this.filters).forEach(function(field) {
 						if (filters_from_report[field.fieldname]) {
 							field.set_input(filters_from_report[field.fieldname]);
@@ -282,7 +282,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						field.input.disabled = true;
 					});
 				}
-				this.add_prepared_report_buttons(data.doc, );
+				this.add_prepared_report_buttons(data.doc);
 			}
 			this.toggle_message(false);
 
@@ -324,9 +324,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.page.set_primary_action(
 				__("New"),
 				() => {
-					this.render_prepared_report_doc = false
-					frappe.set_route(frappe.get_route())
-					this.add_prepared_report_buttons()
+					this.render_prepared_report_doc = false;
+					frappe.set_route(frappe.get_route());
+					this.add_prepared_report_buttons();
 				}
 			);
 		} else {

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -14,6 +14,8 @@ from email.utils import parseaddr, formataddr
 from frappe.utils.data import *
 from six.moves.urllib.parse import quote
 from six import text_type, string_types
+import io
+from gzip import GzipFile
 
 default_fields = ['doctype', 'name', 'owner', 'creation', 'modified', 'modified_by',
 	'parent', 'parentfield', 'parenttype', 'idx', 'docstatus']
@@ -620,3 +622,21 @@ def call(fn, *args, **kwargs):
 			bench --site erpnext.local execute frappe.utils.call --args '''["frappe.get_all", "Activity Log"]''' --kwargs '''{"fields": ["user", "creation", "full_name"], "filters":{"Operation": "Login", "Status": "Success"}, "limit": "10"}'''
 	"""
 	return json.loads(frappe.as_json(frappe.call(fn, *args, **kwargs)))
+
+# Following methods are aken as-is from Python 3 codebase
+# since gzip.compress and gzip.decompress are not available in Python 2.7
+def gzip_compress(data, compresslevel=9):
+	"""Compress data in one shot and return the compressed string.
+	Optional argument is the compression level, in range of 0-9.
+	"""
+	buf = io.BytesIO()
+	with GzipFile(fileobj=buf, mode='wb', compresslevel=compresslevel) as f:
+		f.write(data)
+	return buf.getvalue()
+
+def gzip_decompress(data):
+	"""Decompress a gzip compressed string in one shot.
+	Return the decompressed string.
+	"""
+	with GzipFile(fileobj=io.BytesIO(data)) as f:
+		return f.read()


### PR DESCRIPTION
This fixes a few issues with prepared reports.

#### 1. CSV Serialization
CSV serialization causes information loss for erpnext reports like P&L Statement,
rendering such reports unusable.


**Note**: This will cause all previously generated reports to break, that should be fixed.

| Before        | After         |
| ------------- |:-------------:|
| ![before](https://user-images.githubusercontent.com/8528887/48612113-0870ed80-e9ae-11e8-8de2-36d0937d04fa.png)| ![after](https://user-images.githubusercontent.com/8528887/48612264-83d29f00-e9ae-11e8-8a71-db1573f40c82.png) |

#### 2. Permission Issues

Only Prepared Reports owned by the user is being shown.

**To Do**
- [ ] Permissions on Prepared Reports.
- [ ] Refactor how this is being done.

#### 3. Filter Issues

Filters and data didn't match since data from most recently generated report was being shown.

#### 4. Space Issues
Stored files are gzip compressed to reduce space requirement.

**To Do**
- [ ] Scheduled job to delete old prepared reports.

#### 5. UX Improvements
![pr](https://user-images.githubusercontent.com/8528887/49590332-a21a3200-f991-11e8-91b8-05cfe5bd778b.gif)

**Note**: These changes aren't backwards compatible. Provided patch deletes existing Prepared Reports and associated files.