### PR TITLE
[Fix] Base list ui component missing in build.json

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -301,6 +301,7 @@
 		"public/js/frappe/ui/like.js",
 		"public/js/frappe/ui/liked_by.html",
 		"public/html/print_template.html",
+		"public/js/frappe/ui/base_list.js",
 
 		"public/js/frappe/list/base_list.js",
 		"public/js/frappe/list/list_view.js",


### PR DESCRIPTION
Hi,

The base list UI component is missing in build.json.

Is it on purpose and is this component supposed to be deprecated ? Or is it just a merge issue ?

If it's supposed to be deprecated please note that it is used in the medical record.

Thanks!

