### PR TITLE
[MINOR FEATURE] Export file to TXT #6737

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -39,6 +39,7 @@ def build_response(response_type=None):
 
 	response_type_map = {
 		'csv': as_csv,
+		'txt': as_txt,
 		'download': as_raw,
 		'json': as_json,
 		'page': as_page,
@@ -53,6 +54,14 @@ def as_csv():
 	response.mimetype = 'text/csv'
 	response.charset = 'utf-8'
 	response.headers["Content-Disposition"] = ("attachment; filename=\"%s.csv\"" % frappe.response['doctype'].replace(' ', '_')).encode("utf-8")
+	response.data = frappe.response['result']
+	return response
+
+def as_txt():
+	response = Response()
+	response.mimetype = 'text'
+	response.charset = 'utf-8'
+	response.headers["Content-Disposition"] = ("attachment; filename=\"%s.txt\"" % frappe.response['doctype'].replace(' ', '_')).encode("utf-8")
 	response.data = frappe.response['result']
 	return response
 


### PR DESCRIPTION
Adding txt as a response type in order to export txt because of a requirement on some gov entities.