### PR TITLE
[Fix] After rename, user still able to search document using old name

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -78,6 +78,7 @@ def rename_doc(doctype, old, new, force=False, merge=False, ignore_permissions=F
 		frappe.delete_doc(doctype, old)
 
 	frappe.clear_cache()
+	frappe.enqueue('frappe.utils.global_search.rebuild_for_doctype', doctype=doctype)
 
 	return new
 


### PR DESCRIPTION
### **Issue**
Rename item DINRAIL to DINRAIL + TestR

![screen shot 2018-11-21 at 7 06 28 pm](https://user-images.githubusercontent.com/8780500/48844785-d9e57f00-edc0-11e8-897b-ba9ca390a766.png)


After that in global search added value as DINRAIL and it's showing old item name and not new

![screen shot 2018-11-21 at 7 07 06 pm](https://user-images.githubusercontent.com/8780500/48844778-d6ea8e80-edc0-11e8-8fa8-2a725f3bd68b.png)


### **After Fix**
![screen shot 2018-11-21 at 7 24 48 pm](https://user-images.githubusercontent.com/8780500/48845686-2cc03600-edc3-11e8-9856-4d09d2cfa356.png)
