### PR TITLE
[Fix] From global search data is not displaying

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -357,7 +357,7 @@ frappe.search.SearchDialog = Class.extend({
 			no_results_status: (keyword) => __("<p>No results found for '" + keyword + "' in Global Search</p>"),
 
 			get_results: function(keywords, callback) {
-				var start = 0, limit = 100;
+				var start = 0, limit = 1000;
 				var results = frappe.search.utils.get_nav_results(keywords);
 				frappe.search.utils.get_global_results(keywords, start, limit)
 					.then(function(global_results) {


### PR DESCRIPTION
**Issue**

In list view 2 items are showing, but using the global search only one item is displaying

![image00184491e](https://user-images.githubusercontent.com/8780500/48886922-9a1ba780-ee53-11e8-819f-ded2423c8918.png)

After debug come to know that the limit is hard coded as 100 due to which many records are skipped