### PR TITLE
fix(Markdown): Integrate with Ace editor

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -1,5 +1,6 @@
 {
  "allow_copy": 0, 
+ "allow_events_in_timeline": 0, 
  "allow_guest_to_view": 0, 
  "allow_import": 1, 
  "allow_rename": 0, 
@@ -15,6 +16,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 1, 
    "collapsible": 0, 
@@ -48,6 +50,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 1, 
    "collapsible": 0, 
@@ -80,6 +83,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -111,6 +115,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -143,6 +148,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -177,6 +183,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -207,6 +214,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 1, 
    "collapsible": 0, 
@@ -226,7 +234,7 @@
    "no_copy": 0, 
    "oldfieldname": "fieldtype", 
    "oldfieldtype": "Select", 
-   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nGeolocation\nHTML\nImage\nInt\nLink\nLong Text\nPassword\nPercent\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nText\nText Editor\nTime\nSignature", 
+   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nGeolocation\nHTML\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nText\nText Editor\nTime\nSignature", 
    "permlevel": 0, 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
@@ -241,6 +249,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -275,12 +284,13 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
    "fieldname": "options", 
-   "fieldtype": "Small Text",
+   "fieldtype": "Small Text", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
@@ -307,42 +317,43 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
-   "fieldname": "fetch_from",
-   "fieldtype": "Small Text",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
-   "label": "Fetch From",
-   "length": 0,
-   "no_copy": 0,
-   "permlevel": 0,
-   "precision": "",
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
+   "fieldname": "fetch_from", 
+   "fieldtype": "Small Text", 
+   "hidden": 0, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "label": "Fetch From", 
+   "length": 0, 
+   "no_copy": 0, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 0, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 0, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
-  },
+  }, 
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
+   "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
    "fieldname": "options_help", 
    "fieldtype": "HTML", 
    "hidden": 0, 
@@ -370,6 +381,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -400,6 +412,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -432,6 +445,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -464,6 +478,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -496,6 +511,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -526,6 +542,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -560,6 +577,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -593,6 +611,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -625,6 +644,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -657,6 +677,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -690,6 +711,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -722,6 +744,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -753,6 +776,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -783,6 +807,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -814,6 +839,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -844,6 +870,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -876,6 +903,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -908,6 +936,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -938,6 +967,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -970,6 +1000,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1002,6 +1033,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1032,6 +1064,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1063,6 +1096,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1095,6 +1129,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1126,6 +1161,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1158,6 +1194,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1188,6 +1225,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1220,6 +1258,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -1263,7 +1302,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-05-22 14:44:19.523725",
+ "modified": "2018-11-23 19:56:43.328280", 
  "modified_by": "Administrator", 
  "module": "Custom", 
  "name": "Custom Field", 
@@ -1271,7 +1310,6 @@
  "permissions": [
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 0, 
    "create": 1, 
    "delete": 1, 
@@ -1291,7 +1329,6 @@
   }, 
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 0, 
    "create": 1, 
    "delete": 1, 
@@ -1317,5 +1354,6 @@
  "show_name_in_global_search": 0, 
  "sort_order": "ASC", 
  "track_changes": 1, 
- "track_seen": 0
+ "track_seen": 0, 
+ "track_views": 0
 }

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -35,6 +35,7 @@ class MariaDBDatabase(Database):
 			'Long Text':	('longtext', ''),
 			'Code':			('longtext', ''),
 			'Text Editor':	('longtext', ''),
+			'Markdown Editor':	('longtext', ''),
 			'Date':			('date', ''),
 			'Datetime':		('datetime', '6'),
 			'Time':			('time', '6'),

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -40,6 +40,7 @@ class PostgresDatabase(Database):
 			'Long Text':	('text', ''),
 			'Code':			('text', ''),
 			'Text Editor':	('text', ''),
+			'Markdown Editor':	('longtext', ''),
 			'Date':			('date', ''),
 			'Datetime':		('timestamp', None),
 			'Time':			('time', '6'),

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -17,6 +17,8 @@ data_fieldtypes = (
 	'Long Text',
 	'Code',
 	'Text Editor',
+	'Markdown Editor',
+	'HTML Editor',
 	'Date',
 	'Datetime',
 	'Time',

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -5,16 +5,16 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 	},
 
 	make_ace_editor() {
-		const ace_editor_target = $('<div class="ace-editor-target"></div>')
+		this.ace_editor_target = $('<div class="ace-editor-target"></div>')
 			.appendTo(this.input_area);
 
 		// styling
-		ace_editor_target.addClass('border rounded');
-		ace_editor_target.css('height', 300);
+		this.ace_editor_target.addClass('border rounded');
+		this.ace_editor_target.css('height', 300);
 
 		// initialize
 		const ace = window.ace;
-		this.editor = ace.edit(ace_editor_target.get(0));
+		this.editor = ace.edit(this.ace_editor_target.get(0));
 		this.editor.setTheme('ace/theme/tomorrow');
 		this.set_language();
 
@@ -30,7 +30,8 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 			'Javascript': 'ace/mode/javascript',
 			'JS': 'ace/mode/javascript',
 			'HTML': 'ace/mode/html',
-			'CSS': 'ace/mode/css'
+			'CSS': 'ace/mode/css',
+			'Markdown': 'ace/mode/markdown'
 		};
 		const language = this.df.options;
 

--- a/frappe/public/js/frappe/form/controls/markdown_editor.js
+++ b/frappe/public/js/frappe/form/controls/markdown_editor.js
@@ -1,53 +1,40 @@
 frappe.ui.form.ControlMarkdownEditor = frappe.ui.form.ControlCode.extend({
-	make_input() {
+	make_ace_editor() {
 		this._super();
-		this.$input.height(300);
-		this.text_area = this.$input.first();
+
+		this.ace_editor_target.wrap('<div class="markdown-container">');
+		this.markdown_container = this.$input_wrapper.find('.markdown-container');
+
 		this.showing_preview = false;
+		this.preview_toggle_btn = $(`<button class="btn btn-default btn-xs markdown-toggle">${__('Preview')}</button>`)
+			.click(e => {
+				if (!this.showing_preview) {
+					this.update_preview();
+				}
 
-		this.make_preview_container();
-		this.make_preview_button();
+				const $btn = $(e.target);
+				this.markdown_preview.toggle(!this.showing_preview);
+				this.ace_editor_target.toggle(this.showing_preview);
+
+				this.showing_preview = !this.showing_preview;
+
+				$btn.text(this.showing_preview ? __('Edit') : __('Preview'));
+
+
+			});
+		this.markdown_container.prepend(this.preview_toggle_btn);
+
+		this.markdown_preview = $('<div class="markdown-preview border rounded">').hide();
+		this.markdown_container.append(this.markdown_preview);
 	},
 
-	set_disp_area(value) {
-		value = value || "";
-		this.value = frappe.markdown(value);
+	set_language() {
+		this.df.options = 'Markdown';
 		this._super();
 	},
 
-	set_formatted_input(value) {
-		this._super(value);
-		this.build_preview();
-	},
-
-	make_preview_button() {
-		this.switch_button = $(`<button class="btn btn-default btn-add btn-xs"></button>`).appendTo(this.input_area);
-		this.switch_button.html(__("Show Preview"));
-
-		this.switch_button.click( () => {
-			this.html_preview_area.toggle();
-			this.text_area.toggle();
-			this.showing_preview = !this.showing_preview;
-			if (this.showing_preview) {
-				this.switch_button.html(__("Show Markdown"));
-			} else {
-				this.switch_button.html(__("Show Preview"));
-			}
-		});
-	},
-
-	make_preview_container() {
-		this.html_preview_container = $('<div>').appendTo(this.input_area).addClass('html-preview-container');
-		this.html_preview_area = $('<div>').appendTo(this.html_preview_container).addClass('html-preview-area');
-		this.html_preview_area.hide();
-
-		this.text_area.on('change keyup paste', frappe.utils.debounce(() => {
-			this.build_preview();
-		}, 300));
-	},
-
-	build_preview() {
-		var value = this.get_value() || "";
-		this.html_preview_area.html(frappe.markdown(value));
+	update_preview() {
+		const value = this.get_value() || "";
+		this.markdown_preview.html(frappe.markdown(value));
 	}
 });

--- a/frappe/public/less/controls.less
+++ b/frappe/public/less/controls.less
@@ -44,15 +44,13 @@
 	z-index: 3;
 }
 
-.html-preview-container {
-	.html-preview-label {
-		.text-muted;
-		margin: 10px 0;
-		font-size: @text-medium
-	}
-	.html-preview-area {
-		.border;
-		padding: 5px;
-		margin-bottom: 10px;
-	}
+.markdown-preview {
+	padding: 12px 15px;
+	min-height: 300px;
+	max-height: 600px;
+	overflow: auto;
+}
+
+.markdown-toggle {
+	margin-bottom: 5px;
 }


### PR DESCRIPTION
Markdown Editor was built when Ace Editor was not integrated. Now, since Code depends on Ace Editor and Markdown depends on Code, _some_ changes were needed.



![markdown-editor](https://user-images.githubusercontent.com/9355208/48958691-22d43980-ef61-11e8-9da6-fd4f2f750260.gif)