### PR TITLE
[Fix] Fetch from works after submission of document

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -474,7 +474,8 @@ class BaseDocument(object):
 					setattr(self, df.fieldname, values.name)
 
 					for _df in fields_to_fetch:
-						setattr(self, _df.fieldname, values[_df.fetch_from.split('.')[-1]])
+						if self.docstatus != 1 or _df.allow_on_submit:
+							setattr(self, _df.fieldname, values[_df.fetch_from.split('.')[-1]])
 
 					notify_link_count(doctype, docname)
 


### PR DESCRIPTION
- In Quotation, for selling price list field set territory.price_list in fetch_from field. So that on selection of territory system will fetched the price list from territory and set in the Quotation.

![image](https://user-images.githubusercontent.com/8780500/48909539-8e4fd580-ee93-11e8-8a92-af3b121e8a0c.png)

 **It works fine, but it also works even after submission of quotation**
![image](https://user-images.githubusercontent.com/8780500/48909271-d7ebf080-ee92-11e8-9cb5-cb1804284d88.png)

![image](https://user-images.githubusercontent.com/8780500/48909610-c0f9ce00-ee93-11e8-956f-03bf69599534.png)
