### PR TITLE
[Fix] Dashboard links are not working

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -9,7 +9,8 @@ frappe.views.BaseList = class BaseList {
 		frappe.run_serially([
 			() => this.init(),
 			() => this.before_refresh(),
-			() => this.refresh()
+			() => this.refresh(),
+			() => frappe.route_options = null
 		]);
 	}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1161,7 +1161,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				}
 			}
 		}
-		frappe.route_options = null;
 
 		return filters;
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -268,7 +268,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (frappe.route_options) {
 			// Priority 1: route filters
 			this.filters = this.parse_filters_from_route_options();
-		} else if (this.view_user_settings.filters) {
+		} else if (this.view_user_settings.filters && this.view_user_settings.filters.length) {
 			// Priority 2: saved filters
 			const saved_filters = this.view_user_settings.filters;
 			this.filters = this.validate_filters(saved_filters);


### PR DESCRIPTION
## **Issue**
### **Dashboard links are not working**
#### **Description about issue:**
When user clicks on dashboard links before_refresh method calls two times, in 1st time frappe. route_options becomes null while executing method parse_filters_from_route_options and in second time as the route_options is null, system shows wrong values in list view
![issue_dashboard_links_are_not_working](https://user-images.githubusercontent.com/8780500/48933954-24cdd680-ef28-11e8-9fba-c8f0fae61c1b.gif)

## **After Fix**
![fix_dashboard_links_are_not_working](https://user-images.githubusercontent.com/8780500/48933984-47f88600-ef28-11e8-83f8-71ece56122ff.gif)

