### PR TITLE
Fixed WebsiteGenerator overriding Document's clear_cache

### DIFF
--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -68,6 +68,7 @@ class WebsiteGenerator(Document):
 		return title_field
 
 	def clear_cache(self):
+		super(WebsiteGenerator, self).clear_cache()
 		clear_cache(self.route)
 
 	def scrub(self, text):


### PR DESCRIPTION
### Problem:
The class WebsiteGenerator was overriding the class Document's clear_cache function which was preventing doc.clear_cache() from actually clearing the document cache.

For example when saving and then submitting Sales Invoice the process would try to insert item's defaults (in the Item Default child table) and then clear the cache. But since the cache wasn't being cleared, the item defaults would be inserted in the database multiple times: everytime saving the Sales Invoice and once when submitting the Sales Invoice.

![image](https://user-images.githubusercontent.com/328330/49016469-feb66980-f1a7-11e8-90c8-8825e1565ab6.png)


### Solution:
Call the super function.