### PR TITLE
Apply route_options filters in list view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -7,6 +7,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		const route = frappe.get_route();
 		const doctype = route[1];
 
+		if(frappe.route_options) {
+			return false;
+		}
 		if (route.length === 2) {
 			// List/{doctype} => List/{doctype}/{last_view} or List
 			const user_settings = frappe.get_user_settings(doctype);


### PR DESCRIPTION
When you click a linked document link in a document's dashboard (e.g. the Delivery Note link in a Sales Order), you should be brought to a filtered list of Delivery Notes that reference that Sales Order. However, load_last_view is getting called after the list loads, which applies the last filters used for that list instead of filtering by the appropriate reference document. 

This fix causes load_last_view to exit if route options are present, so that the filters specified in the route options are prioritized and the list is filtered by the reference document as intended. 