### PR TITLE
extract data as string before passing to json.loads in make_form_dict

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -116,8 +116,9 @@ def init_request(request):
 def make_form_dict(request):
 	import json
 
-	if 'application/json' in (request.content_type or '') and request.data:
-		args = json.loads(request.data)
+	request_data = request.get_data(as_text=True)
+	if 'application/json' in (request.content_type or '') and request_data:
+		args = json.loads(request_data)
 	else:
 		args = request.form or request.args
 


### PR DESCRIPTION
curl -X POST localhost:8000/api/method/login -H "Host:site1.ntex.com" -H "content-type:application/json" -H "accept:application/json" -d '{"usr":"Administrator", "pwd":"abcdefg"}'

Running above command would yield following error in python3(pypy3) version.
```
09:21:40 web.1            | 127.0.0.1 - - [28/Nov/2018 09:21:40] "POST /api/method/login HTTP/1.0" 500 -
09:21:40 web.1            | Traceback (most recent call last):
09:21:40 web.1            |   File "/part2/workspace/withrun/11/apps/frappe/frappe/middlewares.py", line 15, in __call__
09:21:40 web.1            |     return super(StaticDataMiddleware, self).__call__(environ, start_response)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/env/site-packages/werkzeug/wsgi.py", line 766, in __call__
09:21:40 web.1            |     return self.app(environ, start_response)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/env/site-packages/werkzeug/wsgi.py", line 766, in __call__
09:21:40 web.1            |     return self.app(environ, start_response)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/env/site-packages/werkzeug/local.py", line 228, in application
09:21:40 web.1            |     return ClosingIterator(app(environ, start_response), self.cleanup)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/env/site-packages/werkzeug/wrappers.py", line 308, in application
09:21:40 web.1            |     resp = f(*args[:-2] + (request,))
09:21:40 web.1            |   File "/part2/workspace/withrun/11/apps/frappe/frappe/app.py", line 90, in application
09:21:40 web.1            |     response = handle_exception(e)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/apps/frappe/frappe/app.py", line 151, in handle_exception
09:21:40 web.1            |     response = frappe.utils.response.report_error(http_status_code)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/apps/frappe/frappe/utils/response.py", line 27, in report_error
09:21:40 web.1            |     if (cint(frappe.db.get_system_setting('allow_error_traceback'))
09:21:40 web.1            |   File "/part2/workspace/withrun/11/env/site-packages/werkzeug/local.py", line 347, in __getattr__
09:21:40 web.1            |     return getattr(self._get_current_object(), name)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/env/site-packages/werkzeug/local.py", line 310, in _get_current_object
09:21:40 web.1            |     raise RuntimeError('no object bound to %s' % self.__name__)

```

While debugging this problem, we found out that exact source of problem is an error which is raised before local.db is initialised. That error was
```
09:21:40 web.1            | Traceback (most recent call last):
09:21:40 web.1            |   File "/part2/workspace/withrun/11/apps/frappe/frappe/app.py", line 58, in application
09:21:40 web.1            |     init_request(request)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/apps/frappe/frappe/app.py", line 121, in init_request
09:21:40 web.1            |     make_form_dict(request)
09:21:40 web.1            |   File "/part2/workspace/withrun/11/apps/frappe/frappe/app.py", line 129, in make_form_dict
09:21:40 web.1            |     args = json.loads(request.data)
09:21:40 web.1            |   File "/home/himanshu/workspace/tarballs/pypy3-v6.0.0-linux64/lib-python/3/json/__init__.py", line 318, in loads
09:21:40 web.1            |     s.__class__.__name__))
09:21:40 web.1            | TypeError: the JSON object must be str, not 'bytes'
09:21:40 web.1            | the JSON object must be str, not 'bytes'
```
The reason for this error is traced to following lines in app.py
```
def make_form_dict(request):
	import json

	if 'application/json' in (request.content_type or '') and request.data:
		args = json.loads(request.data) #<====== request.data is byte array, not string 
	else:
		args = request.form or request.args

```
Here, in python 3, werkzeug is returning a byte array instead of string when its request data is accessed via request.data. This is breaking as json.loads mandatorily requires a string to parse. This error mostly went unnoticed as frappe calls from client have content-type as **x-www-form-urlencoded** instead of **application/json**, hence this code was not being executed for them. 

This PR changes request.data to request.get_data(as_text=True), which is sure to return a string. 

ps: request.get_data call is cached, hence, if it is called once as request.get_data(as_text=True), request.data would also return string throughout same request