### PR TITLE
Hide print for single doctypes

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -107,7 +107,7 @@ frappe.ui.form.Toolbar = Class.extend({
 		var p = this.frm.perm[0];
 		var docstatus = cint(this.frm.doc.docstatus);
 		var is_submittable = frappe.model.is_submittable(this.frm.doc.doctype)
-
+		var issingle = this.frm.meta.issingle;
 		var print_settings = frappe.model.get_doc(":Print Settings", "Print Settings")
 		var allow_print_for_draft = cint(print_settings.allow_print_for_draft);
 		var allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
@@ -116,7 +116,7 @@ frappe.ui.form.Toolbar = Class.extend({
 		if(!is_submittable || docstatus == 1  ||
 			(allow_print_for_cancelled && docstatus == 2)||
 			(allow_print_for_draft && docstatus == 0)) {
-			if(frappe.model.can_print(null, me.frm)) {
+			if(frappe.model.can_print(null, me.frm) && !issingle) {
 				this.page.add_menu_item(__("Print"), function() {
 					me.frm.print_doc();}, true);
 				this.print_icon = this.page.add_action_icon("fa fa-print", function() {


### PR DESCRIPTION
As single DocTypes can't be printed, it causes a confusion when a user clicks on the Print icon and no data is displayed.

Before:

![image](https://user-images.githubusercontent.com/17617465/49138833-4c50e480-f316-11e8-9d6c-226497588a9e.png)

Now:

<img width="998" alt="screenshot 2018-11-28 at 2 00 16 pm" src="https://user-images.githubusercontent.com/17617465/49138789-2f1c1600-f316-11e8-8c59-47bee63c3453.png">
