### PR TITLE
Filters fixes

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -301,7 +301,7 @@ frappe.ui.form.Dashboard = Class.extend({
 			}
 		}
 
-		frappe.set_route("List", doctype);
+		frappe.set_route("List", doctype, "List");
 	},
 	get_document_filter: function(doctype) {
 		// return the default filter for the given document

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -265,22 +265,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	before_refresh() {
-		if (frappe.route_options) {
-			// Priority 1: route filters
-			this.filters = this.parse_filters_from_route_options();
-		} else if (this.view_user_settings.filters && this.view_user_settings.filters.length) {
-			// Priority 2: saved filters
-			const saved_filters = this.view_user_settings.filters;
-			this.filters = this.validate_filters(saved_filters);
-		} else {
-			// Priority 3: filters in listview_settings
-			this.filters = (this.settings.filters || []).map(f => {
-				if (f.length === 3) {
-					f = [this.doctype, f[0], f[1], f[2]];
-				}
-				return f;
-			});
-		}
+		this.filters = this.get_filters_to_apply();
 
 		if (this.filters.length) {
 			return this.filter_area.clear(false)
@@ -288,6 +273,33 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		return Promise.resolve();
+	}
+
+	get_filters_to_apply() {
+		let filters = [];
+
+		if (frappe.route_options) {
+			// Priority 1: route filters
+			filters = this.parse_filters_from_route_options();
+		} else if (this.view_user_settings.filters && this.view_user_settings.filters.length) {
+			// Priority 2: saved filters
+			const saved_filters = this.view_user_settings.filters;
+			filters = this.validate_filters(saved_filters);
+		} else {
+			// Priority 3: filters in listview_settings
+			filters = this.parse_filters_from_settings();
+		}
+
+		return filters;
+	}
+
+	parse_filters_from_settings() {
+		return (this.settings.filters || []).map(f => {
+			if (f.length === 3) {
+				f = [this.doctype, f[0], f[1], f[2]];
+			}
+			return f;
+		});
 	}
 
 	toggle_result_area() {

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -32,10 +32,18 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		this.page_title = this.board_name;
 		this.card_meta = this.get_card_meta();
 
-		return this.get_board()
-			.then(() => {
-				this.filters = this.board.filters_array;
-			});
+		this.menu_items.push({
+			label: __('Save filters'),
+			action: () => {
+				this.save_kanban_board_filters();
+			}
+		})
+
+		return this.get_board();
+	}
+
+	get_filters_to_apply() {
+		return this.board.filters_array;
 	}
 
 	get_board() {
@@ -60,13 +68,28 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		this.save_view_user_settings({
 			last_kanban_board: this.board_name
 		});
+	}
 
+	save_kanban_board_filters() {
 		frappe.call({
 			method: 'frappe.desk.doctype.kanban_board.kanban_board.save_filters',
 			args: {
 				board_name: this.board_name,
 				filters: this.filter_area.get()
 			}
+		})
+		.then(r => {
+			if (r.exc) {
+				frappe.show_alert({
+					indicator: 'red',
+					message: __('There was an error saving filters')
+				});
+				return;
+			}
+			frappe.show_alert({
+				indicator: 'green',
+				message: __('Filters saved')
+			});
 		});
 	}
 

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -37,7 +37,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 			action: () => {
 				this.save_kanban_board_filters();
 			}
-		})
+		});
 
 		return this.get_board();
 	}
@@ -77,8 +77,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 				board_name: this.board_name,
 				filters: this.filter_area.get()
 			}
-		})
-		.then(r => {
+		}).then(r => {
 			if (r.exc) {
 				frappe.show_alert({
 					indicator: 'red',

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -54,6 +54,14 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		this.save_report_settings();
 	}
 
+	get_filters_to_apply() {
+		if (this.report_doc) {
+			return this.report_doc.json.filters;
+		}
+
+		return super.get_filters_to_apply();
+	}
+
 	save_report_settings() {
 		frappe.model.user_settings.save(this.doctype, 'last_view', this.view_name);
 


### PR DESCRIPTION
**Report View (Custom):**
Filters should be loaded from the Report doc.

**Report View (Default):**
Filters should be loaded based on the last filters applied, similar to listview.

**Kanban View:**
Before: Filters were auto saved whenever they were changed
After: Explicit Menu Item to save filters, similar to Report View

![kanban-filters-action](https://user-images.githubusercontent.com/9355208/49145520-ff750a00-f325-11e8-9337-c74ea2fb02eb.gif)
