### PR TITLE
fix: identify production mode for PDF generation

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -729,7 +729,7 @@ def get_url(uri=None, full_address=False):
 
 	port = frappe.conf.http_port or frappe.conf.webserver_port
 
-	if frappe.conf.developer_mode and host_name and not url_contains_port(host_name) and port:
+	if not (frappe.conf.restart_supervisor_on_update or frappe.conf.restart_systemd_on_update) and host_name and not url_contains_port(host_name) and port:
 		host_name = host_name + ':' + str(port)
 
 	url = urljoin(host_name, uri) if uri else host_name


### PR DESCRIPTION
In regards to PDF generation, if developer_mode was set to true, the PDF
generated used to lack css styling. This was because the URL to the CSS
assets used to contain the webserver port number, but given the system
was running in production, the URL was invalid, thereby not being able
to load CSS assets. This fix does not rely on the value of
developer_mode to identify if the system is running in production,
rather, it uses the value of restart_superviosor or systemd_on_update,
to check for the same.
