### PR TITLE
fix(QueryReport): Dynamic Total Row in Query Report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -80,9 +80,6 @@ def generate_report_result(report, filters=None, user=None):
 	if result:
 		result = get_filtered_data(report.ref_doctype, columns, result, user)
 
-	if cint(report.add_total_row) and result:
-		result = add_total_row(result, columns)
-
 	return {
 		"result": result,
 		"columns": columns,

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -356,7 +356,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			inlineFilters: true,
 			treeView: this.tree_report,
 			layout: 'fixed',
-			cellHeight: 33
+			cellHeight: 33,
+			showTotalRow: this.raw_data.add_total_row
 		};
 
 		if (this.report_settings.get_datatable_options) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "awesomplete": "^1.1.2",
     "cookie": "^0.3.1",
     "express": "^4.16.2",
-    "frappe-datatable": "^1.5.5",
+    "frappe-datatable": "^1.6.0",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.2.0",
     "highlight.js": "^9.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,10 +1219,10 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-frappe-datatable@^1.5.5:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.5.5.tgz#52c4e4263b2598d1685cdfc72dff248365091868"
-  integrity sha512-0Euo4otAzkpm1S+NrvhYHQ+Bug0aPus/k2W5FvyCXdRyKyDu5aSYAku+Xquj2mhES/EJGhyfhcuTcGLt0Q1h7g==
+frappe-datatable@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.6.0.tgz#c86c2c7fc054a500c70cdf6c6362b5fed63c6fe6"
+  integrity sha512-40iwguZr0w+X0MV/yTzsYDoKlH7b/GuOq6o2lEOrbVT3p4dZYpalxQmO8mkM9gKjNjSgGMVL1r6Se8peq80Qqg==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
The total row sent by the server does not update when rows are filtered.
Datatable now has a built-in dynamic total row

![datatable-total-row](https://user-images.githubusercontent.com/9355208/49220007-f5710b00-f3fa-11e8-80bc-09db56a412c4.gif)

### Update Datatable to [1.6.0](https://github.com/frappe/datatable/releases):

1. **Filter rows based on the formatted value**
Earlier filtering was done based on the original value of the cell, but
formatters could change the display value

1. **Numeric comparison should compare with cell value**
Numeric comparison like >, < should compare with the cell value and not
the formatted html value

