### PR TITLE
[fix] SQL injection via global search limit field

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -352,6 +352,8 @@ def search(text, start=0, limit=20, doctype=""):
 	:return: Array of result objects
 	"""
 
+	start, limit = _sanitize_parameters(start, limit)
+
 	text = "+" + text + "*"
 	if not doctype:
 		results = frappe.db.sql('''
@@ -393,6 +395,7 @@ def web_search(text, start=0, limit=20):
 	:return: Array of result objects
 	"""
 
+	start, limit = _sanitize_parameters(start, limit)
 	text = "+" + text + "*"
 	results = frappe.db.sql('''
 		select
@@ -405,3 +408,9 @@ def web_search(text, start=0, limit=20):
 		limit {start}, {limit}'''.format(start=start, limit=limit),
 		text, as_dict=True)
 	return results
+
+def _sanitize_parameters(start, limit):
+	start = 0 if isinstance(start, text_type) else cint(start)
+	limit = 20 if isinstance(limit, text_type) else cint(limit)
+
+	return start, limit


### PR DESCRIPTION
Before Fix
----------------------------
```
error:

Traceback (most recent call last):
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/global_search.py", line 422, in web_search
    text, as_dict=True)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/database.py", line 199, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1105, u"XPATH syntax error: ':10.2.13-MariaDB'")

```
---
After Fix:
--------------------

{
	"message":[]
}