### PR TITLE
fix: Add 'parent' argument to frappe.client.get_value.

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -30,13 +30,14 @@ frappe.db = {
 			});
 		});
 	},
-	get_value: function(doctype, filters, fieldname, callback) {
+	get_value: function(doctype, filters, fieldname, callback, parent) {
 		return frappe.call({
 			method: "frappe.client.get_value",
 			args: {
 				doctype: doctype,
 				fieldname: fieldname,
-				filters: filters
+				filters: filters,
+				parent: parent
 			},
 			callback: function(r) {
 				callback && callback(r.message);

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -45,7 +45,9 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 								if (val) {
 									this.set_description(__('{0} already exists. Select another name', [val.name]));
 								}
-							});
+							},
+							this.doc.parenttype
+						);
 						this.last_check = null;
 					}, 1000);
 					this.last_check = timeout;


### PR DESCRIPTION
Add 'parent' to call to get_value in data.js.
Fixes issues with lookups in data.js which check for already existing names. Without this, the get_value calls fail for child fields such as 'barcode' in Item Barcode with PermissionError warning.

Possibly this functionality should be extended to set_value.
Possibly this functionality should not be included at all, and the autocomplete lookups should be changed to use get_list or similar (which already include 'parent').

Fixes this (duplicated) issue:
https://github.com/frappe/erpnext/issues/16047
https://github.com/frappe/erpnext/issues/15886