### PR TITLE
Only apply saved filters on page load

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -52,6 +52,21 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		this.sort_by = this.view_user_settings.sort_by || 'modified';
 		this.sort_order = this.view_user_settings.sort_order || 'desc';
 
+		// set filters from user_settings or list_settings
+		if (this.view_user_settings.filters && this.view_user_settings.filters.length) {
+			// Priority 1: user_settings
+			const saved_filters = this.view_user_settings.filters;
+			this.filters = this.validate_filters(saved_filters);
+		} else {
+			// Priority 2: filters in listview_settings
+			this.filters = (this.settings.filters || []).map(f => {
+				if (f.length === 3) {
+					f = [this.doctype, f[0], f[1], f[2]];
+				}
+				return f;
+			});
+		}
+
 		// build menu items
 		this.menu_items = this.menu_items.concat(this.get_menu_items());
 
@@ -266,23 +281,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	before_refresh() {
 		if (frappe.route_options) {
-			// Priority 1: route filters
 			this.filters = this.parse_filters_from_route_options();
-		} else if (this.view_user_settings.filters && this.view_user_settings.filters.length) {
-			// Priority 2: saved filters
-			const saved_filters = this.view_user_settings.filters;
-			this.filters = this.validate_filters(saved_filters);
-		} else {
-			// Priority 3: filters in listview_settings
-			this.filters = (this.settings.filters || []).map(f => {
-				if (f.length === 3) {
-					f = [this.doctype, f[0], f[1], f[2]];
-				}
-				return f;
-			});
-		}
 
-		if (this.filters.length) {
 			return this.filter_area.clear(false)
 				.then(() => this.filter_area.set(this.filters));
 		}


### PR DESCRIPTION
Filters behaviour are very tricky to handle.

When the page loads for the first time, it should apply the last used filters or default filters for that list view.

On subsequent page routes via `frappe.set_route` or hashed routing based on anchor tags within the app, it should load filters from `frappe.route_options` if it is set.