### PR TITLE
communication: fix attachments in email queue and generated reports

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -279,12 +279,16 @@ def prepare_to_notify(doc, print_html=None, print_format=None, attachments=None)
 			if isinstance(a, string_types):
 				# is it a filename?
 				try:
-					# keep this for error handling
-					_file = frappe.get_doc("File", a)
+					# check for both filename and file id
+					file_id = frappe.db.get_list('File', or_filters={'file_name': a, 'name': a}, limit=1)
+					if not file_id:
+						frappe.throw(_("Unable to find attachment {0}").format(a))
+					file_id = file_id[0]['name']
+					_file = frappe.get_doc("File", file_id)
 					_file.get_content()
 					# these attachments will be attached on-demand
 					# and won't be stored in the message
-					doc.attachments.append({"fid": a})
+					doc.attachments.append({"fid": file_id})
 				except IOError:
 					frappe.throw(_("Unable to find attachment {0}").format(a))
 			else:

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -280,7 +280,7 @@ def prepare_to_notify(doc, print_html=None, print_format=None, attachments=None)
 				# is it a filename?
 				try:
 					# keep this for error handling
-					_file = frappe.get_doc("File", {"file_name": a})
+					_file = frappe.get_doc("File", a)
 					_file.get_content()
 					# these attachments will be attached on-demand
 					# and won't be stored in the message

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -537,7 +537,7 @@ def prepare_message(email, recipient, recipients_list):
 
 		fid = attachment.get("fid")
 		if fid:
-			_file = frappe.get_doc("File", {"file_name": fid})
+			_file = frappe.get_doc("File", fid)
 			fcontent = _file.get_content()
 			attachment.update({
 				'fname': _file.file_name,


### PR DESCRIPTION
so, apparently i messed up some things that were responsible for handling file attachments in email queue and attached on-the-fly generated reports. these issues should be fixed now.

Before:
`file_name` was used to find the file

After:
v12 strictly uses `name` of the file doc to find the file