### PR TITLE
fix: Update Datatable to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "awesomplete": "^1.1.2",
     "cookie": "^0.3.1",
     "express": "^4.16.2",
-    "frappe-datatable": "^1.6.0",
+    "frappe-datatable": "^1.6.1",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.2.0",
     "highlight.js": "^9.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,10 +1219,10 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-frappe-datatable@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.6.0.tgz#c86c2c7fc054a500c70cdf6c6362b5fed63c6fe6"
-  integrity sha512-40iwguZr0w+X0MV/yTzsYDoKlH7b/GuOq6o2lEOrbVT3p4dZYpalxQmO8mkM9gKjNjSgGMVL1r6Se8peq80Qqg==
+frappe-datatable@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.6.1.tgz#e57850923b5f307fd02328c522c5abe35a17dd89"
+  integrity sha512-u2l4I2Pwu4jTLSBF7vW7EDwzcRdfrlKbgaUCyhDUYlOhWl0sRt6rO2ZmIhU7znSYz7TNkKkAt7hkI+x+Mg6ONw==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
Fallback to cell content when cell html is not available. This is the case when you try to filter rows using  the inline filters, but the most of the rows are not in the DOM so they don't have any html.

https://github.com/frappe/datatable/commit/96c7b723da8b6add39726245f871109c8502ecb8