### PR TITLE
Travis Fix: bench reinstall allow setting MariaDB root user/pass

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -125,14 +125,16 @@ def restore(context, sql_file_path, mariadb_root_username=None, mariadb_root_pas
 
 @click.command('reinstall')
 @click.option('--admin-password', help='Administrator Password for reinstalled site')
+@click.option('--mariadb-root-username', help='Root username for MariaDB')
+@click.option('--mariadb-root-password', help='Root password for MariaDB')
 @click.option('--yes', is_flag=True, default=False, help='Pass --yes to skip confirmation')
 @pass_context
-def reinstall(context, admin_password=None, yes=False):
+def reinstall(context, admin_password=None, mariadb_root_username=None, mariadb_root_password=None, yes=False):
 	"Reinstall site ie. wipe all data and start over"
 	site = get_site(context)
-	_reinstall(site, admin_password, yes, verbose=context.verbose)
+	_reinstall(site, admin_password, mariadb_root_username, mariadb_root_password, yes, verbose=context.verbose)
 
-def _reinstall(site, admin_password=None, yes=False, verbose=False):
+def _reinstall(site, admin_password=None, mariadb_root_username=None, mariadb_root_password=None, yes=False, verbose=False):
 	if not yes:
 		click.confirm('This will wipe your database. Are you sure you want to reinstall?', abort=True)
 	try:
@@ -149,8 +151,9 @@ def _reinstall(site, admin_password=None, yes=False, verbose=False):
 		frappe.destroy()
 
 	frappe.init(site=site)
-	_new_site(frappe.conf.db_name, site, verbose=verbose, force=True, reinstall=True,
-		install_apps=installed, admin_password=admin_password)
+	_new_site(frappe.conf.db_name, site, verbose=verbose, force=True, reinstall=True, install_apps=installed,
+		mariadb_root_username=mariadb_root_username, mariadb_root_password=mariadb_root_password,
+		admin_password=admin_password)
 
 @click.command('install-app')
 @click.argument('app')


### PR DESCRIPTION
For: https://github.com/frappe/erpnext/pull/16173

Travis fails at the command `bench reinstall --yes` because it prompts for keyboard input (for root user/pass) and times out. This PR allow passing Travis's MySQL root user/pass to `bench reinstall`