### PR TITLE
fix(report-view): Update Reports dropdown on creation of a Report

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -125,8 +125,11 @@ frappe.views.ListSidebar = class ListSidebar {
 			add_reports(this.list_view.settings.reports);
 		}
 
+		// Sort reports alphabetically
+		var reports = Object.values(frappe.boot.user.all_reports).sort((a,b) => a.title.localeCompare(b.title)) || [];
+
 		// from specially tagged reports
-		add_reports(frappe.boot.user.all_reports || []);
+		add_reports(reports);
 	}
 
 	setup_list_filter() {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -907,6 +907,14 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						return;
 					}
 					if(r.message != this.report_name) {
+						// Rerender the reports dropdown,
+						// so that this report is included in the dropdown as well.
+						frappe.boot.user.all_reports[r.message] = {
+							ref_doctype: "Item",
+							report_type: "Report Builder",
+							title: r.message,
+						};
+						this.list_sidebar.setup_reports();
 						frappe.set_route('List', this.doctype, 'Report', r.message);
 					}
 


### PR DESCRIPTION
This is done by updating frappe.boot.user.all_reports on creation of Report

Also to ensure that reports are properly ordered, report list is explicitly sorted by name.

![cr](https://user-images.githubusercontent.com/8528887/49745971-29cfab80-fcc6-11e8-8b4c-b3ed72e4fa5e.gif)

Fixes https://github.com/frappe/erpnext/issues/16171