### PR TITLE
fix(ui): make footer appear at end of page

### DIFF
--- a/frappe/public/less/website.less
+++ b/frappe/public/less/website.less
@@ -3,9 +3,24 @@
 @import "avatar.less";
 @import "indicator.less";
 
+html, body {
+	height: 100%;
+	margin: 0; padding: 0;  /* to avoid scrollbars */
+}
+
 body {
 	font-family: @font-stack;
 	color: @text-color;
+}
+
+.main-section {
+	display: flex;
+	min-height: 100%;
+	flex-direction: column; 
+}
+
+.wrapper {
+	flex: 1;
 }
 
 a& {

--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -37,7 +37,7 @@
 {% block body %}
 <body data-path="{{ path }}">
 	<div class="main-section">
-		<div>
+		<div class="wrapper">
 			<header>
 			{%- block banner -%}
 				{% include "templates/includes/banner_extension.html" ignore missing %}


### PR DESCRIPTION
Duplicate of #6606 (for travis)

Reference:
https://stackoverflow.com/a/26558049

**Before** (Mobile):

![before-mobile](https://user-images.githubusercontent.com/16315650/49780361-35f25200-fd34-11e8-8049-2a748b6a07a0.png)

**After** (Mobile):

![after-mobile](https://user-images.githubusercontent.com/16315650/49780369-3d196000-fd34-11e8-83bc-8c92e2bcb915.png)

**Before** (Desktop):

![before-desktop](https://user-images.githubusercontent.com/16315650/49780383-4a364f00-fd34-11e8-90b1-260f794ce807.png)

**After** (Desktop):

![after-desktop](https://user-images.githubusercontent.com/16315650/49780394-54f0e400-fd34-11e8-97d8-0857510ef091.png)
