### PR TITLE
fix: comment mentions

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -266,3 +266,10 @@ class TestUser(unittest.TestCase):
 		self.assertEqual(extract_mentions(user_name)[0], "test-user")
 		user_name = "Testing comment, @test.user@example.com please check."
 		self.assertEqual(extract_mentions(user_name)[0], "test.user@example.com")
+		user_name = "<div>@test_user@example.com and @test.again@example1.com</div><div>This is a test.</div>"
+		self.assertEqual(extract_mentions(user_name)[0], "test_user@example.com")
+		self.assertEqual(extract_mentions(user_name)[1], "test.again@example1.com")
+		user_name = "<div>@user@example.com</a> Test @test-comment@xyz.com</div><div>Test for comment mentions @test@abc.com</div>"
+		self.assertEqual(extract_mentions(user_name)[0], "user@example.com")
+		self.assertEqual(extract_mentions(user_name)[1], "test-comment@xyz.com")
+		self.assertEqual(extract_mentions(user_name)[2], "test@abc.com")

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -901,7 +901,7 @@ def notify_admin_access_to_system_manager(login_manager=None):
 def extract_mentions(txt):
 	"""Find all instances of @name in the string.
 	The mentions will be separated by non-word characters or may appear at the start of the string"""
-	txt = txt.replace("<br>", "<br> ")
+	txt = txt.replace("<div>", "<div> ")
 	txt = re.sub(r'(<[a-zA-Z\/][^>]*>)', '', txt)
 	return re.findall(r'(?:[^\w\.\-\@]|^)@([\w\.\-\@]*)', txt)
 


### PR DESCRIPTION
When I fixed this the last time, the comments used to have `<br>` tag if there was any new line in comments. So, had to add an extra space with `<br>` tag so that the comment text and mentions don't get mixed up and cause an issue while sending a mail.
 No idea how the `<br>` tag is replaced with `<div>` so again caused an issue in sending mails to mentions. Hence, the fix.