### PR TITLE
fix: Remove redundant import

### DIFF
--- a/frappe/public/less/chat.less
+++ b/frappe/public/less/chat.less
@@ -2,7 +2,6 @@
 
 // http://codeguide.co - @mdo (Author of Bootstrap)
 
-@import "common.less";
 @import "flex.less";
 
 // Typography
@@ -55,7 +54,7 @@
            margin: @fab-margin;
             width: @fab-size;
            height: @fab-size;
-    
+
     &.frappe-fab-lg
     {
             width: @fab-size-lg;
@@ -80,10 +79,10 @@
     {
          position: fixed;
            bottom: 0px;
-            right: 0px;	
+            right: 0px;
            margin: @chat-popper-margin;
           z-index: @chat-popper-z-index;
-            
+
         & > .frappe-chat-popper-collapse
         {
             & > .panel
@@ -151,7 +150,7 @@
                     {
                         .media-heading, .media-subtitle
                         {
-                            .ellipsis;
+                            text-overflow: ellipsis;
                             max-width: @chat-room-list-content-max-width;
                         }
                     }
@@ -175,7 +174,7 @@
                         right: 0px;
                      overflow: auto;
                 border-radius: 0px;
-        
+
                 .panel-heading
                 {
                     border-radius: 0px;
@@ -194,19 +193,19 @@
             {
                 font-size: @chat-form-font-size;
             }
-    
+
             .dropdown-menu
             {
                 border-radius: @chat-form-menu-border-radius;
             }
-    
+
             // Hints
             .hint-list.list-group
             {
                     margin: 0px;
                 max-height: @chat-form-list-group-height;
                 overflow-y: auto;
-                
+
                 .hint-list-item.list-group-item:first-child, .hint-list-item.list-group-item:last-child
                 {
                     border-radius: 0px !important;
@@ -269,7 +268,7 @@
             {
                 margin-right: @chat-base-spacing;
             }
-            
+
             .avatar
             {
                 width: 32px; height: 32px;
@@ -285,7 +284,7 @@
     .chat-form
     {
         border-top: @chat-form-border;
-    
+
         .input-group-btn
         {
             .btn
@@ -294,7 +293,7 @@
                 border-radius: 0px;
             }
         }
-    
+
         .form-control
         {
               line-height: 27px; // HACK: Makes input and placeholder centered within textarea. Also takes care of the input-btn
@@ -305,7 +304,7 @@
             padding-right: 0px;
                  overflow: hidden;
         }
-        
+
         .fa
         {
              font-size: @chat-base-font-size-lg;
@@ -317,7 +316,7 @@
 
 .chat-list
 {
-        height: 100%; 
+        height: 100%;
     // background: @chat-list-bg-color;
     overflow-y: scroll;
 
@@ -334,22 +333,22 @@
         }
 
         .cursor-pointer;
-        
+
             border: none !important;
            padding: @chat-list-item-padding;
         background: transparent;
-    
+
         .chat-bubble
         {
             max-width: @chat-bubble-max-width;
             display: inline-block;
             padding: @chat-bubble-padding;
             border-radius: @chat-bubble-border-radius;
-            
+
             -webkit-box-shadow: @chat-bubble-box-shadow;
             -moz-box-shadow: @chat-bubble-box-shadow;
             box-shadow: @chat-bubble-box-shadow;
-            
+
             @media (max-width : 768px) {
                 min-width: @chat-bubble-min-width;
             }
@@ -372,7 +371,7 @@
                     }
                 }
             }
-        
+
             &.chat-bubble-r
             {
                       text-align: right;
@@ -386,33 +385,33 @@
                     }
                 }
             }
-    
+
             .chat-bubble-author
             {
                 font-size: @chat-bubble-author-font-size;
-    
+
                 a
                 {
                     .font-bold;
-                    
+
                     text-decoration: none !important;
                 }
             }
-        
+
             .chat-bubble-content
             {
                 margin-bottom: @chat-bubble-content-margin-bottom;
                     word-wrap: break-word;
             }
-        
+
             .chat-bubble-meta
             {
                     font-size: @chat-bubble-meta-font-size;
-    
+
                 & > .chat-bubble-check
                 {
                     margin-left: @chat-base-spacing;
-    
+
                     i
                     {
                         font-size: @chat-bubble-check-font-size;

--- a/frappe/public/less/chat.less
+++ b/frappe/public/less/chat.less
@@ -3,6 +3,7 @@
 // http://codeguide.co - @mdo (Author of Bootstrap)
 
 @import "flex.less";
+@import {reference} "common.less";
 
 // Typography
 @font-weight-bold:								700;
@@ -150,7 +151,7 @@
                     {
                         .media-heading, .media-subtitle
                         {
-                            text-overflow: ellipsis;
+                            .ellipsis;
                             max-width: @chat-room-list-content-max-width;
                         }
                     }


### PR DESCRIPTION
`common.less` is already included in `frappe-web.css` and `desk.css`. No need to include it again in `chat.css`