### PR TITLE
fix: Report total row calculation for Currency field for list of dict

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -314,7 +314,7 @@ def add_total_row(result, columns, meta = None):
 
 
 		if fieldtype=="Link" and options == "Currency":
-			total_row[i] = result[0][i]
+			total_row[i] = result[0].get(fieldname) if isinstance(result[0], dict) else result[0][i]
 
 	for i in has_percent:
 		total_row[i] = flt(total_row[i]) / len(result)


### PR DESCRIPTION
For a report with list of dicts result with currency field, an error was occurring while adding the totals row. Fixed one line.