### PR TITLE
Don't auto-set report as "prepared"

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -58,17 +58,10 @@ def generate_report_result(report, filters=None, user=None):
 		module = report.module or frappe.db.get_value("DocType", report.ref_doctype, "module")
 		if report.is_standard == "Yes":
 			method_name = get_report_module_dotted_path(module, report.name) + ".execute"
-			threshold = 10
 			res = []
 
-			start_time = datetime.datetime.now()
 			# The JOB
 			res = frappe.get_attr(method_name)(frappe._dict(filters))
-
-			end_time = datetime.datetime.now()
-
-			if (end_time - start_time).seconds > threshold and not report.prepared_report:
-				report.db_set('prepared_report', 1)
 
 			columns, result = res[0], res[1]
 			if len(res) > 2:


### PR DESCRIPTION
This behaviour is incredibly implicit and the threshold is hardcoded at 10 seconds. This is poor design that creates confusion and changes UX for the user out of nowhere. It should be up to the developer (or the administrator) if a report should be "prepared" or not. 