### PR TITLE
fix(prepared-report): Show Preapred Report buttons only when necessary

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -983,7 +983,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if(flag){
 			this.prepared_report_action = "New";
 		}
-		this.add_prepared_report_buttons();
+		if(this.prepared_report) {
+			this.add_prepared_report_buttons();
+		}
 	}
 
 	toggle_message(flag, message) {


### PR DESCRIPTION
Preapared Report related buttons were also being rendered on Query Reports not marked as a Prepared Report. this fixes that.


before
![screenshot 2018-12-13 at 2 34 55 pm](https://user-images.githubusercontent.com/8528887/49927630-5d881c80-fee4-11e8-87c9-c479ad28f9fe.png)

after
![screenshot 2018-12-13 at 2 32 50 pm](https://user-images.githubusercontent.com/8528887/49927637-624cd080-fee4-11e8-8972-ebb5a71285c9.png)

**Note:** `Stock Ledger Report` is not marked as Prepared Report
