### PR TITLE
fix(website): Correctly generate route for list item

### DIFF
--- a/frappe/templates/includes/list/list.js
+++ b/frappe/templates/includes/list/list.js
@@ -11,6 +11,7 @@ frappe.ready(function() {
 			pathname: location.pathname,
 		});
 		data.web_form_name = frappe.web_form_name;
+		data.pathname = location.pathname;
 		btn.prop("disabled", true);
 		return $.ajax({
 			url:"/api/method/frappe.www.list.get",

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -24,7 +24,7 @@ def get_context(context, **dict_params):
 	context.update(get(**frappe.local.form_dict))
 
 @frappe.whitelist(allow_guest=True)
-def get(doctype, txt=None, limit_start=0, limit=20, **kwargs):
+def get(doctype, txt=None, limit_start=0, limit=20, pathname=None, **kwargs):
 	"""Returns processed HTML page for a standard listing."""
 	limit_start = cint(limit_start)
 	raw_result = get_list_data(doctype, txt, limit_start, limit=limit + 1, **kwargs)
@@ -54,7 +54,8 @@ def get(doctype, txt=None, limit_start=0, limit=20, **kwargs):
 			new_context.update(new_context.doc.as_dict())
 
 		if not frappe.flags.in_test:
-			new_context["pathname"] = frappe.local.request.path.strip("/ ")
+			pathname = pathname or frappe.local.request.path
+			new_context["pathname"] = pathname.strip("/ ")
 		new_context.update(list_context)
 		set_route(new_context)
 		rendered_row = frappe.render_template(row_template, new_context, is_path=True)


### PR DESCRIPTION
Since route string for list-item in website list view was generated from `frappe.local.request.path`, page part that is acquired by ajax call used to contain incorrect route

e.g. `/api/frappe.www.list.get/CC-SINV-2018-00006` instead of `/invoices/ACC-SINV-2018-00006`


Before
![wl0](https://user-images.githubusercontent.com/8528887/49931381-bf4c8480-feec-11e8-8018-ca11353dba9f.gif)

After
![wl1](https://user-images.githubusercontent.com/8528887/49931391-c4113880-feec-11e8-9d3b-3d4e24a17dcb.gif)
