### PR TITLE
[Fix] Json data for Report Builder based reports

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -232,3 +232,4 @@ frappe.patches.v11_0.multiple_references_in_events
 frappe.patches.v11_0.set_allow_self_approval_in_workflow
 frappe.patches.v11_0.migrate_report_settings_for_new_listview
 frappe.patches.v11_0.delete_all_prepared_reports
+frappe.patches.v11_0.fix_order_by_in_reports_json

--- a/frappe/patches/v11_0/fix_order_by_in_reports_json.py
+++ b/frappe/patches/v11_0/fix_order_by_in_reports_json.py
@@ -1,0 +1,22 @@
+import frappe, json
+
+def execute():
+	reports_data = frappe.get_all('Report',
+		filters={'json': ['not like', '%%%"order_by": "`tab%%%'],
+			'report_type': 'Report Builder', 'is_standard': 'No'}, fields=['name'])
+
+	for d in reports_data:
+		doc = frappe.get_doc('Report', d.get('name'))
+		json_data = json.loads(doc.get('json'))
+
+		parts = []
+		if ('order_by' in json_data) and ('.' in json_data.get('order_by')):
+			parts = json_data.get('order_by').split('.')
+
+			sort_by = parts[1].split(' ')
+
+			json_data['order_by'] = '`tab{0}`.`{1}`'.format(doc.ref_doctype, sort_by[0])
+			json_data['order_by'] += ' {0}'.format(sort_by[1]) if len(sort_by) > 1 else ''
+
+			doc.json = json.dumps(json_data)
+			doc.save()

--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -187,6 +187,7 @@ frappe.ui.SortSelector = Class.extend({
 	},
 	get_sql_string: function() {
 		// build string like `tabTask`.`subject` desc
-		return '`tab' + this.doctype + '`.`' + this.sort_by + '` ' +  this.sort_order;
+		let sort_by = this.sort_by.replace(this.doctype+'.', '');
+		return '`tab' + this.doctype + '`.`' + sort_by + '` ' +  this.sort_order;
 	}
 })

--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -187,7 +187,6 @@ frappe.ui.SortSelector = Class.extend({
 	},
 	get_sql_string: function() {
 		// build string like `tabTask`.`subject` desc
-		let sort_by = this.sort_by.replace(this.doctype+'.', '');
-		return '`tab' + this.doctype + '`.`' + sort_by + '` ' +  this.sort_order;
+		return '`tab' + this.doctype + '`.`' + this.sort_by + '` ' +  this.sort_order;
 	}
 })

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -824,7 +824,8 @@ def get_filter(doctype, f):
 
 	if len(f) == 3:
 		f = (doctype, f[0], f[1], f[2])
-
+	elif len(f) > 4:
+		f = f[0:4]
 	elif len(f) != 4:
 		frappe.throw(frappe._("Filter must have 4 values (doctype, fieldname, operator, value): {0}").format(str(f)))
 


### PR DESCRIPTION
Issue:-
```
Traceback (most recent call last):
  File "/Users/allen/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/Users/allen/frappe-bench/apps/frappe/frappe/desk/reportview.py", line 22, in get
    data = compress(execute(**args), args = args)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/desk/reportview.py", line 27, in execute
    return DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/db_query.py", line 88, in execute
    result = self.build_and_run()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/db_query.py", line 112, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/database.py", line 210, in sql
    self._cursor.execute(query)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1054, u"Unknown column 'tabLead.Lead.modified' in 'order clause'")
```

![reports_issue](https://user-images.githubusercontent.com/11695402/49985831-6ab01480-ff93-11e8-936f-9c8ad5fe61b9.gif)

Fix:-
![reports_fix](https://user-images.githubusercontent.com/11695402/49985834-6d126e80-ff93-11e8-8740-753b8bfb2739.gif)


Data stored in json format when a report is built using Report Builder stores `order_by` field with DocType name and when routing to the report it again appends the DocType name leading to something like - `tabLead.Lead.modified`.

Also fix for auto email report with filters applied - filters data contains 5 elements hence error was generated as it went into fallback error case.
![image](https://user-images.githubusercontent.com/11695402/49996236-91327780-ffb4-11e8-9f7c-eb95d5fc76e8.png)


