### PR TITLE
fix: pass parameters as list

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -149,7 +149,7 @@ class Report(Document):
 			if params.get('sort_by'):
 				order_by = _format(params.get('sort_by').split('.')) + ' ' + params.get('sort_order')
 			else:
-				order_by = _format(self.ref_doctype, 'modified') + ' desc'
+				order_by = _format([self.ref_doctype, 'modified']) + ' desc'
 
 			if params.get('sort_by_next'):
 				order_by += ', ' + _format(params.get('sort_by_next').split('.')) + ' ' + params.get('sort_order_next')

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -53,3 +53,19 @@ class TestReport(unittest.TestCase):
 			report = frappe.get_doc('Report', 'Test Report')
 
 		self.assertNotEquals(report.is_permitted(), True)
+
+	# test for the `_format` method if report data doesn't have sort_by parameter
+	def test_format_method(self):
+		if frappe.db.exists('Report', 'User Activity Report Without Sort'):
+			frappe.delete_doc('Report', 'User Activity Report Without Sort')
+		with open(os.path.join(os.path.dirname(__file__), 'user_activity_report_without_sort.json'), 'r') as f:
+			frappe.get_doc(json.loads(f.read())).insert()
+
+		report = frappe.get_doc('Report', 'User Activity Report Without Sort')
+
+		# this would raise an error without the fix added along with this test case
+		columns, data = report.get_data()
+		self.assertEqual(columns[0].get('label'), 'ID')
+		self.assertEqual(columns[1].get('label'), 'User Type')
+		self.assertTrue('Administrator' in [d[0] for d in data])
+		frappe.delete_doc('Report', 'User Activity Report Without Sort')

--- a/frappe/core/doctype/report/user_activity_report_without_sort.json
+++ b/frappe/core/doctype/report/user_activity_report_without_sort.json
@@ -1,0 +1,17 @@
+{
+	"add_total_row": 0,
+	"apply_user_permissions": 1,
+	"disabled": 0,
+	"docstatus": 0,
+	"doctype": "Report",
+	"is_standard": "No",
+	"javascript": null,
+	"json": "{\"filters\":[],\"columns\":[[\"name\",\"User\"],[\"user_type\",\"User\"],[\"first_name\",\"User\"],[\"last_name\",\"User\"],[\"last_active\",\"User\"],[\"role\",\"Has Role\"]],\"sort_order\":\"desc\",\"sort_by_next\":null,\"sort_order_next\":\"desc\"}",
+	"modified": "2018-12-17 18:27:07.728890",
+	"module": "Core",
+	"name": "User Activity Report Without Sort",
+	"query": null,
+	"ref_doctype": "User",
+	"report_name": "User Activity Report Without Sort",
+	"report_type": "Report Builder"
+  }


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 171, in send_now
    auto_email_report.send()
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 126, in send
    data = self.get_report_content()
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 66, in get_report_content
    filters = self.filters, as_dict=True)
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/core/doctype/report/report.py", line 152, in get_data
    order_by = _format(self.ref_doctype, 'modified') + ' desc'
TypeError: _format() takes exactly 1 argument (2 given)
```