### PR TITLE
fix(Kanban): Fix for New Kanban DDL issue

### DIFF
--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -8,7 +8,6 @@ import json
 from frappe import _
 from frappe.model.document import Document
 from six import iteritems
-from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
 
 class KanbanBoard(Document):
@@ -130,17 +129,8 @@ def update_order(board_name, order):
 @frappe.whitelist()
 def quick_kanban_board(doctype, board_name, field_name, project=None):
 	'''Create new KanbanBoard quickly with default options'''
+
 	doc = frappe.new_doc('Kanban Board')
-
-	if field_name == 'kanban_column':
-		create_custom_field(doctype, {
-			'label': 'Kanban Column',
-			'fieldname': 'kanban_column',
-			'fieldtype': 'Select',
-			'hidden': 1,
-			'owner': 'Administrator'
-		})
-
 	meta = frappe.get_meta(doctype)
 
 	options = ''

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -290,7 +290,7 @@ frappe.views.KanbanView.setup_dropdown_in_sidebar = function(doctype, $dropdown)
 						</a>
 					</div>
 				`
-			}]
+			}];
 		}
 
 		return fields;

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -225,21 +225,18 @@ frappe.views.KanbanView.setup_dropdown_in_sidebar = function(doctype, $dropdown)
 
 		const fields = get_fields_for_dialog();
 
+		let primary_action_label = fields.length > 1 ? __('Save') : '';
+		let primary_action = fields.length > 1 ?
+			({ board_name, field_name, project }) => {
+				make_kanban_board(board_name, field_name, project)
+					.then(() => dialog.hide(), (err) => frappe.msgprint(err));
+			} : null;
+
 		dialog = new frappe.ui.Dialog({
 			title: __('New Kanban Board'),
-			fields: fields,
-
-			primary_action_label: __('Save'),
-			primary_action(values) {
-				const custom_column =
-					values.custom_column !== undefined ?
-						values.custom_column : 1;
-
-				let field_name = custom_column ? 'kanban_column' : values.field_name;
-
-				make_kanban_board(values.board_name, field_name, values.project)
-					.then(() => dialog.hide(), (err) => frappe.msgprint(err));
-			}
+			fields,
+			primary_action_label,
+			primary_action
 		});
 		return dialog;
 	}
@@ -272,26 +269,28 @@ frappe.views.KanbanView.setup_dropdown_in_sidebar = function(doctype, $dropdown)
 				});
 
 		if (select_fields.length > 0) {
-			fields = fields.concat([{
+			fields.push({
 				fieldtype: 'Select',
 				fieldname: 'field_name',
 				label: __('Columns based on'),
 				options: select_fields.map(df => ({label: df.label, value: df.fieldname})),
 				default: select_fields[0],
-				depends_on: 'eval:doc.custom_column===0',
-				reqd: 1
-			},
-
-			{
-				fieldtype: 'Check',
-				fieldname: 'custom_column',
-				label: __('Custom Column'),
-				default: 0,
-				onchange() {
-					const value = this.get_value();
-					this.layout.set_df_property('field_name', 'reqd', !value);
-				}
-			}]);
+				reqd: 1,
+			});
+		} else {
+			fields = [{
+				fieldtype: 'HTML',
+				options: `
+					<div>
+						<p class="text-medium">
+						${__('No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type "Select".')}
+						</p>
+						<a class="btn btn-xs btn-default" href="#Form/Customize Form?doc_type=${doctype}">
+							${__('Customize Form')}
+						</a>
+					</div>
+				`
+			}]
 		}
 
 		return fields;


### PR DESCRIPTION
When making a new Kanban, the User was given an option to create it based on a new Custom Field which was automatically created before creating the Kanban Board. This means there was a DDL statement involved which would create that custom column in the database. Since this is happening from the list view, the `GET` call which gets the data for the listview breaks because DDL statement was being run.

The solution is to delegate the creation of custom field to user. So now, if the user wants to have a Kanban Board based on a different field, he will have to create that field himself. This also means that he has more control over what columns he can have in the field.
If the DocType has no fieldtype of "Select", he will be shown a message that instructs him to create the field manually via Customize Form.

![kanban-ddl-fix](https://user-images.githubusercontent.com/9355208/50139689-630caa80-02c8-11e9-951c-9ffe8f34a9c6.gif)
