### PR TITLE
fix(patch): Skip reports that dont have any json config set

### DIFF
--- a/frappe/patches/v11_0/fix_order_by_in_reports_json.py
+++ b/frappe/patches/v11_0/fix_order_by_in_reports_json.py
@@ -7,6 +7,9 @@ def execute():
 
 	for d in reports_data:
 		doc = frappe.get_doc('Report', d.get('name'))
+
+		if not doc.get('json'): continue
+
 		json_data = json.loads(doc.get('json'))
 
 		parts = []


### PR DESCRIPTION
Some reports don't have any `json` config, they can be skipped from the patch.