### PR TITLE
Update chat.less

### DIFF
--- a/frappe/public/less/chat.less
+++ b/frappe/public/less/chat.less
@@ -2,8 +2,8 @@
 
 // http://codeguide.co - @mdo (Author of Bootstrap)
 
+@import "common.less";	
 @import "flex.less";
-@import {reference} "common.less";
 
 // Typography
 @font-weight-bold:								700;


### PR DESCRIPTION
for new installation 

bench build  
yarn run v1.9.4
$ FRAPPE_ENV=production node rollup/build.js
Production mode
✔ Built js/moment-bundle.min.js
✔ Built js/libs.min.js

Building frappe assets...

SyntaxError: malformed import statement in /Users/macbookpro/TS/*****/apps/frappe/frappe/public/less/chat.less on line 6, column 1:
5 @import "flex.less";
6 @import {reference} "common.less";
7 

SyntaxError: malformed import statement in /Users/macbookpro/TS/*****/apps/frappe/frappe/public/less/chat.less on line 6, column 1:
5 @import "flex.less";
6 @import {reference} "common.less";
7 



this update will fix the issue 

thanks

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.