### PR TITLE
Update child autoname during rename_doc

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -146,6 +146,14 @@ def update_autoname_field(doctype, new, meta):
 		if field and field[0] == "field":
 			frappe.db.sql("UPDATE `tab{0}` SET `{1}`={2} WHERE `name`={2}".format(doctype, field[1], '%s'), (new, new))
 
+def update_child_autoname_field(doctype, link_field, new, old, meta):
+	# update child name value if autoname is set with link field
+	# example autoname is field:user and user is renamed
+	if meta.get('autoname'):
+		field = meta.get('autoname').split(':')
+		if field and field[0] == "field" and field[1] == link_field:
+			frappe.db.sql("UPDATE `tab{0}` SET `name`=%s WHERE `name`=%s".format(doctype), (new, old))
+
 def validate_rename(doctype, new, meta, merge, force, ignore_permissions):
 	# using for update so that it gets locked and someone else cannot edit it while this rename is going on!
 	exists = frappe.db.sql("select name from `tab{doctype}` where name=%s for update".format(doctype=doctype), new)
@@ -210,7 +218,8 @@ def update_link_field_values(link_fields, old, new, doctype):
 		else:
 			# because the table hasn't been renamed yet!
 			parent = field['parent'] if field['parent']!=new else old
-
+			parent_meta = frappe.get_meta(parent)
+			update_child_autoname_field(parent, field['fieldname'], new, old, parent_meta)
 			frappe.db.sql("""
 				update `tab{table_name}` set `{fieldname}`=%s
 				where `{fieldname}`=%s""".format(

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -146,14 +146,6 @@ def update_autoname_field(doctype, new, meta):
 		if field and field[0] == "field":
 			frappe.db.sql("UPDATE `tab{0}` SET `{1}`={2} WHERE `name`={2}".format(doctype, field[1], '%s'), (new, new))
 
-def update_child_autoname_field(doctype, link_field, new, old, meta):
-	# update child name value if autoname is set with link field
-	# example autoname is field:user and user is renamed
-	if meta.get('autoname'):
-		field = meta.get('autoname').split(':')
-		if field and field[0] == "field" and field[1] == link_field:
-			frappe.db.sql("UPDATE `tab{0}` SET `name`=%s WHERE `name`=%s".format(doctype), (new, old))
-
 def validate_rename(doctype, new, meta, merge, force, ignore_permissions):
 	# using for update so that it gets locked and someone else cannot edit it while this rename is going on!
 	exists = frappe.db.sql("select name from `tab{doctype}` where name=%s for update".format(doctype=doctype), new)
@@ -228,6 +220,14 @@ def update_link_field_values(link_fields, old, new, doctype):
 		# update cached link_fields as per new
 		if doctype=='DocType' and field['parent'] == old:
 			field['parent'] = new
+
+def update_child_autoname_field(doctype, link_field, new, old, meta):
+	# update child name value if autoname is set with link field
+	# example autoname is field:user and user is renamed
+	if meta.get('autoname'):
+		field = meta.get('autoname').split(':')
+		if field and field[0] == "field" and field[1] == link_field:
+			frappe.db.sql("UPDATE `tab{0}` SET `name`=%s WHERE `name`=%s".format(doctype), (new, old))
 
 def get_link_fields(doctype):
 	# get link fields from tabDocField


### PR DESCRIPTION
During Doctype is renamed if Link field is also autoname field name value is renamed as well.

Step to replicate, 

- Rename any User Doctype
- Check Chat Profile 

Where is not update of the name and  produce the error:
"Chat Profile <old name> not found"

