### PR TITLE
fix: Customize Form and Custom DocType related fixes

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -35,7 +35,7 @@ frappe.ui.form.on('Custom Field', {
 		return frappe.call({
 			method: 'frappe.custom.doctype.custom_field.custom_field.get_fields_label',
 			args: { doctype: frm.doc.dt, fieldname: frm.doc.fieldname },
-			callback: function(r, rt) {
+			callback: function(r) {
 				if(r) {
 					if(r._server_messages && r._server_messages.length) {
 						frm.set_value("dt", "");

--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -33,14 +33,20 @@ frappe.ui.form.on('Custom Field', {
 			method: 'frappe.custom.doctype.custom_field.custom_field.get_fields_label',
 			args: { doctype: frm.doc.dt, fieldname: frm.doc.fieldname },
 			callback: function(r, rt) {
-				set_field_options('insert_after', r.message);
-				var fieldnames = $.map(r.message, function(v) { return v.value; });
+				if(r) {
+					if(r._server_messages && r._server_messages.length) {
+						frm.set_value("dt", "");
+					} else {
+						set_field_options('insert_after', r.message);
+						var fieldnames = $.map(r.message, function(v) { return v.value; });
 
-				if(insert_after==null || !in_list(fieldnames, insert_after)) {
-					insert_after = fieldnames[-1];
+						if(insert_after==null || !in_list(fieldnames, insert_after)) {
+							insert_after = fieldnames[-1];
+						}
+
+						frm.set_value('insert_after', insert_after);
+					}
 				}
-
-				frm.set_value('insert_after', insert_after);
 			}
 		});
 

--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -9,6 +9,11 @@ frappe.ui.form.on('Custom Field', {
 		frm.set_query('dt', function(doc) {
 			var filters = [
 				['DocType', 'issingle', '=', 0],
+				['DocType', 'custom', '=', 0],
+				['DocType', 'name', 'not in', 'DocType, DocField, DocPerm, User, Role, Has Role, \
+					Page, Has Role, Module Def, Print Format, Report, Customize Form, \
+					Customize Form Field, Property Setter, Custom Field, Custom Script'],
+				['DocType', 'restrict_to_domain', 'in', frappe.boot.active_domains]
 			];
 			if(frappe.session.user!=="Administrator") {
 				filters.push(['DocType', 'module', 'not in', ['Core', 'Custom']])

--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -10,9 +10,7 @@ frappe.ui.form.on('Custom Field', {
 			var filters = [
 				['DocType', 'issingle', '=', 0],
 				['DocType', 'custom', '=', 0],
-				['DocType', 'name', 'not in', 'DocType, DocField, DocPerm, User, Role, Has Role, \
-					Page, Has Role, Module Def, Print Format, Report, Customize Form, \
-					Customize Form Field, Property Setter, Custom Field, Custom Script'],
+				['DocType', 'name', 'not in', frappe.model.core_doctypes_list],
 				['DocType', 'restrict_to_domain', 'in', frappe.boot.active_domains]
 			];
 			if(frappe.session.user!=="Administrator") {

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -7,6 +7,7 @@ import json
 from frappe.utils import cstr
 from frappe import _
 from frappe.model.document import Document
+from frappe.model import core_doctypes_list
 
 class CustomField(Document):
 	def autoname(self):
@@ -83,6 +84,9 @@ class CustomField(Document):
 @frappe.whitelist()
 def get_fields_label(doctype=None):
 	meta = frappe.get_meta(doctype)
+
+	if doctype in core_doctypes_list:
+		return frappe.msgprint(_("Custom Fields cannot be added to core DocTypes."))
 
 	if meta.custom:
 		return frappe.msgprint(_("Custom Fields can only be added to a standard DocType."))

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -82,6 +82,11 @@ class CustomField(Document):
 
 @frappe.whitelist()
 def get_fields_label(doctype=None):
+	meta = frappe.get_meta(doctype)
+
+	if meta.custom:
+		return frappe.msgprint(_("Custom Fields can only be added to a standard DocType."))
+
 	return [{"value": df.fieldname or "", "label": _(df.label or "")}
 		for df in frappe.get_meta(doctype).get("fields")]
 

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -36,7 +36,7 @@ frappe.ui.form.on("Customize Form", {
 				method: "fetch_to_customize",
 				doc: frm.doc,
 				freeze: true,
-				callback: function(r, rt) {
+				callback: function(r) {
 					if(r) {
 						if(r._server_messages && r._server_messages.length) {
 							frm.set_value("doc_type", "");

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -13,9 +13,7 @@ frappe.ui.form.on("Customize Form", {
 				filters: [
 					['DocType', 'issingle', '=', 0],
 					['DocType', 'custom', '=', 0],
-					['DocType', 'name', 'not in', 'DocType, DocField, DocPerm, User, Role, Has Role, \
-						Page, Has Role, Module Def, Print Format, Report, Customize Form, \
-						Customize Form Field, Property Setter, Custom Field, Custom Script'],
+					['DocType', 'name', 'not in', frappe.model.core_doctypes_list],
 					['DocType', 'restrict_to_domain', 'in', frappe.boot.active_domains]
 				]
 			};

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -38,9 +38,15 @@ frappe.ui.form.on("Customize Form", {
 				method: "fetch_to_customize",
 				doc: frm.doc,
 				freeze: true,
-				callback: function(r) {
-					frm.refresh();
-					frm.trigger("setup_sortable");
+				callback: function(r, rt) {
+					if(r) {
+						if(r._server_messages && r._server_messages.length) {
+							frm.set_value("doc_type", "");
+						} else {
+							frm.refresh();
+							frm.trigger("setup_sortable");
+						}
+					}
 				}
 			});
 		} else {

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -11,7 +11,7 @@ import frappe.translate
 from frappe import _
 from frappe.utils import cint
 from frappe.model.document import Document
-from frappe.model import no_value_fields
+from frappe.model import no_value_fields, core_doctypes_list
 from frappe.core.doctype.doctype.doctype import validate_fields_for_doctype
 
 doctype_properties = {
@@ -81,6 +81,9 @@ class CustomizeForm(Document):
 			return
 
 		meta = frappe.get_meta(self.doc_type)
+
+		if self.doc_type in core_doctypes_list:
+			return frappe.msgprint(_("Core DocTypes cannot be customized."))
 
 		if meta.custom:
 			return frappe.msgprint(_("Only standard DocTypes are allowed to be customized from Customize Form."))

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -82,6 +82,9 @@ class CustomizeForm(Document):
 
 		meta = frappe.get_meta(self.doc_type)
 
+		if meta.custom:
+			return frappe.msgprint(_("Only standard DocTypes are allowed to be customized from Customize Form."))
+
 		# doctype properties
 		for property in doctype_properties:
 			self.set(property, meta.get(property))

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -9,28 +9,28 @@ from frappe.core.doctype.doctype.doctype import InvalidFieldNameError
 test_dependencies = ["Custom Field", "Property Setter"]
 class TestCustomizeForm(unittest.TestCase):
 	def insert_custom_field(self):
-		frappe.delete_doc_if_exists("Custom Field", "User-test_custom_field")
+		frappe.delete_doc_if_exists("Custom Field", "Event-test_custom_field")
 		frappe.get_doc({
 			"doctype": "Custom Field",
-			"dt": "User",
+			"dt": "Event",
 			"label": "Test Custom Field",
 			"description": "A Custom Field for Testing",
 			"fieldtype": "Select",
 			"in_list_view": 1,
 			"options": "\nCustom 1\nCustom 2\nCustom 3",
 			"default": "Custom 3",
-			"insert_after": frappe.get_meta('User').fields[-1].fieldname
+			"insert_after": frappe.get_meta('Event').fields[-1].fieldname
 		}).insert()
 
 	def setUp(self):
 		self.insert_custom_field()
 		frappe.db.commit()
-		frappe.clear_cache(doctype="User")
+		frappe.clear_cache(doctype="Event")
 
 	def tearDown(self):
-		frappe.delete_doc("Custom Field", "User-test_custom_field")
+		frappe.delete_doc("Custom Field", "Event-test_custom_field")
 		frappe.db.commit()
-		frappe.clear_cache(doctype="User")
+		frappe.clear_cache(doctype="Event")
 
 	def get_customize_form(self, doctype=None):
 		d = frappe.get_doc("Customize Form")
@@ -46,66 +46,66 @@ class TestCustomizeForm(unittest.TestCase):
 
 		d = self.get_customize_form("Event")
 		self.assertEquals(d.doc_type, "Event")
-		self.assertEquals(len(d.get("fields")), 29)
+		self.assertEquals(len(d.get("fields")), 30)
 
-		d = self.get_customize_form("User")
-		self.assertEquals(d.doc_type, "User")
+		d = self.get_customize_form("Event")
+		self.assertEquals(d.doc_type, "Event")
 
 		self.assertEquals(len(d.get("fields")),
 			len(frappe.get_doc("DocType", d.doc_type).fields) + 1)
 		self.assertEquals(d.get("fields")[-1].fieldname, "test_custom_field")
-		self.assertEquals(d.get("fields", {"fieldname": "location"})[0].in_list_view, 1)
+		self.assertEquals(d.get("fields", {"fieldname": "event_type"})[0].in_list_view, 1)
 
 		return d
 
 	def test_save_customization_property(self):
-		d = self.get_customize_form("User")
+		d = self.get_customize_form("Event")
 		self.assertEquals(frappe.db.get_value("Property Setter",
-			{"doc_type": "User", "property": "allow_copy"}, "value"), None)
+			{"doc_type": "Event", "property": "allow_copy"}, "value"), None)
 
 		d.allow_copy = 1
 		d.run_method("save_customization")
 		self.assertEquals(frappe.db.get_value("Property Setter",
-			{"doc_type": "User", "property": "allow_copy"}, "value"), '1')
+			{"doc_type": "Event", "property": "allow_copy"}, "value"), '1')
 
 		d.allow_copy = 0
 		d.run_method("save_customization")
 		self.assertEquals(frappe.db.get_value("Property Setter",
-			{"doc_type": "User", "property": "allow_copy"}, "value"), None)
+			{"doc_type": "Event", "property": "allow_copy"}, "value"), None)
 
 	def test_save_customization_field_property(self):
-		d = self.get_customize_form("User")
+		d = self.get_customize_form("Event")
 		self.assertEquals(frappe.db.get_value("Property Setter",
-			{"doc_type": "User", "property": "reqd", "field_name": "location"}, "value"), None)
+			{"doc_type": "Event", "property": "reqd", "field_name": "repeat_this_event"}, "value"), None)
 
-		location_field = d.get("fields", {"fieldname": "location"})[0]
-		location_field.reqd = 1
+		repeat_this_event_field = d.get("fields", {"fieldname": "repeat_this_event"})[0]
+		repeat_this_event_field.reqd = 1
 		d.run_method("save_customization")
 		self.assertEquals(frappe.db.get_value("Property Setter",
-			{"doc_type": "User", "property": "reqd", "field_name": "location"}, "value"), '1')
+			{"doc_type": "Event", "property": "reqd", "field_name": "repeat_this_event"}, "value"), '1')
 
-		location_field = d.get("fields", {"fieldname": "location"})[0]
-		location_field.reqd = 0
+		repeat_this_event_field = d.get("fields", {"fieldname": "repeat_this_event"})[0]
+		repeat_this_event_field.reqd = 0
 		d.run_method("save_customization")
 		self.assertEquals(frappe.db.get_value("Property Setter",
-			{"doc_type": "User", "property": "reqd", "field_name": "location"}, "value"), None)
+			{"doc_type": "Event", "property": "reqd", "field_name": "repeat_this_event"}, "value"), None)
 
 	def test_save_customization_custom_field_property(self):
-		d = self.get_customize_form("User")
-		self.assertEquals(frappe.db.get_value("Custom Field", "User-test_custom_field", "reqd"), 0)
+		d = self.get_customize_form("Event")
+		self.assertEquals(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 0)
 
 		custom_field = d.get("fields", {"fieldname": "test_custom_field"})[0]
 		custom_field.reqd = 1
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Custom Field", "User-test_custom_field", "reqd"), 1)
+		self.assertEquals(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 1)
 
 		custom_field = d.get("fields", {"is_custom_field": True})[0]
 		custom_field.reqd = 0
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Custom Field", "User-test_custom_field", "reqd"), 0)
+		self.assertEquals(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 0)
 
 	def test_save_customization_new_field(self):
-		d = self.get_customize_form("User")
+		d = self.get_customize_form("Event")
 		last_fieldname = d.fields[-1].fieldname
 		d.append("fields", {
 			"label": "Test Add Custom Field Via Customize Form",
@@ -114,18 +114,18 @@ class TestCustomizeForm(unittest.TestCase):
 		})
 		d.run_method("save_customization")
 		self.assertEquals(frappe.db.get_value("Custom Field",
-			"User-test_add_custom_field_via_customize_form", "fieldtype"), "Data")
+			"Event-test_add_custom_field_via_customize_form", "fieldtype"), "Data")
 
 		self.assertEquals(frappe.db.get_value("Custom Field",
-			"User-test_add_custom_field_via_customize_form", 'insert_after'), last_fieldname)
+			"Event-test_add_custom_field_via_customize_form", 'insert_after'), last_fieldname)
 
-		frappe.delete_doc("Custom Field", "User-test_add_custom_field_via_customize_form")
+		frappe.delete_doc("Custom Field", "Event-test_add_custom_field_via_customize_form")
 		self.assertEquals(frappe.db.get_value("Custom Field",
-			"User-test_add_custom_field_via_customize_form"), None)
+			"Event-test_add_custom_field_via_customize_form"), None)
 
 
 	def test_save_customization_remove_field(self):
-		d = self.get_customize_form("User")
+		d = self.get_customize_form("Event")
 		custom_field = d.get("fields", {"fieldname": "test_custom_field"})[0]
 		d.get("fields").remove(custom_field)
 		d.run_method("save_customization")
@@ -137,24 +137,24 @@ class TestCustomizeForm(unittest.TestCase):
 
 	def test_reset_to_defaults(self):
 		d = frappe.get_doc("Customize Form")
-		d.doc_type = "User"
+		d.doc_type = "Event"
 		d.run_method('reset_to_defaults')
 
-		self.assertEquals(d.get("fields", {"fieldname": "location"})[0].in_list_view, 0)
+		self.assertEquals(d.get("fields", {"fieldname": "repeat_this_event"})[0].in_list_view, 0)
 
 		frappe.local.test_objects["Property Setter"] = []
 		make_test_records_for_doctype("Property Setter")
 
 	def test_set_allow_on_submit(self):
-		d = self.get_customize_form("User")
-		d.get("fields", {"fieldname": "first_name"})[0].allow_on_submit = 1
+		d = self.get_customize_form("Event")
+		d.get("fields", {"fieldname": "subject"})[0].allow_on_submit = 1
 		d.get("fields", {"fieldname": "test_custom_field"})[0].allow_on_submit = 1
 		d.run_method("save_customization")
 
-		d = self.get_customize_form("User")
+		d = self.get_customize_form("Event")
 
 		# don't allow for standard fields
-		self.assertEquals(d.get("fields", {"fieldname": "first_name"})[0].allow_on_submit or 0, 0)
+		self.assertEquals(d.get("fields", {"fieldname": "subject"})[0].allow_on_submit or 0, 0)
 
 		# allow for custom field
 		self.assertEquals(d.get("fields", {"fieldname": "test_custom_field"})[0].allow_on_submit, 1)
@@ -184,3 +184,10 @@ class TestCustomizeForm(unittest.TestCase):
 		df.default = None
 		d.run_method("save_customization")
 
+	def test_core_doctype_customization(self):
+		d = self.get_customize_form('User')
+		e = self.get_customize_form('Custom Field')
+
+		# core doctype is invalid, hence no attributes are set
+		self.assertEquals(d.get("fields"), [])
+		self.assertEquals(e.get("fields"), [])

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -13,6 +13,9 @@ display_fieldtypes = ('Section Break', 'Column Break', 'HTML', 'Button', 'Image'
 default_fields = ('doctype','name','owner','creation','modified','modified_by',
 	'parent','parentfield','parenttype','idx','docstatus')
 optional_fields = ("_user_tags", "_comments", "_assign", "_liked_by", "_seen")
+core_doctypes_list = ('DocType', 'DocField', 'DocPerm', 'User', 'Role', 'Has Role',
+	'Page', 'Module Def', 'Print Format', 'Report', 'Customize Form',
+	'Customize Form Field', 'Property Setter', 'Custom Field', 'Custom Script')
 
 def copytables(srctype, src, srcfield, tartype, tar, tarfield, srcfields, tarfields=[]):
 	if not tarfields:

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -485,6 +485,9 @@ frappe.ui.form.Layout = Class.extend({
 		if(expression.substr(0,5)=='eval:') {
 			try {
 				out = eval(expression.substr(5));
+				if(parent && parent.istable && expression.includes('is_submittable')) {
+					out = true;
+				}
 			} catch(e) {
 				frappe.throw(__('Invalid "depends_on" expression'));
 			}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -613,7 +613,7 @@ frappe.views.ListView = frappe.ui.BaseList.extend({
 				});
 			}, true);
 		}
-		if (frappe.user_roles.includes('System Manager')) {
+		if (frappe.user_roles.includes('System Manager') && (this.meta && !this.meta.custom)) {
 			this.page.add_menu_item(__('Role Permissions Manager'), function () {
 				frappe.set_route('permission-manager', {
 					doctype: me.doctype

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -613,17 +613,19 @@ frappe.views.ListView = frappe.ui.BaseList.extend({
 				});
 			}, true);
 		}
-		if (frappe.user_roles.includes('System Manager') && (this.meta && !this.meta.custom)) {
+		if (frappe.user_roles.includes('System Manager')) {
 			this.page.add_menu_item(__('Role Permissions Manager'), function () {
 				frappe.set_route('permission-manager', {
 					doctype: me.doctype
 				});
 			}, true);
-			this.page.add_menu_item(__('Customize'), function () {
-				frappe.set_route('Form', 'Customize Form', {
-					doc_type: me.doctype
-				})
-			}, true);
+			if(this.meta && !this.meta.custom) {
+				this.page.add_menu_item(__('Customize'), function () {
+					frappe.set_route('Form', 'Customize Form', {
+						doc_type: me.doctype
+					})
+				}, true);
+			}
 		}
 
 		this.make_bulk_assignment();

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -13,6 +13,10 @@ $.extend(frappe.model, {
 		'_user_tags', '_comments', '_assign', '_liked_by', 'docstatus',
 		'parent', 'parenttype', 'parentfield', 'idx'],
 
+	core_doctypes_list: ['DocType', 'DocField', 'DocPerm', 'User', 'Role', 'Has Role',
+		'Page', 'Module Def', 'Print Format', 'Report', 'Customize Form',
+		'Customize Form Field', 'Property Setter', 'Custom Field', 'Custom Script'],
+
 	std_fields: [
 		{fieldname:'name', fieldtype:'Link', label:__('ID')},
 		{fieldname:'owner', fieldtype:'Link', label:__('Created By'), options: 'User'},


### PR DESCRIPTION
### Custom DocType should not be allowed to be edited through Customize Form

Issue:-
![issue-customize-custom](https://user-images.githubusercontent.com/11695402/50151820-05885600-02e8-11e9-8d56-8aa7838915b9.gif)

Fix:-
![fix-customize-custom](https://user-images.githubusercontent.com/11695402/50151823-07521980-02e8-11e9-8695-fa35373f5ff7.gif)

### Allow on submit not visible for child tables

Fix:-
![fix-child-table-allow](https://user-images.githubusercontent.com/11695402/50151986-6adc4700-02e8-11e9-8563-4f30c11bce6e.gif)


### Using Custom Field to add fields to a Custom DocType

*Bad Practice - Making a Custom `DocType` and then using `Custom Field` DocType to add fields to that custom DocType.

Issue:-
![issue-custom-field-custom](https://user-images.githubusercontent.com/11695402/50152899-eccd6f80-02ea-11e9-93e2-6348e1e03946.gif)

Fix:-
![fix-custom-field-custom](https://user-images.githubusercontent.com/11695402/50152905-ee973300-02ea-11e9-8d4d-f3746990d497.gif)

