### PR TITLE
Fix: Capitalize social factory class 

### DIFF
--- a/frappe/public/js/frappe/social/social_factory.js
+++ b/frappe/public/js/frappe/social/social_factory.js
@@ -1,4 +1,4 @@
-frappe.views.socialFactory = class socialFactory extends frappe.views.Factory {
+frappe.views.SocialFactory = class SocialFactory extends frappe.views.Factory {
 	show() {
 		if (frappe.pages.social) {
 			frappe.container.change_to('social');


### PR DESCRIPTION
Capitalize social factory class to support [recent router changes](https://github.com/frappe/frappe/commit/50af0dc3883b0cea19775ab7161329aa662dd4d3#diff-b4327c1486ba00c053528e60df741cd5R48).