### PR TITLE
fix: Update datatable to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "awesomplete": "^1.1.2",
     "cookie": "^0.3.1",
     "express": "^4.16.2",
-    "frappe-datatable": "^1.7.1",
+    "frappe-datatable": "^1.7.2",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.2.0",
     "highlight.js": "^9.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,10 +1219,10 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-frappe-datatable@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.7.1.tgz#5badb1138c7019e9dce50d6cbbd81c2fdc97e391"
-  integrity sha512-ePD4IDaLDCZCrchqT+TsPquOdnm72oYxh/KYMPfYBxUGSzWUoi2uRgzQD4MBR+uq1WxJhFQNoXe/fD3yOqNNUQ==
+frappe-datatable@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.7.2.tgz#9a2cb3d643959b759b6bc3a883667b58d2ba78fe"
+  integrity sha512-yUSBy46Bkbo4evP4nEcXzPVC0cMLBIcOLV6J509RJfmM+IEoQbhEeOcxta0fQ9RcgvzRHbL+TX+wkib53HsfSw==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
DataTable fixes related to setting height when there are less number of rows

Before:
![image](https://user-images.githubusercontent.com/9355208/50393013-326dba80-0779-11e9-8d69-3313b63326e5.png)

After:
![image](https://user-images.githubusercontent.com/9355208/50393028-5d580e80-0779-11e9-8872-1f9865323f04.png)


https://github.com/frappe/datatable/releases/tag/v1.7.2

