### PR TITLE
[Minor] Add option to route to Home for File view

### DIFF
--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -48,6 +48,12 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 	file_menu_items() {
 		const items = [
 			{
+				label: __('Home'),
+				action: () => {
+					frappe.set_route('List', 'File', 'Home');
+				},
+			},
+			{
 				label: __('Cut'),
 				action: () => {
 					frappe.file_manager.cut(this.get_checked_items(), this.current_folder);


### PR DESCRIPTION
![fix-file-home](https://user-images.githubusercontent.com/11695402/50394858-5f749a00-0786-11e9-9ac6-3441aba1e6a3.gif)

Sometimes searching 'File' from search bar routes to 'List/File/List' which displays nothing and gives false impression that something is wrong. Added an option in Menu that routes to Home view.