### PR TITLE
(Bug-fix) Item description shows some html tags 

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -546,7 +546,7 @@ export default class GridRow {
 
 		//hide html tags in Text Area
 		if (df.fieldtype == 'Text' || df.fieldtype == 'Text Editor') {
-			var column =  this.columns[df.fieldname]
+			var column =  this.columns[df.fieldname];
 			column.field_area.css("display", "none");
 			column.static_area.css({"display":"block"}).addClass("input-sm");
 		}

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -544,7 +544,7 @@ export default class GridRow {
 			}
 		}
 
-		//hide div tags in Text Area
+		//hide html tags in Text Area
 		if (df.fieldtype == 'Text' || df.fieldtype == 'Text Editor') {
 			var column =  this.columns[df.fieldname]
 			column.field_area.css("display", "none");

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -544,10 +544,11 @@ export default class GridRow {
 			}
 		}
 
+		//hide div tags in Text Area
 		if (df.fieldtype == 'Text' || df.fieldtype == 'Text Editor') {
-			var div = document.createElement("div");
-			div.innerHTML = txt;
-			this.doc[df.fieldname] = div.textContent || div.innerText || "";
+			var column =  this.columns[df.fieldname]
+			column.field_area.css("display", "none");
+			column.static_area.css({"display":"block"}).addClass("input-sm");
 		}
 
 		if(txt===undefined && this.frm) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -544,6 +544,12 @@ export default class GridRow {
 			}
 		}
 
+		if (df.fieldtype == 'Text' || df.fieldtype == 'Text Editor') {
+			var div = document.createElement("div");
+			div.innerHTML = txt;
+			this.doc[df.fieldname] = div.textContent || div.innerText || "";
+		}
+
 		if(txt===undefined && this.frm) {
 			var txt = frappe.format(this.doc[fieldname], df,
 				null, this.frm.doc);


### PR DESCRIPTION
If Text Editor is selected in grid view then some html tags are displayed and it is not possible add a rich text editor in grid view, so those columns are made static.

Before:
![screenshot 2018-12-24 at 4 38 19 pm](https://user-images.githubusercontent.com/42651287/50398098-fb100580-079a-11e9-9148-a3f5659e1068.png)

After:
![screenshot 2018-12-24 at 4 38 54 pm](https://user-images.githubusercontent.com/42651287/50398102-006d5000-079b-11e9-82c4-de58f8e5fbf2.png)
