### PR TITLE
fix(permission): KeyError

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -27,7 +27,7 @@ def print_has_permission_check_logs(func):
 		# print only if access denied
 		if not result:
 			msgprint(('<br>').join(frappe.flags['has_permission_check_logs']))
-		del frappe.flags['has_permission_check_logs']
+		frappe.flags.pop('has_permission_check_logs', None)
 		return result
 	return inner
 


### PR DESCRIPTION
While opening attachments there used to be a KeyError inside `print_has_permission_check_logs` function (used as decorator for has_permission)
- The reason was the recursive call to has_permission 
(while checking permission for file access we have controller permission in file which also does a has_permission check) 
<img width="771" alt="screenshot 2018-12-26 at 9 23 40 pm" src="https://user-images.githubusercontent.com/13928957/50450504-8e406b00-0954-11e9-8f52-4906f4c95461.png">



To fix this we used .pop function to avoid KeyError if has_permission_check_logs is not present.