### PR TITLE
Fixed base64 images not visible on website

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -2,6 +2,7 @@
 // MIT License. See license.txt
 
 frappe.provide('frappe.timeline');
+frappe.separator_element = '<div>---</div>';
 
 frappe.ui.form.Timeline = class Timeline {
 	constructor(opts) {
@@ -344,7 +345,7 @@ frappe.ui.form.Timeline = class Timeline {
 			});
 		} else {
 			if(c.communication_type=="Communication" && c.communication_medium=="Email") {
-				c.content = c.content.split('<span data-comment="original-reply" class="hidden">Reply To</span>')[0];
+				c.content = c.content.split(frappe.separator_element)[0];
 				c.content = frappe.utils.strip_original_content(c.content);
 
 				c.original_content = c.content;

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -340,7 +340,10 @@ h6.uppercase, .h6.uppercase {
 	}
 
 	blockquote {
-		font-size: inherit;
+		font-size: 14px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		margin: 0px;
 	}
 
 	.btn-more {

--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -119,3 +119,9 @@
 .ql-editor td {
     border: 1px solid @border-color;
 }
+
+.ql-snow .ql-editor blockquote {
+	font-size: 13px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+}

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -186,6 +186,8 @@ def abs_url(path):
 		return
 	if path.startswith('http://') or path.startswith('https://'):
 		return path
+	if path.startswith('data:image/jpeg'):
+		return path
 	if not path.startswith("/"):
 		path = "/" + path
 	return path


### PR DESCRIPTION
The `abs_url` filter would previously append a '/' before every URL, this would break a base64 image on the website.

Added a check for it in this PR