### PR TITLE
[Base 64 Fix]: Added check for base64 image in abs_url

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -186,7 +186,7 @@ def abs_url(path):
 		return
 	if path.startswith('http://') or path.startswith('https://'):
 		return path
-	if path.startswith('data:image/jpeg'):
+	if path.startswith('data:image/'):
 		return path
 	if not path.startswith("/"):
 		path = "/" + path

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -186,6 +186,8 @@ def abs_url(path):
 		return
 	if path.startswith('http://') or path.startswith('https://'):
 		return path
+	if path.startswith('data:image/jpeg'):
+		return path
 	if not path.startswith("/"):
 		path = "/" + path
 	return path

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -186,7 +186,7 @@ def abs_url(path):
 		return
 	if path.startswith('http://') or path.startswith('https://'):
 		return path
-	if path.startswith('data:image/'):
+	if path.startswith('data:'):
 		return path
 	if not path.startswith("/"):
 		path = "/" + path


### PR DESCRIPTION
The `abs_url` filter would previously append a '/' before every URL, this would break a base64 image on the website.

Added a check for it in this PR