### PR TITLE
fix: Delete View Logs when deleting a document

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -214,7 +214,7 @@ def check_if_doc_is_linked(doc, method="Delete"):
 def check_if_doc_is_dynamically_linked(doc, method="Delete"):
 	'''Raise `frappe.LinkExistsError` if the document is dynamically linked'''
 	for df in get_dynamic_link_map().get(doc.doctype, []):
-		if df.parent in ("Communication", "ToDo", "DocShare", "Email Unsubscribe", "Activity Log", 'File', 'Version'):
+		if df.parent in ("Communication", "ToDo", "DocShare", "Email Unsubscribe", "Activity Log", 'File', 'Version', 'View log'):
 			# don't check for communication and todo!
 			continue
 
@@ -279,6 +279,10 @@ def delete_dynamic_links(doctype, name):
 		where
 			communication_type = 'Comment'
 			and reference_doctype=%s and reference_name=%s""", (doctype, name))
+
+	# delete view logs
+	frappe.db.sql("""delete from `tabView log`
+		where reference_doctype=%s and reference_name=%s""", (doctype, name))
 
 	# unlink communications
 	frappe.db.sql("""update `tabCommunication`


### PR DESCRIPTION
Issue :-
- Cannot delete event because it is dynamically linked to View logs.
- Even if a document were to be deleted by force, its view log would be seen again on any new document that has the same name.
![view-log-issue](https://user-images.githubusercontent.com/11695402/50502243-b7134e00-0a83-11e9-83fd-12c53d1b3a07.gif)

Fix :-
![view-log-fix](https://user-images.githubusercontent.com/11695402/50502245-b975a800-0a83-11e9-9f16-ae52dd6f3547.gif)


*Note :- Even a simple reload creates a new view log record and gets displayed in the timeline. For a DocType that undergoes a lot of changes or is visible by a lot of people, the timeline can easily get clotted with the view logs from the same-person / different-persons. Maybe something could be done about it or was it intentional 🤔
