### PR TITLE
fix(socketio_client): use fallback if socketio is not used for upload

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -287,7 +287,7 @@ frappe.socketio.SocketIOUploader = class SocketIOUploader {
 			{'name': 'System Settings'},
 			'use_socketio_to_upload_file',
 			function(d) {
-				if (d.use_socketio_to_upload_file==1){
+				if (d.use_socketio_to_upload_file==0){
 					if (fallback) {
 						fallback();
 						return;


### PR DESCRIPTION
files were being uploaded twice, this fixes the issue. fallback should only be used when socketio is not being used.

fixes frappe/erpnext#16040