### PR TITLE
fix(chat): register last_seen only if last_message exists

### DIFF
--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1991,7 +1991,9 @@ class extends Component {
 		return (
 			h("li", null,
 				h("a", { class: props.active ? "active": "", onclick: () => {
-					props.last_message.seen.push(frappe.session.user)
+					if (props.last_message) {
+						props.last_message.seen(frappe.session.user);
+					}
 					props.click(props)
 				} },
 					h("div", { class: "row" },


### PR DESCRIPTION
- `seen` is a function not an array (outputs a string)
- can be executed only if `last_message` exists