### PR TITLE
fix: update modified date for Dropbox Settings Doctype

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
@@ -379,7 +379,7 @@
  "issingle": 1, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-08-07 04:00:40.520943", 
+ "modified": "2019-01-03 04:44:40.520943", 
  "modified_by": "Administrator", 
  "module": "Integrations", 
  "name": "Dropbox Settings", 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 273, in get_dropbox_authorize_url
    app_details = get_dropbox_settings(redirect_uri=True)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py", line 238, in get_dropbox_settings
    'file_backup':settings.file_backup
AttributeError: 'DropboxSettings' object has no attribute 'file_backup'
```