### PR TITLE
fix(patch): Rearrange patch execution to fix a patch failure

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -12,14 +12,14 @@ execute:frappe.reload_doc('core', 'doctype', 'docperm') #2018-05-29
 frappe.patches.v8_0.drop_is_custom_from_docperm
 execute:frappe.reload_doc('core', 'doctype', 'module_def') #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'version') #2017-04-01
+frappe.patches.v11_0.replicate_old_user_permissions
+frappe.patches.v11_0.drop_column_apply_user_permissions
 frappe.patches.v11_0.reload_and_rename_view_log #2019-01-03
 frappe.patches.v7_1.rename_scheduler_log_to_error_log
 frappe.patches.v6_1.rename_file_data
 frappe.patches.v7_0.re_route #2016-06-27
 frappe.patches.v8_0.update_records_in_global_search #11-05-2017
 frappe.patches.v8_0.update_published_in_global_search
-frappe.patches.v11_0.replicate_old_user_permissions
-frappe.patches.v11_0.drop_column_apply_user_permissions
 frappe.patches.v11_0.copy_fetch_data_from_options
 frappe.patches.v11_0.change_email_signature_fieldtype
 execute:frappe.reload_doc('core', 'doctype', 'activity_log')


### PR DESCRIPTION
Should fix `"Column 'apply_user_permissions' cannot be null"` error 
while executing `reload_and_rename_view_log` patch

https://github.com/frappe/frappe/issues/6720