### PR TITLE
fix: Display all filters in report view

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -616,15 +616,6 @@ class FilterArea {
 			};
 		}));
 
-		if (fields.length > 3) {
-			fields = fields.map((df, i) => {
-				if (i >= 3) {
-					df.input_class = 'hidden-sm hidden-xs';
-				}
-				return df;
-			});
-		}
-
 		fields.map(df => this.list_view.page.add_field(df));
 
 		// search icon in name filter


### PR DESCRIPTION
Display all filters for small screen sizes.
![filters](https://user-images.githubusercontent.com/42651287/50675819-78970980-1016-11e9-8d1e-f5ac654b9d17.gif)
