### PR TITLE
fix(permission): Role permission check with if_owner enabled

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -190,7 +190,6 @@ def get_role_permissions(doctype_meta, user=None):
 				# only provide read access so that user is able to at-least access list
 				# (and the documents will be filtered based on owner sin further checks)
 				perms[ptype] = 1 if ptype == 'read' else 0
-				# perms[ptype] = 0
 
 		frappe.local.role_permissions[cache_key] = perms
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -187,7 +187,10 @@ def get_role_permissions(doctype_meta, user=None):
 				and ptype != 'create'):
 				perms['if_owner'][ptype] = 1
 				# has no access if not owner
-				perms[ptype] = 0
+				# only provide read access so that user is able to at-least access list
+				# (and the documents will be filtered based on owner sin further checks)
+				perms[ptype] = 1 if ptype == 'read' else 0
+				# perms[ptype] = 0
 
 		frappe.local.role_permissions[cache_key] = perms
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -383,7 +383,17 @@ class TestPermissions(unittest.TestCase):
 		update('Blog Post', 'Blogger', 0, 'read', 1)
 		update('Blog Post', 'Blogger', 0, 'write', 1)
 		update('Blog Post', 'Blogger', 0, 'delete', 1)
+
+		# currently test2 user has not created any document
+		# still he should be able to do get_list query which should
+		# not raise permission error but simply return empty list
+		frappe.set_user("test2@example.com")
+		self.assertEqual(frappe.get_list('Blog Post'), [])
+
+		frappe.set_user("Administrator")
+
 		# creates a custom docperm with just read access
+		# now any user can read any blog post (but other rights are limited to the blog post owner)
 		add_permission('Blog Post', 'Blogger')
 		frappe.clear_cache(doctype="Blog Post")
 


### PR DESCRIPTION
Ideally a user who only has a role for which a DocPerm is created with if_owner enabled should be able to access the list view.

**Previously** such user was not able to access the list view.
<img width="808" alt="screenshot 2019-01-04 at 7 08 52 pm" src="https://user-images.githubusercontent.com/13928957/50690725-66d45700-1054-11e9-95ea-3f3c7a902078.png">


This PR aims to fix that.

**Now** such user can access the list view and will see only the documents created by him/her.
<img width="1218" alt="screenshot 2019-01-04 at 7 09 29 pm" src="https://user-images.githubusercontent.com/13928957/50690743-75bb0980-1054-11e9-940c-7870362738ef.png">


