### PR TITLE
fix: 'dict' object has no attribute 'applicable_for'

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -56,10 +56,10 @@ def get_user_permissions(user=None):
 		if not out.get(perm.allow):
 			out[perm.allow] = []
 
-		out[perm.allow].append({
+		out[perm.allow].append(frappe._dict({
 			'doc': doc_name,
 			'applicable_for': perm.get('applicable_for')
-		})
+		}))
 
 	try:
 		for perm in frappe.get_all('User Permission',
@@ -74,6 +74,7 @@ def get_user_permissions(user=None):
 				for doc in decendants:
 					add_doc_to_perm(perm, doc)
 
+		out = frappe._dict(out)
 		frappe.cache().hset("user_permissions", user, out)
 
 	except frappe.SQLError as e:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/__init__.py", line 20, in get_contact_list
    match_conditions = build_match_conditions('Contact')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/reportview.py", line 347, in build_match_conditions
    match_conditions =  DatabaseQuery(doctype, user=user).build_match_conditions(as_condition=as_condition)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 460, in build_match_conditions
    not has_any_user_permission_for_doctype(self.doctype, self.user, self.reference_doctype)):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 722, in has_any_user_permission_for_doctype
    if not permission.applicable_for or permission.applicable_for == applicable_for:
AttributeError: 'dict' object has no attribute 'applicable_for'
```