### PR TITLE
fix: Auto email report fix for XLSX and CSV format

### DIFF
--- a/frappe/templates/emails/auto_email_report.html
+++ b/frappe/templates/emails/auto_email_report.html
@@ -1,7 +1,11 @@
 {% macro get_alignment(col) %}
 {%- if col.fieldtype in ('Int', 'Float', 'Currency', 'Check') %} class="text-right" {% endif -%}
 {% endmacro %}
-{% set max_width = '100%' if columns|length > 3 else '600px' %}
+{% if columns %}
+	{% set max_width = '100%' if columns|length > 3 else '600px' %}
+{% else %}
+	{% set max_width = '600px' %}
+{% endif %}
 <table class="report-title" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: {{ max_width }}">
 	<tr>
 		<td>


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 171, in send_now
    auto_email_report.send()
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 134, in send
    message = self.get_html_table()
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 104, in get_html_table
    'edit_report_settings': get_link_to_form('Auto Email Report', self.name)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/utils/jinja.py", line 71, in render_template
    return get_jenv().get_template(template).render(context)
  File "/Users/deepesh/frappe-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/deepesh/frappe-bench/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/./templates/emails/auto_email_report.html", line 4, in top-level template code
    {% set max_width = '100%' if columns|length > 3 else '600px' %}
TypeError: object of type 'NoneType' has no len()
```