### PR TITLE
fix: No permission for System Settings while uploading image 

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -282,11 +282,11 @@ frappe.socketio.SocketIOUploader = class SocketIOUploader {
 			frappe.throw(__('File Upload in Progress. Please try again in a few moments.'));
 		}
 
-		if (!frappe.boot.sysdefaults.use_socketio_to_upload_file) {
-			return fallback();
+		function fallback_required() {
+			return !frappe.boot.sysdefaults.use_socketio_to_upload_file || !frappe.socketio.socket.connected;
 		}
 
-		if (!frappe.socketio.socket.connected) {
+		if (fallback_required()) {
 			return fallback ? fallback() : frappe.throw(__('Socketio is not connected. Cannot upload'));
 		}
 

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -282,29 +282,12 @@ frappe.socketio.SocketIOUploader = class SocketIOUploader {
 			frappe.throw(__('File Upload in Progress. Please try again in a few moments.'));
 		}
 
-		frappe.model.get_value(
-			'System Settings',
-			{'name': 'System Settings'},
-			'use_socketio_to_upload_file',
-			function(d) {
-				if (d.use_socketio_to_upload_file==1){
-					if (fallback) {
-						fallback();
-						return;
-					} else {
-						frappe.throw(__('Socketio is not connected. Cannot upload'));
-					}
-				}
-			}
-		);
+		if (!frappe.boot.sysdefaults.use_socketio_to_upload_file) {
+			return fallback();
+		}
 
 		if (!frappe.socketio.socket.connected) {
-			if (fallback) {
-				fallback();
-				return;
-			} else {
-				frappe.throw(__('Socketio is not connected. Cannot upload'));
-			}
+			return fallback ? fallback() : frappe.throw(__('Socketio is not connected. Cannot upload'));
 		}
 
 		this.reader = new FileReader();


### PR DESCRIPTION
While uploading any image, user used to get permission error like following
<img width="672" alt="screenshot 2019-01-08 at 12 34 44 pm" src="https://user-images.githubusercontent.com/13928957/50816274-0ab84e00-1346-11e9-8426-eca0e8b1d6e0.png">

This used to happen because of the `get_value` request which was fetching value of `use_socketio_to_upload_file` in the system setting. Since some users do not have access to System Setting they get permission error while uploading image.

to fix this we can directly check the value of use_socketio_to_upload_file flag from
`frappe.boot.sysdefaults` (which is available for all users) instead of making network request.