### PR TITLE
fix: Unordered list as unordered in print as well

### DIFF
--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -166,3 +166,6 @@ table td div {
 	max-height: 150px;
 }
 
+.print-format li[data-list="bullet"] {
+	list-style-type: disc;
+}


### PR DESCRIPTION
Issue was that the default style for ol tag is  `list-style-type: decimal;`
So when we add an unordered list from text editor, it will change disc to decimal.

Solution:
Added a style so that `data-list="bullet"` have disc

<img width="711" alt="screen shot 2019-01-09 at 10 19 31 am" src="https://user-images.githubusercontent.com/16913064/50877501-2c720d80-13f8-11e9-8f44-30ad8465f641.png">

Issue: https://github.com/frappe/frappe/issues/6743