### PR TITLE
fix: Remove quotes from desktop icon options

### DIFF
--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -307,7 +307,7 @@ def make_user_copy(module_name, user):
 		'module_name': module_name
 	})
 
-	for key in ('app', 'label', 'route', 'type', '_doctype', 'idx', 'reverse', 'force_show'):
+	for key in ('app', 'label', 'route', 'type', '_doctype', 'idx', 'reverse', 'force_show', 'link', 'icon', 'color'):
 		if original.get(key):
 			desktop_icon.set(key, original.get(key))
 

--- a/frappe/public/js/frappe/ui/toolbar/modules_select.js
+++ b/frappe/public/js/frappe/ui/toolbar/modules_select.js
@@ -64,7 +64,7 @@ frappe.ui.toolbar.ModulesSelect = class {
 									resolve(icons
 										.map(icon => {
 											const uncheck = user ? icon.hidden : icon.blocked;
-											return { label: icon.value, value: icon.module_name, checked:!uncheck };
+											return { label: icon.label, value: icon.module_name, checked:!uncheck };
 										}).sort(function(a, b){
 											if(a.label < b.label) return -1;
 											if(a.label > b.label) return 1;


### PR DESCRIPTION
- Fixed code for creating user_copy of icon
- Remove quotes from desktop icon options 
**Before**
<img width="587" alt="screenshot 2019-01-09 at 3 51 37 pm" src="https://user-images.githubusercontent.com/13928957/50893290-87225e00-1426-11e9-882c-d42222e088e2.png">

**After**
<img width="589" alt="screenshot 2019-01-09 at 3 50 34 pm" src="https://user-images.githubusercontent.com/13928957/50893303-8ee20280-1426-11e9-94c0-0d78f527b8e4.png">