### PR TITLE
Enabled --safe-updates in bench mariadb

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -342,7 +342,8 @@ def mariadb(context):
 		'-p'+frappe.conf.db_password,
 		frappe.conf.db_name,
 		'-h', frappe.conf.db_host or "localhost",
-		'--pager=less -SFX','--safe-updates',
+		'--pager=less -SFX',
+		'--safe-updates',
 		"-A"])
 
 @click.command('postgres')

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -342,7 +342,7 @@ def mariadb(context):
 		'-p'+frappe.conf.db_password,
 		frappe.conf.db_name,
 		'-h', frappe.conf.db_host or "localhost",
-		'--pager=less -SFX',
+		'--pager=less -SFX','--safe-updates',
 		"-A"])
 
 @click.command('postgres')


### PR DESCRIPTION
Enabled --safe-updates in bench mariadb for doing safe update operations in the database.