### PR TITLE
Fixes #6749: Pin oauthlib to 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ ndg-httpsclient
 pyasn1
 zxcvbn-python
 unittest-xml-reporting
-oauthlib
+oauthlib==2.1.0
 pdfkit
 PyJWT
 PyPDF2


### PR DESCRIPTION
Pin oauthlib to version 2.1.0 because the next major version 3.0.0 has breaking changes: https://github.com/oauthlib/oauthlib/blob/2.x/oauthlib/oauth2/rfc6749/grant_types/__init__.py