### PR TITLE
fix(list-view): Cast docnames to str before sorting

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -215,7 +215,7 @@ def delete_items():
 	"""delete selected items"""
 	import json
 
-	il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True)
+	il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True, key=str)
 	doctype = frappe.form_dict.get('doctype')
 
 	failed = []


### PR DESCRIPTION
In Python 3 str and non-str comparison is not allowed.

Bulk delete operation fails when selected docnames meet following condition
1. at least on name can be casted to int or other types e.g. "1", "3123423524", "1.0"
2. at least on name that cannot be casted to other types e.g. "A", "56cd83dab1"

The root cause is $.data() which forcefully casts data-name to non string types when possible

This is the traceback without this fix

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/reportview.py", line 218, in delete_items
    il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True)
TypeError: '<' not supported between instances of 'str' and 'int'
```