### PR TITLE
feat: Clear user permissions button

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -95,7 +95,7 @@ def get_applicable_for_doctype_list(doctype, txt, searchfield, start, page_len, 
 	linked_doctypes = get_linked_doctypes(doctype, True).keys()
 	linked_doctypes = list(linked_doctypes)
 	linked_doctypes += [doctype]
-	
+
 	if txt:
 		linked_doctypes = [d for d in linked_doctypes if txt in d.lower()]
 
@@ -110,3 +110,13 @@ def get_applicable_for_doctype_list(doctype, txt, searchfield, start, page_len, 
 def get_permitted_documents(doctype):
 	return [d.get('doc') for d in get_user_permissions().get(doctype, []) \
 		if d.get('doc')]
+
+@frappe.whitelist()
+def clear_user_permissions(user, for_doctype):
+	frappe.only_for('System Manager')
+
+	total = frappe.db.count('User Permission', filters = dict(user=user, allow=for_doctype))
+	if total:
+		frappe.db.sql('DELETE FROM `tabUser Permission` WHERE user=%s AND allow=%s', (user, for_doctype))
+		frappe.clear_cache()
+	return total

--- a/frappe/core/doctype/user_permission/user_permission_list.js
+++ b/frappe/core/doctype/user_permission/user_permission_list.js
@@ -16,7 +16,7 @@ frappe.listview_settings['User Permission'] = {
 							.then((data) => {
 								dialog.hide();
 								frappe.show_alert({
-									message: __('{0} records deleted', [data]),
+									message: __('{0} records deleted', [data == '0' ? 'No': data]),
 									indicator: 'green'
 								});
 								listview.refresh();

--- a/frappe/core/doctype/user_permission/user_permission_list.js
+++ b/frappe/core/doctype/user_permission/user_permission_list.js
@@ -2,7 +2,7 @@ frappe.listview_settings['User Permission'] = {
 	onload: function(list_view) {
 		list_view.page.add_menu_item(__("Clear User Permissions"), () => {
 			const dialog = new frappe.ui.Dialog({
-				title: 'Clear User Permissions',
+				title: __('Clear User Permissions'),
 				fields: [
 					{
 						'fieldname': 'user',
@@ -26,10 +26,16 @@ frappe.listview_settings['User Permission'] = {
 					frappe.confirm(__('Are you sure?'), () => {
 						frappe
 							.xcall('frappe.core.doctype.user_permission.user_permission.clear_user_permissions', data)
-							.then((data) => {
+							.then(data => {
 								dialog.hide();
+								let message = '';
+								if (data === 0) {
+									message = __('No records deleted');
+								} else {
+									message = __('{0} records deleted', [data]);
+								}
 								frappe.show_alert({
-									message: __('{0} records deleted', [data == '0' ? 'No': data]),
+									message,
 									indicator: 'green'
 								});
 								list_view.refresh();

--- a/frappe/core/doctype/user_permission/user_permission_list.js
+++ b/frappe/core/doctype/user_permission/user_permission_list.js
@@ -1,0 +1,32 @@
+frappe.listview_settings['User Permission'] = {
+	onload: function(listview) {
+		listview.page.add_inner_button(__("Clear User Permissions"), () => {
+			let dialog = new frappe.ui.Dialog({
+				title: 'Clear User Permissions',
+				fields: [
+					{fieldname: 'user', label: __('For User'), fieldtype: 'Link', options: 'User', reqd: 1},
+					{fieldname: 'for_doctype', label: __('For Document Type'), fieldtype: 'Link', options: 'DocType', reqd: 1},
+				],
+				primary_action: (data) => {
+					// mandatory not filled
+					if (!data) return;
+
+					frappe.confirm(__('Are you sure?'), () => {
+						frappe.xcall('frappe.core.doctype.user_permission.user_permission.clear_user_permissions', 	data)
+							.then((data) => {
+								dialog.hide();
+								frappe.show_alert({
+									message: __('{0} records deleted', [data]),
+									indicator: 'green'
+								});
+								listview.refresh();
+							});
+
+					}, () => {});
+
+				},
+				primary_action_label: __('Clear')
+			}).show();
+		});
+	}
+};

--- a/frappe/core/doctype/user_permission/user_permission_list.js
+++ b/frappe/core/doctype/user_permission/user_permission_list.js
@@ -1,6 +1,6 @@
 frappe.listview_settings['User Permission'] = {
 	onload: function(list_view) {
-		list_view.page.add_inner_button(__("Clear User Permissions"), () => {
+		list_view.page.add_menu_item(__("Clear User Permissions"), () => {
 			const dialog = new frappe.ui.Dialog({
 				title: 'Clear User Permissions',
 				fields: [

--- a/frappe/core/doctype/user_permission/user_permission_list.js
+++ b/frappe/core/doctype/user_permission/user_permission_list.js
@@ -1,32 +1,46 @@
 frappe.listview_settings['User Permission'] = {
-	onload: function(listview) {
-		listview.page.add_inner_button(__("Clear User Permissions"), () => {
-			let dialog = new frappe.ui.Dialog({
+	onload: function(list_view) {
+		list_view.page.add_inner_button(__("Clear User Permissions"), () => {
+			const dialog = new frappe.ui.Dialog({
 				title: 'Clear User Permissions',
 				fields: [
-					{fieldname: 'user', label: __('For User'), fieldtype: 'Link', options: 'User', reqd: 1},
-					{fieldname: 'for_doctype', label: __('For Document Type'), fieldtype: 'Link', options: 'DocType', reqd: 1},
+					{
+						'fieldname': 'user',
+						'label': __('For User'),
+						'fieldtype': 'Link',
+						'options': 'User',
+						'reqd': 1
+					},
+					{
+						'fieldname': 'for_doctype',
+						'label': __('For Document Type'),
+						'fieldtype': 'Link',
+						'options': 'DocType',
+						'reqd': 1
+					},
 				],
 				primary_action: (data) => {
 					// mandatory not filled
 					if (!data) return;
 
 					frappe.confirm(__('Are you sure?'), () => {
-						frappe.xcall('frappe.core.doctype.user_permission.user_permission.clear_user_permissions', 	data)
+						frappe
+							.xcall('frappe.core.doctype.user_permission.user_permission.clear_user_permissions', data)
 							.then((data) => {
 								dialog.hide();
 								frappe.show_alert({
 									message: __('{0} records deleted', [data == '0' ? 'No': data]),
 									indicator: 'green'
 								});
-								listview.refresh();
+								list_view.refresh();
 							});
-
-					}, () => {});
+					});
 
 				},
 				primary_action_label: __('Clear')
-			}).show();
+			});
+
+			dialog.show();
 		});
 	}
 };

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -153,6 +153,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		this.$wrapper.modal("show");
 		this.primary_action_fulfilled = false;
 		this.is_visible = true;
+		return this;
 	}
 	hide() {
 		this.$wrapper.modal("hide");

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -458,8 +458,5 @@ class TestPermissions(unittest.TestCase):
 
 		self.assertEqual(blog_category_user_permission_count, 1)
 
-		# undo all changes
-		frappe.db.rollback()
-
 		# reset the user
 		frappe.set_user(current_user)

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -14,6 +14,7 @@ from frappe.permissions import (add_user_permission, remove_user_permission,
 	get_valid_perms)
 from frappe.core.page.permission_manager.permission_manager import update, reset
 from frappe.test_runner import make_test_records_for_doctype
+from frappe.core.doctype.user_permission.user_permission import clear_user_permissions
 
 test_dependencies = ['Blogger', 'Blog Post', "User", "Contact", "Salutation"]
 
@@ -428,3 +429,35 @@ class TestPermissions(unittest.TestCase):
 
 		# delete the created doc
 		frappe.delete_doc('Blog Post', '-test-blog-post-title')
+
+	def test_clear_user_permissions(self):
+		clear_user_permissions_for_doctype('Blog Category', 'test2@example.com')
+		clear_user_permissions_for_doctype('Blog Post', 'test2@example.com')
+
+		print(frappe.get_all('Blog Post'))
+
+		add_user_permission("Blog Category", '_Test Blog Category 1', 'test2@example.com')
+
+		add_user_permission('Blog Post', '-test-blog-post-1', 'test2@example.com')
+		add_user_permission('Blog Post', '-test-blog-post-2', 'test2@example.com')
+
+		deleted_user_permission_count = clear_user_permissions('test2example.com', 'Blog Post')
+
+		self.assertEqual(deleted_user_permission_count, 2)
+
+		blog_post_user_permission_count = frappe.db.count('User Permission', filters={
+			'user': 'test2@erpnext.com',
+			'doctype': 'Blog Post'
+		})
+
+		self.assertEqual(blog_post_user_permission_count, 0)
+
+		blog_category_user_permission_count = frappe.db.count('User Permission', filters={
+			'user': 'test2@erpnext.com',
+			'doctype': 'Blog Category'
+		})
+
+		self.assertEqual(blog_category_user_permission_count, 1)
+
+		# undo all changes
+		frappe.db.rollback()

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -431,14 +431,14 @@ class TestPermissions(unittest.TestCase):
 		frappe.delete_doc('Blog Post', '-test-blog-post-title')
 
 	def test_clear_user_permissions(self):
+		current_user = frappe.session.user
 		frappe.set_user('Administrator')
 		clear_user_permissions_for_doctype('Blog Category', 'test2@example.com')
 		clear_user_permissions_for_doctype('Blog Post', 'test2@example.com')
 
-		add_user_permission("Blog Category", '_Test Blog Category 1', 'test2@example.com')
-
 		add_user_permission('Blog Post', '-test-blog-post-1', 'test2@example.com')
 		add_user_permission('Blog Post', '-test-blog-post-2', 'test2@example.com')
+		add_user_permission("Blog Category", '_Test Blog Category 1', 'test2@example.com')
 
 		deleted_user_permission_count = clear_user_permissions('test2@example.com', 'Blog Post')
 
@@ -460,3 +460,6 @@ class TestPermissions(unittest.TestCase):
 
 		# undo all changes
 		frappe.db.rollback()
+
+		# reset the user
+		frappe.set_user(current_user)

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -431,30 +431,29 @@ class TestPermissions(unittest.TestCase):
 		frappe.delete_doc('Blog Post', '-test-blog-post-title')
 
 	def test_clear_user_permissions(self):
+		frappe.set_user('Administrator')
 		clear_user_permissions_for_doctype('Blog Category', 'test2@example.com')
 		clear_user_permissions_for_doctype('Blog Post', 'test2@example.com')
-
-		print(frappe.get_all('Blog Post'))
 
 		add_user_permission("Blog Category", '_Test Blog Category 1', 'test2@example.com')
 
 		add_user_permission('Blog Post', '-test-blog-post-1', 'test2@example.com')
 		add_user_permission('Blog Post', '-test-blog-post-2', 'test2@example.com')
 
-		deleted_user_permission_count = clear_user_permissions('test2example.com', 'Blog Post')
+		deleted_user_permission_count = clear_user_permissions('test2@example.com', 'Blog Post')
 
 		self.assertEqual(deleted_user_permission_count, 2)
 
 		blog_post_user_permission_count = frappe.db.count('User Permission', filters={
-			'user': 'test2@erpnext.com',
-			'doctype': 'Blog Post'
+			'user': 'test2@example.com',
+			'allow': 'Blog Post'
 		})
 
 		self.assertEqual(blog_post_user_permission_count, 0)
 
 		blog_category_user_permission_count = frappe.db.count('User Permission', filters={
-			'user': 'test2@erpnext.com',
-			'doctype': 'Blog Category'
+			'user': 'test2@example.com',
+			'allow': 'Blog Category'
 		})
 
 		self.assertEqual(blog_category_user_permission_count, 1)


### PR DESCRIPTION
Clear user permission button for faster deletion of user permissions in bulk 

![clear_user_permission_2](https://user-images.githubusercontent.com/13928957/51094526-de804f80-17d3-11e9-990a-b509f131b50e.gif)
