### PR TITLE
fix: DataTable date filter

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -625,7 +625,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					const keywordValue = frappe.datetime.user_to_obj(keyword);
 					const cellValue = frappe.datetime.str_to_obj(cell.content);
 					return [+cellValue, +keywordValue];
-				}
+				};
 			}
 
 			return Object.assign(column, {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -616,11 +616,24 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					{for_print: false, always_show_decimals: true}, data);
 			};
 
+			let compareFn = null;
+			if (column.fieldtype === 'Date') {
+				compareFn = (cell, keyword) => {
+					if (!cell.content) return null;
+					if (keyword.length !== 'YYYY-MM-DD'.length) return null;
+
+					const keywordValue = frappe.datetime.user_to_obj(keyword);
+					const cellValue = frappe.datetime.str_to_obj(cell.content);
+					return [+cellValue, +keywordValue];
+				}
+			}
+
 			return Object.assign(column, {
 				id: column.fieldname,
 				name: column.label,
 				width: parseInt(column.width) || null,
 				editable: false,
+				compareValue: compareFn,
 				format: (value, row, column, data) => {
 					if (this.report_settings.formatter) {
 						return this.report_settings.formatter(value, row, column, data, format_cell);

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -823,6 +823,19 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		// child table column
 		const id = doctype !== this.doctype ? `${doctype}:${fieldname}` : fieldname;
 
+		let compareFn = null;
+		if (docfield.fieldtype === 'Date') {
+			compareFn = (cell, keyword) => {
+				if (!cell.content) return null;
+				if (keyword.length !== 'YYYY-MM-DD'.length) return null;
+
+				const keywordValue = frappe.datetime.user_to_obj(keyword);
+				const cellValue = frappe.datetime.str_to_obj(cell.content);
+				return [+cellValue, +keywordValue];
+			}
+		}
+
+
 		return {
 			id: id,
 			field: fieldname,
@@ -832,6 +845,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			width,
 			editable,
 			align,
+			compareValue: compareFn,
 			format: (value, row, column, data) => {
 				const d = row.reduce((acc, curr) => {
 					if (!curr.column.docfield) return acc;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "awesomplete": "^1.1.2",
     "cookie": "^0.3.1",
     "express": "^4.16.2",
-    "frappe-datatable": "^1.7.3",
+    "frappe-datatable": "^1.8.0",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.2.0",
     "highlight.js": "^9.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,10 +1219,10 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-frappe-datatable@^1.7.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.7.3.tgz#dadddf01867723bf0862918dd62cfea4652416a3"
-  integrity sha512-72LUx0ZRRjFPLFQUzgB7Uywpxgk1rFLjyzOq5yQ5Mr2G8u0t3AoUJLRG2lAqFD49JOxezVb6Oa03Qmon1DCExA==
+frappe-datatable@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.8.0.tgz#7f789ed77bdf9800143fffb1bb28a24d5dbdc27c"
+  integrity sha512-j3DdmYtTjhcVXCVkYjKHdZOc8tSwZapanlujdx1xzXcL7Ueo+BFiPR5WptWRfH43K3nboh3m7clcAIX7LdQR4g==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
Date comparison won't work with simple string comparison. Now, [DataTable allows to hook](https://github.com/frappe/datatable/commit/3e044a5ffacadd1f261d9f43e8b1d802dc166ae4) into how cell values are compared.

![datatable-date-filter-fix](https://user-images.githubusercontent.com/9355208/51102769-42237080-1806-11e9-8c1c-db4961f5dfd7.gif)
