### PR TITLE
fix(Caching): Clear document cache during bench migrate

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -49,6 +49,10 @@ def clear_defaults_cache(user=None):
 	elif frappe.flags.in_install!="frappe":
 		frappe.cache().delete_key("defaults")
 
+def clear_document_cache():
+	frappe.local.document_cache = {}
+	frappe.cache().delete_key("document_cache")
+
 def clear_doctype_cache(doctype=None):
 	cache = frappe.cache()
 
@@ -80,4 +84,7 @@ def clear_doctype_cache(doctype=None):
 		# clear all
 		for name in groups:
 			cache.delete_value(name)
+
+	# Clear all document's cache. To clear documents of a specific DocType document_cache should be restructured
+	clear_document_cache()
 


### PR DESCRIPTION
`bench migrate` was not clearing the `document_cache` which led to unexpected behavior after an update to DocType. In my case the error was that `'ItemGroup' object has no attribute 'taxes'` even though my new DocType has the field in PR https://github.com/frappe/erpnext/pull/16377.

Even `bench clear-cache` would not clear the document cache. And even `bench restart` could not clear the document cache for some reason. Rebooting the server cleared the cache though.

Since I could not find a way to clear document cache of only a specific DocType, I went ahead and cleared it all on reloading any DocType.