### PR TITLE
fix: increased threshold for making report as prepared report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -58,7 +58,7 @@ def generate_report_result(report, filters=None, user=None):
 		module = report.module or frappe.db.get_value("DocType", report.ref_doctype, "module")
 		if report.is_standard == "Yes":
 			method_name = get_report_module_dotted_path(module, report.name) + ".execute"
-			threshold = 10
+			threshold = 60
 			res = []
 
 			start_time = datetime.datetime.now()


### PR DESCRIPTION
**Before Fix**
If any report takes time to generate the data more than 10 seconds then system was making that report as Prepared Report

**Before Fix**
Increased the threshold time from 10 seconds to 60 seconds