### PR TITLE
fix: syntax-fix treat obj as list

### DIFF
--- a/frappe/core/doctype/activity_log/feed.py
+++ b/frappe/core/doctype/activity_log/feed.py
@@ -75,8 +75,8 @@ def get_feed_match_conditions(user=None, force=True):
 		if user_permissions:
 			can_read_docs = []
 			for doctype, obj in user_permissions.items():
-				for n in obj.get("docs", []):
-					can_read_docs.append('"{}|{}"'.format(doctype, frappe.db.escape(n)))
+				for n in obj:
+					can_read_docs.append('"{}|{}"'.format(doctype, frappe.db.escape(n.get('doc', ''))))
 
 			if can_read_docs:
 				conditions.append("concat_ws('|', `tabCommunication`.reference_doctype, `tabCommunication`.reference_name) in ({})".format(


### PR DESCRIPTION
obj is list of dict:
 [{u'doc': u'ACC-SINV-2019-00003', u'applicable_for': u'Activity Log'}, {u'doc': u'ACC-SINV-2019-00005', u'applicable_for': u'Activity Log'}]

```
 Traceback (most recent call last):
   File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
     response = frappe.handler.handle()
   File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
     data = execute_cmd(cmd)
   File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
     return frappe.call(method, **frappe.form_dict)
   File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
     return fn(*args, **newargs)
   File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/desk/page/activity/activity.py", line 12, in get_feed
     match_conditions = get_feed_match_conditions(frappe.session.user)
   File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/core/doctype/activity_log/feed.py", line 79, in get_feed_match_conditions
     for n in obj.get("docs", []):
 AttributeError: 'list' object has no attribute 'get'
```