### PR TITLE
fix: AttributeError on link field

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -719,7 +719,7 @@ def has_any_user_permission_for_doctype(doctype, user, applicable_for):
 	doctype_user_permissions = user_permissions.get(doctype, [])
 
 	for permission in doctype_user_permissions:
-		if not permission.applicable_for or permission.applicable_for == applicable_for:
+		if not permission.get('applicable_for') or permission.get('applicable_for') == applicable_for:
 			return True
 
 	return False


### PR DESCRIPTION
Use .get() method to avoid AttributeError error

<img width="647" alt="screenshot 2019-01-17 at 8 02 52 pm" src="https://user-images.githubusercontent.com/13928957/51325662-6e9fec80-1a93-11e9-8e54-f676e55155b4.png">
