### PR TITLE
feat: Show average of Percent field in report totals row

### DIFF
--- a/frappe/public/js/frappe/misc/utils.js
+++ b/frappe/public/js/frappe/misc/utils.js
@@ -658,13 +658,11 @@ Object.assign(frappe.utils, {
 		return route;
 	},
 
-	report_accumulator: function(acc, cell, row, row_count) {
-		if (typeof cell.content === 'number') {
-			acc.content += cell.content;
-
-			if (cell.column.fieldtype == "Percent" && cell.rowIndex === row_count-1) {
-				acc.content /= row_count;
-			}
+	report_total_accumulator: function(column, values, type) {
+		if (column.fieldtype == "Percent" || type === "mean") {
+			return values.reduce((a, b) => ({content: a.content + flt(b.content)})).content / values.length;
+		} else if (frappe.model.is_numeric_field(column.fieldtype)) {
+			return values.reduce((a, b) => ({content: a.content + flt(b.content)})).content;
 		} else {
 			return false;
 		}

--- a/frappe/public/js/frappe/misc/utils.js
+++ b/frappe/public/js/frappe/misc/utils.js
@@ -656,6 +656,18 @@ Object.assign(frappe.utils, {
 			return `<a href="${route}">${name}</a>`;
 		}
 		return route;
+	},
+
+	report_accumulator: function(acc, cell, row, row_count) {
+		if (typeof cell.content === 'number') {
+			acc.content += cell.content;
+
+			if (cell.column.fieldtype == "Percent" && cell.rowIndex === row_count-1) {
+				acc.content /= row_count;
+			}
+		} else {
+			return false;
+		}
 	}
 });
 

--- a/frappe/public/js/frappe/views/reports/grid_report.js
+++ b/frappe/public/js/frappe/views/reports/grid_report.js
@@ -421,7 +421,8 @@ frappe.views.GridReport = Class.extend({
 					data.checked = Boolean(checked);
 
 					this.setup_chart && this.setup_chart();
-				}
+				},
+				accumulator: (acc, cell, row, row_count) => frappe.utils.report_accumulator(acc, cell, row, row_count)
 			}
 		});
 

--- a/frappe/public/js/frappe/views/reports/grid_report.js
+++ b/frappe/public/js/frappe/views/reports/grid_report.js
@@ -421,8 +421,10 @@ frappe.views.GridReport = Class.extend({
 					data.checked = Boolean(checked);
 
 					this.setup_chart && this.setup_chart();
-				},
-				accumulator: (acc, cell, row, row_count) => frappe.utils.report_accumulator(acc, cell, row, row_count)
+				}
+			},
+			hooks: {
+				totalAccumulator: frappe.utils.report_total_accumulator
 			}
 		});
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -411,8 +411,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				layout: 'fixed',
 				cellHeight: 33,
 				showTotalRow: this.raw_data.add_total_row,
-				events: {
-					accumulator: (acc, cell, row, row_count) => frappe.utils.report_accumulator(acc, cell, row, row_count)
+				hooks: {
+					totalAccumulator: frappe.utils.report_total_accumulator
 				}
 			};
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -410,7 +410,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				treeView: this.tree_report,
 				layout: 'fixed',
 				cellHeight: 33,
-				showTotalRow: this.raw_data.add_total_row
+				showTotalRow: this.raw_data.add_total_row,
+				events: {
+					accumulator: (acc, cell, row, row_count) => frappe.utils.report_accumulator(acc, cell, row, row_count)
+				}
 			};
 
 			if (this.report_settings.get_datatable_options) {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -227,7 +227,8 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				onCheckRow: () => {
 					const checked_items = this.get_checked_items();
 					this.toggle_actions_menu_button(checked_items.length > 0);
-				}
+				},
+				accumulator: (acc, cell, row, row_count) => frappe.utils.report_accumulator(acc, cell, row, row_count)
 			},
 			headerDropdown: [{
 				label: __('Add Column'),

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -227,8 +227,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				onCheckRow: () => {
 					const checked_items = this.get_checked_items();
 					this.toggle_actions_menu_button(checked_items.length > 0);
-				},
-				accumulator: (acc, cell, row, row_count) => frappe.utils.report_accumulator(acc, cell, row, row_count)
+				}
+			},
+			hooks: {
+				totalAccumulator: frappe.utils.report_total_accumulator
 			},
 			headerDropdown: [{
 				label: __('Add Column'),


### PR DESCRIPTION
Required: https://github.com/frappe/datatable/pull/55.

Introduced `frappe.utils.report_total_accumulator` to use as a DataTable hook for totals row.

Before             |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/328330/51414306-c4f45480-1b93-11e9-8100-753459fc2275.png)  |  ![image](https://user-images.githubusercontent.com/328330/51414315-d0e01680-1b93-11e9-91d9-9ce5cee91926.png)

