### PR TITLE
fix(Caching): WebsiteGenerator overriding Document's clear_cache (V11)

### DIFF
--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -68,6 +68,7 @@ class WebsiteGenerator(Document):
 		return title_field
 
 	def clear_cache(self):
+		super(WebsiteGenerator, self).clear_cache()
 		clear_cache(self.route)
 
 	def scrub(self, text):


### PR DESCRIPTION
I recently realized my branch got pulled in develop (v12) rather than staging-fixes from the PR https://github.com/frappe/frappe/pull/6542

This should be merged in v11 too