### PR TITLE
fix(requirements): freeze requests-oauthlib to 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pyasn1
 zxcvbn-python
 unittest-xml-reporting
 oauthlib==2.1.0
+requests-oauthlib==1.1.0
 pdfkit
 PyJWT
 PyPDF2


### PR DESCRIPTION
`requests-oauthlib` is being used by `google-auth-oauthlib` & `erpnext`

temporarily freezing `requests-oauthlib` to `1.1.0` until we're compatible with `oauthlib 3.0.0`
(https://github.com/requests/requests-oauthlib)

Alternatively, we can decide to use a newer library created by one of the oauthlib maintainers:
https://github.com/lepture/authlib

@revant Can you help with this please?