### PR TITLE
fix: wrong filter on report view

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -79,6 +79,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	load() {
+		if (this.loading) return;
+
 		if (frappe.get_route().length < 2) {
 			this.toggle_nothing_to_show(true);
 			return;
@@ -94,6 +96,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	load_report() {
+		this.loading = true;
 		this.page.clear_inner_toolbar();
 		this.route = frappe.get_route();
 		this.page_name = frappe.get_route_str();
@@ -109,7 +112,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.setup_page_head(),
 			() => this.refresh_report(),
 			() => this.add_make_chart_button()
-		]);
+		]).then(() => this.loading = false);
 	}
 
 	add_make_chart_button(){

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -112,7 +112,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.setup_page_head(),
 			() => this.refresh_report(),
 			() => this.add_make_chart_button()
-		]).then(() => this.loading = false);
+		]).finally(() => this.loading = false);
 	}
 
 	add_make_chart_button(){


### PR DESCRIPTION
**Before:**
![repeated_filter_problem_1](https://user-images.githubusercontent.com/13928957/51452749-de4afb80-1d61-11e9-8d37-628fdcd283bf.gif)

**After:**
![repeated_filter_problem](https://user-images.githubusercontent.com/13928957/51452729-c2475a00-1d61-11e9-8073-e6dae7978cfd.gif)

This was happening due to the **consecutive call to the load function** of the report. 

First time the load function calls **load_report()** which setups report setting(eg. General Ledger) which is async in nature and on the next immediate call to the load function, **refresh_report()** is called which uses report setting of the previous report(eg. P&L statement) because the report setting of the current report (General ledger) is not yet loaded. Hence the error used to cause due to the mismatch of the report setting.

Cause of consecutive call which made report load twice:

- When you load the application we set up event emitter on frappe.route
- When the URL is changed [we call frappe.route() as well as frappe.route.trigger('change')](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/router.js#L192) which is completely fine. (frappe.route() has the code to load report)
- According to the above statement report should be loaded only once since `frappe.route()` only gets called once. But the issue is with `frappe.route.trigger('change')` which calls `frappe.route()` again.
-
```javascript
init() {
	this.jq = jQuery(this);
},

trigger(evt, data) {
	!this.jq && this.init();
	this.jq.trigger(evt, data);
},
```
This is the code for trigger function in event emitter class. So whenever `.trigger()` function gets called it checks if its initialized with jQuery. If not it will call init function. Now the fact is whenever we pass a function to jQuery it calls it (since it internally calls .apply()). In this case when `jQuery(frappe.route)` gets called it also calls `frappe.route()`.

Due to this, the error used to occur only when you completely reload website when you are on a report page (this is where event emitter will be set up for frappe.route) and then navigate to the other report (this is where the `frappe.route.trigger('change')` will be called for the first time which calls the init function).
 
 

