### PR TITLE
fix: Make event emitter from blank object

### DIFF
--- a/frappe/public/js/frappe/event_emitter.js
+++ b/frappe/public/js/frappe/event_emitter.js
@@ -4,7 +4,7 @@ frappe.provide('frappe.utils');
  */
 const EventEmitterMixin = {
 	init() {
-		this.jq = jQuery(this);
+		this.jq = jQuery({});
 	},
 
 	trigger(evt, data) {


### PR DESCRIPTION
- If a function is passed to jQuery, it calls it 🤷🏻‍♂️
- In hindsight, it is not needed to pass the object to jQuery
- This fixes a weird bug explained here
https://github.com/frappe/frappe/pull/6791
