### PR TITLE
fix(grid): Download hidden fields data from grid

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -683,8 +683,8 @@ export default class Grid {
 			data.push([__("Do not edit headers which are preset in the template")]);
 			data.push(["------"]);
 			$.each(frappe.get_meta(me.df.options).fields, function(i, df) {
-				// don't include the hidden field in the template
-				if(frappe.model.is_value_type(df.fieldtype) && !df.hidden) {
+				// don't include the read-only field in the template
+				if(frappe.model.is_value_type(df.fieldtype) && !df.read_only) {
 					data[1].push(df.label);
 					data[2].push(df.fieldname);
 					let description = (df.description || "") + ' ';


### PR DESCRIPTION
USECASE:

User makes new invoice from SO and then download item table data and upload it after entering qty. As "so_detail" field is hidden, the data gets lost. 

Now, it will download hidden fields data but will ignore read-only fields data (which causes issue in opening invoice creation tool)