### PR TITLE
fix: Use ImportError instead of ModuleNotFoundError

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -106,7 +106,7 @@ def print_by_server(doctype, name, print_format=None, doc=None, no_letterhead=0)
 	print_settings = frappe.get_doc("Print Settings")
 	try:
 		import cups
-	except ModuleNotFoundError:
+	except ImportError:
 		frappe.throw("You need to install pycups to use this feature!")
 		return
 	try:


### PR DESCRIPTION
- ModuleNotFoundError is available in python 3.6
- ImportError works in python 2 and 3 and 3.4 and 3..5 and 3.6 and so on
