### PR TITLE
fix(list-view): Show count that matches number of rows

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -597,7 +597,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			args: {
 				doctype: this.doctype,
 				filters: this.get_filters_for_args(),
-				fields: [`count(${frappe.model.get_full_column_name('name', this.doctype)}) as total_count`]
+				fields: [`count(distinct ${frappe.model.get_full_column_name('name', this.doctype)}) as total_count`],
 			}
 		}).then(r => {
 			this.total_count = r.message.values[0][0] || current_count;


### PR DESCRIPTION
In following scenario

```
DocType DT2

DocType DT1
	DT2 Table field DT1C

DocType DT1C (Child Table in DT1)
	DT2 Link Field DT2
```
Filtering based on child table fields shows incorrect count of rows

Rows in list are grouped by name, but the count string shows count that matches number of child table rows

**Note: Notice the count string e.g. 1 of 1 and 1 of 2**

Before fix
![screenshot 2019-01-21 at 5 45 25 pm](https://user-images.githubusercontent.com/8528887/51474138-63ef9b00-1da4-11e9-8ec8-e1e16bb1eb9f.png)

After fix
![screenshot 2019-01-21 at 5 43 14 pm](https://user-images.githubusercontent.com/8528887/51474139-63ef9b00-1da4-11e9-8f2d-6ea8b00b2471.png)

