### PR TITLE
fix(report): Set empty string if the value is null or undefined

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -612,7 +612,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			}
 
 			const format_cell = (value, row, column, data) => {
-				return frappe.format(value || '', column,
+				return frappe.format(value == null ? '' : value, column,
 					{for_print: false, always_show_decimals: true}, data);
 			};
 
@@ -649,7 +649,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			let row_obj = {};
 			if (Array.isArray(row)) {
 				this.columns.forEach((column, i) => {
-					row_obj[column.id] = row[i] || null;
+					row_obj[column.id] = row[i];
 				});
 
 				return row_obj;


### PR DESCRIPTION
We should show 0 values (in case of float or data field type) instead of setting them empty.

**Before**
<img width="1181" alt="screenshot 2019-01-22 at 4 43 14 pm" src="https://user-images.githubusercontent.com/13928957/51532026-1129e800-1e65-11e9-8831-1db1d3fd9a56.png">

**After**
<img width="1185" alt="screenshot 2019-01-22 at 4 44 03 pm" src="https://user-images.githubusercontent.com/13928957/51532078-30c11080-1e65-11e9-9a06-e2c5c0f6c731.png">
