### PR TITLE
fix(unicode): Import unicode_literals in every file

### DIFF
--- a/frappe/chat/__init__.py
+++ b/frappe/chat/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from   frappe import _
 

--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - standard imports
 import json
 

--- a/frappe/chat/doctype/chat_message/test_chat_message.py
+++ b/frappe/chat/doctype/chat_message/test_chat_message.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - standard imports
 import unittest
 

--- a/frappe/chat/doctype/chat_profile/chat_profile.py
+++ b/frappe/chat/doctype/chat_profile/chat_profile.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - module imports
 from   frappe.model.document import Document
 from   frappe import _

--- a/frappe/chat/doctype/chat_profile/test_chat_profile.py
+++ b/frappe/chat/doctype/chat_profile/test_chat_profile.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - standard imports
 import unittest
 
@@ -16,7 +18,7 @@ class TestChatProfile(unittest.TestCase):
 	# def test_create(self):
 	# 	with self.assertRaises(frappe.ValidationError):
 	# 		chat_profile.create(test_user)
-		
+
 	# 	user = get_user_doc(session.user)
 	# 	if not user.chat_profile:
 	# 		chat_profile.create(user.name)
@@ -47,7 +49,7 @@ class TestChatProfile(unittest.TestCase):
 	# 		))
 
 	# 	user = get_user_doc(session.user)
-	# 	prev = chat_profile.get(user.name) 
+	# 	prev = chat_profile.get(user.name)
 
 	# 	chat_profile.update(user.name, data = dict(
 	# 		status = 'Offline'

--- a/frappe/chat/doctype/chat_room/chat_room.py
+++ b/frappe/chat/doctype/chat_room/chat_room.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - standard imports
 import json
 

--- a/frappe/chat/doctype/chat_room_user/chat_room_user.py
+++ b/frappe/chat/doctype/chat_room_user/chat_room_user.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - module imports
 from   frappe.model.document import Document
 import frappe

--- a/frappe/chat/util/__init__.py
+++ b/frappe/chat/util/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - module imports
 from frappe.chat.util.util import (
 	get_user_doc,

--- a/frappe/chat/util/test_util.py
+++ b/frappe/chat/util/test_util.py
@@ -9,6 +9,7 @@ from frappe.chat.util import (
 	safe_json_loads
 )
 import frappe
+import six
 
 class TestChatUtil(unittest.TestCase):
 	def test_safe_json_loads(self):
@@ -19,7 +20,7 @@ class TestChatUtil(unittest.TestCase):
 		self.assertEqual(type(number), float)
 
 		string = safe_json_loads("foobar")
-		self.assertEqual(type(string), str)
+		self.assertEqual(type(string), six.text_type)
 
 		array  = safe_json_loads('[{ "foo": "bar" }]')
 		self.assertEqual(type(array), list)

--- a/frappe/chat/util/test_util.py
+++ b/frappe/chat/util/test_util.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - standard imports
 import unittest
 
@@ -15,10 +17,10 @@ class TestChatUtil(unittest.TestCase):
 
 		number = safe_json_loads("1.0")
 		self.assertEqual(type(number), float)
-		
+
 		string = safe_json_loads("foobar")
 		self.assertEqual(type(string), str)
-		
+
 		array  = safe_json_loads('[{ "foo": "bar" }]')
 		self.assertEqual(type(array), list)
 

--- a/frappe/chat/util/util.py
+++ b/frappe/chat/util/util.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - third-party imports
 import requests
 
@@ -26,7 +28,7 @@ def get_user_doc(user = None):
 
 	user = user or session.user
 	user = frappe.get_doc('User', user)
-	
+
 	return user
 
 def squashify(what):
@@ -43,9 +45,9 @@ def safe_json_loads(*args):
 			arg = json.loads(arg)
 		except Exception as e:
 			pass
-			
+
 		results.append(arg)
-	
+
 	return squashify(results)
 
 def filter_dict(what, keys, ignore = False):
@@ -68,7 +70,7 @@ def get_if_empty(a, b):
 	if not a:
 		a = b
 	return a
-	
+
 def listify(arg):
 	if not isinstance(arg, list):
 		arg = [arg]
@@ -89,7 +91,7 @@ def check_url(what, raise_err = False):
 			raise ValueError('{what} not a valid URL.')
 		else:
 			return False
-	
+
 	return True
 
 def create_test_user(module):
@@ -110,5 +112,5 @@ def get_emojis():
 		if resp.ok:
 			emojis = resp.json()
 			redis.hset('frappe_emojis', 'emojis', emojis)
-	
+
 	return dictify(emojis)

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from   frappe.chat.util import filter_dict, safe_json_loads
 

--- a/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
+++ b/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 import frappe.defaults
 import unittest

--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from __future__ import unicode_literals
 import frappe
 import frappe.share
 import unittest

--- a/frappe/core/utils.py
+++ b/frappe/core/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
+from __future__ import unicode_literals
 import frappe
 from frappe import _
 

--- a/frappe/data_migration/doctype/data_migration_connector/connectors/base.py
+++ b/frappe/data_migration/doctype/data_migration_connector/connectors/base.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from six import with_metaclass
 from abc import ABCMeta, abstractmethod
 from frappe.utils.password import get_decrypted_password

--- a/frappe/desk/doctype/note/test_note.py
+++ b/frappe/desk/doctype/note/test_note.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # See license.txt
 
+from __future__ import unicode_literals
 import frappe
 import unittest
 

--- a/frappe/desk/page/backups/backups.py
+++ b/frappe/desk/page/backups/backups.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 import frappe
 from frappe import _

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from __future__ import unicode_literals
 import frappe, os
 import unittest, email
 

--- a/frappe/email/inbox.py
+++ b/frappe/email/inbox.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 import json
 

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, unicode_literals
 from __future__ import print_function
 import requests
 import json

--- a/frappe/geo/doctype/country/test_country.py
+++ b/frappe/geo/doctype/country/test_country.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: See license.txt
 
-
+from __future__ import unicode_literals
 import frappe
 test_records = frappe.get_test_records('Country')

--- a/frappe/geo/doctype/currency/test_currency.py
+++ b/frappe/geo/doctype/currency/test_currency.py
@@ -3,5 +3,6 @@
 
 # pre loaded
 
+from __future__ import unicode_literals
 import frappe
 test_records = frappe.get_test_records('Currency')

--- a/frappe/integrations/data_migration_mapping/gcalendar_to_event/__init__.py
+++ b/frappe/integrations/data_migration_mapping/gcalendar_to_event/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import frappe
 from datetime import datetime
 from dateutil.parser import parse

--- a/frappe/integrations/doctype/social_login_keys/social_login_keys.py
+++ b/frappe/integrations/doctype/social_login_keys/social_login_keys.py
@@ -1,4 +1,5 @@
 # see license
+from __future__ import unicode_literals
 from frappe.model.document import Document
 
 class SocialLoginKeys(Document):

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2017, Frappe Technologies and contributors
 # For license information, please see license.txt
 
+from __future__ import unicode_literals
 import frappe
 
 def run_webhooks(doc, method):
@@ -37,7 +38,7 @@ def run_webhooks(doc, method):
 
 	def _webhook_request(webhook):
 		if not webhook.name in frappe.flags.webhooks_executed.get(doc.name, []):
-			frappe.enqueue("frappe.integrations.doctype.webhook.webhook.enqueue_webhook", 
+			frappe.enqueue("frappe.integrations.doctype.webhook.webhook.enqueue_webhook",
 				enqueue_after_commit=True, doc=doc, webhook=webhook)
 
 			# keep list of webhooks executed for this doc in this request

--- a/frappe/model/dynamic_links.py
+++ b/frappe/model/dynamic_links.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
+from __future__ import unicode_literals
 import frappe
 
-# select doctypes that are accessed by the user (not read_only) first, so that the 
-# the validation message shows the user-facing doctype first. 
+# select doctypes that are accessed by the user (not read_only) first, so that the
+# the validation message shows the user-facing doctype first.
 # For example Journal Entry should be validated before GL Entry (which is an internal doctype)
 
 dynamic_link_queries =  [

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Settings saved per user basis
 # such as page_limit, filters, last_view
 

--- a/frappe/modules/__init__.py
+++ b/frappe/modules/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import unicode_literals
 from .utils import *

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, unicode_literals
 from __future__ import print_function
 import frappe
 import pytz

--- a/frappe/patches/v10_0/enable_chat_by_default_within_system_settings.py
+++ b/frappe/patches/v10_0/enable_chat_by_default_within_system_settings.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v10_0/enhance_security.py
+++ b/frappe/patches/v10_0/enhance_security.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 import frappe
 

--- a/frappe/patches/v10_0/increase_single_table_column_length.py
+++ b/frappe/patches/v10_0/increase_single_table_column_length.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 """
 Run this after updating country_info.json and or
 """

--- a/frappe/patches/v10_0/migrate_passwords_passlib.py
+++ b/frappe/patches/v10_0/migrate_passwords_passlib.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.utils.password import LegacyPassword
 

--- a/frappe/patches/v10_0/modify_naming_series_table.py
+++ b/frappe/patches/v10_0/modify_naming_series_table.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 '''
     Modify the Integer 10 Digits Value to BigInt 20 Digit value

--- a/frappe/patches/v10_0/modify_smallest_currency_fraction.py
+++ b/frappe/patches/v10_0/modify_smallest_currency_fraction.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v10_0/refactor_social_login_keys.py
+++ b/frappe/patches/v10_0/refactor_social_login_keys.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 import frappe
 from frappe.utils import cstr

--- a/frappe/patches/v10_0/reload_countries_and_currencies.py
+++ b/frappe/patches/v10_0/reload_countries_and_currencies.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 """
 Run this after updating country_info.json and or
 """

--- a/frappe/patches/v10_0/remove_custom_field_for_disabled_domain.py
+++ b/frappe/patches/v10_0/remove_custom_field_for_disabled_domain.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v10_0/set_default_locking_time.py
+++ b/frappe/patches/v10_0/set_default_locking_time.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v10_0/set_no_copy_to_workflow_state.py
+++ b/frappe/patches/v10_0/set_no_copy_to_workflow_state.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/change_email_signature_fieldtype.py
+++ b/frappe/patches/v11_0/change_email_signature_fieldtype.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/copy_fetch_data_from_options.py
+++ b/frappe/patches/v11_0/copy_fetch_data_from_options.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/delete_all_prepared_reports.py
+++ b/frappe/patches/v11_0/delete_all_prepared_reports.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/delete_duplicate_user_permissions.py
+++ b/frappe/patches/v11_0/delete_duplicate_user_permissions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/drop_column_apply_user_permissions.py
+++ b/frappe/patches/v11_0/drop_column_apply_user_permissions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/fix_order_by_in_reports_json.py
+++ b/frappe/patches/v11_0/fix_order_by_in_reports_json.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, json
 
 def execute():

--- a/frappe/patches/v11_0/get_docs_apps_if_not_present.py
+++ b/frappe/patches/v11_0/get_docs_apps_if_not_present.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.utils.help import setup_apps_for_docs
 

--- a/frappe/patches/v11_0/migrate_report_settings_for_new_listview.py
+++ b/frappe/patches/v11_0/migrate_report_settings_for_new_listview.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, json
 
 def execute():

--- a/frappe/patches/v11_0/multiple_references_in_events.py
+++ b/frappe/patches/v11_0/multiple_references_in_events.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/reload_and_rename_view_log.py
+++ b/frappe/patches/v11_0/reload_and_rename_view_log.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/remove_skip_for_doctype.py
+++ b/frappe/patches/v11_0/remove_skip_for_doctype.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.desk.form.linked_with import get_linked_doctypes
 from frappe.patches.v11_0.replicate_old_user_permissions import get_doctypes_to_skip

--- a/frappe/patches/v11_0/rename_email_alert_to_notification.py
+++ b/frappe/patches/v11_0/rename_email_alert_to_notification.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.model.rename_doc import rename_doc
 

--- a/frappe/patches/v11_0/rename_google_maps_doctype.py
+++ b/frappe/patches/v11_0/rename_google_maps_doctype.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.model.rename_doc import rename_doc
 

--- a/frappe/patches/v11_0/rename_standard_reply_to_email_template.py
+++ b/frappe/patches/v11_0/rename_standard_reply_to_email_template.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.model.rename_doc import rename_doc
 

--- a/frappe/patches/v11_0/rename_workflow_action_to_workflow_action_master.py
+++ b/frappe/patches/v11_0/rename_workflow_action_to_workflow_action_master.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.model.rename_doc import rename_doc
 

--- a/frappe/patches/v11_0/replicate_old_user_permissions.py
+++ b/frappe/patches/v11_0/replicate_old_user_permissions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 import json
 from frappe.utils import cint

--- a/frappe/patches/v11_0/set_allow_self_approval_in_workflow.py
+++ b/frappe/patches/v11_0/set_allow_self_approval_in_workflow.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v11_0/sync_stripe_settings_before_migrate.py
+++ b/frappe/patches/v11_0/sync_stripe_settings_before_migrate.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.utils.password import get_decrypted_password
 

--- a/frappe/patches/v11_0/sync_user_permission_doctype_before_migrate.py
+++ b/frappe/patches/v11_0/sync_user_permission_doctype_before_migrate.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v5_0/clear_website_group_and_notifications.py
+++ b/frappe/patches/v5_0/clear_website_group_and_notifications.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v5_0/communication_parent.py
+++ b/frappe/patches/v5_0/communication_parent.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v5_0/expire_old_scheduler_logs.py
+++ b/frappe/patches/v5_0/expire_old_scheduler_logs.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v5_0/modify_session.py
+++ b/frappe/patches/v5_0/modify_session.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v5_0/move_scheduler_last_event_to_system_settings.py
+++ b/frappe/patches/v5_0/move_scheduler_last_event_to_system_settings.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v5_0/rename_table_fieldnames.py
+++ b/frappe/patches/v5_0/rename_table_fieldnames.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from __future__ import unicode_literals
 import frappe
 from frappe.model.utils.rename_field import rename_field
 from frappe.modules import scrub, get_doctype_module

--- a/frappe/patches/v5_0/update_shared.py
+++ b/frappe/patches/v5_0/update_shared.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 import frappe.share
 

--- a/frappe/patches/v6_0/document_type_rename.py
+++ b/frappe/patches/v6_0/document_type_rename.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v6_0/fix_ghana_currency.py
+++ b/frappe/patches/v6_0/fix_ghana_currency.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 def execute():
 	from frappe.geo.country_info import get_all

--- a/frappe/patches/v6_0/make_task_log_folder.py
+++ b/frappe/patches/v6_0/make_task_log_folder.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe.utils, os
 
 def execute():

--- a/frappe/patches/v6_1/rename_file_data.py
+++ b/frappe/patches/v6_1/rename_file_data.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v6_11/rename_field_in_email_account.py
+++ b/frappe/patches/v6_11/rename_field_in_email_account.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v6_15/set_username.py
+++ b/frappe/patches/v6_15/set_username.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v6_2/rename_backup_manager.py
+++ b/frappe/patches/v6_2/rename_backup_manager.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v6_20x/remove_roles_from_website_user.py
+++ b/frappe/patches/v6_20x/remove_roles_from_website_user.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v6_20x/set_allow_draft_for_print.py
+++ b/frappe/patches/v6_20x/set_allow_draft_for_print.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v6_20x/update_insert_after.py
+++ b/frappe/patches/v6_20x/update_insert_after.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, json
 
 def execute():

--- a/frappe/patches/v6_24/set_language_as_code.py
+++ b/frappe/patches/v6_24/set_language_as_code.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 from frappe.translate import get_lang_dict

--- a/frappe/patches/v6_24/sync_desktop_icons.py
+++ b/frappe/patches/v6_24/sync_desktop_icons.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, json
 
 from frappe.desk.doctype.desktop_icon.desktop_icon import sync_from_app, get_user_copy

--- a/frappe/patches/v7_0/add_communication_in_doc.py
+++ b/frappe/patches/v7_0/add_communication_in_doc.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 from frappe.core.doctype.communication.comment import update_comment_in_doc

--- a/frappe/patches/v7_0/cleanup_list_settings.py
+++ b/frappe/patches/v7_0/cleanup_list_settings.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, json
 
 def execute():

--- a/frappe/patches/v7_0/create_private_file_folder.py
+++ b/frappe/patches/v7_0/create_private_file_folder.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, os
 
 def execute():

--- a/frappe/patches/v7_0/desktop_icons_hidden_by_admin_as_blocked.py
+++ b/frappe/patches/v7_0/desktop_icons_hidden_by_admin_as_blocked.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_0/re_route.py
+++ b/frappe/patches/v7_0/re_route.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.model.base_document import get_controller
 

--- a/frappe/patches/v7_0/rename_bulk_email_to_email_queue.py
+++ b/frappe/patches/v7_0/rename_bulk_email_to_email_queue.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_0/rename_newsletter_list_to_email_group.py
+++ b/frappe/patches/v7_0/rename_newsletter_list_to_email_group.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_0/set_user_fullname.py
+++ b/frappe/patches/v7_0/set_user_fullname.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_0/update_send_after_in_bulk_email.py
+++ b/frappe/patches/v7_0/update_send_after_in_bulk_email.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.utils import now_datetime
 

--- a/frappe/patches/v7_1/rename_chinese_language_codes.py
+++ b/frappe/patches/v7_1/rename_chinese_language_codes.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_1/rename_scheduler_log_to_error_log.py
+++ b/frappe/patches/v7_1/rename_scheduler_log_to_error_log.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_1/sync_language_doctype.py
+++ b/frappe/patches/v7_1/sync_language_doctype.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.translate import get_lang_dict
 

--- a/frappe/patches/v7_2/fix_email_queue_recipient.py
+++ b/frappe/patches/v7_2/fix_email_queue_recipient.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_2/merge_knowledge_base.py
+++ b/frappe/patches/v7_2/merge_knowledge_base.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 from frappe.patches.v7_0.re_route import update_routes

--- a/frappe/patches/v7_2/remove_in_filter.py
+++ b/frappe/patches/v7_2/remove_in_filter.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_2/set_doctype_engine.py
+++ b/frappe/patches/v7_2/set_doctype_engine.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_2/set_in_standard_filter_property.py
+++ b/frappe/patches/v7_2/set_in_standard_filter_property.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 import pymysql
 

--- a/frappe/patches/v7_2/setup_custom_perms.py
+++ b/frappe/patches/v7_2/setup_custom_perms.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.permissions import setup_custom_perms
 from frappe.core.page.permission_manager.permission_manager import get_standard_permissions

--- a/frappe/patches/v7_2/setup_ldap_config.py
+++ b/frappe/patches/v7_2/setup_ldap_config.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.utils import cint
 

--- a/frappe/patches/v7_2/update_communications.py
+++ b/frappe/patches/v7_2/update_communications.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v7_2/update_feedback_request.py
+++ b/frappe/patches/v7_2/update_feedback_request.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_0/deprecate_integration_broker.py
+++ b/frappe/patches/v8_0/deprecate_integration_broker.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.integrations.utils import create_payment_gateway
 

--- a/frappe/patches/v8_0/drop_in_dialog.py
+++ b/frappe/patches/v8_0/drop_in_dialog.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_0/drop_is_custom_from_docperm.py
+++ b/frappe/patches/v8_0/drop_is_custom_from_docperm.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_0/install_new_build_system_requirements.py
+++ b/frappe/patches/v8_0/install_new_build_system_requirements.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, unicode_literals
 from __future__ import print_function
 from subprocess import Popen, call, PIPE
 

--- a/frappe/patches/v8_0/rename_listsettings_to_usersettings.py
+++ b/frappe/patches/v8_0/rename_listsettings_to_usersettings.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from frappe.installer import create_user_settings_table
 from frappe.model.utils.user_settings import update_user_settings
 import frappe, json

--- a/frappe/patches/v8_0/rename_print_to_printing.py
+++ b/frappe/patches/v8_0/rename_print_to_printing.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_0/set_allow_traceback.py
+++ b/frappe/patches/v8_0/set_allow_traceback.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_0/setup_email_inbox.py
+++ b/frappe/patches/v8_0/setup_email_inbox.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, json
 from frappe.core.doctype.user.user import ask_pass_update, setup_user_email_inbox
 

--- a/frappe/patches/v8_0/update_global_search_table.py
+++ b/frappe/patches/v8_0/update_global_search_table.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_0/update_published_in_global_search.py
+++ b/frappe/patches/v8_0/update_published_in_global_search.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_0/update_records_in_global_search.py
+++ b/frappe/patches/v8_0/update_records_in_global_search.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.utils.global_search import get_doctypes_with_global_search, rebuild_for_doctype
 from frappe.utils import update_progress_bar

--- a/frappe/patches/v8_1/delete_custom_docperm_if_doctype_not_exists.py
+++ b/frappe/patches/v8_1/delete_custom_docperm_if_doctype_not_exists.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v8_x/update_user_permission.py
+++ b/frappe/patches/v8_x/update_user_permission.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v9_1/move_feed_to_activity_log.py
+++ b/frappe/patches/v9_1/move_feed_to_activity_log.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe.utils.background_jobs import enqueue
 

--- a/frappe/patches/v9_1/resave_domain_settings.py
+++ b/frappe/patches/v9_1/resave_domain_settings.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/patches/v9_1/revert_domain_settings.py
+++ b/frappe/patches/v9_1/revert_domain_settings.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 def execute():

--- a/frappe/tests/test_patches.py
+++ b/frappe/tests/test_patches.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest, frappe
 from frappe.modules import patch_handler
 

--- a/frappe/tests/ui/test_test_runner.py
+++ b/frappe/tests/ui/test_test_runner.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, unicode_literals
 from __future__ import print_function
 from frappe.utils.selenium_testdriver import TestDriver
 import unittest, os, frappe, time

--- a/frappe/tests/ui/test_todo.py
+++ b/frappe/tests/ui/test_todo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, unicode_literals
 from __future__ import print_function
 from frappe.utils.selenium_testdriver import TestDriver
 import unittest

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 import json, re
 import bleach, bleach_whitelist.bleach_whitelist as bleach_whitelist

--- a/frappe/utils/identicon.py
+++ b/frappe/utils/identicon.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from PIL import Image, ImageDraw
 from hashlib import md5
 import base64

--- a/frappe/utils/make_random.py
+++ b/frappe/utils/make_random.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe, random
 from six.moves import range
 from six import string_types

--- a/frappe/utils/minify.py
+++ b/frappe/utils/minify.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # This code is original from jsmin by Douglas Crockford, it was translated to
 # Python by Baruch Even. The original code had the following copyright and
 # license.

--- a/frappe/utils/reset_doc.py
+++ b/frappe/utils/reset_doc.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 import json, os
 from frappe.modules import scrub, get_module_path, load_doctype_module, utils

--- a/frappe/website/doctype/website_theme/test_website_theme.py
+++ b/frappe/website/doctype/website_theme/test_website_theme.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from __future__ import unicode_literals
 import frappe
 import unittest
 

--- a/frappe/website/purifycss.py
+++ b/frappe/website/purifycss.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 '''
 Check for unused CSS Classes
 

--- a/frappe/www/feedback.py
+++ b/frappe/www/feedback.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.core.doctype.feedback_request.feedback_request import is_valid_feedback_request

--- a/frappe/www/robots.py
+++ b/frappe/www/robots.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import frappe
 
 no_sitemap = 1

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 # imports - standard imports
 import os, shutil
 from distutils.command.clean import clean as Clean


### PR DESCRIPTION
Ran this script

```python3
import os
files = os.popen("git ls-files | grep \.py$ | xargs grep -L 'unicode_literals'").read().split()
for filename in files:
    new_content = None
    with open(filename) as f:
        content = f.readlines()
        if len(content):
            if content[0] == "from __future__ import print_function\n":
                new_content = ["from __future__ import print_function, unicode_literals\n"] + content
            else:
                new_content = ["from __future__ import unicode_literals\n"] + content
    if new_content:
        with open(filename, "w") as f:
            f.writelines(new_content)

```

Basically check if every .py file does `from __future__ import unicode_literals` if not do so.