### PR TITLE
fix(email): Pass args as unicode in Py2 & bytes in Py3 to SMTP.login

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -210,7 +210,7 @@ class SMTPServer:
 				self._sess.ehlo()
 
 			if self.login and self.password:
-				ret = self._sess.login((self.login or ""), (self.password or ""))
+				ret = self._sess.login(str(self.login or ""), str(self.password or ""))
 
 				# check if logged correctly
 				if ret[0]!=235:


### PR DESCRIPTION
Trying to save Email Account (with Password) in Python 2 env yields following traceback

```python-traceback
Traceback (most recent call last):
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/model/document.py", line 296, in _save
    self.run_before_save_methods()
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 73, in validate
    self.check_smtp()
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 139, in check_smtp
    server.sess
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/email/smtp.py", line 214, in sess
    ret = self._sess.login(frappe.safe_decode(self.login or ""), frappe.safe_decode(self.password or ""))
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/smtplib.py", line 614, in login
    (code, resp) = self.docmd(encode_cram_md5(resp, user, password))
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/smtplib.py", line 577, in encode_cram_md5
    response = user + " " + hmac.HMAC(password, challenge).hexdigest()
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/hmac.py", line 75, in __init__
    self.outer.update(key.translate(trans_5C))
TypeError: character mapping must return integer, None or unicode
```

SMTP.login expect both user and password to be bytes in case of Python 2 and unicode in case of Python 3. `str` does exactly that.