### PR TITLE
fix: Use ImportError instead of ModuleNotFoundError

### DIFF
--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -18,7 +18,7 @@ class PrintSettings(Document):
 		printer_list = []
 		try:
 			import cups
-		except ModuleNotFoundError:
+		except ImportError:
 			frappe.throw("You need to install pycups to use this feature!")
 			return
 		try:


### PR DESCRIPTION
- ModuleNotFoundError is available in python 3.6
- ImportError works in python 2 and 3 and 3.4 and 3..5 and 3.6 and so on
- This should have been included in Frappe PR #6797