### PR TITLE
fix(comment): Encoding issue in jinja for mention in comment

### DIFF
--- a/frappe/core/doctype/communication/comment.py
+++ b/frappe/core/doctype/communication/comment.py
@@ -96,15 +96,17 @@ def notify_mentions(doc):
 
 		recipients = [frappe.db.get_value("User", {"enabled": 1, "name": name, "user_type": "System User"}, "email")
 			for name in mentions]
+		link = get_link_to_form(doc.reference_doctype, doc.reference_name, label=parent_doc_label)
+
 		frappe.sendmail(
 			recipients=recipients,
 			sender=frappe.session.user,
 			subject=subject,
 			template="mentioned_in_comment",
 			args={
-				"sender_fullname": sender_fullname,
+				"body_content": _("{0} mentioned you in a comment in {1}").format(sender_fullname, link),
 				"comment": doc,
-				"link": get_link_to_form(doc.reference_doctype, doc.reference_name, label=parent_doc_label)
+				"link": link
 			},
 			header=[_('New Mention'), 'orange']
 		)

--- a/frappe/templates/emails/mentioned_in_comment.html
+++ b/frappe/templates/emails/mentioned_in_comment.html
@@ -1,5 +1,5 @@
 <p>
-	{{ _("{0} mentioned you in a comment in {1}").format(sender_fullname, link) }}
+	{{ body_content }}
 </p>
 <blockquote
 	style="border-left: 3px solid #d1d8dd; padding: 7px 15px; margin-left: 0px;">


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/desk/form/utils.py", line 69, in add_comment
    doc.insert(ignore_permissions=True)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/model/document.py", line 243, in insert
    self.run_method("after_insert")
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/core/doctype/communication/communication.py", line 101, in after_insert
    notify_mentions(self)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/core/doctype/communication/comment.py", line 109, in notify_mentions
    header=[_('New Mention'), 'orange']
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/__init__.py", line 439, in sendmail
    message, text_content = get_email_from_template(template, args)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/utils/jinja.py", line 30, in get_email_from_template
    message = get_template('templates/emails/' + name + '.html').render(args)
  File "/home/frappe/benches/bench-2019-01-09/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-2019-01-09/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/./templates/emails/mentioned_in_comment.html", line 2, in top-level template code
    {{ _("{0} mentioned you in a comment in {1}").format(sender_fullname, link) }}
UnicodeEncodeError: 'ascii' codec can't encode characters in position 2387-2394: ordinal not in range(128)
```