### PR TITLE
fix: Bypass filters that cannot be applied

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -125,7 +125,9 @@ frappe.ui.Filter = class {
 
 	set_values(doctype, fieldname, condition, value) {
 		// presents given (could be via tags!)
-		this.set_field(doctype, fieldname);
+		if (this.set_field(doctype, fieldname) === false) {
+			return
+		}
 
 		if(this.field.df.original_type==='Check') {
 			value = (value==1) ? 'Yes' : 'No';
@@ -154,9 +156,9 @@ frappe.ui.Filter = class {
 
 		let original_docfield = (this.fieldselect.fields_by_name[doctype] || {})[fieldname];
 		if(!original_docfield) {
-			frappe.msgprint(__("Field {0} is not selectable.", [fieldname]));
+			console.warn(`Field ${fieldname} is not selectable.`);
 			this.remove();
-			return;
+			return false;
 		}
 
 		let df = copy_dict(original_docfield);


### PR DESCRIPTION
Use case:
When you enable Workflow for any DocType, it's status is now tracked by `workflow_field` and not `docstatus`. When you navigate from Notification dropdown, it applies a `docstatus` filter on the List View which cannot be applied. This can be ignored and user can apply his own filters.

![workflow-list-filters-fix](https://user-images.githubusercontent.com/9355208/51607887-f7a79f80-1f3b-11e9-8926-4db0601e6e39.gif)
