### PR TITLE
fix(PrintFormat): Section Labels with spaces in them got truncated

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder_section.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_section.html
@@ -1,4 +1,4 @@
-<div class="print-format-builder-section row light-bg" data-label={{ section.label || "" }}>
+<div class="print-format-builder-section row light-bg" data-label="{{ section.label || '' }}">
     <div class="print-format-builder-section-head">
         <a class="section-settings pull-right
             btn-default btn-xs" style="padding-top: 3px">


### PR DESCRIPTION
When you save a Print Format from the Print Format Builder, it builds a JSON of the format with all the settings to reproduce that format. This also includes Section Labels. Section Labels are fetched from the HTML itself, specifically `data-label` attribute. This attribute breaks if you have spaces in your value and you don't have quotes around them.

Here is the issue:

![print-format-builder-issue](https://user-images.githubusercontent.com/9355208/51612885-5541e900-1f48-11e9-922a-082b942be911.gif)
