### PR TITLE
fix(postgres): Enclose user column(identifier) in ` since user is a reserved keyword 

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -117,6 +117,6 @@ def clear_user_permissions(user, for_doctype):
 
 	total = frappe.db.count('User Permission', filters = dict(user=user, allow=for_doctype))
 	if total:
-		frappe.db.sql('DELETE FROM `tabUser Permission` WHERE user=%s AND allow=%s', (user, for_doctype))
+		frappe.db.sql('DELETE FROM `tabUser Permission` WHERE `user`=%s AND `allow`=%s', (user, for_doctype))
 		frappe.clear_cache()
 	return total


### PR DESCRIPTION
Enclose user column(identifier) in ` since **user** is a reserved keyword. 
The deletion query used to work for MariaDB but fails for Postgres.

This should fix the failing test for Postgres.

Reserved keywords list for Postgres: (for future reference)
https://www.postgresql.org/docs/current/sql-keywords-appendix.html