### PR TITLE
fix: Casting docnames and handling unicode

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -214,7 +214,7 @@ def delete_items():
 	"""delete selected items"""
 	import json
 
-	il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True, key=str)
+	il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True, key=frappe.safe_decode)
 	doctype = frappe.form_dict.get('doctype')
 
 	failed = []


### PR DESCRIPTION
```
x = u'["\u6ce5\u677f\u5f00\u53d1", "\u7f8e\u56e2\u56de\u6536"]'
il = sorted(json.loads(x), reverse=True, key=str)
```

Works for python 3 but fails for python 2