### PR TITLE
fix(notifications): ignore mysql internal error 1684 for concurrent ddl statements

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -107,7 +107,8 @@ def get_notifications_for_doctypes(config, notification_count):
 
 				except Exception as e:
 					# OperationalError: (1412, 'Table definition has changed, please retry transaction')
-					if e.args[0]!=1412:
+					# InternalError: (1684, 'Table definition is being modified by concurrent DDL statement')
+					if e.args[0] not in (1412, 1684):
 						raise
 
 				else:
@@ -147,7 +148,7 @@ def get_notifications_for_targets(config, notification_percent):
 					frappe.clear_messages()
 					pass
 				except Exception as e:
-					if e.args[0]!=1412:
+					if e.args[0] not in (1412, 1684):
 						raise
 
 				else:


### PR DESCRIPTION
apparently this occurs when `get_notifications()` is called, and at the same time a table is being modified. to fix this, we just skip the table that is currently being modified.
