### PR TITLE
fix: Skip get_notifications before setup_complete

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -11,7 +11,8 @@ import json
 
 @frappe.whitelist()
 def get_notifications():
-	if frappe.flags.in_install:
+	if (frappe.flags.in_install or
+		not frappe.db.get_single_value('System Settings', 'setup_complete')):
 		return
 
 	config = get_notification_config()


### PR DESCRIPTION
```
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/database.py", line 899, in get_db_table_columns
    return [r[0] for r in self.sql("DESC `%s`" % table)]
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/database.py", line 210, in sql
    self._cursor.execute(query)
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2019-01-23/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1684, u"Table '5fefab8489df3369'.'tabEmployee Tax Exemption Proof Submission' was skipped since its definition is being modified by concurrent DDL statement")
```