### PR TITLE
fix: return empty dict if setup wizard is not completed

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -13,7 +13,13 @@ import json
 def get_notifications():
 	if (frappe.flags.in_install or
 		not frappe.db.get_single_value('System Settings', 'setup_complete')):
-		return { }
+		return {
+			"open_count_doctype": {},
+			"open_count_module": {},
+			"open_count_other": {},
+			"targets": {},
+			"new_messages": []
+		}
 
 	config = get_notification_config()
 


### PR DESCRIPTION
1. When returns empty result

<img width="896" alt="screen shot 2019-01-24 at 10 16 07 pm" src="https://user-images.githubusercontent.com/3784093/51694008-fbafec00-2025-11e9-9f3c-7ef6d108a211.png">

2. when returns empty dict, the system does not load setup wizard though setup wizard is no completed

<img width="1058" alt="screen shot 2019-01-24 at 10 17 28 pm" src="https://user-images.githubusercontent.com/3784093/51694072-066a8100-2026-11e9-8012-c649bd3941a0.png">

3. Fix:
Return dict with empty count
```
return {
     "open_count_doctype": {},
     "open_count_module": {},
     "open_count_other": {},
     "targets": {},
     "new_messages": []
}
```

