### PR TITLE
 fix(unicode): Set default encoding to utf-8 in Python 2

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -17,6 +17,12 @@ from faker import Faker
 from .exceptions import *
 from .utils.jinja import (get_jenv, get_template, render_template, get_email_from_template, get_jloader)
 
+# Hamless for Python 3
+# For Python 2 set default encoding to utf-8
+if sys.version[0] == '2':
+	reload(sys)
+	sys.setdefaultencoding("utf-8")
+
 __version__ = '10.1.70'
 __title__ = "Frappe Framework"
 


### PR DESCRIPTION
### Note: This might have unintended side effects 

https://stackoverflow.com/questions/3828723

**Fix for Jinja Templates**

Jinja templates don't behave like Python script with `from __future__ import unicode_literals`

For example When Sales Order currency is set as Euro. Sales Order > Make > Payment Request 

Jinja template in this example
```jinja
<p>{{ _("Requesting payment against {0} {1} for amount {2}").format(doc.doctype,
	doc.name, doc.get_formatted("grand_total")) }}</p>
```

Expected result
```html
<p>Requesting payment against Sales Order SO-00143 for amount € 21.95</p>
```

Instead Python 2 instance throws `UnicodeDecodeError` with following traceback.
```python-traceback
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/erpnext/erpnext/accounts/doctype/payment_request/payment_request.py", line 305, in make_payment_request
    "message": gateway_account.get("message") or get_dummy_message(ref_doc),
  File "/home/frappe/benches/bench-2019-01-23-a/apps/erpnext/erpnext/accounts/doctype/payment_request/payment_request.py", line 413, in get_dummy_message
    """, dict(doc=doc, payment_url = '{{ payment_url }}'))
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/utils/jinja.py", line 75, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/benches/bench-2019-01-23-a/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-2019-01-23-a/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 5, in top-level template code
UnicodeEncodeError: 'ascii' codec can't encode character u'\u20ac' in position 0: ordinal not in range(128)
```
This patch fixes that.