### PR TITLE
feat: warning user if contact or address already exist after saving

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -152,3 +152,133 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 			valid_doctypes.append([doctype])
 
 	return sorted(valid_doctypes)
+
+# ADDRESS #
+@frappe.whitelist()
+def check_address_email_phone_fax_already_exist(email_id="", phone="", fax="", name=""):
+	'''Check when save an address if the email, phone number or fax is already registered in another address'''
+	email_id = email_id.strip()
+	phone = phone.strip()
+	fax = fax.strip()
+	name = name.strip()
+
+	email_id_address = check_address_email_already_exist(email_id, name)
+	phone_address = check_address_phone_number_already_exist(phone, name)
+	fax_address = check_address_fax_already_exist(fax, name)
+
+	# for cross checking on contact
+	email_id_contact = check_contact_email_already_exist(email_id, name)
+	phone_contact = check_contact_phone_number_already_exist(phone, name)
+	mobile_no_contact = check_contact_mobile_number_already_exist(fax, name)
+
+	return_addresses = email_id_address + email_id_contact + phone_address + phone_contact + fax_address + mobile_no_contact
+
+	if return_addresses != "":
+		return_addresses = return_addresses[:-1]
+
+	return return_addresses
+
+def check_address_email_already_exist(email_id="", name=""):
+	m_return = ""
+	if email_id != "":
+		addresses = frappe.db.sql("""select name from `tabAddress` where trim(email_id) = %s
+			and name <> %s""", (email_id, name), as_dict=True)
+		for address in addresses:
+			m_return += "Email ID/Email ID" + ":" + address.name + ";Address" + ","
+
+	return m_return
+
+def check_address_phone_number_already_exist(phone="", name=""):
+	m_return = ""
+	if phone != "":
+		addresses_phone = frappe.db.sql("""select name from `tabAddress` where replace(trim(phone), ' ', '') = %s and name <> %s""",
+		                          (phone.replace(" ", ""), name), as_dict=True)
+		for address_phone in addresses_phone:
+			m_return += "Phone/Phone" + ":" + address_phone.name + ";Address" + ","
+
+		addresses_fax = frappe.db.sql("""select name from `tabAddress` where replace(trim(fax), ' ', '') = %s and name <> %s""",
+		                          (phone.replace(" ", ""), name), as_dict=True)
+		for address_fax in addresses_fax:
+			m_return += "Phone/Fax" + ":" + address_fax.name + ";Address" + ","
+
+	return m_return
+
+def check_address_fax_already_exist(fax="", name=""):
+	m_return = ""
+	if fax != "":
+		addresses_fax = frappe.db.sql("""select name from `tabAddress` where replace(trim(fax), ' ', '') = %s and name <> %s""",
+		                          (fax.replace(" ", ""), name), as_dict=True)
+		for address_fax in addresses_fax:
+			m_return += "Fax/Fax" + ":" + address_fax.name + ";Address" + ","
+
+		addresses_phone = frappe.db.sql("""select name from `tabAddress` where replace(trim(phone), ' ', '') = %s and name <> %s""",
+		                          (fax.replace(" ", ""), name), as_dict=True)
+		for address_phone in addresses_phone:
+			m_return += "Fax/Phone" + ":" + address_phone.name + ";Address" + ","
+
+	return m_return
+
+# CONTACT #
+@frappe.whitelist()
+def check_contact_email_phone_mobile_number_already_exist(email_id="", phone="", mobile_no="", name=""):
+	'''Check when save a contact if the email, phone number or mobile number is already registered in another contact'''
+	email_id = email_id.strip()
+	phone = phone.strip()
+	mobile_no = mobile_no.strip()
+	name = name.strip()
+
+	email_id_contact = check_contact_email_already_exist(email_id, name)
+	phone_contact = check_contact_phone_number_already_exist(phone, name)
+	mobile_no_contact = check_contact_mobile_number_already_exist(mobile_no, name)
+
+	# for cross checking on address
+	email_id_address = check_address_email_already_exist(email_id, name)
+	phone_address = check_address_phone_number_already_exist(phone, name)
+	fax_address = check_address_fax_already_exist(mobile_no, name)
+
+	return_contacts = email_id_contact + email_id_address + phone_contact + phone_address + mobile_no_contact + fax_address
+
+	if return_contacts != "":
+		return_contacts = return_contacts[:-1]
+
+	return return_contacts
+
+def check_contact_email_already_exist(email_id="", name=""):
+	m_return = ""
+	if email_id != "":
+		contacts = frappe.db.sql("""select name from `tabContact` where trim(email_id) = %s and
+			name <> %s""", (email_id, name), as_dict=True)
+		for contact in contacts:
+			m_return += "Email ID/Email ID" + ":" + contact.name + ";Contact" + ","
+
+	return m_return
+
+def check_contact_phone_number_already_exist(phone="", name=""):
+	m_return = ""
+	if phone != "":
+		contacts_phone = frappe.db.sql("""select name from `tabContact` where replace(trim(phone), ' ', '') = %s and name <> %s""",
+		                         (phone.replace(" ", ""), name), as_dict=True)
+		for contact_phone in contacts_phone:
+			m_return += "Phone/Phone" + ":" + contact_phone.name + ";Contact" + ","
+
+		contacts_mobile_no = frappe.db.sql("""select name from `tabContact` where replace(trim(mobile_no), ' ', '') = %s and name <> %s""",
+		                         (phone.replace(" ", ""), name), as_dict=True)
+		for contact_mobile_no in contacts_mobile_no:
+			m_return += "Phone/Mobile Number" + ":" + contact_mobile_no.name + ";Contact" + ","
+
+	return m_return
+
+def check_contact_mobile_number_already_exist(mobile_no="", name=""):
+	m_return = ""
+	if mobile_no != "":
+		contacts_mobile_no = frappe.db.sql("""select name from `tabContact` where replace(trim(mobile_no), ' ', '') = %s and name <> %s""",
+		                         (mobile_no.replace(" ", ""), name), as_dict=True)
+		for contact_mobile_no in contacts_mobile_no:
+			m_return += "Mobile Number/Mobile Number" + ":" + contact_mobile_no.name + ";Contact" + ","
+
+		contacts_phone = frappe.db.sql("""select name from `tabContact` where replace(trim(phone), ' ', '') = %s and name <> %s""",
+		                         (mobile_no.replace(" ", ""), name), as_dict=True)
+		for contact_phone in contacts_phone:
+			m_return += "Mobile Number/Phone" + ":" + contact_phone.name + ";Contact" + ","
+
+	return m_return

--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -54,7 +54,7 @@ frappe.ui.form.on("Address", {
 				fax: frm.doc.fax,
 				name: frm.doc.name
 			},
-			callback: function (r) {
+			callback: function(r) {
 				if (r.message) {
 					
 					var variant = r.message;

--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -44,5 +44,49 @@ frappe.ui.form.on("Address", {
 				}
 			}
 		]);
+		// Check when save an address if the email, phone number or fax is already registered in another address,
+		// and shows a popup to the user with links to the address
+		frappe.call({
+			method: 'frappe.contacts.address_and_contact.check_address_email_phone_fax_already_exist',
+			args: {
+				email_id: frm.doc.email_id,
+				phone: frm.doc.phone,
+				fax: frm.doc.fax,
+				name: frm.doc.name
+			},
+			callback: function (r) {
+				if (r.message) {
+					
+					var variant = r.message;
+					var values = "";						
+					var addresses = variant.split(",");
+					
+					for (var i=0; i < addresses.length; i++) {
+						var address_field = addresses[i].split(";"); // position [1]
+						var address = address_field[0].split(":");
+						
+						var link = repl('<a target="_blank" href="#Form/' + address_field[1] + '/%(name)s"' +
+								'class="strong variant-click">%(label)s</a>', {
+							name: encodeURIComponent(address[1]),
+							label: address[1]
+						});
+						
+						var address_label = address[0].split("/");
+						
+						if (address_label[0] == "Email ID")
+							values += "* Email ID " + frm.doc.email_id + " is already in use on " + address_field[1] +
+									": " + link + " as an " + address_label[1] + "<br>";
+						else if (address_label[0] == "Phone")
+							values += "* Phone " + frm.doc.phone + " is already in use on " + address_field[1] +
+									": "+ link + " as a " + address_label[1] + "<br>";
+						else
+							values += "* Fax " + frm.doc.fax + " is already in use on " + address_field[1] +
+									": " + link + " as a " + address_label[1] + "<br>";
+					}
+											
+					frappe.show_alert(values, 300);
+				}
+			}
+		});
 	}
 });

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -69,7 +69,7 @@ frappe.ui.form.on("Contact", {
 				mobile_no: frm.doc.mobile_no,
 				name: frm.doc.name
 			},
-			callback: function (r) {
+			callback: function(r) {
 				if (r.message) {
 					
 					var variant = r.message;

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -59,6 +59,50 @@ frappe.ui.form.on("Contact", {
 				}
 			}
 		]);
+		// Check when save a contact if the email, phone number or mobile number is already registered in another contact,
+		// and shows a popup to the user with links to the contact
+		frappe.call({
+			method: 'frappe.contacts.address_and_contact.check_contact_email_phone_mobile_number_already_exist',
+			args: {
+				email_id: frm.doc.email_id,
+				phone: frm.doc.phone,
+				mobile_no: frm.doc.mobile_no,
+				name: frm.doc.name
+			},
+			callback: function (r) {
+				if (r.message) {
+					
+					var variant = r.message;
+					var values = "";						
+					var contacts = variant.split(",");
+					
+					for (var i=0; i < contacts.length; i++) {
+						var contact_field = contacts[i].split(";"); // position [1]
+						var contact = contact_field[0].split(":");
+						
+						var link = repl('<a target="_blank" href="#Form/' + contact_field[1] + '/%(name)s"' +
+								'class="strong variant-click">%(label)s</a>', {
+							name: encodeURIComponent(contact[1]),
+							label: contact[1]
+						});
+						
+						var contact_label = contact[0].split("/");
+						
+						if (contact_label[0] == "Email ID")
+							values += "* Email ID " + frm.doc.email_id + " is already in use on " + contact_field[1] +
+									": " + link + " as an " + contact_label[1] + "<br>";
+						else if (contact_label[0] == "Phone")
+							values += "* Phone " + frm.doc.phone + " is already in use on " + contact_field[1] +
+									": " + link + " as a " + contact_label[1] + "<br>";
+						else
+							values += "* Mobile Number " + frm.doc.mobile_no + " is already in use on " + contact_field[1] +
+									": " + link + " as a " + contact_label[1] + "<br>";
+					}
+											
+					frappe.show_alert(values, 300);
+				}
+			}
+		});
 	}
 });
 


### PR DESCRIPTION
In customer when you change a contact detail (phone, emailid, mobile), it should show an alert with the contacts and link to the contact that already have this information. Same for address with fields (emailid, phone, fax). Also cross checking between them.



![addressncontact](https://user-images.githubusercontent.com/14797383/51809195-2b106400-2285-11e9-8ecd-16f7d2b72813.gif)
