### PR TITLE
fix: use Banker's Rounding in JS round_based_on_smallest_currency_fraction

### DIFF
--- a/frappe/public/js/frappe/misc/number_format.js
+++ b/frappe/public/js/frappe/misc/number_format.js
@@ -237,7 +237,7 @@ function round_based_on_smallest_currency_fraction(value, currency, precision) {
 			value -= remainder_val;
 		}
 	} else {
-		value = Math.round(value);
+		value = _round(value);
 	}
 	return value;
 }


### PR DESCRIPTION
**Problem:**
The client side Rounded Total was being rounded using `Math.round()` which was causing an inconsistency between client-side calculation and server-side calculation which led to confusion.

| Client-side Calculation                                                                                      | Server-side Calculation                                                                                      |
|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/328330/51832440-8179b300-2316-11e9-82aa-c329bd3ca54a.png) | ![image](https://user-images.githubusercontent.com/328330/51832539-c9003f00-2316-11e9-800e-cdaf540e8f31.png) |

**Solution:**
Use the `_round()` function rather than `Math.round()`

**Fixed client-side calculation:**
![image](https://user-images.githubusercontent.com/328330/51832849-9f93e300-2317-11e9-8c7f-41025d4c04af.png)
