### PR TITLE
fix: get request data as string for python 3

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -62,7 +62,7 @@ def application(request):
 
 		elif frappe.request.path.startswith("/api/"):
 			if frappe.local.form_dict.data is None:
-					frappe.local.form_dict.data = request.get_data()
+				frappe.local.form_dict.data = request.get_data(as_text=True)
 			response = frappe.api.handle()
 
 		elif frappe.request.path.startswith('/backups'):


### PR DESCRIPTION
refer to #6705
In Python3, request.get_data returns bytes, instead of text, which breaks when passed to json.loads to make form dict.

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.