### PR TITLE
feat: Minor additional enhancements to Treeview

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -234,7 +234,7 @@ frappe.views.TreeView = Class.extend({
 	},
 	new_node: function(node) {
 		var me = this;
-		var node = node || me.tree.get_selected_node();
+		node = node || me.tree.get_selected_node();
 
 		if(!(node && node.expandable)) {
 			frappe.msgprint(__("Select a group node first."));

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -238,9 +238,9 @@ frappe.views.TreeView = Class.extend({
 			return toolbar
 		}
 	},
-	new_node: function(node) {
+	new_node: function() {
 		var me = this;
-		node = node || me.tree.get_selected_node();
+		var node = me.tree.get_selected_node();
 
 		if(!(node && node.expandable)) {
 			frappe.msgprint(__("Select a group node first."));

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -156,6 +156,12 @@ frappe.views.TreeView = Class.extend({
 		});
 
 		cur_tree = this.tree;
+		this.post_render();
+	},
+
+	post_render: function() {
+		var me = this;
+		me.opts.post_render && me.opts.post_render(me);
 	},
 
 	select_node: function(node) {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -100,17 +100,20 @@ frappe.views.TreeView = Class.extend({
 				filter.default = frappe.route_options[filter.fieldname]
 			}
 
-			filter.change = function() {
-				var val = this.get_value();
-				me.args[filter.fieldname] = val;
-				if (val) {
-					me.root_label = val;
-					me.page.set_title(val);
-				} else {
-					me.root_label = me.opts.root_label;
-					me.set_title();
+			if(!filter.disable_onchange) {
+				filter.change = function() {
+					filter.on_change && filter.on_change();
+					var val = this.get_value();
+					me.args[filter.fieldname] = val;
+					if (val) {
+						me.root_label = val;
+						me.page.set_title(val);
+					} else {
+						me.root_label = me.opts.root_label;
+						me.set_title();
+					}
+					me.make_tree();
 				}
-				me.make_tree();
 			}
 
 			me.page.add_field(filter);

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -219,6 +219,9 @@ frappe.views.TreeView = Class.extend({
 		]
 
 		if(this.opts.toolbar && this.opts.extend_toolbar) {
+			toolbar = toolbar.filter(btn => {
+				return !me.opts.toolbar.find(d => d["label"]==btn["label"]);
+			});
 			return toolbar.concat(this.opts.toolbar)
 		} else if (this.opts.toolbar && !this.opts.extend_toolbar) {
 			return this.opts.toolbar

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -229,9 +229,9 @@ frappe.views.TreeView = Class.extend({
 			return toolbar
 		}
 	},
-	new_node: function() {
+	new_node: function(node) {
 		var me = this;
-		var node = me.tree.get_selected_node();
+		var node = node || me.tree.get_selected_node();
 
 		if(!(node && node.expandable)) {
 			frappe.msgprint(__("Select a group node first."));

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import now
+from frappe.utils import now, cint
 
 class NestedSetRecursionError(frappe.ValidationError): pass
 class NestedSetMultipleRootsError(frappe.ValidationError): pass
@@ -256,9 +256,10 @@ def get_root_of(doctype):
 		and t1.rgt > t1.lft""".format(doctype, doctype))
 	return result[0][0] if result else None
 
-def get_ancestors_of(doctype, name):
+def get_ancestors_of(doctype, name, order_by="lft desc", limit=None):
 	"""Get ancestor elements of a DocType with a tree structure"""
 	lft, rgt = frappe.db.get_value(doctype, name, ["lft", "rgt"])
+	limit = "limit %s" % cint(limit) if limit else ""
 	result = frappe.db.sql_list("""select name from `tab{0}`
-		where lft<%s and rgt>%s order by lft desc""".format(doctype), (lft, rgt))
+		where lft<%s and rgt>%s order by {1} {2}""".format(doctype, order_by, limit), (lft, rgt))
 	return result or []

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -263,3 +263,11 @@ def get_ancestors_of(doctype, name, order_by="lft desc", limit=None):
 	result = frappe.db.sql_list("""select name from `tab{0}`
 		where lft<%s and rgt>%s order by {1} {2}""".format(doctype, order_by, limit), (lft, rgt))
 	return result or []
+
+def get_descendants_of(doctype, name, order_by="lft desc", limit=None):
+	'''Return descendants of the current record'''
+	lft, rgt = frappe.db.get_value(doctype, name, ['lft', 'rgt'])
+	limit = "limit %s" % cint(limit) if limit else ""
+	result = frappe.db.sql_list("""select name from `tab{0}`
+		where lft>%s and rgt<%s order by {1} {2}""".format(doctype, order_by, limit), (lft, rgt))
+	return result or []


### PR DESCRIPTION
### Ability to override buttons of treeview
<details>
<summary>Example</summary>
<p>

```javascript
x = [
	{
		label: "XYZ",
		condition: "something"
	},
	{
		label: "ABC",
		condition: "something else"
	},
	{
		label: "QWE",
		condition: "something more else"
	}
]

y = [
	{
		label: "ZXC",
		condition: "different"
	},
	{
		label: "ABC",
		condition: "different else"
	}
]

x = x.filter(item => {
	return !y.find(d => d["label"]==item["label"]);
});

out = x.concat(y)

out = [
	{
		label: "XYZ",
		condition: "something"
	},
	{
		label: "QWE",
		condition: "something more else"
	},
	{
		label: "ZXC",
		condition: "different"
	},
	{
		label: "ABC",
		condition: "different else"
	}
]
```

</p>
</details>

### Ability to disable on_change for a treeview filter

Need came in because by default every filter that we have in treeview gets a default change trigger which - if the filter field is set will make this value as the root label (not necessarily needed).

<details>
<summary>Example</summary>

```javascript
filter = [
	{
		fieldname: "company",
		fieldtype:"Select",
		options: erpnext.utils.get_tree_options("company"),
		label: __("Company"),
		default: erpnext.utils.get_tree_default("company"),
		on_change: function() {
			// frappe call to fetch parent_company and set it to parent_company filter
		}
	},
	{
		fieldname: "parent_company",
		fieldtype:"Data",
		fetch_from: "company.parent_company",
		label: __("Parent Company"),
		hidden: true,
		disable_onchange: true // disable triggering of default filter.change of treeview
	}
]
```

</details>

<details>
<summary> NestedSet get_ancestors_of tweak </summary>

<p>

![image](https://user-images.githubusercontent.com/11695402/51960017-1bf40680-247d-11e9-99b9-4659faa550a2.png)

</p>


</details>