### PR TITLE
fix: there are 28 fields in Event, not 30

### DIFF
--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -46,7 +46,7 @@ class TestCustomizeForm(unittest.TestCase):
 
 		d = self.get_customize_form("Event")
 		self.assertEquals(d.doc_type, "Event")
-		self.assertEquals(len(d.get("fields")), 30)
+		self.assertEquals(len(d.get("fields")), 28)
 
 		d = self.get_customize_form("Event")
 		self.assertEquals(d.doc_type, "Event")


### PR DESCRIPTION
Refer: https://travis-ci.org/frappe/frappe/jobs/485935273#L1579

Error was done after deliberation while fixing merge conflicts.