### PR TITLE
fix: keep deprecated help commands

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -686,5 +686,7 @@ commands = [
 	watch,
 	_bulk_rename,
 	add_to_email_queue,
+	setup_global_help,
+	setup_help,
 	rebuild_global_search
 ]


### PR DESCRIPTION
before:
https://travis-ci.org/frappe/frappe/jobs/485911309#L1523

after:
![screenshot from 2019-01-29 21-29-07](https://user-images.githubusercontent.com/16315650/51921253-047d3500-240d-11e9-8d34-05e31a54c098.png)
