### PR TITLE
fix(core): Fix base document 

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -754,7 +754,7 @@ class BaseDocument(object):
 				ref_doc = frappe.new_doc(self.doctype)
 			else:
 				# get values from old doc
-				if self.parent:
+				if self.get('parent_doc'):
 					self.parent_doc.get_latest()
 					ref_doc = [d for d in self.parent_doc.get(self.parentfield) if d.name == self.name][0]
 				else:


### PR DESCRIPTION
Fixes "object has no attribute 'parent_doc'" error while saving a doc.

**Example**
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/model/document.py", line 294, in _save
    self.validate_higher_perm_levels()
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/model/document.py", line 554, in validate_higher_perm_levels
    self.reset_values_if_no_permlevel_access(has_access_to, high_permlevel_fields)
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/model/base_document.py", line 758, in reset_values_if_no_permlevel_access
    self.parent_doc.get_latest()
AttributeError: 'Task' object has no attribute 'parent_doc'
```