### PR TITLE
fix: keep deprecated help commands

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -515,5 +515,7 @@ commands = [
 	watch,
 	_bulk_rename,
 	add_to_email_queue,
+	setup_global_help,
+	setup_help,
 	rebuild_global_search
 ]


### PR DESCRIPTION
Before:

<img width="412" alt="screen shot 2019-01-30 at 3 03 15 pm" src="https://user-images.githubusercontent.com/3784093/51971883-42776900-24a0-11e9-96f9-d3f690fc5c26.png">


After:
<img width="515" alt="screen shot 2019-01-30 at 3 02 48 pm" src="https://user-images.githubusercontent.com/3784093/51971891-473c1d00-24a0-11e9-85e0-612b0caca19e.png">
