### PR TITLE
Revert "fix: Print Format Builder not working unexpected string "

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder_section.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_section.html
@@ -1,4 +1,4 @@
-<div class="print-format-builder-section row light-bg" data-label="{{ section.label or '' }}">
+<div class="print-format-builder-section row light-bg" data-label="{{ section.label || '' }}">
     <div class="print-format-builder-section-head">
         <a class="section-settings pull-right
             btn-default btn-xs" style="padding-top: 3px">


### PR DESCRIPTION
Reverts frappe/frappe#6861

The earlier fix was correct. `print_format_builder_section.html` is a JS template so `||` works not `or`.