### PR TITLE
fix(website): Enable socketio on website (for file upload)

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -32,6 +32,7 @@
 			frappe.ready_events.push(fn);
 		}
 		window.dev_server = {{ dev_server }};
+		window.socketio_port = {{ frappe.socketio_port }};
     </script>
 </head>
 {% block body %}

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -134,6 +134,7 @@ def get_allowed_functions_for_jenv():
 				'user': user,
 				'csrf_token': frappe.local.session.data.csrf_token if getattr(frappe.local, "session", None) else ''
 			},
+			"socketio_port": frappe.conf.socketio_port,
 		},
 		'style': {
 			'border_color': '#d1d8dd'

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -427,5 +427,6 @@ frappe.ready(function() {
 				});
 			}
 		}
-	})
+	});
+	frappe.socketio.init(window.socketio_port);
 });


### PR DESCRIPTION
Trying to upload files through web forms gets stuck 

![screenshot 2019-01-30 at 8 19 24 pm](https://user-images.githubusercontent.com/8528887/51989470-23430080-24cd-11e9-9f25-d7c65e660d43.png)

and logs this in browser console
```javascript
upload.js:336 Uncaught TypeError: Cannot read property 'start' of undefined
    at upload_through_socketio (upload.js:336)
    at Object.callback (upload.js:330)
    at Object.200 (website.js:79)
    at i (jquery.min.js:2)
    at Object.add [as done] (jquery.min.js:2)
    at Object.always (jquery.min.js:2)
    at Object.statusCode (jquery.min.js:4)
    at z (jquery.min.js:4)
    at XMLHttpRequest.<anonymous> (jquery.min.js:4)
upload_through_socketio @ upload.js:336
callback @ upload.js:330
200 @ website.js:79
i @ jquery.min.js:2
add @ jquery.min.js:2
always @ jquery.min.js:2
statusCode @ jquery.min.js:4
z @ jquery.min.js:4
(anonymous) @ jquery.min.js:4
load (async)
send @ jquery.min.js:4
ajax @ jquery.min.js:4
call @ website.js:64
read_file @ upload.js:325
upload_file @ upload.js:258
upload_next @ upload.js:235
upload_multiple_files @ upload.js:221
(anonymous) @ upload.js:182
dispatch @ jquery.min.js:3
r.handle @ jquery.min.js:3
```

This fixes that