### PR TITLE
fix(test): Use single quotes for empty string (constant)

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -78,7 +78,6 @@ def get_bootinfo():
 	bootinfo.gsuite_enabled = get_gsuite_status()
 	bootinfo.success_action = get_success_action()
 	bootinfo.update(get_email_accounts(user=frappe.session.user))
-	bootinfo.in_test = frappe.flags.in_test
 
 	return bootinfo
 

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -78,6 +78,7 @@ def get_bootinfo():
 	bootinfo.gsuite_enabled = get_gsuite_status()
 	bootinfo.success_action = get_success_action()
 	bootinfo.update(get_email_accounts(user=frappe.session.user))
+	bootinfo.in_test = frappe.flags.in_test
 
 	return bootinfo
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -458,7 +458,7 @@ class DatabaseQuery(object):
 					f.operator = '='
 
 				value = ""
-				fallback = '""'
+				fallback = "''"
 				can_be_null = True
 
 				if 'ifnull' not in column_name:

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -72,7 +72,7 @@ frappe.Application = Class.extend({
 			frappe.msgprint(frappe.boot.messages);
 		}
 
-		if (frappe.boot.change_log && frappe.boot.change_log.length) {
+		if (frappe.boot.change_log && frappe.boot.change_log.length && !window.Cypress) {
 			this.show_change_log();
 		} else {
 			this.show_notes();

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -72,7 +72,7 @@ frappe.Application = Class.extend({
 			frappe.msgprint(frappe.boot.messages);
 		}
 
-		if (frappe.boot.change_log && frappe.boot.change_log.length && !frappe.boot.in_test) {
+		if (frappe.boot.change_log && frappe.boot.change_log.length) {
 			this.show_change_log();
 		} else {
 			this.show_notes();

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -72,7 +72,7 @@ frappe.Application = Class.extend({
 			frappe.msgprint(frappe.boot.messages);
 		}
 
-		if (frappe.boot.change_log && frappe.boot.change_log.length) {
+		if (frappe.boot.change_log && frappe.boot.change_log.length && !frappe.boot.in_test) {
 			this.show_change_log();
 		} else {
 			this.show_notes();


### PR DESCRIPTION
- Use single quotes for empty string (constant)
since value inside double quotes is considered as Identifier in Postgres

- Avoid change_log modal during test. 
To check if the code is running under test environment, we can check if the window object has Cypress loaded on it.