### PR TITLE
fix(data_import): use relative url

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -16,7 +16,7 @@ from frappe.utils.csvutils import getlink
 from frappe.utils.dateutils import parse_date
 from frappe.utils.file_manager import save_url
 
-from frappe.utils import cint, cstr, flt, getdate, get_datetime, get_url, get_url_to_form
+from frappe.utils import cint, cstr, flt, getdate, get_datetime, get_url, get_absolute_url
 from six import text_type, string_types
 
 
@@ -411,16 +411,16 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 				# log errors
 				if parentfield:
 					log(**{"row": doc.idx, "title": 'Inserted row for "%s"' % (as_link(parenttype, doc.parent)),
-						"link": get_url_to_form(parenttype, doc.parent), "message": 'Document successfully saved', "indicator": "green"})
+						"link": get_absolute_url(parenttype, doc.parent), "message": 'Document successfully saved', "indicator": "green"})
 				elif submit_after_import:
 					log(**{"row": row_idx + 1, "title":'Submitted row for "%s"' % (as_link(doc.doctype, doc.name)),
-						"message": "Document successfully submitted", "link": get_url_to_form(doc.doctype, doc.name), "indicator": "blue"})
+						"message": "Document successfully submitted", "link": get_absolute_url(doc.doctype, doc.name), "indicator": "blue"})
 				elif original:
 					log(**{"row": row_idx + 1,"title":'Updated row for "%s"' % (as_link(doc.doctype, doc.name)),
-						"message": "Document successfully updated", "link": get_url_to_form(doc.doctype, doc.name), "indicator": "green"})
+						"message": "Document successfully updated", "link": get_absolute_url(doc.doctype, doc.name), "indicator": "green"})
 				elif not update_only:
 					log(**{"row": row_idx + 1, "title":'Inserted row for "%s"' % (as_link(doc.doctype, doc.name)),
-						"message": "Document successfully saved", "link": get_url_to_form(doc.doctype, doc.name), "indicator": "green"})
+						"message": "Document successfully saved", "link": get_absolute_url(doc.doctype, doc.name), "indicator": "green"})
 				else:
 					log(**{"row": row_idx + 1, "title":'Ignored row for %s' % (row[1]), "link": None,
 						"message": "Document updation ignored", "indicator": "orange"})
@@ -437,7 +437,7 @@ def upload(rows = None, submit_after_import=None, ignore_encoding_errors=False, 
 				error_trace = frappe.get_traceback()
 				if error_trace:
 					error_log_doc = frappe.log_error(error_trace)
-					error_link = get_url_to_form("Error Log", error_log_doc.name)
+					error_link = get_absolute_url("Error Log", error_log_doc.name)
 				else:
 					error_link = None
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -745,6 +745,9 @@ def get_link_to_form(doctype, name, label=None):
 
 	return """<a href="{0}">{1}</a>""".format(get_url_to_form(doctype, name), label)
 
+def get_absolute_url(doctype, name):
+	return "desk#Form/{0}/{1}".format(quoted(doctype), quoted(name))
+
 def get_url_to_form(doctype, name):
 	return get_url(uri = "desk#Form/{0}/{1}".format(quoted(doctype), quoted(name)))
 


### PR DESCRIPTION
there is no need to prepend the sitename to the url, since browsers/html are/is smart enough to handle relative urls.

this fixes issues wherein a single account is hosted on any hosting platform in production, and setup with a site name different that the actual url of the system.
