### PR TITLE
fix(reportview): cast docname to string

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -214,7 +214,7 @@ def delete_items():
 	"""delete selected items"""
 	import json
 
-	il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True, key=frappe.safe_decode)
+	il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True)
 	doctype = frappe.form_dict.get('doctype')
 
 	failed = []

--- a/frappe/public/js/frappe/views/reports/reportview.js
+++ b/frappe/public/js/frappe/views/reports/reportview.js
@@ -801,7 +801,7 @@ frappe.views.ReportView = frappe.ui.BaseList.extend({
 			});
 
 			this.page.add_menu_item(__("Delete"), function() {
-				var delete_list = $.map(me.get_checked_items(), function(d) { return d.name; });
+				var delete_list = $.map(me.get_checked_items(), function(d) { return d.name.toString(); });
 				if(!delete_list.length)
 					return;
 				if(frappe.confirm(__("This is PERMANENT action and you cannot undo. Continue?"),

--- a/frappe/public/js/frappe/views/reports/reportview.js
+++ b/frappe/public/js/frappe/views/reports/reportview.js
@@ -801,7 +801,9 @@ frappe.views.ReportView = frappe.ui.BaseList.extend({
 			});
 
 			this.page.add_menu_item(__("Delete"), function() {
-				var delete_list = $.map(me.get_checked_items(), function(d) { return d.name.toString(); });
+				var delete_list = $.map(me.get_checked_items(), function(d) {
+					return d.name.toString();
+				});
 				if(!delete_list.length)
 					return;
 				if(frappe.confirm(__("This is PERMANENT action and you cannot undo. Continue?"),


### PR DESCRIPTION
explicitly cast docnames to string to fix sorting in reportview.py:217

sometimes docnames get generated containing only integer values, and thus comparison between int and string causes the following error:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1019, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/reportview.py", line 217, in delete_items
    il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True, key=frappe.safe_decode)
TypeError: '<' not supported between instances of 'int' and 'str'
```

casting docnames to string before passing it to the python method solves this issue