### PR TITLE
fix(Query Report): Do not preformat before frappe.format

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -639,7 +639,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			}
 
 			const format_cell = (value, row, column, data) => {
-				return frappe.format(value == null ? '' : value, column,
+				return frappe.format(value, column,
 					{for_print: false, always_show_decimals: true}, data);
 			};
 


### PR DESCRIPTION
For null values empty strings were being passed to frappe.format which led to fields with fieldtype Int that has value of `null` show as 0 in reports.

![undefined as 0](https://user-images.githubusercontent.com/328330/52181937-7db7c600-2819-11e9-8550-0efdf4338694.gif)

This PR fixes the issue.

![image](https://user-images.githubusercontent.com/328330/52181962-be174400-2819-11e9-830f-4c5572906037.png)
