### PR TITLE
fix: Don't send attachment/download header with PDF files

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -90,13 +90,13 @@ def download_pdf(doctype, name, format=None, doc=None, no_letterhead=0):
 	html = frappe.get_print(doctype, name, format, doc=doc, no_letterhead=no_letterhead)
 	frappe.local.response.filename = "{name}.pdf".format(name=name.replace(" ", "-").replace("/", "-"))
 	frappe.local.response.filecontent = get_pdf(html)
-	frappe.local.response.type = "download"
+	frappe.local.response.type = "pdf"
 
 @frappe.whitelist()
 def report_to_pdf(html, orientation="Landscape"):
 	frappe.local.response.filename = "report.pdf"
 	frappe.local.response.filecontent = get_pdf(html, {"orientation": orientation})
-	frappe.local.response.type = "download"
+	frappe.local.response.type = "pdf"
 
 @frappe.whitelist()
 def print_by_server(doctype, name, print_format=None, doc=None, no_letterhead=0):

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -42,6 +42,7 @@ def build_response(response_type=None):
 		'txt': as_txt,
 		'download': as_raw,
 		'json': as_json,
+		'pdf': as_pdf,
 		'page': as_page,
 		'redirect': redirect,
 		'binary': as_binary
@@ -82,6 +83,13 @@ def as_json():
 	response.mimetype = 'application/json'
 	response.charset = 'utf-8'
 	response.data = json.dumps(frappe.local.response, default=json_handler, separators=(',',':'))
+	return response
+
+def as_pdf():
+	response = Response()
+	response.mimetype = "application/pdf"
+	response.headers["Content-Disposition"] = ("filename=\"%s\"" % frappe.response['filename'].replace(' ', '_')).encode("utf-8")
+	response.data = frappe.response['filecontent']
 	return response
 
 def as_binary():


### PR DESCRIPTION
Due to recent changes to send "attachment" Content-Disposition header with "download" response type PDF files cannot be previewed in browsers.

This PR makes it possible to open the PDF in the browser's PDF viewer rather than forcing the user to download it first.