### PR TITLE
fix: Set field default based on user permissions

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -42,6 +42,9 @@ def get_user_permissions(user=None):
 	if not user:
 		user = frappe.session.user
 
+	if user == "Administrator":
+		return {}
+
 	cached_user_permissions = frappe.cache().hget("user_permissions", user)
 
 	if cached_user_permissions is not None:

--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -12,6 +12,7 @@ import frappe.defaults
 from frappe.model.db_schema import type_map
 import copy
 from frappe.core.doctype.user_permission.user_permission import get_user_permissions
+from frappe.permissions import get_allowed_docs_for_doctype
 
 def get_new_doc(doctype, parent_doc = None, parentfield = None, as_dict=False):
 	if doctype not in frappe.local.new_doc_templates:
@@ -53,36 +54,39 @@ def set_user_and_static_default_values(doc):
 
 	for df in doc.meta.get("fields"):
 		if df.fieldtype in type_map:
-			user_default_value = get_user_default_value(df, defaults, user_permissions)
+			# user permissions for link options
+			doctype_user_permissions = user_permissions.get(df.options, [])
+			# Allowed records for the reference doctype (link field)
+			allowed_records = get_allowed_docs_for_doctype(doctype_user_permissions, df.parent)
+
+			user_default_value = get_user_default_value(df, defaults, doctype_user_permissions, allowed_records)
 			if user_default_value is not None:
 				doc.set(df.fieldname, user_default_value)
 
 			else:
 				if df.fieldname != doc.meta.title_field:
-					static_default_value = get_static_default_value(df, user_permissions)
+					static_default_value = get_static_default_value(df, doctype_user_permissions, allowed_records)
 					if static_default_value is not None:
 						doc.set(df.fieldname, static_default_value)
 
-def get_user_default_value(df, defaults, user_permissions):
+def get_user_default_value(df, defaults, doctype_user_permissions, allowed_records):
 	# don't set defaults for "User" link field using User Permissions!
 	if df.fieldtype == "Link" and df.options != "User":
 		# 1 - look in user permissions only for document_type==Setup
 		# We don't want to include permissions of transactions to be used for defaults.
-		if (frappe.get_meta(df.options).document_type=="Setup"
-			and user_permissions_exist(df, user_permissions)
-			and len(user_permissions.get(df.options))==1):
-			return user_permissions.get(df.options)[0].get("doc")
+		if frappe.get_meta(df.options).document_type=="Setup" and len(allowed_records)==1:
+			return allowed_records[0]
 
 		# 2 - Look in user defaults
 		user_default = defaults.get(df.fieldname)
-		is_allowed_user_default = user_default and (not user_permissions_exist(df, user_permissions)
-			or (user_default in user_permissions.get(df.options, [])))
+		is_allowed_user_default = user_default and (not user_permissions_exist(df, doctype_user_permissions)
+			or user_default in allowed_records)
 
 		# is this user default also allowed as per user permissions?
 		if is_allowed_user_default:
 			return user_default
 
-def get_static_default_value(df, user_permissions):
+def get_static_default_value(df, doctype_user_permissions, allowed_records):
 	# 3 - look in default of docfield
 	if df.get("default"):
 		if df.default == "__user":
@@ -93,8 +97,8 @@ def get_static_default_value(df, user_permissions):
 
 		elif not df.default.startswith(":"):
 			# a simple default value
-			is_allowed_default_value = (not user_permissions_exist(df, user_permissions)
-				or (df.default in user_permissions.get(df.options, [])))
+			is_allowed_default_value = (not user_permissions_exist(df, doctype_user_permissions)
+				or (df.default in allowed_records))
 
 			if df.fieldtype!="Link" or df.options=="User" or is_allowed_default_value:
 				return df.default
@@ -126,10 +130,10 @@ def set_dynamic_default_values(doc, parent_doc, parentfield):
 	if parentfield:
 		doc["parentfield"] = parentfield
 
-def user_permissions_exist(df, user_permissions):
+def user_permissions_exist(df, doctype_user_permissions):
 	return (df.fieldtype=="Link"
 		and not getattr(df, "ignore_user_permissions", False)
-		and df.options in (user_permissions or []))
+		and doctype_user_permissions)
 
 def get_default_based_on_another_field(df, user_permissions, parent_doc):
 	# default value based on another document
@@ -139,7 +143,7 @@ def get_default_based_on_another_field(df, user_permissions, parent_doc):
 	ref_fieldname = ref_doctype.lower().replace(" ", "_")
 	reference_name = parent_doc.get(ref_fieldname) if parent_doc else frappe.db.get_default(ref_fieldname)
 	default_value = frappe.db.get_value(ref_doctype, reference_name, df.fieldname)
-	is_allowed_default_value = (not user_permissions_exist(df, user_permissions) or
+	is_allowed_default_value = (not user_permissions_exist(df, user_permissions.get(df.options)) or
 		(default_value in get_allowed_docs_for_doctype(user_permissions[df.options], df.parent)))
 
 	# is this allowed as per user permissions

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -166,10 +166,10 @@ class Document(BaseDocument):
 			self.latest = frappe.get_doc(self.doctype, self.name)
 		return self.latest
 
-	def check_permission(self, permtype='read', permlabel=None):
+	def check_permission(self, permtype='read', permlevel=None):
 		"""Raise `frappe.PermissionError` if not permitted"""
 		if not self.has_permission(permtype):
-			self.raise_no_permission_to(permlabel or permtype)
+			self.raise_no_permission_to(permlevel or permtype)
 
 	def has_permission(self, permtype="read", verbose=False):
 		"""Call `frappe.has_permission` if `self.flags.ignore_permissions`

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -87,10 +87,8 @@ $.extend(frappe.model, {
 		var doctype = doc.doctype;
 		var docfields = frappe.meta.docfield_list[doctype] || [];
 		var updated = [];
-
 		for(var fid=0;fid<docfields.length;fid++) {
 			var f = docfields[fid];
-
 			if(!in_list(frappe.model.no_value_type, f.fieldtype) && doc[f.fieldname]==null) {
 				var v = frappe.model.get_default_value(f, doc, parent_doc);
 				if(v) {
@@ -126,25 +124,23 @@ $.extend(frappe.model, {
 	get_default_value: function(df, doc, parent_doc) {
 		var user_default = "";
 		var user_permissions = frappe.defaults.get_user_permissions();
+		let allowed_records = [];
+		if(user_permissions) {
+			allowed_records = frappe.perm.get_allowed_docs_for_doctype(user_permissions[df.options], doc.doctype);
+		}
 		var meta = frappe.get_meta(doc.doctype);
 		var has_user_permissions = (df.fieldtype==="Link"
-			&& user_permissions
+			&& !$.isEmptyObject(user_permissions)
 			&& df.ignore_user_permissions != 1
-			&& user_permissions[df.options]);
-
-		function is_doc_allowed(doctype, docname) {
-			return user_permissions[doctype].some(perm => {
-				return perm.doc === docname && (perm.applicable_for === doc.doctype || !perm.applicable_for);
-			});
-		}
+			&& allowed_records.length);
 
 		// don't set defaults for "User" link field using User Permissions!
 		if (df.fieldtype==="Link" && df.options!=="User") {
 			// 1 - look in user permissions for document_type=="Setup".
 			// We don't want to include permissions of transactions to be used for defaults.
 			if (df.linked_document_type==="Setup"
-				&& has_user_permissions && user_permissions[df.options].length===1) {
-				return user_permissions[df.options][0].doc;
+				&& has_user_permissions && allowed_records.length===1) {
+				return allowed_records[0];
 			}
 
 			if(!df.ignore_user_permissions) {
@@ -165,7 +161,7 @@ $.extend(frappe.model, {
 			}
 
 			var is_allowed_user_default = user_default &&
-				(!has_user_permissions || is_doc_allowed(df.options, user_default));
+				(!has_user_permissions || allowed_records.includes(user_default));
 
 			// is this user default also allowed as per user permissions?
 			if (is_allowed_user_default) {
@@ -190,7 +186,7 @@ $.extend(frappe.model, {
 
 			} else if (df["default"][0]===":") {
 				var boot_doc = frappe.model.get_default_from_boot_docs(df, doc, parent_doc);
-				var is_allowed_boot_doc = !has_user_permissions || is_doc_allowed(df.options, boot_doc);
+				var is_allowed_boot_doc = !has_user_permissions || allowed_records.includes(boot_doc);
 
 				if (is_allowed_boot_doc) {
 					return boot_doc;
@@ -201,7 +197,7 @@ $.extend(frappe.model, {
 			}
 
 			// is this default value is also allowed as per user permissions?
-			var is_allowed_default = !has_user_permissions || is_doc_allowed(df.options, df.default);
+			var is_allowed_default = !has_user_permissions || allowed_records.includes(df.default);
 			if (df.fieldtype!=="Link" || df.options==="User" || is_allowed_default) {
 				return df["default"];
 			}
@@ -342,5 +338,3 @@ frappe.new_doc = function (doctype, opts, init_callback) {
 
 	});
 }
-
-

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -82,11 +82,21 @@ class TestPermissions(unittest.TestCase):
 		self.assertFalse("-test-blog-post" in names)
 
 	def test_default_values(self):
+		doc = frappe.new_doc("Blog Post")
+		self.assertFalse(doc.get("blog_category"))
+
+		# Fetch default based on single user permission
 		add_user_permission("Blog Category", "_Test Blog Category 1", "test2@example.com")
 
 		frappe.set_user("test2@example.com")
 		doc = frappe.new_doc("Blog Post")
 		self.assertEqual(doc.get("blog_category"), "_Test Blog Category 1")
+
+		# Don't fetch default if user permissions is more than 1
+		add_user_permission("Blog Category", "_Test Blog Category 2", "test2@example.com")
+
+		doc = frappe.new_doc("Blog Post")
+		self.assertFalse(doc.get("blog_category"))
 
 	def test_user_link_match_doc(self):
 		blogger = frappe.get_doc("Blogger", "_Test Blogger 1")

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -372,7 +372,7 @@ class TestPermissions(unittest.TestCase):
 		posts = frappe.get_all('Blog Post', fields=['name', 'blogger'])
 
 		# Get all posts for admin
-		self.assertEqual(len(posts), 5)
+		self.assertEqual(len(posts), 4)
 
 		frappe.set_user('test2@example.com')
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -93,8 +93,8 @@ class TestPermissions(unittest.TestCase):
 		self.assertEqual(doc.get("blog_category"), "_Test Blog Category 1")
 
 		# Don't fetch default if user permissions is more than 1
-		add_user_permission("Blog Category", "_Test Blog Category 2", "test2@example.com")
-
+		add_user_permission("Blog Category", "_Test Blog Category", "test2@example.com", ignore_permissions=True)
+		frappe.clear_cache()
 		doc = frappe.new_doc("Blog Post")
 		self.assertFalse(doc.get("blog_category"))
 
@@ -372,7 +372,7 @@ class TestPermissions(unittest.TestCase):
 		posts = frappe.get_all('Blog Post', fields=['name', 'blogger'])
 
 		# Get all posts for admin
-		self.assertEqual(len(posts), 4)
+		self.assertEqual(len(posts), 5)
 
 		frappe.set_user('test2@example.com')
 


### PR DESCRIPTION
**Case 1:**
If User permissions created against Administrator, ignore it.

**Case 2:**
If single user permission created for a linked doctype, set it as default

**Case 3:**
Validate against user permission before setting default value based on global default or field's default property

**Case 4:**
Validate against user permission before setting default value in case of dynamic default (eg. cost center is fetched from default cost center defined in company, in this case, we define ":Company" in docfield default property)