### PR TITLE
fix(chat_profile): rename chat profile when email is renamed

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -358,6 +358,9 @@ class User(Document):
 					where `%s`=%s""" % \
 					(tab[0], field, '%s', field, '%s'), (new_name, old_name))
 
+		if frappe.db.exists("Chat Profile", old_name):
+			frappe.rename_doc("Chat Profile", old_name, new_name, force=True)
+
 		# set email
 		frappe.db.sql("""\
 			update `tabUser` set email=%s


### PR DESCRIPTION
chat profile should be renamed when user renames their email id, else it throws the following error: 

`Chat Profile email@example.com not found`