### PR TITLE
fix: remove distinct from count

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -597,7 +597,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			args: {
 				doctype: this.doctype,
 				filters: this.get_filters_for_args(),
-				fields: [`count(distinct ${frappe.model.get_full_column_name('name', this.doctype)}) as total_count`],
+				fields: [`count(${frappe.model.get_full_column_name('name', this.doctype)}) as total_count`],
 			}
 		}).then(r => {
 			this.total_count = r.message.values[0][0] || current_count;


### PR DESCRIPTION
We shouldn't do a distinct count on primary key, as it is not required, and is also slow. See below query times.
```
MariaDB [c6b2c772b91fd3d8]> select count(distinct name) from `tabStock Ledger Entry`;
+----------------------+
| count(distinct name) |
+----------------------+
|              3268372 |
+----------------------+
1 row in set (14.65 sec)

MariaDB [c6b2c772b91fd3d8]> select count(name) from `tabStock Ledger Entry`;
+-------------+
| count(name) |
+-------------+
|     3268372 |
+-------------+
1 row in set (0.24 sec)
```