### PR TITLE
fix: (Critical) Close read_only db connection

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -501,6 +501,7 @@ def read_only():
 			retval = fn(*args, **get_newargs(fn, kwargs))
 
 			if local and hasattr(local, 'master_db'):
+				local.db.close()
 				local.db = local.master_db
 
 			return retval


### PR DESCRIPTION
Close read only db connection, else one might end up with 'Too many connections' error from mysql.

