### PR TITLE
fix: Broken components on web from

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -370,7 +370,8 @@
 		"public/less/list.less",
 		"website/css/web_form.css",
 		"public/less/quill.less",
-		"public/less/datepicker.less"
+		"public/less/datepicker.less",
+		"public/less/awesomplete.less"
 	],
 	"js/print_format_v3.min.js": [
 		"public/js/legacy/layout.js",

--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -369,7 +369,8 @@
 	"css/web_form.css": [
 		"public/less/list.less",
 		"website/css/web_form.css",
-		"public/less/quill.less"
+		"public/less/quill.less",
+		"public/less/datepicker.less"
 	],
 	"js/print_format_v3.min.js": [
 		"public/js/legacy/layout.js",

--- a/frappe/public/less/awesomplete.less
+++ b/frappe/public/less/awesomplete.less
@@ -1,3 +1,4 @@
+@import "variables.less";
 .awesomplete {
 
 	display: inline-block;

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -27,7 +27,7 @@
 	</div>
 	{% endif %}
 	{% if is_list %}
-	<div style="padding-bottom: 15px;">
+	<div class="text-right" style="padding-bottom: 15px;">
 	    <a href="/{{ pathname }}{{ delimeter }}new=1{{ params_from_form_dict}}" class="btn btn-primary btn-new btn-sm">
 	    {{ _("New") }}
 		</a>


### PR DESCRIPTION
This PR adds `datepicker.less` and `awesomplete.less` to `web_form.css`
Also imported variables to `awesomplete.less` 

Broken awesomeplete field
![Broken Awesomeplete](https://user-images.githubusercontent.com/18097732/52393228-35273380-2acb-11e9-82ab-028574c68066.png)

Fixed
![Fixed Awesomeplete](https://user-images.githubusercontent.com/18097732/52393226-335d7000-2acb-11e9-847a-7cf2045d31d1.png)

Fixed Datepicker
![Fixed Datepicker](https://user-images.githubusercontent.com/18097732/52393283-6c95e000-2acb-11e9-832b-1b1ff0b0f7fa.png)

