### PR TITLE
fix: Added check for dict type in frappe/config/init

### DIFF
--- a/frappe/config/__init__.py
+++ b/frappe/config/__init__.py
@@ -27,6 +27,8 @@ def get_modules_from_app(app):
 	except ImportError:
 		return []
 
+	if isinstance(modules, dict):
+		modules = [modules]
 	# Only newly formatted modules that have a category to be shown on desk
 	modules = [m for m in modules if m.get("category")]
 


### PR DESCRIPTION
The function `get_modules_from_app` breaks for a few frappe apps like erpnext_com
Due to this, a session cannot be created making the app inaccessible, this PR contains a small fix for it.

Explanation
The function `get_modules_from_app` takes the app name as an argument, we use `frappe.get_attr(app + '.config.desktop.get_data')() or {}` to get the list of the modules and then we iterate over the modules which is essentially a list of dictionaries.

Now in case an app has only a single module, we get a single dictionary instead of a list of it. Which then breaks for the loop `modules = [m for m in modules if m.get("category")]`

In this PR I added a small check which wraps a dictionary in a list
```python
if isinstance(modules, dict):
		modules = [modules]
```

Even after the fix the modules (like Conference, Partner) from those apps are not visible on the new home, that makes it virtually impossible to navigate it, so other apps have to rewrite their modules conform to the structure required now