### PR TITLE
fix: Set default print language in Notification

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -212,8 +212,15 @@ def get_context(context):
 				please enable Allow Print For {0} in Print Settings""".format(status)),
 				title=_("Error in Notification"))
 		else:
-			return [{"print_format_attachment":1, "doctype":doc.doctype, "name": doc.name,
-				"print_format":self.print_format, "print_letterhead": print_settings.with_letterhead}]
+			return [{
+				"print_format_attachment": 1,
+				"doctype": doc.doctype,
+				"name": doc.name,
+				"print_format": self.print_format,
+				"print_letterhead": print_settings.with_letterhead,
+				"lang": frappe.db.get_value('Print Format', self.print_format, 'default_print_language')
+					if self.print_format else 'en'
+			}]
 
 
 	def get_template(self):

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -175,7 +175,8 @@ def get_email_queue(recipients, sender, subject, **kwargs):
 			if att.get('fid'):
 				_attachments.append(att)
 			elif att.get("print_format_attachment") == 1:
-				att['lang'] = frappe.local.lang
+				if not att.get('lang', None):
+					att['lang'] = frappe.local.lang
 				att['print_letterhead'] = kwargs.get('print_letterhead')
 				_attachments.append(att)
 		e.attachments = json.dumps(_attachments)


### PR DESCRIPTION
In Notifications, if the Print Format has a `default_print_language` set, it will now be considered while sending the email.

![image](https://user-images.githubusercontent.com/9355208/52412523-03cb5980-2b05-11e9-8717-0a90ac4a37df.png)

![image](https://user-images.githubusercontent.com/9355208/52412493-f1e9b680-2b04-11e9-9b68-874d284bfb7a.png)
