### PR TITLE
fix(typo in report): Exection Time -> Execution Time

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -992,7 +992,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	show_footer_message() {
 		const message = __('For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 & 10).');
-		const execution_time_msg = __('Exection Time: {0} sec', [this.execution_time || 0.1]);
+		const execution_time_msg = __('Execution Time: {0} sec', [this.execution_time || 0.1]);
 
 		this.page.footer.removeClass('hide').addClass('text-muted col-md-12')
 			.html(`<span class="text-left col-md-6">${message}</span><span class="text-right col-md-6">${execution_time_msg}</span>`);


### PR DESCRIPTION
Fixed typo in query_report.js

Before:

![image](https://user-images.githubusercontent.com/33246109/52416218-1fd3f880-2b0f-11e9-99ca-f56fe40aef18.png)

After:

![image](https://user-images.githubusercontent.com/33246109/52416226-24001600-2b0f-11e9-9a4e-3b5cbf917423.png)
