### PR TITLE
fix(report): Fix file exports for reports that show totals

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -238,6 +238,7 @@ def export_query():
 		report_name = data["report_name"]
 	if isinstance(data.get("file_format_type"), string_types):
 		file_format_type = data["file_format_type"]
+
 	if isinstance(data.get("visible_idx"), string_types):
 		visible_idx = json.loads(data.get("visible_idx"))
 	else:
@@ -248,35 +249,40 @@ def export_query():
 		data = frappe._dict(data)
 		columns = get_columns_dict(data.columns)
 
-		result = [[]]
-
-		# add column headings
-		for idx in range(len(data.columns)):
-			result[0].append(columns[idx]["label"])
-
-		# build table from result
-		for i, row in enumerate(data.result):
-			# only pick up rows that are visible in the report
-			if i in visible_idx:
-				row_data = []
-
-				if isinstance(row, list):
-					row_data = row
-				elif isinstance(row, dict) and row:
-					for idx in range(len(data.columns)):
-						label = columns[idx]["label"]
-						fieldname = columns[idx]["fieldname"]
-
-						row_data.append(row.get(fieldname, row.get(label, "")))
-
-				result.append(row_data)
-
 		from frappe.utils.xlsxutils import make_xlsx
-		xlsx_file = make_xlsx(result, "Query Report")
+		xlsx_data = build_xlsx_data(columns, data, visible_idx)
+		xlsx_file = make_xlsx(xlsx_data, "Query Report")
 
 		frappe.response['filename'] = report_name + '.xlsx'
 		frappe.response['filecontent'] = xlsx_file.getvalue()
 		frappe.response['type'] = 'binary'
+
+
+def build_xlsx_data(columns, data, visible_idx):
+	result = [[]]
+
+	# add column headings
+	for idx in range(len(data.columns)):
+		result[0].append(columns[idx]["label"])
+
+	# build table from result
+	for i, row in enumerate(data.result):
+		# only pick up rows that are visible in the report
+		if i in visible_idx:
+			row_data = []
+
+			if isinstance(row, list):
+				row_data = row
+			elif isinstance(row, dict) and row:
+				for idx in range(len(data.columns)):
+					label = columns[idx]["label"]
+					fieldname = columns[idx]["fieldname"]
+
+					row_data.append(row.get(fieldname, row.get(label, "")))
+
+			result.append(row_data)
+
+	return result
 
 
 def get_report_module_dotted_path(module, report_name):

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -244,7 +244,6 @@ def export_query():
 		visible_idx = None
 
 	if file_format_type == "Excel":
-
 		data = run(report_name, filters)
 		data = frappe._dict(data)
 		columns = get_columns_dict(data.columns)
@@ -255,19 +254,22 @@ def export_query():
 		for idx in range(len(data.columns)):
 			result[0].append(columns[idx]["label"])
 
-		# build table from dict
-		if isinstance(data.result[0], dict):
-			for i,row in enumerate(data.result):
-				# only rows which are visible in the report
-				if row and (i in visible_idx):
-					row_list = []
+		# build table from result
+		for i, row in enumerate(data.result):
+			# only pick up rows that are visible in the report
+			if i in visible_idx:
+				row_data = []
+
+				if isinstance(row, list):
+					row_data = row
+				elif isinstance(row, dict) and row:
 					for idx in range(len(data.columns)):
-						row_list.append(row.get(columns[idx]["fieldname"], row.get(columns[idx]["label"], "")))
-					result.append(row_list)
-				elif not row:
-					result.append([])
-		else:
-			result = result + [d for i,d in enumerate(data.result) if (i in visible_idx)]
+						label = columns[idx]["label"]
+						fieldname = columns[idx]["fieldname"]
+
+						row_data.append(row.get(fieldname, row.get(label, "")))
+
+				result.append(row_data)
 
 		from frappe.utils.xlsxutils import make_xlsx
 		xlsx_file = make_xlsx(result, "Query Report")

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+
+import unittest
+
+import frappe
+from frappe.desk.query_report import build_xlsx_data
+import frappe.utils
+
+
+class TestQueryReport(unittest.TestCase):
+	def test_xlsx_data_with_multiple_datatypes(self):
+		"""Test exporting report using rows with multiple datatypes (list, dict)"""
+
+		# Describe the columns
+		columns = {
+			0: {"label": "Column A", "fieldname": "column_a"},
+			1: {"label": "Column B", "fieldname": "column_b"},
+			2: {"label": "Column C", "fieldname": "column_c"}
+		}
+
+		# Create mock data
+		data = frappe._dict()
+		data.columns = ["column_a", "column_b", "column_c"]
+		data.result = [
+			[1.0, 3.0, 5.5],
+			{"column_a": 22.1, "column_b": 21.8, "column_c": 30.2},
+			{"column_b": 5.1, "column_c": 9.5, "column_a": 11.1},
+			[3.0, 1.5, 7.5],
+		]
+
+		# Define the visible rows
+		visible_idx = [0, 2, 3]
+
+		# Build the result
+		xlsx_data = build_xlsx_data(columns, data, visible_idx)
+
+		self.assertEqual(type(xlsx_data), list)
+		self.assertEqual(len(xlsx_data), 4)  # columns + data
+
+		for row in xlsx_data:
+			self.assertEqual(type(row), list)


### PR DESCRIPTION
**Problem:**

Exporting a report with the "Show Totals" check toggled on breaks.

```diff
AttributeError: 'list' object has no attribute 'get'
  File "frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "frappe/__init__.py", line 1019, in call
    return fn(*args, **newargs)
  File "frappe/desk/query_report.py", line 265, in export_query
    row_list.append(row.get(columns[idx]["fieldname"], row.get(columns[idx]["label"], "")))

AttributeError: 'list' object has no attribute 'get'
```

**Solution:**

Check each row's datatype before adding them to the resulting list for export.