### PR TITLE
fix: locale lang format issue

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -226,7 +226,7 @@ def formatdate(string_date=None, format_string=None):
 		format_string = get_user_format()
 	format_string = format_string.replace("mm", "MM")
 	try:
-		formatted_date = babel.dates.format_date(date, format_string, locale=(frappe.local.lang or "").replace("-", "_"))
+		formatted_date = babel.dates.format_date(date, format_string, locale=get_locale())
 	except UnknownLocaleError:
 		format_string = format_string.replace("MM", "%m").replace("dd", "%d").replace("yyyy", "%Y")
 		formatted_date = date.strftime(format_string)
@@ -234,10 +234,17 @@ def formatdate(string_date=None, format_string=None):
 
 def format_time(txt):
 	try:
-		formatted_time = babel.dates.format_time(get_time(txt), locale=(frappe.local.lang or "").replace("-", "_"))
+		formatted_time = babel.dates.format_time(get_time(txt), locale=get_locale())
 	except UnknownLocaleError:
 		formatted_time = get_time(txt).strftime("%H:%M:%S")
 	return formatted_time
+
+def get_locale():
+	if '-' in frappe.local.lang:
+		parts = [d.strip() for d in (frappe.local.lang or "").split('-')]
+		return '_'.join(parts)
+
+	return frappe.local.lang
 
 def format_datetime(datetime_string, format_string=None):
 	if not datetime_string:


### PR DESCRIPTION
**Issue**
User has set language as "Ang - PT" and getting below error

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/__init__.py", line 1019, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/www/printview.py", line 187, in get_html_and_style
    no_letterhead=no_letterhead, trigger_print=trigger_print),
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/www/printview.py", line 158, in get_html
    html = template.render(args, filters={"len": len})
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/./templates/print_formats/standard.html", line 32, in top-level template code
    {{ render_field(df, doc) }}
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/jinja2/runtime.py", line 579, in _invoke
    rv = self._func(*arguments)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/./templates/print_formats/standard_macros.html", line 21, in template
    {{ render_field_with_label(df, doc) }}
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/jinja2/runtime.py", line 579, in _invoke
    rv = self._func(*arguments)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/./templates/print_formats/standard_macros.html", line 88, in template
    {{ _(print_value(df, doc)) }}{% endif %}
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/jinja2/runtime.py", line 579, in _invoke
    rv = self._func(*arguments)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/./templates/print_formats/standard_macros.html", line 134, in template
    {{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/model/base_document.py", line 712, in get_formatted
    return format_value(val, df=df, doc=doc, currency=currency)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/utils/formatters.py", line 46, in format_value
    return formatdate(value)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/utils/data.py", line 229, in formatdate
    formatted_date = babel.dates.format_date(date, format_string, locale=(frappe.local.lang or "").replace("-", "_"))
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/babel/dates.py", line 696, in format_date
    locale = Locale.parse(locale)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/babel/core.py", line 268, in parse
    parts = parse_locale(identifier, sep=sep)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/babel/core.py", line 1094, in parse_locale
    raise ValueError('expected only letters, got %r' % lang)
ValueError: expected only letters, got u'ang '
```