### PR TITLE
fix: scrub new lines and white spaces from options and fetch_from field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -56,7 +56,6 @@ class DocType(Document):
 			self.permissions = []
 
 		self.scrub_field_names()
-		self.scrub_options_in_select()
 		self.set_default_in_list_view()
 		self.set_default_translatable()
 		self.validate_series()
@@ -194,17 +193,6 @@ class DocType(Document):
 
 			# unique is automatically an index
 			if d.unique: d.search_index = 0
-
-	def scrub_options_in_select(self):
-		"""Strip options for whitespaces"""
-		for field in self.fields:
-			if field.fieldtype == "Select" and field.options is not None:
-				options_list = []
-				for i, option in enumerate(field.options.split("\n")):
-					_option = option.strip()
-					if i==0 or _option:
-						options_list.append(_option)
-				field.options = '\n'.join(options_list)
 
 	def validate_series(self, autoname=None, name=None):
 		"""Validate if `autoname` property is correctly set."""
@@ -693,6 +681,21 @@ def validate_fields(meta):
 				re.match("""[\w\.:_]+\s*={1}\s*[\w\.@'"]+""", depends_on):
 				frappe.throw(_("Invalid {0} condition").format(frappe.unscrub(field)), frappe.ValidationError)
 
+	def scrub_options_in_select(field):
+		"""Strip options for whitespaces"""
+
+		if field.fieldtype == "Select" and field.options is not None:
+			options_list = []
+			for i, option in enumerate(field.options.split("\n")):
+				_option = option.strip()
+				if i==0 or _option:
+					options_list.append(_option)
+			field.options = '\n'.join(options_list)
+
+	def scrub_fetch_from(field):
+		if hasattr(field, 'fetch_from') and getattr(field, 'fetch_from'):
+			field.fetch_from = field.fetch_from.strip('\n').strip()
+
 	fields = meta.get("fields")
 	fieldname_list = [d.fieldname for d in fields]
 
@@ -720,6 +723,8 @@ def validate_fields(meta):
 		check_illegal_default(d)
 		check_unique_and_text(d)
 		check_illegal_depends_on_conditions(d)
+		scrub_options_in_select(d)
+		scrub_fetch_from(d)
 
 	check_fold(fields)
 	check_search_fields(meta, fields)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/model/document.py", line 221, in insert
    self._validate_links()
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/model/document.py", line 731, in _validate_links
    invalid_links, cancelled_links = self.get_invalid_links()
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/model/base_document.py", line 468, in get_invalid_links
    values_to_fetch, as_dict=True)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/database.py", line 484, in get_value
    order_by, cache=cache)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/database.py", line 528, in get_values
    out = self._get_values_from_table(fields, filters, doctype, as_dict, debug, order_by, update)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/database.py", line 670, in _get_values_from_table
    as_dict=as_dict, debug=debug, update=update)
  File "/home/frappe/benches/bench-2019-02-06/apps/frappe/frappe/database.py", line 199, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1054, u"Unknown column 'brn_no\n\n\n\n\n' in 'field list'")
```

---

- Moved code for scrub_options_in_select to `validate_fields` , to validate changes done from custom fields and customize form.