### PR TITLE
fix: Skip get_open_count during migrate or install

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -249,6 +249,11 @@ def get_open_count(doctype, name, items=[]):
 	:param transactions: List of transactions (json/dict)
 	:param filters: optional filters (json/list)'''
 
+	if frappe.flags.in_migrate or frappe.flags.in_install:
+		return {
+			'count': []
+		}
+
 	frappe.has_permission(doc=frappe.get_doc(doctype, name), throw=True)
 
 	meta = frappe.get_meta(doctype)


### PR DESCRIPTION
```
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2019-02-06/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1054, u"Unknown column 'tabBOM.purchase_invoice' in 'where clause'")
```

```
{
	"type": "GET",
	"args": {
		"doctype": "Purchase Invoice",
		"name": "PINV-XXXX",
		"cmd": "frappe.desk.notifications.get_open_count"
	},
	"url": "/"
}
```