### PR TITLE
fix: Fallback for get_build_version

### DIFF
--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -85,4 +85,9 @@ def get_desk_assets(build_version):
 	}
 
 def get_build_version():
-	return str(os.path.getmtime(os.path.join(frappe.local.sites_path, '.build')))
+	try:
+		return str(os.path.getmtime(os.path.join(frappe.local.sites_path, '.build')))
+	except OSError:
+		# .build can sometimes not exist
+		# this is not a major problem so send fallback
+		return frappe.utils.random_string(8)


### PR DESCRIPTION
Sometimes .build does not exist and this is not a problem, so provide a fallback.

```
 File "/home/frappe/frappe-bench/env/lib64/python2.7/genericpath.py", line 54, in getmtime
    return os.stat(filename).st_mtime
OSError: [Errno 2] No such file or directory: './.build'
```