### PR TITLE
fix(desk): Prepared Report fixes

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -214,8 +214,8 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 					"columns": json.loads(doc.columns) if doc.columns else data[0],
 					"result": data
 				}
-		except:
-			doc = frappe.delete_doc("Prepared Report", doc.name)
+		except Exception:
+			frappe.delete_doc("Prepared Report", doc.name)
 			frappe.db.commit()
 			doc = None
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -191,19 +191,18 @@ def run(report_name, filters=None, user=None):
 
 def get_prepared_report_result(report, filters, dn="", user=None):
 	latest_report_data = {}
-	# Only look for completed prepared reports with given filters.
-	doc_list = frappe.get_all("Prepared Report",
-		filters={"status": "Completed", "report_name": report.name, "filters": json.dumps(filters), "owner": user})
-
 	doc = None
-	if len(doc_list):
-		if dn:
-			# Get specified dn
-			doc = frappe.get_doc("Prepared Report", dn)
-		else:
+	if dn:
+		# Get specified dn
+		doc = frappe.get_doc("Prepared Report", dn)
+	else:
+		# Only look for completed prepared reports with given filters.
+		doc_list = frappe.get_all("Prepared Report", filters={"status": "Completed", "filters": json.dumps(filters), "owner": user})
+		if doc_list:
 			# Get latest
 			doc = frappe.get_doc("Prepared Report", doc_list[0])
 
+	if doc:
 		# Prepared Report data is stored in a GZip compressed JSON file
 		attached_file_name = frappe.db.get_value("File", {"attached_to_doctype": doc.doctype, "attached_to_name":doc.name}, "name")
 		compressed_content = get_file(attached_file_name)[1]

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -203,16 +203,21 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 			doc = frappe.get_doc("Prepared Report", doc_list[0])
 
 	if doc:
-		# Prepared Report data is stored in a GZip compressed JSON file
-		attached_file_name = frappe.db.get_value("File", {"attached_to_doctype": doc.doctype, "attached_to_name":doc.name}, "name")
-		compressed_content = get_file(attached_file_name)[1]
-		uncompressed_content = gzip_decompress(compressed_content)
-		data = json.loads(uncompressed_content)
-		if data:
-			latest_report_data = {
-				"columns": json.loads(doc.columns) if doc.columns else data[0],
-				"result": data
-			}
+		try:
+			# Prepared Report data is stored in a GZip compressed JSON file
+			attached_file_name = frappe.db.get_value("File", {"attached_to_doctype": doc.doctype, "attached_to_name":doc.name}, "name")
+			compressed_content = get_file(attached_file_name)[1]
+			uncompressed_content = gzip_decompress(compressed_content)
+			data = json.loads(uncompressed_content)
+			if data:
+				latest_report_data = {
+					"columns": json.loads(doc.columns) if doc.columns else data[0],
+					"result": data
+				}
+		except:
+			doc = frappe.delete_doc("Prepared Report", doc.name)
+			frappe.db.commit()
+			doc = None
 
 	latest_report_data.update({
 		"prepared_report": True,

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -193,7 +193,7 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 	latest_report_data = {}
 	# Only look for completed prepared reports with given filters.
 	doc_list = frappe.get_all("Prepared Report",
-		filters={"status": "Completed", "report_name": report.name, "filters": filters, "owner": user})
+		filters={"status": "Completed", "report_name": report.name, "filters": json.dumps(filters), "owner": user})
 
 	doc = None
 	if len(doc_list):


### PR DESCRIPTION
1. Show prepared report matching given filters instead of the latest one
2. Ignore filters when prepared_report_name is set
3. Delete prepared report and fail silently if the attached file is missing/corrupted 