### PR TITLE
fix: Permlevel check in Print

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -326,7 +326,7 @@ def is_visible(df, doc):
 		if df.fieldname in doc.hide_in_print_layout:
 			return False
 
-	if df.permlevel or 0 > 0 and not doc.has_permlevel_access_to(df.fieldname, df):
+	if (df.permlevel or 0) > 0 and not doc.has_permlevel_access_to(df.fieldname, df):
 		return False
 
 	return not doc.is_print_hide(df.fieldname, df)


### PR DESCRIPTION
Stupid check hides fields with permlevel > 0 no matter who has access