### PR TITLE
fix: Add custom get_value to multiselect

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -46,7 +46,7 @@ frappe.ui.form.ControlMultiSelect = frappe.ui.form.ControlAutocomplete.extend({
 	},
 
 	set_formatted_input(value) {
-		if (!value) return
+		if (!value) return;
 		// find label of value from option list and set from it as input
 		if (this.df.options[0].label) {
 			value = value.split(',').map(d => d.trim()).map(val => {

--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -39,9 +39,7 @@ frappe.ui.form.ControlMultiSelect = frappe.ui.form.ControlAutocomplete.extend({
 			data = data.split(',').map(op => op.trim());
 			data = data.map(val => {
 				let option = this.df.options.find(op => op.label === val);
-				if(option) {
-					return option.value;
-				}
+				return option ? option.value : null;
 			}).filter(n => n != null).join(', ');
 		}
 		return data;

--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -32,6 +32,33 @@ frappe.ui.form.ControlMultiSelect = frappe.ui.form.ControlAutocomplete.extend({
 		});
 	},
 
+	get_value() {
+		let data = this._super();
+		// find value of label from option list and return actual value string
+		if (this.df.options[0].label) {
+			data = data.split(',').map(op => op.trim());
+			data = data.map(val => {
+				let option = this.df.options.find(op => op.label === val);
+				if(option) {
+					return option.value;
+				}
+			}).filter(n => n != null).join(', ');
+		}
+		return data;
+	},
+
+	set_formatted_input(value) {
+		if (!value) return
+		// find label of value from option list and set from it as input
+		if (this.df.options[0].label) {
+			value = value.split(',').map(d => d.trim()).map(val => {
+				let option = this.df.options.find(op => op.value === val);
+				return option ? option.label : val;
+			}).filter(n => n != null).join(', ');
+		}
+		this._super(value);
+	},
+
 	get_values() {
 		const value = this.get_value() || '';
 		const values = value.split(/\s*,\s*/).filter(d => d);


### PR DESCRIPTION
Previously, multiselect used to get the label as value which used to cause problems when the labels are translated to different language
<img width="1013" alt="screenshot 2019-02-16 at 6 33 17 pm" src="https://user-images.githubusercontent.com/13928957/52900245-a2e50500-3219-11e9-938f-95a1ac9b4bf1.png">

Now, after adding custom get_value function to multiselect we will get respective value of the selected label in the option list.
<img width="1011" alt="screenshot 2019-02-16 at 6 31 12 pm" src="https://user-images.githubusercontent.com/13928957/52900247-a7112280-3219-11e9-80fb-69e8c1f09f00.png">
