### PR TITLE
fix: delete_bulk_fix

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -222,12 +222,13 @@ def delete_items():
 		delete_bulk(doctype, items)
 
 def delete_bulk(doctype, items):
-	for i, d in enumerate(il):
+	failed = []
+	for i, d in enumerate(items):
 		try:
 			frappe.delete_doc(doctype, d)
-			if len(il) >= 5:
+			if len(items) >= 5:
 				frappe.publish_realtime("progress",
-					dict(progress=[i+1, len(il)], title=_('Deleting {0}').format(doctype), description=d),
+					dict(progress=[i+1, len(items)], title=_('Deleting {0}').format(doctype), description=d),
 						user=frappe.session.user)
 		except Exception:
 			failed.append(d)


### PR DESCRIPTION
Delete Bulk function was iterated over empty list

- Before :
![delete-bulk-before](https://user-images.githubusercontent.com/7310479/52913179-70064400-32e1-11e9-8381-388965cdc02a.gif)

- After :
![delete-bulk-after](https://user-images.githubusercontent.com/7310479/52913181-7399cb00-32e1-11e9-83f3-6268101a7f0a.gif)
