### PR TITLE
fix: Doctypes not showing in data export

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -157,7 +157,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			me.set_custom_query(args);
 
 			frappe.call({
-				type: "GET",
+				type: "POST",
 				method:'frappe.desk.search.search_link',
 				no_spinner: true,
 				args: args,


### PR DESCRIPTION
![screenshot 2019-02-18 at 5 48 21 pm](https://user-images.githubusercontent.com/42651287/52950870-71e60b00-33a6-11e9-8f3f-383c5c2ffd23.png)

The maximum length for a `GET` request is 4096 bytes which is crossed in this case.