### PR TITLE
fix(email): default UIDVALIDITY to 0

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -190,12 +190,10 @@ class EmailServer:
 		# compare the UIDVALIDITY of email account and imap server
 		uid_validity = self.settings.uid_validity
 
-		responce, message = self.imap.status("Inbox", "(UIDVALIDITY UIDNEXT)")
-		current_uid_validity = self.parse_imap_responce("UIDVALIDITY", message[0])
-		if not current_uid_validity:
-			frappe.throw(_("Can not find UIDVALIDITY in imap status response"))
+		response, message = self.imap.status("Inbox", "(UIDVALIDITY UIDNEXT)")
+		current_uid_validity = self.parse_imap_response("UIDVALIDITY", message[0]) or 0
 
-		uidnext = int(self.parse_imap_responce("UIDNEXT", message[0]) or "1")
+		uidnext = int(self.parse_imap_response("UIDNEXT", message[0]) or "1")
 		frappe.db.set_value("Email Account", self.settings.email_account, "uidnext", uidnext)
 
 		if not uid_validity or uid_validity != current_uid_validity:
@@ -223,9 +221,9 @@ class EmailServer:
 		elif uid_validity == current_uid_validity:
 			return
 
-	def parse_imap_responce(self, cmd, responce):
+	def parse_imap_response(self, cmd, response):
 		pattern = r"(?<={cmd} )[0-9]*".format(cmd=cmd)
-		match = re.search(pattern, responce.decode('utf-8'), re.U | re.I)
+		match = re.search(pattern, response.decode('utf-8'), re.U | re.I)
 		if match:
 			return match.group(0)
 		else:


### PR DESCRIPTION
```
{'event': u'all', 'retry': 0, 'log': <function log at 0x7f47a2757a28>, 'site': u'droidforge.erpnext.com', 'job_name': u'pull_from_email_account|Admin', 'method_name': u'pull_from_email_account', 'method': <function pull_from_email_account at 0x7f47a26de320>, 'user': u'Administrator', 'kwargs': {'email_account': u'Admin'}, 'is_async': True}
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/utils/background_jobs.py", line 103, in execute_job
    method(**kwargs)
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 713, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 261, in receive
    emails = email_server.get_messages()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/email/receive.py", line 116, in get_messages
    uid_list = email_list = self.get_new_mails()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/email/receive.py", line 176, in get_new_mails
    self.check_imap_uidvalidity()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/email/receive.py", line 196, in check_imap_uidvalidity
    frappe.throw(_("Can not find UIDVALIDITY in imap status response"))
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/__init__.py", line 351, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/__init__.py", line 337, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/__init__.py", line 310, in _raise_exception
    raise raise_exception(msg)
ValidationError: Can not find UIDVALIDITY in imap status response
```