### PR TITLE
fix: Render Signature and Geolocation after dialog is shown

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -16,7 +16,7 @@ frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlCode.extend({
 		if ($input_wrapper.is(':visible')) {
 			this.make_map();
 		} else {
-			$(document).on('quick-entry-dialog-open', () => {
+			$(document).on('frappe.ui.Dialog:shown', () => {
 				this.make_map();
 			});
 		}

--- a/frappe/public/js/frappe/form/controls/signature.js
+++ b/frappe/public/js/frappe/form/controls/signature.js
@@ -7,7 +7,14 @@ frappe.ui.form.ControlSignature = frappe.ui.form.ControlData.extend({
 
 		// make jSignature field
 		this.body = $('<div class="signature-field"></div>').appendTo(me.wrapper);
-		this.make_pad();
+
+		if (this.body.is(':visible')) {
+			this.make_pad();
+		} else {
+			$(document).on('frappe.ui.Dialog:shown', () => {
+				this.make_pad();
+			});
+		}
 
 		this.img_wrapper = $(`<div class="signature-display">
 			<div class="missing-image attach-missing-image">

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -116,9 +116,6 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 
 		this.dialog.onhide = () => frappe.quick_entry = null;
 		this.dialog.show();
-		this.dialog.$wrapper.on('shown.bs.modal', function() {
-			$(document).trigger('quick-entry-dialog-open');
-		});
 
 		this.dialog.refresh_dependency();
 		this.set_defaults();

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -83,8 +83,8 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				window.cur_dialog = me;
 				frappe.ui.open_dialogs.push(me);
 				me.focus_on_first_input();
-                me.on_page_show && me.on_page_show();
-                $(document).trigger('frappe.ui.Dialog:shown');
+				me.on_page_show && me.on_page_show();
+				$(document).trigger('frappe.ui.Dialog:shown');
 			})
 			.on('scroll', function() {
 				var $input = $('input:focus');

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -83,7 +83,8 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				window.cur_dialog = me;
 				frappe.ui.open_dialogs.push(me);
 				me.focus_on_first_input();
-				me.on_page_show && me.on_page_show();
+                me.on_page_show && me.on_page_show();
+                $(document).trigger('frappe.ui.Dialog:shown');
 			})
 			.on('scroll', function() {
 				var $input = $('input:focus');


### PR DESCRIPTION
Dialogs are hidden the first time they are created, some fields need to
calculate the dimensions of their container which is not possible when
they are hidden, we fix it by rendering them after the dialog is shown.

![signature-field-deferred](https://user-images.githubusercontent.com/9355208/53068410-60b01200-34fe-11e9-9355-91fc339ec86e.gif)
