### PR TITLE
fix: Dont set doctype if it is not set

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -119,7 +119,7 @@ frappe.ui.form.on("Customize Form", {
 			frm.set_df_property("sort_field", "options", fields);
 		}
 
-		if(frappe.route_options) {
+		if(frappe.route_options && frappe.route_options.doc_type) {
 			setTimeout(function() {
 				frm.set_value("doc_type", frappe.route_options.doc_type);
 				frappe.route_options = null;


### PR DESCRIPTION
Without this fix, even if `frappe.route_options.doc_type` is not set, it will refresh the form, resulting in an empty form.