### PR TITLE
fix: Report filters in Custom Reports

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -290,8 +290,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (frappe.route_options) {
 			this.filters = this.parse_filters_from_route_options();
 
-			return this.filter_area.clear(false)
-				.then(() => this.filter_area.set(this.filters));
+			if (this.filters.length > 0) {
+				return this.filter_area.clear(false)
+					.then(() => this.filter_area.set(this.filters));
+			}
 		}
 
 		return Promise.resolve();

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -68,6 +68,14 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		});
 	}
 
+	before_refresh() {
+		if (this.report_doc) {
+			// don't parse frappe.route_options if this is a Custom Report
+			return Promise.resolve();
+		}
+		return super.before_refresh();
+	}
+
 	before_render() {
 		if (this.report_doc) {
 			this.set_dirty_state_for_custom_report();


### PR DESCRIPTION
- frappe.route_options should not override Report Filters

![report-filters-before](https://user-images.githubusercontent.com/9355208/53170861-2c744880-3607-11e9-8720-20afb9e734d3.gif)
