### PR TITLE
fix: typo on `frappe.client.attach_file` which resulted in error

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -358,7 +358,7 @@ def attach_file(filename=None, filedata=None, doctype=None, docname=None, folder
 		doc.set(docfield, _file.file_url)
 		doc.save()
 
-	return f.as_dict()
+	return _file.as_dict()
 
 def check_parent_permission(parent, child_doctype):
 	if parent:


### PR DESCRIPTION
It returned `f.as_dict()`. `f` is not declared in the current scope.\Changed it with `_file`.
`return _file.as_dict()`

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.