### PR TITLE
fix(desk): Use DocType instead of Doctype

### DIFF
--- a/frappe/config/__init__.py
+++ b/frappe/config/__init__.py
@@ -71,7 +71,7 @@ def get_all_empty_tables_by_module():
 		SELECT
 			name, module
 		FROM information_schema.tables as i
-		JOIN tabDoctype as d
+		JOIN tabDocType as d
 			ON i.table_name = CONCAT('tab', d.name)
 		WHERE table_rows = 0;
 


### PR DESCRIPTION
Accessing /desk will show following error without this patch

![screenshot 2019-02-27 at 3 03 04 pm](https://user-images.githubusercontent.com/8528887/53482259-d428c500-3aa4-11e9-83f9-633c3e817de3.png)
