### PR TITLE
fix: web form will show footer save button only if form is greater than window height

### DIFF
--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -151,7 +151,7 @@
 				<!-- save/next button -->
 				{% if (loop.index == layout|len or frappe.form_dict.new) %}
 					{% if not read_only %}
-				    <button type="submit" class="btn btn-primary btn-sm btn-form-submit">
+				    <button type="submit" class="btn btn-primary btn-sm btn-form-submit footer-button">
 				    	{{ _("Save") }}</button>
 					{% endif %}
 				{% elif layout|len > 1 %}

--- a/frappe/website/js/web_form.js
+++ b/frappe/website/js/web_form.js
@@ -37,7 +37,7 @@ frappe.ready(function() {
 		$('body').css('display', 'block');
 
 		// remove footer save button if form height is less than window height
-		if($('.webform-wrapper').height() < window.innerHeight){
+		if($('.webform-wrapper').height() < window.innerHeight) {
 			$(".footer-button").addClass("hide");
 		}
 

--- a/frappe/website/js/web_form.js
+++ b/frappe/website/js/web_form.js
@@ -36,6 +36,11 @@ frappe.ready(function() {
 	setTimeout(() => {
 		$('body').css('display', 'block');
 
+		// remove footer save button if form height is grater less than window height
+		if(!($('.webform-wrapper').height() > window.innerHeight)){
+			$(".footer-button").addClass("hide");
+		}
+
 		if (frappe.init_client_script) {
 			frappe.init_client_script();
 

--- a/frappe/website/js/web_form.js
+++ b/frappe/website/js/web_form.js
@@ -36,8 +36,8 @@ frappe.ready(function() {
 	setTimeout(() => {
 		$('body').css('display', 'block');
 
-		// remove footer save button if form height is grater less than window height
-		if(!($('.webform-wrapper').height() > window.innerHeight)){
+		// remove footer save button if form height is less than window height
+		if($('.webform-wrapper').height() < window.innerHeight){
 			$(".footer-button").addClass("hide");
 		}
 


### PR DESCRIPTION
Before: the webform have two save button.
Now: Removed the footer save button if form is not larger than window height. 

**Before**

![screenshot 2019-02-03 at 8 02 44 pm](https://user-images.githubusercontent.com/14824451/52178707-cd859580-27f7-11e9-9d99-f84cc3433601.png)

**Now**

![screenshot 2019-03-01 at 11 34 59 am](https://user-images.githubusercontent.com/32095923/53619665-1faeb080-3c16-11e9-8d71-048c2ec53151.png)


