### PR TITLE
fix: Avoid default of field if its depends_on field is not set

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -90,7 +90,7 @@ $.extend(frappe.model, {
 		for(var fid=0;fid<docfields.length;fid++) {
 			var f = docfields[fid];
 			if(!in_list(frappe.model.no_value_type, f.fieldtype) && doc[f.fieldname]==null) {
-				var v = frappe.model.get_default_value(f, doc, parent_doc);
+				var v = !f.depends_on || doc[f.depends_on] ? frappe.model.get_default_value(f, doc, parent_doc) : null;
 				if(v) {
 					if(in_list(["Int", "Check"], f.fieldtype))
 						v = cint(v);


### PR DESCRIPTION
Avoid default of field if its depends_on field is not set

For example, We have a field **represents_company** in Customer DocType. This field is relevant only if the **Is Internal Customer** checkbox is checked. So the problem is even if **is_internal_customer** is unchecked by default the system sets the default for **represents_company**.

This PR fixes that.