### PR TITLE
fix: errprint not working

### DIFF
--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -202,6 +202,7 @@ def get_error_snapshot_path():
 
 def get_frame_locals():
 	traceback = sys.exc_info()[2]
+	frames = []
 	if traceback:
 		frames = inspect.getinnerframes(traceback, context=0)
 	_locals = ['Locals (most recent call last):']


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 1026, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 848, in submit
    self._submit()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 837, in _submit
    self.save()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 313, in _save
    self.run_post_save_methods()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 908, in run_post_save_methods
    self.run_method("on_submit")
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 78, in on_submit
    self.update_stock_ledger()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 573, in update_stock_ledger
    self.make_sl_entries(sl_entries, self.amended_from and 'Yes' or 'No')
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 273, in make_sl_entries
    make_sl_entries(sl_entries, is_amended, allow_negative_stock, via_landed_cost_voucher)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 40, in make_sl_entries
    update_bin(args, allow_negative_stock, via_landed_cost_voucher)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/utils.py", line 146, in update_bin
    bin.update_stock(args, allow_negative_stock, via_landed_cost_voucher)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/doctype/bin/bin.py", line 35, in update_stock
    }, allow_negative_stock=allow_negative_stock, via_landed_cost_voucher=via_landed_cost_voucher)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 109, in __init__
    self.build()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 116, in build
    self.process_sle(sle)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 174, in process_sle
    self.get_fifo_values(sle)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 360, in get_fifo_values
    frappe.errprint([self.valuation_rate, stock_value, stock_qty])
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 278, in errprint
    error_log.append({"exc": escape_html(msg), "locals": get_frame_locals()})
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/utils/error.py", line 208, in get_frame_locals
    for frame, filename, lineno, function, __, __ in frames:
UnboundLocalError: local variable 'frames' referenced before assignment


```