### PR TITLE
fix: Removed unexpected keword argument 'indicator'

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1216,7 +1216,7 @@ class Document(BaseDocument):
 
 		if file_lock.lock_exists(self.get_signature()):
 			frappe.throw(_('This document is currently queued for execution. Please try again'),
-				title=_('Document Queued'), indicator='red')
+				title=_('Document Queued'))
 
 		self.lock()
 		enqueue('frappe.model.document.execute_action', doctype=self.doctype, name=self.name,


### PR DESCRIPTION
Removed unexpected keyword argument 'indicator' from frappe.throw function.