### PR TITLE
fix: compulsorily shift db

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -499,12 +499,14 @@ def read_only():
 		def wrapper_fn(*args, **kwargs):
 			if conf.use_slave_for_read_only:
 				connect_read_only()
-
-			retval = fn(*args, **get_newargs(fn, kwargs))
-
-			if local and hasattr(local, 'master_db'):
-				local.db.close()
-				local.db = local.master_db
+			try:
+				retval = fn(*args, **get_newargs(fn, kwargs))
+			except:
+				raise
+			finally:
+				if local and hasattr(local, 'master_db'):
+					local.db.close()
+					local.db = local.master_db
 
 			return retval
 		return wrapper_fn


### PR DESCRIPTION
If an error is raised in the report, 
1. system tries to write error log to slave_db
2. Primary DB connection stays open
as db_switch doesn't happen until successful report execution, and frappe.db refers to slave db object.

This PR forces DB switch to master regardless of report execution.