### PR TITLE
fix(desk): use pre-existing container for desk

### DIFF
--- a/frappe/public/js/frappe/views/pageview.js
+++ b/frappe/public/js/frappe/views/pageview.js
@@ -43,18 +43,20 @@ frappe.views.pageview = {
 			name = (frappe.boot ? frappe.boot.home_page : window.page_name);
 
 			if(name === "desktop") {
-				let page = frappe.container.add_page('desktop');
+				if(!frappe.pages.desktop) {
+					let page = frappe.container.add_page('desktop');
+					let container = $('<div class="container"></div>').appendTo(page);
+					container = $('<div></div>').appendTo(container);
+
+					Vue.prototype.__ = window.__;
+					Vue.prototype.frappe = window.frappe;
+					new Vue({
+						el: container[0],
+						render: h => h(Desktop)
+					});
+				}
+
 				frappe.container.change_to('desktop');
-
-				let container = $('<div class="container"></div>').appendTo(page);
-				container = $('<div></div>').appendTo(container);
-
-				Vue.prototype.__ = window.__;
-				Vue.prototype.frappe = window.frappe;
-				new Vue({
-					el: container[0],
-					render: h => h(Desktop)
-				});
 				return;
 			}
 		}


### PR DESCRIPTION
Fixes the link redirect issue in desk, that was caused by new containers being created for every reroute to desk.