### PR TITLE
fix: Refactor frappe.require(web version) and fix timeline

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
 		"es6": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 6,
+		"ecmaVersion": 8,
 		"sourceType": "module"
 	},
 	"extends": "eslint:recommended",

--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -301,7 +301,7 @@ frappe.ui.form.Timeline = class Timeline {
 	}
 
 	prepare_timeline_item(c) {
-		if(!c.sender) c.sender = c.owner;
+		if(!c.sender) c.sender = c.owner || 'Guest';
 
 		if(c.sender && c.sender.indexOf("<")!==-1) {
 			c.sender = c.sender.split("<")[1].split(">")[0];

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -13,35 +13,31 @@ $.extend(frappe, {
 		lang: 'en'
 	},
 	_assets_loaded: [],
-	require: function(url, callback) {
-
-		let async = false;
-		if (callback) {
-			async = true;
+	require: async function(links, callback) {
+		if (typeof (links) === 'string') {
+			links = [links];
 		}
-
-		if(frappe._assets_loaded.indexOf(url)!==-1) {
-			callback && callback();
-			return;
+		for (let link of links) {
+			await this.add_asset_to_head(link);
 		}
-
-		return $.ajax({
-			url: url,
-			async: async,
-			dataType: "text",
-			success: function(data) {
-				var el;
-				if(url.split(".").splice(-1) == "js") {
-					el = document.createElement('script');
-				} else {
-					el = document.createElement('style');
-				}
-				el.appendChild(document.createTextNode(data));
-				document.getElementsByTagName('head')[0].appendChild(el);
-				frappe._assets_loaded.push(url);
-
-				callback && callback();
+		callback && callback();
+	},
+	add_asset_to_head(link) {
+		return new Promise(resolve => {
+			if (frappe._assets_loaded.includes(link)) return resolve();
+			let el;
+			if(link.split('.').pop() === 'js') {
+				el = document.createElement('script');
+				el.type = 'text/javascript';
+			} else {
+				el = document.createElement('style');
 			}
+			document.getElementsByTagName('head')[0].appendChild(el);
+			el.onload = () => {
+				frappe._assets_loaded.push(link);
+				resolve();
+			};
+			el.src = link;
 		});
 	},
 	hide_message: function() {

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -29,15 +29,18 @@ $.extend(frappe, {
 			if(link.split('.').pop() === 'js') {
 				el = document.createElement('script');
 				el.type = 'text/javascript';
+				el.src = link;
 			} else {
-				el = document.createElement('style');
+				el = document.createElement('link');
+				el.type = 'text/css';
+				el.rel = 'stylesheet';
+				el.href = link;
 			}
 			document.getElementsByTagName('head')[0].appendChild(el);
 			el.onload = () => {
 				frappe._assets_loaded.push(link);
 				resolve();
 			};
-			el.src = link;
 		});
 	},
 	hide_message: function() {


### PR DESCRIPTION
- Refactor frappe.require(website version) to support multiple asset import
**API**:
for single import `frappe.require('some/javascript/asset.js')` 
for multiple import `frappe.require(['some/javascript/asset.js', 'some/style/asset.css'])`
- Set `ecmaVersion: 8` in eslintrc to allow async await syntax
- Fixed timeline 
Set owner of doc as 'Guest' if doc.owner is `undefined` 
 previously it used to show loggedin user as owner which was wrong

**Before:**
<img width="843" alt="screenshot 2019-03-07 at 9 57 19 am" src="https://user-images.githubusercontent.com/13928957/53933470-84f61c00-40c4-11e9-837c-16ac07c0c904.png">

**After:**
<img width="631" alt="screenshot 2019-03-07 at 9 56 53 am" src="https://user-images.githubusercontent.com/13928957/53933482-95a69200-40c4-11e9-933b-7882b4ceb554.png">

**Note:** Do not squash this one 



