### PR TITLE
fix: Overwrite existing reply on selecting template

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -195,21 +195,9 @@ frappe.views.CommunicationComposer = Class.extend({
 				}
 				var content_field = me.dialog.fields_dict.content;
 				var subject_field = me.dialog.fields_dict.subject;
-				var content = content_field.get_value() || "";
-				var subject = subject_field.get_value() || "";
 
-				var parts = content.split('<!-- salutation-ends -->');
-
-				if(parts.length===2) {
-					content = [reply.message, "<br>", parts[1]];
-				} else {
-					content = [reply.message, "<br>", content];
-				}
-
-				content_field.set_value(content.join(''));
-				if(subject === "") {
-					subject_field.set_value(reply.subject);
-				}
+				content_field.set_value(reply.message);
+				subject_field.set_value(reply.subject);
 
 				me.reply_added = email_template;
 			}


### PR DESCRIPTION
Problem:
Currently when you select the Email template, it prepends to the existing text. If you change the email template also, it again prepends and there are multiple template text.

<img width="643" alt="screen shot 2019-03-07 at 11 30 15 am" src="https://user-images.githubusercontent.com/16913064/53935814-c939ea00-40cd-11e9-9bf0-5a5de1aef1c4.png">


Expected behavior:
It makes sense that when Email Template is selected it should replace the message and subject, not prepend. It does not even need Salutation, it should be added from template.