### PR TITLE
Fix:The server Error for attendance Gantt

### DIFF
--- a/frappe/public/js/frappe/views/gantt/gantt_view.js
+++ b/frappe/public/js/frappe/views/gantt/gantt_view.js
@@ -8,7 +8,9 @@ frappe.views.GanttView = class GanttView extends frappe.views.ListView {
 	setup_defaults() {
 		super.setup_defaults();
 		this.page_title = this.page_title + ' ' + __('Gantt');
-		this.calendar_settings = frappe.views.calendar[this.doctype] || {};
+        if(temp_key == "Attendance")
+            temp_key = "AttendanceGantt";
+		this.calendar_settings = frappe.views.calendar[temp_key] || {};
 		if(this.calendar_settings.order_by) {
 			this.sort_by = this.calendar_settings.order_by;
 			this.sort_order = 'asc';


### PR DESCRIPTION
Server Error on Attendance gantt :
InternalError: (1054, u"Unknown column 'tabAttendance.date' in 'order clause'")
In case of attendance gantt, set the field map form AttendanceGantt form attendance_calaendar.js

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.