### PR TITLE
feat(tests): Record time required for each test

### DIFF
--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals, print_function
 
 import frappe
 import unittest, json, sys, os
+import time
 import xmlrunner
 import importlib
 from frappe.modules import load_doctype_module, get_module_name
@@ -90,6 +91,19 @@ def set_test_email_config():
 		"admin_password": "admin"
 	})
 
+
+class TimeLoggingTestResult(unittest.TextTestResult):
+	def startTest(self, test):
+		self._started_at = time.time()
+		super().startTest(test)
+
+	def addSuccess(self, test):
+		elapsed = time.time() - self._started_at
+		name = self.getDescription(test)
+		self.stream.write("\n{} ({:.03}s)\n".format(name, elapsed))
+		super().addSuccess(test)
+
+
 def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False, failfast=False):
 	import os
 
@@ -115,7 +129,7 @@ def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False, failfa
 		pr = cProfile.Profile()
 		pr.enable()
 
-	out = unittest_runner(verbosity=1+(verbose and 1 or 0), failfast=failfast).run(test_suite)
+	out = unittest_runner(resultclass=TimeLoggingTestResult, verbosity=1+(verbose and 1 or 0), failfast=failfast).run(test_suite)
 
 	if profile:
 		pr.disable()

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -95,13 +95,13 @@ def set_test_email_config():
 class TimeLoggingTestResult(unittest.TextTestResult):
 	def startTest(self, test):
 		self._started_at = time.time()
-		super().startTest(test)
+		super(TimeLoggingTestResult, self).startTest(test)
 
 	def addSuccess(self, test):
 		elapsed = time.time() - self._started_at
 		name = self.getDescription(test)
 		self.stream.write("\n{} ({:.03}s)\n".format(name, elapsed))
-		super().addSuccess(test)
+		super(TimeLoggingTestResult, self).addSuccess(test)
 
 
 def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False, failfast=False):


### PR DESCRIPTION
Test Logs Before
```
..........................................................
----------------------------------------------------------------------
Ran 348 tests in 165.471s
OK
```

After

```
.
test_record_without_sql_queries (frappe.tests.test_recorder.TestRecorder) (0.00291s)
.
test_start (frappe.tests.test_recorder.TestRecorder) (0.00299s)
.
test_delete (frappe.tests.test_client.TestClient) (0.101s)
.
test_set_value (frappe.tests.test_client.TestClient) (0.112s)
.
test_authenticate_for_2factor (frappe.tests.test_twofactor.TestTwoFactor)
Verification obj and tmp_id should be set in frappe.local. (3.3s)
.
test_bypass_restict_ip (frappe.tests.test_twofactor.TestTwoFactor) (9.98s)
```