### PR TITLE
fix: Miscellaneous fixes for v12

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1478,8 +1478,10 @@ def logger(module=None, with_more_info=True):
 
 def log_error(message=None, title=None):
 	'''Log error to Error Log'''
-	return get_doc(dict(doctype='Error Log', error=as_unicode(message or get_traceback()),
+	doc = get_doc(dict(doctype='Error Log', error=as_unicode(message or get_traceback()),
 		method=title)).insert(ignore_permissions=True)
+	db.commit()
+	return doc
 
 def get_desk_link(doctype, name):
 	return '<a href="#Form/{0}/{1}" style="font-weight: bold;">{2} {1}</a>'.format(doctype, name, _(doctype))

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1478,10 +1478,8 @@ def logger(module=None, with_more_info=True):
 
 def log_error(message=None, title=None):
 	'''Log error to Error Log'''
-	doc = get_doc(dict(doctype='Error Log', error=as_unicode(message or get_traceback()),
+	return get_doc(dict(doctype='Error Log', error=as_unicode(message or get_traceback()),
 		method=title)).insert(ignore_permissions=True)
-	db.commit()
-	return doc
 
 def get_desk_link(doctype, name):
 	return '<a href="#Form/{0}/{1}" style="font-weight: bold;">{2} {1}</a>'.format(doctype, name, _(doctype))

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -316,8 +316,9 @@ def evaluate_alert(doc, alert, event):
 	except TemplateError:
 		frappe.throw(_("Error while evaluating Notification {0}. Please fix your template.").format(alert))
 	except Exception as e:
-		frappe.log_error(message=frappe.get_traceback(), title=str(e))
-		frappe.throw(_("Error in Notification"))
+		error_log = frappe.log_error(message=frappe.get_traceback(), title=str(e))
+		frappe.throw(_("Error in Notification: {}".format(
+			frappe.utils.get_link_to_form('Error Log', error_log.name))))
 
 def get_context(doc):
 	return {"doc": doc, "nowdate": nowdate, "frappe.utils": frappe.utils}

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1015,7 +1015,8 @@ class Document(BaseDocument):
 		version = frappe.new_doc('Version')
 		if version.set_diff(self._doc_before_save, self):
 			version.insert(ignore_permissions=True)
-			follow_document(self.doctype, self.name, frappe.session.user)
+			if not frappe.flags.in_migrate:
+				follow_document(self.doctype, self.name, frappe.session.user)
 
 	@staticmethod
 	def whitelist(f):

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -200,6 +200,7 @@ frappe.patches.v9_1.move_feed_to_activity_log
 execute:frappe.delete_doc('Page', 'data-import-tool', ignore_missing=True)
 frappe.patches.v10_0.reload_countries_and_currencies
 frappe.patches.v10_0.refactor_social_login_keys
+execute:frappe.reload_doc('email', 'doctype', 'document_follow')
 frappe.patches.v10_0.enable_chat_by_default_within_system_settings
 frappe.patches.v10_0.remove_custom_field_for_disabled_domain
 execute:frappe.delete_doc("Page", "chat")

--- a/frappe/patches/v11_0/delete_duplicate_user_permissions.py
+++ b/frappe/patches/v11_0/delete_duplicate_user_permissions.py
@@ -9,5 +9,5 @@ def execute():
 
 	for record in duplicateRecords:
 		frappe.db.sql("""delete from `tabUser Permission`
-			where allow='{0}' and user='{1}' and for_value='{2}' limit {3}"""
-			.format(record.allow, record.user, frappe.db.escape(record.for_value), record.count - 1))
+			where allow=%s and user=%s and for_value=%s limit {0}"""
+			.format(record.count - 1), (record.allow, record.user, record.for_value))

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -729,7 +729,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-09-05 14:01:05.658719", 
+ "modified": "2017-09-05 14:02:05.658719", 
  "modified_by": "Administrator", 
  "module": "Printing", 
  "name": "Print Format", 


### PR DESCRIPTION
- Always commit Error Logs, so that if `frappe.throw` is called immediately after, they are not lost
- Add Error Log form link when Error in Notification evaluation is found
- Default Print Language field is not picked up in migrations, update modified.