### PR TITLE
fix(email): Fixed py3 email byte-content decoding 

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -357,9 +357,13 @@ class Email:
 		"""Parses headers, content, attachments from given raw message.
 
 		:param content: Raw message."""
-		self.raw = safe_encode(content) if six.PY2 else safe_decode(content)
-		self.mail = email.message_from_string(self.raw)
-
+		if six.PY2:
+			self.mail = email.message_from_string( safe_encode(content) )
+		else:
+			if isinstance(content, bytes):
+				self.mail = email.message_from_bytes(content)
+			else:
+				self.mail = email.message_from_string( safe_decode(content) )
 
 		self.text_content = ''
 		self.html_content = ''

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import unittest, os, base64
+from frappe.email.receive import Email
 from frappe.email.email_body import (replace_filename_with_cid,
 	get_email, inline_style_in_html, get_header)
 
@@ -136,6 +137,20 @@ d85b; border-radius:8px; display:inline-block; height:8px; margin-right:5px=
 		html = get_header('This is string')
 		self.assertTrue('<span>This is string</span>' in html)
 
+	def test_8bit_utf_8_decoding(self):
+		text_content_bytes = b"\xed\x95\x9c\xea\xb8\x80\xe1\xa5\xa1\xe2\x95\xa5\xe0\xba\xaa\xe0\xa4\x8f"
+		text_content = text_content_bytes.decode('utf-8')
+
+		content_bytes = b"""MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+From: test1_@erpnext.com
+Reply-To: test2_@erpnext.com
+""" + text_content_bytes
+
+		mail = Email(content_bytes)
+		self.assertEqual(mail.text_content, text_content)
 
 def fixed_column_width(string, chunk_size):
 	parts = [string[0+i:chunk_size+i] for i in range(0, len(string), chunk_size)]


### PR DESCRIPTION
Fixed python3 email content decoding ([message_from_string](https://docs.python.org/2.7/library/email.parser.html?highlight=message_from_string#email.message_from_string) > [message_from_bytes](https://docs.python.org/3.5/library/email.parser.html?highlight=message_from_string#email.message_from_bytes) for py3).
Email class unit test added.

[Mirror PR to develop branch](https://github.com/frappe/frappe/pull/7030)

["Discussion"](https://discuss.erpnext.com/t/updated-3-on-python3-email-response-from-outside-to-erpnext-contain-escaped-unicode-character-codes-instead-of-utf-chars/46319) detailing problem
[GitHub Issue](https://github.com/frappe/frappe/issues/7029)

Also see [THIS](https://bugs.python.org/issue18271#msg191536) communication.

# Also 

now safe_decode for py3 is useless, as it probably will always get string thus returning same value.
