### PR TITLE
fix: editor does not allow html rendering

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -361,7 +361,6 @@ frappe.ui.form.Timeline = class Timeline {
 			} else {
 				c.content_html = c.content;
 				c.content_html = frappe.utils.strip_whitespace(c.content_html);
-				c.content_html = c.content_html.replace(/&lt;/g,"<").replace(/&gt;/g,">");
 			}
 
 			// bold @mentions


### PR DESCRIPTION
Removed the following line
```javascript
c.content_html.replace(/&lt;/g,"<").replace(/&gt;/g,">")
```

This line would replace the escaped lt/gt with angular brackets, resulting in the content being rendered as html. 
The consequence is that someone can enter a peice of malicious javascript code that would get executed