### PR TITLE
fix(desk): Set routes for unhandled shortcut tags

### DIFF
--- a/frappe/public/js/frappe/views/components/utils.js
+++ b/frappe/public/js/frappe/views/components/utils.js
@@ -24,6 +24,8 @@ function generate_route(item) {
 		}
 
 		route = '#' + route;
+	} else {
+		route = item.route;
 	}
 
 	if(item.route_options) {


### PR DESCRIPTION
Route for shortcut tags like Chart of Accounts and
Gantt Chart aren't set properly, handle them

Before
![Screenshot 2019-03-13 at 7 35 14 PM](https://user-images.githubusercontent.com/8528887/54285063-36b2b280-45c7-11e9-8307-4da2f5921b27.png)

After
![Screenshot 2019-03-13 at 7 34 37 PM](https://user-images.githubusercontent.com/8528887/54285068-3a463980-45c7-11e9-8cf1-0a1b43c8267c.png)

