### PR TITLE
feat(response): force download html or xml private files

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -191,7 +191,13 @@ def send_private_file(path):
 		response = Response(wrap_file(frappe.local.request.environ, f), direct_passthrough=True)
 
 	# no need for content disposition and force download. let browser handle its opening.
-	# response.headers.add(b'Content-Disposition', b'attachment', filename=filename.encode("utf-8"))
+	# Except for those that can be injected with scripts.
+
+	extension = os.path.splitext(path)[1]
+	blacklist = ['.svg', '.html', '.htm', '.xml']
+
+	if extension.lower() in blacklist:
+		response.headers.add(b'Content-Disposition', b'attachment', filename=filename.encode("utf-8"))
 
 	response.mimetype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
 


### PR DESCRIPTION
- [ ] Production PR in Bench
- [ ] Also for Public files?

### Previewing files
Contaminated files aren't a problem when previewed as they are sandboxed:
<img width="1168" alt="Screenshot 2019-03-14 at 8 44 43 AM" src="https://user-images.githubusercontent.com/5196925/54329107-5fbe5c00-4636-11e9-8ea8-b5c7defa1048.png">


### Fetching files
So this PR handles them for the case they are fetched, in the response:

![svg_browseer](https://user-images.githubusercontent.com/5196925/54329166-909e9100-4636-11e9-870a-e07e34907fbd.gif)
