### PR TITLE
fix: Don't escape traceback

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -274,8 +274,7 @@ def errprint(msg):
 	if not request or (not "cmd" in local.form_dict) or conf.developer_mode:
 		print(msg)
 
-	from .utils import escape_html
-	error_log.append({"exc": escape_html(msg), "locals": get_frame_locals()})
+	error_log.append({"exc": msg, "locals": get_frame_locals()})
 
 def log(msg):
 	"""Add to `debug_log`.

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -77,7 +77,7 @@ def render_template(template, context, is_path=None, safe_render=True):
 		try:
 			return get_jenv().from_string(template).render(context)
 		except TemplateError:
-			throw(title="Jinja Template Error", msg="<pre>{template}</pre><pre>{tb}</pre>".format(template=template, tb=escape_html(get_traceback())))
+			throw(title="Jinja Template Error", msg="<pre>{template}</pre><pre>{tb}</pre>".format(template=template, tb=get_traceback()))
 
 
 def get_allowed_functions_for_jenv():


### PR DESCRIPTION
Traceback breaks when there is a python object <frappe.model.Document>.
This is occasional, and other tracebacks are not clean, so reverting.