### PR TITLE
fix(rollup): endsWith check for .js and .vue files

### DIFF
--- a/rollup/watch.js
+++ b/rollup/watch.js
@@ -32,7 +32,7 @@ function watch_assets() {
 
 			case 'BUNDLE_START': {
 				const output = event.output[0];
-				if (output.endsWith('.js', '.vue')) {
+				if (output.endsWith('.js') || output.endsWith('.vue')) {
 					log('Rebuilding', path.basename(event.output[0]));
 				}
 				break;


### PR DESCRIPTION
JS files didn't pass the endsWith check and were not logged in console.