### PR TITLE
fix(request): Pop data from form_dict when it isn't needed

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -53,6 +53,7 @@ def handle():
 
 	if call=="method":
 		frappe.local.form_dict.cmd = doctype
+		frappe.local.form_dict.pop("data", None)
 		return frappe.handler.handle()
 
 	elif call=="resource":


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/6926 Clicking "Expand all" on "Chart of Accounts" shows following errors.
![Screenshot 2019-03-13 at 7 53 39 PM](https://user-images.githubusercontent.com/8528887/54286398-cc4f4180-45c9-11e9-8d80-fae5b1a720e6.png)


```python-traceback
Traceback (most recent call last):
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/__init__.py", line 1026, in call
    return fn(*args, **newargs)
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/desk/treeview.py", line 20, in get_all_nodes
    data = tree_method(doctype, parent, **filters)
TypeError: get_children() got an unexpected keyword argument 'data'
```