### PR TITLE
fix: display js rebuilding logs in bench watch

### DIFF
--- a/rollup/watch.js
+++ b/rollup/watch.js
@@ -32,7 +32,7 @@ function watch_assets() {
 
 			case 'BUNDLE_START': {
 				const output = event.output[0];
-				if (output.endsWith('.js', '.vue')) {
+				if (output.endsWith('.js') || output.endsWith('.vue')) {
 					log('Rebuilding', path.basename(event.output[0]));
 				}
 				break;


### PR DESCRIPTION
Earlier logs were not showing js build
![Screenshot 2019-03-14 at 2 31 29 PM](https://user-images.githubusercontent.com/14824451/54345496-2f43e580-4669-11e9-9121-0985e79a76c3.png)
displays logs
![Screenshot 2019-03-14 at 2 32 32 PM](https://user-images.githubusercontent.com/14824451/54345502-310da900-4669-11e9-97f6-1d68ed2a534b.png)
