### PR TITLE
fix(desk): Pop data from keyword arguments when it isn't needed

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -12,6 +12,8 @@ def get_all_nodes(doctype, parent, tree_method, **filters):
 	if 'cmd' in filters:
 		del filters['cmd']
 
+	filters.pop('data', None)
+
 	tree_method = frappe.get_attr(tree_method)
 
 	if not tree_method in frappe.whitelisted:


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/6926 Clicking "Expand all" on tree views, e.g. 'Account', 'Cost Center', 'Warehouse' etc. shows following error.
![Screenshot 2019-03-13 at 7 53 39 PM](https://user-images.githubusercontent.com/8528887/54286398-cc4f4180-45c9-11e9-8d80-fae5b1a720e6.png)


```python-traceback
Traceback (most recent call last):
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/__init__.py", line 1026, in call
    return fn(*args, **newargs)
  File "/Users/aditya/Frappe/frappe/apps/frappe/frappe/desk/treeview.py", line 20, in get_all_nodes
    data = tree_method(doctype, parent, **filters)
TypeError: get_children() got an unexpected keyword argument 'data'
```