### PR TITLE
fix: moduleview force routing to /List

### DIFF
--- a/frappe/public/js/frappe/views/components/utils.js
+++ b/frappe/public/js/frappe/views/components/utils.js
@@ -13,7 +13,7 @@ function generate_route(item) {
 				if (item.filters) {
 					frappe.route_options=item.filters;
 				}
-				route="List/" + item.doctype;
+				route="List/" + item.doctype + "/List";
 			}
 		} else if(item.type==="report" && item.is_query_report) {
 			route="query-report/" + item.name;


### PR DESCRIPTION
Moduleview routes items to either /Report or /List depending on last used route. This fix forces the route generation to always point to /List if not set /Report explicitly.