### PR TITLE
feat: Flip sitemap switch

### DIFF
--- a/frappe/templates/pages/integrations/braintree_checkout.py
+++ b/frappe/templates/pages/integrations/braintree_checkout.py
@@ -8,7 +8,6 @@ import json
 from frappe.integrations.doctype.braintree_settings.braintree_settings import get_client_token, get_gateway_controller
 
 no_cache = 1
-no_sitemap = 1
 
 expected_keys = ('amount', 'title', 'description', 'reference_doctype', 'reference_docname',
 	'payer_name', 'payer_email', 'order_id', 'currency')

--- a/frappe/templates/pages/integrations/razorpay_checkout.py
+++ b/frappe/templates/pages/integrations/razorpay_checkout.py
@@ -8,7 +8,6 @@ import json
 from six import string_types
 
 no_cache = 1
-no_sitemap = 1
 
 expected_keys = ('amount', 'title', 'description', 'reference_doctype', 'reference_docname',
 	'payer_name', 'payer_email', 'order_id')

--- a/frappe/templates/pages/integrations/stripe_checkout.py
+++ b/frappe/templates/pages/integrations/stripe_checkout.py
@@ -8,7 +8,6 @@ import json
 from frappe.integrations.doctype.stripe_settings.stripe_settings import get_gateway_controller
 
 no_cache = 1
-no_sitemap = 1
 
 expected_keys = ('amount', 'title', 'description', 'reference_doctype', 'reference_docname',
 	'payer_name', 'payer_email', 'order_id', 'currency')

--- a/frappe/tests/test_sitemap.py
+++ b/frappe/tests/test_sitemap.py
@@ -4,8 +4,9 @@ import frappe, unittest
 from frappe.tests.test_website import get_html_for_route
 
 class TestSitemap(unittest.TestCase):
-	def test_page_load(self):
+	def test_sitemap(self):
+		blogs = frappe.db.get_all('Blog Post', {'published': 1}, ['route'], limit=1)
 		xml = get_html_for_route('sitemap.xml')
 		self.assertTrue('/about</loc>' in xml)
 		self.assertTrue('/contact</loc>' in xml)
-		self.assertTrue('/blog/general</loc>' in xml)
+		self.assertTrue(blogs[0].route in xml)

--- a/frappe/tests/test_sitemap.py
+++ b/frappe/tests/test_sitemap.py
@@ -1,0 +1,11 @@
+from __future__ import unicode_literals
+
+import frappe, unittest
+from frappe.tests.test_website import get_html_for_route
+
+class TestSitemap(unittest.TestCase):
+	def test_page_load(self):
+		xml = get_html_for_route('sitemap.xml')
+		self.assertTrue('/about</loc>' in xml)
+		self.assertTrue('/contact</loc>' in xml)
+		self.assertTrue('/blog/general</loc>' in xml)

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -7,7 +7,6 @@ from frappe.utils.pdf import get_pdf,cleanup
 from PyPDF2 import PdfFileWriter
 
 no_cache = 1
-no_sitemap = 1
 
 base_template_path = "templates/www/printview.html"
 standard_format = "templates/print_formats/standard.html"

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -38,7 +38,7 @@ def update_controller_context(context, controller):
 
 	if module:
 		# get config fields
-		for prop in ("base_template_path", "template", "no_cache", "no_sitemap",
+		for prop in ("base_template_path", "template", "no_cache", "sitemap",
 			"condition_field"):
 			if hasattr(module, prop):
 				context[prop] = getattr(module, prop)
@@ -89,7 +89,7 @@ def build_context(context):
 			if ret:
 				context.update(ret)
 
-		for prop in ("no_cache", "no_sitemap"):
+		for prop in ("no_cache", "sitemap"):
 			if not prop in context:
 				context[prop] = getattr(context.doc, prop, False)
 

--- a/frappe/www/404.py
+++ b/frappe/www/404.py
@@ -2,4 +2,3 @@
 # MIT License. See license.txt
 from __future__ import unicode_literals
 
-no_sitemap = 1

--- a/frappe/www/about.py
+++ b/frappe/www/about.py
@@ -4,6 +4,8 @@
 from __future__ import unicode_literals
 import frappe
 
+sitemap = 1
+
 def get_context(context):
 	context.doc = frappe.get_doc("About Us Settings", "About Us Settings")
 

--- a/frappe/www/complete_signup.py
+++ b/frappe/www/complete_signup.py
@@ -3,4 +3,3 @@
 
 from __future__ import unicode_literals
 
-no_sitemap = 1

--- a/frappe/www/contact.py
+++ b/frappe/www/contact.py
@@ -7,6 +7,8 @@ import frappe
 from frappe.utils import now
 from frappe import _
 
+sitemap = 1
+
 def get_context(context):
 	doc = frappe.get_doc("Contact Us Settings", "Contact Us Settings")
 

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -3,7 +3,6 @@
 
 from __future__ import unicode_literals, print_function
 
-no_sitemap = 1
 no_cache = 1
 base_template_path = "templates/www/desk.html"
 

--- a/frappe/www/error.py
+++ b/frappe/www/error.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals, print_function
 import frappe
 
 no_cache = 1
-no_sitemap = 1
 
 def get_context(context):
 	if frappe.flags.in_migrate: return

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -9,7 +9,6 @@ from frappe.model.document import get_controller, Document
 from frappe import _
 
 no_cache = 1
-no_sitemap = 1
 
 def get_context(context, **dict_params):
 	"""Returns context for a list standard list page.

--- a/frappe/www/me.py
+++ b/frappe/www/me.py
@@ -7,7 +7,6 @@ from frappe import _
 import frappe.www.list
 
 no_cache = 1
-no_sitemap = 1
 
 def get_context(context):
 	if frappe.session.user=='Guest':

--- a/frappe/www/message.py
+++ b/frappe/www/message.py
@@ -7,7 +7,6 @@ import frappe
 from frappe.utils import strip_html_tags
 
 no_cache = 1
-no_sitemap = 1
 
 def get_context(context):
 	message_context = {}

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -11,7 +11,6 @@ from frappe.utils import cint, strip_html
 from six import string_types
 
 no_cache = 1
-no_sitemap = 1
 
 base_template_path = "templates/www/printview.html"
 standard_format = "templates/print_formats/standard.html"

--- a/frappe/www/profile.py
+++ b/frappe/www/profile.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 
 no_cache = 1
-no_sitemap = 1
 
 def get_context(context):
 	context.show_sidebar=True

--- a/frappe/www/robots.py
+++ b/frappe/www/robots.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import frappe
 
-no_sitemap = 1
 base_template_path = "templates/www/robots.txt"
 
 def get_context(context):

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -11,7 +11,6 @@ from six import iteritems
 from six.moves.urllib.parse import quote, urljoin
 
 no_cache = 1
-no_sitemap = 1
 base_template_path = "templates/www/sitemap.xml"
 
 def get_context(context):

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -3,6 +3,8 @@
 
 from __future__ import unicode_literals
 
+import frappe
+from frappe.model.document import get_controller
 from frappe.utils import get_request_site_address, get_datetime, nowdate
 from frappe.website.router import get_pages, get_all_page_context_from_doctypes
 from six import iteritems
@@ -17,16 +19,39 @@ def get_context(context):
 	host = get_request_site_address()
 	links = []
 	for route, page in iteritems(get_pages()):
-		if not page.no_sitemap:
+		if page.sitemap:
 			links.append({
 				"loc": urljoin(host, quote(page.name.encode("utf-8"))),
 				"lastmod": nowdate()
 			})
 
-	for route, data in iteritems(get_all_page_context_from_doctypes()):
+	for route, data in iteritems(get_public_pages_from_doctypes()):
 		links.append({
 			"loc": urljoin(host, quote((route or "").encode("utf-8"))),
 			"lastmod": get_datetime(data.get("modified")).strftime("%Y-%m-%d")
 		})
 
 	return {"links":links}
+
+def get_public_pages_from_doctypes():
+	'''Returns pages from doctypes that are publicly accessible'''
+	routes = {}
+	doctypes_with_web_view = [d.name for d in frappe.db.get_all('DocType', {
+		'has_web_view': 1,
+		'allow_guest_to_view': 1
+	})]
+
+	for doctype in doctypes_with_web_view:
+		controller = get_controller(doctype)
+		meta = frappe.get_meta(doctype)
+		condition_field = meta.is_published_field or controller.website.condition_field
+
+		try:
+			res = frappe.db.get_all(doctype, ['route', 'name', 'modified'], { condition_field: 1 })
+			for r in res:
+				routes[r.route] = {"doctype": doctype, "name": r.name, "modified": r.modified}
+
+		except Exception as e:
+			if not frappe.db.is_missing_column(e): raise e
+
+	return routes

--- a/frappe/www/sitemap.xml
+++ b/frappe/www/sitemap.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-	{% for link in links %}<url><loc>{{ link.loc }}</loc><lastmod>{{ link.lastmod }}</lastmod></url>
+	{% for link in links %}
+	<url>
+		<loc>{{ link.loc }}</loc>
+		<lastmod>{{ link.lastmod }}</lastmod>
+	</url>
 	{% endfor %}
 </urlset>

--- a/frappe/www/third_party_apps.py
+++ b/frappe/www/third_party_apps.py
@@ -4,7 +4,6 @@ from frappe import _
 import frappe.www.list
 
 no_cache = 1
-no_sitemap = 1
 
 def get_context(context):
 	if frappe.session.user == 'Guest':

--- a/frappe/www/update_password.py
+++ b/frappe/www/update_password.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from frappe import _
 
-no_sitemap = 1
 no_cache = 1
 
 def get_context(context):

--- a/frappe/www/website_script.py
+++ b/frappe/www/website_script.py
@@ -6,7 +6,6 @@ import frappe
 from frappe.utils import strip
 from frappe.website.doctype.website_theme.website_theme import get_active_theme
 
-no_sitemap = 1
 base_template_path = "templates/www/website_script.js"
 
 def get_context(context):


### PR DESCRIPTION
BREAKING CHANGE
A route is added to the sitemap if no_sitemap is not set. This PR reverses this design. Because sitemap should contain publicly accessible pages and not utility pages. Also, having lots of utility pages on sitemap does more harm than good.

Reference: https://moz.com/blog/xml-sitemaps

Before:
![image](https://user-images.githubusercontent.com/9355208/54595893-9393ea00-4a59-11e9-9947-ac6599caa3ef.png)

After:
![image](https://user-images.githubusercontent.com/9355208/54595853-7c54fc80-4a59-11e9-8f16-4b180fb76b68.png)
