### PR TITLE
fix: Variable bleed in response

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -106,7 +106,8 @@ def make_logs(response = None):
 
 	if frappe.error_log:
 		response['exc'] = json.dumps([frappe.utils.cstr(d["exc"]) for d in frappe.local.error_log])
-		response['locals'] = json.dumps([frappe.utils.cstr(d["locals"]) for d in frappe.local.error_log])
+		if frappe.conf.developer_mode:
+			response['locals'] = json.dumps([frappe.utils.cstr(d["locals"]) for d in frappe.local.error_log])
 
 	if frappe.local.message_log:
 		response['_server_messages'] = json.dumps([frappe.utils.cstr(d) for


### PR DESCRIPTION
Capturing local variables in response, this is an awesome feature, but in bad hands this can be deadly. This should not be available on production machine.