### PR TITLE
bug: extra indentation "validate_email_address"

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -80,7 +80,7 @@ def validate_email_add(email_str, throw=False):
 	"""
 	return validate_email_address(email_str, throw=False)
 
- def validate_email_address(email_str, throw=False):
+def validate_email_address(email_str, throw=False):
 	"""Validates the email string"""
 	email = email_str = (email_str or "").strip()
 


### PR DESCRIPTION
An extra space of indentation broke this python file.  All I've done is backspaced to fix it.