### PR TITLE
fix: Dont append request data to form_dict

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -57,8 +57,6 @@ def application(request):
 			response = frappe.handler.handle()
 
 		elif frappe.request.path.startswith("/api/"):
-			if frappe.local.form_dict.data is None:
-					frappe.local.form_dict.data = request.get_data()
 			response = frappe.api.handle()
 
 		elif frappe.request.path.startswith('/backups'):


### PR DESCRIPTION
This breaks many whitelisted methods which do not expect a data arg, and also the methods which expect an optional data arg but the value is not passed.

Examples:
frappe.desk.reportview.get
frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs