### PR TITLE
fix: Reload doctype in patch

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -237,4 +237,4 @@ frappe.patches.v11_0.set_default_letter_head_source
 frappe.patches.v12_0.setup_comments_from_communications
 frappe.patches.v12_0.init_desk_settings #11-03-2019
 frappe.patches.v12_0.replace_null_values_in_tables
-frappe.patches.v12_0.remove_deprecated_fields_from_doctype
+frappe.patches.v12_0.remove_deprecated_fields_from_doctype #1

--- a/frappe/patches/v12_0/remove_deprecated_fields_from_doctype.py
+++ b/frappe/patches/v12_0/remove_deprecated_fields_from_doctype.py
@@ -1,6 +1,7 @@
 import frappe
 
 def execute():
+	frappe.reload_doc('core', 'doctype', 'doctype')
 	frappe.db.sql('''
 		ALTER TABLE tabDocType
 		DROP COLUMN IF EXISTS hide_heading,


### PR DESCRIPTION
Reload doctype in remove_deprecated_fields patch, so that patches in other apps have the updated columns. This fixes failing patch test in ERPNext.