### PR TITLE
Enhancements: (for link field) it'll allow user to process raw awesomplete results(json format)

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -229,6 +229,13 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				item.action.apply(me);
 			}
 
+			// If user need to process result values including decsription
+			// then they can process it by defining process_result function
+			// while creating custom link field
+			if(me.df.process_result && typeof(me.df.process_result==='function')){ 
+				me.df.process_result(item); 
+			}
+
 			// if remember_last_selected is checked in the doctype against the field,
 			// then add this value
 			// to defaults so you do not need to set it again


### PR DESCRIPTION
Using this feature user can easily update the other fields values in same page.

For Instange:
We've custom query for batch number in POS(batch_id, sum(actual_qty) as qty, warehouse) which return three fields(batch_id, actual_qty, warehouse from `Stock Ledger Entry` table).
Batch ID(first field) will be the value for link field, but if user also need other two fields (actual_qty and warehouse) then user can call process_result function on link field and can manipulate.

Example:
We've added batch field in POS which fetch batches from all the  warehouse(using **IN** operator in sql rather than **=**).
```
 this.batch_field = frappe.ui.form.make_control({
                                        df: {
                                                fieldtype: 'Link',
                                                label: ''",
                                                fieldname: 'batch',
                                                options: 'Batch',
                                                reqd: 1,
                                                only_select: true,
                                                process_result: function(result){
                                                        var warehouse = result.description.split(", ")[1];
                                                        frappe.model.set_value(item.doctype, item.name, "warehouse", warehouse);
                                                },
                                               get_query: function() {
                                                        return {
                                                                filters: {
                                                                        item: item.item_code,
                                                                        warehouse: [frappe.boot.erp.company_setting.default_warehouse,
                                                                                frappe.boot.erp.company_setting.blox_warehouse]
                                                                },
                                                                query: 'erp.controllers.queries.get_batch_number'
                                                   }
                                         },
                                        parent: $item2.find('.'+item.item_code+'.batch-no'),
                                        render_input: true
                             });
```
On selection of batch number we have to update the warehouse also. So that's why we need to process the complete results include warehouse also.(Otherwise user have to send another request to check the warehouse for selected batch).
![screen-batch](https://user-images.githubusercontent.com/30634335/54876343-c35f3b00-4e27-11e9-8f14-82ad8bf5843e.png)



