### PR TITLE
fix(tests): Show test duration if it exceeds SLOW_TEST_THRESHOLD

### DIFF
--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -17,6 +17,7 @@ from six.moves import reload_module
 from frappe.model.naming import revert_series_if_last
 
 unittest_runner = unittest.TextTestRunner
+SLOW_TEST_THRESHOLD = 2
 
 def xmlrunner_wrapper(output):
 	"""Convenience wrapper to keep method signature unchanged for XMLTestRunner and TextTestRunner"""
@@ -100,7 +101,8 @@ class TimeLoggingTestResult(unittest.TextTestResult):
 	def addSuccess(self, test):
 		elapsed = time.time() - self._started_at
 		name = self.getDescription(test)
-		self.stream.write("\n{} ({:.03}s)\n".format(name, elapsed))
+		if elapsed >= SLOW_TEST_THRESHOLD:
+			self.stream.write("\n{} ({:.03}s)\n".format(name, elapsed))
 		super(TimeLoggingTestResult, self).addSuccess(test)
 
 


### PR DESCRIPTION
Show following in travis logs

```shell
..........................................................
test_authenticate_for_2factor (frappe.tests.test_twofactor.TestTwoFactor)
Verification obj and tmp_id should be set in frappe.local. (2.92s)
.
test_bypass_restict_ip (frappe.tests.test_twofactor.TestTwoFactor) (7.02s)
.
```

instead of

```shell
test_record_without_sql_queries (frappe.tests.test_recorder.TestRecorder) (0.00295s)
.
test_start (frappe.tests.test_recorder.TestRecorder) (0.0023s)
.
test_delete (frappe.tests.test_client.TestClient) (0.0823s)
.
test_set_value (frappe.tests.test_client.TestClient) (0.0973s)
.
test_authenticate_for_2factor (frappe.tests.test_twofactor.TestTwoFactor)
Verification obj and tmp_id should be set in frappe.local. (2.8s)
.
test_bypass_restict_ip (frappe.tests.test_twofactor.TestTwoFactor) (6.96s)
```