### PR TITLE
fix: convert name of documents to string

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -898,7 +898,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	get_checked_items(only_docnames) {
 		const docnames = Array.from(this.$checks || [])
-			.map(check => $(check).data().name);
+			.map(check => cstr($(check).data().name));
 
 		if (only_docnames) return docnames;
 


### PR DESCRIPTION
`get_checked_items` used to skip documents with numerical names because of mismatch in type.

**Before**
<img width="1440" alt="Screenshot 2019-03-25 at 4 49 25 PM" src="https://user-images.githubusercontent.com/13928957/54915822-0e5b7a00-4f1e-11e9-843c-b48d21e7c205.png">

**After**
<img width="1367" alt="Screenshot 2019-03-25 at 4 48 17 PM" src="https://user-images.githubusercontent.com/13928957/54915891-3814a100-4f1e-11e9-9a4a-e0837fef0372.png">


