### PR TITLE
fix(integrations): complete file-api migration of GSuite Templates

### DIFF
--- a/frappe/integrations/doctype/gsuite_templates/gsuite_templates.py
+++ b/frappe/integrations/doctype/gsuite_templates/gsuite_templates.py
@@ -22,11 +22,11 @@ def create_gsuite_doc(doctype, docname, gs_template=None):
 	json_data = doc.as_dict()
 	filename = templ.document_name.format(**json_data)
 
-	r = run_gsuite_script('new', filename, templ.template_id, templ.destination_id, json_data)
+	response = run_gsuite_script('new', filename, templ.template_id, templ.destination_id, json_data)
 
 	_file = frappe.get_doc({
 		"doctype": "File",
-		"file_url": r['url'],
+		"file_url": response['url'],
 		"file_name": filename,
 		"attached_to_doctype": doctype,
 		"attached_to_name": docname,
@@ -36,15 +36,15 @@ def create_gsuite_doc(doctype, docname, gs_template=None):
 
 	comment = frappe.get_doc(doctype, docname).add_comment("Attachment",
 		_("added {0}").format("<a href='{file_url}' target='_blank'>{file_name}</a>{icon}".format(**{
-			"icon": ' <i class="fa fa-lock text-warning"></i>' if filedata.is_private else "",
-			"file_url": filedata.file_url.replace("#", "%23") if filedata.file_name else filedata.file_url,
-			"file_name": filedata.file_name or filedata.file_url
+			"icon": ' <i class="fa fa-lock text-warning"></i>' if _file.is_private else "",
+			"file_url": _file.file_url.replace("#", "%23") if _file.file_name else _file.file_url,
+			"file_name": _file.file_name or _file.file_url
 		})))
 
 	return {
-		"name": filedata.name,
-		"file_name": filedata.file_name,
-		"file_url": filedata.file_url,
-		"is_private": filedata.is_private,
+		"name": _file.name,
+		"file_name": _file.file_name,
+		"file_url": _file.file_url,
+		"is_private": _file.is_private,
 		"comment": comment.as_dict() if comment else {}
 		}


### PR DESCRIPTION
### Problem
* GSuite Templates were migrated to the new file-api in #6055
* The variable `filedata` was changed to `_file` in one place only. 
* This resulted in `filedata` being undefined.

### Solution
* This commit changes `filedata` to `_file` in the rest of the function, so that `filedata` will no longer be undefined.