### PR TITLE
fix: Allow fetching doc fields data in API

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -362,9 +362,10 @@ def attach_file(filename=None, filedata=None, doctype=None, docname=None, folder
 def check_parent_permission(parent, child_doctype):
 	if parent:
 		# User may pass fake parent and get the information from the child table
-		if child_doctype and not frappe.db.exists('DocField',
-			{'parent': parent, 'options': child_doctype}):
-			raise frappe.PermissionError
+		if child_doctype and child_doctype != 'DocField':
+			if not frappe.db.exists('DocField',
+				{'parent': parent, 'options': child_doctype}):
+				raise frappe.PermissionError
 
 		if frappe.permissions.has_permission(parent):
 			return


### PR DESCRIPTION
Hi,

The following PR: https://github.com/frappe/frappe/pull/6509 has added additional validations for child tables, but without taking into consideration the possibility to query the DocField child table to get the metadata linked to a particular DocType.

This PR excludes the DocField child table since the user should be able to fetch the fields corresponding to a DocType for which he/she has the correct rights.

Query example: get_list(doctype="DocField", parent="Contact", fields=["*"], filters={"parent": "Contact"}, limit_page_length=500)