### PR TITLE
fix: Google calendar connexion + data migration tool

### DIFF
--- a/frappe/data_migration/doctype/data_migration_run/data_migration_run.py
+++ b/frappe/data_migration/doctype/data_migration_run/data_migration_run.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe, json, math
 from frappe.model.document import Document
 from frappe import _
-from frappe.utils import get_source_value
+from frappe.utils import get_source_value, cstr
 
 class DataMigrationRun(Document):
 	def run(self):
@@ -213,19 +213,19 @@ class DataMigrationRun(Document):
 	def get_deleted_local_data(self):
 		'''Fetch local deleted data using `frappe.get_all`. Used during Push'''
 		mapping = self.get_mapping(self.current_mapping)
-		or_filters = self.get_or_filters(mapping)
-		filters = dict(
-			deleted_doctype=mapping.local_doctype
-		)
+		filters = self.get_last_modified_condition()
+		filters.update({
+			"deleted_doctype": mapping.local_doctype
+		})
 
-		data = frappe.get_all('Deleted Document', fields=['data'],
-			filters=filters, or_filters=or_filters)
+		data = frappe.get_all('Deleted Document', fields=['name', 'data'],
+			filters=filters)
 
 		_data = []
 		for d in data:
 			doc = json.loads(d.data)
 			if doc.get(mapping.migration_id_field):
-				doc['_deleted_document_name'] = d.name
+				doc['_deleted_document_name'] = d["name"]
 				_data.append(doc)
 
 		return _data
@@ -306,8 +306,8 @@ class DataMigrationRun(Document):
 				self.update_log('push_insert', 1)
 				# post process after insert
 				self.post_process_doc(local_doc=d, remote_doc=response_doc)
-			except Exception:
-				self.update_log('push_failed', d.name)
+			except Exception as e:
+				self.update_log('push_failed', {d.name: cstr(e)})
 
 		# update page_start
 		self.db_set('current_mapping_start',
@@ -338,8 +338,8 @@ class DataMigrationRun(Document):
 				self.update_log('push_update', 1)
 				# post process after update
 				self.post_process_doc(local_doc=d, remote_doc=response_doc)
-			except Exception:
-				self.update_log('push_failed', d.name)
+			except Exception as e:
+				self.update_log('push_failed', {d.name: cstr(e)})
 
 		# update page_start
 		self.db_set('current_mapping_start',
@@ -370,8 +370,8 @@ class DataMigrationRun(Document):
 				self.update_log('push_delete', 1)
 				# post process only when action is success
 				self.post_process_doc(local_doc=d, remote_doc=response_doc)
-			except Exception:
-				self.update_log('push_failed', d.name)
+			except Exception as e:
+				self.update_log('push_failed', {d.name: cstr(e)})
 
 		# update page_start
 		self.db_set('current_mapping_start',
@@ -414,7 +414,7 @@ class DataMigrationRun(Document):
 					self.post_process_doc(remote_doc=d, local_doc=local_doc)
 				except Exception:
 					# failed, append to log
-					self.update_log('pull_failed', migration_id_value)
+					self.update_log('push_failed', {migration_id_value: cstr(e)})
 
 		if len(data) < mapping.page_length:
 			# last page, done with pull

--- a/frappe/data_migration/doctype/data_migration_run/data_migration_run.py
+++ b/frappe/data_migration/doctype/data_migration_run/data_migration_run.py
@@ -414,7 +414,7 @@ class DataMigrationRun(Document):
 					self.post_process_doc(remote_doc=d, local_doc=local_doc)
 				except Exception:
 					# failed, append to log
-					self.update_log('push_failed', {migration_id_value: cstr(e)})
+					self.update_log('pull_failed', {migration_id_value: cstr(e)})
 
 		if len(data) < mapping.page_length:
 			# last page, done with pull

--- a/frappe/integrations/data_migration_mapping/event_to_gcalendar/event_to_gcalendar.json
+++ b/frappe/integrations/data_migration_mapping/event_to_gcalendar/event_to_gcalendar.json
@@ -35,6 +35,51 @@
   }, 
   {
    "is_child_table": 0, 
+   "local_fieldname": "repeat_on", 
+   "remote_fieldname": "repeat_on"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "repeat_till", 
+   "remote_fieldname": "repeat_till"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "monday", 
+   "remote_fieldname": "monday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "tuesday", 
+   "remote_fieldname": "tuesday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "wednesday", 
+   "remote_fieldname": "wednesday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "thursday", 
+   "remote_fieldname": "thursday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "friday", 
+   "remote_fieldname": "friday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "saturday", 
+   "remote_fieldname": "saturday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "sunday", 
+   "remote_fieldname": "sunday"
+  }, 
+  {
+   "is_child_table": 0, 
    "local_fieldname": "name", 
    "remote_fieldname": "name"
   }
@@ -45,8 +90,8 @@
  "mapping_name": "Event to GCalendar", 
  "mapping_type": "Push", 
  "migration_id_field": "gcalendar_sync_id", 
- "modified": "2018-05-18 14:38:43.658069", 
- "modified_by": "chdecultot@dokos.io", 
+ "modified": "2019-03-26 10:16:45.400150", 
+ "modified_by": "Administrator", 
  "name": "Event to GCalendar", 
  "owner": "Administrator", 
  "page_length": 10, 

--- a/frappe/integrations/data_migration_mapping/gcalendar_to_event/gcalendar_to_event.json
+++ b/frappe/integrations/data_migration_mapping/gcalendar_to_event/gcalendar_to_event.json
@@ -35,6 +35,51 @@
   }, 
   {
    "is_child_table": 0, 
+   "local_fieldname": "repeat_on", 
+   "remote_fieldname": "repeat_on"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "repeat_till", 
+   "remote_fieldname": "repeat_till"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "monday", 
+   "remote_fieldname": "monday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "tuesday", 
+   "remote_fieldname": "tuesday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "wednesday", 
+   "remote_fieldname": "wednesday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "thursday", 
+   "remote_fieldname": "thursday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "friday", 
+   "remote_fieldname": "friday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "saturday", 
+   "remote_fieldname": "saturday"
+  }, 
+  {
+   "is_child_table": 0, 
+   "local_fieldname": "sunday", 
+   "remote_fieldname": "sunday"
+  }, 
+  {
+   "is_child_table": 0, 
    "local_fieldname": "gcalendar_sync_id", 
    "remote_fieldname": "id"
   }, 
@@ -50,8 +95,8 @@
  "mapping_name": "GCalendar to Event", 
  "mapping_type": "Pull", 
  "migration_id_field": "gcalendar_sync_id", 
- "modified": "2018-05-18 14:38:43.694867", 
- "modified_by": "chdecultot@dokos.io", 
+ "modified": "2019-03-26 10:16:45.426138", 
+ "modified_by": "Administrator", 
  "name": "GCalendar to Event", 
  "owner": "Administrator", 
  "page_length": 250, 

--- a/frappe/integrations/data_migration_plan/gcalendar_sync/gcalendar_sync.json
+++ b/frappe/integrations/data_migration_plan/gcalendar_sync/gcalendar_sync.json
@@ -2,7 +2,7 @@
  "creation": "2018-03-23 19:10:23.715161", 
  "docstatus": 0, 
  "doctype": "Data Migration Plan", 
- "idx": 4, 
+ "idx": 22, 
  "mappings": [
   {
    "enabled": 1, 
@@ -13,8 +13,8 @@
    "mapping": "GCalendar to Event"
   }
  ], 
- "modified": "2018-05-18 14:38:43.559026", 
- "modified_by": "chdecultot@dokos.io", 
+ "modified": "2019-03-26 10:16:45.369037", 
+ "modified_by": "Administrator", 
  "module": "Integrations", 
  "name": "GCalendar Sync", 
  "owner": "Administrator", 


### PR DESCRIPTION
Hi,

This PR aims at correcting some of the issues described in https://github.com/frappe/frappe/issues/7002.

1. The connector no longer filters events based on the current timestamp and sends all available Events to Google Calendar.

2. If the repetition happens on certain days only, the mapping of the days in rrule has been corrected

3. Additional fields have been added in the data migration mapping to handle repetition properly.

4. The filter to fetch deleted documents in the data migration tool didn't work correctly and was incorrect. I have changed it to only fetch recently modified deleted documents of a particular DocType. It should avoid the deletion action to go into a loop.

5. I have added the exception message in the error log of the data migration run to obtain additional information regarding the failure for each document