### PR TITLE
fix(comment): allow both `sender` and `comment_email` to render a comment

### DIFF
--- a/frappe/templates/includes/comments/comment.html
+++ b/frappe/templates/includes/comments/comment.html
@@ -1,8 +1,8 @@
 {% from "frappe/templates/includes/macros.html" import square_image_with_fallback %}
 
 <div class="comment-row media">
-	{{ square_image_with_fallback(src=frappe.get_gravatar(comment.comment_email), size='48px', alt=comment.sender_full_name, class='align-self-start mr-3') }}
-	<div class="media-body">
+    {{ square_image_with_fallback(src=frappe.get_gravatar(comment.comment_email or comment.sender), size='48px', alt=comment.sender_full_name, class='align-self-start mr-3') }}
+    <div class="media-body">
         <div class="d-flex justify-content-between align-items-start">
             <span class="font-weight-bold text-muted">
                 {{ comment.sender_full_name }}
@@ -11,8 +11,8 @@
                 {{ comment.creation | global_date_format }}
             </span>
         </div>
-		<div class="text-muted">
+        <div class="text-muted">
             {{ comment.content | markdown }}
         </div>
-	</div>
+    </div>
 </div>


### PR DESCRIPTION
Reported by a user while trying to give feedback:

<img width="1025" alt="Screenshot 2019-03-26 at 6 50 36 PM" src="https://user-images.githubusercontent.com/5196925/55000265-2d2e3f00-4ff8-11e9-8bac-b5601a0f682a.png">


### Replication ...

![Screenshot 2019-03-26 at 6 48 03 PM](https://user-images.githubusercontent.com/5196925/55000287-38816a80-4ff8-11e9-8445-0b42fcd38c48.png)

### ... and Fix
<img width="548" alt="Screenshot 2019-03-26 at 6 46 36 PM" src="https://user-images.githubusercontent.com/5196925/55000290-3a4b2e00-4ff8-11e9-9f70-530859588ea5.png">
