### PR TITLE
fix(set_chart): Don't truncate null labels

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -493,10 +493,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			const type = chart_type.toLowerCase();
 			const colors = color ? [color] : undefined;
 
-			let labels = get_column_values(x_field)
-				.filter(Boolean)
-				.map(d => d.trim())
-				.filter(Boolean);
+			let labels = get_column_values(x_field);
 
 			let dataset_values = get_column_values(y_field).map(d => Number(d));
 


### PR DESCRIPTION
Fixes the following scenario: errored offsets

<img width="1241" alt="lvfkLGD" src="https://user-images.githubusercontent.com/5196925/55077332-7f856380-50bd-11e9-8c1d-34b247597c32.png">
