### PR TITLE
fix: Dont escape tracebacks in errprint

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -274,8 +274,7 @@ def errprint(msg):
 	if not request or (not "cmd" in local.form_dict) or conf.developer_mode:
 		print(msg.encode('utf-8'))
 
-	from .utils import escape_html
-	error_log.append({"exc": escape_html(msg), "locals": get_frame_locals()})
+	error_log.append({"exc": msg, "locals": get_frame_locals()})
 
 def log(msg):
 	"""Add to `debug_log`.

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -60,7 +60,6 @@ def render_template(template, context, is_path=None, safe_render=True):
 	'''
 
 	from frappe import get_traceback, throw
-	from frappe.utils import escape_html
 	from jinja2 import TemplateError
 
 	if not template:
@@ -77,7 +76,7 @@ def render_template(template, context, is_path=None, safe_render=True):
 		try:
 			return get_jenv().from_string(template).render(context)
 		except TemplateError:
-			throw(title="Jinja Template Error", msg="<pre>{template}</pre><pre>{tb}</pre>".format(template=template, tb=escape_html(get_traceback())))
+			throw(title="Jinja Template Error", msg="<pre>{template}</pre><pre>{tb}</pre>".format(template=template, tb=get_traceback()))
 
 
 def get_allowed_functions_for_jenv():


### PR DESCRIPTION
Because they become unreadable:

![image](https://user-images.githubusercontent.com/9355208/55146682-0e9c8500-516b-11e9-840e-0b77ab169d14.png)
