### PR TITLE
fix: Unable to save doctype even with route field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -158,10 +158,8 @@ class DocType(Document):
 
 	def validate_website(self):
 		"""Ensure that website generator has field 'route'"""
-		if self.has_web_view:
-			# route field must be present
-			if not 'route' in [d.fieldname for d in self.fields]:
-				frappe.throw(_('Field "route" is mandatory for Web Views'), title='Missing Field')
+		if self.has_web_view and (not self.route):
+			frappe.throw(_('Field "route" is mandatory for Web Views'), title='Missing Field')
 
 			# clear website cache
 			frappe.website.render.clear_cache()


### PR DESCRIPTION
A validation missing route field is shown even when route filed is provided
![Screenshot 2019-03-28 at 3 03 18 PM](https://user-images.githubusercontent.com/42651287/55149025-676e1c80-516f-11e9-98ee-56d041ba918a.png)