### PR TITLE
fix: No need to fetch complete user list to get two usernames

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -136,8 +136,8 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 	# Search for email address in description -- i.e. assignee
 	from frappe.utils import get_link_to_form
 	assignment = get_link_to_form(doc_type, doc_name, label="%s: %s" % (doc_type, doc_name))
-	owner_name = frappe.get_cached_value('User', owner, 'fullname')
-	user_name = frappe.get_cached_value('User', frappe.session.user, 'fullname')
+	owner_name = frappe.get_cached_value('User', owner, 'full_name')
+	user_name = frappe.get_cached_value('User', frappe.session.user, 'full_name')
 	if action=='CLOSE':
 		if owner == frappe.session.get('user'):
 			arg = {

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -133,14 +133,11 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 	if assigned_by==owner:
 		return
 
-	from frappe.boot import get_fullnames
-	user_info = get_fullnames()
-
 	# Search for email address in description -- i.e. assignee
 	from frappe.utils import get_link_to_form
 	assignment = get_link_to_form(doc_type, doc_name, label="%s: %s" % (doc_type, doc_name))
-	owner_name = user_info.get(owner, {}).get('fullname')
-	user_name = user_info.get(frappe.session.get('user'), {}).get('fullname')
+	owner_name = frappe.get_cached_value('User', owner, 'fullname')
+	user_name = frappe.get_cached_value('User', frappe.session.user, 'fullname')
 	if action=='CLOSE':
 		if owner == frappe.session.get('user'):
 			arg = {


### PR DESCRIPTION
notify_assignment function was using get_fullnames, which basically fetches all the details from User table. This is arbitrarily long, and a call that will slow down as data size increases. 

Replaced it with get cached value instead.