### PR TITLE
fix: Add reference_doctype and reference_name to the to send_workflow_action_email function

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -187,8 +187,8 @@ def send_workflow_action_email(users_data, doc):
 				'actions': d.get('possible_actions'),
 				'message': message
 			},
-			"reference_name":doc.name,
-			"reference_doctype":doc.doctype
+			'reference_name': doc.name,
+			'reference_doctype': doc.doctype
 		}
 		email_args.update(common_args)
 		enqueue(method=frappe.sendmail, queue='short', **email_args)

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -187,6 +187,8 @@ def send_workflow_action_email(users_data, doc):
 				'actions': d.get('possible_actions'),
 				'message': message
 			},
+			"reference_name":doc.name,
+			"reference_doctype":doc.doctype
 		}
 		email_args.update(common_args)
 		enqueue(method=frappe.sendmail, queue='short', **email_args)


### PR DESCRIPTION
Add reference_doctype and reference_name to the to send_workflow_action_email function as it necessary to keep track from which document the email will be sent