### PR TITLE
fix: Preserve state in query report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -92,7 +92,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.load_report();
 		} else {
 			// same report
-			this.refresh_report();
+			// don't do anything to preserve state
+			// like filters and datatable column widths
 		}
 	}
 


### PR DESCRIPTION
After navigating back to a query report, the filters were setup again,
we can skip that and do nothing to preserve state.

![query-report-filters](https://user-images.githubusercontent.com/9355208/55306327-79063b80-5471-11e9-981a-9461488fdd19.gif)
