### PR TITLE
fix(permission): use .get to avoid key error

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -28,7 +28,7 @@ def print_has_permission_check_logs(func):
 		# print only if access denied
 		# and if user is checking his own permission
 		if not result and self_perm_check:
-			msgprint(('<br>').join(frappe.flags['has_permission_check_logs']))
+			msgprint(('<br>').join(frappe.flags.get('has_permission_check_logs')))
 		frappe.flags.pop('has_permission_check_logs', None)
 		return result
 	return inner


### PR DESCRIPTION
Fix permission log by using .get method to avoid key error

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/rq/worker.py", line 793, in perform_job
    rv = job.perform()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/rq/job.py", line 599, in perform
    self._result = self._execute()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/rq/job.py", line 605, in _execute
    return self.func(*self.args, **self.kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 41, in run_background
    create_json_gz_file(result['result'], 'Prepared Report', instance.name)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 70, in create_json_gz_file
    _file.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 210, in insert
    self.check_permission("create")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 171, in check_permission
    if not self.has_permission(permtype):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 181, in has_permission
    return frappe.has_permission(self.doctype, permtype, self, verbose=verbose)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 576, in has_permission
    out = frappe.permissions.has_permission(doctype, ptype, doc=doc, verbose=verbose, user=user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 31, in inner
    msgprint(('<br>').join(frappe.flags['has_permission_check_logs']))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/werkzeug/local.py", line 377, in <lambda>
    __getitem__ = lambda x, i: x._get_current_object()[i]
KeyError: u'has_permission_check_logs'
```