### PR TITLE
fix: Export parent fields while exporting fixtures

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -71,7 +71,7 @@ def import_file_by_path(path, ignore_links=False, overwrite=False, submit=False,
 
 def export_json(doctype, path, filters=None, or_filters=None, name=None, order_by="creation asc"):
 	def post_process(out):
-		del_keys = ('parent', 'parentfield', 'parenttype', 'modified_by', 'creation', 'owner', 'idx')
+		del_keys = ('modified_by', 'creation', 'owner', 'idx')
 		for doc in out:
 			for key in del_keys:
 				if key in doc:


### PR DESCRIPTION
- To allow the export of doctypes like "Custom DocPerm"  which needs parent fields.
