### PR TITLE
Fix for print format builder in languages other than english

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -771,6 +771,12 @@ frappe.PrintFormatBuilder = Class.extend({
 						df.fieldtype = "HTML";
 						df.options = $($this.find(".html-content")[0]).data('content');
 					}
+					
+					if($this.attr("data-reptext")){
+						this.innerText = $this.attr("data-reptext");
+						alert($this.attr("data-reptext"));
+					}
+					
 					data.push(df);
 				});
 			});

--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -2,7 +2,7 @@
     {% if(field.print_hide) { %}style="background-color: #F7FAFC; color: #8D99A6;"
         title="{{ __("Hidden") }}"{% } %}
     data-fieldname="{%= field.fieldname %}"
-    data-label="{{ __(field.label) }}"
+    data-label="{{ (field.label) }}"
 
 	{% if field.align %}data-align="{{ field.align }}"{% endif %}
     data-fieldtype="{%= field.fieldtype %}"
@@ -25,7 +25,7 @@
 				data-custom-html-id={{ field.custom_html_id }}{% endif %}>
 			{{ field.options || me.get_no_content() }}</div>
     {% } else { %}
-        <span class="field-label">{{ __(field.label) }}</span>
+        <span class="field-label" data-reptext="{{ (field.label) }}">{{ __(field.label) }}</span>
         {% if(field.fieldtype==="Table") { %}
             <span> ({%= __("Table") %})</span>
             <a class="pull-right select-columns btn btn-default btn-xs">


### PR DESCRIPTION
Added attribute "data-reptext" to all fields which holds the original english text needed for auto translation.
Data is shown in the user-language but on save the text will be set to the text stored in "data-reptext".
