### PR TITLE
fix: hide empy categories in Desktop

### DIFF
--- a/frappe/public/js/frappe/views/components/Desktop.vue
+++ b/frappe/public/js/frappe/views/components/Desktop.vue
@@ -12,7 +12,7 @@
 				{{ __('Show / Hide Cards') }}
 			</a>
 			<desk-section
-				v-if="get_modules_for_category(category)"
+				v-if="get_modules_for_category(category).length"
 				:category="category"
 				:modules="get_modules_for_category(category)"
 				@update_home_settings="hs => update_modules_with_home_settings(hs)"


### PR DESCRIPTION
Fix broken conditional rendering for `desk-section` component.

Before:
![before](https://user-images.githubusercontent.com/24732036/55593148-7fcbd180-5743-11e9-9ce4-a988cd6a71c6.png)

After:
![after](https://user-images.githubusercontent.com/24732036/55593152-84908580-5743-11e9-9271-f5413dbe82e8.png)
