### PR TITLE
fix: Social login in Python3

### DIFF
--- a/frappe/integrations/oauth2_logins.py
+++ b/frappe/integrations/oauth2_logins.py
@@ -2,14 +2,16 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
+
 import frappe
 import frappe.utils
-from frappe.utils.oauth import login_via_oauth2, login_via_oauth2_id_token
-import json
+from frappe.utils.oauth import (login_via_oauth2, login_via_oauth2_id_token,
+                                oauth_decoder)
+
 
 @frappe.whitelist(allow_guest=True)
 def login_via_google(code, state):
-	login_via_oauth2("google", code, state, decoder=json.loads)
+	login_via_oauth2("google", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_github(code, state):
@@ -17,20 +19,20 @@ def login_via_github(code, state):
 
 @frappe.whitelist(allow_guest=True)
 def login_via_facebook(code, state):
-	login_via_oauth2("facebook", code, state, decoder=json.loads)
+	login_via_oauth2("facebook", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_frappe(code, state):
-	login_via_oauth2("frappe", code, state, decoder=json.loads)
+	login_via_oauth2("frappe", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_office365(code, state):
-	login_via_oauth2_id_token("office_365", code, state, decoder=json.loads)
+	login_via_oauth2_id_token("office_365", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_salesforce(code, state):
-	login_via_oauth2("salesforce", code, state, decoder=json.loads)
+	login_via_oauth2("salesforce", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_fairlogin(code, state):
-	login_via_oauth2("fairlogin", code, state, decoder=json.loads)
+	login_via_oauth2("fairlogin", code, state, decoder=oauth_decoder)

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -270,7 +270,7 @@ def update_oauth_user(user, data, provider):
 	elif provider=="fairlogin" and not user.get_social_login_userid(provider):
 		save = True
 		user.set_social_login_userid(provider, userid=data["preferred_username"])
-	
+
 	if save:
 		user.flags.ignore_permissions = True
 		user.flags.no_welcome_mail = True
@@ -291,3 +291,8 @@ def redirect_post_login(desk_user):
 
 	# the #desktop is added to prevent a facebook redirect bug
 	frappe.local.response["location"] = "/desk#desktop" if desk_user else "/"
+
+def oauth_decoder(data):
+	if isinstance(data, bytes):
+		data = data.decode("utf-8")
+	return json.loads(data)

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 import frappe.utils
-from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys, login_via_oauth2, login_via_oauth2_id_token, login_oauth_user as _login_oauth_user, redirect_post_login
+from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys, login_via_oauth2, login_via_oauth2_id_token, login_oauth_user as _login_oauth_user, redirect_post_login, oauth_decoder
 import json
 from frappe import _
 from frappe.auth import LoginManager
@@ -56,7 +56,7 @@ def get_context(context):
 
 @frappe.whitelist(allow_guest=True)
 def login_via_google(code, state):
-	login_via_oauth2("google", code, state, decoder=json.loads)
+	login_via_oauth2("google", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_github(code, state):
@@ -64,15 +64,15 @@ def login_via_github(code, state):
 
 @frappe.whitelist(allow_guest=True)
 def login_via_facebook(code, state):
-	login_via_oauth2("facebook", code, state, decoder=json.loads)
+	login_via_oauth2("facebook", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_frappe(code, state):
-	login_via_oauth2("frappe", code, state, decoder=json.loads)
+	login_via_oauth2("frappe", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_via_office365(code, state):
-	login_via_oauth2_id_token("office_365", code, state, decoder=json.loads)
+	login_via_oauth2_id_token("office_365", code, state, decoder=oauth_decoder)
 
 @frappe.whitelist(allow_guest=True)
 def login_oauth_user(data=None, provider=None, state=None, email_id=None, key=None, generate_login_token=False):


### PR DESCRIPTION
In Pyhton3, requests response content is in bytes type. So decoder
have to handle both `str` and `bytes` to make it compatible with
both python 2 and 3

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.

fixes issue #7209

