### PR TITLE
fix: hide empty categories in Show / Hide Cards dialog

### DIFF
--- a/frappe/public/js/frappe/views/components/Desktop.vue
+++ b/frappe/public/js/frappe/views/components/Desktop.vue
@@ -107,7 +107,7 @@ export default {
 			});
 			const d = new frappe.ui.Dialog({
 				title: __('Show / Hide Cards'),
-				fields,
+				fields: fields.filter(f => f.options.length > 0),
 				primary_action_label: __('Save'),
 				primary_action: (values) => {
 					let all_modules = this.modules.map(m => m.module_name);


### PR DESCRIPTION
Hide empty categories in Desktop 'Show / Hide Cards' dialog.

Before:
![before](https://user-images.githubusercontent.com/24732036/55641784-670cfb80-57d7-11e9-96ad-ad8837229373.png)

After:
![after](https://user-images.githubusercontent.com/24732036/55641798-71c79080-57d7-11e9-9729-e399ead16c69.png)
