### PR TITLE
feat: Add frappe cmd and doctype to request headers for analytics and load balancing

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -197,7 +197,7 @@ frappe.request.call = function(opts) {
 		headers: Object.assign({
 			"X-Frappe-CSRF-Token": frappe.csrf_token,
 			"Accept": "application/json",
-			"X-Frappe-CMD": (opts.args && opts.args.cmd  || '') || ''
+			"X-Frappe-CMD": opts.get('args', {}).get('cmd', '')
 		}, opts.headers),
 		cache: false
 	};

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -196,10 +196,15 @@ frappe.request.call = function(opts) {
 		async: opts.async,
 		headers: Object.assign({
 			"X-Frappe-CSRF-Token": frappe.csrf_token,
-			"Accept": "application/json"
+			"Accept": "application/json",
+			"X-Frappe-CMD": (opts.args && opts.args.cmd  || '') || ''
 		}, opts.headers),
 		cache: false
 	};
+
+	if (opts.args && opts.args.doctype) {
+		ajax_args.headers["X-Frappe-Doctype"] = opts.args.doctype;
+	}
 
 	frappe.last_request = ajax_args.data;
 


### PR DESCRIPTION
Frappe CMD and Doctype details are deep inside the POSTed HTTP body. If brought at the HTTP header level would help in more powerful load balancing at the webserver level and also in logging. 

e.g. following snippet in nginx config allows routing based on http header to different backend ERPNext servers - 

```
map $http_x_frappe_cmd $backend_server {
  "frappe.desk.reportview.export_query" replica-first;
  "frappe.desk.reportview.get_sidebar_stats" replica-first;
  "frappe.desk.reportview.get" replica-first;
  "frappe.desk.query_report.run" replica-first;
  "frappe.model.db_query.get_list" replica-first;
  "frappe.client.get_count" replica-first;
  "frappe.desk.notifications.get_open_count" replica-first;
  "frappe.utils.print_format.download_multi_pdf" quarantine;
}

upstream primary-first {
  server wra01.ntex.com;
}

upstream replica-first {
  server wra01.ntex.com;
  server wra02.ntex.com;
  server wra03.ntex.com;
  server backup-wra.ntex.com backup;
}

upstream quarantine {
  server wra03.ntex.com;
  server backup-wra.ntex.com backup;
}


location / {
    if ( $backend_server ) {
      add_header x-served-from $backend_server;
      proxy_pass http://$backend_Server;
      break;
    }

    add_header x-served-from "master";
    proxy_pass http://primary-first;

  }

```
