### PR TITLE
fix: Add salutation to contact display 😁

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -102,7 +102,7 @@ def get_contact_details(contact):
 	out = {
 		"contact_person": contact.get("name"),
 		"contact_display": " ".join(filter(None,
-			[contact.get("first_name"), contact.get("last_name")])),
+			[contact.get("salutation"), contact.get("first_name"), contact.get("last_name")])),
 		"contact_email": contact.get("email_id"),
 		"contact_mobile": contact.get("mobile_no"),
 		"contact_phone": contact.get("phone"),


### PR DESCRIPTION
Currently, the salutation added in Contact is not referenced when fetching a contact's name on documents where the contact is displayed (like Quotation, Orders, etc, in ERPNext)

**Before/Salutation left blank**:

![image](https://user-images.githubusercontent.com/33246109/55783490-26a9c800-5acc-11e9-8d61-4a7bfffd7f05.png)

**If Salutation added**

![image](https://user-images.githubusercontent.com/33246109/55783584-5f49a180-5acc-11e9-9a88-38f8e7c6fa64.png)

**Contact view in Customer**

![image](https://user-images.githubusercontent.com/33246109/55783671-90c26d00-5acc-11e9-973f-295ed2e6069d.png)


