### PR TITLE
fix: query delete_duplicate_custom_fields

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -282,12 +282,12 @@ class DocType(Document):
 			return
 
 		fields = [d.fieldname for d in self.fields if d.fieldtype in data_fieldtypes]
-
-		frappe.db.sql('''delete from
+		if fields:
+			frappe.db.sql('''delete from
 				`tabCustom Field`
-			where
-				 dt = {0} and fieldname in ({1})
-		'''.format('%s', ', '.join(['%s'] * len(fields))), tuple([self.name] + fields), as_dict=True)
+				where
+				dt = {0} and fieldname in ({1})
+				'''.format('%s', ', '.join(['%s'] * len(fields))), tuple([self.name] + fields), as_dict=True)
 
 	def sync_global_search(self):
 		'''If global search settings are changed, rebuild search properties for this table'''


### PR DESCRIPTION
Problem during migrate:
<img width="922" alt="Screen Shot 2019-04-09 at 5 32 13 PM" src="https://user-images.githubusercontent.com/16913064/55799050-17d40d00-5aee-11e9-8923-1a3fb9398d8a.png">

Issue occurs when there are no duplicate fields to delete and in where clause it appears empty throwing sql error. `('Website Route Meta',)`

Fix:
Check if duplicate fields are there or not.