### PR TITLE
fix: Get all ancestors

### DIFF
--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -260,7 +260,7 @@ def get_ancestors_of(doctype, name, order_by="lft desc", limit=None):
 	"""Get ancestor elements of a DocType with a tree structure"""
 	lft, rgt = frappe.db.get_value(doctype, name, ["lft", "rgt"])
 
-	result = [d["name"] for d in frappe.db.get_list(doctype, {"lft": ["<", lft], "rgt": [">", rgt]},
+	result = [d["name"] for d in frappe.db.get_all(doctype, {"lft": ["<", lft], "rgt": [">", rgt]},
 		"name", order_by=order_by, limit_page_length=limit)]
 
 	return result or []


### PR DESCRIPTION
When a file is uploaded by Guest, the folder size needs to be updated, which breaks because get_ancestors uses `get_list`.

![image](https://user-images.githubusercontent.com/9355208/55872079-b6717400-5ba9-11e9-8477-6d4fd1729181.png)
