### PR TITLE
fix: showing doctype name where required in error message.

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -550,7 +550,7 @@ def validate_fields(meta):
 
 		if getattr(d, "unique", False):
 			if d.fieldtype not in ("Data", "Link", "Read Only"):
-				frappe.throw(_("[{0}]Fieldtype {1} for {2} cannot be unique").format(self.name, d.fieldtype, d.label))
+				frappe.throw(_("[{0}]: Fieldtype {1} for {2} cannot be unique").format(self.name, d.fieldtype, d.label))
 
 			if not d.get("__islocal"):
 				try:
@@ -570,7 +570,7 @@ def validate_fields(meta):
 				else:
 					# else of try block
 					if has_non_unique_values and has_non_unique_values[0][0]:
-						frappe.throw(_("[{0}]Field '{1}' cannot be set as Unique as it has non-unique values").format(self.name, d.label))
+						frappe.throw(_("[{0}]: Field '{1}' cannot be set as Unique as it has non-unique values").format(self.name, d.label))
 
 		if d.search_index and d.fieldtype in ("Text", "Long Text", "Small Text", "Code", "Text Editor"):
 			frappe.throw(_("Fieldtype {0} for {1} cannot be indexed").format(d.fieldtype, d.label))

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -483,27 +483,27 @@ def validate_fields(meta):
 	def check_unique_fieldname(fieldname):
 		duplicates = list(filter(None, map(lambda df: df.fieldname==fieldname and str(df.idx) or None, fields)))
 		if len(duplicates) > 1:
-			frappe.throw(_("[{0}]: Fieldname {1} appears multiple times in rows {2}").format(self.name, fieldname, ", ".join(duplicates)))
+			frappe.throw(_("{0}: Fieldname {1} appears multiple times in rows {2}").format(self.name, fieldname, ", ".join(duplicates)))
 
 	def check_fieldname_length(fieldname):
 		validate_column_length(fieldname)
 
 	def check_illegal_mandatory(d):
 		if (d.fieldtype in no_value_fields) and d.fieldtype!="Table" and d.reqd:
-			frappe.throw(_("[{0}]: Field {1} of type {2} cannot be mandatory").format(self.name, d.label, d.fieldtype))
+			frappe.throw(_("{0}: Field {1} of type {2} cannot be mandatory").format(self.name, d.label, d.fieldtype))
 
 	def check_link_table_options(d):
 		if d.fieldtype in ("Link", "Table"):
 			if not d.options:
-				frappe.throw(_("[{0}]: Options required for Link or Table type field {1} in row {2}").format(self.name, d.label, d.idx))
+				frappe.throw(_("{0}: Options required for Link or Table type field {1} in row {2}").format(self.name, d.label, d.idx))
 			if d.options=="[Select]" or d.options==d.parent:
 				return
 			if d.options != d.parent:
 				options = frappe.db.get_value("DocType", d.options, "name")
 				if not options:
-					frappe.throw(_("[{0}]: Options must be a valid DocType for field {1} in row {2}").format(self.name, d.label, d.idx))
+					frappe.throw(_("{0}: Options must be a valid DocType for field {1} in row {2}").format(self.name, d.label, d.idx))
 				elif not (options == d.options):
-					frappe.throw(_("[{0}]: Options {1} must be the same as doctype name {2} for the field {3}")
+					frappe.throw(_("{0}: Options {1} must be the same as doctype name {2} for the field {3}")
 						.format(self.name, d.options, options, d.label))
 				else:
 					# fix case
@@ -511,7 +511,7 @@ def validate_fields(meta):
 
 	def check_hidden_and_mandatory(d):
 		if d.hidden and d.reqd and not d.default:
-			frappe.throw(_("[{0}]: Field {1} in row {2} cannot be hidden and mandatory without default").format(self.name, d.label, d.idx))
+			frappe.throw(_("{0}: Field {1} in row {2} cannot be hidden and mandatory without default").format(self.name, d.label, d.idx))
 
 	def check_width(d):
 		if d.fieldtype == "Currency" and cint(d.width) < 100:
@@ -550,7 +550,7 @@ def validate_fields(meta):
 
 		if getattr(d, "unique", False):
 			if d.fieldtype not in ("Data", "Link", "Read Only"):
-				frappe.throw(_("[{0}]: Fieldtype {1} for {2} cannot be unique").format(self.name, d.fieldtype, d.label))
+				frappe.throw(_("{0}: Fieldtype {1} for {2} cannot be unique").format(self.name, d.fieldtype, d.label))
 
 			if not d.get("__islocal"):
 				try:
@@ -570,7 +570,7 @@ def validate_fields(meta):
 				else:
 					# else of try block
 					if has_non_unique_values and has_non_unique_values[0][0]:
-						frappe.throw(_("[{0}]: Field '{1}' cannot be set as Unique as it has non-unique values").format(self.name, d.label))
+						frappe.throw(_("{0}: Field '{1}' cannot be set as Unique as it has non-unique values").format(self.name, d.label))
 
 		if d.search_index and d.fieldtype in ("Text", "Long Text", "Small Text", "Code", "Text Editor"):
 			frappe.throw(_("Fieldtype {0} for {1} cannot be indexed").format(d.fieldtype, d.label))

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -483,35 +483,35 @@ def validate_fields(meta):
 	def check_unique_fieldname(fieldname):
 		duplicates = list(filter(None, map(lambda df: df.fieldname==fieldname and str(df.idx) or None, fields)))
 		if len(duplicates) > 1:
-			frappe.throw(_("Fieldname {0} appears multiple times in rows {1}").format(fieldname, ", ".join(duplicates)))
+			frappe.throw(_("[{0}]: Fieldname {1} appears multiple times in rows {2}").format(self.name, fieldname, ", ".join(duplicates)))
 
 	def check_fieldname_length(fieldname):
 		validate_column_length(fieldname)
 
 	def check_illegal_mandatory(d):
 		if (d.fieldtype in no_value_fields) and d.fieldtype!="Table" and d.reqd:
-			frappe.throw(_("Field {0} of type {1} cannot be mandatory").format(d.label, d.fieldtype))
+			frappe.throw(_("[{0}]: Field {1} of type {2} cannot be mandatory").format(self.name, d.label, d.fieldtype))
 
 	def check_link_table_options(d):
 		if d.fieldtype in ("Link", "Table"):
 			if not d.options:
-				frappe.throw(_("Options required for Link or Table type field {0} in row {1}").format(d.label, d.idx))
+				frappe.throw(_("[{0}]: Options required for Link or Table type field {1} in row {2}").format(self.name, d.label, d.idx))
 			if d.options=="[Select]" or d.options==d.parent:
 				return
 			if d.options != d.parent:
 				options = frappe.db.get_value("DocType", d.options, "name")
 				if not options:
-					frappe.throw(_("Options must be a valid DocType for field {0} in row {1}").format(d.label, d.idx))
+					frappe.throw(_("[{0}]: Options must be a valid DocType for field {1} in row {2}").format(self.name, d.label, d.idx))
 				elif not (options == d.options):
-					frappe.throw(_("Options {0} must be the same as doctype name {1} for the field {2}")
-						.format(d.options, options, d.label))
+					frappe.throw(_("[{0}]: Options {1} must be the same as doctype name {2} for the field {3}")
+						.format(self.name, d.options, options, d.label))
 				else:
 					# fix case
 					d.options = options
 
 	def check_hidden_and_mandatory(d):
 		if d.hidden and d.reqd and not d.default:
-			frappe.throw(_("Field {0} in row {1} cannot be hidden and mandatory without default").format(d.label, d.idx))
+			frappe.throw(_("[{0}]: Field {1} in row {2} cannot be hidden and mandatory without default").format(self.name, d.label, d.idx))
 
 	def check_width(d):
 		if d.fieldtype == "Currency" and cint(d.width) < 100:
@@ -550,7 +550,7 @@ def validate_fields(meta):
 
 		if getattr(d, "unique", False):
 			if d.fieldtype not in ("Data", "Link", "Read Only"):
-				frappe.throw(_("Fieldtype {0} for {1} cannot be unique").format(d.fieldtype, d.label))
+				frappe.throw(_("[{0}]Fieldtype {1} for {2} cannot be unique").format(self.name, d.fieldtype, d.label))
 
 			if not d.get("__islocal"):
 				try:
@@ -570,7 +570,7 @@ def validate_fields(meta):
 				else:
 					# else of try block
 					if has_non_unique_values and has_non_unique_values[0][0]:
-						frappe.throw(_("Field '{0}' cannot be set as Unique as it has non-unique values").format(d.label))
+						frappe.throw(_("[{0}]Field '{1}' cannot be set as Unique as it has non-unique values").format(self.name, d.label))
 
 		if d.search_index and d.fieldtype in ("Text", "Long Text", "Small Text", "Code", "Text Editor"):
 			frappe.throw(_("Fieldtype {0} for {1} cannot be indexed").format(d.fieldtype, d.label))


### PR DESCRIPTION
For situations where we are setting any property of a DocType dynamically by using `property_setter`, if any error occurs, the dialog does not show which DocType has raised the error.

This PR fixes that by adding Docname right before the error message