### PR TITLE
fix(xlsx): Fix for handle failed html parse

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -66,7 +66,7 @@ def handle_html(data):
 		value = obj.handle(h)
 	except Exception:
 		# unable to parse html, send it raw
-		return value
+		return data
 
 	value = ", ".join(value.split('  \n'))
 	value = " ".join(value.split('\n'))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1030, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 258, in export_query
    xlsx_file = make_xlsx(xlsx_data, "Query Report")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/xlsxutils.py", line 29, in make_xlsx
    value = handle_html(item)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/xlsxutils.py", line 69, in handle_html
    return value
UnboundLocalError: local variable 'value' referenced before assignment
```