### PR TITLE
fix: Remove leaderboard link from desktop

### DIFF
--- a/frappe/config/desktop.py
+++ b/frappe/config/desktop.py
@@ -98,16 +98,5 @@ def get_data():
 			'standard': 1,
 			'idx': 15,
 			"description": "Build your profile and share posts with other users."
-		},
-		{
-			"module_name": 'leaderboard',
-			"category": "Places",
-			"label": _('Leaderboard'),
-			"icon": "octicon octicon-list-ordered",
-			"type": "link",
-			"link": "#social/users",
-			"color": '#FF4136',
-			'standard': 1,
-			'idx': 16
-		},
+		}
 	]

--- a/frappe/public/js/frappe/social/components/PostSidebar.vue
+++ b/frappe/public/js/frappe/social/components/PostSidebar.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex flex-column">
-		<a class="route-link"
+		<a class="leaderboard-link"
 			@click.prevent="go_to_user_list()">
 			{{ __('Leaderboard') }}
 		</a>
@@ -55,6 +55,10 @@ export default {
 .route-link {
 	margin: 0px 10px 10px 0;
 	text-transform: capitalize;
+}
+.leaderboard-link {
+	.route-link;
+	margin-bottom: 15px;
 }
 .stats {
 	min-height: 150px

--- a/frappe/public/less/social.less
+++ b/frappe/public/less/social.less
@@ -41,7 +41,7 @@ body[data-route*="social"] {
 			padding: 15px;
 			flex: 25%;
 			.event {
-				margin: 15px 0;
+				margin-bottom: 15px;
 			}
 		}
 	}
@@ -141,7 +141,7 @@ body[data-route*="social"] {
 
 	.muted-title {
 		&:extend(.text-muted);
-		margin-bottom: 15px;
+		margin-bottom: 10px;
 		text-transform: uppercase;
 		font-size: 10px;
 		font-weight: 600;


### PR DESCRIPTION
- Remove leaderboard link from desktop
- fix proximity between post sidebar links

**Before:** 
<img width="245" alt="Screenshot 2019-04-12 at 3 25 46 PM" src="https://user-images.githubusercontent.com/13928957/56029310-c028e200-5d37-11e9-9173-5e1a6ee73288.png">

**After:**
<img width="260" alt="Screenshot 2019-04-12 at 3 25 27 PM" src="https://user-images.githubusercontent.com/13928957/56029317-c454ff80-5d37-11e9-8eca-995ee021791e.png">

