### PR TITLE
fix: Hide Standard field since it is not editable

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -18,6 +18,7 @@ frappe.ui.form.on("Print Format", {
 			frm.set_intro(__("Please duplicate this to make changes"));
 		}
 		frm.trigger('render_buttons');
+		frm.toggle_display('standard', frappe.boot.developer_mode);
 	},
 	render_buttons: function(frm) {
 		frm.page.clear_inner_toolbar();


### PR DESCRIPTION
- Standard can only be set in developer mode

Before:
![image](https://user-images.githubusercontent.com/9355208/56060507-b1b4e780-5d84-11e9-9f99-660a9d97c0af.png)

After:
![image](https://user-images.githubusercontent.com/9355208/56060498-a6fa5280-5d84-11e9-8dd6-278edb98e84e.png)
