### PR TITLE
fix: Refresh query report if route options are passed

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -93,10 +93,16 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.toggle_nothing_to_show(true);
 			return;
 		}
+
 		if (this.report_name !== frappe.get_route()[1]) {
 			// this.toggle_loading(true);
 			// different report
 			this.load_report();
+		}
+		else if (frappe.route_options){
+			// filters passed through routes
+			// so refresh report again
+			this.refresh_report();
 		} else {
 			// same report
 			// don't do anything to preserve state


### PR DESCRIPTION
1. Select a customer, click through to the Accounting Ledger
2. Generate report - no problem - it is all correct
3. THEN, go into a different customer record, click through to the Accounting Ledger
4. As you can see, it is STILL selecting the previous customer - it has not updated the customer to the new customer from where the Accounting Ledger report was initiated

5. It is the same problem also if we are clicking through from the Account Tree ("View Ledger") or Supplier record ("View - Accounting Ledger") - it does not change the filter from the previously generated report.
![route options](https://user-images.githubusercontent.com/42651287/56082230-e7fd7000-5e33-11e9-8056-b2882d0082ff.gif)
