### PR TITLE
Expose Recipients in Notifications

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -146,6 +146,7 @@ def get_context(context):
 			reference_doctype = doc.doctype,
 			reference_name = doc.name,
 			attachments = attachments,
+			expose_recipients="header",
 			print_letterhead = ((attachments
 				and attachments[0].get('print_letterhead')) or False))
 


### PR DESCRIPTION
Hello,

is there any specific reason we do not expose recipients in Notifications? Prior to v11 (Email Alerts) we did neither.

Example:
We use cc in the recipients, and want to have it visible. 

bcc, however, should always be hidden. expose_recipients should handle that by default if I am not mistaking.

I am looking forward for opinions.

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.