### PR TITLE
feat(desk): Link preview popover

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -376,14 +376,16 @@ def check_parent_permission(parent, child_doctype):
 @frappe.whitelist()
 def get_preview_data(doctype, docname, fields):
 	fields = json.loads(fields)
+	if frappe.get_meta(doctype).has_field('image') : 
+		fields.append('image')
 	preview_data = frappe.cache().hget('preview_data', (doctype, docname))
-	print('abcde')
 	if preview_data == None:
-		print('nimu')
 		preview_data = frappe.get_all(doctype, filters={
 			'name': docname
 		}, fields=fields, limit=1)
-		if preview_data: preview_data = preview_data[0]
+		if preview_data: 
+			preview_data = preview_data[0]
+			preview_data = {k: v for k, v in preview_data.items() if v is not None}
 		frappe.cache().hset('preview_data', (doctype, docname), preview_data)
 
 	return preview_data

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -373,22 +373,3 @@ def check_parent_permission(parent, child_doctype):
 	# Either parent not passed or the user doesn't have permission on parent doctype of child table!
 	raise frappe.PermissionError
 
-@frappe.whitelist()
-def get_preview_data(doctype, docname, fields):
-	fields = json.loads(fields)
-	if frappe.get_meta(doctype).has_field('image') : 
-		fields.append('image')
-	preview_data = frappe.cache().hget('preview_data', (doctype, docname))
-	if preview_data == None:
-		preview_data = frappe.get_all(doctype, filters={
-			'name': docname
-		}, fields=fields, limit=1)
-		if preview_data: 
-			preview_data = preview_data[0]
-			preview_data = {k: v for k, v in preview_data.items() if v is not None}
-		frappe.cache().hset('preview_data', (doctype, docname), preview_data)
-
-	return preview_data
-
-def clear_preview_cache(doc, method):
-	frappe.cache().delete_value('preview_data', (doc.get('doctype', doc.get('name'))))

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -372,3 +372,21 @@ def check_parent_permission(parent, child_doctype):
 			return
 	# Either parent not passed or the user doesn't have permission on parent doctype of child table!
 	raise frappe.PermissionError
+
+@frappe.whitelist()
+def get_preview_data(doctype, docname, fields):
+	fields = json.loads(fields)
+	preview_data = frappe.cache().hget('preview_data', (doctype, docname))
+	print('abcde')
+	if preview_data == None:
+		print('nimu')
+		preview_data = frappe.get_all(doctype, filters={
+			'name': docname
+		}, fields=fields, limit=1)
+		if preview_data: preview_data = preview_data[0]
+		frappe.cache().hset('preview_data', (doctype, docname), preview_data)
+
+	return preview_data
+
+def clear_preview_cache(doc, method):
+	frappe.cache().delete_value('preview_data', (doc.get('doctype', doc.get('name'))))

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -63,10 +63,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Label",
    "length": 0,
@@ -104,21 +101,14 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Type",
    "length": 0,
    "no_copy": 0,
    "oldfieldname": "fieldtype",
    "oldfieldtype": "Select",
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRating\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
-=======
    "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
->>>>>>> Add preview popover on hover to all link fields
    "permlevel": 0,
    "print_hide": 0,
    "print_hide_if_no_value": 0,
@@ -147,10 +137,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Name",
    "length": 0,
@@ -185,10 +172,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Mandatory",
    "length": 0,
@@ -227,10 +211,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Precision",
    "length": 0,
@@ -265,10 +246,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Length",
    "length": 0,
@@ -302,10 +280,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Index",
    "length": 0,
@@ -342,10 +317,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In List View",
    "length": 0,
@@ -380,10 +352,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In Standard Filter",
    "length": 0,
@@ -418,10 +387,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In Global Search",
    "length": 0,
@@ -447,8 +413,6 @@
    "collapsible": 0,
    "columns": 0,
    "fetch_if_empty": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "fieldname": "in_preview",
    "fieldtype": "Check",
    "hidden": 0,
@@ -483,7 +447,6 @@
    "collapsible": 0,
    "columns": 0,
    "fetch_if_empty": 0,
->>>>>>> Add preview popover on hover to all link fields
    "fieldname": "allow_in_quick_entry",
    "fieldtype": "Check",
    "hidden": 0,
@@ -492,10 +455,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Allow in Quick Entry",
    "length": 0,
@@ -529,10 +489,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Bold",
    "length": 0,
@@ -568,10 +525,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Translatable",
    "length": 0,
@@ -606,10 +560,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Collapsible",
    "length": 255,
@@ -644,10 +595,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Collapsible Depends On",
    "length": 0,
@@ -682,10 +630,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -718,10 +663,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Options",
    "length": 0,
@@ -756,10 +698,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Default",
    "length": 0,
@@ -794,10 +733,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Fetch From",
    "length": 0,
@@ -832,10 +768,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Fetch If Empty",
    "length": 0,
@@ -869,10 +802,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Permissions",
    "length": 0,
@@ -905,10 +835,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Display Depends On",
    "length": 255,
@@ -944,10 +871,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Hidden",
    "length": 0,
@@ -984,10 +908,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Read Only",
    "length": 0,
@@ -1022,10 +943,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Unique",
    "length": 0,
@@ -1060,10 +978,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Set Only Once",
    "length": 0,
@@ -1097,10 +1012,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Allow Bulk Edit",
    "length": 0,
@@ -1134,10 +1046,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1170,10 +1079,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Perm Level",
    "length": 0,
@@ -1211,10 +1117,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Ignore User Permissions",
    "length": 0,
@@ -1248,10 +1151,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Allow on Submit",
    "length": 0,
@@ -1288,10 +1188,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Report Hide",
    "length": 0,
@@ -1329,10 +1226,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Remember Last Selected Value",
    "length": 0,
@@ -1367,10 +1261,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Ignore XSS Filter",
    "length": 0,
@@ -1404,10 +1295,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Display",
    "length": 0,
@@ -1440,10 +1328,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In Filter",
    "length": 0,
@@ -1480,10 +1365,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "No Copy",
    "length": 0,
@@ -1520,10 +1402,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Print Hide",
    "length": 0,
@@ -1561,10 +1440,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Print Hide If No Value",
    "length": 0,
@@ -1598,10 +1474,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Print Width",
    "length": 0,
@@ -1634,10 +1507,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Width",
    "length": 0,
@@ -1676,10 +1546,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Columns",
    "length": 0,
@@ -1713,10 +1580,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1748,10 +1612,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Description",
    "length": 0,
@@ -1788,10 +1649,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1825,10 +1683,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
-=======
    "in_preview": 0,
->>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1848,20 +1703,14 @@
   }
  ],
  "has_web_view": 0,
- "hide_heading": 0,
  "hide_toolbar": 0,
  "idx": 1,
- "image_view": 0,
  "in_create": 0,
  "is_submittable": 0,
  "issingle": 0,
  "istable": 1,
  "max_attachments": 0,
-<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
- "modified": "2019-03-18 17:59:57.873790",
-=======
- "modified": "2019-03-20 14:30:21.672655",
->>>>>>> Add preview popover on hover to all link fields
+ "modified": "2019-04-08 12:19:53.415372",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",
@@ -1869,7 +1718,6 @@
  "permissions": [],
  "quick_entry": 0,
  "read_only": 0,
- "read_only_onload": 0,
  "show_name_in_global_search": 0,
  "sort_order": "ASC",
  "track_changes": 0,

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -30,6 +30,7 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+   "in_preview": 0,
    "in_standard_filter": 0,
    "label": "",
    "length": 0,
@@ -62,6 +63,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Label",
    "length": 0,
@@ -99,13 +104,21 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Type",
    "length": 0,
    "no_copy": 0,
    "oldfieldname": "fieldtype",
    "oldfieldtype": "Select",
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
    "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRating\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
+=======
+   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
+>>>>>>> Add preview popover on hover to all link fields
    "permlevel": 0,
    "print_hide": 0,
    "print_hide_if_no_value": 0,
@@ -134,6 +147,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Name",
    "length": 0,
@@ -168,6 +185,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Mandatory",
    "length": 0,
@@ -206,6 +227,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Precision",
    "length": 0,
@@ -240,6 +265,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Length",
    "length": 0,
@@ -273,6 +302,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Index",
    "length": 0,
@@ -309,6 +342,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In List View",
    "length": 0,
@@ -343,6 +380,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In Standard Filter",
    "length": 0,
@@ -377,6 +418,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In Global Search",
    "length": 0,
@@ -402,6 +447,43 @@
    "collapsible": 0,
    "columns": 0,
    "fetch_if_empty": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "fieldname": "in_preview",
+   "fieldtype": "Check",
+   "hidden": 0,
+   "ignore_user_permissions": 0,
+   "ignore_xss_filter": 0,
+   "in_filter": 0,
+   "in_global_search": 0,
+   "in_list_view": 0,
+   "in_preview": 0,
+   "in_standard_filter": 0,
+   "label": "In Preview",
+   "length": 0,
+   "no_copy": 0,
+   "permlevel": 0,
+   "precision": "",
+   "print_hide": 0,
+   "print_hide_if_no_value": 0,
+   "read_only": 0,
+   "remember_last_selected_value": 0,
+   "report_hide": 0,
+   "reqd": 0,
+   "search_index": 0,
+   "set_only_once": 0,
+   "translatable": 0,
+   "unique": 0
+  },
+  {
+   "allow_bulk_edit": 0,
+   "allow_in_quick_entry": 0,
+   "allow_on_submit": 0,
+   "bold": 0,
+   "collapsible": 0,
+   "columns": 0,
+   "fetch_if_empty": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "fieldname": "allow_in_quick_entry",
    "fieldtype": "Check",
    "hidden": 0,
@@ -410,6 +492,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Allow in Quick Entry",
    "length": 0,
@@ -443,6 +529,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Bold",
    "length": 0,
@@ -478,6 +568,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Translatable",
    "length": 0,
@@ -512,6 +606,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Collapsible",
    "length": 255,
@@ -546,6 +644,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Collapsible Depends On",
    "length": 0,
@@ -580,6 +682,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -612,6 +718,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Options",
    "length": 0,
@@ -646,6 +756,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Default",
    "length": 0,
@@ -680,6 +794,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Fetch From",
    "length": 0,
@@ -714,6 +832,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Fetch If Empty",
    "length": 0,
@@ -747,6 +869,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Permissions",
    "length": 0,
@@ -779,6 +905,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Display Depends On",
    "length": 255,
@@ -814,6 +944,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Hidden",
    "length": 0,
@@ -850,6 +984,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Read Only",
    "length": 0,
@@ -884,6 +1022,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Unique",
    "length": 0,
@@ -918,6 +1060,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Set Only Once",
    "length": 0,
@@ -951,6 +1097,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Allow Bulk Edit",
    "length": 0,
@@ -984,6 +1134,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1016,6 +1170,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Perm Level",
    "length": 0,
@@ -1053,6 +1211,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Ignore User Permissions",
    "length": 0,
@@ -1086,6 +1248,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Allow on Submit",
    "length": 0,
@@ -1122,6 +1288,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Report Hide",
    "length": 0,
@@ -1159,6 +1329,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Remember Last Selected Value",
    "length": 0,
@@ -1193,6 +1367,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Ignore XSS Filter",
    "length": 0,
@@ -1226,6 +1404,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Display",
    "length": 0,
@@ -1258,6 +1440,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "In Filter",
    "length": 0,
@@ -1294,6 +1480,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "No Copy",
    "length": 0,
@@ -1330,6 +1520,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Print Hide",
    "length": 0,
@@ -1367,6 +1561,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Print Hide If No Value",
    "length": 0,
@@ -1400,6 +1598,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Print Width",
    "length": 0,
@@ -1432,6 +1634,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Width",
    "length": 0,
@@ -1470,6 +1676,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Columns",
    "length": 0,
@@ -1503,6 +1713,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1534,6 +1748,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 1,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "label": "Description",
    "length": 0,
@@ -1570,6 +1788,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1603,6 +1825,10 @@
    "in_filter": 0,
    "in_global_search": 0,
    "in_list_view": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
+=======
+   "in_preview": 0,
+>>>>>>> Add preview popover on hover to all link fields
    "in_standard_filter": 0,
    "length": 0,
    "no_copy": 0,
@@ -1631,7 +1857,11 @@
  "issingle": 0,
  "istable": 1,
  "max_attachments": 0,
+<<<<<<< bb1d5f7107c860375dcdf38e5aadebea7122c31e
  "modified": "2019-03-18 17:59:57.873790",
+=======
+ "modified": "2019-03-20 14:30:21.672655",
+>>>>>>> Add preview popover on hover to all link fields
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -49,6 +49,7 @@ CREATE TABLE `tabDocField` (
   `description` text,
   `in_list_view` int(1) NOT NULL DEFAULT 0,
   `in_standard_filter` int(1) NOT NULL DEFAULT 0,
+  `in_preview` int(1) NOT NULL DEFAULT 0,
   `read_only` int(1) NOT NULL DEFAULT 0,
   `precision` varchar(255) DEFAULT NULL,
   `length` int(11) NOT NULL DEFAULT 0,

--- a/frappe/database/postgres/framework_postgres.sql
+++ b/frappe/database/postgres/framework_postgres.sql
@@ -49,6 +49,7 @@ CREATE TABLE "tabDocField" (
   "description" text,
   "in_list_view" smallint NOT NULL DEFAULT 0,
   "in_standard_filter" smallint NOT NULL DEFAULT 0,
+  "in_preview" smallint NOT NULL DEFAULT 0,
   "read_only" smallint NOT NULL DEFAULT 0,
   "precision" varchar(255) DEFAULT NULL,
   "length" bigint NOT NULL DEFAULT 0,

--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -6,30 +6,24 @@ import json
 def get_preview_data(doctype, docname, fields):
 	fields = json.loads(fields)
 	preview_fields = [field['name'] for field in fields if field['type'] not in no_value_fields]
-	if 'title' not in fields and frappe.get_meta(doctype).has_field('title'):
-		preview_fields.append('title')
+	preview_fields.append(frappe.get_meta(doctype).get_title_field())
 	if 'name' not in fields:
 		preview_fields.append('name')
 	if frappe.get_meta(doctype).has_field('image'):
 		preview_fields.append('image')
 
-	preview_data = frappe.cache().hget('preview_data', (doctype, docname))
-	if preview_data == None:
-		preview_data = frappe.get_list(doctype, filters={
-			'name': docname
-		}, fields=preview_fields, limit=1)
-		if preview_data:
-			preview_data = preview_data[0]
+	preview_data = frappe.get_list(doctype, filters={
+		'name': docname
+	}, fields=preview_fields, limit=1)
+	if preview_data:
+		preview_data = preview_data[0]
 
-			preview_data = {k: v for k, v in preview_data.items() if v is not None}
-			for k,v in preview_data.items():
-				if frappe.get_meta(doctype).has_field(k):
-					preview_data[k] = frappe.format(v,frappe.get_meta(doctype).get_field(k).fieldtype)
+		preview_data = {k: v for k, v in preview_data.items() if v is not None}
+		for k,v in preview_data.items():
+			if frappe.get_meta(doctype).has_field(k):
+				preview_data[k] = frappe.format(v,frappe.get_meta(doctype).get_field(k).fieldtype)
 
-		frappe.cache().hset('preview_data', (doctype, docname), preview_data)
 	if not preview_data:
 		return None
 	return preview_data
 
-def clear_preview_cache(doc, method):
-	frappe.cache().delete_value('preview_data', (doc.get('doctype', doc.get('name'))))

--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -1,0 +1,35 @@
+import frappe
+from frappe.model import no_value_fields
+import json
+
+@frappe.whitelist()
+def get_preview_data(doctype, docname, fields):
+	fields = json.loads(fields)
+	preview_fields = [field['name'] for field in fields if field['type'] not in no_value_fields]
+	if 'title' not in fields and frappe.get_meta(doctype).has_field('title'):
+		preview_fields.append('title')
+	if 'name' not in fields:
+		preview_fields.append('name')
+	if frappe.get_meta(doctype).has_field('image'):
+		preview_fields.append('image')
+
+	preview_data = frappe.cache().hget('preview_data', (doctype, docname))
+	if preview_data == None:
+		preview_data = frappe.get_all(doctype, filters={
+			'name': docname
+		}, fields=preview_fields, limit=1)
+		if preview_data:
+			preview_data = preview_data[0]
+
+			preview_data = {k: v for k, v in preview_data.items() if v is not None}
+			for k,v in preview_data.items():
+				if frappe.get_meta(doctype).has_field(k):
+					preview_data[k] = frappe.format(v,frappe.get_meta(doctype).get_field(k).fieldtype)
+
+		frappe.cache().hset('preview_data', (doctype, docname), preview_data)
+	if not preview_data:
+		return None
+	return preview_data
+
+def clear_preview_cache(doc, method):
+	frappe.cache().delete_value('preview_data', (doc.get('doctype', doc.get('name'))))

--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -9,8 +9,7 @@ def get_preview_data(doctype, docname, fields):
 	preview_fields.append(frappe.get_meta(doctype).get_title_field())
 	if 'name' not in fields:
 		preview_fields.append('name')
-	if frappe.get_meta(doctype).has_field('image'):
-		preview_fields.append('image')
+	preview_fields.append(frappe.get_meta(doctype).image_field)
 
 	preview_data = frappe.get_list(doctype, filters={
 		'name': docname

--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -15,7 +15,7 @@ def get_preview_data(doctype, docname, fields):
 
 	preview_data = frappe.cache().hget('preview_data', (doctype, docname))
 	if preview_data == None:
-		preview_data = frappe.get_all(doctype, filters={
+		preview_data = frappe.get_list(doctype, filters={
 			'name': docname
 		}, fields=preview_fields, limit=1)
 		if preview_data:

--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -167,6 +167,7 @@
 		"public/js/frappe/ui/keyboard.js",
 		"public/js/frappe/ui/colors.js",
 		"public/js/frappe/ui/sidebar.js",
+		"public/js/frappe/ui/link_preview.js",
 
 		"public/js/frappe/request.js",
 		"public/js/frappe/socketio_client.js",

--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -123,6 +123,7 @@
 		"public/less/page.less",
 		"public/less/tree.less",
 		"public/less/desktop.less",
+		"public/less/link_preview.less",
 		"public/less/form.less",
 		"public/less/mobile.less",
 		"public/less/kanban.less",

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -124,7 +124,7 @@ frappe.Application = Class.extend({
 				}
 			}
 		}
-
+		this.link_preview = new frappe.ui.LinkPreview();
 	},
 
 	setup_frappe_vue() {

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -1,0 +1,123 @@
+frappe.provide('frappe.pages');
+
+frappe.ui.LinkPreview = class {
+
+    constructor() {
+        this.$links = [];
+        this.popover_timeout = null
+        this.get_links();
+    }
+
+    get_links() {
+        $(document.body).on('mouseover', 'a[href*="/"]', (e) => {
+            this.link_hovered = true;
+            let link = $(e.currentTarget).attr('href');
+            let link_arr = link.split('/');
+            const link_element = $(e.currentTarget);
+            let popover = link_element.data("bs.popover");
+            this.setup_popover_control(popover, link_arr, link_element);
+        });
+    }
+
+    setup_popover_control(popover, link_arr, $link) {
+        if(!popover) {
+            if(link_arr.length > 2) {
+                let name = decodeURI(link_arr[link_arr.length - 1]);
+                let doctype = decodeURI(link_arr[link_arr.length -2]);
+                let preview_fields = this.get_preview_fields(doctype);
+                if(preview_fields.length) {
+                    this.data_timeout = setTimeout(() => {
+                        this.get_preview_fields_value(doctype, name, preview_fields).then((preview_data)=> {
+                            if(preview_data) {
+                                if (this.popover_timeout) {
+                                    clearTimeout(this.popover_timeout)
+                                }
+                                this.popover_timeout = setTimeout(() => {
+                                    this.init_preview_popover($link, preview_data, doctype);
+                                }, 1000);
+                            }
+                        });
+                    }, 1000);
+                    
+                }
+            }
+        } else {
+            this.popover_timeout = setTimeout(() => {
+                popover.show();
+            }, 1000);
+        }
+
+        $(document.body).on('mouseout', 'a[href*="/"]', () => {
+            this.link_hovered = false;
+            if(this.data_timeout) {
+                clearTimeout(this.data_timeout)
+            }
+            if (this.popover_timeout) {
+                clearTimeout(this.popover_timeout)
+            }
+        })
+        $(document.body).on('mousemove', () => {
+            if (!this.link_hovered) {
+                this.$links.forEach($link => $link.popover('hide'));
+            }
+        })
+    }
+
+    get_preview_fields(dt) {
+        let fields = []
+        frappe.model.with_doctype(dt, () => { 
+            frappe.get_meta(dt).fields.filter((field) => {
+                if(field.in_preview) fields.push(field.fieldname);
+            })
+        });
+        return fields;
+    }
+
+    get_preview_fields_value(dt, field_name, field_list) {
+        return frappe.xcall('frappe.client.get_preview_data', {
+            'doctype': dt,
+            'docname': field_name,
+            'fields': field_list
+        });
+    }
+
+    init_preview_popover($link, preview_data, dt) {
+        console.log('create popover')
+        let content_html = '';
+        console.log('preview_data', preview_data);
+
+        Object.keys(preview_data).forEach(key => {
+            content_html += `
+                <p class="link-preview-field text-regular">
+                    <b> ${frappe.meta.get_label(dt, key)} </b>:  ${preview_data[key]} 
+                </p>
+            `;
+        })
+
+        $link.popover({
+            container: 'body',
+            html: true,
+            content: content_html,
+            trigger: 'manual',
+            animation: false
+            // delay: {'show':show_delay,'hide':hide_delay}
+        });
+        this.$links.push($link);
+        $link.popover('show');
+
+        // $link.data('bs.popover').options.content = content_html;
+        // $link.popover('show');
+        // setTimeout(() => {
+        //     $link.popover('show')
+        // }, 1000);
+
+    
+        // $link.mouseleave(() => {
+        //     $link.popover('hide')
+        // });
+
+    }
+
+
+
+}

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -9,37 +9,81 @@ frappe.ui.LinkPreview = class {
     }
 
     get_links() {
-        $(document.body).on('mouseover', 'a[href*="/"]', (e) => {
+        $(document.body).on('mouseover', 'a[href*="/"], input[data-fieldname], .popover', (e) => {
             this.link_hovered = true;
-            let link = $(e.currentTarget).attr('href');
-            let link_arr = link.split('/');
-            const link_element = $(e.currentTarget);
-            let popover = link_element.data("bs.popover");
-            this.setup_popover_control(popover, link_arr, link_element);
+            let element = $(e.currentTarget);
+            let name;
+            let doctype;
+            let is_link = true;
+            let link_control;
+            if(element.attr('href')) {
+                let link = element.attr('href');
+                let link_arr = link.split('/');
+                if(link_arr.length > 2) {
+                    name = decodeURI(link_arr[link_arr.length - 1]);
+                    doctype = decodeURI(link_arr[link_arr.length -2]);
+                }           
+            }
+            else {
+                is_link = false;
+                // let linked_field = element.parents('.link-field').find('.link-btn')
+                // if(linked_field.length) {
+                // console.log('yes linked field', linked_field)
+                link_control = element.parents('.control-input-wrapper').find('.control-value').children('a').attr('href');
+                console.log(link_control);
+                if(link_control) {
+                    let link_arr = link_control.split('/');
+                    console.log('arr', link_arr);
+                    if(link_arr.length > 2) {
+                        name = decodeURI(link_arr[link_arr.length - 1]);
+                        doctype = decodeURI(link_arr[link_arr.length -2]);
+                    }
+                }
+                // }
+                else {
+                    name = element.parent().next().text();
+                    doctype = element.attr('data-doctype');
+                }
+            }
+            let popover = element.data("bs.popover");
+            if(name && doctype) {
+                this.setup_popover_control(e, popover, name, doctype, element, is_link, link_control);
+            }
         });
     }
 
-    setup_popover_control(popover, link_arr, $link) {
-        if(!popover) {
-            if(link_arr.length > 2) {
-                let name = decodeURI(link_arr[link_arr.length - 1]);
-                let doctype = decodeURI(link_arr[link_arr.length -2]);
+
+    setup_popover_control(e, popover, name, doctype, $link, is_link, link_control) {
+        if(!popover || !is_link) {
                 let preview_fields = this.get_preview_fields(doctype);
                 if(preview_fields.length) {
                     this.data_timeout = setTimeout(() => {
                         this.get_preview_fields_value(doctype, name, preview_fields).then((preview_data)=> {
                             if(preview_data) {
+                                console.log('preview', preview_data);
                                 if (this.popover_timeout) {
                                     clearTimeout(this.popover_timeout)
                                 }
                                 this.popover_timeout = setTimeout(() => {
-                                    this.init_preview_popover($link, preview_data, doctype);
+                                    if(popover) {
+                                        let new_content = this.get_content_html(preview_data, doctype, link_control)
+                                        popover.options.content = new_content;
+                                    }
+                                    else {
+                                        this.init_preview_popover($link, preview_data, doctype, is_link, link_control);
+                                    }
+                                    if(!is_link) {
+                                        var left = e.pageX;
+                                        $link.popover('show');
+                                        $('.control-field-popover').css('left', (left+30) + 'px');
+                                    }                              
+                                    else {
+                                        $link.popover('show');
+                                    }
                                 }, 1000);
                             }
                         });
                     }, 1000);
-                    
-                }
             }
         } else {
             this.popover_timeout = setTimeout(() => {
@@ -47,7 +91,7 @@ frappe.ui.LinkPreview = class {
             }, 1000);
         }
 
-        $(document.body).on('mouseout', 'a[href*="/"]', () => {
+        $(document.body).on('mouseout', 'a[href*="/"], input[data-fieldname], .popover', () => {
             this.link_hovered = false;
             if(this.data_timeout) {
                 clearTimeout(this.data_timeout)
@@ -81,30 +125,24 @@ frappe.ui.LinkPreview = class {
         });
     }
 
-    init_preview_popover($link, preview_data, dt) {
-        console.log('create popover')
-        let content_html = '';
+    init_preview_popover($link, preview_data, dt, is_link, link_control) {
         console.log('preview_data', preview_data);
-
-        Object.keys(preview_data).forEach(key => {
-            content_html += `
-                <p class="link-preview-field text-regular">
-                    <b> ${frappe.meta.get_label(dt, key)} </b>:  ${preview_data[key]} 
-                </p>
-            `;
-        })
-
+        let content_html = this.get_content_html(preview_data, dt, link_control);
+        console.log('content', content_html)
         $link.popover({
             container: 'body',
             html: true,
             content: content_html,
             trigger: 'manual',
+            // placement: !is_link?'auto bottom':'auto right',
             animation: false
             // delay: {'show':show_delay,'hide':hide_delay}
         });
+        if(!is_link) {
+            $link.data('bs.popover').tip().addClass('control-field-popover');
+        }
         this.$links.push($link);
-        $link.popover('show');
-
+        // return content_html;
         // $link.data('bs.popover').options.content = content_html;
         // $link.popover('show');
         // setTimeout(() => {
@@ -116,6 +154,31 @@ frappe.ui.LinkPreview = class {
         //     $link.popover('hide')
         // });
 
+    }
+
+    get_content_html(preview_data, dt, link_control) {
+        let content_html = '';
+        if(preview_data['image']) {
+            let image_url = encodeURI(preview_data['image']);
+            content_html += `
+            <div class="link-preview-field">
+                <img src=${image_url} style="max-width:200px; max-height:150px"></img> 
+            </div>
+        `;
+        }
+        Object.keys(preview_data).forEach(key => {
+            if(key!='image'){
+                content_html += `
+                    <p class="link-preview-field" style="font-size:0.9em">
+                        <b> ${frappe.meta.get_label(dt, key)} </b>:  ${preview_data[key]} 
+                    </p>
+                `;
+            }
+        })
+        if(link_control) {
+            content_html+= `<a href=${link_control}><span>${'View'}</span></a>`
+        }
+        return content_html;
     }
 
 

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -1,244 +1,244 @@
 frappe.ui.LinkPreview = class {
 
-    constructor() {
-        this.$links = [];
-        this.popover_timeout = null;
-        this.get_links();
-    }
+	constructor() {
+		this.$links = [];
+		this.popover_timeout = null;
+		this.get_links();
+	}
 
-    get_links() {
+	get_links() {
 
-        $(document.body).on('mouseover', 'a[href*="/"], input[data-fieldname], .popover', (e) => {
-            this.link_hovered = true;
-            let element = $(e.currentTarget);
-            let name, doctype, link;
-            let is_link = true;
+		$(document.body).on('mouseover', 'a[href*="/"], input[data-fieldname], .popover', (e) => {
+			this.link_hovered = true;
+			let element = $(e.currentTarget);
+			let name, doctype, link;
+			let is_link = true;
 
-            if(!element.parents().find('.popover').length) {
-                if(element.attr('href')) {
-                    link = element.attr('href');
-                    let details = this.get_details(link,element);
-                    name = details.name;
-                    doctype = details.doctype;
-                } else {
-                    is_link = false;
-                    link = element.parents('.control-input-wrapper').find('.control-value').children('a').attr('href');
+			if(!element.parents().find('.popover').length) {
+				if(element.attr('href')) {
+					link = element.attr('href');
+					let details = this.get_details(link,element);
+					name = details.name;
+					doctype = details.doctype;
+				} else {
+					is_link = false;
+					link = element.parents('.control-input-wrapper').find('.control-value').children('a').attr('href');
 
-                    if(link) {
-                        let details = this.get_details(link,element);
-                        name = details.name;
-                        doctype = details.doctype;
-                    } else {
-                        name = element.parent().next().text();
-                        doctype = element.attr('data-doctype');
-                    }
-                }
+					if(link) {
+						let details = this.get_details(link,element);
+						name = details.name;
+						doctype = details.doctype;
+					} else {
+						name = element.parent().next().text();
+						doctype = element.attr('data-doctype');
+					}
+				}
 
-                let popover = element.data("bs.popover");
-                if(name && doctype) {
-                    this.setup_popover_control(e, popover, name, doctype, element, is_link, link);
-                }
-            }
-        });
+				let popover = element.data("bs.popover");
+				if(name && doctype) {
+					this.setup_popover_control(e, popover, name, doctype, element, is_link, link);
+				}
+			}
+		});
 
-    }
+	}
 
-    get_details(link, element) {
-        let details = {};
-        let link_arr = link.split('/');
+	get_details(link, element) {
+		let details = {};
+		let link_arr = link.split('/');
 
-        if(link_arr.length > 2) {
-            details.name = decodeURI(link_arr[link_arr.length - 1]);
-            details.doctype = decodeURI(link_arr[link_arr.length -2]);
-            details.name = details.name.replace(new RegExp('%2F', 'g'), '/');
-        }
-        let title = element.attr('title');
-        if( title && title.includes('/')) {
-            details.name = title.trim();
-            details.doctype = decodeURI(link_arr[link_arr.length-3]);
-        }
-        return details;
-    }
+		if(link_arr.length > 2) {
+			details.name = decodeURI(link_arr[link_arr.length - 1]);
+			details.doctype = decodeURI(link_arr[link_arr.length -2]);
+			details.name = details.name.replace(new RegExp('%2F', 'g'), '/');
+		}
+		let title = element.attr('title');
+		if( title && title.includes('/')) {
+			details.name = title.trim();
+			details.doctype = decodeURI(link_arr[link_arr.length-3]);
+		}
+		return details;
+	}
 
 
-    setup_popover_control(e, popover, name, doctype, $el, is_link, link) {
+	setup_popover_control(e, popover, name, doctype, $el, is_link, link) {
 
-        if(!popover || !is_link) {
-                let preview_fields = this.get_preview_fields(doctype);
-                if(preview_fields.length) {
-                    this.data_timeout = setTimeout(() => {
-                        this.get_preview_fields_value(doctype, name, preview_fields).then((preview_data)=> {
-                            if(preview_data) {
-                                if(this.popover_timeout) {
-                                    clearTimeout(this.popover_timeout);
-                                }
+		if(!popover || !is_link) {
+			let preview_fields = this.get_preview_fields(doctype);
+			if(preview_fields.length) {
+				this.data_timeout = setTimeout(() => {
+					this.get_preview_fields_value(doctype, name, preview_fields).then((preview_data)=> {
+						if(preview_data) {
+							if(this.popover_timeout) {
+								clearTimeout(this.popover_timeout);
+							}
 
-                                this.popover_timeout = setTimeout(() => {
+							this.popover_timeout = setTimeout(() => {
 
-                                    if(popover) {
-                                        let new_content = this.get_popover_html(preview_data, doctype, link);
-                                        popover.options.content = new_content;
-                                    } else {
-                                        this.init_preview_popover($el, preview_data, doctype, is_link, link);
-                                    }
+								if(popover) {
+									let new_content = this.get_popover_html(preview_data, doctype, link);
+									popover.options.content = new_content;
+								} else {
+									this.init_preview_popover($el, preview_data, doctype, is_link, link);
+								}
 
-                                    if(!is_link) {
-                                        var left = e.pageX;
-                                        $el.popover('show');
-                                        var width =$('.popover').width();
-                                        $('.control-field-popover').css('left', (left-(width/2)) + 'px');
-                                    } else {
-                                        $el.popover('show');
-                                    }
+								if(!is_link) {
+									var left = e.pageX;
+									$el.popover('show');
+									var width =$('.popover').width();
+									$('.control-field-popover').css('left', (left-(width/2)) + 'px');
+								} else {
+									$el.popover('show');
+								}
 
-                                }, 1000);
-                            }
-                        });
-                    }, 1000);
-            }
-        } else {
-            this.popover_timeout = setTimeout(() => {
-                popover.show();
-            }, 1000);
-        }
+							}, 1000);
+						}
+					});
+				}, 1000);
+			}
+		} else {
+			this.popover_timeout = setTimeout(() => {
+				popover.show();
+			}, 1000);
+		}
 
-        this.handle_popover_hide();
-    }
+		this.handle_popover_hide();
+	}
 
-    handle_popover_hide() {
-        $(document.body).on('mouseout', 'a[href*="/"], input[data-fieldname], .popover', () => {
-            this.link_hovered = false;
-            if(this.data_timeout) {
-                clearTimeout(this.data_timeout);
-            }
-            if (this.popover_timeout) {
-                clearTimeout(this.popover_timeout);
-            }
-        });
+	handle_popover_hide() {
+		$(document.body).on('mouseout', 'a[href*="/"], input[data-fieldname], .popover', () => {
+			this.link_hovered = false;
+			if(this.data_timeout) {
+				clearTimeout(this.data_timeout);
+			}
+			if (this.popover_timeout) {
+				clearTimeout(this.popover_timeout);
+			}
+		});
 
-        $(document.body).on('mousemove', () => {
-            if (!this.link_hovered) {
-                this.$links.forEach($el => $el.popover('hide'));
-            }
-        });
-    }
+		$(document.body).on('mousemove', () => {
+			if (!this.link_hovered) {
+				this.$links.forEach($el => $el.popover('hide'));
+			}
+		});
+	}
 
-    get_preview_fields(dt) {
-        let fields = [];
-        frappe.model.with_doctype(dt, () => {
-            frappe.get_meta(dt).fields.filter((field) => {
-                if(field.in_preview) {
+	get_preview_fields(dt) {
+		let fields = [];
+		frappe.model.with_doctype(dt, () => {
+			frappe.get_meta(dt).fields.filter((field) => {
+				if(field.in_preview) {
 					fields.push({'name':field.fieldname,'type':field.fieldtype});
-                }
-            });
-        });
+				}
+			});
+		});
 
-        if(!fields.length) {
-            frappe.model.with_doctype(dt, () => {
-                frappe.get_meta(dt).fields.filter((field) => {
-                    if(field.reqd) {
-                        fields.push({'name':field.fieldname,'type':field.fieldtype});
-                    }
-                });
-            });
-        }
-        return fields;
-    }
+		if(!fields.length) {
+			frappe.model.with_doctype(dt, () => {
+				frappe.get_meta(dt).fields.filter((field) => {
+					if(field.reqd) {
+						fields.push({'name':field.fieldname,'type':field.fieldtype});
+					}
+				});
+			});
+		}
+		return fields;
+	}
 
-    get_preview_fields_value(dt, field_name, field_list) {
-        return frappe.xcall('frappe.desk.link_preview.get_preview_data', {
-            'doctype': dt,
-            'docname': field_name,
-            'fields': field_list,
-        });
-    }
+	get_preview_fields_value(dt, field_name, field_list) {
+		return frappe.xcall('frappe.desk.link_preview.get_preview_data', {
+			'doctype': dt,
+			'docname': field_name,
+			'fields': field_list,
+		});
+	}
 
-    init_preview_popover($el, preview_data, dt, is_link, link) {
+	init_preview_popover($el, preview_data, dt, is_link, link) {
 
-        let popover_content = this.get_popover_html(preview_data, dt, link);
-        $el.popover({
-            container: 'body',
-            html: true,
-            content: popover_content,
-            trigger: 'manual',
-            placement: 'top auto',
-            animation: false,
-        });
+		let popover_content = this.get_popover_html(preview_data, dt, link);
+		$el.popover({
+			container: 'body',
+			html: true,
+			content: popover_content,
+			trigger: 'manual',
+			placement: 'top auto',
+			animation: false,
+		});
 
-        if(!is_link) {
-            $el.data('bs.popover').tip().addClass('control-field-popover');
-        }
+		if(!is_link) {
+			$el.data('bs.popover').tip().addClass('control-field-popover');
+		}
 
-        this.$links.push($el);
+		this.$links.push($el);
 
-    }
+	}
 
-    get_popover_html(preview_data, dt, link) {
-        if(!link) {
-            link = window.location.href;
-        }
+	get_popover_html(preview_data, dt, link) {
+		if(!link) {
+			link = window.location.href;
+		}
 
-        if(link && link.includes(' ')) {
-            link = link.replace(new RegExp(' ', 'g'), '%20');
-        }
+		if(link && link.includes(' ')) {
+			link = link.replace(new RegExp(' ', 'g'), '%20');
+		}
 
-        let image_html = '';
-        let title_html = '';
-        let content_html = `<table class="preview-table">`;
+		let image_html = '';
+		let title_html = '';
+		let content_html = `<table class="preview-table">`;
 
-        if(preview_data['image']) {
-            let image_url = encodeURI(preview_data['image']);
-            image_html += `
-            <div class="preview-header">
-                <img src=${image_url} class="preview-image"></img> 
-            </div>`;
-        }
-        if(preview_data['title']) {
-            title_html+= `<a class="preview-title small" href=${link}>${preview_data['title']}</a>`;
-        }
+		if(preview_data['image']) {
+			let image_url = encodeURI(preview_data['image']);
+			image_html += `
+			<div class="preview-header">
+				<img src=${image_url} class="preview-image"></img> 
+			</div>`;
+		}
+		if(preview_data['title']) {
+			title_html+= `<a class="preview-title small" href=${link}>${preview_data['title']}</a>`;
+		}
 
-        Object.keys(preview_data).forEach(key => {
-            if(key!='image' && key!='name') {
-                let value = this.truncate_value(preview_data[key]);            
-                let label = this.truncate_value(frappe.meta.get_label(dt, key));
-                content_html += `
-                <tr class="preview-field">
-                    <td class='text-muted small field-name'>${label}</td> 
-                    <td class="field-value small"> ${value} </td>
-                </tr>
-                `;
-            }
-        })
-        content_html+=`</table>`;
+		Object.keys(preview_data).forEach(key => {
+			if(key!='image' && key!='name') {
+				let value = this.truncate_value(preview_data[key]);            
+				let label = this.truncate_value(frappe.meta.get_label(dt, key));
+				content_html += `
+				<tr class="preview-field">
+					<td class='text-muted small field-name'>${label}</td> 
+					<td class="field-value small"> ${value} </td>
+				</tr>
+				`;
+			}
+		});
+		content_html+=`</table>`;
 
-        let popover_content = `<div class="preview-popover-header">
-                                    ${image_html}
-                                    <div class="preview-header">
-                                        <div class="preview-main">
-                                            <a class="preview-name text-bold" href=${link}>${preview_data['name']}</a>
-                                            ${title_html}
-                                            <span class="text-muted small">${dt}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <hr>
-                                <div class="popover-body">
-                                    ${content_html}
-                                </div>`;
+		let popover_content = `<div class="preview-popover-header">
+									${image_html}
+									<div class="preview-header">
+										<div class="preview-main">
+											<a class="preview-name text-bold" href=${link}>${preview_data['name']}</a>
+											${title_html}
+											<span class="text-muted small">${dt}</span>
+										</div>
+									</div>
+								</div>
+								<hr>
+								<div class="popover-body">
+									${content_html}
+								</div>`;
 
-        if(!link) {
-            $('.preview-name').removeAttr('href');
-            $('.preview-title').removeAttr('href');
-        }
+		if(!link) {
+			$('.preview-name').removeAttr('href');
+			$('.preview-title').removeAttr('href');
+		}
 
-        return popover_content;
-    }
+		return popover_content;
+	}
 
-    truncate_value(value) {
-        if (value.length > 100) {
-            value = value.slice(0,100) + '...';
-        }
-        return value;
-    }
+	truncate_value(value) {
+		if (value.length > 100) {
+			value = value.slice(0,100) + '...';
+		}
+		return value;
+	}
 
-}
+};

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -74,7 +74,6 @@ frappe.ui.LinkPreview = class {
 				this.popover.show();
 			}, 1000);
 		}
-		console.log('this', this);
 		this.handle_popover_hide();
 	}
 
@@ -178,7 +177,6 @@ frappe.ui.LinkPreview = class {
 
 	get_popover_html(preview_data) {
 		if(!this.link) {
-			console.log('here');
 			this.link = window.location.href;
 		}
 
@@ -215,17 +213,20 @@ frappe.ui.LinkPreview = class {
 		});
 		content_html+=`</table>`;
 
-		let popover_content = `<div class="preview-popover-header">${image_html}<div class="preview-header">
-									<div class="preview-main">
-										<a class="preview-name text-bold" href=${this.link}>${preview_data['name']}</a>
-										${title_html}
-										<span class="text-muted small">${this.doctype}</span>
-									</div>
-								</div></div>
-								<hr>
-								<div class="popover-body">
-									${content_html}
-								</div>`;
+		let popover_content = 
+			`<div class="preview-popover-header">${image_html}
+				<div class="preview-header">
+					<div class="preview-main">
+						<a class="preview-name text-bold" href=${this.link}>${preview_data['name']}</a>
+						${title_html}
+						<span class="text-muted small">${this.doctype}</span>
+					</div>
+				</div>
+			</div>
+			<hr>
+			<div class="popover-body">
+				${content_html}
+			</div>`;
 
 		return popover_content;
 	}

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -16,6 +16,9 @@ frappe.ui.LinkPreview = class {
 			if(!this.element.parents().find('.popover').length) {
 				if(this.element.attr('href')) {
 					this.link = this.element.attr('href');
+					if(this.link.startsWith('http')) {
+						return;
+					}
 					let details = this.get_details();
 					this.name = details.name;
 					this.doctype = details.doctype;
@@ -34,7 +37,7 @@ frappe.ui.LinkPreview = class {
 				}
 
 				this.popover = this.element.data("bs.popover");
-				if(this.name && this.doctype && this.doctype!=='files') {
+				if(this.name && this.doctype) {
 					this.setup_popover_control(e);
 				}
 			}

--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -1,85 +1,96 @@
-frappe.provide('frappe.pages');
-
 frappe.ui.LinkPreview = class {
 
     constructor() {
         this.$links = [];
-        this.popover_timeout = null
+        this.popover_timeout = null;
         this.get_links();
     }
 
     get_links() {
+
         $(document.body).on('mouseover', 'a[href*="/"], input[data-fieldname], .popover', (e) => {
             this.link_hovered = true;
             let element = $(e.currentTarget);
-            let name;
-            let doctype;
+            let name, doctype, link;
             let is_link = true;
-            let link_control;
-            if(element.attr('href')) {
-                let link = element.attr('href');
-                let link_arr = link.split('/');
-                if(link_arr.length > 2) {
-                    name = decodeURI(link_arr[link_arr.length - 1]);
-                    doctype = decodeURI(link_arr[link_arr.length -2]);
-                }           
-            }
-            else {
-                is_link = false;
-                // let linked_field = element.parents('.link-field').find('.link-btn')
-                // if(linked_field.length) {
-                // console.log('yes linked field', linked_field)
-                link_control = element.parents('.control-input-wrapper').find('.control-value').children('a').attr('href');
-                console.log(link_control);
-                if(link_control) {
-                    let link_arr = link_control.split('/');
-                    console.log('arr', link_arr);
-                    if(link_arr.length > 2) {
-                        name = decodeURI(link_arr[link_arr.length - 1]);
-                        doctype = decodeURI(link_arr[link_arr.length -2]);
+
+            if(!element.parents().find('.popover').length) {
+                if(element.attr('href')) {
+                    link = element.attr('href');
+                    let details = this.get_details(link,element);
+                    name = details.name;
+                    doctype = details.doctype;
+                } else {
+                    is_link = false;
+                    link = element.parents('.control-input-wrapper').find('.control-value').children('a').attr('href');
+
+                    if(link) {
+                        let details = this.get_details(link,element);
+                        name = details.name;
+                        doctype = details.doctype;
+                    } else {
+                        name = element.parent().next().text();
+                        doctype = element.attr('data-doctype');
                     }
                 }
-                // }
-                else {
-                    name = element.parent().next().text();
-                    doctype = element.attr('data-doctype');
+
+                let popover = element.data("bs.popover");
+                if(name && doctype) {
+                    this.setup_popover_control(e, popover, name, doctype, element, is_link, link);
                 }
             }
-            let popover = element.data("bs.popover");
-            if(name && doctype) {
-                this.setup_popover_control(e, popover, name, doctype, element, is_link, link_control);
-            }
         });
+
+    }
+
+    get_details(link, element) {
+        let details = {};
+        let link_arr = link.split('/');
+
+        if(link_arr.length > 2) {
+            details.name = decodeURI(link_arr[link_arr.length - 1]);
+            details.doctype = decodeURI(link_arr[link_arr.length -2]);
+            details.name = details.name.replace(new RegExp('%2F', 'g'), '/');
+        }
+        let title = element.attr('title');
+        if( title && title.includes('/')) {
+            details.name = title.trim();
+            details.doctype = decodeURI(link_arr[link_arr.length-3]);
+        }
+        return details;
     }
 
 
-    setup_popover_control(e, popover, name, doctype, $link, is_link, link_control) {
+    setup_popover_control(e, popover, name, doctype, $el, is_link, link) {
+
         if(!popover || !is_link) {
                 let preview_fields = this.get_preview_fields(doctype);
                 if(preview_fields.length) {
                     this.data_timeout = setTimeout(() => {
                         this.get_preview_fields_value(doctype, name, preview_fields).then((preview_data)=> {
                             if(preview_data) {
-                                console.log('preview', preview_data);
-                                if (this.popover_timeout) {
-                                    clearTimeout(this.popover_timeout)
+                                if(this.popover_timeout) {
+                                    clearTimeout(this.popover_timeout);
                                 }
+
                                 this.popover_timeout = setTimeout(() => {
+
                                     if(popover) {
-                                        let new_content = this.get_content_html(preview_data, doctype, link_control)
+                                        let new_content = this.get_popover_html(preview_data, doctype, link);
                                         popover.options.content = new_content;
+                                    } else {
+                                        this.init_preview_popover($el, preview_data, doctype, is_link, link);
                                     }
-                                    else {
-                                        this.init_preview_popover($link, preview_data, doctype, is_link, link_control);
-                                    }
+
                                     if(!is_link) {
                                         var left = e.pageX;
-                                        $link.popover('show');
-                                        $('.control-field-popover').css('left', (left+30) + 'px');
-                                    }                              
-                                    else {
-                                        $link.popover('show');
+                                        $el.popover('show');
+                                        var width =$('.popover').width();
+                                        $('.control-field-popover').css('left', (left-(width/2)) + 'px');
+                                    } else {
+                                        $el.popover('show');
                                     }
+
                                 }, 1000);
                             }
                         });
@@ -91,96 +102,143 @@ frappe.ui.LinkPreview = class {
             }, 1000);
         }
 
+        this.handle_popover_hide();
+    }
+
+    handle_popover_hide() {
         $(document.body).on('mouseout', 'a[href*="/"], input[data-fieldname], .popover', () => {
             this.link_hovered = false;
             if(this.data_timeout) {
-                clearTimeout(this.data_timeout)
+                clearTimeout(this.data_timeout);
             }
             if (this.popover_timeout) {
-                clearTimeout(this.popover_timeout)
+                clearTimeout(this.popover_timeout);
             }
-        })
+        });
+
         $(document.body).on('mousemove', () => {
             if (!this.link_hovered) {
-                this.$links.forEach($link => $link.popover('hide'));
+                this.$links.forEach($el => $el.popover('hide'));
             }
-        })
+        });
     }
 
     get_preview_fields(dt) {
-        let fields = []
-        frappe.model.with_doctype(dt, () => { 
+        let fields = [];
+        frappe.model.with_doctype(dt, () => {
             frappe.get_meta(dt).fields.filter((field) => {
-                if(field.in_preview) fields.push(field.fieldname);
-            })
+                if(field.in_preview) {
+					fields.push({'name':field.fieldname,'type':field.fieldtype});
+                }
+            });
         });
+
+        if(!fields.length) {
+            frappe.model.with_doctype(dt, () => {
+                frappe.get_meta(dt).fields.filter((field) => {
+                    if(field.reqd) {
+                        fields.push({'name':field.fieldname,'type':field.fieldtype});
+                    }
+                });
+            });
+        }
         return fields;
     }
 
     get_preview_fields_value(dt, field_name, field_list) {
-        return frappe.xcall('frappe.client.get_preview_data', {
+        return frappe.xcall('frappe.desk.link_preview.get_preview_data', {
             'doctype': dt,
             'docname': field_name,
-            'fields': field_list
+            'fields': field_list,
         });
     }
 
-    init_preview_popover($link, preview_data, dt, is_link, link_control) {
-        console.log('preview_data', preview_data);
-        let content_html = this.get_content_html(preview_data, dt, link_control);
-        console.log('content', content_html)
-        $link.popover({
+    init_preview_popover($el, preview_data, dt, is_link, link) {
+
+        let popover_content = this.get_popover_html(preview_data, dt, link);
+        $el.popover({
             container: 'body',
             html: true,
-            content: content_html,
+            content: popover_content,
             trigger: 'manual',
-            // placement: !is_link?'auto bottom':'auto right',
-            animation: false
-            // delay: {'show':show_delay,'hide':hide_delay}
+            placement: 'top auto',
+            animation: false,
         });
-        if(!is_link) {
-            $link.data('bs.popover').tip().addClass('control-field-popover');
-        }
-        this.$links.push($link);
-        // return content_html;
-        // $link.data('bs.popover').options.content = content_html;
-        // $link.popover('show');
-        // setTimeout(() => {
-        //     $link.popover('show')
-        // }, 1000);
 
-    
-        // $link.mouseleave(() => {
-        //     $link.popover('hide')
-        // });
+        if(!is_link) {
+            $el.data('bs.popover').tip().addClass('control-field-popover');
+        }
+
+        this.$links.push($el);
 
     }
 
-    get_content_html(preview_data, dt, link_control) {
-        let content_html = '';
+    get_popover_html(preview_data, dt, link) {
+        if(!link) {
+            link = window.location.href;
+        }
+
+        if(link && link.includes(' ')) {
+            link = link.replace(new RegExp(' ', 'g'), '%20');
+        }
+
+        let image_html = '';
+        let title_html = '';
+        let content_html = `<table class="preview-table">`;
+
         if(preview_data['image']) {
             let image_url = encodeURI(preview_data['image']);
-            content_html += `
-            <div class="link-preview-field">
-                <img src=${image_url} style="max-width:200px; max-height:150px"></img> 
-            </div>
-        `;
+            image_html += `
+            <div class="preview-header">
+                <img src=${image_url} class="preview-image"></img> 
+            </div>`;
         }
+        if(preview_data['title']) {
+            title_html+= `<a class="preview-title small" href=${link}>${preview_data['title']}</a>`;
+        }
+
         Object.keys(preview_data).forEach(key => {
-            if(key!='image'){
+            if(key!='image' && key!='name') {
+                let value = this.truncate_value(preview_data[key]);            
+                let label = this.truncate_value(frappe.meta.get_label(dt, key));
                 content_html += `
-                    <p class="link-preview-field" style="font-size:0.9em">
-                        <b> ${frappe.meta.get_label(dt, key)} </b>:  ${preview_data[key]} 
-                    </p>
+                <tr class="preview-field">
+                    <td class='text-muted small field-name'>${label}</td> 
+                    <td class="field-value small"> ${value} </td>
+                </tr>
                 `;
             }
         })
-        if(link_control) {
-            content_html+= `<a href=${link_control}><span>${'View'}</span></a>`
+        content_html+=`</table>`;
+
+        let popover_content = `<div class="preview-popover-header">
+                                    ${image_html}
+                                    <div class="preview-header">
+                                        <div class="preview-main">
+                                            <a class="preview-name text-bold" href=${link}>${preview_data['name']}</a>
+                                            ${title_html}
+                                            <span class="text-muted small">${dt}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <hr>
+                                <div class="popover-body">
+                                    ${content_html}
+                                </div>`;
+
+        if(!link) {
+            $('.preview-name').removeAttr('href');
+            $('.preview-title').removeAttr('href');
         }
-        return content_html;
+
+        return popover_content;
     }
 
-
+    truncate_value(value) {
+        if (value.length > 100) {
+            value = value.slice(0,100) + '...';
+        }
+        return value;
+    }
 
 }

--- a/frappe/public/less/link_preview.less
+++ b/frappe/public/less/link_preview.less
@@ -1,0 +1,53 @@
+.popover {
+    border-radius: 0;
+    max-width: 100%;
+    .popover-content {
+        padding: 0;
+        .preview-popover-header {
+            background: #f7fafc;
+            padding: 10px;
+
+            .preview-header {
+                display: inline-block;
+                vertical-align: top;
+            }
+
+            .preview-image {
+                width: 70px;
+                height: 70px;
+                object-fit: cover;
+                margin-right: 10px;
+                border-radius: 6px;
+            }
+
+            .preview-name {
+                display: block;
+            }
+
+            .preview-title {
+                display: block;
+            }
+        }
+
+        hr {
+            margin: 0;
+        }
+
+        .preview-table {
+            margin: 10px;
+            max-width: 330px;
+            min-width: 200px;
+        }
+
+        .preview-field {
+            td {
+                padding: 3px;
+                vertical-align: top;
+            }
+
+            .field-name {
+                width: 39%;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Preview popover appears on hover of all link and control fields:
![Screen Shot 2019-04-15 at 3 58 43 PM](https://user-images.githubusercontent.com/19775888/56125650-09c33800-5f97-11e9-88a8-e1a8eb2fecc2.png)

By default all mandatory fields are shown in the preview. The fields can be manually selected by setting `in_preview`.