### PR TITLE
fix: Bad croniter version (installation broken)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyotp==2.2.7
 pyqrcode==1.2.1
 pypng==0.0.18
 premailer==3.2.0
-croniter==0.3.26
+croniter==0.3.29
 googlemaps==3.0.2
 urllib3==1.23
 GitPython==2.1.11


### PR DESCRIPTION
There is no longer a _croniter_ version 0.3.26 available in the PyPi online package repository.  Example:

**$ pip install croniter==0.3.26**

This throws an error.  So I have updated this requirements (install_requires) file to show version 0.3.29 instead.