### PR TITLE
fix: Auto Repeat remove submittable doctypes limitations

### DIFF
--- a/frappe/desk/doctype/auto_repeat/auto_repeat.js
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat.js
@@ -13,7 +13,6 @@ frappe.ui.form.on('Auto Repeat', {
 		frm.fields_dict['reference_document'].get_query = function() {
 			return {
 				filters: {
-					"docstatus": 1,
 					"auto_repeat": ''
 				}
 			};


### PR DESCRIPTION
Modified the `get_query` filters for the Auto Repeat on Reference DocType field to include any documents that are not submittable by default.