### PR TITLE
fix:Do not rename files and folders before rename for custom doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -329,7 +329,8 @@ class DocType(Document):
 		if merge:
 			frappe.throw(_("DocType can not be merged"))
 
-		if not frappe.flags.in_test and not frappe.flags.in_patch:
+		# Do not rename and move files and folders for custom doctype
+		if not self.custom and not frappe.flags.in_test and not frappe.flags.in_patch:
 			self.rename_files_and_folders(old, new)
 
 	def after_rename(self, old, new, merge=False):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/__init__.py", line 1027, in call
    return fn(*args, **newargs)
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/model/rename_doc.py", line 36, in rename_doc
    out = old_doc.run_method("before_rename", old, new, merge) or {}
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 333, in before_rename
    self.rename_files_and_folders(old, new)
  File "/Users/deepesh/bench-v10/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 348, in rename_files_and_folders
    subprocess.check_output(['mv', get_doc_path(self.module, 'doctype', old), new_path])
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 223, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
CalledProcessError: Command '[u'mv', u'/Users/deepesh/bench-v10/apps/erpnext/erpnext/hotels/doctype/test_custom_doctype', u'/Users/deepesh/bench-v10/apps/erpnext/erpnext/hotels/doctype/test_new_custom_doctype']' returned non-zero exit status 1
```