### PR TITLE
fix: Ignore permission while creating a revert doc

### DIFF
--- a/frappe/public/js/frappe/form/review.js
+++ b/frappe/public/js/frappe/form/review.js
@@ -115,6 +115,7 @@ frappe.ui.form.Review = class Review {
 				label: __('Reason')
 			}],
 			primary_action: (values) => {
+				review_dialog.disable_primary_action();
 				if (values.points > this.points.review_points) {
 					return frappe.msgprint(__('You do not have enough points'));
 				}
@@ -133,6 +134,8 @@ frappe.ui.form.Review = class Review {
 					this.frm.get_docinfo().energy_point_logs.unshift(review);
 					this.frm.timeline.refresh();
 					this.update_reviewers();
+				}).finally(() => {
+					review_dialog.enable_primary_action();
 				});
 			},
 			primary_action_label: __('Submit')

--- a/frappe/public/js/frappe/form/review.js
+++ b/frappe/public/js/frappe/form/review.js
@@ -88,7 +88,6 @@ frappe.ui.form.Review = class Review {
 				fieldtype: 'Autocomplete',
 				label: __('To User'),
 				options: user_options,
-				default: user_options.includes(doc_owner) ? doc_owner : user_options[0],
 				description: __('Only users involved in the document are listed')
 			}, {
 				fieldname: 'review_type',

--- a/frappe/public/js/frappe/misc/energy_point_utils.js
+++ b/frappe/public/js/frappe/misc/energy_point_utils.js
@@ -32,6 +32,7 @@ Object.assign(frappe.energy_points, {
 	get_history_log_message(log) {
 		const doc_link = frappe.utils.get_form_link(log.reference_doctype, log.reference_name, true);
 		const owner_name = frappe.user.full_name(log.owner).bold();
+		const user = frappe.user.full_name(log.user).bold();
 		if (log.type === 'Appreciation') {
 			return __('{0} appreciated on {1}', [owner_name, doc_link]);
 		}
@@ -39,7 +40,7 @@ Object.assign(frappe.energy_points, {
 			return __('{0} criticized on {1}', [owner_name, doc_link]);
 		}
 		if (log.type === 'Revert') {
-			return __('{0} reverted {1}', [owner_name,
+			return __('{0} reverted {1}', [user,
 				frappe.utils.get_form_link('Energy Point Log', log.revert_of, true)]);
 		}
 		return __('via automatic rule {0} on {1}', [log.rule.bold(), doc_link]);

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -183,7 +183,7 @@ def revert(name, reason):
 		frappe.throw(_('This document cannot be reverted'))
 
 	doc_to_revert.reverted = 1
-	doc_to_revert.save()
+	doc_to_revert.save(ignore_permissions=True)
 
 	revert_log = frappe.get_doc({
 		'doctype': 'Energy Point Log',
@@ -194,7 +194,7 @@ def revert(name, reason):
 		'reference_doctype': doc_to_revert.reference_doctype,
 		'reference_name': doc_to_revert.reference_name,
 		'revert_of': doc_to_revert.name
-	}).insert()
+	}).insert(ignore_permissions=True)
 
 	return revert_log
 


### PR DESCRIPTION
- Ignore permission while saving revert doc since only system manager can revert points
- Show who reverted points instead of the owner of that points
- Disable submit button while doing network request to avoid duplicate entries
- Remove default for user from review dialog
   let users explicitly select whom they want to review