### PR TITLE
fix: Show Hidden fields in Report Builder

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -720,9 +720,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		let out = {};
 
 		const standard_fields_filter = df =>
-			!in_list(frappe.model.no_value_type, df.fieldtype) &&
-			!df.report_hide && df.fieldname !== 'naming_series' &&
-			!df.hidden;
+			!in_list(frappe.model.no_value_type, df.fieldtype) && !df.report_hide;
 
 		let doctype_fields = frappe.meta.get_docfields(this.doctype).filter(standard_fields_filter);
 


### PR DESCRIPTION
User should be allowed to see all columns even if they are hidden, so that he can export them to Excel / CSV.