### PR TITLE
fix: On assignment, system sending an email to the assigned user even if notify to email is disabled

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import frappe
 from frappe import _
+from frappe.utils import cint
 from frappe.desk.form.load import get_docinfo
 import frappe.share
 
@@ -160,7 +161,7 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 			'notify': notify
 		}
 
-	if arg and arg.get("notify"):
+	if arg and cint(arg.get("notify")):
 		_notify(arg)
 
 def _notify(args):


### PR DESCRIPTION
**Issue**
Notify to email is disabled 

![Screen Shot 2019-04-18 at 12 32 51 pm](https://user-images.githubusercontent.com/8780500/56342677-49c42e00-61d6-11e9-950b-37290c57b9d2.png)

Still notified by email :
![Screen Shot 2019-04-18 at 12 34 58 pm](https://user-images.githubusercontent.com/8780500/56342725-6b251a00-61d6-11e9-8729-87a769cd0d7a.png)


