### PR TITLE
fix: Do not set page_length as null

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -82,8 +82,6 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 		return Object.assign(args, {
 			with_comment_count: false,
-			start: 0,
-			page_length: null,
 			group_by: this.group_by_control.group_by || null,
 			order_by: this.group_by_control.order_by || null,
 		});


### PR DESCRIPTION
Do not set page_length as null since due to this all the records are fetched at once which slows down the system if there are thousands of records
