### PR TITLE
fix: Grid Upload

### DIFF
--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -11,7 +11,8 @@ export default class FileUploader {
 		folder,
 		restrictions,
 		upload_notes,
-		allow_multiple
+		allow_multiple,
+		as_dataurl
 	} = {}) {
 		if (!wrapper) {
 			this.make_dialog();
@@ -31,7 +32,8 @@ export default class FileUploader {
 					on_success,
 					restrictions,
 					upload_notes,
-					allow_multiple
+					allow_multiple,
+					as_dataurl
 				}
 			})
 		});

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -640,9 +640,11 @@ export default class Grid {
 			// upload
 			frappe.flags.no_socketio = true;
 			$(this.wrapper).find(".grid-upload").removeClass("hide").on("click", function() {
-				frappe.prompt({fieldtype:"Attach", label:"Upload File", fieldname: "upload_file"},
-					function(data) {
-						var data = frappe.utils.csv_to_array(frappe.upload.get_string(data.upload_file));
+				new frappe.ui.FileUploader({
+					as_dataurl: true,
+					allow_multiple: false,
+					on_success(file) {
+						var data = frappe.utils.csv_to_array(frappe.upload.get_string(file.dataurl));
 						// row #2 contains fieldnames;
 						var fieldnames = data[2];
 
@@ -680,8 +682,8 @@ export default class Grid {
 
 						me.frm.refresh_field(me.df.fieldname);
 						frappe.msgprint({message:__('Table updated'), title:__('Success'), indicator:'green'})
-
-					}, __("Edit via Upload"), __("Update"));
+					}
+				});
 				return false;
 			});
 		}


### PR DESCRIPTION
Grid Upload only requires the base64 string and then parses it into rows to add them to the child table.


Usage:

```js
new frappe.ui.FileUploader({
	as_dataurl: true,
	on_success(file) {
		// the file is not uploaded to the server
		file.dataurl // contains the base64 string
	}
})
```