### PR TITLE
feat: Maintain list of tables touched during migrate

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -153,6 +153,10 @@ class Database(object):
 					frappe.log(values)
 					frappe.log(">>>>")
 				self._cursor.execute(query, values)
+
+				if frappe.flags.in_migrate:
+					self.log_touched_tables(query, values)
+
 			else:
 				if debug:
 					if explain:
@@ -164,6 +168,9 @@ class Database(object):
 					frappe.log(">>>>")
 
 				self._cursor.execute(query)
+
+				if frappe.flags.in_migrate:
+					self.log_touched_tables(query)
 
 			if debug:
 				time_end = time()
@@ -911,6 +918,20 @@ class Database(object):
 			), values)
 		else:
 			frappe.throw('No conditions provided')
+
+	def log_touched_tables(self, query, values=None):
+		if values:
+			query = frappe.safe_decode(self._cursor.mogrify(query, values))
+		if query.strip().lower().split()[0] in ('insert', 'delete', 'update', 'alter'):
+			# ([`\"']?) Captures ', " or ` at the begining of the table name (if provided)
+			# (tab([A-Z]\w+)( [A-Z]\w+)*) Captures table names that start with "tab"
+			# and are continued with multiple words that start with a captital letter
+			# e.g. 'tabXxx' or 'tabXxx Xxx' or 'tabXxx Xxx Xxx' and so on
+			# \1 matches the first captured group (quote character) at the end of the table name
+			tables = [groups[1] for groups in re.findall(r'([`"\']?)(tab([A-Z]\w+)( [A-Z]\w+)*)\1', query)]
+			if frappe.flags.touched_tables is None:
+				frappe.flags.touched_tables = set()
+			frappe.flags.touched_tables.update(tables)
 
 
 def enqueue_jobs_after_commit():

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -3,6 +3,8 @@
 
 from __future__ import unicode_literals
 
+import json
+import os
 import frappe
 import frappe.translate
 import frappe.modules.patch_handler
@@ -25,39 +27,52 @@ def migrate(verbose=True, rebuild_website=False):
 	- sync web pages (from /www)
 	- run after migrate hooks
 	'''
-	frappe.flags.in_migrate = True
-	clear_global_cache()
 
-	#run before_migrate hooks
-	for app in frappe.get_installed_apps():
-		for fn in frappe.get_hooks('before_migrate', app_name=app):
-			frappe.get_attr(fn)()
+	touched_tables_file = frappe.get_site_path('touched_tables.json')
+	if os.path.exists(touched_tables_file):
+		os.remove(touched_tables_file)
 
-	# run patches
-	frappe.modules.patch_handler.run_all()
-	# sync
-	frappe.model.sync.sync_all(verbose=verbose)
-	frappe.translate.clear_cache()
-	sync_fixtures()
-	sync_customizations()
-	sync_languages()
+	try:
+		frappe.flags.touched_tables = set()
+		frappe.flags.in_migrate = True
 
-	frappe.get_doc('Portal Settings', 'Portal Settings').sync_menu()
+		clear_global_cache()
 
-	# syncs statics
-	render.clear_cache()
+		#run before_migrate hooks
+		for app in frappe.get_installed_apps():
+			for fn in frappe.get_hooks('before_migrate', app_name=app):
+				frappe.get_attr(fn)()
 
-	# add static pages to global search
-	router.sync_global_search()
+		# run patches
+		frappe.modules.patch_handler.run_all()
+		# sync
+		frappe.model.sync.sync_all(verbose=verbose)
+		frappe.translate.clear_cache()
+		sync_fixtures()
+		sync_customizations()
+		sync_languages()
 
-	#run after_migrate hooks
-	for app in frappe.get_installed_apps():
-		for fn in frappe.get_hooks('after_migrate', app_name=app):
-			frappe.get_attr(fn)()
+		frappe.get_doc('Portal Settings', 'Portal Settings').sync_menu()
 
-	frappe.db.commit()
+		# syncs statics
+		render.clear_cache()
 
-	clear_notifications()
+		# add static pages to global search
+		router.sync_global_search()
 
-	frappe.publish_realtime("version-update")
-	frappe.flags.in_migrate = False
+		#run after_migrate hooks
+		for app in frappe.get_installed_apps():
+			for fn in frappe.get_hooks('after_migrate', app_name=app):
+				frappe.get_attr(fn)()
+
+		frappe.db.commit()
+
+		clear_notifications()
+
+		frappe.publish_realtime("version-update")
+		frappe.flags.in_migrate = False
+	finally:
+		with open(touched_tables_file, 'w') as f:
+			json.dump(list(frappe.flags.touched_tables), f, sort_keys=True, indent=4)
+		frappe.flags.touched_tables.clear()
+

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -6,6 +6,7 @@
 from __future__ import unicode_literals
 import unittest
 import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
 class TestDB(unittest.TestCase):
 	def test_get_value(self):
@@ -30,3 +31,31 @@ class TestDB(unittest.TestCase):
 
 		limit = frappe.db.get_single_value('System Settings', 'backup_limit')
 		self.assertEqual(limit, 5)
+
+	def test_log_touched_tables(self):
+		frappe.flags.in_migrate = True
+		frappe.flags.touched_tables = set()
+		frappe.db.set_value('System Settings', 'System Settings', 'backup_limit', 5)
+		self.assertIn('tabSingles', frappe.flags.touched_tables)
+
+		frappe.flags.touched_tables = set()
+		todo = frappe.get_doc({'doctype': 'ToDo', 'description': 'Random Description'})
+		todo.save()
+		self.assertIn('tabToDo', frappe.flags.touched_tables)
+
+		frappe.flags.touched_tables = set()
+		todo.description = "Another Description"
+		todo.save()
+		self.assertIn('tabToDo', frappe.flags.touched_tables)
+
+		frappe.flags.touched_tables = set()
+		todo.delete()
+		self.assertIn('tabToDo', frappe.flags.touched_tables)
+
+		frappe.flags.touched_tables = set()
+		create_custom_field('ToDo', {'label': 'ToDo Custom Field'})
+
+		self.assertIn('tabToDo', frappe.flags.touched_tables)
+		self.assertIn('tabCustom Field', frappe.flags.touched_tables)
+		frappe.flags.in_migrate = False
+		frappe.flags.touched_tables.clear()


### PR DESCRIPTION
This can be used to selectively restore changed tables from a backup
after migration failure

Scan INSERT, DELETE, UPDATE and ALTER queries for tables names and maintain the list of changed tables in `frappe.flags.touched_tables` and later written to `touched_tables.json`

Uses following regex

```regex
([`\"']?)(tab([A-Z]\w+)( [A-Z]\w+)*)\1
```

#### Explanation
```regex
([`\"']?)
```
Captures `'`, `"` or ``` ` ``` at the begining of the table name (if provided)

```regex
(tab([A-Z]\w+)( [A-Z]\w+)*)
``` 
Captures table names that start with "tab" and are continued with multiple words that start with a captital letter

e.g. "tabXxx" or "tabXxx Xxx" or "tabXxx Xxx Xxx" and so on

`\1` matches the first captured group (quote character) at the end of the table name

**Note:** This list might contain false positives

List of captured tables after a failed migrate
```
 1) "tabPricing Rule Detail"
 2) "tabPurchase Invoice"
 3) "tabTask"
 4) "tabItem Variant Attribute"
 5) "tabItem"
 6) "tabTerritory"
 7) "tabPurchase Invoice Item"
 8) "tabItem Barcode"

...

60) "tabSupplier Quotation Item"
61) "tabDocField"
62) "tabVersion"
63) "tabPurchase Order Item"
64) "tabToDo"
65) "tabReport"
66) "tabCustom Field"
67) "tabDelivery Note"
68) "tabDocType"
69) "tabUser"
70) "tabSeries"
71) "tabCommunication"
72) "tabItem Tax Template Detail"
73) "tabMaterial Request Item"
74) "tabUOM Conversion Detail"
75) "tabActivity Log"
76) "tabDocument Follow"
77) "tabSales Order"
```