### PR TITLE
fix: Page Title wrapping and centering

### DIFF
--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -1,13 +1,13 @@
-<div class="page-head">
+<div class="page-head flex align-center">
 	<div class="container">
-		<div class="row">
+		<div class="row flex align-center">
 			<div class="col-md-7 col-sm-8 col-xs-6 page-title">
 				<!-- title -->
-				<h1>
+				<h1 class="flex" style="margin: auto;">
 					<div class="title-image hide hidden-md hidden-lg">
 					</div>
 					<div class="ellipsis title-text"></div>
-					<span class="indicator hide"></span>
+					<span class="indicator whitespace-nowrap hide"></span>
 				</h1>
 			</div>
 			<div class="text-right col-md-5 col-sm-4 col-xs-6 page-actions">

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -138,7 +138,7 @@ frappe.ui.Page = Class.extend({
 	},
 
 	clear_indicator: function() {
-		return this.indicator.removeClass().addClass("indicator hide");
+		return this.indicator.removeClass().addClass("indicator whitespace-nowrap hide");
 	},
 
 	get_icon_label: function(icon, label) {

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -1070,3 +1070,9 @@ body.full-width {
 		}
 	}
 }
+
+// utilities
+
+.whitespace-nowrap {
+	white-space: nowrap;
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9355208/56586386-46c5a500-65fd-11e9-9a89-6cc2cb9a213e.png)


After:
![image](https://user-images.githubusercontent.com/9355208/56586147-c3a44f00-65fc-11e9-8190-6ed6f7f61897.png)
