### PR TITLE
style: Linting for boilerplate files

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/test_controller._py
+++ b/frappe/core/doctype/doctype/boilerplate/test_controller._py
@@ -3,7 +3,7 @@
 # See license.txt
 from __future__ import unicode_literals
 
-import frappe
+# import frappe
 import unittest
 
 class Test{classname}(unittest.TestCase):

--- a/frappe/core/doctype/report/boilerplate/controller.js
+++ b/frappe/core/doctype/report/boilerplate/controller.js
@@ -6,4 +6,4 @@ frappe.query_reports["{name}"] = {{
 	"filters": [
 
 	]
-}}
+}};

--- a/frappe/core/doctype/report/boilerplate/controller.py
+++ b/frappe/core/doctype/report/boilerplate/controller.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-import frappe
+# import frappe
 
 def execute(filters=None):
 	columns, data = [], []


### PR DESCRIPTION
Reopened https://github.com/frappe/frappe/pull/7349

**Linting for boilerplate files:**
Codacy fails on newly (automatically) created controller files from boilerplate so this is to solve this issue.