### PR TITLE
feat: DocType JSON changes for cleaner Git Diffs (v12)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1297,7 +1297,7 @@ def get_value(*args, **kwargs):
 
 def as_json(obj, indent=1):
 	from frappe.utils.response import json_handler
-	return json.dumps(obj, indent=indent, sort_keys=True, default=json_handler)
+	return json.dumps(obj, indent=indent, sort_keys=True, default=json_handler, separators=(',', ': '))
 
 def are_emails_muted():
 	from frappe.utils import cint

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -255,7 +255,8 @@ class DocType(Document):
 		self.update_fields_to_fetch()
 
 		from frappe import conf
-		if not self.custom and not (frappe.flags.in_import or frappe.flags.in_test) and conf.get('developer_mode'):
+		allow_doctype_export = frappe.flags.allow_doctype_export or (not frappe.flags.in_test and conf.get('developer_mode'))
+		if not self.custom and not frappe.flags.in_import and allow_doctype_export:
 			self.export_doc()
 			self.make_controller_template()
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -453,7 +453,7 @@ class DocType(Document):
 				pass
 
 	@staticmethod
-	def prepare_docdict_for_import(docdict):
+	def prepare_for_import(docdict):
 		# set order of fields from field_order
 		if docdict.get("field_order"):
 			new_field_dicts = []

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -439,13 +439,13 @@ class DocType(Document):
 					remaining_field_names = [f.fieldname for f in self.fields]
 
 					for fieldname in old_field_names:
-						field_dict = filter(lambda d: d['fieldname'] == fieldname, docdict['fields'])
+						field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict['fields']))
 						if field_dict:
 							new_field_dicts.append(field_dict[0])
 							remaining_field_names.remove(fieldname)
 
 					for fieldname in remaining_field_names:
-						field_dict = filter(lambda d: d['fieldname'] == fieldname, docdict['fields'])
+						field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict['fields']))
 						new_field_dicts.append(field_dict[0])
 
 					docdict['fields'] = new_field_dicts

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -460,13 +460,13 @@ class DocType(Document):
 			remaining_field_names = [f['fieldname'] for f in docdict.get('fields', [])]
 
 			for fieldname in docdict.get('field_order'):
-				field_dict = filter(lambda d: d['fieldname'] == fieldname, docdict.get('fields', []))
+				field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict.get('fields', [])))
 				if field_dict:
 					new_field_dicts.append(field_dict[0])
 					remaining_field_names.remove(fieldname)
 
 			for fieldname in remaining_field_names:
-				field_dict = filter(lambda d: d['fieldname'] == fieldname, docdict.get('fields', []))
+				field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict.get('fields', [])))
 				new_field_dicts.append(field_dict[0])
 
 			docdict['fields'] = new_field_dicts

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -152,7 +152,7 @@ class TestDocType(unittest.TestCase):
 			os.remove(path)
 
 		try:
-			frappe.flags.in_test = 0
+			frappe.flags.allow_doctype_export = 1
 			test_doctype.save()
 
 			# assert that field_order list is being created with the default order
@@ -222,8 +222,7 @@ class TestDocType(unittest.TestCase):
 			test_doctype_json = frappe.get_file_json(path)
 			self.assertListEqual([f['fieldname'] for f in test_doctype_json['fields']], ['field_1', 'field_2', 'field_4', 'field_5'])
 			self.assertListEqual(test_doctype_json['field_order'], ['field_4', 'field_5', 'field_1', 'field_2'])
-		except Exception:
-			frappe.flags.in_test = 1
+		except:
 			raise
-
-		frappe.flags.in_test = 1
+		finally:
+			frappe.flags.allow_doctype_export = 0

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -105,3 +105,125 @@ class TestDocType(unittest.TestCase):
 				condition = field.get(depends_on)
 				if condition:
 					self.assertFalse(re.match(pattern, condition))
+
+	def test_load_file_field_order(self):
+		from frappe.modules.import_file import get_file_path
+		import os
+
+		# create test doctype
+		test_doctype = frappe.get_doc({
+			"doctype": "DocType",
+			"module": "Core",
+			"fields": [
+				{
+					"label": "Field 1",
+					"fieldname": "field_1",
+					"fieldtype": "Data"
+				},
+				{
+					"label": "Field 2",
+					"fieldname": "field_2",
+					"fieldtype": "Data"
+				},
+				{
+					"label": "Field 3",
+					"fieldname": "field_3",
+					"fieldtype": "Data"
+				},
+				{
+					"label": "Field 4",
+					"fieldname": "field_4",
+					"fieldtype": "Data"
+				}
+			],
+			"permissions": [{
+				"role": "System Manager",
+				"read": 1
+			}],
+			"name": "Test Field Order DocType",
+			"__islocal": 1
+		})
+
+		path = get_file_path(test_doctype.module, test_doctype.doctype, test_doctype.name)
+		initial_fields_order = ['field_1', 'field_2', 'field_3', 'field_4']
+
+		frappe.delete_doc_if_exists("DocType", "Test Field Order DocType")
+		if os.path.isfile(path):
+			os.remove(path)
+
+		try:
+			frappe.flags.in_test = 0
+			test_doctype.save()
+
+			# assert that field_order list is being created with the default order
+			test_doctype_json = frappe.get_file_json(path)
+			self.assertTrue(test_doctype_json.get("field_order"))
+			self.assertEqual(len(test_doctype_json['fields']), len(test_doctype_json['field_order']))
+			self.assertListEqual([f['fieldname'] for f in test_doctype_json['fields']], test_doctype_json['field_order'])
+			self.assertListEqual([f['fieldname'] for f in test_doctype_json['fields']], initial_fields_order)
+			self.assertListEqual(test_doctype_json['field_order'], initial_fields_order)
+
+			# remove field_order to test reload_doc/sync/migrate is backwards compatible without field_order
+			del test_doctype_json['field_order']
+			with open(path, 'w+') as txtfile:
+				txtfile.write(frappe.as_json(test_doctype_json))
+
+			# assert that field_order is actually removed from the json file
+			test_doctype_json = frappe.get_file_json(path)
+			self.assertFalse(test_doctype_json.get("field_order"))
+
+			# make sure that migrate/sync is backwards compatible without field_order
+			frappe.reload_doctype(test_doctype.name, force=True)
+			test_doctype.reload()
+
+			# assert that field_order list is being created with the default order again
+			test_doctype.save()
+			test_doctype_json = frappe.get_file_json(path)
+			self.assertTrue(test_doctype_json.get("field_order"))
+			self.assertEqual(len(test_doctype_json['fields']), len(test_doctype_json['field_order']))
+			self.assertListEqual([f['fieldname'] for f in test_doctype_json['fields']], test_doctype_json['field_order'])
+			self.assertListEqual([f['fieldname'] for f in test_doctype_json['fields']], initial_fields_order)
+			self.assertListEqual(test_doctype_json['field_order'], initial_fields_order)
+
+			# reorder fields: swap row 1 and 3
+			test_doctype.fields[0], test_doctype.fields[2] = test_doctype.fields[2], test_doctype.fields[0]
+			for i, f in enumerate(test_doctype.fields):
+				f.idx = i + 1
+
+			# assert that reordering fields only affects `field_order` rather than `fields` attr
+			test_doctype.save()
+			test_doctype_json = frappe.get_file_json(path)
+			self.assertListEqual([f['fieldname'] for f in test_doctype_json['fields']], initial_fields_order)
+			self.assertListEqual(test_doctype_json['field_order'], ['field_3', 'field_2', 'field_1', 'field_4'])
+
+			# reorder `field_order` in the json file: swap row 2 and 4
+			test_doctype_json['field_order'][1], test_doctype_json['field_order'][3] = test_doctype_json['field_order'][3], test_doctype_json['field_order'][1]
+			with open(path, 'w+') as txtfile:
+				txtfile.write(frappe.as_json(test_doctype_json))
+
+			# assert that reordering `field_order` from json file is reflected in DocType upon migrate/sync
+			frappe.reload_doctype(test_doctype.name, force=True)
+			test_doctype.reload()
+			self.assertListEqual([f.fieldname for f in test_doctype.fields], ['field_3', 'field_4', 'field_1', 'field_2'])
+
+			# insert row in the middle and remove first row (field 3)
+			test_doctype.append("fields", {
+				"label": "Field 5",
+				"fieldname": "field_5",
+				"fieldtype": "Data"
+			})
+			test_doctype.fields[4], test_doctype.fields[3] = test_doctype.fields[3], test_doctype.fields[4]
+			test_doctype.fields[3], test_doctype.fields[2] = test_doctype.fields[2], test_doctype.fields[3]
+			test_doctype.remove(test_doctype.fields[0])
+			for i, f in enumerate(test_doctype.fields):
+				f.idx = i + 1
+
+			test_doctype.save()
+			test_doctype_json = frappe.get_file_json(path)
+			self.assertListEqual([f['fieldname'] for f in test_doctype_json['fields']], ['field_1', 'field_2', 'field_4', 'field_5'])
+			self.assertListEqual(test_doctype_json['field_order'], ['field_4', 'field_5', 'field_1', 'field_2'])
+		except Exception:
+			frappe.flags.in_test = 1
+			raise
+
+		frappe.flags.in_test = 1

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -106,7 +106,7 @@ class TestDocType(unittest.TestCase):
 				if condition:
 					self.assertFalse(re.match(pattern, condition))
 
-	def test_load_file_field_order(self):
+	def test_sync_field_order(self):
 		from frappe.modules.import_file import get_file_path
 		import os
 

--- a/frappe/modules/export_file.py
+++ b/frappe/modules/export_file.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import frappe, os
 import frappe.model
 from frappe.modules import scrub, get_module_path, scrub_dt_dn
-import json
 
 def export_doc(doc):
 	export_to_files([[doc.doctype, doc.name]])

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -89,6 +89,27 @@ def read_doc_from_file(path):
 	else:
 		raise IOError('%s missing' % path)
 
+	# set order of fields from field_order
+	if doc.get("doctype") == "DocType":
+		if doc.get("field_order") and doc.get("fields"):
+			new_field_dicts = []
+			remaining_field_names = [f['fieldname'] for f in doc['fields']]
+
+			for fieldname in doc['field_order']:
+				field_dict = filter(lambda d: d['fieldname'] == fieldname, doc['fields'])
+				if field_dict:
+					new_field_dicts.append(field_dict[0])
+					remaining_field_names.remove(fieldname)
+
+			for fieldname in remaining_field_names:
+				field_dict = filter(lambda d: d['fieldname'] == fieldname, doc['fields'])
+				new_field_dicts.append(field_dict[0])
+
+			doc['fields'] = new_field_dicts
+
+		if "field_order" in doc:
+			del doc['field_order']
+
 	return doc
 
 ignore_doctypes = [""]

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals, print_function
 
 import frappe, os, json
-from frappe.modules import get_module_path, scrub_dt_dn, load_doctype_module
+from frappe.modules import get_module_path, scrub_dt_dn
 from frappe.utils import get_datetime_str
 from frappe.model.base_document import get_controller
 

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -100,8 +100,8 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 	docdict["__islocal"] = 1
 
 	controller = get_controller(docdict['doctype'])
-	if controller and hasattr(controller, 'prepare_docdict_for_import') and callable(getattr(controller, 'prepare_docdict_for_import')):
-		controller.prepare_docdict_for_import(docdict)
+	if controller and hasattr(controller, 'prepare_for_import') and callable(getattr(controller, 'prepare_for_import')):
+		controller.prepare_for_import(docdict)
 
 	doc = frappe.get_doc(docdict)
 


### PR DESCRIPTION
Reopened https://github.com/frappe/frappe/pull/7305 for v12

### Problem:
You want to reorder some fields in a DocType OR you want to create new fields. Here's an example git diff of reordering fields

<details><summary><b>Git Diff of reordering only 2 fields of Project DocType</b></summary>

```diff
@@ -432,7 +432,7 @@
    "collapsible": 1, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "customer_details", 
+   "fieldname": "section_break0", 
    "fieldtype": "Section Break", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
@@ -441,11 +441,11 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Customer Details", 
+   "label": "Notes", 
    "length": 0, 
    "no_copy": 0, 
    "oldfieldtype": "Section Break", 
-   "options": "fa fa-user", 
+   "options": "fa fa-list", 
    "permlevel": 0, 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
@@ -466,29 +466,28 @@
    "collapsible": 0, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "customer", 
-   "fieldtype": "Link", 
+   "fieldname": "notes", 
+   "fieldtype": "Text Editor", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
    "in_filter": 0, 
-   "in_global_search": 1, 
+   "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Customer", 
+   "label": "Notes", 
    "length": 0, 
    "no_copy": 0, 
-   "oldfieldname": "customer", 
-   "oldfieldtype": "Link", 
-   "options": "Customer", 
+   "oldfieldname": "notes", 
+   "oldfieldtype": "Text Editor", 
    "permlevel": 0, 
-   "print_hide": 1, 
+   "print_hide": 0, 
    "print_hide_if_no_value": 0, 
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
    "reqd": 0, 
-   "search_index": 1, 
+   "search_index": 0, 
    "set_only_once": 0, 
    "translatable": 0, 
    "unique": 0
@@ -498,11 +497,11 @@
    "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
-   "collapsible": 0, 
+   "collapsible": 1, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "column_break_14", 
-   "fieldtype": "Column Break", 
+   "fieldname": "customer_details", 
+   "fieldtype": "Section Break", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
@@ -510,10 +509,12 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
+   "label": "Customer Details", 
    "length": 0, 
    "no_copy": 0, 
+   "oldfieldtype": "Section Break", 
+   "options": "fa fa-user", 
    "permlevel": 0, 
-   "precision": "", 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
    "read_only": 0, 
@@ -533,28 +534,29 @@
    "collapsible": 0, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "sales_order", 
+   "fieldname": "customer", 
    "fieldtype": "Link", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
    "in_filter": 0, 
-   "in_global_search": 0, 
+   "in_global_search": 1, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Sales Order", 
+   "label": "Customer", 
    "length": 0, 
    "no_copy": 0, 
-   "options": "Sales Order", 
+   "oldfieldname": "customer", 
+   "oldfieldtype": "Link", 
+   "options": "Customer", 
    "permlevel": 0, 
-   "precision": "", 
-   "print_hide": 0, 
+   "print_hide": 1, 
    "print_hide_if_no_value": 0, 
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
    "reqd": 0, 
-   "search_index": 0, 
+   "search_index": 1, 
    "set_only_once": 0, 
    "translatable": 0, 
    "unique": 0
@@ -564,11 +566,11 @@
    "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
-   "collapsible": 1, 
+   "collapsible": 0, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "users_section", 
-   "fieldtype": "Section Break", 
+   "fieldname": "column_break_14", 
+   "fieldtype": "Column Break", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
@@ -576,7 +578,6 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Users", 
    "length": 0, 
    "no_copy": 0, 
    "permlevel": 0, 
@@ -599,10 +600,9 @@
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
-   "description": "Project will be accessible on the website to these users", 
    "fetch_if_empty": 0, 
-   "fieldname": "users", 
-   "fieldtype": "Table", 
+   "fieldname": "sales_order", 
+   "fieldtype": "Link", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
@@ -610,10 +610,10 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Users", 
+   "label": "Sales Order", 
    "length": 0, 
    "no_copy": 0, 
-   "options": "Project User", 
+   "options": "Sales Order", 
    "permlevel": 0, 
    "precision": "", 
    "print_hide": 0, 
@@ -632,10 +632,10 @@
    "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
-   "collapsible": 0, 
+   "collapsible": 1, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "sb_milestones", 
+   "fieldname": "users_section", 
    "fieldtype": "Section Break", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
@@ -644,12 +644,11 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Tasks", 
+   "label": "Users", 
    "length": 0, 
    "no_copy": 0, 
-   "oldfieldtype": "Section Break", 
-   "options": "fa fa-flag", 
    "permlevel": 0, 
+   "precision": "", 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
    "read_only": 0, 
@@ -668,8 +667,9 @@
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
+   "description": "Project will be accessible on the website to these users", 
    "fetch_if_empty": 0, 
-   "fieldname": "tasks", 
+   "fieldname": "users", 
    "fieldtype": "Table", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
@@ -678,10 +678,10 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Tasks", 
+   "label": "Users", 
    "length": 0, 
    "no_copy": 0, 
-   "options": "Project Task", 
+   "options": "Project User", 
    "permlevel": 0, 
    "precision": "", 
    "print_hide": 0, 
@@ -703,23 +703,24 @@
    "collapsible": 0, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "copied_from", 
-   "fieldtype": "Data", 
-   "hidden": 1, 
+   "fieldname": "sb_milestones", 
+   "fieldtype": "Section Break", 
+   "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
    "in_filter": 0, 
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Copied From", 
+   "label": "Tasks", 
    "length": 0, 
    "no_copy": 0, 
+   "oldfieldtype": "Section Break", 
+   "options": "fa fa-flag", 
    "permlevel": 0, 
-   "precision": "", 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
-   "read_only": 1, 
+   "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
    "reqd": 0, 
@@ -733,11 +734,11 @@
    "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
-   "collapsible": 1, 
+   "collapsible": 0, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "section_break0", 
-   "fieldtype": "Section Break", 
+   "fieldname": "tasks", 
+   "fieldtype": "Table", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
@@ -745,12 +746,12 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Notes", 
+   "label": "Tasks", 
    "length": 0, 
    "no_copy": 0, 
-   "oldfieldtype": "Section Break", 
-   "options": "fa fa-list", 
+   "options": "Project Task", 
    "permlevel": 0, 
+   "precision": "", 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
    "read_only": 0, 
@@ -770,24 +771,23 @@
    "collapsible": 0, 
    "columns": 0, 
    "fetch_if_empty": 0, 
-   "fieldname": "notes", 
-   "fieldtype": "Text Editor", 
-   "hidden": 0, 
+   "fieldname": "copied_from", 
+   "fieldtype": "Data", 
+   "hidden": 1, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
    "in_filter": 0, 
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Notes", 
+   "label": "Copied From", 
    "length": 0, 
    "no_copy": 0, 
-   "oldfieldname": "notes", 
-   "oldfieldtype": "Text Editor", 
    "permlevel": 0, 
+   "precision": "", 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
-   "read_only": 0, 
+   "read_only": 1, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
    "reqd": 0, 
@@ -1954,7 +1954,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 4, 
- "modified": "2019-03-09 01:40:08.247289", 
+ "modified": "2019-04-17 18:18:58.503442", 
  "modified_by": "Administrator", 
  "module": "Projects", 
  "name": "Project", 
```

</details>

**As a maintainer:** This makes no sense as this diff make NO sense about what has changed or what has been reordered or even if there is a change or just reorder.
**As a developer/customizer/service provider:** This will lead to perpetual merge conflicts and you'll start fearing the idea of updating your feature branch or your master/fork/client branch

### Solution
* Is backwards compatible!
* DocField are defined in the `fields` list attribute (just as before)
* Order of fields are defined in the `field_order` list attribute (this is new)
* When a field is reordered, nothing changes in the `fields` list-of-dicts attribute. Only the `field_order` list-of-fieldnames attribute changes, which is quite minimal.
* When a field is added, it's DocField definitions is appended at the and of the `fields` list and inserted in the `field_order` in between the fieldnames where it should be positioned.
* When a field is removed, it is removed from both: `fields` list and `field_order` list

**Additionally**

* Remove null and empty attributes from the JSON file (like `"fetch_if_empty": 0)
* Remove trailing spaces (change `, ` to `,`)

--------------------------------

<details><summary><b>Git Diff of no changes, only introducing the new field_order attribute and removing null/default fields</b></summary>

```diff
diff --git a/erpnext/setup/doctype/territory/territory.json b/erpnext/setup/doctype/territory/territory.json
index 38d0e0fc80..aa2bdb8d4e 100644
--- a/erpnext/setup/doctype/territory/territory.json
+++ b/erpnext/setup/doctype/territory/territory.json
@@ -1,402 +1,134 @@
 {
- "allow_copy": 0,
- "allow_guest_to_view": 0,
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "field:territory_name",
- "beta": 0,
  "creation": "2013-01-10 16:34:24",
- "custom": 0,
  "description": "Classification of Customers by region",
- "docstatus": 0,
  "doctype": "DocType",
  "document_type": "Setup",
- "editable_grid": 0,
+ "field_order": [
+  "territory_name",
+  "parent_territory",
+  "is_group",
+  "cb0",
+  "territory_manager",
+  "lft",
+  "rgt",
+  "old_parent",
+  "target_details_section_break",
+  "targets",
+  "distribution_id"
+ ],
  "fields": [
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "fieldname": "territory_name",
    "fieldtype": "Data",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
    "in_list_view": 1,
-   "in_standard_filter": 0,
    "label": "Territory Name",
-   "length": 0,
    "no_copy": 1,
    "oldfieldname": "territory_name",
    "oldfieldtype": "Data",
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
    "reqd": 1,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
    "unique": 1
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
    "bold": 1,
-   "collapsible": 0,
-   "columns": 0,
-   "description": "",
    "fieldname": "parent_territory",
    "fieldtype": "Link",
-   "hidden": 0,
    "ignore_user_permissions": 1,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
    "in_list_view": 1,
-   "in_standard_filter": 0,
    "label": "Parent Territory",
-   "length": 0,
-   "no_copy": 0,
    "oldfieldname": "parent_territory",
    "oldfieldtype": "Link",
-   "options": "Territory",
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "options": "Territory"
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
    "bold": 1,
-   "collapsible": 0,
-   "columns": 0,
-   "description": "",
    "fieldname": "is_group",
    "fieldtype": "Check",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
    "in_list_view": 1,
-   "in_standard_filter": 0,
    "label": "Is Group",
-   "length": 0,
-   "no_copy": 0,
    "oldfieldname": "is_group",
-   "oldfieldtype": "Select",
-   "options": "",
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "oldfieldtype": "Select"
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "fieldname": "cb0",
-   "fieldtype": "Column Break",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
-   "length": 0,
-   "no_copy": 0,
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "fieldtype": "Column Break"
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "description": "For reference",
    "fieldname": "territory_manager",
    "fieldtype": "Link",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
    "in_list_view": 1,
-   "in_standard_filter": 0,
    "label": "Territory Manager",
-   "length": 0,
-   "no_copy": 0,
    "oldfieldname": "territory_manager",
    "oldfieldtype": "Link",
    "options": "Sales Person",
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 1,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "search_index": 1
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "fieldname": "lft",
    "fieldtype": "Int",
    "hidden": 1,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
    "label": "lft",
-   "length": 0,
    "no_copy": 1,
    "oldfieldname": "lft",
    "oldfieldtype": "Int",
-   "permlevel": 0,
    "print_hide": 1,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 1,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "search_index": 1
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "fieldname": "rgt",
    "fieldtype": "Int",
    "hidden": 1,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
    "label": "rgt",
-   "length": 0,
    "no_copy": 1,
    "oldfieldname": "rgt",
    "oldfieldtype": "Int",
-   "permlevel": 0,
    "print_hide": 1,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 1,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "search_index": 1
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
-   "description": "",
    "fieldname": "old_parent",
    "fieldtype": "Link",
    "hidden": 1,
    "ignore_user_permissions": 1,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
    "label": "old_parent",
-   "length": 0,
    "no_copy": 1,
    "oldfieldname": "old_parent",
    "oldfieldtype": "Data",
    "options": "Territory",
-   "permlevel": 0,
    "print_hide": 1,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 1,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "report_hide": 1
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "description": "Set Item Group-wise budgets on this Territory. You can also include seasonality by setting the Distribution.",
    "fieldname": "target_details_section_break",
    "fieldtype": "Section Break",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
    "label": "Territory Targets",
-   "length": 0,
-   "no_copy": 0,
-   "oldfieldtype": "Section Break",
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "oldfieldtype": "Section Break"
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "fieldname": "targets",
    "fieldtype": "Table",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
    "label": "Targets",
-   "length": 0,
-   "no_copy": 0,
    "oldfieldname": "target_details",
    "oldfieldtype": "Table",
-   "options": "Target Detail",
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "options": "Target Detail"
   },
   {
-   "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
-   "allow_on_submit": 0,
-   "bold": 0,
-   "collapsible": 0,
-   "columns": 0,
    "description": "Select Monthly Distribution to unevenly distribute targets across months.",
    "fieldname": "distribution_id",
    "fieldtype": "Link",
-   "hidden": 0,
-   "ignore_user_permissions": 0,
-   "ignore_xss_filter": 0,
-   "in_filter": 0,
-   "in_global_search": 0,
-   "in_list_view": 0,
-   "in_standard_filter": 0,
    "label": "Target Distribution",
-   "length": 0,
-   "no_copy": 0,
    "oldfieldname": "distribution_id",
    "oldfieldtype": "Link",
-   "options": "Monthly Distribution",
-   "permlevel": 0,
-   "print_hide": 0,
-   "print_hide_if_no_value": 0,
-   "read_only": 0,
-   "remember_last_selected_value": 0,
-   "report_hide": 0,
-   "reqd": 0,
-   "search_index": 0,
-   "set_only_once": 0,
-   "translatable": 0,
-   "unique": 0
+   "options": "Monthly Distribution"
   }
  ],
- "has_web_view": 0,
- "hide_heading": 0,
- "hide_toolbar": 0,
  "icon": "fa fa-map-marker",
  "idx": 1,
- "image_view": 0,
- "in_create": 0,
- "is_submittable": 0,
- "issingle": 0,
- "istable": 0,
- "max_attachments": 0,
- "modified": "2018-08-29 06:26:38.918259",
+ "modified": "2019-04-22 20:15:25.735898",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Territory",
@@ -404,108 +136,44 @@
  "owner": "Administrator",
  "permissions": [
   {
-   "amend": 0,
-   "cancel": 0,
    "create": 1,
    "delete": 1,
    "email": 1,
    "export": 1,
-   "if_owner": 0,
    "import": 1,
-   "permlevel": 0,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "Sales Master Manager",
    "set_user_permissions": 1,
    "share": 1,
-   "submit": 0,
    "write": 1
   },
   {
-   "amend": 0,
-   "cancel": 0,
-   "create": 0,
-   "delete": 0,
    "email": 1,
-   "export": 0,
-   "if_owner": 0,
-   "import": 0,
-   "permlevel": 0,
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Sales Manager",
-   "set_user_permissions": 0,
-   "share": 0,
-   "submit": 0,
-   "write": 0
+   "role": "Sales Manager"
   },
   {
-   "amend": 0,
-   "cancel": 0,
-   "create": 0,
-   "delete": 0,
    "email": 1,
-   "export": 0,
-   "if_owner": 0,
-   "import": 0,
-   "permlevel": 0,
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Sales User",
-   "set_user_permissions": 0,
-   "share": 0,
-   "submit": 0,
-   "write": 0
+   "role": "Sales User"
   },
   {
-   "amend": 0,
-   "cancel": 0,
-   "create": 0,
-   "delete": 0,
-   "email": 0,
-   "export": 0,
-   "if_owner": 0,
-   "import": 0,
-   "permlevel": 0,
-   "print": 0,
    "read": 1,
-   "report": 0,
-   "role": "Stock User",
-   "set_user_permissions": 0,
-   "share": 0,
-   "submit": 0,
-   "write": 0
+   "role": "Stock User"
   },
   {
-   "amend": 0,
-   "cancel": 0,
-   "create": 0,
-   "delete": 0,
-   "email": 0,
-   "export": 0,
-   "if_owner": 0,
-   "import": 0,
-   "permlevel": 0,
-   "print": 0,
    "read": 1,
-   "report": 0,
-   "role": "Maintenance User",
-   "set_user_permissions": 0,
-   "share": 0,
-   "submit": 0,
-   "write": 0
+   "role": "Maintenance User"
   }
  ],
  "quick_entry": 1,
- "read_only": 0,
- "read_only_onload": 0,
  "search_fields": "parent_territory,territory_manager",
  "show_name_in_global_search": 1,
- "sort_order": "DESC",
- "track_changes": 0,
- "track_seen": 0,
- "track_views": 0
+ "sort_order": "DESC"
 }
\ No newline at end of file
```

</details>

<details><summary><b>Git Diff of reordering only 2 fields of Project DocType (same scenario as above)</b></summary>

*Showing changes inside `field_order` list*

```diff
@@ -26,6 +26,8 @@
   "priority", 
   "expected_start_date", 
   "expected_end_date", 
+  "section_break0", 
+  "notes", 
   "customer_details", 
   "customer", 
   "column_break_14", 
@@ -35,8 +37,6 @@
   "sb_milestones", 
   "tasks", 
   "copied_from", 
-  "section_break0", 
-  "notes", 
   "section_break_18", 
   "actual_start_date", 
   "actual_time", 
@@ -2013,7 +2013,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 4, 
- "modified": "2019-04-17 18:35:34.955364", 
+ "modified": "2019-04-17 18:37:56.623562", 
  "modified_by": "Administrator", 
  "module": "Projects", 
  "name": "Project", 
```

</details>

<details><summary><b>Git Diff of changing some DocField property and reordering at the same time</b></summary>

```diff
@@ -21,6 +21,7 @@
   "is_active", 
   "percent_complete_method", 
   "percent_complete", 
+  "cost_center", 
   "column_break_5", 
   "department", 
   "priority", 
@@ -53,7 +54,6 @@
   "total_billable_amount", 
   "total_billed_amount", 
   "total_consumed_material_cost", 
-  "cost_center", 
   "margin", 
   "gross_margin", 
   "column_break_37", 
@@ -1403,7 +1403,7 @@
    "ignore_xss_filter": 0, 
    "in_filter": 0, 
    "in_global_search": 0, 
-   "in_list_view": 0, 
+   "in_list_view": 1, 
    "in_standard_filter": 0, 
    "label": "Default Cost Center", 
    "length": 0, 
@@ -1415,7 +1415,7 @@
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
-   "reqd": 0, 
+   "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
    "translatable": 0, 
@@ -2013,7 +2013,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 4, 
- "modified": "2019-04-17 18:45:15.293250", 
+ "modified": "2019-04-17 18:46:49.421717", 
  "modified_by": "Administrator", 
  "module": "Projects", 
  "name": "Project", 
```

</details>

----------------------------

### Next Step

Once this PR is approved and merged, to prevent unexpected changes in order due to this new feature, all DocTypes should be updated (without any DocType changes though) so that `field_order` list is produced.

After that I would like to work on a GitHub check that will point out if any DocType JSON file is messing up the git diff. This is mainly due to trailing whitespaces produced by Frappe but removed by most IDEs.