### PR TITLE
feat: Add a rank column for leaderboard

### DIFF
--- a/frappe/public/js/frappe/misc/datetime.js
+++ b/frappe/public/js/frappe/misc/datetime.js
@@ -74,6 +74,14 @@ $.extend(frappe.datetime, {
 		return moment(d).add(months, "months").format();
 	},
 
+	week_start: function() {
+		return moment().startOf("week").format();
+	},
+
+	week_end: function() {
+		return moment().endOf("week").format();
+	},
+
 	month_start: function() {
 		return moment().startOf("month").format();
 	},

--- a/frappe/public/js/frappe/misc/energy_point_utils.js
+++ b/frappe/public/js/frappe/misc/energy_point_utils.js
@@ -21,29 +21,30 @@ Object.assign(frappe.energy_points, {
 	format_history_log(log) {
 		// redundant code to honor readability and to avoid confusion
 		const separator = `<span>&nbsp;-&nbsp;</span>`;
+		const route = frappe.utils.get_form_link(log.reference_doctype, log.reference_name);
 		const formatted_log = `<span>
 			${this.get_points(log.points)}&nbsp;
-			<a href="#Form/Energy Point Log/${log.name}">${this.get_history_log_message(log)}</a>
+			<a href="${route}">${this.get_history_log_message(log)}</a>
 			${log.reason ? separator + log.reason: ''}
 			${separator + frappe.datetime.comment_when(log.creation)}
 		</span>`;
 		return formatted_log;
 	},
 	get_history_log_message(log) {
-		const doc_link = frappe.utils.get_form_link(log.reference_doctype, log.reference_name, true);
 		const owner_name = frappe.user.full_name(log.owner).bold();
 		const user = frappe.user.full_name(log.user).bold();
+		const ref_doc = log.reference_name;
+
 		if (log.type === 'Appreciation') {
-			return __('{0} appreciated on {1}', [owner_name, doc_link]);
+			return __('{0} appreciated on {1}', [owner_name, ref_doc]);
 		}
 		if (log.type === 'Criticism') {
-			return __('{0} criticized on {1}', [owner_name, doc_link]);
+			return __('{0} criticized on {1}', [owner_name, ref_doc]);
 		}
 		if (log.type === 'Revert') {
-			return __('{0} reverted {1}', [user,
-				frappe.utils.get_form_link('Energy Point Log', log.revert_of, true)]);
+			return __('{0} reverted {1}', [user, log.revert_of]);
 		}
-		return __('via automatic rule {0} on {1}', [log.rule.bold(), doc_link]);
+		return __('via automatic rule {0} on {1}', [log.rule.bold(), ref_doc]);
 	},
 	get_form_log_message(log) {
 		// redundant code to honor readability and to avoid confusion

--- a/frappe/public/js/frappe/social/pages/UserList.vue
+++ b/frappe/public/js/frappe/social/pages/UserList.vue
@@ -198,6 +198,7 @@ export default {
 }
 .rank-column {
 	flex: 0 0 30px;
+	align-self: center;
 	.text-muted
 }
 .flex-20 {

--- a/frappe/public/js/frappe/social/pages/UserList.vue
+++ b/frappe/public/js/frappe/social/pages/UserList.vue
@@ -2,6 +2,7 @@
 	<div class="user-list-container">
 		<ul class="list-unstyled user-list">
 			<li class="user-card user-list-header text-medium">
+				<span class="rank-column"></span>
 				<span class="user-details text-muted">
 					<input
 						class="form-control"
@@ -18,6 +19,7 @@
 				</span>
 			</li>
 			<li class="user-card user-list-header text-medium">
+				<span class="rank-column">#</span>
 				<span class="user-details text-muted">{{ __('User') }}</span>
 				<span
 					class="flex-20 text-muted"
@@ -25,9 +27,10 @@
 					:key="title"
 				>{{ __(title) }}</span>
 			</li>
-			<li v-for="user in filtered_users" :key="user.name">
+			<li v-for="(user, index) in filtered_users" :key="user.name">
 				<div class="user-card" @click="toggle_log(user.name)">
 					<span class="user-details flex">
+						<span class="rank-column">{{ index + 1 }}</span>
 						<span v-html="get_avatar(user.name)"></span>
 						<span>
 							<a @click="go_to_profile_page(user.name)">{{ user.fullname }}</a>
@@ -176,7 +179,7 @@ export default {
 };
 </script>
 <style lang="less" scoped>
-@import 'frappe/public/less/variables';
+@import 'frappe/public/less/common';
 .user-list {
 	border-left: 1px solid @border-color;
 	border-right: 1px solid @border-color;
@@ -192,6 +195,10 @@ export default {
 			}
 		}
 	}
+}
+.rank-column {
+	flex: 0 0 30px;
+	.text-muted
 }
 .flex-20 {
 	flex: 0 0 20%;

--- a/frappe/public/js/frappe/social/pages/UserList.vue
+++ b/frappe/public/js/frappe/social/pages/UserList.vue
@@ -71,23 +71,22 @@ export default {
 			sort_users_by: 'energy_points',
 			sort_order: 'desc',
 			show_log_for: null,
-			period_options: ['Lifetime', 'Last Month', 'Last Week', 'Today'],
-			period: 'Lifetime'
+			period_options: ['Lifetime', 'This Month', 'This Week', 'Today'],
+			period: 'This Month'
 		};
 	},
 	computed: {
 		from_date() {
-			const days_to_deduct = {
-				'Last Week': 7,
-				'Last Month': 30
-			};
-			if (this.period === 'Lifetime') {
-				return null;
+			if (this.period === 'This Month') {
+				return frappe.datetime.month_start();
+			}
+			if (this.period === 'This Week') {
+				return frappe.datetime.week_start;
 			}
 			if (this.period === 'Today') {
 				return frappe.datetime.get_today();
 			}
-			return frappe.datetime.add_days(moment(), -days_to_deduct[this.period]);
+			return null;
 		},
 		filtered_users() {
 			let filtered = this.users.slice();


### PR DESCRIPTION
- Add a rank column for leaderboard
<img width="1178" alt="Screenshot 2019-04-25 at 11 09 23 AM" src="https://user-images.githubusercontent.com/13928957/56712230-623ec600-674b-11e9-8f52-e277db6528a6.png">

- Add single link for history log which redirects to reference doc.
- Add utils for the "week start"
- Show stats for This Week/Month instead of Last Week/ Month
- Get data for "This Month" by default