### PR TITLE
feat(ux): Save document with any unpublished comments

### DIFF
--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -55,12 +55,7 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 	},
 
 	submit() {
-		// return submit promise
-		if (this.on_submit) {
-			return this.on_submit(this.get_value());
-		} else {
-			return Promise.resolve();
-		}
+		this.on_submit && this.on_submit(this.get_value());
 	},
 
 	update_state() {

--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -16,7 +16,7 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 				<div class="comment-input-container">
 					<div class="frappe-control"></div>
 					<div class="text-muted small">
-						${__("Ctrl+Enter to add comment")}
+						${__("Ctrl+Enter or Ctrl+S to add comment")}
 					</div>
 				</div>
 			</div>
@@ -43,7 +43,7 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 
 		this.$wrapper.on('keydown', e => {
 			const key = frappe.ui.keys.get_key(e);
-			if (key === 'ctrl+enter') {
+			if (['ctrl+enter', 'ctrl+s'].includes(key)) {
 				e.preventDefault();
 				this.submit();
 			}

--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -16,7 +16,7 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 				<div class="comment-input-container">
 					<div class="frappe-control"></div>
 					<div class="text-muted small">
-						${__("Ctrl+Enter or Ctrl+S to add comment")}
+						${__("Ctrl+Enter to add comment")}
 					</div>
 				</div>
 			</div>
@@ -43,7 +43,7 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 
 		this.$wrapper.on('keydown', e => {
 			const key = frappe.ui.keys.get_key(e);
-			if (['ctrl+enter', 'ctrl+s'].includes(key)) {
+			if (key === 'ctrl+enter') {
 				e.preventDefault();
 				this.submit();
 			}
@@ -55,7 +55,12 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 	},
 
 	submit() {
-		this.on_submit && this.on_submit(this.get_value());
+		// return submit promise
+		if (this.on_submit) {
+			return this.on_submit(this.get_value());
+		} else {
+			return Promise.resolve();
+		}
 	},
 
 	update_state() {

--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -28,12 +28,7 @@ frappe.ui.form.Timeline = class Timeline {
 			render_input: true,
 			only_input: true,
 			on_submit: (val) => {
-				// return new comment promise
-				if (strip_html(val)) {
-					return this.insert_comment("Comment", val, this.comment_area.button);
-				} else {
-					return Promise.resolve();
-				}
+				strip_html(val) && this.insert_comment("Comment", val, this.comment_area.button);
 			}
 		});
 

--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -28,7 +28,12 @@ frappe.ui.form.Timeline = class Timeline {
 			render_input: true,
 			only_input: true,
 			on_submit: (val) => {
-				val && this.insert_comment("Comment", val, this.comment_area.button);
+				// return new comment promise
+				if (strip_html(val)) {
+					return this.insert_comment("Comment", val, this.comment_area.button);
+				} else {
+					return Promise.resolve();
+				}
 			}
 		});
 

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -714,18 +714,15 @@ _f.Frm.prototype._save = function(save_action, callback, btn, on_error, resolve,
 	if((!this.meta.in_dialog || this.in_form) && !this.meta.istable) {
 		frappe.utils.scroll_to(0);
 	}
-	var after_save = function (r) {
-		// init add comment promise to handle promise chain on success or fail
-		let add_new_comment = Promise.resolve();
-
+	var after_save = function(r) {
 		if (!r.exc) {
 			if (["Save", "Update", "Amend"].indexOf(save_action) !== -1) {
 				frappe.utils.play_sound("click");
 			}
 
 			me.script_manager.trigger("after_save");
-			// wait for comment promise to resolve
-			add_new_comment = me.timeline.comment_area.submit();
+			// submit comment if entered
+			me.timeline.comment_area.submit();
 			me.refresh();
 		} else {
 			if (on_error) {
@@ -735,8 +732,7 @@ _f.Frm.prototype._save = function(save_action, callback, btn, on_error, resolve,
 		}
 
 		callback && callback(r);
-		// chains the save promise with add new comment promise
-		resolve(add_new_comment);
+		resolve();
 	};
 
 	var fail = () => {


### PR DESCRIPTION
**Problem:**

If a comment is added on a document, saving the document does not automatically add the comment, which leads to bad UX.

**Screenshots / GIFs:**

![new-comment](https://user-images.githubusercontent.com/13396535/58254921-777a3500-7d89-11e9-89d4-37886fd9a4a5.gif)