### PR TITLE
fix: GSTR-1 report not working if show totals is enabled

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -360,6 +360,8 @@ def add_total_row(result, columns, meta = None):
 			options = col.get("options")
 
 		for row in result:
+			if i >= len(row): continue
+
 			cell = row.get(fieldname) if isinstance(row, dict) else row[i]
 			if fieldtype in ["Currency", "Int", "Float", "Percent"] and flt(cell):
 				total_row[i] = flt(total_row[i]) + flt(cell)


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 48, in run_background
result = generate_report_result(report, filters=instance.filters, user=instance.owner)
File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 104, in generate_report_result
result = add_total_row(result, columns)
File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 369, in add_total_row
cell = row.get(fieldname) if isinstance(row, dict) else row[i]
IndexError: list index out of range
```


**After Fix**

![Screen Shot 2019-04-29 at 1 50 12 pm](https://user-images.githubusercontent.com/8780500/56883934-c8965200-6a85-11e9-83f1-706b7665236e.png)
