### PR TITLE
fix: while saving employee user getting user permissions error

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -25,16 +25,18 @@ def print_has_permission_check_logs(func):
 		frappe.flags['has_permission_check_logs'] = []
 		result = func(*args, **kwargs)
 		self_perm_check = True if not kwargs.get('user') else kwargs.get('user') == frappe.session.user
+		raise_exception = False if kwargs.get('raise_exception') == False else True
+
 		# print only if access denied
 		# and if user is checking his own permission
-		if not result and self_perm_check:
+		if not result and self_perm_check and raise_exception:
 			msgprint(('<br>').join(frappe.flags.get('has_permission_check_logs')))
 		frappe.flags.pop('has_permission_check_logs', None)
 		return result
 	return inner
 
 @print_has_permission_check_logs
-def has_permission(doctype, ptype="read", doc=None, verbose=False, user=None):
+def has_permission(doctype, ptype="read", doc=None, verbose=False, user=None, raise_exception=True):
 	"""Returns True if user has permission `ptype` for given `doctype`.
 	If `doc` is passed, it also checks user, share and owner permissions.
 


### PR DESCRIPTION
**Issue** 

While saving the employee user getting below error

![Screen Shot 2019-04-29 at 7 14 42 pm](https://user-images.githubusercontent.com/8780500/56900310-21c8aa80-6ab3-11e9-9cc2-98d03868f01f.png)


On saving employee, if the employee is linked with the user then the system auto creates the user permissions. But before that, we check if the user has permissions to create the user permission or not
