### PR TITLE
fix: Set user language in print preview

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -114,13 +114,8 @@ frappe.ui.form.PrintPreview = Class.extend({
 	},
 	set_default_print_language: function () {
  		var print_format = this.get_print_format();
-
- 		if (print_format.default_print_language) {
- 			this.lang_code = print_format.default_print_language;
- 			this.language_sel.val(this.lang_code);
- 		} else {
-			this.language_sel.val(frappe.boot.lang);
-		}
+		this.lang_code = print_format.default_print_format || frappe.boot.lang;
+		this.language_sel.val(this.lang_code);
  	},
 	multilingual_preview: function () {
 		var me = this;
@@ -210,7 +205,10 @@ frappe.ui.form.PrintPreview = Class.extend({
 		}
 	},
 	get_print_html: function (callback) {
-		frappe.call({
+		if (this._req) {
+			this._req.abort();
+		}
+		this._req = frappe.call({
 			method: "frappe.www.printview.get_html_and_style",
 			args: {
 				doc: this.frm.doc,


### PR DESCRIPTION
The User language was set in the select control but the value didn't pass correctly in the request, because `this.lang_code` wasn't set. We also abort duplicate requests.

![image](https://user-images.githubusercontent.com/9355208/57009006-9fa2c800-6c11-11e9-94cc-7fe29f5f6058.png)
