### PR TITLE
fix(UX): Don't set root_label as page title in tree

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -107,11 +107,10 @@ frappe.views.TreeView = Class.extend({
 					me.args[filter.fieldname] = val;
 					if (val) {
 						me.root_label = val;
-						me.page.set_title(val);
 					} else {
 						me.root_label = me.opts.root_label;
-						me.set_title();
 					}
+					me.set_title();
 					me.make_tree();
 				}
 			}


### PR DESCRIPTION
Root label is already shown in the Tree and in some cases the filter

![image](https://user-images.githubusercontent.com/9355208/57010393-f6140480-6c19-11e9-8ed2-9ecd85b966e7.png)
