### PR TITLE
fix: Bulk user Permission unhandled condition(v11)

### DIFF
--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -15,6 +15,12 @@ class TestUserPermission(unittest.TestCase):
 		created = add_user_permissions(param)
 		self.assertEquals(created, 1)
 
+	def test_for_apply_to_all_on_update_from_apply_all(self):
+		user = get_user()
+		param = get_params(user, apply= 1)
+		create = add_user_permissions(param)
+		self.assertEquals(create, 0)
+
 	def test_for_applicable_on_update_from_apply_to_all(self):
 		''' Update User Permission from all to some applicable Doctypes'''
 		user = get_user()

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -11,46 +11,55 @@ class TestUserPermission(unittest.TestCase):
 	def test_apply_to_all(self):
 		''' Create User permission for User having access to all applicable Doctypes'''
 		user = get_user()
-		param = get_params(user, apply = 1)
-		created = add_user_permissions(param)
-		self.assertEquals(created, 1)
+		param = get_params(user, apply_to_all = 1)
+		is_created = add_user_permissions(param)
+		self.assertEquals(is_created, 1)
 
 	def test_for_apply_to_all_on_update_from_apply_all(self):
 		user = get_user()
-		param = get_params(user, apply= 1)
-		create = add_user_permissions(param)
-		self.assertEquals(create, 0)
+		param = get_params(user, apply_to_all= 1)
+
+		add_user_permissions(param)
+
+		is_created = add_user_permissions(param)
+		self.assertEquals(is_created, 0)
 
 	def test_for_applicable_on_update_from_apply_to_all(self):
 		''' Update User Permission from all to some applicable Doctypes'''
 		user = get_user()
 		param = get_params(user, applicable = ["Chat Room", "Chat Message"])
-		create = add_user_permissions(param)
+
+		add_user_permissions(get_params(user, apply_to_all= 1))
+
+		is_created = add_user_permissions(param)
 		frappe.db.commit()
 
 		removed_apply_to_all = frappe.db.exists("User Permission", get_exists_param(user))
-		created_applicable_first = frappe.db.exists("User Permission", get_exists_param(user, applicable = "Chat Room"))
-		created_applicable_second = frappe.db.exists("User Permission", get_exists_param(user, applicable = "Chat Message"))
+		is_created_applicable_first = frappe.db.exists("User Permission", get_exists_param(user, applicable = "Chat Room"))
+		is_created_applicable_second = frappe.db.exists("User Permission", get_exists_param(user, applicable = "Chat Message"))
 
 		self.assertIsNone(removed_apply_to_all)
-		self.assertIsNotNone(created_applicable_first)
-		self.assertIsNotNone(created_applicable_second)
-		self.assertEquals(create, 1)
+		self.assertIsNotNone(is_created_applicable_first)
+		self.assertIsNotNone(is_created_applicable_second)
+		self.assertEquals(is_created, 1)
 
 	def test_for_apply_to_all_on_update_from_applicable(self):
 		''' Update User Permission from some to all applicable Doctypes'''
 		user = get_user()
-		param = get_params(user, apply = 1)
-		created = add_user_permissions(param)
-		created_apply_to_all = frappe.db.exists("User Permission", get_exists_param(user))
+		param = get_params(user, apply_to_all = 1)
+
+		add_user_permissions(get_params(user, applicable = ["Chat Room", "Chat Message"]))
+
+		is_created = add_user_permissions(param)
+		is_created_apply_to_all = frappe.db.exists("User Permission", get_exists_param(user))
 		removed_applicable_first = frappe.db.exists("User Permission", get_exists_param(user, applicable = "Chat Room"))
 		removed_applicable_second = frappe.db.exists("User Permission", get_exists_param(user, applicable = "Chat Message"))
 
 
-		self.assertIsNotNone(created_apply_to_all)
+		self.assertIsNotNone(is_created_apply_to_all)
 		self.assertIsNone(removed_applicable_first)
 		self.assertIsNone(removed_applicable_second)
-		self.assertEquals(created, 1)
+		self.assertEquals(is_created, 1)
 
 def get_user():
 	if frappe.db.exists('User', 'test_bulk_creation_update@example.com'):
@@ -62,14 +71,14 @@ def get_user():
 		user.add_roles("System Manager")
 		return user
 
-def get_params(user, apply = None , applicable = None):
+def get_params(user, apply_to_all = None , applicable = None):
 	''' Return param to insert '''
 	param = {
 		"user": user.name,
 		"doctype":"User",
 		"docname":user.name
 	}
-	if apply:
+	if apply_to_all:
 		param.update({"apply_to_all_doctypes": 1})
 		param.update({"applicable_doctypes": []})
 	if applicable:

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -17,7 +17,7 @@ class TestUserPermission(unittest.TestCase):
 
 	def test_for_apply_to_all_on_update_from_apply_all(self):
 		user = get_user()
-		param = get_params(user, apply_to_all= 1)
+		param = get_params(user, apply_to_all=1)
 
 		add_user_permissions(param)
 

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -19,7 +19,9 @@ class TestUserPermission(unittest.TestCase):
 		user = get_user()
 		param = get_params(user, apply_to_all= 1)
 
-		add_user_permissions(param)
+		check = add_user_permissions(param)
+
+		self.assertIsNotNone(check)
 
 		is_created = add_user_permissions(param)
 		self.assertEquals(is_created, 0)
@@ -29,7 +31,9 @@ class TestUserPermission(unittest.TestCase):
 		user = get_user()
 		param = get_params(user, applicable = ["Chat Room", "Chat Message"])
 
-		add_user_permissions(get_params(user, apply_to_all= 1))
+		check = add_user_permissions(get_params(user, apply_to_all= 1))
+
+		self.assertIsNotNone(check)
 
 		is_created = add_user_permissions(param)
 		frappe.db.commit()
@@ -48,7 +52,9 @@ class TestUserPermission(unittest.TestCase):
 		user = get_user()
 		param = get_params(user, apply_to_all = 1)
 
-		add_user_permissions(get_params(user, applicable = ["Chat Room", "Chat Message"]))
+		check = add_user_permissions(get_params(user, applicable = ["Chat Room", "Chat Message"]))
+
+		self.assertIsNotNone(check)
 
 		is_created = add_user_permissions(param)
 		is_created_apply_to_all = frappe.db.exists("User Permission", get_exists_param(user))

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -158,12 +158,17 @@ def add_user_permissions(data):
 	data = frappe._dict(data)
 
 	d = check_applicable_doc_perm(data.user, data.doctype, data.docname)
-	exists = frappe.db.exists("User Permission", {"user": data.user, "allow": data.doctype, "for_value": data.docname, "apply_to_all_doctypes": 1})
+	exists = frappe.db.exists("User Permission", {
+		"user": data.user,
+		"allow": data.doctype,
+		"for_value": data.docname,
+		"apply_to_all_doctypes": 1
+	})
 	if data.apply_to_all_doctypes == 1 and not exists:
 		remove_applicable(d, data.user, data.doctype, data.docname)
 		insert_user_perm(data.user, data.doctype, data.docname, apply_to_all = 1)
 		return 1
-	else:
+	elif len(data.applicable_doctypes) > 0 and data.apply_to_all_doctypes != 1:
 		remove_apply_to_all(data.user, data.doctype, data.docname)
 		update_applicable(d, data.applicable_doctypes, data.user, data.doctype, data.docname)
 		for applicable in data.applicable_doctypes :


### PR DESCRIPTION
On creating user permission with `apply_to_all_doctypes = 1`, the existing user permission used to get deleted.

This PR aims to fix that.