### PR TITLE
fix(pdf): Define filedata before it is used

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -18,12 +18,14 @@ def get_pdf(html, options=None, output=None):
 		"disable-local-file-access": "",
 	})
 
+	filedata = ''
+
 	try:
 		# Set filename property to false, so no file is actually created
 		filedata = pdfkit.from_string(html, False, options=options or {})
 
 		# https://pythonhosted.org/PyPDF2/PdfFileReader.html
-		# create in-memory binary streams from filedata and create a PdfFileReader objcet
+		# create in-memory binary streams from filedata and create a PdfFileReader object
 		reader = PdfFileReader(io.BytesIO(filedata))
 
 	except IOError as e:


### PR DESCRIPTION
To avoid the following error

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1026, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/print_format.py", line 91, in download_pdf
    frappe.local.response.filecontent = get_pdf(html)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/pdf.py", line 36, in get_pdf
    if filedata:
UnboundLocalError: local variable 'filedata' referenced before assignment
```