### PR TITLE
fix: link_title not getting set in address and contact

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -152,3 +152,11 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 	valid_doctypes = [[doctype] for doctype in valid_doctypes]
 
 	return valid_doctypes
+
+def set_link_title(doc):
+	if not doc.links:
+		return
+	for link in doc.links:
+		if not link.link_title:
+			linked_doc = frappe.get_doc(link.link_doctype, link.link_name)
+			link.link_title = linked_doc.get("title_field") or linked_doc.get("name")

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -15,6 +15,7 @@ from frappe.model.naming import make_autoname
 from frappe.core.doctype.dynamic_link.dynamic_link import deduplicate_dynamic_links
 from six import iteritems, string_types
 from past.builtins import cmp
+from frappe.contacts.address_and_contact import set_link_title
 
 import functools
 
@@ -39,7 +40,7 @@ class Address(Document):
 	def validate(self):
 		self.link_address()
 		self.validate_reference()
-		self.set_link_title()
+		set_link_title(self)
 		deduplicate_dynamic_links(self)
 
 	def link_address(self):
@@ -53,14 +54,6 @@ class Address(Document):
 				return True
 
 		return False
-
-	def set_link_title(self):
-		if not self.links:
-			return
-		for address in self.links:
-			if not address.link_title:
-				linked_doc = frappe.get_doc(address.link_doctype, address.link_name)
-				address.link_title = linked_doc.get("title_field") or linked_doc.get("name")
 
 	def validate_reference(self):
 		if self.is_your_company_address:

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -57,14 +57,10 @@ class Address(Document):
 	def set_link_title(self):
 		if not self.links:
 			return
-		else:
-			for address in self.links:
-				if not address.link_title:
-					linked_doc = frappe.get_doc(address.link_doctype, address.link_name)
-					try:
-						address.link_title = linked_doc.title_field
-					except AttributeError:
-						address.link_title = linked_doc.name
+		for address in self.links:
+			if not address.link_title:
+				linked_doc = frappe.get_doc(address.link_doctype, address.link_name)
+				address.link_title = linked_doc.get("title_field") or linked_doc.get("name")
 
 	def validate_reference(self):
 		if self.is_your_company_address:

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -39,6 +39,7 @@ class Address(Document):
 	def validate(self):
 		self.link_address()
 		self.validate_reference()
+		self.set_link_title()
 		deduplicate_dynamic_links(self)
 
 	def link_address(self):
@@ -52,6 +53,18 @@ class Address(Document):
 				return True
 
 		return False
+
+	def set_link_title(self):
+		if not self.links:
+			return
+		else:
+			for address in self.links:
+				if not address.link_title:
+					linked_doc = frappe.get_doc(address.link_doctype, address.link_name)
+					try:
+						address.link_title = linked_doc.title_field
+					except AttributeError:
+						address.link_title = linked_doc.name
 
 	def validate_reference(self):
 		if self.is_your_company_address:

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -10,6 +10,7 @@ from frappe.core.doctype.dynamic_link.dynamic_link import deduplicate_dynamic_li
 from six import iteritems
 from past.builtins import cmp
 from frappe.model.naming import append_number_if_name_exists
+from frappe.contacts.address_and_contact import set_link_title
 
 import functools
 
@@ -31,7 +32,7 @@ class Contact(Document):
 		if self.email_id:
 			self.email_id = self.email_id.strip()
 		self.set_user()
-		self.set_link_title()
+		set_link_title(self)
 		if self.email_id and not self.image:
 			self.image = has_gravatar(self.email_id)
 
@@ -40,14 +41,6 @@ class Contact(Document):
 	def set_user(self):
 		if not self.user and self.email_id:
 			self.user = frappe.db.get_value("User", {"email": self.email_id})
-
-	def set_link_title(self):
-		if not self.links:
-			return
-		for contact in self.links:
-			if not contact.link_title:
-				linked_doc = frappe.get_doc(contact.link_doctype, contact.link_name)
-				contact.link_title = linked_doc.get("title_field") or linked_doc.get("name")
 
 	def get_link_for(self, link_doctype):
 		'''Return the link name, if exists for the given link DocType'''

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -44,14 +44,10 @@ class Contact(Document):
 	def set_link_title(self):
 		if not self.links:
 			return
-		else:
-			for contact in self.links:
-				if not contact.link_title:
-					linked_doc = frappe.get_doc(contact.link_doctype, contact.link_name)
-					try:
-						contact.link_title = linked_doc.title_field
-					except AttributeError:
-						contact.link_title = linked_doc.name
+		for contact in self.links:
+			if not contact.link_title:
+				linked_doc = frappe.get_doc(contact.link_doctype, contact.link_name)
+				contact.link_title = linked_doc.get("title_field") or linked_doc.get("name")
 
 	def get_link_for(self, link_doctype):
 		'''Return the link name, if exists for the given link DocType'''

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -31,6 +31,7 @@ class Contact(Document):
 		if self.email_id:
 			self.email_id = self.email_id.strip()
 		self.set_user()
+		self.set_link_title()
 		if self.email_id and not self.image:
 			self.image = has_gravatar(self.email_id)
 
@@ -39,6 +40,18 @@ class Contact(Document):
 	def set_user(self):
 		if not self.user and self.email_id:
 			self.user = frappe.db.get_value("User", {"email": self.email_id})
+
+	def set_link_title(self):
+		if not self.links:
+			return
+		else:
+			for contact in self.links:
+				if not contact.link_title:
+					linked_doc = frappe.get_doc(contact.link_doctype, contact.link_name)
+					try:
+						contact.link_title = linked_doc.title_field
+					except AttributeError:
+						contact.link_title = linked_doc.name
 
 	def get_link_for(self, link_doctype):
 		'''Return the link name, if exists for the given link DocType'''


### PR DESCRIPTION
Link Title would not automatically get set when creating a contact or address programatically. There are client functions to set `link_title` for the child table, however it's not available as a server side method. This PR fixes the issue.

<img width="943" alt="Screenshot 2019-05-06 at 3 16 06 PM" src="https://user-images.githubusercontent.com/18097732/57221214-ef233280-701b-11e9-8922-8d10a4ed0bb0.png">
