### PR TITLE
fix: Disable Portal Routes

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -16,6 +16,9 @@ def resolve_route(path):
 
 	The only exceptions are `/about` and `/contact` these will be searched in Web Pages
 	first before checking the standard pages."""
+
+	raise_if_disabled(path)
+
 	if path not in ("about", "contact"):
 		context = get_page_info_from_template(path)
 		if context:
@@ -26,6 +29,21 @@ def resolve_route(path):
 		if context:
 			return context
 		return get_page_info_from_template(path)
+
+def raise_if_disabled(path):
+	routes = frappe.db.get_all('Portal Menu Item',
+		fields=['route', 'enabled'],
+		filters={
+			'route': ['like', '%{0}'.format(path)],
+			'enabled': 0
+		}
+	)
+
+	for r in routes:
+		_path = r.route.lstrip('/')
+		if path == _path and not r.enabled:
+			raise frappe.PermissionError
+
 
 def get_page_context(path):
 	page_context = None


### PR DESCRIPTION
Disabling Portal Menu Items in Portal Settings only removes them from the sidebar but they are accessible via the URL. Now, those routes are disabled.

![disable-routes](https://user-images.githubusercontent.com/9355208/57218505-19242700-7013-11e9-9e45-64b33790c4d1.gif)
