### PR TITLE
feat: disable customize option for single doctypes

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -87,6 +87,9 @@ class CustomizeForm(Document):
 		if self.doc_type in core_doctypes_list:
 			return frappe.msgprint(_("Core DocTypes cannot be customized."))
 
+		if meta.issingle:
+			return frappe.msgprint(_("Single DocTypes cannot be customized."))
+
 		if meta.custom:
 			return frappe.msgprint(_("Only standard DocTypes are allowed to be customized from Customize Form."))
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -160,7 +160,7 @@ frappe.ui.form.Toolbar = Class.extend({
 				me.frm.savetrash();}, true);
 		}
 
-		if(frappe.user_roles.includes("System Manager")) {
+		if(frappe.user_roles.includes("System Manager") && me.frm.meta.issingle === 0) {
 			this.page.add_menu_item(__("Customize"), function() {
 				frappe.set_route("Form", "Customize Form", {
 					doc_type: me.frm.doctype


### PR DESCRIPTION
The PR contains the following changes.

- Remove Customize Option from toolbar.js
- Check if doctype is single at server side