### PR TITLE
fix: listview count while filtering with child table

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -646,14 +646,23 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	get_count_str() {
 		const current_count = this.data.length;
+		const filters = this.get_filters_for_args();
+		const with_child_table_filter = filters.some(filter => {
+			return filter[0] !== this.doctype;
+		});
+
+		const fields = [
+			// can break this line as in adds extra \n's and \t's which breaks the query
+			`count(${with_child_table_filter ? 'distinct': ''}${frappe.model.get_full_column_name('name', this.doctype)}) AS total_count`
+		];
 
 		return frappe.call({
 			type: 'GET',
 			method: this.method,
 			args: {
 				doctype: this.doctype,
-				filters: this.get_filters_for_args(),
-				fields: [`count(${frappe.model.get_full_column_name('name', this.doctype)}) as total_count`],
+				filters,
+				fields,
 			}
 		}).then(r => {
 			this.total_count = r.message.values[0][0] || current_count;

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -652,7 +652,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		});
 
 		const fields = [
-			// can break this line as in adds extra \n's and \t's which breaks the query
+			// cannot break this line as it adds extra \n's and \t's which breaks the query
 			`count(${with_child_table_filter ? 'distinct': ''}${frappe.model.get_full_column_name('name', this.doctype)}) AS total_count`
 		];
 


### PR DESCRIPTION
**Issue:**
Previously, the count value was wrong when list view was filtered with a child table. Actually, it used to show the no. of matching rows of the child table.

**Solution:**
Add distinct to count query if filter includes child table.

Note: Cannot use distinct always as it slows down the count query.
Analysis: https://github.com/frappe/frappe/commit/5c14f2c256660bf8f15db09d876b098ff859a53c

**Before:**
<img width="1178" alt="Screenshot 2019-05-07 at 10 34 15 AM" src="https://user-images.githubusercontent.com/13928957/57273127-3c52e300-70b4-11e9-9595-f4809bade809.png">

**After:**
<img width="1171" alt="Screenshot 2019-05-07 at 10 34 36 AM" src="https://user-images.githubusercontent.com/13928957/57273143-45dc4b00-70b4-11e9-83d8-967f9580b7fe.png">
