### PR TITLE
fix: Skip energy point log creation if user from the rule comes out to be an admin

### DIFF
--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -105,6 +105,19 @@ class TestEnergyPointLog(unittest.TestCase):
 		self.assertEquals(energy_points_after_review, energy_points_before_review - criticism_points)
 		self.assertEquals(review_points_after_review, review_points_before_review - criticism_points)
 
+	def test_user_energy_point_as_admin(self):
+		frappe.set_user('Administrator')
+		create_energy_point_rule_for_todo()
+		created_todo = create_a_todo()
+
+		created_todo.status = 'Closed'
+		created_todo.save()
+
+		points_after_closing_todo = get_points('Administrator')
+
+		# no points for admin
+		self.assertEquals(points_after_closing_todo, 0)
+
 def create_energy_point_rule_for_todo(multiplier_field=None):
 	name = 'ToDo Closed'
 	point_rule = frappe.db.get_all(

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -53,7 +53,7 @@ def process_energy_points(doc, state):
 
 	for d in frappe.cache_manager.get_doctype_map('Energy Point Rule', doc.doctype,
 		dict(reference_doctype = doc.doctype, enabled=1)):
-		frappe.get_doc('Energy Point Rule', d.name).apply(doc)
+		frappe.get_doc('Energy Point Rule', d.get('name')).apply(doc)
 
 def get_energy_point_doctypes():
 	return [

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -33,7 +33,7 @@ class EnergyPointRule(Document):
 			if not points: return
 
 			# if user_field has no value
-			if not user: return
+			if not user or user == 'Administrator': return
 
 			try:
 				create_energy_points_log(reference_doctype, reference_name, {
@@ -48,8 +48,7 @@ class EnergyPointRule(Document):
 def process_energy_points(doc, state):
 	if (frappe.flags.in_patch
 		or frappe.flags.in_install
-		or not is_energy_point_enabled()
-		or frappe.session.user == 'Administrator'):
+		or not is_energy_point_enabled()):
 		return
 
 	for d in frappe.cache_manager.get_doctype_map('Energy Point Rule', doc.doctype,


### PR DESCRIPTION
Skip energy point log creation if a user from the rule comes out to be an admin. 

