### PR TITLE
fix: typo in user permission validation message

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -53,7 +53,7 @@ class UserPermission(Document):
 			}, limit=1)
 		if overlap_exists:
 			ref_link = frappe.get_desk_link(self.doctype, overlap_exists[0].name)
-			frappe.throw(_("{0} has already assigned default vaue for {1}.".format(ref_link, self.allow)))
+			frappe.throw(_("{0} has already assigned default value for {1}.".format(ref_link, self.allow)))
 
 @frappe.whitelist()
 def get_user_permissions(user=None):


### PR DESCRIPTION
Display a better message on validation for overlapping default user permission.