### PR TITLE
fix: add parameter minutes(v11)

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -70,7 +70,7 @@ def to_timedelta(time_str):
 	else:
 		return time_str
 
-def add_to_date(date, years=0, months=0, days=0, hours=0, seconds=0, as_string=False, as_datetime=False):
+def add_to_date(date, years=0, months=0, days=0, hours=0, minutes=0, seconds=0, as_string=False, as_datetime=False):
 	"""Adds `days` to the given date"""
 	from dateutil.relativedelta import relativedelta
 
@@ -86,7 +86,7 @@ def add_to_date(date, years=0, months=0, days=0, hours=0, seconds=0, as_string=F
 			as_datetime = True
 		date = parser.parse(date)
 
-	date = date + relativedelta(years=years, months=months, days=days, hours=hours, seconds=seconds)
+	date = date + relativedelta(years=years, months=months, days=days, hours=hours, minutes=minutes, seconds=seconds)
 
 	if as_string:
 		if as_datetime:


### PR DESCRIPTION
Previous implementation of the API did not handle minutes or seconds level granularity. This PR adds seconds and minutes parameters