### PR TITLE
fix(report): Allow report export only if user has export permission on ref doctype

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -280,6 +280,10 @@ def export_query():
 		filters = json.loads(data["filters"])
 	if isinstance(data.get("report_name"), string_types):
 		report_name = data["report_name"]
+		frappe.permissions.can_export(
+			frappe.get_cached_value('Report', report_name, 'ref_doctype'),
+			raise_exception=True
+		)
 	if isinstance(data.get("file_format_type"), string_types):
 		file_format_type = data["file_format_type"]
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -162,7 +162,7 @@ def validate_rename(doctype, new, meta, merge, force, ignore_permissions):
 	if (not merge) and exists:
 		frappe.msgprint(_("Another {0} with name {1} exists, select another name").format(doctype, new), raise_exception=1)
 
-	if not (ignore_permissions or frappe.has_permission(doctype, "write")):
+	if not (ignore_permissions or frappe.permissions.has_permission(doctype, "write", raise_exception=False)):
 		frappe.msgprint(_("You need write permission to rename"), raise_exception=1)
 
 	if not (force or ignore_permissions) and not meta.allow_rename:

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -977,6 +977,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			{
 				label: __('Export'),
 				action: () => this.export_report(),
+				condition: () => frappe.model.can_export(this.report_doc.ref_doctype),
 				standard: true
 			},
 			{


### PR DESCRIPTION
Allow export only if the user has export permission on the reference doctype of the report