### PR TITLE
fix: Disallow editing standard print formats

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,15 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.13.3
-ignore: {}
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-AWESOMPLETE-174474:
+    - awesomplete:
+        reason: No patch available
+        expires: '2019-06-11T14:12:04.995Z'
+  'npm:mem:20180117':
+    - showdown > yargs > os-locale > mem:
+        reason: No patch available
+        expires: '2019-06-11T14:12:04.995Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:extend:20180424':

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.3
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:extend:20180424':
+    - superagent > extend:
+        patched: '2019-05-09T10:14:19.246Z'

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -12,10 +12,9 @@ frappe.pages['print-format-builder'].on_page_show = function(wrapper) {
 		});
 	} else if(frappe.route_options) {
 		if(frappe.route_options.make_new) {
-			var doctype = frappe.route_options.doctype;
-			var name = frappe.route_options.name;
+			let { doctype, name, based_on } = frappe.route_options;
 			frappe.route_options = null;
-			frappe.print_format_builder.setup_new_print_format(doctype, name);
+			frappe.print_format_builder.setup_new_print_format(doctype, name, based_on);
 		} else {
 			frappe.print_format_builder.print_format = frappe.route_options.doc;
 			frappe.route_options = null;
@@ -130,23 +129,14 @@ frappe.PrintFormatBuilder = Class.extend({
 
 		});
 	},
-	setup_new_print_format: function(doctype, name) {
-		var me = this;
-		frappe.call({
-			method: "frappe.client.insert",
-			args: {
-				doc: {
-					doctype: "Print Format",
-					name: name,
-					standard: "No",
-					doc_type: doctype,
-					print_format_builder: 1
-				}
-			},
-			callback: function(r) {
-				me.print_format = r.message;
-				me.refresh();
-			}
+	setup_new_print_format: function(doctype, name, based_on) {
+		frappe.call('frappe.printing.page.print_format_builder.print_format_builder.create_custom_format', {
+			doctype,
+			name,
+			based_on
+		}).then((r) => {
+			this.print_format = r.message;
+			this.refresh();
 		});
 	},
 	setup_print_format: function() {

--- a/frappe/printing/page/print_format_builder/print_format_builder.py
+++ b/frappe/printing/page/print_format_builder/print_format_builder.py
@@ -1,0 +1,12 @@
+import frappe
+
+@frappe.whitelist()
+def create_custom_format(doctype, name, based_on):
+	doc = frappe.new_doc('Print Format')
+	doc.doc_type = doctype
+	doc.name = name
+	doc.print_format_builder = 1
+	doc.format_data = frappe.db.get_value('Print Format', based_on, 'format_data') \
+		if based_on != 'Standard' else None
+	doc.insert()
+	return doc

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -81,26 +81,42 @@ frappe.ui.form.PrintPreview = Class.extend({
 
 		this.wrapper.find(".btn-print-edit").on("click", function () {
 			let print_format = me.get_print_format();
-			if (print_format && print_format.name) {
-				if (print_format.print_format_builder) {
-					frappe.set_route("print-format-builder", print_format.name);
-				} else {
-					frappe.set_route("Form", "Print Format", print_format.name);
+			let is_custom_format = print_format.name
+				&& print_format.print_format_builder
+				&& print_format.standard === 'No';
+			let is_standard_but_editable = print_format.name && print_format.custom_format;
+
+			if (is_standard_but_editable) {
+				frappe.set_route("Form", "Print Format", print_format.name);
+				return;
+			}
+			if (is_custom_format) {
+				frappe.set_route("print-format-builder", print_format.name);
+				return;
+			}
+			// start a new print format
+			frappe.prompt([
+				{
+					label: __("New Print Format Name"),
+					fieldname: "print_format_name",
+					fieldtype: "Data",
+					reqd: 1,
+				},
+				{
+					label: __('Based On'),
+					fieldname: 'based_on',
+					fieldtype: 'Read Only',
+					default: print_format.name || 'Standard'
 				}
-			} else {
-				// start a new print format
-				frappe.prompt({
-					fieldname: "print_format_name", fieldtype: "Data", reqd: 1,
-					label: "New Print Format Name"
-				}, function (data) {
+			], function (data) {
 					frappe.route_options = {
 						make_new: true,
 						doctype: me.frm.doctype,
-						name: data.print_format_name
+						name: data.print_format_name,
+						based_on: data.based_on
 					};
 					frappe.set_route("print-format-builder");
 				}, __("New Custom Print Format"), __("Start"));
-			}
 		});
 	},
 	set_user_lang: function () {

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -109,14 +109,14 @@ frappe.ui.form.PrintPreview = Class.extend({
 					default: print_format.name || 'Standard'
 				}
 			], function (data) {
-					frappe.route_options = {
-						make_new: true,
-						doctype: me.frm.doctype,
-						name: data.print_format_name,
-						based_on: data.based_on
-					};
-					frappe.set_route("print-format-builder");
-				}, __("New Custom Print Format"), __("Start"));
+				frappe.route_options = {
+					make_new: true,
+					doctype: me.frm.doctype,
+					name: data.print_format_name,
+					based_on: data.based_on
+				};
+				frappe.set_route("print-format-builder");
+			}, __("New Custom Print Format"), __("Start"));
 		});
 	},
 	set_user_lang: function () {


### PR DESCRIPTION
Print Formats with `standard` set as `Yes` were allowed to be customised because it would affect the `json` file. Now, they won't be allowed to be customized, instead a copy would be created.

![custom-print-format](https://user-images.githubusercontent.com/9355208/57444704-5e906080-726e-11e9-9713-8953f0e2df58.gif)
