### PR TITLE
fix: Text editor styles when readonly

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -38,24 +38,6 @@ class MyLink extends Link {
 
 Quill.register(MyLink);
 
-
-// hidden blot
-class HiddenBlock extends Block {
-	static create(value) {
-		const node = super.create(value);
-		node.setAttribute('data-comment', value);
-		node.classList.add('hidden');
-		return node;
-	}
-
-	static formats(node) {
-		return node.getAttribute('data-comment');
-	}
-}
-HiddenBlock.blotName = 'hiddenblot';
-HiddenBlock.tagName = 'SPAN';
-Quill.register(HiddenBlock, true);
-
 // image uploader
 const Uploader = Quill.import('modules/uploader');
 Uploader.DEFAULTS.mimetypes.push('image/gif');
@@ -73,6 +55,11 @@ Quill.register(AlignStyle, true);
 Quill.register(DirectionStyle, true);
 
 frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
+	make_wrapper() {
+		this._super();
+		this.$wrapper.find(".like-disabled-input").addClass("ql-editor");
+	},
+
 	make_input() {
 		this.has_input = true;
 		this.make_quill_editor();


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9355208/57446521-7bc72e00-7272-11e9-81e8-c038b422c68b.png)

After:
![image](https://user-images.githubusercontent.com/9355208/57446536-85e92c80-7272-11e9-8bd8-e6d45b2215e8.png)
