### PR TITLE
fix: Process for energy points on any doc changes

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -118,7 +118,6 @@ doc_events = {
 			"frappe.core.doctype.activity_log.feed.update_feed",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
-			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",
 			"frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone"
 		],
 		"after_rename": "frappe.desk.notifications.clear_doctype_notifications",
@@ -131,8 +130,9 @@ doc_events = {
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions"
 		],
 		"on_change": [
-			"frappe.core.doctype.feedback_trigger.feedback_trigger.trigger_feedback_request"
-		]
+			"frappe.core.doctype.feedback_trigger.feedback_trigger.trigger_feedback_request",
+			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points"
+		],
 	},
 	"Email Group Member": {
 		"validate": "frappe.email.doctype.email_group.email_group.restrict_email_group"


### PR DESCRIPTION
Previously, changes on the submitted documents were not processed for energy points
