### PR TITLE
feat(core): Allow action on msgprint and throw calls

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -120,6 +120,11 @@ frappe.msgprint = function(msg, title) {
 			}
 		});
 
+		// setup and bind an action to the primary button
+		if (data.primary_action) {
+			frappe.msg_dialog.set_primary_action(__(data.primary_action.label || "Done"), data.primary_action.action);
+		}
+
 		// class "msgprint" is used in tests
 		frappe.msg_dialog.msg_area = $('<div class="msgprint">')
 			.appendTo(frappe.msg_dialog.body);
@@ -137,6 +142,12 @@ frappe.msgprint = function(msg, title) {
 
 	if(data.message.search(/<br>|<p>|<li>/)==-1) {
 		msg = frappe.utils.replace_newlines(data.message);
+	}
+
+	if (data.primary_action) {
+		frappe.msg_dialog.get_primary_btn().show();
+	} else {
+		frappe.msg_dialog.get_primary_btn().hide();
 	}
 
 	var msg_exists = false;


### PR DESCRIPTION
Made to hotfix at #7446.

<hr>

**Use-Case:** Sometimes, an extra action may be required on a message print or when an error is raised.

![image](https://user-images.githubusercontent.com/13396535/57511858-d8385500-7327-11e9-91bb-bd223f26a156.png)