### PR TITLE
Apply Customer role instead of Blogger

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -130,7 +130,7 @@ def create_user(params):
 			"language": "",
 			"user_type": "System User",
 			"roles": [{
-				"role": _("Blogger")
+				"role": _("Customer")
 			}]
 		})
 


### PR DESCRIPTION
Partially fixes https://github.com/frappe/frappe/issues/7444

Blogger as default role for LDAP users does not make much sense in corporate environments and when users login via LDAP for webshop. Better solution would be to be able to define a `role profile` in the LDAP settings. 