### PR TITLE
Fix: Wrong variable used for this.lang_code

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -114,7 +114,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 	},
 	set_default_print_language: function () {
  		var print_format = this.get_print_format();
-		this.lang_code = print_format.default_print_format || frappe.boot.lang;
+		this.lang_code = print_format.default_print_language || frappe.boot.lang;
 		this.language_sel.val(this.lang_code);
  	},
 	multilingual_preview: function () {


### PR DESCRIPTION
Fix: Wrong variable used for this.lang_code

The update is good, but it uses the wrong variable, so it always falls back to frappe.boot.lang. 

This fix solves it.