### PR TITLE
fix: Clickable show card button

### DIFF
--- a/frappe/public/js/frappe/views/components/Desktop.vue
+++ b/frappe/public/js/frappe/views/components/Desktop.vue
@@ -1,16 +1,15 @@
 <template>
 	<div class="modules-page-container" v-if="home_settings_fetched">
+		<a
+			class="btn-show-hide text-muted text-medium"
+			@click="show_hide_cards_dialog"
+		>
+			{{ __('Show / Hide Cards') }}
+		</a>
 		<div
 			class="modules-section"
 			v-for="(category, i) in module_categories" :key="category"
 		>
-			<a
-				v-if="i === 0"
-				class="btn-show-hide text-muted text-medium"
-				@click="show_hide_cards_dialog"
-			>
-				{{ __('Show / Hide Cards') }}
-			</a>
 			<desk-section
 				v-if="get_modules_for_category(category).length"
 				:category="category"
@@ -131,19 +130,22 @@ export default {
 
 <style lang="less" scoped>
 .modules-page-container {
+	position: relative;
 	margin-top: 40px;
 	margin-bottom: 30px;
+	padding-top: 1px;
 }
 
 .modules-section {
 	position: relative;
-	padding-top: 30px;
+	margin-top: 30px;
 }
 
 .btn-show-hide {
 	position: absolute;
 	right: 0;
-	top: 36px;
+	top: 39px;
+	z-index: 1;
 }
 
 .toolbar-underlay {


### PR DESCRIPTION
Show / Hide cards button is not clickable if there are no modules.

![show-hide-cards](https://user-images.githubusercontent.com/9355208/57607917-bb9b5780-7589-11e9-99aa-bd621e475c5c.gif)
