### PR TITLE
fix: auto repeat showing next schedule date wrong for backdated entries

### DIFF
--- a/frappe/desk/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat.py
@@ -34,9 +34,14 @@ class AutoRepeat(Document):
 		validate_template(self.message or "")
 
 	def before_submit(self):
+		start_date_copy = self.start_date
+
+		if start_date_copy < today():
+			start_date_copy = today()
+
 		if not self.next_schedule_date:
 			self.next_schedule_date = get_next_schedule_date(
-				self.start_date, self.frequency, self.repeat_on_day)
+				start_date_copy, self.frequency, self.repeat_on_day)
 
 	def on_submit(self):
 		self.update_auto_repeat_id()
@@ -116,14 +121,15 @@ class AutoRepeat(Document):
 			days = 60 if self.frequency in ['Daily', 'Weekly'] else 365
 			end_date_copy = add_days(today_copy, days)
 
+		start_date_copy = get_next_schedule_date(start_date_copy, self.frequency, self.repeat_on_day)
 		while (getdate(start_date_copy) < getdate(end_date_copy)):
-			start_date_copy = get_next_schedule_date(start_date_copy, self.frequency, self.repeat_on_day)
 			row = {
 				"reference_document" : self.reference_document,
 				"frequency" : self.frequency,
 				"next_scheduled_date" : start_date_copy
 			}
 			schedule_details.append(row)
+			start_date_copy = get_next_schedule_date(start_date_copy, self.frequency, self.repeat_on_day)
 
 		return schedule_details
 

--- a/frappe/desk/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat.py
@@ -35,9 +35,10 @@ class AutoRepeat(Document):
 
 	def before_submit(self):
 		start_date_copy = self.start_date
+		today_copy = add_days(today(), -1)
 
-		if start_date_copy < today():
-			start_date_copy = today()
+		if start_date_copy <= today_copy:
+			start_date_copy = today_copy
 
 		if not self.next_schedule_date:
 			self.next_schedule_date = get_next_schedule_date(

--- a/frappe/desk/doctype/auto_repeat/auto_repeat_schedule.html
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat_schedule.html
@@ -12,7 +12,7 @@
 		<tr>
 			<td>{{ schedule_details[i].reference_document }}</td>
 			<td> {{ schedule_details[i].frequency }} </td>
-			<td> {{ frappe.format_date(schedule_details[i].next_scheduled_date) }} </td>
+			<td> {{ schedule_details[i].next_scheduled_date }} </td>
 		</tr>
 	{% } %}
 	</tbody>

--- a/frappe/desk/doctype/auto_repeat/auto_repeat_schedule.html
+++ b/frappe/desk/doctype/auto_repeat/auto_repeat_schedule.html
@@ -12,7 +12,7 @@
 		<tr>
 			<td>{{ schedule_details[i].reference_document }}</td>
 			<td> {{ schedule_details[i].frequency }} </td>
-			<td> {{ schedule_details[i].next_scheduled_date }} </td>
+			<td> {{ frappe.format_date(schedule_details[i].next_scheduled_date) }} </td>
 		</tr>
 	{% } %}
 	</tbody>

--- a/frappe/desk/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/desk/doctype/auto_repeat/test_auto_repeat.py
@@ -8,7 +8,7 @@ import unittest
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.desk.doctype.auto_repeat.auto_repeat import get_auto_repeat_entries, create_repeated_entries, disable_auto_repeat
-from frappe.utils import today, add_days, getdate
+from frappe.utils import today, add_days, getdate, add_months
 
 
 def add_custom_fields():
@@ -44,8 +44,8 @@ class TestAutoRepeat(unittest.TestCase):
 		self.assertEqual(todo.get('description'), new_todo.get('description'))
 
 	def test_monthly_auto_repeat(self):
-		start_date = '2018-01-01'
-		end_date = '2018-12-31'
+		start_date = today()
+		end_date = add_months(start_date, 12)
 
 		todo = frappe.get_doc(
 			dict(doctype='ToDo', description='test recurring todo', assigned_by='Administrator')).insert()
@@ -103,7 +103,7 @@ def make_auto_repeat(**args):
 		'reference_document': args.reference_document or frappe.db.get_value('ToDo', {'docstatus': 1}, 'name'),
 		'frequency': args.frequency or 'Daily',
 		'start_date': args.start_date or add_days(today(), -1),
-		'end_date': args.end_date or add_days(today(), 1),
+		'end_date': args.end_date or add_days(today(), 2),
 		'submit_on_creation': args.submit_on_creation or 0,
 		'notify_by_email': args.notify or 0,
 		'recipients': args.recipients or "",


### PR DESCRIPTION
**Issue**

![image41b66d](https://user-images.githubusercontent.com/8780500/57683352-164bb680-7651-11e9-9bbb-4395b8c4ecdc.png)
