### PR TITLE
fix: quoting special characters and appropriately encoding non-ASCII filename

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -21,6 +21,7 @@ from frappe.core.doctype.file.file import check_file_permission
 from frappe.website.render import render
 from frappe.utils import cint
 from six import text_type
+from six.moves.urllib.parse import quote
 
 def report_error(status_code):
 	'''Build error. Show traceback in developer mode'''
@@ -178,7 +179,7 @@ def send_private_file(path):
 	if frappe.local.request.headers.get('X-Use-X-Accel-Redirect'):
 		path = '/protected/' + path
 		response = Response()
-		response.headers['X-Accel-Redirect'] = frappe.utils.encode(path)
+		response.headers['X-Accel-Redirect'] = frappe.utils.encode(quote(path))
 
 	else:
 		filepath = frappe.utils.get_site_path(path)


### PR DESCRIPTION
Duplicate of #7677

**Cannot Download Attachments with UTF-8 name**
If you upload a file with Chinese characters in the filename, you can "internal server error" when you try to download it.

![GIF](https://user-images.githubusercontent.com/42132869/57675360-582a2c00-7654-11e9-8beb-be4a806e3866.gif)

download works on the development server, but fails in production.
web.error.log shows:

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 183, in handle_request
    resp.close()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/http/wsgi.py", line 409, in close
    self.send_headers()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/http/wsgi.py", line 329, in send_headers
    util.write(self.sock, util.to_bytestring(header_str, "ascii"))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/util.py", line 507, in to_bytestring
    return value.encode(encoding)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 182-187: ordinal not in range(128)
```