### PR TITLE
fix: delete filedata if upload file through socketio

### DIFF
--- a/frappe/public/js/frappe/upload.js
+++ b/frappe/public/js/frappe/upload.js
@@ -321,6 +321,9 @@ frappe.upload = {
 			upload_with_filedata();
 			return;
 		} else {
+			if (args.filedata) {
+				delete args.filedata;
+			}
 			args.file_size = fileobj.size;
 			frappe.call({
 				method: 'frappe.utils.file_manager.validate_filename',


### PR DESCRIPTION
**File data gets saved with wrong content for multi-file uploads**
If I upload two files, one file size less than 24576 and the other file size greater than 24576, the smaller file will gets stored to the bigger file's content.

![GIF](https://user-images.githubusercontent.com/42132869/57684738-f58f5b00-7668-11e9-9a45-e497d574c534.gif)
