### PR TITLE
fix: if more than 20 records are available then system removing last row in the multi select modal

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -208,7 +208,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 			txt: me.dialog.fields_dict["search_term"].get_value(),
 			filters: filters,
 			filter_fields: Object.keys(me.setters).concat([me.date_field]),
-			page_length: this.page_length + 1,
+			page_length: this.page_length,
 			query: this.get_query ? this.get_query().query : '',
 			as_dict: 1
 		}
@@ -220,10 +220,6 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 			callback: function(r) {
 				let results = [], more = 0;
 				if(r.values.length) {
-					if(r.values.length > me.page_length){
-						r.values.pop();
-						more = 1;
-					}
 					r.values.forEach(function(result) {
 						if(me.date_field in result) {
 							result["Date"] = result[me.date_field]


### PR DESCRIPTION
Goto Sales Invoice > click on Get Items From > select Delivery Note

1. The Delivery Notes are filtered by specifying the Customer and Date Range.

2. If the actual number of Delivery Notes are less than 20, the correct number of Delivery Notes are shown in the 'Select Delivery Notes' window.

3. When the number of Delivery Notes supposed to be fetched by the filter is 21 or more, 1 less row (delivery note) is fetched. In case of 21 Delivery Notes that should be shown in the window, only 20 are shown. Similarly in case of 30 Delivery Notes, 29 are shown,  in case of 100, 99 are shown and so on.

4. It is always the last row, sorted by id, which is left out.