### PR TITLE
fix: Don't show no value type fields in options for custom columns

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -992,9 +992,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								change: () => {
 									let doctype = d.get_value('doctype');
 									frappe.model.with_doctype(doctype, () => {
-										let fields = frappe.meta.get_docfields(doctype)
-											.map(df => ({ label: df.label, value: df.fieldname }));
-										d.set_df_property('field', 'options', fields);
+										let field_list = []
+										frappe.meta.get_docfields(doctype)
+											.map(df => {
+												if (!in_list(frappe.model.no_value_type, df.fieldtype)) {
+													let fields = { label: df.label, value: df.fieldname }
+													field_list.push(fields);
+												}
+											});
+										d.set_df_property('field', 'options', field_list);
 
 									});
 								}

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -992,15 +992,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								change: () => {
 									let doctype = d.get_value('doctype');
 									frappe.model.with_doctype(doctype, () => {
-										let field_list = []
-										frappe.meta.get_docfields(doctype)
-											.map(df => {
-												if (!in_list(frappe.model.no_value_type, df.fieldtype)) {
-													let fields = { label: df.label, value: df.fieldname }
-													field_list.push(fields);
-												}
-											});
-										d.set_df_property('field', 'options', field_list);
+										let options = frappe.meta.get_docfields(doctype)
+											.filter(frappe.model.is_value_type)
+											.map(df => ({ label: df.label, value: df.fieldname }));
+
+										d.set_df_property('field', 'options', options);
 
 									});
 								}


### PR DESCRIPTION
Hotfix: https://github.com/frappe/frappe/pull/7496