### PR TITLE
fix: Add a patch to apply customization to custom doctype

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -236,3 +236,4 @@ frappe.patches.v11_0.fix_order_by_in_reports_json
 execute:frappe.delete_doc('Page', 'applications', ignore_missing=True)
 frappe.patches.v11_0.set_missing_creation_and_modified_value_for_user_permissions
 frappe.patches.v11_0.remove_doctype_user_permissions_for_page_and_report #2019-05-01
+frappe.patches.v11_0.apply_customization _to_custom_doctype

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -236,4 +236,4 @@ frappe.patches.v11_0.fix_order_by_in_reports_json
 execute:frappe.delete_doc('Page', 'applications', ignore_missing=True)
 frappe.patches.v11_0.set_missing_creation_and_modified_value_for_user_permissions
 frappe.patches.v11_0.remove_doctype_user_permissions_for_page_and_report #2019-05-01
-frappe.patches.v11_0.apply_customization _to_custom_doctype
+frappe.patches.v11_0.apply_customization_to_custom_doctype

--- a/frappe/patches/v11_0/apply_customization_to_custom_doctype.py
+++ b/frappe/patches/v11_0/apply_customization_to_custom_doctype.py
@@ -1,0 +1,52 @@
+import frappe
+from frappe.utils import cint
+
+# This patch aims to apply & delete all the customization
+# on custom doctypes done through customize form
+
+# This is required because customize form in now blocked
+# for custom doctypes and user may not be able to
+# see previous customization
+
+def execute():
+	custom_doctypes = frappe.get_all('DocType', filters={
+		'custom': 1
+	})
+
+	for doctype in custom_doctypes:
+		property_setters = frappe.get_all('Property Setter', filters={
+			'doc_type': doctype.name,
+			'doctype_or_field': 'DocField'
+		}, fields=['name', 'property', 'value', 'property_type', 'field_name'])
+
+		custom_fields = frappe.get_all('Custom Field',
+			filters={'dt': doctype.name},
+			fields=['*']
+		)
+
+		property_setters_map = {}
+
+		for property in property_setters:
+			property_setters_map[property.field_name] = property
+			frappe.db.sql('DELETE FROM `tabProperty Setter` WHERE `name`=%s', property.name)
+
+		meta = frappe.get_doc('DocType', doctype.name)
+
+		for df in meta.fields:
+			ps = property_setters_map.get(df.fieldname, None)
+			if ps:
+				value = cint(ps.value) if ps.property_type == 'Int' else ps.value
+				df.set(ps.property, value)
+
+		for cf in custom_fields:
+			df = frappe.new_doc('DocField', meta, 'fields')
+			cf.pop('parenttype')
+			cf.pop('parentfield')
+			cf.pop('parent')
+			cf.pop('name')
+			df.update(cf)
+			meta.fields.append(df)
+			frappe.db.sql('DELETE FROM `tabCustom Field` WHERE name=%s', cf.name)
+
+		meta.save()
+

--- a/frappe/patches/v11_0/apply_customization_to_custom_doctype.py
+++ b/frappe/patches/v11_0/apply_customization_to_custom_doctype.py
@@ -24,16 +24,16 @@ def execute():
 			fields=['*']
 		)
 
-		property_setters_map = {}
+		property_setter_map = {}
 
-		for property in property_setters:
-			property_setters_map[property.field_name] = property
-			frappe.db.sql('DELETE FROM `tabProperty Setter` WHERE `name`=%s', property.name)
+		for prop in property_setters:
+			property_setter_map[prop.field_name] = prop
+			frappe.db.sql('DELETE FROM `tabProperty Setter` WHERE `name`=%s', prop.name)
 
 		meta = frappe.get_doc('DocType', doctype.name)
 
 		for df in meta.fields:
-			ps = property_setters_map.get(df.fieldname, None)
+			ps = property_setter_map.get(df.fieldname, None)
 			if ps:
 				value = cint(ps.value) if ps.property_type == 'Int' else ps.value
 				df.set(ps.property, value)


### PR DESCRIPTION
This patch aims to apply customization & then delete all the customization records for  custom doctypes done through customize form

This is required because customize form is now blocked
for custom doctypes and user may not be able to
see the previous customization