### PR TITLE
fix: Report Print format for indented rows

### DIFF
--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -31,15 +31,17 @@
                     {% var value = col.fieldname ? row[col.fieldname] : row[col.id]; %}
 
                     <td>
-                        {{
-                            col.formatter
-                                ? col.formatter(row._index, col._index, value, col, row, true)
-                                : col.format
-                                    ? col.format(value, row, col, data)
-                                    : col.docfield
-                                        ? frappe.format(value, col.docfield)
-                                        : value
-                        }}
+                        <span {% if col._index == 0 %} style="padding-left: {%= cint(row.indent) * 2 %}em" {% endif %}>
+                            {{
+                                col.formatter
+                                    ? col.formatter(row._index, col._index, value, col, row, true)
+                                    : col.format
+                                        ? col.format(value, row, col, data)
+                                        : col.docfield
+                                            ? frappe.format(value, col.docfield)
+                                            : value
+                            }}
+                        </span>
                     </td>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
It was not showing indent in report Print Format. This PR is to fix that.

Port of https://github.com/frappe/frappe/pull/7506