### PR TITLE
fix: print format builder setup

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -132,7 +132,6 @@ frappe.PrintFormatBuilder = Class.extend({
 	setup_new_print_format: function(doctype, name, based_on) {
 		frappe.call({
 			method: 'frappe.printing.page.print_format_builder.print_format_builder.create_custom_format',
-
 			args: {
 				doctype: doctype,
 				name: name,

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -130,13 +130,22 @@ frappe.PrintFormatBuilder = Class.extend({
 		});
 	},
 	setup_new_print_format: function(doctype, name, based_on) {
-		frappe.call('frappe.printing.page.print_format_builder.print_format_builder.create_custom_format', {
-			doctype,
-			name,
-			based_on
-		}).then((r) => {
-			this.print_format = r.message;
-			this.refresh();
+		frappe.call({
+			method: 'frappe.printing.page.print_format_builder.print_format_builder.create_custom_format',
+
+			args: {
+				doctype: doctype,
+				name: name,
+				based_on: based_on
+			},
+			callback: (r) => {
+				if(!r.exc) {
+					if(r.message) {
+						this.print_format = r.message;
+						this.refresh();
+					}
+				}
+			},
 		});
 	},
 	setup_print_format: function() {

--- a/frappe/printing/page/print_format_builder/print_format_builder.py
+++ b/frappe/printing/page/print_format_builder/print_format_builder.py
@@ -1,7 +1,7 @@
 import frappe
 
 @frappe.whitelist()
-def create_custom_format(doctype, name, based_on):
+def create_custom_format(doctype, name, based_on='Standard'):
 	doc = frappe.new_doc('Print Format')
 	doc.doc_type = doctype
 	doc.name = name


### PR DESCRIPTION
fixes: TypeError: create_custom_format() takes exactly 3 arguments (2 given)