### PR TITLE
fix: check payment status before capturing the payment

### DIFF
--- a/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py
+++ b/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py
@@ -312,8 +312,12 @@ def capture_payment(is_sandbox=False, sanbox_response=None):
 				data = json.loads(doc.data)
 				settings = controller.get_settings(data)
 
-				resp = make_post_request("https://api.razorpay.com/v1/payments/{0}/capture".format(data.get("razorpay_payment_id")),
+				resp = make_get_request("https://api.razorpay.com/v1/payments/{0}".format(data.get("razorpay_payment_id")),
 					auth=(settings.api_key, settings.api_secret), data={"amount": data.get("amount")})
+
+				if resp.get('status') == "authorized":
+					resp = make_post_request("https://api.razorpay.com/v1/payments/{0}/capture".format(data.get("razorpay_payment_id")),
+						auth=(settings.api_key, settings.api_secret), data={"amount": data.get("amount")})
 
 			if resp.get("status") == "captured":
 				frappe.db.set_value("Integration Request", doc.name, "status", "Completed")


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py", line 316, in capture_payment
    auth=(settings.api_key, settings.api_secret), data={"amount": data.get("amount")})
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/utils.py", line 50, in make_post_request
    raise exc
HTTPError: 400 Client Error: Bad Request for url: https://api.razorpay.com/v1/payments/**********/capture
```