### PR TITLE
fix: patch sequence fix and add commit after reload doc

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -1,4 +1,6 @@
-frappe.patches.v12_0.remove_deprecated_fields_from_doctype #3
+frappe.patches.v12_0.remove_deprecated_fields_from_doctype #4
+execute:frappe.reload_doc('core', 'doctype', 'communication_link')
+execute:frappe.reload_doc('core', 'doctype', 'communication')
 execute:frappe.db.sql("""update `tabPatch Log` set patch=replace(patch, '.4_0.', '.v4_0.')""") #2014-05-12
 frappe.patches.v5_0.convert_to_barracuda_and_utf8mb4
 execute:frappe.utils.global_search.setup_global_search_table()
@@ -241,6 +243,4 @@ frappe.patches.v12_0.reset_home_settings
 frappe.patches.v12_0.update_print_format_type
 frappe.patches.v11_0.remove_doctype_user_permissions_for_page_and_report #2019-05-01
 frappe.patches.v12_0.remove_feedback_rating
-execute:frappe.reload_doc('core', 'doctype', 'communication_link')
-execute:frappe.reload_doc('core', 'doctype', 'communication')
 frappe.patches.v12_0.move_timeline_links_to_dynamic_links

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -1,4 +1,4 @@
-frappe.patches.v12_0.remove_deprecated_fields_from_doctype #4
+frappe.patches.v12_0.remove_deprecated_fields_from_doctype #3
 execute:frappe.reload_doc('core', 'doctype', 'communication_link')
 execute:frappe.reload_doc('core', 'doctype', 'communication')
 execute:frappe.db.sql("""update `tabPatch Log` set patch=replace(patch, '.4_0.', '.v4_0.')""") #2014-05-12

--- a/frappe/patches/v12_0/remove_deprecated_fields_from_doctype.py
+++ b/frappe/patches/v12_0/remove_deprecated_fields_from_doctype.py
@@ -1,7 +1,9 @@
 import frappe
 
 def execute():
-	frappe.reload_doc('core', 'doctype', 'doctype', force=1)
+	frappe.reload_doc('core', 'doctype', 'doctype')
+	frappe.db.commit()
+
 	frappe.model.delete_fields({
 		'DocType': ['hide_heading', 'image_view', 'read_only_onload']
 	}, delete=1)

--- a/frappe/patches/v12_0/remove_deprecated_fields_from_doctype.py
+++ b/frappe/patches/v12_0/remove_deprecated_fields_from_doctype.py
@@ -1,7 +1,7 @@
 import frappe
 
 def execute():
-	frappe.reload_doc('core', 'doctype', 'doctype')
+	frappe.reload_doc('core', 'doctype', 'doctype', force=1)
 	frappe.model.delete_fields({
 		'DocType': ['hide_heading', 'image_view', 'read_only_onload']
 	}, delete=1)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 229, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 48, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v12_0/remove_deprecated_fields_from_doctype.py", line 7, in execute
    }, delete=1)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/__init__.py", line 121, in delete_fields
    frappe.db.sql(query)
  File "/home/travis/frappe-bench/apps/frappe/frappe/database/database.py", line 125, in sql
    self.check_transaction_status(query)
  File "/home/travis/frappe-bench/apps/frappe/frappe/database/database.py", line 248, in check_transaction_status
    raise Exception('This statement can cause implicit commit')
Exception: This statement can cause implicit commit
```