### PR TITLE
fix: Error message for invalid Workflow Transition

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -128,10 +128,20 @@ def validate_workflow(doc):
 
 	# if transitioning, check if user is allowed to transition
 	if current_state != next_state:
+		bold_current = frappe.bold(current_state)
+		bold_next = frappe.bold(next_state)
+
+		if not doc._doc_before_save:
+			# transitioning directly to a state other than the first
+			# e.g from data import
+			frappe.throw(_('Workflow State transition not allowed from {0} to {1}').format(bold_current, bold_next),
+				WorkflowPermissionError)
+
 		transitions = get_transitions(doc._doc_before_save)
 		transition = [d for d in transitions if d.next_state == next_state]
 		if not transition:
-			frappe.throw(_('Workflow State {0} is not allowed').format(frappe.bold(next_state)), WorkflowPermissionError)
+			frappe.throw(_('Workflow State transition not allowed from {0} to {1}').format(bold_current, bold_next),
+				WorkflowPermissionError)
 
 def get_workflow(doctype):
 	return frappe.get_doc('Workflow', get_workflow_name(doctype))


### PR DESCRIPTION
When you import a document of a DocType which has a workflow, you
shouldn't be able to set the workflow_state to a state except the first.
This patch shows a better error message.

![image](https://user-images.githubusercontent.com/9355208/58316358-fb3b2c80-7e30-11e9-9e43-b49cac5db59c.png)