### PR TITLE
fix: Fix routing issue causing dynamic links to disappear

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -185,7 +185,10 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			throw "saving";
 		}
 
-		frappe.ui.form.remove_old_form_route();
+		// ensure we remove new docs routes ONLY
+		if ( frm.is_new() ) {
+			frappe.ui.form.remove_old_form_route();
+		}
 		frappe.ui.form.is_saving = true;
 
 		return frappe.call({
@@ -219,14 +222,9 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 }
 
 frappe.ui.form.remove_old_form_route = () => {
-	let index = -1;
-	let current_route = frappe.get_route();
-	frappe.route_history.map((arr, i) => {
-		if (arr.join("/") === current_route.join("/")) {
-			index = i;
-		}
-	});
-	frappe.route_history.splice(index, 1);
+	let current_route = frappe.get_route().join("/");
+	frappe.route_history = frappe.route_history
+		.filter((route) => route.join("/") !== current_route);
 }
 
 frappe.ui.form.update_calling_link = (newdoc) => {


### PR DESCRIPTION
Made to develop at #7558.

<hr>

**Problem:**

Fixes issue where Address and Contact doctypes would sometimes not populate with the right info in their Dynamic Link tables.

**Steps to Reproduce:**

- Go to an existing Customer.
- Change any field so "Save" button is enabled and click Save.
- Click "New Address" or "New Contact".
- New Address or Contact form appears.
- The Dynamic Link table now doesn't populate the Customer that this document should have been linked to.

**Solution:**

The initial fix was added (at https://github.com/frappe/frappe/pull/3673) to remove new documents from the route history, but it also removed references to existing documents.

Now, we only remove route histories for new documents.

<hr>

**Screenshots / GIFs:**

**Before:**

![dynamic-link-issue](https://user-images.githubusercontent.com/13396535/58321130-ef546800-7e3a-11e9-9e06-57337c6b0f02.gif)

**After:**

![dynamic-link-issue-fix](https://user-images.githubusercontent.com/13396535/58321476-dc8e6300-7e3b-11e9-9887-5e81cb3b1aa6.gif)