### PR TITLE
fix: check if frappe.db exists

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -178,10 +178,10 @@ class Database(object):
 				frappe.errprint(("Execution time: {0} sec").format(round(time_end - time_start, 2)))
 
 		except Exception as e:
-			if(frappe.db.db_type == 'postgres'):
+			if frappe.db and frappe.db.db_type == 'postgres':
 				self.rollback()
 
-			if frappe.db.db_type == 'mariadb' and self.is_syntax_error(e):
+			if frappe.db and frappe.db.db_type == 'mariadb' and self.is_syntax_error(e):
 				frappe.errprint('Syntax error in query:')
 				frappe.errprint(query)
 


### PR DESCRIPTION
```

Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/frappe/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/develop-bench/apps/frappe/frappe/commands/site.py", line 33, in new_site
    db_type = db_type)
  File "/home/frappe/develop-bench/apps/frappe/frappe/commands/site.py", line 66, in _new_site
    source_sql=source_sql,force=force, reinstall=reinstall, db_type=db_type)
  File "/home/frappe/develop-bench/apps/frappe/frappe/installer.py", line 35, in install_db
    setup_database(force, source_sql, verbose)
  File "/home/frappe/develop-bench/apps/frappe/frappe/database/__init__.py", line 16, in setup_database
    return frappe.database.mariadb.setup_db.setup_database(force, source_sql, verbose)
  File "/home/frappe/develop-bench/apps/frappe/frappe/database/mariadb/setup_db.py", line 40, in setup_database
    dbman.delete_user(db_name)
  File "/home/frappe/develop-bench/apps/frappe/frappe/database/db_manager.py", line 33, in delete_user
    self.db.sql("DROP USER '%s'@'%s';" % (target, host))
  File "/home/frappe/develop-bench/apps/frappe/frappe/database/database.py", line 181, in sql
    if(frappe.db.db_type == 'postgres'):
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/werkzeug/local.py", line 348, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/home/frappe/develop-bench/env/lib/python2.7/site-packages/werkzeug/local.py", line 311, in _get_current_object
    raise RuntimeError("no object bound to %s" % self.__name__)
RuntimeError: no object bound to db

```