### PR TITLE
fix: incorrect doctype mapping in dynamic link while making quotation from the item

### DIFF
--- a/frappe/public/js/legacy/client_script_helpers.js
+++ b/frappe/public/js/legacy/client_script_helpers.js
@@ -509,7 +509,8 @@ _f.Frm.prototype.make_new = function(doctype) {
 
 			// set link fields (if found)
 			frappe.get_meta(doctype).fields.forEach(function(df) {
-				if(df.fieldtype==='Link' && df.options==="DocType") {
+				if(df.fieldtype==='Select' && df.options
+					&& in_list(df.options.split("\n"), me.doctype)) {
 					new_doc[df.fieldname] = me.doctype;
 				}
 


### PR DESCRIPTION
**Issue**

![issue_item_redirect_to_quotation](https://user-images.githubusercontent.com/8780500/58457447-5aa47f80-8144-11e9-810a-5b8bed451f2e.gif)


**After Fix**
![fixed_item_redirect_to_quotation](https://user-images.githubusercontent.com/8780500/58457454-61cb8d80-8144-11e9-9722-569833c5f693.gif)
