### PR TITLE
fix: Use different class for link preview popover

### DIFF
--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -175,9 +175,10 @@ frappe.ui.LinkPreview = class {
 			animation: false,
 		});
 
-		if(!this.is_link) {
-			this.element.data('bs.popover').tip().addClass('control-field-popover');
-		}
+		const $popover = this.element.data('bs.popover').tip();
+
+		$popover.addClass('link-preview-popover');
+		$popover.toggleClass('control-field-popover', this.is_link);
 
 		this.$links.push(this.element);
 

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -464,27 +464,6 @@ li.user-progress {
 	border-radius: 0px;
 }
 
-// like pop-over
-.liked-by-popover {
-	.popover-content {
-		padding: 0px;
-		overflow: scroll;
-		max-height: 150px;
-	}
-	min-width: 100px;
-	ul {
-		margin: 0px;
-		li {
-			padding: 10px;
-			cursor: pointer;
-			&:hover {
-				background: @btn-bg;
-			}
-		}
-	}
-
-}
-
 .screenshot {
 	border: 1px solid @border-color;
 	box-shadow: 1px 1px 7px rgba(0,0,0,0.15);
@@ -1072,6 +1051,27 @@ img.img-loading:after {
 	.popover-content {
 		padding: 12px;
 	}
+}
+
+// like pop-over
+.liked-by-popover {
+	.popover-content {
+		padding: 0px;
+		overflow: scroll;
+		max-height: 150px;
+	}
+	min-width: 100px;
+	ul {
+		margin: 0px;
+		li {
+			padding: 10px;
+			cursor: pointer;
+			&:hover {
+				background: @btn-bg;
+			}
+		}
+	}
+
 }
 
 body.full-width {

--- a/frappe/public/less/link_preview.less
+++ b/frappe/public/less/link_preview.less
@@ -1,4 +1,4 @@
-.popover {
+.link-preview-popover {
     border-radius: 0;
     max-width: 100%;
     .popover-content {


### PR DESCRIPTION
Because the style changes for link preview popover used to affect other popovers

**Before**
<img width="300" alt="Screenshot 2019-05-29 at 9 49 43 AM" src="https://user-images.githubusercontent.com/13928957/58529183-6309c280-81f7-11e9-9a4d-8d2164c0ecd8.png">


**After**
<img width="300" alt="Screenshot 2019-05-29 at 9 49 55 AM" src="https://user-images.githubusercontent.com/13928957/58529191-6a30d080-81f7-11e9-8868-fa0d2547a5f9.png">

<hr>


**Before**
<img width="187" alt="Screenshot 2019-05-29 at 10 21 22 AM" src="https://user-images.githubusercontent.com/13928957/58530393-35734800-81fc-11e9-88d0-54ea8148f877.png">

**After**
<img width="173" alt="Screenshot 2019-05-29 at 10 22 39 AM" src="https://user-images.githubusercontent.com/13928957/58530578-cfd38b80-81fc-11e9-8444-da6a3977f355.png">


**After re-arranging style**
<img width="168" alt="Screenshot 2019-05-29 at 10 23 12 AM" src="https://user-images.githubusercontent.com/13928957/58530450-681d4080-81fc-11e9-9b26-e138b452cb96.png">
