### PR TITLE
fix: Check if value is string

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -381,7 +381,7 @@ class DatabaseQuery(object):
 
 		elif f.operator.lower() in ('in', 'not in'):
 			values = f.value or ''
-			if not isinstance(values, (list, tuple)):
+			if isinstance(values, frappe.string_types):
 				values = values.split(",")
 
 			fallback = "''"


### PR DESCRIPTION
Breaks the check when value is a map. So we reverse the check.