### PR TITLE
fix: Update regex for capturing touched tables from query

### DIFF
--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -46,6 +46,11 @@ class TestDB(unittest.TestCase):
 		self.assertIn('tabToDo', frappe.flags.touched_tables)
 
 		frappe.flags.touched_tables = set()
+		frappe.db.sql("UPDATE tabToDo SET description = 'Updated Description'")
+		self.assertNotIn('tabToDo SET', frappe.flags.touched_tables)
+		self.assertIn('tabToDo', frappe.flags.touched_tables)
+
+		frappe.flags.touched_tables = set()
 		todo.delete()
 		self.assertIn('tabToDo', frappe.flags.touched_tables)
 


### PR DESCRIPTION
Backporting https://github.com/frappe/frappe/pull/7588

Previous regex used to yield false positives and false negatives
for queries like

UPDATE tabToDo SET description = "something"

Instead of yielding "tabToDo" it used to yield "tabToDo SET".

Now two separate regexes handle single word and multi-word names
In case of multi-word surrounding quotes are a must