### PR TITLE
fix: Update regex for capturing touched tables from query

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -987,12 +987,26 @@ class Database:
 		if values:
 			query = self._cursor.mogrify(query, values)
 		if query.strip().lower().split()[0] in ('insert', 'delete', 'update', 'alter'):
-			# ([`\"']?) Captures ', " or ` at the begining of the table name (if provided)
+			# single_word_regex is designed to match following patterns
+			# `tabXxx`, tabXxx and "tabXxx"
+
+			# multi_word_regex is designed to match following patterns
+			# `tabXxx Xxx` and "tabXxx Xxx"
+
+			# ([`"]?) Captures " or ` at the begining of the table name (if provided)
+			# \1 matches the first captured group (quote character) at the end of the table name
+			# multi word table name must have surrounding quotes.
+
 			# (tab([A-Z]\w+)( [A-Z]\w+)*) Captures table names that start with "tab"
 			# and are continued with multiple words that start with a captital letter
 			# e.g. 'tabXxx' or 'tabXxx Xxx' or 'tabXxx Xxx Xxx' and so on
-			# \1 matches the first captured group (quote character) at the end of the table name
-			tables = [groups[1] for groups in re.findall(r'([`"\']?)(tab([A-Z]\w+)( [A-Z]\w+)*)\1', query)]
+
+			single_word_regex = r'([`"]?)(tab([A-Z]\w+))\1'
+			multi_word_regex = r'([`"])(tab([A-Z]\w+)( [A-Z]\w+)+)\1'
+			tables = []
+			for regex in (single_word_regex, multi_word_regex):
+				tables += [groups[1] for groups in re.findall(regex, query)]
+
 			if frappe.flags.touched_tables is None:
 				frappe.flags.touched_tables = set()
 			frappe.flags.touched_tables.update(tables)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -46,6 +46,11 @@ class TestDB(unittest.TestCase):
 		self.assertIn('tabToDo', frappe.flags.touched_tables)
 
 		frappe.flags.touched_tables = set()
+		frappe.db.sql("UPDATE tabToDo SET description = 'Updated Description'")
+		self.assertNotIn('tabToDo SET', frappe.flags.touched_tables)
+		self.assertIn('tabToDo', frappe.flags.touched_tables)
+
+		frappe.flags.touched_tables = set()
 		todo.delete()
 		self.assertIn('tabToDo', frappe.flags.touched_tables)
 


### PR DESCRIPTION
Backporting https://github.com/frappe/frappe/pull/7588

Previous regex used to yield false positives and false negatives
for queries like

UPDATE tabToDo SET description = "something"

Instead of yielding "tabToDo" it used to yield "tabToDo SET".

Now two separate regexes handle single word and multi-word names
In case of multi-word surrounding quotes are a must
