### PR TITLE
fix(email): Search contacts by email_id as well

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -23,7 +23,7 @@ def get_contact_list(txt, page_length=20):
 		out = frappe.db.sql("""select email_id as value,
 			concat(first_name, ifnull(concat(' ',last_name), '' )) as description
 			from tabContact
-			where name like %(txt)s
+			where name like %(txt)s or email_id like %(txt)s
 			%(condition)s
 			limit %(page_length)s""", {
 				'txt': '%' + txt + '%',


### PR DESCRIPTION
Front porting https://github.com/frappe/frappe/pull/7594

Email auto suggest now performs lookup on name and email_id fields
