### PR TITLE
fix: dropbox exception formatting

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -30,7 +30,7 @@ class DropboxSettings(Document):
 
 @frappe.whitelist()
 def take_backup():
-	"Enqueue longjob for taking backup to dropbox"
+	"""Enqueue longjob for taking backup to dropbox"""
 	enqueue("frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backup_to_dropbox", queue='long', timeout=1500)
 	frappe.msgprint(_("Queued for backup. It may take a few minutes to an hour."))
 
@@ -61,8 +61,11 @@ def take_backup_to_dropbox(retry_count=0, upload_db_backup=True):
 			enqueue("frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backup_to_dropbox",
 				queue='long', timeout=1500, **args)
 	except Exception:
-		file_and_error = [" - ".join(f) for f in zip(did_not_upload, error_log)]
-		error_message = ("\n".join(file_and_error) + "\n" + frappe.get_traceback())
+		if isinstance(error_log, str):
+			error_message = error_log + "\n" + frappe.get_traceback()
+		else:
+			file_and_error = [" - ".join(f) for f in zip(did_not_upload, error_log)]
+			error_message = ("\n".join(file_and_error) + "\n" + frappe.get_traceback())
 		frappe.errprint(error_message)
 		send_email(False, "Dropbox", error_message)
 


### PR DESCRIPTION
So usually when dropbox backup fails, the function `backup_to_dropbox` returns two arrays, one with a list of the files not uploaded and other array with reasons for not uploading.

In case if there is any other error, say network issue or authentication failure, the error that is returned is a string, so when formatting the string, we [zip](https://docs.python.org/3.3/library/functions.html#zip) it assuming they are arrays. 

[code ref](https://github.com/frappe/frappe/pull/7597/files#diff-4ef92efc2ea093ce67817ef58a17e619L64)

This just add a string check for it

![bDW89Ej (1)](https://user-images.githubusercontent.com/18097732/58616518-8312b200-82db-11e9-9046-9cde17f35879.png)
