### PR TITLE
fix(list-view): Escape quotes in data-name

### DIFF
--- a/frappe/public/js/frappe/list/list_item_subject.html
+++ b/frappe/public/js/frappe/list/list_item_subject.html
@@ -1,5 +1,5 @@
 {% if (_checkbox) { %}
-<input class="list-row-checkbox hidden-xs" type="checkbox" data-name="{{name}}">
+<input class="list-row-checkbox hidden-xs" type="checkbox" data-name="{{ escape(name) }}">
 {% } %}
 {% if (!_hide_activity) { %}
 <span class="liked-by" data-liked-by=\'{{ JSON.stringify(_liked_by) }}\'>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -836,7 +836,7 @@ frappe.views.ListView = frappe.ui.BaseList.extend({
 
 	get_checked_items: function () {
 		var names = this.$page.find('.list-row-checkbox:checked').map(function (i, item) {
-			return cstr($(item).data().name);
+			return cstr(unescape($(item).data().name));
 		}).toArray();
 
 		return this.data.filter(function (doc) {


### PR DESCRIPTION
Fixes misbehavior in bulk actions when selected documents have names
with quotes.

Also merge

- [ ] https://github.com/frappe/frappe/pull/7599
- [ ] https://github.com/frappe/frappe/pull/7600