### PR TITLE
fix(doctype): Fieldname should not be in restricted fieldnames

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -203,6 +203,9 @@ class DocType(Document):
 							d.fieldname = d.fieldname + '_column'
 					else:
 						d.fieldname = d.fieldtype.lower().replace(" ","_") + "_" + str(d.idx)
+				else:
+					if d.fieldname in restricted:
+						frappe.throw(_("Fieldname {0} is restricted").format(d.fieldname), InvalidFieldNameError)
 
 				d.fieldname = re.sub('''['",./%@()<>{}]''', '', d.fieldname)
 

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import unittest
 from frappe.core.doctype.doctype.doctype import UniqueFieldnameError, IllegalMandatoryError, DoctypeLinkError, WrongOptionsDoctypeLinkError,\
- HiddenAndMandatoryWithoutDefaultError, CannotIndexedError
+ HiddenAndMandatoryWithoutDefaultError, CannotIndexedError, InvalidFieldNameError
 
 # test_records = frappe.get_test_records('DocType')
 
@@ -240,6 +240,16 @@ class TestDocType(unittest.TestCase):
 		field_2.fieldtype = 'Data'
 
 		self.assertRaises(UniqueFieldnameError, doc.insert)
+
+	def test_fieldname_is_not_name(self):
+		doc = self.new_doctype('Test Name Field')
+		field_1 = doc.append('fields', {})
+		field_1.label  = 'Name'
+		field_1.fieldtype = 'Data'
+		doc.insert()
+		self.assertEqual(doc.fields[1].fieldname, "name1")
+		doc.fields[1].fieldname  = 'name'
+		self.assertRaises(InvalidFieldNameError, doc.save)
 
 	def test_illegal_mandatory_validation(self):
 		doc = self.new_doctype('Test Illegal mandatory')


### PR DESCRIPTION
If fieldname wasn't provided and the fieldname generated from label
was found to be in restricted names then 1 was appended to the newly
prepared fieldname
e.g. Name becomes name1

But the fieldname was allowed to be edited later to bypass this restriction
i.e.. name1 can be renamed to name

This fixes that.

Co-authored-by: Suraj Shetty <surajshetty3416@gmail.com>