### PR TITLE
fix(query-report): Adding custom column data when result row is a tuple

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -210,6 +210,9 @@ def add_data_to_custom_columns(columns, result):
 	data = []
 	for row in result:
 		row_obj = {}
+		if isinstance(row, tuple):
+			row = list(row)
+
 		if isinstance(row, list):
 			for idx, column in enumerate(columns):
 				if column.get('link_field'):


### PR DESCRIPTION
Result row can be a list, dict or a tuple.

Previously handled cases:
**Case dict**: row can be used as it is
**Case list:** row is converted to an equivalent dict

Unhandled case (fixed with this commit):
**Case tuple:** row is converted to a list so that it can be handled with the list case

**Note**: To replicate failure, add a column in BOM Stock Report 