### PR TITLE
fix: Query report print fix

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -347,6 +347,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 				this.render_datatable();
 			} else {
+				this.data = [];
 				this.toggle_nothing_to_show(true);
 			}
 
@@ -925,6 +926,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	get_data_for_print() {
+
+		if (!this.data.length) {
+			return [];
+		}
+
 		const rows = this.datatable.datamanager.rowViewOrder.map(index => {
 			if (this.datatable.bodyRenderer.visibleRowIndices.includes(index)) {
 				return this.data[index];


### PR DESCRIPTION
Data getting printed even if there is no data to print

Report:
![image](https://user-images.githubusercontent.com/42651287/58702050-584f5900-83c2-11e9-90f0-a8a7c9c8f3a5.png)

Print:
![Screenshot 2019-05-31 at 3 26 15 PM](https://user-images.githubusercontent.com/42651287/58702011-3d7ce480-83c2-11e9-9098-45636ec400e4.png)
