### PR TITLE
fix(list-view bug): fix for overlapping text

### DIFF
--- a/frappe/public/less/list.less
+++ b/frappe/public/less/list.less
@@ -502,7 +502,7 @@ input.list-check-all, input.list-row-checkbox {
 }
 
 .list-item {
-	display: flex;
+	display: inline-table;
 	align-items: center;
 	cursor: pointer;
 


### PR DESCRIPTION
### display: flex  property is overlapping the long text.

Overlapping long text:
![ezgif com-video-to-gif-2](https://user-images.githubusercontent.com/30634335/58724514-db39d900-83ed-11e9-887e-8c7d0c6f48d5.gif)

After fixes:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/30634335/58724492-c6f5dc00-83ed-11e9-89e2-3a97e69df0de.gif)

**It's working fine on Firefox, Safari and mobile phone.**

**the margin between the list items can also be reduce by reducing the list-item padding.**
