### PR TITLE
fix(Communication): table doesn't exist

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -286,7 +286,6 @@ def on_doctype_update():
 	"""Add indexes in `tabCommunication`"""
 	frappe.db.add_index("Communication", ["reference_doctype", "reference_name"])
 	frappe.db.add_index("Communication", ["status", "communication_type"])
-	frappe.db.add_index("Communication Link", ["link_doctype", "link_name"])
 
 def has_permission(doc, ptype, user):
 	if ptype=="read":

--- a/frappe/core/doctype/communication_link/communication_link.py
+++ b/frappe/core/doctype/communication_link/communication_link.py
@@ -3,7 +3,7 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class CommunicationLink(Document):

--- a/frappe/core/doctype/communication_link/communication_link.py
+++ b/frappe/core/doctype/communication_link/communication_link.py
@@ -8,3 +8,6 @@ from frappe.model.document import Document
 
 class CommunicationLink(Document):
 	pass
+
+def on_doctype_update():
+	frappe.db.add_index("Communication Link", ["link_doctype", "link_name"])


### PR DESCRIPTION
While reinstalling site "Communication Link" is indexed in on_doctype_update which leads to table doesn't exist.
![Screenshot 2019-06-01 at 2 57 00 PM](https://user-images.githubusercontent.com/7310479/58746636-f8b68380-847d-11e9-8890-5a04c9baa0de.png)
