### PR TITLE
fix: follow redirect-to query parameter after login

### DIFF
--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 import frappe.utils
 import json, jwt
+import base64
 from frappe import _
 from frappe.utils.password import get_decrypted_password
 from six import string_types
@@ -58,16 +59,17 @@ def get_oauth_keys(provider):
 			"client_secret": keys["client_secret"]
 		}
 
-def get_oauth2_authorize_url(provider):
+def get_oauth2_authorize_url(provider, redirect_to):
 	flow = get_oauth2_flow(provider)
 
-	state = { "site": frappe.utils.get_url(), "token": frappe.generate_hash() }
+	state = { "site": frappe.utils.get_url(), "token": frappe.generate_hash(), "redirect_to": redirect_to 	}
+
 	frappe.cache().set_value("{0}:{1}".format(provider, state["token"]), True, expires_in_sec=120)
 
 	# relative to absolute url
 	data = {
 		"redirect_uri": get_redirect_uri(provider),
-		"state": json.dumps(state)
+		"state": base64.b64encode(bytes(json.dumps(state)).encode("utf-8"))
 	}
 
 	oauth2_providers = get_oauth2_providers()
@@ -167,6 +169,7 @@ def login_oauth_user(data=None, provider=None, state=None, email_id=None, key=No
 		data = json.loads(data)
 
 	if isinstance(state, string_types):
+		state = base64.b64decode(state)
 		state = json.loads(state)
 
 	if not (state and state["token"]):
@@ -204,8 +207,13 @@ def login_oauth_user(data=None, provider=None, state=None, email_id=None, key=No
 
 		frappe.response["login_token"] = login_token
 
+
 	else:
-		redirect_post_login(desk_user=frappe.local.response.get('message') == 'Logged In')
+		redirect_to = state.get("redirect_to")
+		redirect_post_login(
+			desk_user=frappe.local.response.get('message') == 'Logged In',
+			redirect_to=redirect_to,
+		)
 
 def update_oauth_user(user, data, provider):
 	if isinstance(data.get("location"), dict):
@@ -281,9 +289,12 @@ def get_last_name(data):
 def get_email(data):
 	return data.get("email") or data.get("upn") or data.get("unique_name")
 
-def redirect_post_login(desk_user):
+def redirect_post_login(desk_user, redirect_to=None):
 	# redirect!
 	frappe.local.response["type"] = "redirect"
 
-	# the #desktop is added to prevent a facebook redirect bug
-	frappe.local.response["location"] = "/desk#desktop" if desk_user else "/"
+	if not redirect_to:
+		# the #desktop is added to prevent a facebook redirect bug
+		redirect_to = "/desk#desktop" if desk_user else "/"
+
+	frappe.local.response["location"] = redirect_to

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -15,8 +15,12 @@ from frappe.utils.html_utils import get_icon_html
 no_cache = True
 
 def get_context(context):
+	redirect_to = frappe.local.request.args.get("redirect-to")
+
 	if frappe.session.user != "Guest":
-		frappe.local.flags.redirect_location = "/" if frappe.session.data.user_type=="Website User" else "/desk"
+		if not redirect_to:
+			redirect_to = "/" if frappe.session.data.user_type=="Website User" else "/desk"
+		frappe.local.flags.redirect_location = redirect_to
 		raise frappe.Redirect
 
 	# get settings from site config
@@ -34,7 +38,7 @@ def get_context(context):
 			context.provider_logins.append({
 				"name": provider,
 				"provider_name": frappe.get_value("Social Login Key", provider, "provider_name"),
-				"auth_url": get_oauth2_authorize_url(provider),
+				"auth_url": get_oauth2_authorize_url(provider, redirect_to),
 				"icon": icon
 			})
 			context["social_login"] = True


### PR DESCRIPTION
Problem / Issue :
 - Login with username and password follows the `/login?redirect-to=/api/method/ping` query parameter as expected.
 - Login using social login key does not follow the redirect-to after login is complete.

Solution :
 - state stores the redirect to location, it is base64 encoded, because now it may contain redirect url
