### PR TITLE
chore: disable pdf encryption for multipdf

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -50,10 +50,8 @@ def get_pdf(html, options=None, output=None):
 			password = frappe.safe_encode(password)
 
 	if output:
-		# Encrypt if required
-		if "password" in options:
-			output.encrypt(password)
-		return get_file_data_from_writer(output)
+		output.appendPagesFromReader(reader)
+		return output
 
 	writer = PdfFileWriter()
 	writer.appendPagesFromReader(reader)


### PR DESCRIPTION
In `print_format.py` at the following code
https://github.com/frappe/frappe/blob/20b220a6c87428e61ce06e670d9d4b0338fb9703/frappe/utils/print_format.py#L62-L64

`output` in the start of the loop is a PdfFileWriter object, later however in get_pdf.py it would get a stream of the pdf file, so in the next loops, in `get_pdf` from `pdf.py`  in the following `if` block, `get_file_data_from_writer` would throw an error.

https://github.com/frappe/frappe/blob/20b220a6c87428e61ce06e670d9d4b0338fb9703/frappe/utils/pdf.py#L52-L56

Instead of sending back file data, we return the PdfFileWriter object itself.

It's also to be noted that if the output cannot be encrypted, as the function is to be called inside a loop, the encryption option had to be removed for this.