### PR TITLE
fix: Modal UI 

### DIFF
--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -1,7 +1,7 @@
 // common file between desk and website
 
-frappe.avatar = function(user, css_class, title) {
-	if(user) {
+frappe.avatar = function (user, css_class, title, image_url = null) {
+	if (user) {
 		// desk
 		var user_info = frappe.user_info(user);
 	} else {
@@ -11,21 +11,21 @@ frappe.avatar = function(user, css_class, title) {
 			fullname: frappe.get_cookie("full_name"),
 			abbr: frappe.get_abbr(frappe.get_cookie("full_name")),
 			color: frappe.get_palette(frappe.get_cookie("full_name"))
-		}
+		};
 	}
 
-	if(!title) {
+	if (!title) {
 		title = user_info.fullname;
 	}
 
-	if(!css_class) {
+	if (!css_class) {
 		css_class = "avatar-small";
 	}
 
-	if(user_info.image) {
+	if (user_info.image || image_url) {
+		image_url = image_url || user_info.image;
 
-		var image = (window.cordova && user_info.image.indexOf('http')===-1) ?
-			frappe.base_url + user_info.image : user_info.image;
+		const image = (window.cordova && image_url.indexOf('http') === -1) ? frappe.base_url + image_url : image_url;
 
 		return `<span class="avatar ${css_class}" title="${title}">
 				<span class="avatar-frame" style='background-image: url("${image}")'
@@ -33,15 +33,15 @@ frappe.avatar = function(user, css_class, title) {
 			</span>`;
 	} else {
 		var abbr = user_info.abbr;
-		if(css_class==='avatar-small' || css_class=='avatar-xs') {
+		if (css_class === 'avatar-small' || css_class == 'avatar-xs') {
 			abbr = abbr.substr(0, 1);
 		}
 		return `<span class="avatar ${css_class}" title="${title}">
 			<div class="standard-image" style="background-color: ${user_info.color};">
 				${abbr}</div>
-		</span>`
+		</span>`;
 	}
-}
+};
 
 frappe.ui.scroll = function(element, animate, additional_offset) {
 	var header_offset = $(".navbar").height() + $(".page-head").height();
@@ -75,7 +75,6 @@ frappe.get_abbr = function(txt, max_length) {
 			// continue
 			return true;
 		}
-87
 		abbr += w.trim()[0];
 	});
 

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -1096,7 +1096,7 @@ body.full-width {
 	.modal-dialog {
 		z-index: 101;
 		position: fixed;
-		right: 0;
+		right: 15px;
 		bottom: 0;
 		margin: 0;
 		max-width: 500px;

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -261,6 +261,12 @@ def format_datetime(datetime_string, format_string=None):
 def get_weekdays():
 	return ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 
+def get_weekday(datetime=None):
+	if not datetime:
+		datetime = now_datetime()
+	weekdays = get_weekdays()
+	return weekdays[datetime.weekday()]
+
 def global_date_format(date, format="long"):
 	"""returns localized date in the form of January 1, 2012"""
 	date = getdate(date)


### PR DESCRIPTION
- fix: Leave some space to the right side of the minimized modal

**Before:**
<img width="534" alt="Screenshot 2019-06-07 at 1 10 00 PM" src="https://user-images.githubusercontent.com/13928957/59088604-977f2c00-8925-11e9-8c7d-eb3668b33a85.png">

**After:**
<img width="556" alt="Screenshot 2019-06-07 at 1 09 19 PM" src="https://user-images.githubusercontent.com/13928957/59088622-a2d25780-8925-11e9-8963-07c7fce5de46.png">


- feat: Add `get_weekday` utility function

- feat: Get avatar just by passing URL of the image
Can be useful in creating an avatar for a non-system user (like Customer, Contact image)