### PR TITLE
fix(prepared-report): Show translated column names

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -255,8 +255,11 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 			uncompressed_content = gzip_decompress(compressed_content)
 			data = json.loads(uncompressed_content)
 			if data:
+				columns = json.loads(doc.columns) if doc.columns else data[0]
+				for column in columns:
+					column["label"] = _(column["label"])
 				latest_report_data = {
-					"columns": json.loads(doc.columns) if doc.columns else data[0],
+					"columns": columns,
 					"result": data
 				}
 		except Exception:


### PR DESCRIPTION
Prepared Report column names were being shown untranslated
Before
![Screenshot 2019-06-10 at 4 17 59 PM](https://user-images.githubusercontent.com/8528887/59191099-25fce300-8b9c-11e9-9f12-d5b836552f61.png)
After
![Screenshot 2019-06-10 at 4 19 20 PM](https://user-images.githubusercontent.com/8528887/59191100-26957980-8b9c-11e9-9e46-de70bbbc3851.png)

