### PR TITLE
fix: JavaScript error in form_sidebar.js on reload_docinfo

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -178,8 +178,8 @@ frappe.ui.form.Sidebar = Class.extend({
 		frappe.call({
 			method: "frappe.desk.form.load.get_docinfo",
 			args: {
-				doctype: this.doctype,
-				name: this.doc.name
+				doctype: this.frm.doctype,
+				name: this.frm.docname
 			},
 			callback: (r) => {
 				// docinfo will be synced


### PR DESCRIPTION
JavaScript error on reload_docinfo (triggered by closing assignment modal)

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.

Exception Stack (this PR resolves):
```
form_sidebar.js:182 Uncaught TypeError: Cannot read property 'name' of undefined
    at init.reload_docinfo (form_sidebar.js:182)
    at Dialog.d.onhide (share.js:78)
    at HTMLDivElement.<anonymous> (dialog.js:82)
    at HTMLDivElement.dispatch (jquery.min.js:3)
    at HTMLDivElement.r.handle (jquery.min.js:3)
    at Object.trigger (jquery.min.js:4)
    at HTMLDivElement.<anonymous> (jquery.min.js:4)
    at Function.each (jquery.min.js:2)
    at n.fn.init.each (jquery.min.js:2)
    at n.fn.init.trigger (jquery.min.js:4)
```