### PR TITLE
fix: Deduct a month instead of 30 days for accurate month range

### DIFF
--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -241,10 +241,9 @@ def send_summary(timespan):
 
 	if not is_energy_point_enabled():
 		return
-
-	from_date = frappe.utils.add_days(None, -7)
+	from_date = frappe.utils.add_to_date(None, weeks=-1)
 	if timespan == 'Monthly':
-		from_date = frappe.utils.add_days(None, -30)
+		from_date = frappe.utils.add_to_date(None, months=-1)
 
 	user_points = get_user_energy_and_review_points(from_date=from_date, as_dict=False)
 


### PR DESCRIPTION
- Deduct a month instead of hardcoded 30 days for accurate month range