### PR TITLE
fix:  Pass report name in filters for prepared report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -243,11 +243,13 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 	else:
 		# Only look for completed prepared reports with given filters.
 		doc_list = frappe.get_all("Prepared Report",
-			filters={"status": "Completed",
+			filters={
+				"status": "Completed",
 				"filters": json.dumps(filters),
 				"owner": user,
 				"report_name": report.report_name
-		})
+			}
+		)
 
 		if doc_list:
 			# Get latest

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -242,7 +242,13 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 		doc = frappe.get_doc("Prepared Report", dn)
 	else:
 		# Only look for completed prepared reports with given filters.
-		doc_list = frappe.get_all("Prepared Report", filters={"status": "Completed", "filters": json.dumps(filters), "owner": user})
+		doc_list = frappe.get_all("Prepared Report",
+			filters={"status": "Completed",
+				"filters": json.dumps(filters),
+				"owner": user,
+				"report_name": report.report_name
+		})
+
 		if doc_list:
 			# Get latest
 			doc = frappe.get_doc("Prepared Report", doc_list[0])


### PR DESCRIPTION
**Current Scenario**: If a report is prepared report then on loading the report the latest prepared report doc with the matching filters is fetched

**Problem**: Since reports like Accounts Receivable and Accounts Receivable Summary have same filters, so if we go to Accounts Receivable Summary from Accounts Receivable or vice versa then the same prepared report doc is fetched in both reports.

**Solution**: Pass report name as well in filters
