### PR TITLE
fix: Translate report column title

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -683,7 +683,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 			return Object.assign(column, {
 				id: column.fieldname,
-				name: column.label,
+				name: __(column.label),
 				width: parseInt(column.width) || null,
 				editable: false,
 				compareValue: compareFn,


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/13928957/59436517-657e3600-8e0d-11e9-9066-5c952353d226.png)

**After**

<img width="752" alt="Screenshot 2019-06-13 at 6 57 50 PM" src="https://user-images.githubusercontent.com/13928957/59436488-54cdc000-8e0d-11e9-9fd1-a760671a1db6.png">

Develop fix:
https://github.com/frappe/frappe/pull/7694