### PR TITLE
fix: Ace editor double render

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -5,6 +5,7 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 	},
 
 	make_ace_editor() {
+		if (this.editor) return;
 		this.ace_editor_target = $('<div class="ace-editor-target"></div>')
 			.appendTo(this.input_area);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9355208/59489663-6ca25400-8ea0-11e9-8529-593037d7cc40.png)

Alternative fix for https://github.com/frappe/frappe/pull/7656