### PR TITLE
fix: Do not send password update notification to disabled users

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -205,7 +205,7 @@ class User(Document):
 						if frappe.session.user != 'Guest':
 							msgprint(_("Welcome email sent"))
 						return
-			else:
+			elif self.enabled:
 				self.email_new_password(new_password)
 
 		except frappe.OutgoingEmailError:

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -152,7 +152,7 @@ class User(Document):
 		if new_password and not self.flags.in_insert:
 			_update_password(user=self.name, pwd=new_password, logout_all_sessions=self.logout_all_sessions)
 
-			if self.send_password_update_notification:
+			if self.send_password_update_notification and self.enabled:
 				self.password_update_mail(new_password)
 				frappe.msgprint(_("New password emailed"))
 
@@ -205,7 +205,7 @@ class User(Document):
 						if frappe.session.user != 'Guest':
 							msgprint(_("Welcome email sent"))
 						return
-			elif self.enabled:
+			else:
 				self.email_new_password(new_password)
 
 		except frappe.OutgoingEmailError:


### PR DESCRIPTION
If password for a user is changed and user is disabled even then password update notification is send to user