### PR TITLE
fix: Rounding behavior in Python 3

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -340,6 +340,7 @@ def ceil(s):
 
 def cstr(s, encoding='utf-8'):
 	return frappe.as_unicode(s, encoding)
+
 def rounded(num, precision=0):
 	"""round method for round halfs to nearest even algorithm aka banker's rounding - compatible with python3"""
 	precision = cint(precision)
@@ -354,7 +355,10 @@ def rounded(num, precision=0):
 	if not precision and decimal_part == 0.5:
 		num = floor if (floor % 2 == 0) else floor + 1
 	else:
-		num = round(num)
+		if decimal_part == 0.5:
+			num = floor + 1
+		else:
+			num = round(num)
 
 	return (num / multiplier) if precision else num
 


### PR DESCRIPTION
rounded had different behavior in python 2 and python 3

Previous behavior

|   | Py 3 | Py 2 |
|---|---|---|
| rounded(0.125, 2) | 0.12 | 0.13 |
| rounded(12.5) | 12 | 12 |

New behavior

|   | Py 3 | Py 2 |
|---|---|---|
| rounded(0.125, 2) | 0.13 | 0.13 |
| rounded(12.5) | 12 | 12 |


This matches client-side function _round()
