### PR TITLE
fix: if maintenance mode on, connect database explicitly before rendering 503 page

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -109,7 +109,9 @@ def init_request(request):
 		raise NotFound
 
 	if frappe.local.conf.get('maintenance_mode'):
-		raise frappe.SessionStopped
+		frappe.local.db = frappe.database.get_db(user = frappe.local.conf.db_name, \
+			password = getattr(frappe.local.conf, 'db_password', ''))
+		raise frappe.SessionStopped('Session Stopped')
 
 	make_form_dict(request)
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -109,8 +109,7 @@ def init_request(request):
 		raise NotFound
 
 	if frappe.local.conf.get('maintenance_mode'):
-		frappe.local.db = frappe.database.get_db(user = frappe.local.conf.db_name, \
-			password = getattr(frappe.local.conf, 'db_password', ''))
+		frappe.connect()
 		raise frappe.SessionStopped('Session Stopped')
 
 	make_form_dict(request)


### PR DESCRIPTION
### Before:
---
<img width="1246" alt="Screen Shot 2019-06-19 at 7 43 35 PM" src="https://user-images.githubusercontent.com/3784093/59773096-a7eeb980-92ca-11e9-820f-112e5990f6b3.png">

```
19:43:34 web.1            | Traceback (most recent call last):
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/middlewares.py", line 15, in __call__
19:43:34 web.1            |     return super(StaticDataMiddleware, self).__call__(environ, start_response)
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/werkzeug/wsgi.py", line 766, in __call__
19:43:34 web.1            |     return self.app(environ, start_response)
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/werkzeug/wsgi.py", line 766, in __call__
19:43:34 web.1            |     return self.app(environ, start_response)
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/werkzeug/local.py", line 228, in application
19:43:34 web.1            |     return ClosingIterator(app(environ, start_response), self.cleanup)
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/werkzeug/wrappers.py", line 308, in application
19:43:34 web.1            |     resp = f(*args[:-2] + (request,))
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/app.py", line 78, in application
19:43:34 web.1            |     response = frappe.utils.response.handle_session_stopped()
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/utils/response.py", line 210, in handle_session_stopped
19:43:34 web.1            |     return frappe.website.render.render("message", http_status_code=503)
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/website/render.py", line 33, in render
19:43:34 web.1            |     raise_if_disabled(path)
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/website/render.py", line 332, in raise_if_disabled
19:43:34 web.1            |     routes = frappe.db.get_all('Portal Menu Item',
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/werkzeug/local.py", line 347, in __getattr__
19:43:34 web.1            |     return getattr(self._get_current_object(), name)
19:43:34 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/werkzeug/local.py", line 310, in _get_current_object
19:43:34 web.1            |     raise RuntimeError('no object bound to %s' % self.__name__)
19:43:34 web.1            | RuntimeError: no object bound to db

```

---

### After
---

<img width="1187" alt="Screen Shot 2019-06-19 at 7 43 18 PM" src="https://user-images.githubusercontent.com/3784093/59773151-c2c12e00-92ca-11e9-8402-4cc4b214eae1.png">


