### PR TITLE
fix: Update user activity using ORM

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -230,17 +230,11 @@ class Session:
 		if self.user!="Guest":
 			self.insert_session_record()
 
-			# update user
-			frappe.db.sql("""UPDATE `tabUser`
-				SET
-					last_login = %(now)s,
-					last_ip = %(ip)s,
-					last_active = %(now)s
-				WHERE name=%(name)s""", {
-					'now': frappe.utils.now(),
-					'ip': frappe.local.request_ip,
-					'name': self.data['user']
-				})
+			user = frappe.get_doc("User", self.data['user'])
+			user.last_ip = frappe.local.request_ip
+			user.last_active = frappe.utils.now()
+			user.last_login = frappe.utils.now()
+			user.save(ignore_permissions=True)
 
 			frappe.db.commit()
 


### PR DESCRIPTION
User activity such as `last_ip` and `last_active` was updated directly using query. Features such as Notification which depend on Value Change of such fields don't work as a result.

Website users can't log in without `ignore_permissions=True`
