### PR TITLE
fix: Update print dialog to translate options

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -472,8 +472,8 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head) {
 		fieldname: "orientation",
 		label: __("Orientation"),
 		options: [
-		    { "value": "Landscape", "label": __("Landscape") },
-		    { "value": "Portrait", "label": __("Portrait") }
+			{ "value": "Landscape", "label": __("Landscape") },
+			{ "value": "Portrait", "label": __("Portrait") }
 		],
 		default: "Landscape"
 	}];

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -471,7 +471,10 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head) {
 		fieldtype: "Select",
 		fieldname: "orientation",
 		label: __("Orientation"),
-		options: "Landscape\nPortrait",
+		options: [
+		    { "value": "Landscape", "label": __("Landscape") },
+		    { "value": "Portrait", "label": __("Portrait") }
+		],
 		default: "Landscape"
 	}];
 


### PR DESCRIPTION
Orientation options translations are not translated properly.

![Captura de pantalla 2019-06-20 a les 21 29 50](https://user-images.githubusercontent.com/1292888/59876037-c6c07f00-93a2-11e9-80a5-9915f47d04f6.png)
