### PR TITLE
fix: Link control route

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -25,8 +25,9 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		this.$input.on("focus", function() {
 			setTimeout(function() {
 				if(me.$input.val() && me.get_options()) {
-					me.$link.toggle(true);
-					me.$link_open.attr('href', '#Form/' + me.get_options() + '/' + me.$input.val());
+					let doctype = me.get_options();
+					let name = me.$input.val();
+					me.$link_open.attr('href', frappe.utils.get_form_link(doctype, name));
 				}
 
 				if(!me.$input.val()) {

--- a/frappe/public/js/frappe/misc/utils.js
+++ b/frappe/public/js/frappe/misc/utils.js
@@ -652,6 +652,8 @@ Object.assign(frappe.utils, {
 		};
 	},
 	get_form_link: function(doctype, name, html = false) {
+		doctype = encodeURIComponent(doctype);
+		name = encodeURIComponent(name);
 		const route = ['#Form', doctype, name].join('/');
 		if (html) {
 			return `<a href="${route}">${name}</a>`;


### PR DESCRIPTION
- Encode doctype and name of the link route to support % character in the link route.

**Issue:**

![route_link_bug](https://user-images.githubusercontent.com/13928957/59936539-e53f7c80-946d-11e9-878a-e8c1207699b6.gif)

**After Fix:**

![route_link_fix](https://user-images.githubusercontent.com/13928957/59936567-f1c3d500-946d-11e9-9439-6ceedda25f67.gif)


develop: https://github.com/frappe/frappe/pull/7743