### PR TITLE
Set visibility of body by class

### DIFF
--- a/frappe/website/js/web_form.js
+++ b/frappe/website/js/web_form.js
@@ -4,6 +4,7 @@ import make_datatable from './grid_list';
 frappe.ready(function() {
 	if(web_form_settings.is_list) {
 		$('body').show();
+		$('body').addClass('show');
 		if($('.web-form-list').length) {
 			make_datatable('.web-form-list', web_form_settings.web_form_doctype);
 		}
@@ -35,6 +36,7 @@ frappe.ready(function() {
 
 	setTimeout(() => {
 		$('body').css('display', 'block');
+		$('body').addClass('show');
 
 		// remove footer save button if form height is less than window height
 		if($('.webform-wrapper').height() < window.innerHeight) {


### PR DESCRIPTION
When including an external JS code, for example, the popular Rocket Chat Live Chat Widget, the external application (in this case Rocket Chat Live Chat) resets the inline styles of the body tag and makes the webform disappear quickly after it appeared.

As this is a strange behavior of the Rocket Chat Live Chat Widget, I will report it there. However, in this case, in my opinion, it's still more elegant to set the visibility of the body tag by the bootstrap class 'show'.

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.