### PR TITLE
fix: Handle AttributeError when adding seen

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1141,10 +1141,8 @@ class Document(BaseDocument):
 			user = frappe.session.user
 
 		if self.meta.track_seen:
-			if self._seen:
-				_seen = json.loads(self._seen)
-			else:
-				_seen = []
+			_seen = self.get('_seen') or []
+			_seen = frappe.parse_json(_seen)
 
 			if user not in _seen:
 				_seen.append(user)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/__init__.py", line 1032, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/desk/form/load.py", line 52, in getdoc
    doc.add_seen()
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 1144, in add_seen
    if self._seen:
AttributeError: 'Document' object has no attribute '_seen'
```