### PR TITLE
fix: Encode path before passing to urllib.quote

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -179,7 +179,7 @@ def send_private_file(path):
 	if frappe.local.request.headers.get('X-Use-X-Accel-Redirect'):
 		path = '/protected/' + path
 		response = Response()
-		response.headers['X-Accel-Redirect'] = frappe.utils.encode(quote(path))
+		response.headers['X-Accel-Redirect'] = quote(frappe.utils.encode(path))
 
 	else:
 		filepath = frappe.utils.get_site_path(path)


### PR DESCRIPTION
Downloading private files in production with filename containing Unicode characters throws KeyError

```python-traceback
Traceback (most recent call last):
  File "/Users/aditya/Frappe/benches/12-2/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.utils.response.download_private_file(request.path)
  File "/Users/aditya/Frappe/benches/12-2/apps/frappe/frappe/utils/response.py", line 172, in download_private_file
    return send_private_file(path.split("/private", 1)[1])
  File "/Users/aditya/Frappe/benches/12-2/apps/frappe/frappe/utils/response.py", line 184, in send_private_file
    print(type(frappe.utils.encode(quote(path))), frappe.utils.encode(quote(path)))
  File "/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib.py", line 1298, in quote
    return ''.join(map(quoter, s))
KeyError: u'\u06c1'
```

