### PR TITLE
fix: Encode path before passing to urllib.quote

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -179,7 +179,7 @@ def send_private_file(path):
 	if frappe.local.request.headers.get('X-Use-X-Accel-Redirect'):
 		path = '/protected/' + path
 		response = Response()
-		response.headers['X-Accel-Redirect'] = frappe.utils.encode(quote(path))
+		response.headers['X-Accel-Redirect'] = quote(frappe.utils.encode(path))
 
 	else:
 		filepath = frappe.utils.get_site_path(path)


### PR DESCRIPTION
Backporting https://github.com/frappe/frappe/pull/7757