### PR TITLE
fix(Communication): Upload Attachment and Save as Draft when standalone Communication

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -430,12 +430,11 @@ frappe.views.CommunicationComposer = Class.extend({
 		if(me.dialog.display) {
 			let wrapper = $(me.dialog.fields_dict.select_attachments.wrapper);
 
-			// find already checked items
-			var checked_items = wrapper.find('[data-file-name]:not(:checked)').map(function() {
+			let unchecked_items = wrapper.find('[data-file-name]:not(:checked)').map(function() {
 				return $(this).attr("data-file-name");
 			});
 
-			$.each(checked_items, function(i, filename) {
+			$.each(unchecked_items, function(i, filename) {
 				wrapper.find('[data-file-name="'+ filename +'"]').prop("checked", true);
 			});
 		}

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -423,6 +423,22 @@ frappe.views.CommunicationComposer = Class.extend({
 					.appendTo(attach)
 			});
 		}
+		this.select_attachments();
+	},
+	select_attachments:function(){
+		let me = this;
+		if(me.dialog.display) {
+			let wrapper = $(me.dialog.fields_dict.select_attachments.wrapper);
+
+			// find already checked items
+			var checked_items = wrapper.find('[data-file-name]:not(:checked)').map(function() {
+				return $(this).attr("data-file-name");
+			});
+
+			$.each(checked_items, function(i, filename) {
+				wrapper.find('[data-file-name="'+ filename +'"]').prop("checked", true);
+			});
+		}
 	},
 	setup_email: function() {
 		// email

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -369,7 +369,10 @@ frappe.views.CommunicationComposer = Class.extend({
 
 		let args = {
 			folder: 'Home/Attachments',
-			on_success: attachment => this.attachments.push(attachment)
+			on_success: attachment => {
+				this.attachments.push(attachment);
+				this.render_attach();
+			}
 		};
 
 		if(this.frm) {
@@ -482,7 +485,7 @@ frappe.views.CommunicationComposer = Class.extend({
 	},
 
 	save_as_draft: function() {
-		if (this.dialog) {
+		if (this.dialog && this.frm) {
 			try {
 				let message = this.dialog.get_value('content');
 				message = message.split(frappe.separator_element)[0];


### PR DESCRIPTION
- Render function was not called after Uploading attachments to a standalone Communication.
- A standalone Communication cannot be saved as draft.

Before Fix:
![unfix](https://user-images.githubusercontent.com/7310479/60005764-c8cd5b00-968c-11e9-9348-9d91f0230bf6.gif)

After Fix:
![fix](https://user-images.githubusercontent.com/7310479/60005774-cc60e200-968c-11e9-86e4-fcf6d5e9b0e3.gif)
