### PR TITLE
fix: Error when running "build-message-files"

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -575,7 +575,7 @@ def write_csv_file(path, app_messages, lang_dict):
 			t = lang_dict.get(m, '')
 			# strip whitespaces
 			t = re.sub('{\s?([0-9]+)\s?}', "{\g<1>}", t)
-			w.writerow([p.encode('utf-8') if p else '', m.encode('utf-8'), t.encode('utf-8')])
+			w.writerow([p if p else '', m, t])
 
 def get_untranslated(lang, untranslated_file, get_all=False):
 	"""Returns all untranslated strings for a language and writes in a file

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -575,7 +575,6 @@ def write_csv_file(path, app_messages, lang_dict):
 			t = lang_dict.get(m, '')
 			# strip whitespaces
 			t = re.sub('{\s?([0-9]+)\s?}', "{\g<1>}", t)
-			
 			w.writerow([p if p else '', m, t])
 
 def get_untranslated(lang, untranslated_file, get_all=False):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -575,6 +575,7 @@ def write_csv_file(path, app_messages, lang_dict):
 			t = lang_dict.get(m, '')
 			# strip whitespaces
 			t = re.sub('{\s?([0-9]+)\s?}', "{\g<1>}", t)
+			
 			w.writerow([p if p else '', m, t])
 
 def get_untranslated(lang, untranslated_file, get_all=False):


### PR DESCRIPTION
I get the following error when running "bench build-message-files":

>  File "/Users/__________/frappe-gmuni/apps/frappe/frappe/translate.py", line 578, in write_csv_file
>     w.writerow([p.encode('utf-8') if p else '', m.encode('utf-8'), t.encode('utf-8')])
> TypeError: a bytes-like object is required, not 'str'