### PR TITLE
fix(search): Escape DocType name

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -425,7 +425,7 @@ def search(text, start=0, limit=20, doctype=""):
 		mariadb_conditions = ''
 		postgres_conditions = ''
 		if doctype:
-			mariadb_conditions = postgres_conditions = '`doctype` = {} AND '.format(doctype)
+			mariadb_conditions = postgres_conditions = '`doctype` = {} AND '.format(frappe.db.escape(doctype))
 
 		mariadb_conditions += 'MATCH(`content`) AGAINST ({} IN BOOLEAN MODE)'.format(frappe.db.escape('+' + text + '*'))
 		postgres_conditions += 'TO_TSVECTOR("content") @@ PLAINTO_TSQUERY({})'.format(frappe.db.escape(text))


### PR DESCRIPTION
Searching for something in Awesome Bar, clicking on `Search for ..`, then clicking on a DocType in the sidebar and then clicking on **More** throws this error

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/global_search.py", line 441, in search
    }, as_dict=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 917, in multisql
    return self.sql(query, values, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 171, in sql
    self._cursor.execute(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1054, u"Unknown column 'Item' in 'where clause'")
```

Query before patch
```sql
SELECT `doctype`, `name`, `content`
FROM `__global_search`
WHERE `doctype` = Item AND MATCH(`content`) AGAINST ('+It*' IN BOOLEAN MODE)
LIMIT 20 OFFSET
```

After
```sql
SELECT `doctype`, `name`, `content`
FROM `__global_search`
WHERE `doctype` = 'Item' AND MATCH(`content`) AGAINST ('+It*' IN BOOLEAN MODE)
LIMIT 20 OFFSET
```
