### PR TITLE
fix: report export in excel

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -336,7 +336,7 @@ def build_xlsx_data(columns, data, visible_idx):
 	# build table from result
 	for i, row in enumerate(data.result):
 		# only pick up rows that are visible in the report
-		if i in visible_idx:
+		if str(i) in visible_idx:
 			row_data = []
 
 			if isinstance(row, dict) and row:

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -336,15 +336,17 @@ def build_xlsx_data(columns, data, visible_idx):
 	# build table from result
 	for i, row in enumerate(data.result):
 		# only pick up rows that are visible in the report
-		if str(i) in visible_idx:
+		if i in visible_idx:
 			row_data = []
 
 			if isinstance(row, dict) and row:
 				for idx in range(len(data.columns)):
 					label = columns[idx]["label"]
 					fieldname = columns[idx]["fieldname"]
-
-					row_data.append(row.get(fieldname, row.get(label, "")))
+					cell_value = row.get(fieldname, row.get(label, ""))
+					if 'indent' in row and idx == 0:
+						cell_value = ('    ' * cint(row['indent'])) + cell_value
+					row_data.append(cell_value)
 			else:
 				row_data = row
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -890,9 +890,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					filters = Object.assign(frappe.urllib.get_dict("prepared_report_name"), filters);
 				}
 
-				const visible_idx = this.datatable.datamanager.getFilteredRowIndices();
-				if (visible_idx.length + 1 === this.data.length) {
-					visible_idx.push(visible_idx.length);
+				let rows = this.datatable.datamanager.rows;
+				let visible_index = this.get_visible_rows(rows);
+				if (visible_index.length + 1 === this.data.length) {
+					visible_index.push(visible_index.length);
 				}
 
 				const args = {
@@ -900,12 +901,30 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					report_name: this.report_name,
 					file_format_type: file_format,
 					filters: filters,
-					visible_idx: visible_idx,
+					visible_idx: visible_index,
 				};
 
 				open_url_post(frappe.request.url, args);
 			}
 		}, __('Export Report: '+ this.report_name), __('Download'));
+	}
+
+	get_visible_rows(rows){
+		let visible_index = [];
+		for (let i in rows ){
+			if (rows[i][1].indent == 0 ){
+				visible_index.push(i);
+			}else{
+				if(rows[i].meta.isTreeNodeClose == false && rows[i][1] && rows[i].meta.isLeaf == false){
+					visible_index.push(i);
+				}
+				if(rows[i].meta.isLeaf == true && rows[i-1].meta.isTreeNodeClose == false){
+					visible_index.push(i);
+				}
+			}
+
+		}
+		return visible_index;
 	}
 
 	get_data_for_csv(with_indentation = false) {

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -32,7 +32,7 @@ class TestQueryReport(unittest.TestCase):
 		]
 
 		# Define the visible rows
-		visible_idx = [0, 2, 3]
+		visible_idx = ['0', '2', '3]
 
 		# Build the result
 		xlsx_data = build_xlsx_data(columns, data, visible_idx)

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -32,7 +32,7 @@ class TestQueryReport(unittest.TestCase):
 		]
 
 		# Define the visible rows
-		visible_idx = ['0', '2', '3]
+		visible_idx = [0, 2, 3]
 
 		# Build the result
 		xlsx_data = build_xlsx_data(columns, data, visible_idx)


### PR DESCRIPTION
before: 
it shows all collapsed rows when export in Excel.
now:
It will not show collapsed rows.