### PR TITLE
fix(link): Show right arrow after Link Field

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -27,6 +27,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				if(me.$input.val() && me.get_options()) {
 					let doctype = me.get_options();
 					let name = me.$input.val();
+					me.$link.toggle(true);
 					me.$link_open.attr('href', frappe.utils.get_form_link(doctype, name));
 				}
 


### PR DESCRIPTION
Fixes a bug introduced with https://github.com/frappe/frappe/pull/7743

**Before**


![Screenshot 2019-06-26 at 6 31 19 PM](https://user-images.githubusercontent.com/8528887/60181821-ada34c80-9840-11e9-8d12-5332f4b57ebe.png)

**After**
![Screenshot 2019-06-26 at 6 29 47 PM](https://user-images.githubusercontent.com/8528887/60181807-a8460200-9840-11e9-9659-4d113850071e.png)
