### PR TITLE
Fix: set_user function initialising form_dict as empty

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -185,7 +185,11 @@ def connect(site=None, db_name=None):
 		init(site)
 
 	local.db = get_db(user=db_name or local.conf.db_name)
+	# set_user will override form_dict to an empty one.
+	# So we have to repopulate it.
+	form_dict = local.form_dict
 	set_user("Administrator")
+	local.form_dict = form_dict
 
 def connect_replica():
 	from frappe.database import get_db


### PR DESCRIPTION
set_user function will make local.form_dict empty. So we have to
keep a copy form local.form_dict and then repopulate it after set_user

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.