### PR TITLE
fix(ux): show year with month in goal chart

### DIFF
--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -91,7 +91,7 @@ def get_monthly_goal_graph_data(title, doctype, docname, goal_value_field, goal_
 	for i in range(0, 12):
 		date_value = add_months(today(), -i)
 		month_value = formatdate(date_value, "MM-yyyy")
-		month_word = getdate(date_value).strftime('%b')
+		month_word = getdate(date_value).strftime('%b %y')
 		month_year = getdate(date_value).strftime('%B') + ', ' + getdate(date_value).strftime('%Y')
 		months.insert(0, month_word)
 		months_formatted.insert(0, month_year)


### PR DESCRIPTION
Previous
<img width="1162" alt="Year not mentioned - Don't show for blank" src="https://user-images.githubusercontent.com/18097732/60234154-b3407700-98c0-11e9-97e9-6b24573166a9.png">

After the changes
<img width="1176" alt="After" src="https://user-images.githubusercontent.com/18097732/60234158-bcc9df00-98c0-11e9-9ab6-a14e2101dbeb.png">

