### PR TITLE
fix(ui): added null check for currency

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -948,7 +948,7 @@ frappe.ui.form.Form = class FrappeForm {
 	set_currency_labels(fields_list, currency, parentfield) {
 		// To set the currency in the label
 		// For example Total Cost(INR), Total Cost(USD)
-
+		if (!currency) return
 		var me = this;
 		var doctype = parentfield ? this.fields_dict[parentfield].grid.doctype : this.doc.doctype;
 		var field_label_map = {};

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -948,7 +948,7 @@ frappe.ui.form.Form = class FrappeForm {
 	set_currency_labels(fields_list, currency, parentfield) {
 		// To set the currency in the label
 		// For example Total Cost(INR), Total Cost(USD)
-		if (!currency) return
+		if (!currency) return;
 		var me = this;
 		var doctype = parentfield ? this.fields_dict[parentfield].grid.doctype : this.doc.doctype;
 		var field_label_map = {};


### PR DESCRIPTION
The following permission requires a currency field
https://github.com/frappe/frappe/blob/2cdadc75052e8b2143f4ca6b8f72a671ace49704/frappe/public/js/frappe/form/form.js#L948

In case the field is not provided,`undefined is printed along with the label (see screenshot)

<img width="418" alt="Rate undefined in material request" src="https://user-images.githubusercontent.com/18097732/60245210-bc8a0d80-98d9-11e9-8c89-220f7aace6d5.png">

For example, the following [code](https://github.com/frappe/erpnext/blob/0b39c4ecff88fc491381d7fb8e0cc215a3181759/erpnext/public/js/controllers/transaction.js#L1049-L1050)  would add currency from the current doc. However if the currency is not available, the value passed in `undefined`
```
this.frm.set_currency_labels(["rate", "net_rate", "price_list_rate", "amount", "net_amount"],
	this.frm.doc.currency, "items");
```
---

This PR adds a simple null check, returns directly in case currency is not given or is `null`


