### PR TITLE
fix(link): Show right arrow after Link Field

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -27,6 +27,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				if(me.$input.val() && me.get_options()) {
 					let doctype = me.get_options();
 					let name = me.$input.val();
+					me.$link.toggle(true);
 					me.$link_open.attr('href', frappe.utils.get_form_link(doctype, name));
 				}
 


### PR DESCRIPTION
Backporting https://github.com/frappe/frappe/pull/7779