### PR TITLE
fix: charts in query report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -545,12 +545,18 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		function preview_chart() {
 			const wrapper = $(dialog.fields_dict["chart_preview"].wrapper);
 			const values = dialog.get_values(true);
-			let options = make_chart_options(values);
-
-			wrapper.empty();
-			new frappe.Chart(wrapper[0], options);
-			wrapper.find('.chart-container .title, .chart-container .sub-title').hide();
-			wrapper.show();
+			if (values.x_field && values.y_field) {
+				let options = make_chart_options(values);
+				wrapper.empty();
+				new frappe.Chart(wrapper[0], options);
+				wrapper.find('.chart-container .title, .chart-container .sub-title').hide();
+				wrapper.show();
+			}
+			else {
+				wrapper[0].innerHTML = `<div class="flex justify-center align-center text-muted" style="height: 120px; display: flex;">
+					<div>Please select X and Y fields</div>
+				</div>`
+			}
 		}
 
 		function get_options(fields) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -555,7 +555,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			else {
 				wrapper[0].innerHTML = `<div class="flex justify-center align-center text-muted" style="height: 120px; display: flex;">
 					<div>Please select X and Y fields</div>
-				</div>`
+				</div>`;
 			}
 		}
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -510,7 +510,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		function get_column_values(column_name) {
 			if (Array.isArray(rows[0])) {
-				let column_index = columns.findIndex(column => column.label == column_name);
+				let column_index = columns.findIndex(column => column.fieldname == column_name);
 				return rows.map(row => row[column_index]);
 			} else {
 				return rows.map(row => row[column_name]);


### PR DESCRIPTION
This PR has a few fixes and a few improvement.

## Added Null State for no chart
| Before  | After |
| ------------- | ------------- |
| <img width="596" alt="No Null State" src="https://user-images.githubusercontent.com/18097732/60257485-2cf05900-98f1-11e9-9df4-141a10978239.png"> | <img width="594" alt="Screenshot 2019-06-27 at 3 05 42 PM" src="https://user-images.githubusercontent.com/18097732/60257504-3679c100-98f1-11e9-9ef6-da76aae6b73d.png"> |


## Fix Charts
Charts were no being created because of a small bug in `make_chart_options`. It would search `fieldname` against the `label` field in `columns`, resulting in `NaN` or `undefined` value

| Before  | After |
| ------------- | ------------- |
| <img width="595" alt="This broken again -_-" src="https://user-images.githubusercontent.com/18097732/60257250-b7848880-98f0-11e9-81cf-3c9324c1ef93.png"> | <img width="595" alt="after" src="https://user-images.githubusercontent.com/18097732/60257147-87d58080-98f0-11e9-9a92-9917b5eccd59.png"> |




