### PR TITLE
fix: List context fixes in web form

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form_list.js
+++ b/frappe/public/js/frappe/web_form/web_form_list.js
@@ -91,6 +91,7 @@ export default class WebFormList {
 				doctype: this.doctype,
 				fields: this.fields_list.map(df => df.fieldname),
 				limit_start: this.web_list_start,
+				web_form_name: this.web_form_name,
 				...this.filters
 			}
 		});

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -141,7 +141,9 @@ def get_context(context):
 			if self.allow_edit:
 				if self.allow_multiple:
 					if not frappe.form_dict.name and not frappe.form_dict.new:
-						self.build_as_list(context)
+						pass
+						# list data is queried via JS
+						context.is_list = True
 				else:
 					if frappe.session.user != 'Guest' and not frappe.form_dict.name:
 						frappe.form_dict.name = frappe.db.get_value(self.doc_type, {"owner": frappe.session.user}, "name")
@@ -194,38 +196,6 @@ def get_context(context):
 			if self.allow_comments:
 				context.comment_list = get_comment_list(context.doc.doctype,
 					context.doc.name)
-
-	def build_as_list(self, context):
-		'''Web form is a list, show render as list.html'''
-		from frappe.www.list import get_context as get_list_context
-
-		# set some flags to make list.py/list.html happy
-		frappe.form_dict.web_form_name = self.name
-		frappe.form_dict.doctype = self.doc_type
-		frappe.flags.web_form = self
-
-		self.update_params_from_form_dict(context)
-		self.update_list_context(context)
-		get_list_context(context)
-		context.is_list = True
-
-	def update_params_from_form_dict(self, context):
-		'''Copy params from list view to new view'''
-		context.params_from_form_dict = ''
-
-		params = {}
-		for key, value in iteritems(frappe.form_dict):
-			if frappe.get_meta(self.doc_type).get_field(key):
-				params[key] = value
-
-		if params:
-			context.params_from_form_dict = '&' + urlencode(params)
-
-
-	def update_list_context(self, context):
-		'''update list context for stanard modules'''
-		if hasattr(self, 'web_form_module') and hasattr(self.web_form_module, 'get_list_context'):
-			self.web_form_module.get_list_context(context)
 
 	def get_payment_gateway_url(self, doc):
 		if self.accept_payment:
@@ -334,10 +304,11 @@ def get_context(context):
 
 	def set_web_form_module(self):
 		'''Get custom web form module if exists'''
+		self.web_form_module = self.get_web_form_module()
+
+	def get_web_form_module(self):
 		if self.is_standard:
-			self.web_form_module = get_doc_module(self.module, self.doctype, self.name)
-		else:
-			self.web_form_module = None
+			return get_doc_module(self.module, self.doctype, self.name)
 
 	def validate_mandatory(self, doc):
 		'''Validate mandatory web form fields'''
@@ -513,16 +484,6 @@ def check_webform_perm(doctype, name):
 def get_web_form_filters(web_form_name):
 	web_form = frappe.get_doc("Web Form", web_form_name)
 	return [field for field in web_form.web_form_fields if field.show_in_filter]
-
-def get_web_form_list(doctype, txt, filters, limit_start, limit_page_length=20, order_by=None):
-	from frappe.www.list import get_list
-	if not filters:
-		filters = {}
-
-	filters["owner"] = frappe.session.user
-
-	return get_list(doctype, txt, filters, limit_start, limit_page_length, order_by=order_by,
-		ignore_permissions=True)
 
 def make_route_string(parameters):
 	route_string = ""

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -141,7 +141,6 @@ def get_context(context):
 			if self.allow_edit:
 				if self.allow_multiple:
 					if not frappe.form_dict.name and not frappe.form_dict.new:
-						pass
 						# list data is queried via JS
 						context.is_list = True
 				else:

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -70,7 +70,7 @@ def get(doctype, txt=None, limit_start=0, limit=20, pathname=None, **kwargs):
 	}
 
 @frappe.whitelist(allow_guest=True)
-def get_list_data(doctype, txt=None, limit_start=0, fields=None, cmd=None, limit=20, **kwargs):
+def get_list_data(doctype, txt=None, limit_start=0, fields=None, cmd=None, limit=20, web_form_name=None, **kwargs):
 	"""Returns processed HTML page for a standard listing."""
 	limit_start = cint(limit_start)
 
@@ -82,7 +82,7 @@ def get_list_data(doctype, txt=None, limit_start=0, fields=None, cmd=None, limit
 	meta = frappe.get_meta(doctype)
 
 	filters = prepare_filters(doctype, controller, kwargs)
-	list_context = get_list_context(frappe._dict(), doctype)
+	list_context = get_list_context(frappe._dict(), doctype, web_form_name)
 	list_context.title_field = getattr(controller, 'website',
 		{}).get('page_title_field', meta.title_field or 'name')
 
@@ -142,38 +142,34 @@ def prepare_filters(doctype, controller, kwargs):
 
 	return filters
 
-def get_list_context(context, doctype):
+def get_list_context(context, doctype, web_form_name):
 	from frappe.modules import load_doctype_module
-	from frappe.website.doctype.web_form.web_form import get_web_form_list
 
 	list_context = context or frappe._dict()
 	meta = frappe.get_meta(doctype)
 
-	if not meta.custom:
-		# custom doctypes don't have modules
-		module = load_doctype_module(doctype)
+	def update_context_from_module(module, list_context):
+		# call the user defined method `get_list_context`
+		# from the python module
 		if hasattr(module, "get_list_context"):
 			out = frappe._dict(module.get_list_context(list_context) or {})
 			if out:
 				list_context = out
 
+	# get context from the doctype module
+	if not meta.custom:
+		# custom doctypes don't have modules
+		module = load_doctype_module(doctype)
+		update_context_from_module(module, list_context)
+
+	# get context from web form module
+	if web_form_name:
+		web_form = frappe.get_doc('Web Form', web_form_name)
+		update_context_from_module(web_form.get_web_form_module(), list_context)
+
 	# get path from '/templates/' folder of the doctype
 	if not list_context.row_template:
 		list_context.row_template = meta.get_row_template()
-
-	# is web form, show the default web form filters
-	# which is only the owner
-	if frappe.form_dict.web_form_name:
-		list_context.web_form_name = frappe.form_dict.web_form_name
-		if not list_context.get("get_list"):
-			list_context.get_list = get_web_form_list
-
-		if not frappe.flags.web_form:
-			# update list context from web_form
-			frappe.flags.web_form = frappe.get_doc('Web Form', frappe.form_dict.web_form_name)
-
-		if frappe.flags.web_form.is_standard:
-			frappe.flags.web_form.update_list_context(list_context)
 
 	return list_context
 


### PR DESCRIPTION
- Custom list context was lost in web form list view 
- Default `get_list methods` was called even `get_list_context` methods was defined in web forms.