### PR TITLE
fix: minor fixes in webform

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -312,7 +312,7 @@
 		"public/js/frappe/ui/group_by/group_by.js"
 	],
 	"js/web_form.min.js": [
-		"public/js/frappe/misc/datetime.js",
+		"public/js/frappe/utils/datetime.js",
 		"public/js/frappe/web_form/webform_script.js",
 		"public/js/lib/datepicker/datepicker.min.js",
 		"public/js/lib/datepicker/datepicker.en.js"

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -104,6 +104,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			args: {
 				data: data,
 				web_form: this.name,
+				docname: this.doc.name,
 				for_payment
 			},
 			callback: response => {

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -136,7 +136,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	print() {
 		window.location.href = `/printview?
 			doctype=${this.doc_type}
-			&name=${this.doc_name}
+			&name=${this.doc.name}
 			&format=${this.print_format || "Standard"}`;
 	}
 

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -84,8 +84,10 @@ $(".file-size").each(function() {
 	$(this).text(frappe.form.formatters.FileSize($(this).text()));
 });
 </script>
+
 {% if is_list %}
 {# web form list #}
+<script type="text/javascript" src="/assets/js/moment-bundle.min.js"></script>
 <script type="text/javascript" src="/assets/js/dialog.min.js"></script>
 <script type="text/javascript" src="/assets/js/web_form.min.js"></script>
 <script type="text/javascript" src="/assets/js/bootstrap-4-web.min.js"></script>

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -45,7 +45,7 @@ class TestWebForm(unittest.TestCase):
 		self.assertNotEquals(frappe.db.get_value("Event",
 			self.event_name, "description"), doc.get('description'))
 
-		accept(web_form='manage-events', data=json.dumps(doc))
+		accept(web_form='manage-events', docname=self.event_name, data=json.dumps(doc))
 
 		self.assertEqual(frappe.db.get_value("Event",
 			self.event_name, "description"), doc.get('description'))

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -352,7 +352,7 @@ def get_context(context):
 
 
 @frappe.whitelist(allow_guest=True)
-def accept(web_form, data, for_payment=False):
+def accept(web_form, data, docname=None, for_payment=False):
 	'''Save the web form'''
 	data = frappe._dict(json.loads(data))
 	for_payment = frappe.parse_json(for_payment)
@@ -368,9 +368,9 @@ def accept(web_form, data, for_payment=False):
 	frappe.flags.in_web_form = True
 	meta = frappe.get_meta(data.doctype)
 
-	if data.name:
+	if docname:
 		# update
-		doc = frappe.get_doc(data.doctype, data.name)
+		doc = frappe.get_doc(data.doctype, docname)
 	else:
 		# insert
 		doc = frappe.new_doc(data.doctype)
@@ -543,9 +543,6 @@ def get_form_data(doctype, docname=None, web_form_name=None):
 
 	out = frappe._dict()
 	out.web_form = web_form
-
-	if frappe.session.user != 'Guest' and not docname:
-		docname = frappe.db.get_value(doctype, {"owner": frappe.session.user}, "name")
 
 	if docname:
 		doc = frappe.get_doc(doctype, docname)

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -544,6 +544,9 @@ def get_form_data(doctype, docname=None, web_form_name=None):
 	out = frappe._dict()
 	out.web_form = web_form
 
+	if frappe.session.user != 'Guest' and not docname and not web_form.allow_multiple:
+		docname = frappe.db.get_value(doctype, {"owner": frappe.session.user}, "name")
+
 	if docname:
 		doc = frappe.get_doc(doctype, docname)
 		if has_web_form_permission(doctype, docname, ptype='read'):


### PR DESCRIPTION
Fixes the following:
1. New form page would load data from previous doctype.
(Introduced because of the following: https://github.com/frappe/frappe/pull/7784/files#diff-bc2f1db5dbdea8dd4de0ac18e40ac770R547)

1. added check for  `Allow Multiple` in `get_form_data` 
 
1. Saving an existing doc (editing) would create a new document. Fixed this by sending the docname correctly

1. Added datetime.js in build.json to solve `frappe.datetime.user_to_str` not defined issue
(Introduced in webforms here: https://github.com/frappe/frappe/pull/7784/files#diff-a687fcd38156ff5e6cacf3b8846ab94eR130)

1. Fixes print function, use `this.doc.name` instead of `this.doc_name` when constructing URL