### PR TITLE
fix: Extend frappe.datetime in date.js

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -1,6 +1,6 @@
 
 
-frappe.ui.form.ControlDate = frappe.ui.form.ControlData.extend({
+frappe.ui.form.ControlDate = frappe.ui.form.ControlData.extend(frappe.datetime, {
 	make_input: function() {
 		this._super();
 		this.set_date_options();


### PR DESCRIPTION
Fix for:
![Screenshot 2019-06-29 at 10 59 35 AM](https://user-images.githubusercontent.com/42651287/60383669-84c5c600-9a91-11e9-95a6-b415112cac10.png)
