### PR TITLE
fix: update self after db.set_value

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1147,6 +1147,7 @@ class Document(BaseDocument):
 			if user not in _seen:
 				_seen.append(user)
 				frappe.db.set_value(self.doctype, self.name, '_seen', json.dumps(_seen), update_modified=False)
+				self._seen = json.dumps(_seen)
 				frappe.local.flags.commit = True
 
 	def add_viewed(self, user=None):


### PR DESCRIPTION
Solves the TypeError in Chats

Local self was not updated in `add_seen()` in document.py after `frappe.db.set_value`, so in `chat_message.py` the `seen` method would get the value of `self._seen` to always be None, this was causing a TypeError

Traceback for reference
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/chat/doctype/chat_message/chat_message.py", line 151, in seen
    resp = dict(message = message, data = dict(seen = json.loads(mess._seen)))
  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: expected string or buffer
```

