### PR TITLE
fix: get_form_link display name

### DIFF
--- a/frappe/public/js/frappe/misc/utils.js
+++ b/frappe/public/js/frappe/misc/utils.js
@@ -652,11 +652,12 @@ Object.assign(frappe.utils, {
 		};
 	},
 	get_form_link: function(doctype, name, html = false) {
+		const display_name = name;
 		doctype = encodeURIComponent(doctype);
 		name = encodeURIComponent(name);
 		const route = ['#Form', doctype, name].join('/');
 		if (html) {
-			return `<a href="${route}">${name}</a>`;
+			return `<a href="${route}">${display_name}</a>`;
 		}
 		return route;
 	},


### PR DESCRIPTION
Do not encode display name.

Issue:
<img width="244" alt="Screenshot 2019-07-01 at 11 49 30 AM" src="https://user-images.githubusercontent.com/13928957/60414662-70e7a480-9bf6-11e9-97b5-65937feacd76.png">