### PR TITLE
fix: Custom fields order error in fixtures

### DIFF
--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -64,4 +64,5 @@ def export_fixtures():
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))
 
-			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"), filters=filters, or_filters=or_filters)
+			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"),
+						filters=filters, or_filters=or_filters, order_by="idx asc, creation asc")

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -64,4 +64,5 @@ def export_fixtures():
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))
 
-			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"), filters=filters, or_filters=or_filters)
+			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"),
+						filters=filters, or_filters=or_filters, order_by="name asc, idx asc")


### PR DESCRIPTION
### Issue:
Sometimes, when you have a custom app with some custom fields, the customized doctypes (the ones with custom fields) start to mess up the order of the fields.

### Reason:
The reason for this to happen is that, in the `custom_fields.json` file, there are fields that have an `insert_after` referring to a field that is after them in the file. This means that at the moment that the first field is created in the DB, the reference of the `insert_after` does not exists  so it puts 0 as the field's `idx` and that messes up the order of the fields in the doctype.

### Steps to recreate:
We are going to need a clean site (frappe + erpnext only) and a clean app (a new app with nothing in it).
- Install the new app in the clean site
- Go to company and then customize the doctype like in the image below. Click on "update" after adding each field, this is to simulate an "addition in differents dates".
![Example1](https://user-images.githubusercontent.com/46027152/60439251-e2b8f180-9be8-11e9-8c01-07569767546d.png)
![Example2](https://user-images.githubusercontent.com/46027152/60439252-e51b4b80-9be8-11e9-9548-6f5e24a3ab6d.png)
- Add the Company doctype to the hooks of the app:
```
fixtures = [
    {
        "dt": "Custom Field",
        "filters": [["dt", "in", ("Company")]]
    }
]
```
- Export fixtures of the site (`bench --site SITE_NAME export-fixtures`)
- Delete your new fields from the `tabCustom Fields` in the DB to simulate a new installation
- Migrate the site (`bench --site SITE_NAME migrate`)
- If the bug was correctly recreated the fields should not be in order, like here:
![After migrate](https://user-images.githubusercontent.com/46027152/60439431-404d3e00-9be9-11e9-89e0-663490d88813.png)

### Solution:
I changed the `export_fixtures` function in `fixtures.py` to order the fields by `idx` and `creation` (this last order is to maintain the order of the doctypes that do not have different `idx` per entry).


