### PR TITLE
fix: Fetch color field in list view by default

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -160,7 +160,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.meta.track_seen ? '_seen' : null,
 			this.sort_by,
 			'enabled',
-			'disabled'
+			'disabled',
+			'color'
 		);
 
 		fields.forEach(f => this._add_field(f));


### PR DESCRIPTION
Some views like Calendar, Gantt and Kanban use the color field for labeling. Currently, you have to add the color field in `{doctype}_list.js` for it to be fetched.

![image](https://user-images.githubusercontent.com/9355208/60505463-67873680-9ce1-11e9-824b-8d98668ad018.png)
