### PR TITLE
fix(Automatic Email Linking): double email text getting copied

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -74,8 +74,8 @@ frappe.ui.form.Timeline = class Timeline {
 			});
 		});
 
-		this.email_link.on("click", ".copy-to-clipboard", function() {
-			let text = $(".copy-to-clipboard").text();
+		this.email_link.on("click", function(e) {
+			let text = $(e.currentTarget).find(".copy-to-clipboard").text();
 			frappe.utils.copy_to_clipboard(text);
 		});
 	}


### PR DESCRIPTION

![copy_bug](https://user-images.githubusercontent.com/19775888/60511020-97890680-9cee-11e9-94cf-e27752fb0bc6.gif)
