### PR TITLE
refactor: disable checkbox for read-only grids

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -448,7 +448,7 @@ export default class Grid {
 		this.refresh();
 	}
 	toggle_checkboxes(enable) {
-		let check_boxes = this.wrapper.find(".grid-row-check")
+		this.wrapper.find(".grid-row-check").prop('disabled', !enable)
 		check_boxes.each((item) => {
 			check_boxes[item].disabled = !enable;
 		})

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -254,7 +254,6 @@ export default class Grid {
 		// toolbar
 		this.setup_toolbar();
 		this.toggle_checkboxes(this.display_status !== 'Read');
-		else this.toggle_checkboxes(true);
 
 		// sortable
 		if(this.frm && this.is_sortable() && !this.sortable_setup_done) {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -253,6 +253,8 @@ export default class Grid {
 
 		// toolbar
 		this.setup_toolbar();
+		if (this.display_status == 'Read') this.toggle_checkboxes(false);
+		else this.toggle_checkboxes(true);
 
 		// sortable
 		if(this.frm && this.is_sortable() && !this.sortable_setup_done) {
@@ -444,6 +446,12 @@ export default class Grid {
 	toggle_display(fieldname, show) {
 		this.get_docfield(fieldname).hidden = show ? 0 : 1;
 		this.refresh();
+	}
+	toggle_checkboxes(enable) {
+		let check_boxes = this.wrapper.find(".grid-row-check")
+		check_boxes.each((item) => {
+			check_boxes[item].disabled = !enable;
+		})
 	}
 	get_docfield(fieldname) {
 		return frappe.meta.get_docfield(this.doctype, fieldname, this.frm ? this.frm.docname : null);

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -449,9 +449,6 @@ export default class Grid {
 	}
 	toggle_checkboxes(enable) {
 		this.wrapper.find(".grid-row-check").prop('disabled', !enable)
-		check_boxes.each((item) => {
-			check_boxes[item].disabled = !enable;
-		})
 	}
 	get_docfield(fieldname) {
 		return frappe.meta.get_docfield(this.doctype, fieldname, this.frm ? this.frm.docname : null);

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -253,7 +253,7 @@ export default class Grid {
 
 		// toolbar
 		this.setup_toolbar();
-		if (this.display_status == 'Read') this.toggle_checkboxes(false);
+		this.toggle_checkboxes(this.display_status !== 'Read');
 		else this.toggle_checkboxes(true);
 
 		// sortable


### PR DESCRIPTION
If a child table is marked Read Only, example 'Item Attributes' table in Items is disabled for a variant. ([ref](https://github.com/frappe/erpnext/blob/7763d0a0592083288021494b01937bc734985c4e/erpnext/stock/doctype/item/item.js#L689-L727))

In that case the Add and Delete buttons are removed, however the checkbox is the still enabled. This PR disables the checkboxes (does not hide them) in case the grid is set to `read_only`