### PR TITLE
chore: updated frappe-charts to v1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cookie": "^0.3.1",
     "express": "^4.16.2",
     "fast-deep-equal": "^2.0.1",
-    "frappe-charts": "^1.2.2",
+    "frappe-charts": "^1.2.3",
     "frappe-datatable": "^1.13.4",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,10 +1753,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-frappe-charts@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.2.2.tgz#2af592c1dfce07554b8278ad2fb330922fbcd5d8"
-  integrity sha512-TrZ/JPqvr/RWHKW0fneh3dDzKPm3d+oDEMJj8aREbOWXNhOOIwfonp0uLwo8hxyGEZPwpDAKqs0154GgahSXkA==
+frappe-charts@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.2.3.tgz#ee1840864cfe5c9371b61f8ec9b8624633fdc84d"
+  integrity sha512-nHDCERSKni0JDT/0eooGpR3nE/NBKcAJEgbZfjojoA5D3jK4cT6B4kRT3m9EgIqMkwPllZncWUPp0zYtN8WSsQ==
 
 frappe-datatable@^1.13.4:
   version "1.13.4"


### PR DESCRIPTION
Updated frappe-charts to v1.2.3

Changes referenced in the following release
https://github.com/frappe/charts/releases/tag/1.2.3