### PR TITLE
fix: not able to save event because of customized event category

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -71,7 +71,7 @@ class Event(Document):
 		communication.communication_date = self.starts_on
 		communication.reference_doctype = self.doctype
 		communication.reference_name = self.name
-		communication.communication_medium = communication_mapping[self.event_category] if self.event_category else ""
+		communication.communication_medium = communication_mapping.get(self.event_category) if self.event_category else ""
 		communication.status = "Linked"
 		communication.add_link(participant.reference_doctype, participant.reference_docname)
 		communication.save(ignore_permissions=True)


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/model/document.py", line 313, in _save
    self.run_post_save_methods()
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/model/document.py", line 905, in run_post_save_methods
    self.run_method("on_update")
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/desk/doctype/event/event.py", line 35, in on_update
    self.sync_communication()
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/desk/doctype/event/event.py", line 49, in sync_communication
    self.update_communication(participant, communication)
  File "/home/frappe/benches/bench-11-2019-07-02/apps/frappe/frappe/desk/doctype/event/event.py", line 69, in update_communication
    communication.communication_medium = communication_mapping[self.event_category] if self.event_category else ""
KeyError: u'Visit On-site'
```