### PR TITLE
fix: calendar view routing to last viewed

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -10,7 +10,7 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 		if (route.length === 3) {
 			const doctype = route[1];
 			const user_settings = frappe.get_user_settings(doctype)['Calendar'] || {};
-			route.push(user_settings.last_calendar_view || 'Default');
+			route.push(user_settings.last_calendar || 'Default');
 			frappe.set_route(route);
 			return true;
 		} else {


### PR DESCRIPTION
Due to variable name mismatch, last calendar would not be loaded and instead it would get set to Default. Since no default existed, the client would send bad data resulting in the following traceback

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/desk/calendar.py", line 57, in get_events
    return frappe.get_list(doctype, fields=fields, filters=filters)
  File "/home/frappe/benches/bench-11-2019-06-26-3/apps/frappe/frappe/__init__.py", line 1264, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
   .
   .
   .
  File "/home/frappe/benches/bench-11-2019-06-26-3/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-11-2019-06-26-3/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-11-2019-06-26-3/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1054, u"Unknown column 'start' in 'field list'")
```