### PR TITLE
fix: Inline graph for RTL languages

### DIFF
--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -215,6 +215,19 @@
 	}
 }
 
+.frappe-rtl .inline-graph {
+	direction: ltr;
+	display: block;
+	transform: scaleX(-1);
+	.inline-graph-count {
+		transform: scaleX(-1);
+		text-align: right;
+	}
+	.inline-graph-half:first-child .inline-graph-count {
+		text-align: left;
+	}
+}
+
 .progress-area {
 	padding-top: 15px;
 	padding-bottom: 15px;


### PR DESCRIPTION
**Before for RTL language:**
<img width="1196" alt="Screenshot 2019-07-04 at 3 07 23 PM" src="https://user-images.githubusercontent.com/13928957/60656928-03de4400-9e6e-11e9-993b-9e083ab4bc8a.png">

**After for RTL language:**
<img width="1214" alt="Screenshot 2019-07-04 at 3 06 46 PM" src="https://user-images.githubusercontent.com/13928957/60656940-0b055200-9e6e-11e9-932e-2d4419ac8ea9.png">

**Unchanged for LTR language:**
<img width="1426" alt="Screenshot 2019-07-04 at 3 14 13 PM" src="https://user-images.githubusercontent.com/13928957/60657150-6cc5bc00-9e6e-11e9-9c87-f02e621d4cdf.png">
