### PR TITLE
fix(website): Dialog message

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -163,9 +163,9 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			}
 		});
 
+		success_dialog.show();
 		const success_message =
 			this.success_message || __("Your information has been submitted");
 		success_dialog.set_message(success_message);
-		success_dialog.show();
 	}
 }


### PR DESCRIPTION
Set message after the dialog is shown.

Because while showing the dialog it clears messages which are already there in the dialog. [Check this commit](https://github.com/frappe/frappe/commit/78c3a5de2d0b524081f5eea250e44cf6a4ccbdff)

**Before:** 
<img width="888" alt="Screenshot 2019-07-04 at 4 31 47 PM" src="https://user-images.githubusercontent.com/13928957/60662186-540ed380-9e79-11e9-81eb-406a47af290c.png">

**After:**
<img width="870" alt="Screenshot 2019-07-04 at 4 32 11 PM" src="https://user-images.githubusercontent.com/13928957/60662198-5bce7800-9e79-11e9-99fe-643293685e48.png">
