### PR TITLE
fix: Set session user only for new document

### DIFF
--- a/frappe/website/doctype/personal_data_download_request/personal_data_download_request.js
+++ b/frappe/website/doctype/personal_data_download_request/personal_data_download_request.js
@@ -2,7 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Personal Data Download Request', {
-	onload: function(frm){
-		frm.doc.user = frappe.session.user;
+	onload: function(frm) {
+		if (frm.is_new()) {
+			frm.doc.user = frappe.session.user;
+		}
 	},
 });


### PR DESCRIPTION
**DocType:** Personal Data Download Request

It used to show session user in the user field even if the document had another user.