### PR TITLE
fix: changes for heatmap data API

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -416,7 +416,7 @@ frappe.ui.form.Dashboard = Class.extend({
 
 	update_heatmap: function(data) {
 		if(this.heatmap) {
-			this.heatmap.update(data);
+			this.heatmap.update({dataPoints: data});
 		}
 	},
 


### PR DESCRIPTION
Heatmap requires the following format for data
```
{
  dataPoints: {
    <timestamp>: <value>,
    <timestamp>: <value>,
    <timestamp>: <value>,
   ...
    <timestamp>: <value>,
  }
}
```

Previously we would just send a dictionary with timestamps.

This PR just assigns the value we get from `get_timeline_data` to `dataPoints` and updates the chart