### PR TITLE
feat: Auto revert points on the doc if the doc gets canceled

### DIFF
--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -214,6 +214,8 @@ def revert(name, reason):
 	if doc_to_revert.type != 'Auto':
 		frappe.throw(_('This document cannot be reverted'))
 
+	if doc_to_revert.reverted: return
+
 	doc_to_revert.reverted = 1
 	doc_to_revert.save(ignore_permissions=True)
 


### PR DESCRIPTION
When the user cancels and amends a doc that user used to get duplicate points. So to avoid this, revert points on the canceled doc.