### PR TITLE
fix: bench run-ui-tests command

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -564,10 +564,7 @@ def browse(context, site):
 	site = site.lower()
 
 	if site in frappe.utils.get_sites():
-		webbrowser.open('http://{site}:{port}'.format(
-			site=site,
-			port=frappe.get_conf(site).webserver_port
-		), new=2)
+		webbrowser.open(frappe.utils.get_site_url(site), new=2)
 	else:
 		click.echo("\nSite named \033[1m{}\033[0m doesn't exist\n".format(site))
 

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -459,26 +459,23 @@ def run_tests(context, app=None, module=None, doctype=None, test=(),
 		sys.exit(ret)
 
 @click.command('run-ui-tests')
-@click.option('--app', help="App to run tests on, leave blank for all apps")
-@click.option('--test', help="Path to the specific test you want to run")
-@click.option('--test-list', help="Path to the txt file with the list of test cases")
-@click.option('--profile', is_flag=True, default=False)
+@click.argument('app')
+@click.option('--headless', is_flag=True, help="Run UI Test in headless mode")
 @pass_context
-def run_ui_tests(context, app=None, test=False, test_list=False, profile=False):
+def run_ui_tests(context, app, headless=False):
 	"Run UI tests"
-	import frappe.test_runner
 
 	site = get_site(context)
-	frappe.init(site=site)
-	frappe.connect()
+	app_base_path = os.path.abspath(os.path.join(frappe.get_app_path(app), '..'))
+	site_url = frappe.utils.get_site_url(site)
 
-	ret = frappe.test_runner.run_ui_tests(app=app, test=test, test_list=test_list, verbose=context.verbose,
-		profile=profile)
-	if len(ret.failures) == 0 and len(ret.errors) == 0:
-		ret = 0
+	# override baseUrl using env variable
+	site_env = 'CYPRESS_baseUrl={}'.format(site_url)
 
-	if os.environ.get('CI'):
-		sys.exit(ret)
+	# run for headless mode
+	run_or_open = 'run' if headless else 'open'
+
+	frappe.commands.popen(site_env + ' yarn run cypress ' + run_or_open, cwd=app_base_path)
 
 @click.command('run-setup-wizard-ui-test')
 @click.option('--app', help="App to run tests on, leave blank for all apps")

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -468,14 +468,17 @@ def run_ui_tests(context, app, headless=False):
 	site = get_site(context)
 	app_base_path = os.path.abspath(os.path.join(frappe.get_app_path(app), '..'))
 	site_url = frappe.utils.get_site_url(site)
+	admin_password = frappe.get_conf(site).admin_password
 
 	# override baseUrl using env variable
 	site_env = 'CYPRESS_baseUrl={}'.format(site_url)
+	password_env = 'CYPRESS_adminPassword={}'.format(admin_password) if admin_password else ''
 
 	# run for headless mode
 	run_or_open = 'run' if headless else 'open'
 
-	frappe.commands.popen(site_env + ' yarn run cypress ' + run_or_open, cwd=app_base_path)
+	parts = dict(site_env=site_env, password_env=password_env, run_or_open=run_or_open)
+	frappe.commands.popen('{site_env} {password_env} yarn run cypress {run_or_open}'.format(parts), cwd=app_base_path)
 
 @click.command('run-setup-wizard-ui-test')
 @click.option('--app', help="App to run tests on, leave blank for all apps")

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -476,9 +476,9 @@ def run_ui_tests(context, app, headless=False):
 
 	# run for headless mode
 	run_or_open = 'run' if headless else 'open'
-
-	parts = dict(site_env=site_env, password_env=password_env, run_or_open=run_or_open)
-	frappe.commands.popen('{site_env} {password_env} yarn run cypress {run_or_open}'.format(parts), cwd=app_base_path)
+	command = '{site_env} {password_env} yarn run cypress {run_or_open}'
+	formatted_command = command.format(site_env=site_env, password_env=password_env, run_or_open=run_or_open)
+	frappe.commands.popen(formatted_command, cwd=app_base_path)
 
 @click.command('run-setup-wizard-ui-test')
 @click.option('--app', help="App to run tests on, leave blank for all apps")

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -316,6 +316,12 @@ def get_backups_path():
 def get_request_site_address(full_address=False):
 	return get_url(full_address=full_address)
 
+def get_site_url(site):
+	return 'http://{site}:{port}'.format(
+		site=site,
+		port=frappe.get_conf(site).webserver_port
+	)
+
 def encode_dict(d, encoding="utf-8"):
 	for key in d:
 		if isinstance(d[key], string_types) and isinstance(d[key], text_type):


### PR DESCRIPTION
BREAKING CHANGE
This replaces the old run-ui-tests command which used selenium to run UI tests with Cypress.

Usage:

```sh
bench --site [sitename] run-ui-tests [app]
bench --site [sitename] run-ui-tests [app] --headless
```