### PR TITLE
fix: get_list_context function signature error

### DIFF
--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -142,7 +142,7 @@ def prepare_filters(doctype, controller, kwargs):
 
 	return filters
 
-def get_list_context(context, doctype, web_form_name):
+def get_list_context(context, doctype, web_form_name=None):
 	from frappe.modules import load_doctype_module
 
 	list_context = context or frappe._dict()


### PR DESCRIPTION
get_list_context is only given 2 arguments but new signature enforces 3 mandatory args by default.

line 20 in the same file throws an error due the above mentioned bug.
context.update(get_list_context(context, doctype) or {})

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.