### PR TITLE
fix: rendering results on filter

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -142,6 +142,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 			clearTimeout($this.data('timeout'));
 			$this.data('timeout', setTimeout(function() {
 				frappe.flags.auto_scroll = false;
+				me.empty_list();
 				me.get_results();
 			}, 300));
 		});
@@ -198,7 +199,6 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 
 	render_result_list: function(results, more = 0) {
 		var me = this;
-
 		var more_btn = me.dialog.fields_dict.more_btn.$wrapper;
 
 		// Make empty result set if filter is set
@@ -207,7 +207,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 		}
 
 		if(results.length === 0) {
-			this.$results.empty();
+			this.empty_list();
 			more_btn.hide();
 			return;
 		} else if(more) {
@@ -221,6 +221,10 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 		if (frappe.flags.auto_scroll) {
 			this.$results.animate({scrollTop: me.$results.prop('scrollHeight')}, 500);
 		}
+	},
+
+	empty_list: function() {
+		this.$results.find('.list-item-container').remove();
 	},
 
 	get_results: function() {


### PR DESCRIPTION
Fix rendering issues with multiselect dialog

| Before  | After Fix |
| ------------- | ------------- |
| ![BeforeMultiSelectFix](https://user-images.githubusercontent.com/18097732/60869847-5c865600-a24d-11e9-8d41-22731f2086ec.gif) | ![MultiSelect](https://user-images.githubusercontent.com/18097732/60869825-51cbc100-a24d-11e9-863c-c63699c7aa67.gif) |

The results would not be cleared when fetching new data on input in search field. If it would, it would also delete the header. Fixed both in this PR