### PR TITLE
fix(About): show version

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -26,6 +26,8 @@ frappe.ui.misc.about = function() {
 						show_versions(r.message);
 					}
 				})
+			} else {
+				show_versions(frappe.versions);
 			}
 		};
 


### PR DESCRIPTION
#### Show Frappe Versions if frappe.versions is already set (v11)

- Before Fix
![Screenshot 2019-07-09 at 6 05 41 PM](https://user-images.githubusercontent.com/7310479/60888354-3627e100-a274-11e9-969e-282f5a6ffd6b.png)

- After Fix
![Screenshot 2019-07-09 at 6 02 24 PM](https://user-images.githubusercontent.com/7310479/60888232-efd28200-a273-11e9-8d82-5f5ed8d0da03.png)