### PR TITLE
fix: Format report chart values by passing fieldtype

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -493,6 +493,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		if (!(options && options.data && options.data.labels && options.data.labels.length > 0)) return;
 
+		if (options.fieldtype) {
+			options.tooltipOptions = {
+				formatTooltipY: d => frappe.format(d, {
+					fieldtype: options.fieldtype,
+					options: options.options
+				})
+			};
+		}
+
 		return options;
 	}
 


### PR DESCRIPTION
Values of the report chart will be formatted based on the passed fieldtype

### Example report

**Before**
<img width="1172" alt="Screenshot 2019-07-09 at 5 56 01 PM" src="https://user-images.githubusercontent.com/13928957/60905026-da6c5080-a291-11e9-9f8e-557ac64b02c6.png">

**After**
<img width="1163" alt="Screenshot 2019-07-09 at 5 54 42 PM" src="https://user-images.githubusercontent.com/13928957/60904699-17841300-a291-11e9-9084-f6b2c244238f.png">
