### PR TITLE
fix: Allow overriding breadcrumbs modules

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -11,6 +11,16 @@ frappe.breadcrumbs = {
 		"Dashboard Chart Source": "Customization",
 	},
 
+	module_map: {
+		'Core': 'Settings',
+		'Email': 'Settings',
+		'Custom': 'Settings',
+		'Workflow': 'Settings',
+		'Printing': 'Settings',
+		'Automation': 'Settings',
+		'Setup': 'Settings',
+	},
+
 	set_doctype_module: function(doctype, module) {
 		localStorage["preferred_breadcrumbs:" + doctype] = module;
 	},
@@ -73,8 +83,8 @@ frappe.breadcrumbs = {
 		}
 
 		if(breadcrumbs.module) {
-			if(in_list(["Core", "Email", "Custom", "Workflow", "Print"], breadcrumbs.module)) {
-				breadcrumbs.module = "Setup";
+			if (frappe.breadcrumbs.module_map[breadcrumbs.module]) {
+				breadcrumbs.module = frappe.breadcrumbs.module_map[breadcrumbs.module];
 			}
 
 			if(frappe.get_module(breadcrumbs.module)) {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -62,7 +62,7 @@ frappe.views.TreeView = Class.extend({
 
 		this.page = this.parent.page;
 		frappe.container.change_to(this.page_name);
-		frappe.breadcrumbs.add(me.opts.breadcrumb || locals.DocType[me.doctype].module);
+		frappe.breadcrumbs.add(me.opts.breadcrumb || locals.DocType[me.doctype].module, me.doctype);
 
 		this.set_title();
 


### PR DESCRIPTION
Some modules like Core, Email, Automation are shown in the Settings
module. This change will allow apps to define which module the original
module should map to.

ERPNext PR: https://github.com/frappe/erpnext/pull/18235