### PR TITLE
fix: Revert "feat: Frontmatter support in .md files"

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -231,20 +231,11 @@ def get_page_info(path, app, start, basepath=None, app_path=None, fname=None):
 
 def setup_source(page_info):
 	'''Get the HTML source of the template'''
-	from frontmatter import Frontmatter
-
 	jenv = frappe.get_jenv()
 	source = jenv.loader.get_source(jenv, page_info.template)[0]
 	html = ''
 
 	if page_info.template.endswith('.md'):
-		# extract frontmatter block if exists
-		# values will be used to update page_info
-		res = Frontmatter.read(source)
-		if res['attributes']:
-			page_info.update(res['attributes'])
-			source = res['body']
-
 		source = frappe.utils.md_to_html(source)
 
 		if not page_info.show_sidebar:
@@ -286,7 +277,7 @@ def extend_from_base_template(page_info, source):
 	'''
 
 	if (('</body>' not in source) and ('{% block' not in source)
-		and ('<!-- base_template:' not in source)) and 'base_template' not in page_info:
+		and ('<!-- base_template:' not in source)):
 		page_info.only_content = True
 		source = '''{% extends "templates/web.html" %}
 			{% block page_content %}\n''' + source + '\n{% endblock %}'
@@ -307,13 +298,16 @@ def load_properties_from_source(page_info):
 	if not page_info.title:
 		page_info.title = extract_title(page_info.source, page_info.route)
 
-	base_template = extract_comment_tag(page_info.source, 'base_template')
-	if base_template:
-		page_info.base_template = base_template
+	custom_base_template = extract_comment_tag(page_info.source, 'base_template')
 
-	if page_info.base_template:
+	page_info.meta_tags = frappe._dict()
+
+	page_info.meta_tags.name = extract_comment_tag(page_info.source, 'meta:name')
+	page_info.meta_tags.description = extract_comment_tag(page_info.source, 'meta:description')
+
+	if custom_base_template:
 		page_info.source = '''{{% extends "{0}" %}}
-			{{% block page_content %}}{1}{{% endblock %}}'''.format(page_info.base_template, page_info.source)
+			{{% block page_content %}}{1}{{% endblock %}}'''.format(custom_base_template, page_info.source)
 		page_info.no_cache = 1
 
 	if "<!-- no-breadcrumbs -->" in page_info.source:

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,4 +62,3 @@ psycopg2==2.7.5
 psycopg2-binary==2.7.5
 sqlparse==0.2.4
 Pygments==2.2.0
-frontmatter


### PR DESCRIPTION
Reverts frappe/frappe#7853

This Pull Request is wreaking havoc on the [ERPNext Website and Documentation](https://github.com/frappe/erpnext_com) and likely any other sites using markdown similar to ERPNext Docs (as my application does). Furthermore, it is proving quite difficult to understand the exact formatting for what markdown syntax is supported when using Frontmatter.

Even worse, due to the global caching implemented by default by Frappe, one bad line kills the entire site.

I **STRONGLY** suggest this be backed out until much stronger testing is created, and at the very least, the ERPNext Site/Documentation builds and renders without error. At least this way, people can have a valid/working example to draw from.

A few examples that break everything (as currently used in the ERPNext Site/Docs):
* In [Sales Person Target Allocation](https://github.com/frappe/erpnext_com/blob/master/erpnext_com/www/docs/user/manual/en/selling/sales-person-target-allocation.md):
`**Selling > Settings > Territory > (Edit specific Territory)**`
* In [Managing Dynamic Link Fields](https://github.com/frappe/erpnext_com/blob/master/erpnext_com/www/docs/user/manual/en/customize-erpnext/articles/managing-dynamic-link-fields.md):
```
-- Doctype
---- Sales Order
---- Purchase Invoice
---- Quotation
---- Sales Invoice
---- Employee
---- Work Order
.. and so on.
```