### PR TITLE
fix: Wrap frontmatter parsing in try except

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -239,11 +239,15 @@ def setup_source(page_info):
 
 	if page_info.template.endswith('.md'):
 		# extract frontmatter block if exists
-		# values will be used to update page_info
-		res = Frontmatter.read(source)
-		if res['attributes']:
-			page_info.update(res['attributes'])
-			source = res['body']
+		try:
+			# values will be used to update page_info
+			res = Frontmatter.read(source)
+			if res['attributes']:
+				page_info.update(res['attributes'])
+				source = res['body']
+		except Exception as e:
+			print('Error parsing ' + page_info.template)
+			print(e)
 
 		source = frappe.utils.md_to_html(source)
 


### PR DESCRIPTION
Some markdown syntax is not parsed correctly by YAML parser. It's safe to ignore those and leave it to the `.md` author to fix the syntax. Should not break existing files as they did without this fix.