### PR TITLE
fix: Add wrapper and block for overrides

### DIFF
--- a/frappe/templates/web.html
+++ b/frappe/templates/web.html
@@ -4,6 +4,7 @@
 {% block content %}
 
 {% macro main_content() %}
+<div class="page-content-wrapper">
 	<!-- breadcrumbs -->
 	<div class="page-breadcrumbs">
 		{% block breadcrumbs %}
@@ -11,6 +12,7 @@
 		{% endblock %}
 	</div>
 
+	{% block page_container %}
 	<main class="container my-5">
 		<div class="d-flex justify-content-between align-items-center">
 			<div class="page-header">
@@ -27,7 +29,13 @@
 		<div class="page_content">
 			{%- block page_content -%}{%- endblock -%}
 		</div>
+
+		<div class="page-footer">
+			{%- block page_footer -%}{%- endblock -%}
+		</div>
 	</main>
+	{% endblock %}
+</div>
 {% endmacro %}
 
 {% macro container_attributes() %}

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -213,7 +213,8 @@ def add_sidebar_data(context):
 
 
 def add_metatags(context):
-	tags = context.get("metatags")
+	tags = frappe._dict(context.get("metatags") or {})
+
 	if tags:
 		if not "twitter:card" in tags:
 			tags["twitter:card"] = "summary_large_image"
@@ -260,8 +261,10 @@ def add_metatags(context):
 		and frappe.db.exists('Website Route Meta', route))
 
 	if route_exists:
-		context.setdefault('metatags', frappe._dict({}))
 		website_route_meta = frappe.get_doc('Website Route Meta', route)
 		for meta_tag in website_route_meta.meta_tags:
 			d = meta_tag.get_meta_dict()
-			context.metatags.update(d)
+			tags.update(d)
+
+	# update tags in context
+	context.metatags = tags


### PR DESCRIPTION
Frappe Theme uses `.page-content-wrapper` and no container for its templates. This change is to allow apps to do that.

https://github.com/frappe/frappe_theme/pull/29