### PR TITLE
fix: Chat attachments not working

### DIFF
--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -126,6 +126,7 @@ def get_new_chat_message(user, room, content, type = "Content"):
 		mentions  = json.loads(mess.mentions),
 		creation  = mess.creation,
 		seen      = json.loads(mess._seen) if mess._seen else [ ],
+		type      = mess.type,
 	)
 
 	return resp

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1955,7 +1955,7 @@ class extends Component {
 				const content = message.content
 
 				if ( message.type === "File" ) {
-					item.subtitle = `📁 ${content.name}`
+					item.subtitle = `📁 ${content.name || content.path}`
 				} else {
 					item.subtitle = props.last_message.content
 				}
@@ -2396,7 +2396,7 @@ class extends Component {
 						h("small","",
 							props.type === "File" ?
 								h("a", { class: "no-decoration", href: content.path, target: "_blank" },
-									h(frappe.components.FontAwesome, { type: "file", fixed: true }), ` ${content.name}`
+									h(frappe.components.FontAwesome, { type: "file", fixed: true }), ` ${content.name || content.path}`
 								)
 								:
 								content

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -2131,10 +2131,10 @@ class extends Component {
 				label: "File",
 				onclick: ( ) => {
 					const dialog = frappe.upload.make({
-							args: { doctype: "Chat Room", docname: props.name },
+							args: { doctype: "Chat Room", docname: props.name, from_form: 1 },
 						callback: (a, b, args) => {
-							const { file_url, filename } = args
-							frappe.chat.message.send(props.name, { path: file_url, name: filename }, "File")
+							const { file_url, file_name } = a
+							frappe.chat.message.send(props.name, { path: file_url, name: file_name }, "File")
 						}
 					})
 				}


### PR DESCRIPTION
# Issue:
The attach file button from the chat doesn't work, it sends and empty message and doesn't upload the selected file except if it is an url.

# Solution
I solved this by analyzing the used functions and deducting that there where some data missing in the communications between client and server. After that was solved, I modified some things in the chat.js file to show correctly the file messages.

# Screenshots
Common message and file message working:
![mediumlow_message and file](https://user-images.githubusercontent.com/46027152/61129251-5f21bf00-a48a-11e9-84ee-c8e558818ff6.gif)

Uploading a file by URL:
![mediumlow_url file](https://user-images.githubusercontent.com/46027152/61129288-72348f00-a48a-11e9-9687-0d4269f42763.gif)
