### PR TITLE
fix: append base_url for requests from cordova app

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -464,6 +464,11 @@ frappe.Application = Class.extend({
 		return frappe.call('frappe.client.get_hooks', { hook: 'app_logo_url' })
 			.then(r => {
 				frappe.app.logo_url = (r.message || []).slice(-1)[0];
+				if (window.cordova) {
+					let host = frappe.request.url;
+					host = host.slice(0, host.length - 1);
+					frappe.app.logo_url = host + frappe.app.logo_url;
+				}
 			});
 	},
 

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -80,6 +80,11 @@ frappe.call = function(opts) {
 	let url = opts.url;
 	if (!url) {
 		url = '/api/method/' + args.cmd;
+		if (window.cordova) {
+			let host = frappe.request.url;
+			host = host.slice(0, host.length - 1);
+			url = host + url;
+		}
 		delete args.cmd;
 	}
 


### PR DESCRIPTION
Requests from the cordova container would go to `/` instead of the actual base url of the site the user wants to connect to. 

This PR fixes this