### PR TITLE
fix: Dont set falsy value

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -107,6 +107,7 @@ frappe.ui.form.ControlMultiSelectList = frappe.ui.form.ControlData.extend({
 	},
 
 	set_value(value) {
+		if (!value) return Promise.resolve();
 		if (typeof value === 'string') {
 			value = [value];
 		}


### PR DESCRIPTION
Falsy values like `false`, `''`, `undefined` shouldn't be set as values.