### PR TITLE
fix(postgres): Remove typcasting for date

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -113,10 +113,7 @@ class PostgresDatabase(Database):
 		if not date:
 			return '0001-01-01'
 
-		if isinstance(date, frappe.string_types):
-			if ':' not in date:
-				date = date
-		else:
+		if not isinstance(date, frappe.string_types):
 			date = date.strftime('%Y-%m-%d')
 
 		return date

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -111,13 +111,13 @@ class PostgresDatabase(Database):
 
 	def format_date(self, date):
 		if not date:
-			return '0001-01-01::DATE'
+			return '0001-01-01'
 
 		if isinstance(date, frappe.string_types):
 			if ':' not in date:
-				date = date + '::DATE'
+				date = date
 		else:
-			date = date.strftime('%Y-%m-%d') + '::DATE'
+			date = date.strftime('%Y-%m-%d')
 
 		return date
 


### PR DESCRIPTION
Typecasting may not be required since Postgres itself does that before querying

Also, the implementation was not correct. It should have been like `'0001-01-01'::DATE` and not `'0001-01-01::DATE'`. This used to raise the following error.
https://travis-ci.org/frappe/frappe/jobs/558905466

Code commit: https://github.com/frappe/frappe/pull/5919/commits/64c981c0fe9b9949fad5c1ea3bfc9b9ea63a03d6