### PR TITLE
fix: Website Theme UX

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -553,6 +553,10 @@ class Database(object):
 		val = val[0][0] if val else None
 
 		df = frappe.get_meta(doctype).get_field(fieldname)
+
+		if not df:
+			frappe.throw(_('Invalid field name: {0}').format(frappe.bold(fieldname)), self.InvalidColumnName)
+
 		if df.fieldtype in frappe.model.numeric_fieldtypes:
 			val = cint(val)
 

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -236,6 +236,7 @@ setup_wizard_exception = "frappe.desk.page.setup_wizard.setup_wizard.email_setup
 before_write_file = "frappe.limits.validate_space_limit"
 
 before_migrate = ['frappe.patches.v11_0.sync_user_permission_doctype_before_migrate.execute']
+after_migrate = ['frappe.website.doctype.website_theme.website_theme.generate_theme_files_if_not_exist']
 
 otp_methods = ['OTP App','Email','SMS']
 user_privacy_documents = [

--- a/frappe/patches/v5_0/style_settings_to_website_theme.py
+++ b/frappe/patches/v5_0/style_settings_to_website_theme.py
@@ -25,7 +25,7 @@ def migrate_style_settings():
 	website_theme.no_sidebar = cint(frappe.db.get_single_value("Website Settings", "no_sidebar"))
 
 	website_theme.save()
-	website_theme.use_theme()
+	website_theme.set_as_default()
 
 def map_color_fields(style_settings, website_theme):
 	color_fields_map = {

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -184,7 +184,7 @@ frappe.ui.form.Toolbar = Class.extend({
 				})
 			}, true);
 
-			if (frappe.boot.developer_mode===1 && me.frm.meta.issingle) {
+			if (frappe.boot.developer_mode===1) {
 				// edit doctype
 				this.page.add_menu_item(__("Edit DocType"), function() {
 					frappe.set_route('Form', 'DocType', me.frm.doctype);

--- a/frappe/website/doctype/website_theme/website_theme.js
+++ b/frappe/website/doctype/website_theme/website_theme.js
@@ -3,11 +3,20 @@
 
 frappe.ui.form.on('Website Theme', {
 	refresh(frm) {
-		frm.set_intro(__('Default theme is set in {0}', ['<a href="#Form/Website Settings">'
-			+ __('Website Settings') + '</a>']));
-
 		frm.toggle_display(["module", "custom"], !frappe.boot.developer_mode);
 
+		frm.trigger('setup_configure_theme');
+		frm.trigger('set_default_theme_button_and_indicator');
+
+		if (!frm.doc.custom && !frappe.boot.developer_mode) {
+			frm.set_read_only();
+			frm.disable_save();
+		} else {
+			frm.enable_save();
+		}
+	},
+
+	setup_configure_theme(frm) {
 		frm.add_custom_button(__('Configure Theme'), () => {
 			const d = new frappe.ui.Dialog({
 				title: __('Configure Theme'),
@@ -95,13 +104,23 @@ frappe.ui.form.on('Website Theme', {
 			}
 			d.show();
 		});
+	},
 
-		if (!frm.doc.custom && !frappe.boot.developer_mode) {
-			frm.set_read_only();
-			frm.disable_save();
-		} else {
-			frm.enable_save();
-		}
+	set_default_theme_button_and_indicator(frm) {
+		frappe.db.get_single_value('Website Settings', 'website_theme')
+			.then(value => {
+				if (value === frm.doc.name) {
+					frm.page.set_indicator(__('Default Theme'), 'green');
+				} else {
+					frm.page.clear_indicator();
+					// show set as default button
+					if (!frm.is_new() && !frm.is_dirty()) {
+						frm.add_custom_button(__('Set as Default Theme'), () => {
+							frm.call('set_as_default');
+						});
+					}
+				}
+			});
 	},
 
 	set_theme_from_config(frm, config) {

--- a/frappe/website/doctype/website_theme/website_theme.js
+++ b/frappe/website/doctype/website_theme/website_theme.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('Website Theme', {
 	refresh(frm) {
+		frm.clear_custom_buttons();
 		frm.toggle_display(["module", "custom"], !frappe.boot.developer_mode);
 
 		frm.trigger('setup_configure_theme');
@@ -116,7 +117,7 @@ frappe.ui.form.on('Website Theme', {
 					// show set as default button
 					if (!frm.is_new() && !frm.is_dirty()) {
 						frm.add_custom_button(__('Set as Default Theme'), () => {
-							frm.call('set_as_default');
+							frm.call('set_as_default').then(() => frm.trigger('refresh'));
 						});
 					}
 				}

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -79,12 +79,11 @@ class WebsiteTheme(Document):
 	def use_theme(self):
 		use_theme(self.name)
 
-@frappe.whitelist()
-def use_theme(theme):
-	website_settings = frappe.get_doc("Website Settings", "Website Settings")
-	website_settings.website_theme = theme
-	website_settings.ignore_validate = True
-	website_settings.save()
+	def set_as_default(self):
+		website_settings = frappe.get_doc('Website Settings')
+		website_settings.website_theme = self.name
+		website_settings.ignore_validate = True
+		website_settings.save()
 
 def add_website_theme(context):
 	context.theme = frappe._dict()

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from os.path import join as join_path, exists as path_exists
 
 class WebsiteTheme(Document):
 	def validate(self):
@@ -55,7 +56,6 @@ class WebsiteTheme(Document):
 
 	def generate_bootstrap_theme(self):
 		from subprocess import Popen, PIPE
-		from os.path import join as join_path
 
 		file_name = frappe.scrub(self.name) + '_' + frappe.generate_hash('Website Theme', 8) + '.css'
 		output_path = join_path(frappe.utils.get_bench_path(), 'sites', 'assets', 'css', file_name)
@@ -76,8 +76,11 @@ class WebsiteTheme(Document):
 
 		frappe.msgprint(_('Compiled Successfully'), alert=True)
 
-	def use_theme(self):
-		use_theme(self.name)
+	def generate_theme_if_not_exist(self):
+		bench_path = frappe.utils.get_bench_path()
+		theme_path = join_path(bench_path, 'sites', self.theme_url[1:])
+		if not path_exists(theme_path):
+			self.generate_bootstrap_theme()
 
 	def set_as_default(self):
 		website_settings = frappe.get_doc('Website Settings')
@@ -98,4 +101,15 @@ def get_active_theme():
 		try:
 			return frappe.get_doc("Website Theme", website_theme)
 		except frappe.DoesNotExistError:
+			pass
+
+def generate_theme_files_if_not_exist():
+	print('Generating Website Theme Files...')
+	themes = frappe.get_all('Website Theme')
+	for theme in themes:
+		doc = frappe.get_doc('Website Theme', theme.name)
+		try:
+			doc.generate_theme_if_not_exist()
+			doc.save()
+		except Exception:
 			pass


### PR DESCRIPTION
![website-theme-ux](https://user-images.githubusercontent.com/9355208/61279059-0a0be300-a7d3-11e9-9da5-a3f3ec401f1a.gif)

Apart from this:

1. frappe.db.get_single_value will throw an error if invalid fieldname is provided
1. **Edit DocType** button will be shown in all Forms in developer mode. Earlier it used to show only in Single DocTypes.
1. When a site is migrated between benches, theme files are not migrated. Added an `after_migrate` hook which will generate those theme files if they don't exist already.