### PR TITLE
fix: z-index for dropdown

### DIFF
--- a/frappe/public/less/page.less
+++ b/frappe/public/less/page.less
@@ -104,6 +104,7 @@
 .form-inner-toolbar .dropdown-menu {
 	right: 0px;
 	left: auto;
+	z-index: 100;
 }
 
 .layout-main-section {


### PR DESCRIPTION
Z-Index of dropdown was greater than page-head which made it to overlap head.

- before fix
![Screenshot 2019-07-16 at 4 30 22 PM](https://user-images.githubusercontent.com/7310479/61289482-139f4600-a7e7-11e9-8b76-3a2ad1dc23f1.png)

- after fix
![Screenshot 2019-07-16 at 4 29 58 PM](https://user-images.githubusercontent.com/7310479/61289488-1601a000-a7e7-11e9-8c55-192adef2cb08.png)
