### PR TITLE
fix: workflow action creation is not skipped

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -302,4 +302,4 @@ def get_state_optional_field_value(workflow_name, state):
 	return frappe.get_cached_value('Workflow Document State', {
 		'parent': workflow_name,
 		'state': state
-	}, 'is_state_optional')
+	}, 'is_optional_state')


### PR DESCRIPTION
Workflow action creation check is not properly executed due to incorrect field name used in validation.

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.