### PR TITLE
fix: Do not show "List" in "Go To" button for single doctypes

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -22,9 +22,15 @@ frappe.ui.form.on('DocType', {
 		}
 
 		if (!frm.is_new() && !frm.doc.istable) {
-			frm.add_custom_button(__('Go to {0} List', [frm.doc.name]), () => {
-				frappe.set_route('List', frm.doc.name, 'List');
-			});
+			if (frm.doc.issingle) {
+				frm.add_custom_button(__('Go to {0}', [frm.doc.name]), () => {
+					frappe.set_route('Form', frm.doc.name);
+				});
+			} else {
+				frm.add_custom_button(__('Go to {0} List', [frm.doc.name]), () => {
+					frappe.set_route('List', frm.doc.name, 'List');
+				});
+			}
 		}
 
 		if(!frappe.boot.developer_mode && !frm.doc.custom) {


### PR DESCRIPTION
**Before:** 
<img width="1192" alt="Screenshot 2019-07-17 at 4 33 23 PM" src="https://user-images.githubusercontent.com/13928957/61370721-b96ab780-a8b0-11e9-885c-1e1e5dea4d9c.png">

**After:**
<img width="1180" alt="Screenshot 2019-07-17 at 4 32 28 PM" src="https://user-images.githubusercontent.com/13928957/61370750-c4bde300-a8b0-11e9-8350-7fc40cb42329.png">

