### PR TITLE
fix(Email): first responded on

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -529,7 +529,7 @@ def update_mins_to_first_communication(parent, communication):
 		if frappe.db.get_all('User', filters={'email': communication.sender,
 			'user_type': 'System User', 'enabled': 1}, limit=1):
 			first_responded_on = communication.creation
-			if parent.meta.has_field('first_responded_on'):
+			if parent.meta.has_field('first_responded_on') and communication.sent_or_received == "Sent":
 				parent.db_set('first_responded_on', first_responded_on)
 			parent.db_set('mins_to_first_response', round(time_diff_in_seconds(first_responded_on, parent.creation) / 60), 2)
 


### PR DESCRIPTION
- When an Issue is raised via a custom app, following steps are followed:
  - An Issue is created
  - Communication is linked to the Issue
- In this process, when a communication is linked to the issue, it triggers `update_mins_to_first_communication` in `email.py` which in turn sets `first_responded_on` even if the `sent_or_received` is set as `Received`.
- This PR fixes this by setting `first_responded_on` only if the `sent_or_received` is set as `Received`.
- Before Fix (When SLA is enabled)
![em-wfix](https://user-images.githubusercontent.com/7310479/61378836-ea081c80-a8c3-11e9-8d01-bcc4e0c6287e.gif)

-After Fix (When SLA is enabled)
![em-fix](https://user-images.githubusercontent.com/7310479/61378843-ee343a00-a8c3-11e9-8c8c-b6353e0db41c.gif)
