### PR TITLE
fix: report builder error while editing childtable fields

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -509,15 +509,16 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				control.set_value(value);
 				return this.set_control_value(doctype, docname, fieldname, value)
 					.then((updated_doc) => {
-						const _data = this.data.find(d => d.name === updated_doc.name);
+						const _data = this.data.filter(b => b.name === updated_doc.name)
+							.find(a => (doctype != updated_doc.doctype && a[doctype + ":name"] == docname) || doctype == updated_doc.doctype)
+
 						for (let field in _data) {
 							if (field.includes(':')) {
 								// child table field
 								const [cdt, _field] = field.split(':');
 								const cdt_row = Object.keys(updated_doc)
 									.filter(key => Array.isArray(updated_doc[key]) && updated_doc[key][0].doctype === cdt)
-									.map(key => updated_doc[key])
-									.map(a => a[0])
+									.map(key => updated_doc[key])[0]
 									.filter(cdoc => cdoc.name === _data[cdt + ':name'])[0];
 								if (cdt_row) {
 									_data[field] = cdt_row[_field];

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -510,7 +510,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				return this.set_control_value(doctype, docname, fieldname, value)
 					.then((updated_doc) => {
 						const _data = this.data.filter(b => b.name === updated_doc.name)
-							.find(a => (doctype != updated_doc.doctype && a[doctype + ":name"] == docname) || doctype == updated_doc.doctype)
+							.find(a => (doctype != updated_doc.doctype && a[doctype + ":name"] == docname) || doctype == updated_doc.doctype);
 
 						for (let field in _data) {
 							if (field.includes(':')) {


### PR DESCRIPTION
fix #7839
This is a pretty bad bug. This makes the report builder useless for editing childtables.

**Related links**:
https://discuss.erpnext.com/t/report-builder-and-data-editing-in-v11/48186
#7354