### PR TITLE
fix(File): initial value must be string

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -406,7 +406,7 @@ def get_web_image(file_url):
 			frappe.msgprint(_("Unable to read file format for {0}").format(file_url))
 		raise
 
-	image = Image.open(StringIO(r.content))
+	image = Image.open(StringIO(str(r.content)))
 
 	try:
 		filename, extn = file_url.rsplit("/", 1)[1].rsplit(".", 1)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -406,7 +406,7 @@ def get_web_image(file_url):
 			frappe.msgprint(_("Unable to read file format for {0}").format(file_url))
 		raise
 
-	image = Image.open(StringIO(str(r.content)))
+	image = Image.open(StringIO(frappe.safe_decode(r.content)))
 
 	try:
 		filename, extn = file_url.rsplit("/", 1)[1].rsplit(".", 1)


### PR DESCRIPTION
- Dependent PR [#18413](https://github.com/frappe/erpnext/pull/18413)
- When uploading file using a URL, `content` should be string and not bytes
![up](https://user-images.githubusercontent.com/7310479/61454429-87c02200-a97e-11e9-9163-75e7c527c095.gif)
