### PR TITLE
 feat (web-form): enabled translations for web_forms 

### DIFF
--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -79,7 +79,7 @@ frappe.boot = {
 };
 // for backward compatibility of some libs
 frappe.sys_defaults = frappe.boot.sysdefaults;
-frappe.boot.lang_dict = {{ lang_dict }};
+frappe._messages = {{ translated_messages }};
 $(".file-size").each(function() {
 	$(this).text(frappe.form.formatters.FileSize($(this).text()));
 });

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -79,7 +79,7 @@ frappe.boot = {
 };
 // for backward compatibility of some libs
 frappe.sys_defaults = frappe.boot.sysdefaults;
-
+frappe.boot.lang_dict = {{ lang_dict }};
 $(".file-size").each(function() {
 	$(this).text(frappe.form.formatters.FileSize($(this).text()));
 });

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -10,7 +10,6 @@ from frappe.website.utils import get_comment_list
 from frappe.custom.doctype.customize_form.customize_form import docfield_properties
 from frappe.core.doctype.file.file import get_max_file_size
 from frappe.core.doctype.file.file import remove_file_by_url
-from frappe.translate import get_lang_dict
 from frappe.modules.utils import export_module_json, get_doc_module
 from six.moves.urllib.parse import urlencode
 from frappe.integrations.utils import get_payment_gateway_controller
@@ -174,7 +173,11 @@ def get_context(context):
 			context.max_attachment_size = get_max_file_size() / 1024 / 1024
 
 		context.show_in_grid = self.show_in_grid
-		context.lang_dict = frappe.as_json(get_lang_dict())
+		self.load_translations(context)
+
+	def load_translations(self, context):
+		translated_messages = frappe.translate.get_dict('doctype', self.doc_type)
+		context.translated_messages = frappe.as_json(translated_messages)
 
 	def load_document(self, context):
 		'''Load document `doc` and `layout` properties for template'''

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -10,6 +10,7 @@ from frappe.website.utils import get_comment_list
 from frappe.custom.doctype.customize_form.customize_form import docfield_properties
 from frappe.core.doctype.file.file import get_max_file_size
 from frappe.core.doctype.file.file import remove_file_by_url
+from frappe.translate import get_lang_dict
 from frappe.modules.utils import export_module_json, get_doc_module
 from six.moves.urllib.parse import urlencode
 from frappe.integrations.utils import get_payment_gateway_controller
@@ -173,6 +174,7 @@ def get_context(context):
 			context.max_attachment_size = get_max_file_size() / 1024 / 1024
 
 		context.show_in_grid = self.show_in_grid
+		context.lang_dict = frappe.as_json(get_lang_dict())
 
 	def load_document(self, context):
 		'''Load document `doc` and `layout` properties for template'''


### PR DESCRIPTION
> boot.py made me question my life

Web Forms were not translated to user language before. Here's an interesting new learning on how `frappe.boot` works

So desk.py sets the context variable. This provides the bootinfo which is put in `frappe.boot`. Now for translations there is `frappe.boot.__messages`, this is populated in kinda smart way. All the messages, etc for a certain doctype or report or page is fetched and translated to the user language, this is assigned to `frappe.boot.__messages`. 

So in translate.js a function `window.__` is attached to window which essentially refers `frappe._messages` looks for the txt, replaces it with the translated one. 

https://github.com/frappe/frappe/blob/fac9df46eca12361af396704bf7a1fcf35606b37/frappe/public/js/frappe/translate.js#L5-L17

P.S. `frappe._messages` is populated with the objects from `frappe.boot.__messages` in `desk.js` in `load_bootinfo`

https://github.com/frappe/frappe/blob/fac9df46eca12361af396704bf7a1fcf35606b37/frappe/public/js/frappe/desk.js#L217

So this brings us to the question, how do you translate a web form.
Simple, populate `frappe._messages` however the f#ck you can. Now boot.py is not the best code to look at, so what we do is look at `translate.py` the `get_dict` function will easily give you all the translations for any doctype. So in this PR, I took the translations for `self.doc_type` and adding to the context and assigned it to `frappe._messages`

Thanks @sahil28297 for the help.