### PR TITLE
fix: Check wrong OpenID's spec email claims

### DIFF
--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -142,7 +142,7 @@ def get_info_via_oauth(provider, code, decoder=None, id_token=False):
 		api_endpoint_args = oauth2_providers[provider].get("api_endpoint_args")
 		info = session.get(api_endpoint, params=api_endpoint_args).json()
 
-	if not (info.get("verified_email") or info.get("verified")):
+	if not (info.get("email_verified") or info.get("email")):
 		frappe.throw(_("Email not verified with {0}").format(provider.title()))
 
 	return info


### PR DESCRIPTION
According to OpenID's spec: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.

I'm integrating ERPNext with my Keycloak IDP and get an exception about OpenID returned email fields: "Email not verified with [provider]".

Turn out this exception caused by wrong field name checking. After changing it to correct field name, I can login by my Keycloak social login successfully.