### PR TITLE
fix: Get desktop settings method

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -339,7 +339,7 @@ def get_desktop_settings():
 				for m in user_modules]
 		else:
 			user_modules_by_category[category] = [apply_user_saved_links(m) \
-				for m in all_modules if m['category'] == category]
+				for m in all_modules if m.get('category') == category]
 
 	# filter out hidden modules
 	if home_settings.hidden_modules:


### PR DESCRIPTION
Fixes desk on-load error
```
Traceback (most recent call last):
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/moduleview.py", line 342, in get_desktop_settings
    for m in all_modules if m['category'] == category]
KeyError: u'category'
```