### PR TITLE
fix: Do not print frontmatter error logs

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -246,8 +246,7 @@ def setup_source(page_info):
 				page_info.update(res['attributes'])
 				source = res['body']
 		except Exception as e:
-			print('Error parsing ' + page_info.template)
-			print(e)
+			pass
 
 		source = frappe.utils.md_to_html(source)
 


### PR DESCRIPTION
Do not print frontmatter error logs

<img width="717" alt="Screenshot 2019-07-22 at 12 29 31 PM" src="https://user-images.githubusercontent.com/13928957/61612505-6b70fd80-ac7c-11e9-9ca6-f2ef30ac2425.png">
