### PR TITLE
fix(MultiSelect): Do not auto check oldest value in MultiSelect Dialog results

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -304,9 +304,9 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 					});
 
 					// Preselect oldest entry
-					// if (me.start < 1) {
-					// 	results[0].checked = 1;
-					// }
+					if (me.start < 1 && r.values.length === 1) {
+						results[0].checked = 1;
+					}
 				}
 				me.render_result_list(results, more);
 			}

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -201,7 +201,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 
 		let $row = $(`<div class="list-item">
 			<div class="list-item__content" style="flex: 0 0 10px;">
-				<input type="checkbox" class="list-row-check">
+				<input type="checkbox" class="list-row-check" ${result.checked ? 'checked' : ''}>
 			</div>
 			${contents}
 		</div>`);
@@ -291,6 +291,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 						if(me.date_field in result) {
 							result["Date"] = result[me.date_field]
 						}
+						result.checked = 0;
 						result.parsed_date = Date.parse(result["Date"]);
 						results.push(result);
 					});
@@ -303,9 +304,9 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 					});
 
 					// Preselect oldest entry
-					if (me.start < 1) {
-						results[0].checked = 1;
-					}
+					// if (me.start < 1) {
+					// 	results[0].checked = 1;
+					// }
 				}
 				me.render_result_list(results, more);
 			}

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -201,7 +201,7 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 
 		let $row = $(`<div class="list-item">
 			<div class="list-item__content" style="flex: 0 0 10px;">
-				<input type="checkbox" class="list-row-check" ${result.checked ? 'checked' : ''}>
+				<input type="checkbox" class="list-row-check">
 			</div>
 			${contents}
 		</div>`);

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -291,7 +291,6 @@ frappe.ui.form.MultiSelectDialog = Class.extend({
 						if(me.date_field in result) {
 							result["Date"] = result[me.date_field]
 						}
-						result.checked = 0;
 						result.parsed_date = Date.parse(result["Date"]);
 						results.push(result);
 					});


### PR DESCRIPTION
- First value of the result of MultiSelect Dialog box was being autochecked.

Before
![mul](https://user-images.githubusercontent.com/7310479/61623168-c7934c00-ac93-11e9-9315-f9621afd5518.gif)

After
![mul-fix](https://user-images.githubusercontent.com/7310479/61623248-e5f94780-ac93-11e9-83b3-46c4d45019a5.gif)