### PR TITLE
fix: Show/Hide cards

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -404,7 +404,7 @@ def get_options_for_show_hide_cards():
 		module = frappe._dict(module)
 		options.append({
 			'category': module.category,
-			'label': module.label,
+			'label': module.label or module.module_name,
 			'value': module.module_name,
 			'checked': module.module_name not in hidden_modules
 		})


### PR DESCRIPTION
Show module name if the label is missing.

**Before:** 
<img width="631" alt="Screenshot 2019-07-23 at 11 38 34 AM" src="https://user-images.githubusercontent.com/13928957/61686857-7f7d3380-ad3e-11e9-960a-0974dc38f359.png">

**After:**
<img width="665" alt="Screenshot 2019-07-23 at 11 39 14 AM" src="https://user-images.githubusercontent.com/13928957/61686911-9d4a9880-ad3e-11e9-9434-440d1e0d1974.png">

 