### PR TITLE
fix: Check is_private when checking for duplicates

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -457,7 +457,7 @@ class File(NestedSet):
 				return
 
 			self.file_url = unquote(self.file_url)
-			self.file_size = frappe.form_dict.file_size
+			self.file_size = frappe.form_dict.file_size or self.file_size
 
 
 	def get_uploaded_content(self):

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -188,14 +188,20 @@ class File(NestedSet):
 			# check duplicate name
 
 			# check duplicate assignement
-			n_records = frappe.db.sql("""select name from `tabFile`
-				where content_hash=%s
-				and name!=%s
-				and attached_to_doctype=%s
-				and attached_to_name=%s""", (self.content_hash, self.name, self.attached_to_doctype,
-					self.attached_to_name))
-			if len(n_records) > 0:
-				self.duplicate_entry = n_records[0][0]
+			filters = {
+				'content_hash': self.content_hash,
+				'is_private': self.is_private,
+				'name': ('!=', self.name)
+			}
+			if self.attached_to_doctype and self.attached_to_name:
+				filters.update({
+					'attached_to_doctype': self.attached_to_doctype,
+					'attached_to_name': self.attached_to_name
+				})
+			duplicate_file = frappe.db.get_value('File', filters)
+
+			if duplicate_file:
+				self.duplicate_entry = duplicate_file
 				frappe.throw(_("Same file has already been attached to the record"),
 					frappe.DuplicateEntryError)
 
@@ -484,7 +490,13 @@ class File(NestedSet):
 		self.content_hash = get_content_hash(self.content)
 		self.content_type = mimetypes.guess_type(self.file_name)[0]
 
-		_file = frappe.get_value("File", {"content_hash": self.content_hash}, ["file_url"])
+		# check if a file exists with the same content hash and is also in the same folder (public or private)
+		_file = frappe.get_value("File", {
+				"content_hash": self.content_hash,
+				"is_private": self.is_private
+			},
+			["file_url"])
+
 		if _file:
 			self.file_url  = _file
 			file_exists = True


### PR DESCRIPTION
If a file is uploaded as a public file, and later the same file is uploaded as a private file, the duplicate file would get the URL of the original file which is in `public` in this case. This problem also occurs when the original file is private, and later it is uploaded as public.