### PR TITLE
fix: changed reset password button label

### DIFF
--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -87,7 +87,7 @@
 			<span class="indicator blue" data-text="{{ _("Forgot Password") }}"></span></div>
 		<input type="email" id="forgot_email"
 			class="form-control" placeholder="{{ _('Email address') }}" required autofocus>
-		<button class="btn btn-sm btn-primary btn-block btn-forgot" type="submit">{{ _("Send Password") }}</button>
+		<button class="btn btn-sm btn-primary btn-block btn-forgot" type="submit">{{ _("Reset Password") }}</button>
 	</form>
 	</div>
 	<div class='form-footer'>


### PR DESCRIPTION
Fixed the label of Reset Password Button.

Before:
![image](https://user-images.githubusercontent.com/46772424/61703075-73a16980-ad5e-11e9-92a6-2e13bc95ada3.png)


After:
![image](https://user-images.githubusercontent.com/46772424/61703050-66847a80-ad5e-11e9-88cc-4e60b5dfa3de.png)
