### PR TITLE
fix: Session Defaults

### DIFF
--- a/frappe/core/doctype/session_default_settings/session_default_settings.js
+++ b/frappe/core/doctype/session_default_settings/session_default_settings.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+// MIT License. See license.txt
+
+frappe.ui.form.on('Session Default Settings', {
+	refresh: function(frm) {
+    frm.set_query('ref_doctype', 'session_defaults', function() {
+      return {
+        filters: {
+          issingle: 0,
+          istable: 0
+        }
+      };
+    });
+	}
+});

--- a/frappe/core/doctype/session_default_settings/session_default_settings.js
+++ b/frappe/core/doctype/session_default_settings/session_default_settings.js
@@ -3,13 +3,13 @@
 
 frappe.ui.form.on('Session Default Settings', {
 	refresh: function(frm) {
-    frm.set_query('ref_doctype', 'session_defaults', function() {
-      return {
-        filters: {
-          issingle: 0,
-          istable: 0
-        }
-      };
-    });
+		frm.set_query('ref_doctype', 'session_defaults', function() {
+			return {
+				filters: {
+					issingle: 0,
+					istable: 0
+				}
+			};
+		});
 	}
 });

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -617,7 +617,7 @@ class FilterArea {
 					options = options.join("\n");
 				}
 			}
-			let default_value = fieldtype === 'Link' ? frappe.defaults.get_user_default(options) : null
+			let default_value = fieldtype === 'Link' ? frappe.defaults.get_user_default(options) : null;
 			return {
 				fieldtype: fieldtype,
 				label: __(df.label),

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -617,12 +617,14 @@ class FilterArea {
 					options = options.join("\n");
 				}
 			}
+			let default_value = fieldtype === 'Link' ? frappe.defaults.get_user_default(options) : null
 			return {
 				fieldtype: fieldtype,
 				label: __(df.label),
 				options: options,
 				fieldname: df.fieldname,
 				condition: condition,
+				default: default_value,
 				onchange: () => this.refresh_list_view(),
 				ignore_link_validation: fieldtype === 'Dynamic Link'
 			};

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -255,6 +255,12 @@ frappe.ui.toolbar.setup_session_defaults = function() {
 				};
 			}
 			frappe.prompt(fields, function(values) {
+				//if default is not set for a particular field in prompt
+				fields.forEach(function(d) {
+					if (!values[d.fieldname]) {
+						values[d.fieldname] = "";
+					}
+				});
 				frappe.call({
 					method: 'frappe.core.doctype.session_default_settings.session_default_settings.set_session_default_values',
 					args: {
@@ -266,7 +272,6 @@ frappe.ui.toolbar.setup_session_defaults = function() {
 								'message': __('Session Defaults Saved'),
 								'indicator': 'green'
 							});
-							frappe.clear_cache();
 						}	else {
 							frappe.show_alert({
 								'message': __('An error occurred while setting Session Defaults'),

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -272,6 +272,7 @@ frappe.ui.toolbar.setup_session_defaults = function() {
 								'message': __('Session Defaults Saved'),
 								'indicator': 'green'
 							});
+							frappe.ui.toolbar.clear_cache();
 						}	else {
 							frappe.show_alert({
 								'message': __('An error occurred while setting Session Defaults'),


### PR DESCRIPTION
Fixes for:
- Session Default value not set in List View.
- Setting Session Defaults allowed for Single doctypes and child tables.
- Reload to reflect the session defaults.
- Session Defaults not cleared if prompt fields are cleared.