### PR TITLE
fix: oauth redirect issue

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -47,7 +47,11 @@ frappe.route = function() {
 	if(route[0]) {
 		const title_cased_route = frappe.utils.to_title_case(route[0]);
 
-		if(route[1] && frappe.views[title_cased_route + "Factory"]) {
+		if (title_cased_route === 'Desktop') {
+			frappe.views.pageview.show('');
+		}
+
+		if (route[1] && frappe.views[title_cased_route + "Factory"]) {
 			// has a view generator, generate!
 			if(!frappe.view_factory[title_cased_route]) {
 				frappe.view_factory[title_cased_route] = new frappe.views[title_cased_route + "Factory"]();

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -290,7 +290,7 @@ def redirect_post_login(desk_user):
 	frappe.local.response["type"] = "redirect"
 
 	# the #desktop is added to prevent a facebook redirect bug
-	frappe.local.response["location"] = "/desk#desktop" if desk_user else "/"
+	frappe.local.response["location"] = "/desk#" if desk_user else "/me"
 
 def oauth_decoder(data):
 	if isinstance(data, bytes):

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -290,7 +290,7 @@ def redirect_post_login(desk_user):
 	frappe.local.response["type"] = "redirect"
 
 	# the #desktop is added to prevent a facebook redirect bug
-	frappe.local.response["location"] = "/desk#" if desk_user else "/me"
+	frappe.local.response["location"] = "/desk#desktop" if desk_user else "/me"
 
 def oauth_decoder(data):
 	if isinstance(data, bytes):

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -16,7 +16,7 @@ no_cache = True
 
 def get_context(context):
 	if frappe.session.user != "Guest":
-		frappe.local.flags.redirect_location = "/" if frappe.session.data.user_type=="Website User" else "/desk"
+		frappe.local.flags.redirect_location = "/me" if frappe.session.data.user_type=="Website User" else "/desk"
 		raise frappe.Redirect
 
 	# get settings from site config

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -16,7 +16,7 @@ no_cache = True
 
 def get_context(context):
 	if frappe.session.user != "Guest":
-		frappe.local.flags.redirect_location = "/me" if frappe.session.data.user_type=="Website User" else "/desk"
+		frappe.local.flags.redirect_location = "/" if frappe.session.data.user_type=="Website User" else "/desk"
 		raise frappe.Redirect
 
 	# get settings from site config


### PR DESCRIPTION
When redirected to `/` if no route is selected, it would be routed to login and then desk or home causing too many redirects. Set the redirect to `/me` explicitly in this PR