### PR TITLE
fix: Patch to create file in right location

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -473,7 +473,7 @@ class File(NestedSet):
 		return None
 
 
-	def save_file(self, content=None, decode=False):
+	def save_file(self, content=None, decode=False, ignore_existing_file_check=False):
 		file_exists = False
 		self.content = content
 		if decode:
@@ -490,12 +490,15 @@ class File(NestedSet):
 		self.content_hash = get_content_hash(self.content)
 		self.content_type = mimetypes.guess_type(self.file_name)[0]
 
+		_file = False
+
 		# check if a file exists with the same content hash and is also in the same folder (public or private)
-		_file = frappe.get_value("File", {
-				"content_hash": self.content_hash,
-				"is_private": self.is_private
-			},
-			["file_url"])
+		if not ignore_existing_file_check:
+			_file = frappe.get_value("File", {
+					"content_hash": self.content_hash,
+					"is_private": self.is_private
+				},
+				["file_url"])
 
 		if _file:
 			self.file_url  = _file

--- a/frappe/patches/v12_0/fix_public_private_files.py
+++ b/frappe/patches/v12_0/fix_public_private_files.py
@@ -1,0 +1,33 @@
+import frappe
+import os
+
+def execute():
+	files = frappe.get_all('File',
+		fields=['is_private', 'file_url', 'name'],
+		filters={'is_folder': 0})
+
+	for file in files:
+		file_url = file.file_url
+		if file.is_private:
+			if not file_url.startswith('/private/files/'):
+				generate_file(file.name)
+		else:
+			if file_url.startswith('/private/files/'):
+				generate_file(file.name)
+
+def generate_file(file_name):
+	try:
+		file_doc = frappe.get_doc('File', file_name)
+		# private
+		new_doc = frappe.new_doc('File')
+		new_doc.is_private = file_doc.is_private
+		new_doc.file_name = file_doc.file_name
+		# to create copy of file in right location
+		# if the file doc is private file will be created in /private folder
+		# if the file doc is public file will be created in /files folder
+		new_doc.save_file(content=file_doc.get_content(), ignore_existing_file_check=True)
+
+		file_doc.file_url = new_doc.file_url
+		file_doc.save()
+	except IOError:
+		pass

--- a/frappe/patches/v12_0/fix_public_private_files.py
+++ b/frappe/patches/v12_0/fix_public_private_files.py
@@ -23,8 +23,8 @@ def generate_file(file_name):
 		new_doc.is_private = file_doc.is_private
 		new_doc.file_name = file_doc.file_name
 		# to create copy of file in right location
-		# if the file doc is private file will be created in /private folder
-		# if the file doc is public file will be created in /files folder
+		# if the file doc is private then the file will be created in /private folder
+		# if the file doc is public then the file will be created in /files folder
 		new_doc.save_file(content=file_doc.get_content(), ignore_existing_file_check=True)
 
 		file_doc.file_url = new_doc.file_url


### PR DESCRIPTION
Patch to support following fix.
https://github.com/frappe/frappe/pull/7957

This patch will create a file in the right location depending on `is_private` check and will also update the `file_url` in the file doc.

- if the file doc is private then the file will be created in `/private` folder
- if the file doc is public then the file will be created in `/files` folder

