### PR TITLE
fix: Unknown string format:', u'Total'

### DIFF
--- a/frappe/templates/emails/auto_email_report.html
+++ b/frappe/templates/emails/auto_email_report.html
@@ -33,9 +33,15 @@
 		{% for row in data %}
 		<tr>
 			{% for col in columns %}
-			<td {{- get_alignment(col) }}>
-				{{- frappe.format(row[col.fieldname], col, row) -}}
-			</td>
+				{% if row[col.fieldname] == 'Total' %}
+					<td {{- get_alignment(col) }}> 
+						{{- row[col.fieldname] -}}
+					</td>
+				{% else %}
+					<td {{- get_alignment(col) }}> 
+						{{- frappe.format(row[col.fieldname], col, row) -}}
+					</td>
+				{% endif %}
 			{% endfor %}
 		</td>
 		{% endfor %}


### PR DESCRIPTION
**Issue**

Total is set under column posting date which has fieldtype Date, now when system trying to formate Total getting below error

```
{'event': u'daily', 'retry': 0, 'log': <function log at 0x7efe5260d5f0>, 'site': u'icctravel.erpnext.com', 'job_name': u'frappe.email.doctype.auto_email_report.auto_email_report.send_daily', 'method_name': u'frappe.email.doctype.auto_email_report.auto_email_report.send_daily', 'method': <function send_daily at 0x7efe2c45fcf8>, 'user': u'Administrator', 'kwargs': {}, 'is_async': True}
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/utils/background_jobs.py", line 103, in execute_job
    method(**kwargs)
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 191, in send_daily
    auto_email_report.send()
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 126, in send
    data = self.get_report_content()
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 77, in get_report_content
    return self.get_html_table(columns, data)
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 104, in get_html_table
    'edit_report_settings': get_link_to_form('Auto Email Report', self.name)
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/utils/jinja.py", line 72, in render_template
    return get_jenv().get_template(template).render(context)
  File "/home/frappe/benches/bench-2019-07-23/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-2019-07-23/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/./templates/emails/auto_email_report.html", line 37, in top-level template code
    {{- frappe.format(row[col.fieldname], col, row) -}}
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/__init__.py", line 1331, in format_value
    return frappe.utils.formatters.format_value(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/utils/formatters.py", line 46, in format_value
    return formatdate(value)
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/utils/data.py", line 229, in formatdate
    date = getdate(string_date)
  File "/home/frappe/benches/bench-2019-07-23/apps/frappe/frappe/utils/data.py", line 41, in getdate
    return parser.parse(string_date).date()
  File "/home/frappe/benches/bench-2019-07-23/env/lib/python2.7/site-packages/dateutil/parser/_parser.py", line 1358, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2019-07-23/env/lib/python2.7/site-packages/dateutil/parser/_parser.py", line 649, in parse
    raise ValueError("Unknown string format:", timestr)
ValueError: (u'Unknown string format:', u'Total')
```