### PR TITLE
fix: Check private file permissions for all docs

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -554,7 +554,7 @@ class File(NestedSet):
 			if has_permission(self, 'read'):
 				return True
 
-			raise frappe.PermissionError
+			return False
 
 	def get_extension(self):
 		'''returns split filename and extension'''


### PR DESCRIPTION
A file may be attached to multiple documents. It's permission is decided
based on the attached document's permissions. So, the permission
should be checked for each document and should be allowed if atleast
one document is accessible.