### PR TITLE
refactor: upgraded frappe charts and enabled number shortening

### DIFF
--- a/frappe/core/page/dashboard/dashboard.js
+++ b/frappe/core/page/dashboard/dashboard.js
@@ -232,7 +232,8 @@ class DashboardChart {
 			type: chart_type_map[this.chart_doc.type],
 			colors: [this.chart_doc.color || "light-blue"],
 			axisOptions: {
-				xIsSeries: this.chart_doc.timeseries
+				xIsSeries: this.chart_doc.timeseries,
+				shortenYAxisNumbers: 1
 			}
 		};
 		this.chart_container.find('.chart-loading-state').addClass('hide');

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -495,7 +495,10 @@ frappe.ui.form.Dashboard = Class.extend({
 		this.chart_area.empty().removeClass('hidden');
 		$.extend(args, {
 			type: 'line',
-			colors: ['green']
+			colors: ['green'],
+			axisOptions: {
+				shortenYAxisNumbers: 1
+			}
 		});
 		this.show();
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -535,7 +535,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				]
 			},
 			type: type,
-			colors: colors
+			colors: colors,
+			axisOptions: {
+				shortenYAxisNumbers: 1
+			}
 		};
 
 		function get_column_values(column_name) {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -492,6 +492,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			data: data,
 			type: args.chart_type,
 			colors: ['#70E078', 'light-blue', 'orange', 'red'],
+			axisOptions: {
+				shortenYAxisNumbers: 1
+			},
 
 			format_tooltip_x: value => value.doc.name,
 			format_tooltip_y:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cookie": "^0.3.1",
     "express": "^4.16.2",
     "fast-deep-equal": "^2.0.1",
-    "frappe-charts": "^1.2.3",
+    "frappe-charts": "^1.2.4",
     "frappe-datatable": "^1.13.5",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,9 +1754,9 @@ fragment-cache@^0.2.1:
     map-cache "^0.2.2"
 
 frappe-charts@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.2.3.tgz#ee1840864cfe5c9371b61f8ec9b8624633fdc84d"
-  integrity sha512-nHDCERSKni0JDT/0eooGpR3nE/NBKcAJEgbZfjojoA5D3jK4cT6B4kRT3m9EgIqMkwPllZncWUPp0zYtN8WSsQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.2.4.tgz#d9f4bf6eda5a3f270d0707682f6fa14014292326"
+  integrity sha512-aTTOwZ99PTNbBPbujyZnUFwnbcBUksDol8FKXEiUkY7CYKZdvHaRzVrXsw2r48B05xdn+HFMEKfOl5X2zqMYsg==
 
 frappe-datatable@^1.13.5:
   version "1.13.5"


### PR DESCRIPTION
This PR has the following changes
- Upgraded frappe charts to [1.2.4](https://github.com/frappe/charts/releases/tag/1.2.4)
- Enabled `shortenYAxisNumbers` across frappe ('200000' will be shortened to '200 K')

<img width="579" alt="Screenshot 2019-07-30 at 1 03 52 PM" src="https://user-images.githubusercontent.com/18097732/62109747-8ff75600-b2ca-11e9-9b72-585afe9d1a9b.png">

