### PR TITLE
fix: Module check in get_desktop_settings

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -336,7 +336,7 @@ def get_desktop_settings():
 		if category in user_saved_modules_by_category:
 			user_modules = user_saved_modules_by_category[category]
 			user_modules_by_category[category] = [apply_user_saved_links(modules_by_name[m]) \
-				for m in user_modules]
+				for m in user_modules if modules_by_name.get(m)]
 		else:
 			user_modules_by_category[category] = [apply_user_saved_links(m) \
 				for m in all_modules if m.get('category') == category]


### PR DESCRIPTION
Fixes 

```py
Traceback (most recent call last):
  File "/Users/farisansari/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/farisansari/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/farisansari/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/farisansari/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/farisansari/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/Users/farisansari/frappe-bench/apps/frappe/frappe/desk/moduleview.py", line 339, in get_desktop_settings
    for m in user_modules]
  File "/Users/farisansari/frappe-bench/apps/frappe/frappe/desk/moduleview.py", line 339, in <listcomp>
    for m in user_modules]
KeyError: 'Core'
```