### PR TITLE
fix(email): Fixed py3 chardet error - Expected object of type bytes or bytearray, got: <class 'str'>

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -481,7 +481,10 @@ class Email:
 		"""Detect chartset."""
 		charset = part.get_content_charset()
 		if not charset:
-			charset = chardet.detect(str(part))['encoding']
+			if six.PY2:
+				charset = chardet.detect(str(part))['encoding']
+			else:
+				charset = chardet.detect(b part)['encoding']
 
 		return charset
 


### PR DESCRIPTION
+ In python 3 there is change in chardet module and hence the error
+ Error is at line https://github.com/frappe/frappe/blob/develop/frappe/email/receive.py#L484
+existing code, works fine in python 2.7
+ in python 3 it breaks
+ fix for python3 i.e. make it byte
So in summary, following is the fix that should work for both python2  and python3 at receive.py#L484
        if not charset:
            if six.PY2:
                charset = chardet.detect(str(part))['encoding']
            else:
                charset = chardet.detect(b part)['encoding']

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.