### PR TITLE
fix(email): Fixed py3 chardet error - Expected object of type bytes or bytearray, got: <class 'str'>

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -481,7 +481,10 @@ class Email:
 		"""Detect chartset."""
 		charset = part.get_content_charset()
 		if not charset:
-			charset = chardet.detect(str(part))['encoding']
+			if six.PY2:
+				charset = chardet.detect(str(part))['encoding']
+			else:
+				charset = chardet.detect(part.encode())['encoding']
 
 		return charset
 


### PR DESCRIPTION
+it is fix for #8058
+existing code, works fine in python 2.7
+in python 3 it breaks
+In python 3 there is change in chardet module and hence the error
+convert-string-to-bytes-in-python-3
+this is also fixed in v11-hotfix branch

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.