### PR TITLE
fix(scheduler): Show scheduler status

### DIFF
--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -115,9 +115,12 @@ def set_maintenance_mode(context, state, site=None):
 
 @click.command('doctor') #Passing context always gets a site and if there is no use site it breaks
 @click.option('--site', help='site name')
-def doctor(site=None):
+@pass_context
+def doctor(context, site=None):
 	"Get diagnostic info about background workers"
 	from frappe.utils.doctor import doctor as _doctor
+	if not site:
+		site = get_site(context)
 	return _doctor(site=site)
 
 @click.command('show-pending-jobs')

--- a/frappe/core/page/background_jobs/background_jobs.js
+++ b/frappe/core/page/background_jobs/background_jobs.js
@@ -13,6 +13,12 @@ frappe.pages['background_jobs'].on_page_load = function(wrapper) {
 
 frappe.pages['background_jobs'].on_page_show = function(wrapper) {
 	frappe.pages.background_jobs.refresh_jobs();
+	frappe.call({
+		method: 'frappe.core.page.background_jobs.background_jobs.get_scheduler_status',
+		callback: function(r) {
+			frappe.pages.background_jobs.page.set_indicator(...r.message);
+		}
+	});
 }
 
 frappe.pages.background_jobs.refresh_jobs = function() {

--- a/frappe/core/page/background_jobs/background_jobs.py
+++ b/frappe/core/page/background_jobs/background_jobs.py
@@ -7,6 +7,8 @@ import frappe
 from rq import Queue, Worker
 from frappe.utils.background_jobs import get_redis_conn
 from frappe.utils import format_datetime, cint
+from frappe.utils.scheduler import is_scheduler_inactive
+from frappe import _
 
 colors = {
 	'queued': 'orange',
@@ -49,3 +51,9 @@ def get_info(show_failed=False):
 				for j in q.get_jobs()[:10]: add_job(j, q.name)
 
 	return jobs
+
+@frappe.whitelist()
+def get_scheduler_status():
+	if is_scheduler_inactive():
+		return [_("Inactive"), "red"]
+	return [_("Active"), "green"]

--- a/frappe/utils/doctor.py
+++ b/frappe/utils/doctor.py
@@ -3,7 +3,7 @@ import frappe.utils
 from collections import defaultdict
 from rq import Worker, Connection
 from frappe.utils.background_jobs import get_redis_conn, get_queue, get_queue_list
-from frappe.utils.scheduler import is_scheduler_disabled
+from frappe.utils.scheduler import is_scheduler_disabled, is_scheduler_inactive
 from six import iteritems
 
 
@@ -107,8 +107,19 @@ def doctor(site=None):
 	for s in sites:
 		frappe.init(s)
 		frappe.connect()
+
 		if is_scheduler_disabled():
 			print("Scheduler disabled for", s)
+
+		if frappe.local.conf.maintenance_mode:
+			print("Maintenance mode on for", s)
+
+		if frappe.local.conf.pause_scheduler:
+			print("Scheduler paused for", s)
+
+		if is_scheduler_inactive():
+			print("Scheduler inactive for", s)
+
 		frappe.destroy()
 
 	# TODO improve this

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -78,14 +78,8 @@ def enqueue_events_for_site(site, queued_jobs):
 
 	try:
 		frappe.init(site=site)
-		if frappe.local.conf.maintenance_mode:
-			return
-
-		if frappe.local.conf.pause_scheduler:
-			return
-
 		frappe.connect()
-		if is_scheduler_disabled():
+		if is_scheduler_inactive():
 			return
 
 		enqueue_events(site=site, queued_jobs=queued_jobs)
@@ -224,6 +218,18 @@ def get_enabled_scheduler_events():
 
 	return ["all", "hourly", "hourly_long", "daily", "daily_long",
 		"weekly", "weekly_long", "monthly", "monthly_long", "cron"]
+
+def is_scheduler_inactive():
+	if frappe.local.conf.maintenance_mode:
+		return True
+
+	if frappe.local.conf.pause_scheduler:
+		return True
+
+	if is_scheduler_disabled():
+		return True
+
+	return False
 
 def is_scheduler_disabled():
 	if frappe.conf.disable_scheduler:


### PR DESCRIPTION
Status on Background Jobs page
![Screenshot 2019-07-31 at 8 18 10 PM](https://user-images.githubusercontent.com/8528887/62222248-adaee300-b3d0-11e9-9c5a-be8ae8beb8b6.png)
![Screenshot 2019-07-31 at 8 19 13 PM](https://user-images.githubusercontent.com/8528887/62222249-adaee300-b3d0-11e9-90ee-44566b50bf62.png)



Output of `bench doctor`

```sh
$ bench doctor                                                                                             -----Checking scheduler status-----
...
Scheduler disabled for 12.local
Scheduler paused for 12.local
Scheduler inactive for 12.local
...
Workers online: 3
----- Jobs-----
...
```