### PR TITLE
fix: Disable drag-n-reorder in mobile

### DIFF
--- a/frappe/public/js/frappe/views/components/DeskSection.vue
+++ b/frappe/public/js/frappe/views/components/DeskSection.vue
@@ -30,7 +30,9 @@ export default {
 		}
 	},
 	mounted() {
-		this.setup_sortable();
+		if (!frappe.utils.is_mobile()) {
+			this.setup_sortable();
+		}
 	},
 	methods: {
 		setup_sortable() {


### PR DESCRIPTION
Drag and reorder makes mobile scrolling useless. This PR disables it in mobile view. Reordering should be done in desktop.