### PR TITLE
fix: Pick sitemap host from request

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -714,9 +714,10 @@ def get_url(uri=None, full_address=False):
 		return uri
 
 	if not host_name:
-		if hasattr(frappe.local, "request") and frappe.local.request and frappe.local.request.host:
-			protocol = 'https://' if 'https' == frappe.get_request_header('X-Forwarded-Proto', "") else 'http://'
-			host_name = protocol + frappe.local.request.host
+		request_host_name = get_host_name_from_request()
+
+		if request_host_name:
+			host_name = request_host_name
 
 		elif frappe.local.site:
 			protocol = 'http://'
@@ -752,6 +753,11 @@ def get_url(uri=None, full_address=False):
 	url = urljoin(host_name, uri) if uri else host_name
 
 	return url
+
+def get_host_name_from_request():
+	if hasattr(frappe.local, "request") and frappe.local.request and frappe.local.request.host:
+		protocol = 'https://' if 'https' == frappe.get_request_header('X-Forwarded-Proto', "") else 'http://'
+		return protocol + frappe.local.request.host
 
 def url_contains_port(url):
 	parts = url.split(':')

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -15,7 +15,12 @@ base_template_path = "templates/www/sitemap.xml"
 
 def get_context(context):
 	"""generate the sitemap XML"""
-	host = get_request_site_address()
+
+	# the site might be accessible from multiple host_names
+	# for e.g gadgets.erpnext.com and gadgetsinternational.com
+	# so it should be picked from the request
+	host = frappe.utils.get_host_name_from_request()
+
 	links = []
 	for route, page in iteritems(get_pages()):
 		if page.sitemap:


### PR DESCRIPTION
In case of sitemap, the host_name is important. It should show the hostname from the request address it is accessed from. Earlier it used to be overridden by the `host_name` value in `site_config.json`.