### PR TITLE
fix: handle data too long exception

### DIFF
--- a/frappe/core/doctype/communication/comment.py
+++ b/frappe/core/doctype/communication/comment.py
@@ -9,7 +9,7 @@ from frappe.core.doctype.user.user import extract_mentions
 from frappe.utils import get_fullname, get_link_to_form
 from frappe.website.render import clear_cache
 from frappe.model.db_schema import add_column
-from frappe.exceptions import ImplicitCommitError
+from frappe.exceptions import ImplicitCommitError, DataTooLongException
 
 def on_trash(doc):
 	if doc.communication_type != "Comment":
@@ -146,6 +146,8 @@ def update_comments_in_parent(reference_doctype, reference_name, _comments):
 			# missing column and in request, add column and update after commit
 			frappe.local._comments = (getattr(frappe.local, "_comments", [])
 				+ [(reference_doctype, reference_name, _comments)])
+		elif e.args[0] == 1406:
+			raise DataTooLongException
 		else:
 			raise ImplicitCommitError
 

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -84,3 +84,4 @@ class RetryBackgroundJobError(Exception): pass
 class DocumentLockedError(ValidationError): pass
 class CircularLinkingError(ValidationError): pass
 class SecurityException(Exception): pass
+class DataTooLongException(ValidationError): pass


### PR DESCRIPTION

<img width="415" alt="Screen Shot 2019-08-01 at 2 23 43 PM" src="https://user-images.githubusercontent.com/3784093/62279587-067d8a80-b468-11e9-9ce8-322ffe104b68.png">

- instead of data too long exception, the system used to raise ImplicitCommitError.