### PR TITLE
fix(patch): empty file_url if file does not have file_url

### DIFF
--- a/frappe/patches/v12_0/fix_public_private_files.py
+++ b/frappe/patches/v12_0/fix_public_private_files.py
@@ -7,7 +7,7 @@ def execute():
 		filters={'is_folder': 0})
 
 	for file in files:
-		file_url = file.file_url
+		file_url = file.file_url or ""
 		if file.is_private:
 			if not file_url.startswith('/private/files/'):
 				generate_file(file.name)


### PR DESCRIPTION
Handle exception if the `file_url` of a file doc is `None`