### PR TITLE
fix: refresh table after item is scanned (v12)

### DIFF
--- a/frappe/public/js/frappe/form/script_helpers.js
+++ b/frappe/public/js/frappe/form/script_helpers.js
@@ -23,11 +23,7 @@ window.refresh_field = function(n, docname, table_field) {
 			field = field[0];
 			var meta = frappe.meta.get_docfield(field.parent, field.fieldname, docname);
 			$.extend(field, meta);
-			if (docname){
-				cur_frm.fields_dict[table_field].grid.grid_rows_by_docname[docname].refresh_field(n);
-			} else {
-				cur_frm.fields_dict[table_field].grid.refresh();
-			}
+			cur_frm.fields_dict[table_field].grid.refresh();
 		}
 	} else if(cur_frm) {
 		cur_frm.refresh_field(n);


### PR DESCRIPTION
**Problem:**

When scanning serialized items (barcodes, serial numbers or batches), the system adds an unnamed row for the item and tries to refresh the corresponding field in the row. This causes the item to get added, but not get displayed on the form, since it can't find the new row.

**Solution:**

Instead of refreshing a specific field in the row, it's just easier to refresh the table, which shows the added item.

<hr>

**Screenshots / GIFs:**

**Before**

![non-working-scan](https://user-images.githubusercontent.com/13396535/62288912-0aff6e80-b47b-11e9-9b41-877a3984508a.gif)

**After**

![working-scan](https://user-images.githubusercontent.com/13396535/62288919-0e92f580-b47b-11e9-8d23-adb87ad0bcda.gif)