### PR TITLE
chore: Enable few eslint rules to enforce consistent code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -51,7 +51,11 @@
 		],
 		"no-control-regex": [
 			"off"
-		]
+		],
+		"space-before-blocks": "warn",
+		"keyword-spacing": "warn",
+		"comma-spacing": "warn",
+		"key-spacing": "warn",
 	},
 	"root": true,
 	"globals": {


### PR DESCRIPTION
Enabled following ESLint rules

[space-before-blocks](https://eslint.org/docs/rules/space-before-blocks)
[keyword-spacing](https://eslint.org/docs/rules/keyword-spacing)
[comma-spacing](https://eslint.org/docs/rules/comma-spacing)
[key-spacing](https://eslint.org/docs/rules/key-spacing)