### PR TITLE
fix: reportbuilder errorediting childtable fields

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -189,7 +189,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						// child table field
 						const [cdt, _field] = fieldname.split(':');
 						const cdt_row = Object.keys(doc)
-							.filter(key => Array.isArray(doc[key]) && doc[key][0].doctype === cdt)
+							.filter(key =>
+								Array.isArray(doc[key])
+								&& doc[key].length
+								&& doc[key][0].doctype === cdt
+							)
 							.map(key => doc[key])
 							.map(a => a[0])
 							.filter(cdoc => cdoc.name === d[cdt + ':name'])[0];
@@ -509,15 +513,24 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				control.set_value(value);
 				return this.set_control_value(doctype, docname, fieldname, value)
 					.then((updated_doc) => {
-						const _data = this.data.filter(b => b.name === updated_doc.name)
-							.find(a => (doctype != updated_doc.doctype && a[doctype + ":name"] == docname) || doctype == updated_doc.doctype);
+						const _data = this.data
+							.filter(b => b.name === updated_doc.name)
+							.find(a =>
+								// child table cell
+								(doctype != updated_doc.doctype && a[doctype + ":name"] == docname)
+								|| doctype == updated_doc.doctype
+							);
 
 						for (let field in _data) {
 							if (field.includes(':')) {
 								// child table field
 								const [cdt, _field] = field.split(':');
 								const cdt_row = Object.keys(updated_doc)
-									.filter(key => Array.isArray(updated_doc[key]) && updated_doc[key][0].doctype === cdt)
+									.filter(key =>
+										Array.isArray(updated_doc[key])
+										&& updated_doc[key].length
+										&& updated_doc[key][0].doctype === cdt
+									)
 									.map(key => updated_doc[key])[0]
 									.filter(cdoc => cdoc.name === _data[cdt + ':name'])[0];
 								if (cdt_row) {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -509,15 +509,16 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				control.set_value(value);
 				return this.set_control_value(doctype, docname, fieldname, value)
 					.then((updated_doc) => {
-						const _data = this.data.find(d => d.name === updated_doc.name);
+						const _data = this.data.filter(b => b.name === updated_doc.name)
+							.find(a => (doctype != updated_doc.doctype && a[doctype + ":name"] == docname) || doctype == updated_doc.doctype);
+
 						for (let field in _data) {
 							if (field.includes(':')) {
 								// child table field
 								const [cdt, _field] = field.split(':');
 								const cdt_row = Object.keys(updated_doc)
 									.filter(key => Array.isArray(updated_doc[key]) && updated_doc[key][0].doctype === cdt)
-									.map(key => updated_doc[key])
-									.map(a => a[0])
+									.map(key => updated_doc[key])[0]
 									.filter(cdoc => cdoc.name === _data[cdt + ':name'])[0];
 								if (cdt_row) {
 									_data[field] = cdt_row[_field];


### PR DESCRIPTION
Includes @Don-Leopardo 's [PR](https://github.com/frappe/frappe/pull/7960) with an additional fix for the following error while editing child table fields in Report Builder:

![image](https://user-images.githubusercontent.com/9355208/62363015-df908880-b53b-11e9-9628-216a942e0909.png)
