### PR TITLE
fix: Use text-light instead of text-color for timeline text

### DIFF
--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -363,7 +363,7 @@ h6.uppercase, .h6.uppercase {
 	margin-top: 0px;
 
 	b {
-		color: @text-color !important;
+		color: @text-light !important;
 	}
 
 	blockquote {


### PR DESCRIPTION
Since timeline texts are not the primary content of the form,
use a lighter color for texts in the timeline

**Before:**
<img width="933" alt="Screenshot 2019-08-05 at 2 02 01 PM" src="https://user-images.githubusercontent.com/13928957/62461787-54b1c700-b7a3-11e9-8d6b-9ecf46a1a2d4.png">

**After:**
<img width="956" alt="Screenshot 2019-08-05 at 2 01 38 PM" src="https://user-images.githubusercontent.com/13928957/62461820-7317c280-b7a3-11e9-98bb-a373a47704eb.png">

