### PR TITLE
feat: Add color red and green to form-message for alert or success

### DIFF
--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -56,6 +56,14 @@
 		background-color: @blue-extra-light;
 }
 
+.form-message.red {
+		background-color: @red-extra-light;
+}
+
+.form-message.green {
+		background-color: @green-extra-light;
+}
+
 .document-flow-wrapper {
 	padding: 40px 15px 30px;
 	font-size: @text-medium;


### PR DESCRIPTION
Fix: Add color red and green to form-message for alert or success

![image](https://user-images.githubusercontent.com/1592496/62599894-b446ca00-b8aa-11e9-8b06-31ef101df635.png)

![image](https://user-images.githubusercontent.com/1592496/62599939-cc1e4e00-b8aa-11e9-93b3-482135fdcd58.png)

![image](https://user-images.githubusercontent.com/1592496/62599963-e1937800-b8aa-11e9-9b6f-b1f1b9a34e86.png)
