### PR TITLE
fix: Fix for dropdown menu not working on mobile

### DIFF
--- a/frappe/public/less/common.less
+++ b/frappe/public/less/common.less
@@ -107,6 +107,10 @@ kbd {
 
 /* dropdowns */
 
+.dropdown-backdrop {
+	display: none;
+}
+
 .dropdown-menu > li > a {
 	padding: 14px;
 	white-space: normal;


### PR DESCRIPTION
Fixes #8103 

Dropdown menu works: 
![dropdown](https://user-images.githubusercontent.com/19775888/62609577-aed79700-b91f-11e9-9834-c4606f3eed0a.gif)

