### PR TITLE
fix: Improvements to Energy Point Notifications 

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js
+++ b/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js
@@ -13,6 +13,7 @@ frappe.ui.EnergyPointsNotifications = class {
 		this.get_energy_points_list(this.max_length).then(user_points_list => {
 			this.dropdown_items = user_points_list;
 			this.render_energy_points_dropdown();
+			this.setup_view_full_log();
 			if (this.$dropdown_list.find('.unseen').length) {
 				this.$notification_indicator.show();
 			}
@@ -106,7 +107,7 @@ frappe.ui.EnergyPointsNotifications = class {
 				let item_html = this.get_dropdown_item_html(field);
 				if (item_html) body_html += item_html;
 			});
-			view_full_log_html = `<li><a href="#List/Energy%20Point%20Log/List" class="text-muted text-center">${__('View Full Log')}</a></li>`;
+			view_full_log_html = `<li><a class="text-muted text-center full-log-btn">${__('View Full Log')}</a></li>`;
 		} else {
 			body_html += `<li><a href="#" onclick = "return false" class="text-muted text-center">${__('No activity')}</a></li>`;
 		}
@@ -161,6 +162,12 @@ frappe.ui.EnergyPointsNotifications = class {
 			}
 		}
 		return message_html;
+	}
+
+	setup_view_full_log() {
+		this.$dropdown_list.find('.full-log-btn').on('click', () => {
+			frappe.set_route('List', 'Energy Point Log', {user: frappe.session.user});
+		});
 	}
 
 };

--- a/frappe/public/less/navbar.less
+++ b/frappe/public/less/navbar.less
@@ -309,7 +309,9 @@
 
 .points-updates-header {
 	background: @navbar-bg;
-	padding: 9px;
+	padding: 10px;
+	position: sticky;
+	top: 0;
 }
 
 .points-date-range {


### PR DESCRIPTION
- Made header sticky

 

- Added current user filter when viewing full energy point log list

![notifications](https://user-images.githubusercontent.com/19775888/62678261-a68a6500-b9ce-11e9-8ce4-1b67d90c86f6.gif)
