### PR TITLE
fix: Headings and line breaks not seen in print formats

### DIFF
--- a/frappe/templates/print_formats/standard.html
+++ b/frappe/templates/print_formats/standard.html
@@ -22,8 +22,8 @@
 
 	{% for section in page %}
     <div class="row section-break">
-		{%- if doc.line_breaks and loop.index != 1 -%}<hr>{%- endif -%}
-		{%- if doc.show_section_headings and section.label and section.has_data -%}
+		{%- if doc.print_line_breaks and loop.index != 1 -%}<hr>{%- endif -%}
+		{%- if doc.print_section_headings and section.label and section.has_data -%}
 		<h4 class='col-sm-12'>{{ _(section.label) }}</h4>
 		{%- endif -%}
         {% for column in section.columns %}

--- a/frappe/templates/print_formats/standard.html
+++ b/frappe/templates/print_formats/standard.html
@@ -20,10 +20,10 @@
 	</div>
 	{% endif %}
 
-    {% for section in page %}
+	{% for section in page %}
     <div class="row section-break">
-		{%- if doc._line_breaks and loop.index != 1 -%}<hr>{%- endif -%}
-		{%- if doc._show_section_headings and section.label and section.has_data -%}
+		{%- if doc.line_breaks and loop.index != 1 -%}<hr>{%- endif -%}
+		{%- if doc.show_section_headings and section.label and section.has_data -%}
 		<h4 class='col-sm-12'>{{ _(section.label) }}</h4>
 		{%- endif -%}
         {% for column in section.columns %}

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -71,7 +71,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {%- macro render_field_with_label(df, doc) -%}
 		<div class="row {% if df.bold %}important{% endif %} data-field" {{ fieldmeta(df) }}>
 			<div class="col-xs-{{ "9" if df.fieldtype=="Check" else "5" }}
-				{%- if doc._align_labels_right %} text-right{%- endif -%}">
+				{%- if doc.align_labels_right %} text-right{%- endif -%}">
 
 				{% if df.fieldtype not in ("Image","HTML","Check") and
 					doc.get(df.fieldname) != None %}

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -96,9 +96,9 @@ def get_html(doc, name=None, print_format=None, meta=None,
 
 	# determine template
 	if print_format:
-		doc._show_section_headings = print_format.show_section_headings
-		doc._line_breaks = print_format.line_breaks
-		doc._align_labels_right = print_format.align_labels_right
+		doc.show_section_headings = print_format.show_section_headings
+		doc.line_breaks = print_format.line_breaks
+		doc.align_labels_right = print_format.align_labels_right
 
 		def get_template_from_string():
 			return jenv.from_string(get_print_format(doc.doctype,

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -96,8 +96,8 @@ def get_html(doc, name=None, print_format=None, meta=None,
 
 	# determine template
 	if print_format:
-		doc.show_section_headings = print_format.show_section_headings
-		doc.line_breaks = print_format.line_breaks
+		doc.print_section_headings = print_format.show_section_headings
+		doc.print_line_breaks = print_format.line_breaks
 		doc.align_labels_right = print_format.align_labels_right
 
 		def get_template_from_string():


### PR DESCRIPTION
Attribute names starting with _ stopped working in jinja and were declared unsafe maybe due to recent security fixes