### PR TITLE
fix: Video links in learn section

### DIFF
--- a/frappe/public/js/frappe/views/components/ModuleLinkItem.vue
+++ b/frappe/public/js/frappe/views/components/ModuleLinkItem.vue
@@ -6,8 +6,9 @@
 		<span :class="['indicator', indicator_color]"></span>
 
 		<span v-if="disabled_dependent" class="link-content text-muted">{{ label || __(name) }}</span>
-		<a v-else class="link-content" :href="route">{{ label || __(name) }}</a>
-
+		<a v-else class="link-content" :href="route" @click.prevent="handle_click">
+			{{ label || __(name) }}
+		</a>
 		<div v-if="disabled_dependent" v-show="popover_active"
 			@mouseover="popover_hover = true" @mouseleave="popover_hover = false"
 			class="module-link-popover popover fade top in" role="tooltip"
@@ -24,7 +25,8 @@
 
 <script>
 export default {
-	props: ['label', 'name', 'dependencies', 'incomplete_dependencies', 'onboard', 'count', 'route', 'doctype', 'open_count'],
+	props: ['label', 'name', 'dependencies', 'incomplete_dependencies',
+		'onboard', 'count', 'route', 'doctype', 'open_count', 'youtube_id'],
 	data() {
 		return {
 			hover: false,
@@ -60,6 +62,14 @@ export default {
 			setTimeout(() => {
 				this.hover = false;
 			}, 300);
+		},
+
+		handle_click(e) {
+			if (this.youtube_id) {
+				frappe.help.show_video(this.youtube_id);
+			} else {
+				frappe.set_route(this.route);
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Before:**
![v12 issue](https://user-images.githubusercontent.com/50285544/62603958-9ada6800-b914-11e9-9b0c-a6b5bd515bd3.gif)

**After:**
![fix_video_link](https://user-images.githubusercontent.com/13928957/62619235-e3554e00-b933-11e9-83ca-faca7bd839f5.gif)

fixes: https://github.com/frappe/frappe/issues/8118