### PR TITLE
feat: added default filter condition to setup

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -620,12 +620,16 @@ class FilterArea {
 			if (['__default', '__global'].includes(default_value)) {
 				default_value = null;
 			}
+
+			let default_condition = this.list_view.settings.filter_conditions &&
+				this.list_view.settings.filter_conditions[df.fieldname]
+
 			return {
 				fieldtype: fieldtype,
 				label: __(df.label),
 				options: options,
 				fieldname: df.fieldname,
-				condition: condition,
+				condition: default_condition || condition,
 				default: default_value,
 				onchange: () => this.refresh_list_view(),
 				ignore_link_validation: fieldtype === 'Dynamic Link'


### PR DESCRIPTION
PR to fix https://github.com/frappe/erpnext/issues/18377
The default condition for `from_date` and `to_date` is `=`, so the filter wont work for a date range. Added a option in list view settings `filter_conditions` which overrides as the default condition

To test use the following configuration
```javascript
frappe.listview_settings['Leave Application'] = {
	add_fields: ["leave_type", "employee", "employee_name", "total_leave_days", "from_date", "to_date"],
	get_indicator: function (doc) {
		if (doc.status === "Approved") {
			return [__("Approved"), "green", "status,=,Approved"];
		} else if (doc.status === "Rejected") {
			return [__("Rejected"), "red", "status,=,Rejected"];
		}
	},
	filter_conditions: {
		from_date: ">=",
		to_date: "<="
	}
};
```
ToDo: After reload the filters are not updated in their respective field but set a custom filter as shown below
<img width="967" alt="Screenshot 2019-08-07 at 7 12 24 PM" src="https://user-images.githubusercontent.com/18097732/62627603-52886d80-b947-11e9-9acb-ed6be315997b.png">
