### PR TITLE
NULL should be consider the same as None

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -265,7 +265,10 @@ class DbColumn:
 		if "decimal" in current_def['type']:
 			return self.default_changed_for_decimal(current_def)
 		else:
-			return current_def['default'] != self.default
+			default = None
+			if current_def['default'] != "NULL":
+				default = current_def['default']
+			return default != self.default
 
 	def default_changed_for_decimal(self, current_def):
 		try:


### PR DESCRIPTION
frappe should consider NULL and None the same.
this will solve the problem of this error

https://github.com/frappe/frappe/issues/8123

https://discuss.erpnext.com/t/pymysql-err-internalerror-1069-utoo-many-keys-specified-max-64-keys-allowed-v12-branch/50272/17

https://discuss.erpnext.com/t/too-many-keys-specified-max-64-keys-allowed-on-cuztomizing-a-new-field-in-customize-form/51600/5


because the existing logic NULL is not the same with None so frappe will always create a modify statement on every field that the default is NULL.
