### PR TITLE
fix: json.loads getting none value in chat

### DIFF
--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -146,7 +146,7 @@ def seen(message, user = None):
 	if has_message:
 		mess = frappe.get_doc('Chat Message', message)
 		mess.add_seen(user)
-
+		mess.load_from_db()
 		room = mess.room
 		resp = dict(message = message, data = dict(seen = json.loads(mess._seen)))
 


### PR DESCRIPTION
The following is the `seen` function for chat.
```python
@frappe.whitelist(allow_guest = True)
def seen(message, user = None):
	authenticate(user)

	has_message = frappe.db.exists('Chat Message', message)

	if has_message:
		mess = frappe.get_doc('Chat Message', message)
		mess.add_seen(user)
		room = mess.room
		resp = dict(message = message, data = dict(seen = json.loads(mess._seen)))
```
The `mess.add_seen` function would update the seen value but the `mess` object in memory would not be updated, so every time the user would open a chat message, they would get an error with the following traceback

```python
Traceback (most recent call last):
File "/home/deploy/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
response = frappe.api.handle()
...
File "/home/deploy/frappe-bench/apps/frappe/frappe/chat/doctype/chat_message/chat_message.py", line 151, in seen
resp = dict(message = message, data = dict(seen = json.loads(mess._seen)))
...
File "/usr/lib64/python2.7/json/decoder.py", line 364, in decode
obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: expected string or buffer
```

This PR fixes this by reloading the mess object from the DB using `load_from_db()`