### PR TITLE
fix: check_default method for column in schema.py

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -29,9 +29,6 @@ class DBTable:
 		# load
 		self.get_columns_from_docfields()
 
-	def __repr__(self):
-		return self.table_name
-
 	def sync(self):
 		if self.is_new():
 			self.create()
@@ -203,9 +200,6 @@ class DbColumn:
 		self.options = options
 		self.unique = unique
 		self.precision = precision
-
-	def __repr__(self):
-		return self.table.table_name + '_' + self.fieldname + '_(' + self.fieldtype + ')'
 
 	def get_definition(self, with_default=1):
 		column_def = get_definition(self.fieldtype, precision=self.precision, length=self.length)

--- a/frappe/patches/v12_0/delete_duplicate_indexes.py
+++ b/frappe/patches/v12_0/delete_duplicate_indexes.py
@@ -1,0 +1,42 @@
+import frappe
+
+# This patch deletes all the duplicate indexes created for same column
+# The patch only checks for indexes with UNIQUE constraints
+
+def execute():
+	all_tables = frappe.db.get_tables()
+
+	final_deletion_map = frappe._dict()
+
+	for table in all_tables:
+		indexes_to_keep_map = frappe._dict()
+		indexes_to_delete = []
+		index_info = frappe.db.sql("""
+			SELECT
+				column_name,
+				index_name,
+				non_unique
+			FROM information_schema.STATISTICS
+			WHERE table_name=%s
+			AND non_unique=0
+			ORDER BY index_name;
+		""", table, as_dict=1)
+
+		for index in index_info:
+			if not indexes_to_keep_map.get(index.column_name):
+				indexes_to_keep_map[index.column_name] = index
+			else:
+				indexes_to_delete.append(index.index_name)
+		if indexes_to_delete:
+			final_deletion_map[table] = indexes_to_delete
+
+	# build drop index query
+	for (table_name, index_list) in final_deletion_map.items():
+		query = "ALTER TABLE `{}` ".format(table_name)
+		query_parts = []
+		for index in index_list:
+			query_parts.append("DROP INDEX `{}`".format(index))
+
+		query = query + ', '.join(query_parts)
+
+		frappe.db.sql(query)

--- a/frappe/patches/v12_0/delete_duplicate_indexes.py
+++ b/frappe/patches/v12_0/delete_duplicate_indexes.py
@@ -4,6 +4,7 @@ import frappe
 # The patch only checks for indexes with UNIQUE constraints
 
 def execute():
+	if frappe.db.db_type != 'mariadb': return
 	all_tables = frappe.db.get_tables()
 
 	final_deletion_map = frappe._dict()


### PR DESCRIPTION
Previously, due to wrong "default" value comparison, alter method used to fire "MODIFY COLUMN" query even for the column with no changes. This also led to the creation of multiple indexes for columns(Only for columns with UNIQUE constraint).

fixes: https://github.com/frappe/frappe/issues/6841