### PR TITLE
fix: Button should be visible even with only Read perm

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -78,7 +78,7 @@ frappe.ui.form.Control = Class.extend({
 		// hide if no value
 		if (this.doctype && status==="Read" && !this.only_input
 			&& is_null(frappe.model.get_value(this.doctype, this.docname, this.df.fieldname))
-			&& !in_list(["HTML", "Image"], this.df.fieldtype)) {
+			&& !in_list(["HTML", "Image", "Button"], this.df.fieldtype)) {
 
 			// eslint-disable-next-line
 			if(explain) console.log("By Hide Read-only, null fields: None");

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -56,16 +56,16 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 	refresh_input: function() {
 		var me = this;
 		var make_input = function() {
-			if(!me.has_input) {
+			if (!me.has_input) {
 				me.make_input();
-				if(me.df.on_make) {
+				if (me.df.on_make) {
 					me.df.on_make(me);
 				}
 			}
 		};
 
 		var update_input = function() {
-			if(me.doctype && me.docname) {
+			if (me.doctype && me.docname) {
 				me.set_input(me.value);
 			} else {
 				me.set_input(me.value || null);
@@ -74,18 +74,18 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 
 		if (me.disp_status != "None") {
 			// refresh value
-			if(me.doctype && me.docname) {
+			if (me.doctype && me.docname) {
 				me.value = frappe.model.get_value(me.doctype, me.docname, me.df.fieldname);
 			}
 
-			if(me.disp_status=="Write") {
+			if (me.can_write()) {
 				me.disp_area && $(me.disp_area).toggle(false);
 				$(me.input_area).toggle(true);
 				me.$input && me.$input.prop("disabled", false);
 				make_input();
 				update_input();
 			} else {
-				if(me.only_input) {
+				if (me.only_input) {
 					make_input();
 					update_input();
 				} else {
@@ -103,6 +103,10 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 			me.set_mandatory(me.value);
 			me.set_bold();
 		}
+	},
+
+	can_write() {
+		return this.disp_status == "Write";
 	},
 
 	set_disp_area: function(value) {

--- a/frappe/public/js/frappe/form/controls/button.js
+++ b/frappe/public/js/frappe/form/controls/button.js
@@ -1,4 +1,8 @@
 frappe.ui.form.ControlButton = frappe.ui.form.ControlData.extend({
+	can_write() {
+		// should be always true in case of button
+		return true;
+	},
 	make_input: function() {
 		var me = this;
 		this.$input = $('<button class="btn btn-default btn-xs">')


### PR DESCRIPTION
Previously, the button was not visible if the DocType had a DocPerm only with Read permission.

This PR fixes that. Button control should be visible even with only Read permission