### PR TITLE
fix: "Ignore User Permission" check visibility

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -1008,6 +1008,7 @@
    "allow_bulk_edit": 0,
    "allow_in_quick_entry": 0,
    "allow_on_submit": 0,
+   "depends_on": "eval:in_list(['Link', 'Dynamic Link'], doc.fieldtype)",
    "bold": 0,
    "collapsible": 0,
    "columns": 0,

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -1008,7 +1008,7 @@
    "allow_bulk_edit": 0,
    "allow_in_quick_entry": 0,
    "allow_on_submit": 0,
-   "depends_on": "eval:in_list(['Link', 'Dynamic Link'], doc.fieldtype)",
+   "depends_on": "eval:doc.fieldtype==='Link'",
    "bold": 0,
    "collapsible": 0,
    "columns": 0,


### PR DESCRIPTION
"Ignore User Permission" check should be only visible if type `fieldtype` is Link