### PR TITLE
feat: Allow utils inside Energy Point Rule condition 

### DIFF
--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -19,7 +19,7 @@ class EnergyPointRule(Document):
 
 	def apply(self, doc):
 		whitelisted_globals = {
-			"getdate": frappe.utils.getdate
+			"utils": frappe.utils
 		}
 		if frappe.safe_eval(self.condition, whitelisted_globals, {'doc': doc.as_dict()}):
 			multiplier = 1

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -19,7 +19,7 @@ class EnergyPointRule(Document):
 
 	def apply(self, doc):
 		whitelisted_globals = {
-			"getdate": getdate
+			"getdate": frappe.utils.getdate
 		}
 		if frappe.safe_eval(self.condition, whitelisted_globals, {'doc': doc.as_dict()}):
 			multiplier = 1

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -19,7 +19,7 @@ class EnergyPointRule(Document):
 
 	def apply(self, doc):
 		whitelisted_globals = {
-			"utils": frappe.utils
+			'utils': frappe.utils
 		}
 		if frappe.safe_eval(self.condition, whitelisted_globals, {'doc': doc.as_dict()}):
 			multiplier = 1

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -18,7 +18,10 @@ class EnergyPointRule(Document):
 		frappe.cache_manager.clear_doctype_map('Energy Point Rule', self.name)
 
 	def apply(self, doc):
-		if frappe.safe_eval(self.condition, None, {'doc': doc.as_dict()}):
+		whitelisted_globals = {
+			"getdate": getdate
+		}
+		if frappe.safe_eval(self.condition, whitelisted_globals, {'doc': doc.as_dict()}):
 			multiplier = 1
 
 			if self.multiplier_field:


### PR DESCRIPTION
Allow `utils` inside Energy Point Rule condition for various comparison/check purposes