### PR TITLE
fix(Print): Show warning for column overflow

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -648,6 +648,13 @@ frappe.PrintFormatBuilder = Class.extend({
 				d.hide();
 			});
 
+			let update_column_count_message = () => {
+				// show a warning if user selects more than 10 columns for a table
+				let columns_count = $body.find("input:checked").length;
+				$body.find('.help-message').toggle(columns_count > 10);
+			}
+			update_column_count_message();
+
 			// enable / disable input based on selection
 			$body.on("click", "input[type='checkbox']", function() {
 				var disabled = !$(this).prop("checked"),
@@ -655,6 +662,8 @@ frappe.PrintFormatBuilder = Class.extend({
 
 				input.prop("disabled", disabled);
 				if(disabled) input.val("");
+
+				update_column_count_message();
 			});
 
 			d.show();

--- a/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
@@ -1,5 +1,8 @@
 <p class="text-muted">{{ __("Check columns to select, drag to set order.") }}
-    <br>{{ __("Widths can be set in px or %.") }}</p>
+	{{ __("Widths can be set in px or %.") }}</p>
+<p class="help-message alert alert-warning">
+	{{ __('Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.') }}
+</p>
 <div class="row">
     <div class="col-sm-6"><h4>{{ __("Column") }}</h4></div>
     <div class="col-sm-6 text-right"><h4>{{ __("Width") }}</h4></div>

--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -166,3 +166,6 @@ table td div {
 	max-height: 150px;
 }
 
+.print-format [data-fieldtype="Table"] {
+	overflow: auto;
+}


### PR DESCRIPTION
#### Show warning when user selects more than 10 columns for a table:

![image](https://user-images.githubusercontent.com/9355208/62721492-f0ecff80-ba29-11e9-92e3-a92954f11c17.png)

#### Also, overflow the table container in Print Preview

Before:
![image](https://user-images.githubusercontent.com/9355208/62721573-209c0780-ba2a-11e9-919d-b956f79b66a5.png)

After:
![image](https://user-images.githubusercontent.com/9355208/62721555-124deb80-ba2a-11e9-81e4-ab3842d3e9fd.png)
