### PR TITLE
feat: multilanguage fix and improvement

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -90,19 +90,21 @@ class HTTPRequest:
 		languages = site_enabled_languages or frappe.translate.get_all_languages()
 		lang = None
 
-		def clear_url_languages():
+		def clean_url_language_parameters():
 			frappe.form_dict._lang = None
 			frappe.form_dict._set_lang = None
 
 		# 0. Browser language defined into frappe.local.lang by "set_lang" method
 
-		# 1. By path: /en/...
+		# 1. By path: /en/... or /en-GB/
 		# - Only for actual request
 		path = frappe.local.request.path
-		if len(path) >= 4 and path[3] == '/' and path[1:3] in site_enabled_languages:
+		if len(path) >= 4 and path[3] == '/' and path[1:3] in languages:
 			frappe.local.request.path = path[3:]
 			lang = path[1:3]
-			# clear_url_languages()
+		elif len(path) >= 7 and path[3] == '-' and path[6] == '/' and path[1:6] in languages:
+			frappe.local.request.path = path[6:]
+			lang = path[1:6]
 
 		# 2. By url ?_set_lang=en
 		# - Keep language for next requests because it set it as user language (Guest and logged)
@@ -142,7 +144,7 @@ class HTTPRequest:
 		if lang and lang in languages:
 			frappe.local.lang = lang
 
-		clear_url_languages()
+		clean_url_language_parameters()
 
 	def get_db_name(self):
 		"""get database name from conf"""

--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -136,7 +136,9 @@ def build_response(path, data, http_status_code, headers=None):
 
 def render_page_by_language(path):
 	translated_languages = frappe.get_hooks("translated_languages_for_website")
-	user_lang = guess_language(translated_languages)
+	user_lang = frappe.lang
+	if translated_languages and user_lang not in translated_languages:
+		user_lang = translated_languages[0]
 	if translated_languages and user_lang in translated_languages:
 		try:
 			if path and path != "index":


### PR DESCRIPTION
This PR solves one issue and improves multilanguage support for Frappe. It adds search engine friendly multilanguage site (As defined into Google guidelines for "Managing multi-regional and multilingual sites")

**Frappe multilanguage issues that led me to start this PR**

- Default language is browser language. If some Guest user want to see the English version with a Spanish browser is not possible unless user changes browser language.

- I must be logged to properly define a language into my desk profile (or site user profile). Not useful for most public websites where users have no profile yet (most commercial sites).

- If _lang=xx parameter is used, it only affects to page loaded and next pages will be rendered with browser language.

- There is neither language defined into HTML tag, nor in the _alternate links_ (pages into different language related to actual one) for proper search engine indexation.


**Issue resolved**

- "render_page_by_language" method will render language choosed by user instead of browser default language. ([Commit 790dc57](https://github.com/frappe/frappe/commit/a52514c6528c5576915b94944e5a65bcf790dc57))


**Previous existent features**

- **"_lang=xx"** url parameter. Allows render page called into that language. Not kept for next pages navigated.


**New features**

- **Enabled languages** can be defined. If defined, not enabled languages will throw 404 error into website pages. If not defined all languages are enabled. First language becomes the default one. Add "translated_languages_for_website = ['es', 'en', 'it', 'fr']" to your site app hooks.py file.

- **"_set_lang=xx"** url parameter. Allows setting user|guest session language. Language is kept between future pages navigation.

  - If user is logged, language will be updated into he or she profile.

  - If user is not logged, it applies to its "Guest" user session (saved into Redis server cache)

- The **beginning of url path** can be used to define language: **/xx**/url-path/

- **Language selector**. Allows user change between "enabled languages". Add _&lt;!-- no-cache --&gt;_ tag to avoid language selections being cached.

Example with "_set_lang":
```
{% for lang in languages %}
    {%- if lang == language -%}
        {{ lang }}
    {%- else -%}
        <a href="?_set_lang={{ lang }}">{{ lang }}</a>
    {%- endif -%}
    &nbsp;
{%- endfor %}
```

Example with language at the beginning of url path: /xx/url-path/:
```
{% for lang in languages %}
    {%- if lang == language -%}
        {{ lang }}
    {%- else -%}
        {%- if lang == languages[0] -%}
            <a href="{{ frappe.utils.get_url(path) }}">{{ lang }}</a>
        {%- else -%}
            <a href="{{ frappe.utils.get_url(lang + '/' + path) }}">{{ lang }}</a>
        {%- endif -%}
    {%- endif -%}
    &nbsp;
{%- endfor %}
```

Alternate links example:
```
{% for lang in languages %}
    {%- if lang == languages[0] -%}
        <link rel="alternate" href="{{ frappe.utils.get_url(path) }}" hreflang="x-default" />
    {%- else -%}
        <link rel="alternate" href="{{ frappe.utils.get_url(lang + '/' + path) }}" hreflang="{{ lang }}" />
    {%- endif -%}
{%- endfor %}
```

Define language into html tag:
```
<html lang="{{ language }}">
```

**To be done**
- Add this functionality as **Site Module**

Please tell me if you need some more explanation or I can help you :). I love your open source software and I am sure that I can help you to improve it :)