### PR TITLE
fix: Pass no_letterhead to download_multi_pdf

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -12,7 +12,7 @@ base_template_path = "templates/www/printview.html"
 standard_format = "templates/print_formats/standard.html"
 
 @frappe.whitelist()
-def download_multi_pdf(doctype, name, format=None):
+def download_multi_pdf(doctype, name, format=None, no_letterhead=0):
 	"""
 	Concatenate multiple docs as PDF .
 
@@ -60,13 +60,13 @@ def download_multi_pdf(doctype, name, format=None):
 
 		# Concatenating pdf files
 		for i, ss in enumerate(result):
-			output = frappe.get_print(doctype, ss, format, as_pdf = True, output = output)
+			output = frappe.get_print(doctype, ss, format, as_pdf = True, output = output, no_letterhead=no_letterhead)
 		frappe.local.response.filename = "{doctype}.pdf".format(doctype=doctype.replace(" ", "-").replace("/", "-"))
 	else:
 		for doctype_name in doctype:
 			for doc_name in doctype[doctype_name]:
 				try:
-					output = frappe.get_print(doctype_name, doc_name, format, as_pdf = True, output = output)
+					output = frappe.get_print(doctype_name, doc_name, format, as_pdf = True, output = output, no_letterhead=no_letterhead)
 				except Exception:
 					frappe.log_error("Permission Error on doc {} of doctype {}".format(doc_name, doctype_name))
 		frappe.local.response.filename = "{}.pdf".format(name)


### PR DESCRIPTION
When you say you don't want to print with letterhead:

![image](https://user-images.githubusercontent.com/9355208/62722871-f8fa6e80-ba2c-11e9-8cc2-cb2c413d9b6d.png)

It would still show the letterhead:

![image](https://user-images.githubusercontent.com/9355208/62722900-0dd70200-ba2d-11e9-96f0-4d057a130b3b.png)

But after this PR is merged, it will obey the checkbox:

![image](https://user-images.githubusercontent.com/9355208/62722895-07488a80-ba2d-11e9-8989-95432d817f62.png)


