### PR TITLE
fix: Pass no_letterhead to download_multi_pdf

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -13,7 +13,7 @@ base_template_path = "templates/www/printview.html"
 standard_format = "templates/print_formats/standard.html"
 
 @frappe.whitelist()
-def download_multi_pdf(doctype, name, format=None):
+def download_multi_pdf(doctype, name, format=None, no_letterhead=0):
 	"""
 	Concatenate multiple docs as PDF .
 
@@ -61,13 +61,13 @@ def download_multi_pdf(doctype, name, format=None):
 
 		# Concatenating pdf files
 		for i, ss in enumerate(result):
-			output = frappe.get_print(doctype, ss, format, as_pdf = True, output = output)
+			output = frappe.get_print(doctype, ss, format, as_pdf = True, output = output, no_letterhead=no_letterhead)
 		frappe.local.response.filename = "{doctype}.pdf".format(doctype=doctype.replace(" ", "-").replace("/", "-"))
 	else:
 		for doctype_name in doctype:
 			for doc_name in doctype[doctype_name]:
 				try:
-					output = frappe.get_print(doctype_name, doc_name, format, as_pdf = True, output = output)
+					output = frappe.get_print(doctype_name, doc_name, format, as_pdf = True, output = output, no_letterhead=no_letterhead)
 				except Exception:
 					frappe.log_error("Permission Error on doc {} of doctype {}".format(doc_name, doctype_name))
 		frappe.local.response.filename = "{}.pdf".format(name)


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/pull/8143 for version 11