### PR TITLE
fix(email): AttributeError: 'Message' object has no attribute 'encode'

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -484,7 +484,7 @@ class Email:
 			if six.PY2:
 				charset = chardet.detect(str(part))['encoding']
 			else:
-				charset = chardet.detect(part.encode())['encoding']
+				charset = chardet.detect(str(part).encode())['encoding']
 
 		return charset
 


### PR DESCRIPTION
Fix for https://github.com/frappe/frappe/issues/8146
The issue is python3 and it is checked as below
![image](https://user-images.githubusercontent.com/29812965/62749973-1b67a880-ba7c-11e9-9dc8-3be6b337839e.png)


Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.