### PR TITLE
refactor: Remove background fields from user

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -53,9 +53,6 @@
   "email_signature",
   "email_inbox",
   "user_emails",
-  "background",
-  "background_image",
-  "background_style",
   "sb_allow_modules",
   "modules_html",
   "block_modules",
@@ -405,24 +402,6 @@
   },
   {
    "collapsible": 1,
-   "depends_on": "enabled",
-   "fieldname": "background",
-   "fieldtype": "Section Break",
-   "label": "Desktop Background"
-  },
-  {
-   "fieldname": "background_image",
-   "fieldtype": "Attach",
-   "label": "Background Image"
-  },
-  {
-   "fieldname": "background_style",
-   "fieldtype": "Select",
-   "label": "Background Style",
-   "options": "Fill Screen\nTile"
-  },
-  {
-   "collapsible": 1,
    "fieldname": "sb_allow_modules",
    "fieldtype": "Section Break",
    "label": "Allow Modules",
@@ -614,8 +593,8 @@
  "idx": 413,
  "image_field": "user_image",
  "max_attachments": 5,
- "modified": "2019-07-12 11:35:17.469656",
- "modified_by": "prasadsherlock@gmail.com",
+ "modified": "2019-08-09 10:34:56.912283",
+ "modified_by": "Administrator",
  "module": "Core",
  "name": "User",
  "owner": "Administrator",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -280,7 +280,7 @@ user_privacy_documents = [
 		'doctype': 'User',
 		'match_field': 'name',
 		'personal_fields': ['email', 'username', 'first_name', 'middle_name', 'last_name', 'full_name', 'birth_date',
-			'user_image', 'phone', 'mobile_no', 'location', 'banner_image', 'interest', 'bio', 'email_signature', 'background_image'],
+			'user_image', 'phone', 'mobile_no', 'location', 'banner_image', 'interest', 'bio', 'email_signature'],
 		'applies_to_website_user': 1
 	},
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -178,7 +178,7 @@ class UserPermissions:
 
 	def load_user(self):
 		d = frappe.db.sql("""select email, first_name, last_name, creation,
-			email_signature, user_type, language, background_style, background_image,
+			email_signature, user_type, language, background_style,
 			mute_sounds, send_me_a_copy, document_follow_notify
 			from tabUser where name = %s""", (self.name,), as_dict=1)[0]
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -178,7 +178,7 @@ class UserPermissions:
 
 	def load_user(self):
 		d = frappe.db.sql("""select email, first_name, last_name, creation,
-			email_signature, user_type, language, background_style,
+			email_signature, user_type, language,
 			mute_sounds, send_me_a_copy, document_follow_notify
 			from tabUser where name = %s""", (self.name,), as_dict=1)[0]
 

--- a/frappe/www/desk.html
+++ b/frappe/www/desk.html
@@ -33,11 +33,6 @@
 		<footer></footer>
 	</div>
 
-	<!-- hack! load background image asap, before desktop is rendered -->
-	{% if background_image %}
-	<img src="{{ background_image }}" style="height: 1px; width: 1px; margin-bottom: -1px;">
-	{% endif %}
-
 	<script type="text/javascript" src="/assets/frappe/js/lib/jquery/jquery.min.js"></script>
 
 	<script type="text/javascript">

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -41,8 +41,6 @@ def get_context(context):
 		"sounds": hooks["sounds"],
 		"boot": boot if context.get("for_mobile") else boot_json,
 		"csrf_token": csrf_token,
-		"background_image": (boot.status != 'failed' and
-			(boot.user.background_image or boot.default_background_image) or None),
 		"google_analytics_id": frappe.conf.get("google_analytics_id"),
 		"mixpanel_id": frappe.conf.get("mixpanel_id")
 	})


### PR DESCRIPTION
Background image is no longer configurable in version 12. This PR removes the unnecessary fields for the same