### PR TITLE
fix(print): Use double quotes inside templates

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
@@ -1,7 +1,7 @@
 <p class="text-muted">{{ __("Check columns to select, drag to set order.") }}
 	{{ __("Widths can be set in px or %.") }}</p>
 <p class="help-message alert alert-warning">
-	{{ __('Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.') }}
+	{{ __("Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.") }}
 </p>
 <div class="row">
     <div class="col-sm-6"><h4>{{ __("Column") }}</h4></div>


### PR DESCRIPTION
Single quotes result in following JS code

```js
frappe.templates["print_format_builder_column_selector"] = ' .... {{ __('Some columns might get cut off when printing to PDF.Try to keep number of columns under 10. ') }} ... ';
```
instead of 
```js
frappe.templates["print_format_builder_column_selector"] = ' .... {{ __("Some columns might get cut off when printing to PDF.Try to keep number of columns under 10. "') }} ... ';
```
Which throws following on visiting Print Format Builder page
```js
VM669:5 Uncaught SyntaxError: Unexpected identifier
    at Object.eval (dom.js:33)
    at new init (pageview.js:99)
    at pageview.js:68
    at Object.with_page (pageview.js:25)
    at pageview.js:63
    at Object.with_doctype (model.js:108)
    at Object.show (pageview.js:62)
    at Object.frappe.route (router.js:65)
    at init.startup (desk.js:70)
    at new init (desk.js:26)
```