### PR TITLE
fix(permissions): Perform case-insensitive substring check

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -125,7 +125,7 @@ def get_applicable_for_doctype_list(doctype, txt, searchfield, start, page_len, 
 	linked_doctypes += [doctype]
 
 	if txt:
-		linked_doctypes = [d for d in linked_doctypes if txt in d.lower()]
+		linked_doctypes = [d for d in linked_doctypes if txt.lower() in d.lower()]
 
 	linked_doctypes.sort()
 


### PR DESCRIPTION
For example following combination yields a positive result
```python
linked_doctypes = ["Activity Log"]
txt = "activity"
```
but following one yields a negative result
```python
linked_doctypes = ["Activity Log"]
txt = "Activity"
```