### PR TITLE
fix: Replace alert with frappe.msgprint

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -644,8 +644,8 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	amend_doc() {
-		if(!this.fields_dict['amended_from']) {
-			alert('"amended_from" field must be present to do an amendment.');
+		if (!this.fields_dict['amended_from']) {
+			frappe.msgprint(__('"amended_from" field must be present to do an amendment.'));
 			return;
 		}
 		this.validate_form_action("Amend");


### PR DESCRIPTION
Yeah! There's `alert()` in our codebase.