### PR TITLE
fix: Use sr_BA instead of sr_SP since sr_SP is not supported by Babel

### DIFF
--- a/frappe/geo/languages.json
+++ b/frappe/geo/languages.json
@@ -1,322 +1,322 @@
 [
  {
-  "code": "af", 
+  "code": "af",
   "name": "Afrikaans"
- }, 
+ },
  {
-  "code": "am", 
+  "code": "am",
   "name": "\u12a0\u121b\u122d\u129b"
- }, 
+ },
  {
-  "code": "ar", 
+  "code": "ar",
   "name": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629"
- }, 
+ },
  {
-  "code": "bg", 
+  "code": "bg",
   "name": "B\u01celgarski"
- }, 
+ },
  {
-  "code": "bn", 
+  "code": "bn",
   "name": "\u09ac\u09be\u0999\u09be\u09b2\u09bf"
- }, 
+ },
  {
-  "code": "bo", 
+  "code": "bo",
   "name": "\u0f63\u0fb7\u0f0b\u0f66\u0f60\u0f72\u0f0b\u0f66\u0f90\u0f51\u0f0b"
- }, 
+ },
  {
-  "code": "bs", 
+  "code": "bs",
   "name": "Bosanski"
- }, 
+ },
  {
-  "code": "ca", 
+  "code": "ca",
   "name": "Catal\u00e0"
- }, 
+ },
  {
-  "code": "cs", 
+  "code": "cs",
   "name": "\u010desky"
- }, 
+ },
  {
-  "code": "da", 
+  "code": "da",
   "name": "Dansk"
- }, 
+ },
  {
-  "code": "da-DK", 
+  "code": "da-DK",
   "name": "Dansk (Danmark)"
- }, 
+ },
  {
-  "code": "de", 
+  "code": "de",
   "name": "Deutsch"
- }, 
+ },
  {
-  "code": "el", 
+  "code": "el",
   "name": "\u03b5\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac"
- }, 
+ },
  {
-  "code": "en", 
+  "code": "en",
   "name": "English"
- }, 
+ },
  {
-  "code": "en-GB", 
+  "code": "en-GB",
   "name": "English (United Kingdom)"
- }, 
+ },
  {
-  "code": "en-US", 
+  "code": "en-US",
   "name": "English (United States)"
- }, 
+ },
  {
-  "code": "es", 
+  "code": "es",
   "name": "Espa\u00f1ol"
- }, 
+ },
  {
-  "code": "es-AR", 
+  "code": "es-AR",
   "name": "Espa\u00f1ol (Argentina)"
- }, 
+ },
  {
-  "code": "es-BO", 
+  "code": "es-BO",
   "name": "Espa\u00f1ol (Bolivia)"
- }, 
+ },
  {
-  "code": "es-CL", 
+  "code": "es-CL",
   "name": "Espa\u00f1ol (Chile)"
- }, 
+ },
  {
-  "code": "es-CO", 
+  "code": "es-CO",
   "name": "Espa\u00f1ol (Colombia)"
- }, 
+ },
  {
-  "code": "es-DO", 
+  "code": "es-DO",
   "name": "Espa\u00f1ol (Rep\u00fablica Dominicana)"
- }, 
+ },
  {
-  "code": "es-EC", 
+  "code": "es-EC",
   "name": "Espa\u00f1ol (Ecuador)"
- }, 
+ },
  {
-  "code": "es-GT", 
+  "code": "es-GT",
   "name": "Espa\u00f1ol (Guatemala)"
- }, 
+ },
  {
-  "code": "es-MX", 
+  "code": "es-MX",
   "name": "Espa\u00f1ol (M\u00e9xico)"
- }, 
+ },
  {
-  "code": "es-NI", 
+  "code": "es-NI",
   "name": "Espa\u00f1ol (Nicaragua)"
- }, 
+ },
  {
-  "code": "es-PE", 
+  "code": "es-PE",
   "name": "Espa\u00f1ol (Per\u00fa)"
- }, 
+ },
  {
-  "code": "et", 
+  "code": "et",
   "name": "Eesti"
- }, 
+ },
  {
-  "code": "fa", 
+  "code": "fa",
   "name": "\u067e\u0627\u0631\u0633\u06cc"
- }, 
+ },
  {
-  "code": "fi", 
+  "code": "fi",
   "name": "Suomi"
- }, 
+ },
  {
-  "code": "fr", 
+  "code": "fr",
   "name": "Fran\u00e7ais"
- }, 
+ },
  {
-  "code": "fr-CA", 
+  "code": "fr-CA",
   "name": "Fran\u00e7ais Canadien"
- }, 
+ },
  {
-  "code": "gu", 
+  "code": "gu",
   "name": "\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0"
- }, 
+ },
  {
-  "code": "he", 
+  "code": "he",
   "name": "\u05e2\u05d1\u05e8\u05d9\u05ea"
- }, 
+ },
  {
-  "code": "hi", 
+  "code": "hi",
   "name": "\u0939\u093f\u0902\u0926\u0940"
- }, 
+ },
  {
-  "code": "hr", 
+  "code": "hr",
   "name": "Hrvatski"
- }, 
+ },
  {
-  "code": "hu", 
+  "code": "hu",
   "name": "Magyar"
- }, 
+ },
  {
-  "code": "id", 
+  "code": "id",
   "name": "Indonesia"
- }, 
+ },
  {
-  "code": "is", 
+  "code": "is",
   "name": "\u00edslenska"
- }, 
+ },
  {
-  "code": "it", 
+  "code": "it",
   "name": "Italiano"
- }, 
+ },
  {
-  "code": "ja", 
+  "code": "ja",
   "name": "\u65e5\u672c\u8a9e"
- }, 
+ },
  {
-  "code": "km", 
+  "code": "km",
   "name": "\u1797\u17b6\u179f\u17b6\u1781\u17d2\u1798\u17c2\u179a"
- }, 
+ },
  {
-  "code": "kn", 
+  "code": "kn",
   "name": "\u0c95\u0ca8\u0ccd\u0ca8\u0ca1"
- }, 
+ },
  {
-  "code": "ko", 
+  "code": "ko",
   "name": "\ud55c\uad6d\uc758"
- }, 
+ },
  {
-  "code": "ku", 
+  "code": "ku",
   "name": "\u06a9\u0648\u0631\u062f\u06cc"
- }, 
+ },
  {
-  "code": "lo", 
+  "code": "lo",
   "name": "\u0ea5\u0eb2\u0ea7"
- }, 
+ },
  {
-  "code": "lt", 
+  "code": "lt",
   "name": "Lietuvi\u0173 kalba"
- }, 
+ },
  {
-  "code": "lv", 
+  "code": "lv",
   "name": "Latvie\u0161u valoda"
- }, 
+ },
  {
-  "code": "mk", 
+  "code": "mk",
   "name": "\u043c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438"
- }, 
+ },
  {
-  "code": "ml", 
+  "code": "ml",
   "name": "\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02"
- }, 
+ },
  {
-  "code": "mr", 
+  "code": "mr",
   "name": "\u092e\u0930\u093e\u0920\u0940"
- }, 
+ },
  {
-  "code": "ms", 
+  "code": "ms",
   "name": "Melayu"
- }, 
+ },
  {
-  "code": "my", 
+  "code": "my",
   "name": "\u1019\u103c\u1014\u103a\u1019\u102c"
- }, 
+ },
  {
-  "code": "nl", 
+  "code": "nl",
   "name": "Nederlands"
- }, 
+ },
  {
-  "code": "no", 
+  "code": "no",
   "name": "Norsk"
- }, 
+ },
  {
-  "code": "pl", 
+  "code": "pl",
   "name": "Polski"
- }, 
+ },
  {
-  "code": "ps", 
+  "code": "ps",
   "name": "\u067e\u069a\u062a\u0648"
- }, 
+ },
  {
-  "code": "pt", 
+  "code": "pt",
   "name": "Portugu\u00eas"
- }, 
+ },
  {
-  "code": "pt-BR", 
+  "code": "pt-BR",
   "name": "Portugu\u00eas Brasileiro"
- }, 
+ },
  {
-  "code": "ro", 
+  "code": "ro",
   "name": "Rom\u00e2n"
- }, 
+ },
  {
-  "code": "ru", 
+  "code": "ru",
   "name": "\u0440\u0443\u0441\u0441\u043a\u0438\u0439"
- }, 
+ },
  {
-  "code": "rw", 
+  "code": "rw",
   "name": "Kinyarwanda"
- }, 
+ },
  {
-  "code": "si", 
+  "code": "si",
   "name": "\u0dc3\u0dd2\u0d82\u0dc4\u0dbd"
- }, 
+ },
  {
-  "code": "sk", 
+  "code": "sk",
   "name": "Sloven\u010dina (Slovak)"
- }, 
+ },
  {
-  "code": "sl", 
+  "code": "sl",
   "name": "Sloven\u0161\u010dina (Slovene)"
- }, 
+ },
  {
-  "code": "sq", 
+  "code": "sq",
   "name": "Shqiptar"
- }, 
+ },
  {
-  "code": "sr", 
+  "code": "sr",
   "name": "\u0441\u0440\u043f\u0441\u043a\u0438"
- }, 
+ },
  {
-  "code": "sr-SP", 
+  "code": "sr-BA",
   "name": "Srpski"
- }, 
+ },
  {
-  "code": "sv", 
+  "code": "sv",
   "name": "Svenska"
- }, 
+ },
  {
-  "code": "sw", 
+  "code": "sw",
   "name": "Swahili"
- }, 
+ },
  {
-  "code": "ta", 
+  "code": "ta",
   "name": "\u0ba4\u0bae\u0bbf\u0bb4\u0bcd"
- }, 
+ },
  {
-  "code": "te", 
+  "code": "te",
   "name": "\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41"
- }, 
+ },
  {
-  "code": "th", 
+  "code": "th",
   "name": "\u0e44\u0e17\u0e22"
- }, 
+ },
  {
-  "code": "tr", 
+  "code": "tr",
   "name": "Türkçe"
- }, 
+ },
  {
-  "code": "uk", 
+  "code": "uk",
   "name": "\u0443\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430"
- }, 
+ },
  {
-  "code": "ur", 
+  "code": "ur",
   "name": "\u0627\u0631\u062f\u0648"
- }, 
+ },
  {
-  "code": "uz", 
+  "code": "uz",
   "name": "\u040e\u0437\u0431\u0435\u043a"
- }, 
+ },
  {
-  "code": "vi", 
+  "code": "vi",
   "name": "Vi\u1ec7t"
- }, 
+ },
  {
-  "code": "zh", 
+  "code": "zh",
   "name": "\u7b80\u4f53\u4e2d\u6587"
- }, 
+ },
  {
-  "code": "zh-TW", 
+  "code": "zh-TW",
   "name": "\u7e41\u9ad4\u4e2d\u6587"
  }
 ]

--- a/frappe/translations/sr-BA.csv
+++ b/frappe/translations/sr-BA.csv
@@ -1,0 +1,484 @@
+apps/frappe/frappe/desk/doctype/todo/todo_list.js +22,Assigned By Me,Dodijelio drugima
+apps/frappe/frappe/desk/doctype/note/note_list.js +3,Notes,Bilješke
+DocType: Desktop Icon,_doctype,_doctype
+DocType: Desktop Icon,List,Lista
+DocType: Report,Report Type,Vrsta izvještaja
+DocType: System Settings,Session Expiry,Sesija ističe
+apps/frappe/frappe/public/js/frappe/form/toolbar.js +197,New {0} (Ctrl+B),Novi {0} (Ctrl-B)
+DocType: DocShare,DocShare,Dijeljenje dokumenta
+apps/frappe/frappe/public/js/frappe/ui/filters/filter_list.js +144,Add Filter,Dodaj filter
+DocType: Address,Contacts,Kontakti
+apps/frappe/frappe/public/js/frappe/form/save.js +12,Submitting,Potvrđivanje
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js +43,Editing Row,Izmjena u redu
+apps/frappe/frappe/public/js/legacy/form.js +173,You are not allowed to print this document,Немате дозволу да штампате овај документ
+DocType: Auto Repeat,End Date,Datum završetka
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html +51,What do you need help with?,Oko čega Vam je potrebna pomoć?
+DocType: ToDo,Allocated To,Dodijeljeno je
+DocType: Custom DocPerm,Delete,Obriši
+apps/frappe/frappe/app.py +158,You do not have enough permissions to complete the action,Немате дозволу да завршите ову акцију.
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js +262,Project,Projekti
+DocType: ToDo,Due Date,Datum dospijeća
+apps/frappe/frappe/public/js/frappe/model/model.js +26,Assigned To,Dodijeljeno prema
+apps/frappe/frappe/model/rename_doc.py +79,renamed from {0} to {1},Preimenuj iz {0} u {1}
+apps/frappe/frappe/public/js/legacy/form.js +348,Submit this document to confirm,Potvrdi ovaj dokument da bi ga zaključio
+apps/frappe/frappe/utils/bot.py +150,You can find things by asking 'find orange in customers',"Можете тражити ствари претрагом ""тражи наранџасто у купцима"""
+DocType: Note Seen By,Note Seen By,Bilješku je vidio
+apps/frappe/frappe/public/js/frappe/list/list_sidebar_stat.html +21,Show Tags,Prikaži tagove
+apps/frappe/frappe/templates/includes/navbar/navbar_login.html +23,Switch To Desk,Pređi na radnu površinu
+apps/frappe/frappe/public/js/frappe/dom.js +295,Confirm,Potvrdi
+apps/frappe/frappe/public/js/frappe/form/footer/assign_to.js +138,Assign to me,Dodijeljeno meni
+apps/frappe/frappe/desk/form/save.py +34,Did not save,Nije se sačuvalo
+apps/frappe/frappe/public/js/frappe/roles_editor.js +40,Clear all roles,Obriši sve role
+apps/frappe/frappe/core/page/desktop/desktop.js +38,Explore,Istraži
+DocType: Address,Sales User,Korisnik prodaje
+DocType: Custom DocPerm,Set User Permissions,Postavite korisnička prava
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js +20,Between,Između
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +63,e.g.:,npr:
+DocType: Country,Country Name,Ime države
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js +58,Make a new,Napravite novi
+DocType: Workflow State,Download,Preuzmi
+apps/frappe/frappe/handler.py +94,You have been successfully logged out,Успешно сте се одјавили
+apps/frappe/frappe/website/doctype/web_form/web_form.py +133,You don't have the permissions to access this document,Немате дозволу да приступите овом документу.
+DocType: Website Settings,Brand Image,Slika brenda
+apps/frappe/frappe/utils/bot.py +89,show,Prikaži
+DocType: Page,Yes,Da
+DocType: Custom DocPerm,Role,Uloga
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js +856,Totals,Ukupno
+apps/frappe/frappe/public/js/frappe/request.js +137,You do not have enough permissions to access this resource. Please contact your manager to get access.,Немате дозволу да приступите овоме. Молимо јавите се свом менаџеру да добијете приступ.
+apps/frappe/frappe/public/js/frappe/views/treeview.js +183,Add Child,Dodaj podređeni
+apps/frappe/frappe/core/doctype/user/user.py +935,Invalid Password: ,Pogrešna lozinka:
+DocType: System Settings,System Settings,Sistemska podešavanja
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js +697,You can add dynamic properties from the document by using Jinja templating.,Можете да додате динамичке вредности из документа помоћу Jinja шаблона.
+apps/frappe/frappe/core/report/feedback_ratings/feedback_ratings.js +40,To Date,Do datuma
+DocType: Chat Profile,Offline,Van mreže (offline)
+DocType: Chat Message,System Manager,Menadžer sistema
+apps/frappe/frappe/www/update-password.html +18,New Password,Nova lozinka
+apps/frappe/frappe/desk/query_report.py +26,You don't have permission to get a report on: {0},Немате дозволу да добијете извештај о: {0}
+DocType: User,Middle Name (Optional),Srednje ime (opciono)
+apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html +7,Can Share,Može dijeliti
+apps/frappe/frappe/public/js/frappe/form/layout.js +108,Dashboard,Nadzorna ploča
+DocType: Contact,Last Name,Prezime
+apps/frappe/frappe/public/js/frappe/views/pageview.js +112,Sorry! You are not permitted to view this page.,Niste autorizovani za prikaz ove stranice.
+DocType: Web Form,Success Message,Poruka o uspjehu
+apps/frappe/frappe/public/js/frappe/form/form_sidebar.js +62,{0} created this {1},{1} {0} je kreirao/la ovo.
+DocType: Chat Profile,Online,Na mreži
+apps/frappe/frappe/core/doctype/file/file.py +586,Folder {0} does not exist,Folder {0} ne postoji
+DocType: Activity Log,Subject,Naslov
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js +79,Enter folder name,Unesi naziv foldera
+DocType: Workflow State,Tags,Tagovi
+apps/frappe/frappe/patches/v6_19/comment_feed_communication.py +131,Assignment,Dodjeljivanje
+DocType: Workflow State,move,Kretanje
+DocType: Language,Language,Jezik
+apps/frappe/frappe/public/js/legacy/form.js +775,Permanently Submit {0}?,Trajno potvrdi {0} ?
+DocType: Address,Maintenance User,Korisnik održavanja
+DocType: Contact,Image,Slika
+apps/frappe/frappe/public/js/frappe/model/model.js +538,Rename {0},Preimenuj {0}
+apps/frappe/frappe/public/js/frappe/socketio_client.js +357,File Upload,Dodavanje fajla
+DocType: Report,Add Total Row,Dodaj red ukupno bez PDV-a
+,Setup Wizard,Čarobnjak za postavke
+apps/frappe/frappe/core/report/feedback_ratings/feedback_ratings.js +33,From Date,Od datuma
+DocType: Auto Repeat,Amended From,Izmijenjena iz
+apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py +166,Desktop Icon already exists,Ikona na radnoj površini već postoji
+DocType: Communication,Attachment Removed,Prilog uklonjen
+DocType: Chat Room,Users,Korisnici
+DocType: Data Import,Import Log,Log uvoza
+apps/frappe/frappe/public/js/frappe/form/controls/comment.js +11,Add a comment,Dodaj komentar
+apps/frappe/frappe/public/js/frappe/model/model.js +518,Permanently delete {0}?,Trajno obriši dokument {0} ?
+DocType: Custom DocPerm,Export,Izvezi
+DocType: Communication,Cancelled,Otkazan
+DocType: Contact,Open,Otvoren
+apps/frappe/frappe/www/desk.py +18,You are not permitted to access this page.,Немате дозволу да приступите овој страници.
+DocType: File,Attached To DocType,Priložen u vrstu dokumetu
+apps/frappe/frappe/public/js/frappe/request.js +31,You are not connected to Internet. Retry after sometime.,Нисте повезани са Интернетом. Покушајте касније.
+apps/frappe/frappe/config/desk.py +32,Chat messages and other notifications.,Poruke i ostala obavještenja.
+apps/frappe/frappe/website/doctype/blog_post/blog_post.py +80,{0} comments,{0} komentara
+apps/frappe/frappe/public/js/frappe/socketio_client.js +267,Upload Failed,Dodavanje priloga neuspješno
+apps/frappe/frappe/public/js/frappe/form/toolbar.js +171,Customize,Prilagodite
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +291,Users with role {0}:,Korisnici sa rolom {0} :
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +401,Did not add,Nije dodato
+apps/frappe/frappe/config/desk.py +19,Files,Fajlovi
+DocType: Communication,Opened,Otvoreno
+apps/frappe/frappe/desk/reportview.py +269,No Tags,Nema tag-ova
+DocType: Workflow State,picture,Slika
+DocType: Workflow State,Edit,Izmijeni
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js +562,Make ,Napravi
+apps/frappe/frappe/public/js/frappe/views/treeview.js +242,New {0},Novi {0}
+apps/frappe/frappe/public/js/frappe/views/treeview.js +380,Chart of Accounts,Kontni plan
+apps/frappe/frappe/email/doctype/email_group/email_group.js +9,View,Pogledaj
+DocType: Notification,Print Settings,Podešavanje štampanja
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html +87,Search or type a command,Pretražite ili otkucajte komandu
+DocType: About Us Team Member,Image Link,Link za sliku
+DocType: Workflow State,folder-close,Folder-zatvori
+DocType: List Filter,Filter Name,Naziv filtera
+DocType: Calendar View,Subject Field,Polje naslova
+apps/frappe/frappe/core/doctype/file/test_file.py +202,Home/Test Folder 1,Naslovna / Test Folder1
+DocType: Chat Token,Country,Država
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js +65,New Folder,Novi folder
+DocType: Communication,Email,Email
+apps/frappe/frappe/public/js/frappe/form/save.js +150,Mandatory fields required in {0},Obavezna polja koja se moraju unijeti u dijelu {0}
+DocType: Chat Message Attachment,Attachment,Prilog
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js +11,Not equals,Nije jednak
+DocType: Help Article,Knowledge Base Contributor,Saradnik zs bazu znanja
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js +127,Help on Search,Pomoć oko pretrage
+apps/frappe/frappe/public/js/frappe/ui/page.html +23,Menu,Meni
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js +163,No {0} mail,{0} email nije nađen
+DocType: Email Account,Attachment Limit (MB),Prilog limitiran na (MB)
+DocType: Error Snapshot,Error Snapshot,Snimak grešaka (snapshot)
+apps/frappe/frappe/public/js/frappe/model/model.js +27,Document Status,Status dokumenta
+apps/frappe/frappe/public/js/frappe/form/save.js +11,Saving,Čuvanje
+DocType: About Us Settings,Website,Web sajt
+apps/frappe/frappe/desk/page/activity/activity.js +58,Show Likes,Prikaži lajkove
+apps/frappe/frappe/config/core.py +27,Script or Query reports,Skripte ili query izvještaji
+apps/frappe/frappe/integrations/doctype/gsuite_templates/gsuite_templates.py +38,Added {0},Dodatо {0}
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js +61,You are not allowed to create columns,Немате дозволу да правите колоне
+apps/frappe/frappe/public/js/frappe/views/treeview.js +378,Add to Desktop,Dodaj na radnu površinu
+apps/frappe/frappe/public/js/frappe/upload.js +26,Upload Attachment,Priloži datoteku
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html +58,Documentation,Dokumentacija
+apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js +10,Gantt,Gantogram
+DocType: Contact,First Name,Ime
+apps/frappe/frappe/templates/emails/new_user.html +16,You can also copy-paste this link in your browser,Можете и да копирате и налепите овај линк у свој претраживач.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +30,User Permissions,Prava pristupa korisnika
+DocType: Contact,More Information,Više informacija
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py +179,Confirm Your Email,Potvrdi tvoj E mail
+apps/frappe/frappe/public/js/frappe/form/controls/attach.js +58,Select from existing attachments,Odaberite neku od već dodatih
+DocType: Contact,Accounts Manager,Menadžer računa
+apps/frappe/frappe/email/doctype/notification/notification.js +33,Created On,Kreirano
+DocType: Email Account,Yandex.Mail,Yandex.Mail
+apps/frappe/frappe/website/doctype/blog_post/blog_post.py +78,1 comment,1 komentar
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js +53,Date Range,Opseg datuma
+apps/frappe/frappe/public/js/frappe/views/treeview.js +75,Expand All,Proširi sve
+apps/frappe/frappe/website/doctype/web_form/web_form.py +366,You are not allowed to update this Web Form Document,Немате дозволу да ажурирате овај Документ Веб Форме
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js +111,New,Novi
+apps/frappe/frappe/core/doctype/file/file.py +216,Cannot delete Home and Attachments folders,Ne možete brisati foldere Naslovna i prilozi
+DocType: User,Desktop Background,Pozadina radne površine
+apps/frappe/frappe/core/doctype/data_import/data_import.js +43,Attach File,Priloži dokument
+DocType: ToDo,High,Visok
+apps/frappe/frappe/website/doctype/web_form/templates/web_form.html +134,Payment Complete,Plaćanje zaključeno
+apps/frappe/frappe/www/printview.py +199,No {0} permission,{0} Nema dozvolu
+apps/frappe/frappe/public/js/frappe/list/list_view.js +1066,Delete {0} items permanently?,Trajno obriši stavke{0} ?
+DocType: Address,Postal Code,Poštanski broj
+apps/frappe/frappe/workflow/doctype/workflow/workflow_list.js +7,Not active,Nije aktivna
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html +19,Add,Dodaj
+DocType: Email Account,Add Signature,Dodaj potpis
+apps/frappe/frappe/desk/like.py +38,You cannot like something that you created,Не можете лајковати нешто што сте Ви направили.
+apps/frappe/frappe/public/js/frappe/list/list_filter.js +22,Save Filter,Sačuvaj filter
+DocType: Deleted Document,New Name,Novi naziv
+DocType: Feedback Trigger,Enabled,Aktivan
+DocType: ToDo,ToDo,To Do
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js +197,Report {0},Izvještaj {0}
+apps/frappe/frappe/public/js/frappe/views/communication.js +15,New Email,Novi email
+apps/frappe/frappe/public/js/frappe/ui/slides.js +29,Add More,Dodaj još
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +606,Pick Columns,Odaberi kolone
+DocType: Footer Item,Company,Preduzeće
+DocType: Address,Purchase User,Korisnik u nabavci
+apps/frappe/frappe/public/js/frappe/model/model.js +18,Created By,Kreirao
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +738,Export Report: {0},Izvoz izvještaja: {0}
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js +52,Insert Below,Ubacite ispod
+apps/frappe/frappe/public/js/frappe/form/footer/assign_to.js +137,Assign To,Dodijeli
+apps/frappe/frappe/www/update-password.html +71,Invalid Password,Pogrešna lozinka
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py +335,Dropbox Setup,Dropbox podešavanje
+apps/frappe/frappe/public/js/frappe/form/share.js +57,Share {0} with,Podijeli {0} sa
+apps/frappe/frappe/public/js/frappe/form/controls/attach.js +60,Clear Attachment,Obriši dodatu sliku
+,Addresses And Contacts,Adrese i kontakti
+DocType: Address,Accounts User,Računi korisnik
+DocType: File,File Name,Naziv dokumenta
+DocType: Has Role,Has Role,Ima ulogu
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html +63,Shared With,Podijeljeno sa
+DocType: Contact,Contact,Kontakt
+apps/frappe/frappe/desk/page/activity/activity_row.html +34,{0} {1} to {2},{0} {1} do {2}
+apps/frappe/frappe/templates/includes/comments/comments.html +25,Add Comment,Dodaj komentar
+DocType: Error Log,Title,Naslov
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html +44,Assign,Dodijeli
+DocType: Note,Note,Bilješke
+apps/frappe/frappe/public/js/frappe/list/list_renderer.js +629,No {0} found,{0} nije nadjen
+DocType: Email Group,Newsletter Manager,Menadžer newsletter-a
+apps/frappe/frappe/core/doctype/communication/communication.js +77,Add Contact,Dodaj kontakt
+apps/frappe/frappe/core/doctype/version/version.js +5,Show all Versions,Prikaži sve verzije
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js +49,Insert Above,Ubacite iznad
+apps/frappe/frappe/core/doctype/version/version_view.html +14,New Value,Nova vrijednost
+apps/frappe/frappe/templates/pages/integrations/payment-failed.html +3,Payment Failed,Plaćanje nije uspjelo
+apps/frappe/frappe/public/js/frappe/form/templates/form_links.html +13,Open {0},Otvoren {0}
+DocType: DocType,Sort Order,Sortiranje
+DocType: DocField,Password,Lozinka
+DocType: Post,Post,Pošalji
+DocType: Customize Form,Image Field,Polje sa slikom
+apps/frappe/frappe/public/js/frappe/form/share.js +36,Shared with {0},Podijeljeno sa {0}
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js +55,Duplicate,Dupliraj
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +208,You cannot unset 'Read Only' for field {0},"Не можете искључити ""Само за читање"" за поље {0}"
+DocType: Blog Category,Blogger,Blogger
+DocType: User,Change Password,Promjena lozinke
+apps/frappe/frappe/public/js/frappe/views/treeview.js +342,View List,Prikaz liste
+DocType: Communication,Delivery Status,Status isporuke
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js +790,Saved,Sačuvano
+DocType: Workflow State,share-alt,Podijeli-alt
+apps/frappe/frappe/public/js/frappe/ui/upload.html +12,Web Link,Url adresa
+DocType: Web Form,Amount,Vrijednost
+,Address and Contacts,Adresa i kontakti
+apps/frappe/frappe/config/desk.py +26,Event and other calendars.,Događaji i ostali kalendari.
+apps/frappe/frappe/public/js/frappe/form/controls/comment.js +19,Ctrl+Enter to add comment,Ctrl + enter da dodate komentar
+DocType: Workflow State,Comment,Komentar
+DocType: User,Timezone,Vremenska zona
+DocType: Workflow State,Refresh,Osvježi
+apps/frappe/frappe/desk/query_report.py +23,You don't have access to Report: {0},Немате дозволу да приступите Извештају: {0}
+apps/frappe/frappe/website/doctype/website_theme/website_theme.py +30,You are not allowed to delete a standard Website Theme,Немате дозволу за брисање стандардне Вебсајт Теме
+apps/frappe/frappe/core/doctype/file/test_file.py +217,Home/Test Folder 2,Nalovna/ Test Folder2
+DocType: Contact Us Settings,Email ID,Email adresa
+DocType: Chat Profile,Status,Status
+apps/frappe/frappe/desk/query_report.py +30,Report {0} is disabled,Izvještaj {0} јe onemogućen
+apps/frappe/frappe/config/desktop.py +8,Tools,Alati
+DocType: Communication,Deleted,Obrisan
+DocType: System Settings,Setup Complete,Podešavanje završeno
+apps/frappe/frappe/core/doctype/user/user.js +94,Reset Password,Resetuju lozinku
+DocType: Contact,Salutation,Titula
+DocType: Activity Log,Date,Datum
+,Desktop,Radna površina
+apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html +39,Share this document with,Podijelite ovaj dokument sa
+apps/frappe/frappe/templates/pages/integrations/braintree_checkout.html +29,Pay,Plati
+apps/frappe/frappe/public/js/frappe/views/image/image_view.js +13,Images,Slike
+,Document Share Report,Izvještaj o dijeljenim dokumentima
+apps/frappe/frappe/public/js/frappe/form/form_viewers.js +35,{0} is currently viewing this document,{0} trenutno gleda ovaj dokumenat
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html +26,Tree,Stablo
+DocType: Chat Message,Type,Tip
+DocType: DocField,Attach Image,Dodajte sliku
+DocType: Custom DocPerm,Submit,Potvrdi
+apps/frappe/frappe/public/js/frappe/form/save.js +157,Missing Fields,Polja koja nisu unešena
+DocType: Website Settings,Brand,Brend
+apps/frappe/frappe/public/js/frappe/chat.js +1703,You don't have any messages yet.,Још увек немате порука.
+DocType: Email Queue,Attachments,Prilozi
+DocType: Contact,Sales Manager,Menadžer prodaje
+DocType: Report,Report Manager,Menadžer za izvještaje
+DocType: Desktop Icon,Desktop Icon,Ikone na radnoj površini
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js +67,Get Items,Dodaj stavke
+apps/frappe/frappe/public/js/frappe/model/meta.js +182,Last Modified On,Poslednji put izmijenjeno
+apps/frappe/frappe/public/js/frappe/form/save.js +147,"Mandatory fields required in table {0}, Row {1}","Obavezna polja koja se moraju unijeti u tabeli {0}, Red {1}"
+apps/frappe/frappe/public/js/frappe/form/link_selector.js +26,You can use wildcard %,Можете да користите џокер %
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js +579,Added,Dodato
+DocType: Workflow,Is Active,Je aktivan
+apps/frappe/frappe/www/login.html +84,Forgot Password,Zaboravili ste lozinku
+DocType: Page,No,Ne
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +788,New Report name,Novi naziv izvještaja
+apps/frappe/frappe/www/login.py +48,Mobile Number,Mobilni br. telefona
+apps/frappe/frappe/public/js/frappe/model/indicator.js +19,Not Saved,Nije sačuvano
+apps/frappe/frappe/public/js/frappe/views/interaction.js +156,Add Attachment,Dodaj prilog
+apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js +144,Week,Nedelja
+DocType: Activity Log,Full Name,Puno ime
+apps/frappe/frappe/public/js/frappe/form/quick_entry.js +216,Edit in full page,Izmijeni u punoj strani
+apps/frappe/frappe/public/js/legacy/form.js +809,Permanently Cancel {0}?,Trajno otkaži {0} ?
+apps/frappe/frappe/core/doctype/data_import/exporter.py +62,Notes:,Bilješke :
+DocType: Notification,Save,Sačuvaj
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js +38,File Manager,Fajlovi
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py +23,; not allowed in condition,; није дозвољенa у услову
+DocType: File,Folder,Folder
+apps/frappe/frappe/core/doctype/data_import/data_import.js +67,Help,Pomoć
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js +419,Attach Your Picture,Priložite svoju fotografiju
+DocType: Address,Disabled,Neaktivni
+DocType: Communication,Email Account,Email nalog
+apps/frappe/frappe/public/js/frappe/form/grid.js +69,Add Multiple,Dodaj više
+DocType: Custom DocPerm,Import,Uvoz
+DocType: User,Security Settings,Bezbjedonosna podešavanja
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js +26,Search term,Pretraga
+apps/frappe/frappe/www/login.html +21,Email Address,Email adresa
+DocType: Google Maps Settings,Home Address,Kućna adresa
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js +67,Ctrl + Up,Ctrl + up
+DocType: Communication,Assigned,Dodijeljeno
+DocType: Desktop Icon,_report,_izvještaj
+apps/frappe/frappe/config/setup.py +147,Restore or permanently delete a document.,Vrati ili trajno obriši dokument.
+DocType: About Us Settings,Website Manager,Menadžer za web sajt
+DocType: GCalendar Settings,State,Država (USA)
+DocType: Activity Log,Closed,Zatvoreno
+apps/frappe/frappe/core/doctype/has_role/has_role.py +12,User '{0}' already has the role '{1}',Korisnik '{0}' već sarži rolu  '{1}'
+apps/frappe/frappe/public/js/frappe/form/controls/link.js +172,Create a new {0},Kreirajte {0}
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html +11,Loading...,Učitavanje ...
+apps/frappe/frappe/public/js/frappe/form/form_sidebar.js +59,{0} edited this {1},{1} {0} je izmijenio/la ovo
+DocType: Error Log,Error Log,Log grešaka
+DocType: DocField,Description,Opis
+DocType: Newsletter,Newsletter,Newsletter
+apps/frappe/frappe/desk/moduleview.py +94,Standard Reports,Standardni izvještaji
+apps/frappe/frappe/templates/pages/integrations/payment-success.html +3,Payment Success,Plaćanje uspješno
+DocType: User,Reset Password Key,Resetuj ključ lozinke
+,Activity,Aktivnost
+DocType: Communication,Submitted,Potvrđen
+DocType: File,Is Folder,Da li je Folder
+DocType: Page,Roles,Role
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py +115,You are not permitted to view the newsletter.,Немате дозволу да видите овај билтен.
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js +132,Make a new record,Napravite novi zapis
+apps/frappe/frappe/core/doctype/user/user_list.js +12,Active,Aktivan
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +17,"You can change Submitted documents by cancelling them and then, amending them.",Можете да измените потврђене документе тако што ћете их поништити а затим изменити.
+DocType: Workflow State,Calendar,Kalendar
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js +90,Import Zip,Uvoz zip arhive
+DocType: Custom DocPerm,Amend,Izmijeni
+apps/frappe/frappe/public/js/frappe/form/layout.js +170,Hide Details,Sakrij detalje
+apps/frappe/frappe/core/doctype/version/version_view.html +47,Success,Uspješno
+apps/frappe/frappe/core/doctype/data_import/exporter.py +53,Data Import Template,Šablon za uvoz podataka
+apps/frappe/frappe/public/js/frappe/form/formatters.js +135,{0} to {1},{0} do {1}
+DocType: User,Background Image,Pozadinska slika
+DocType: Web Form,Payments,Plaćanja
+apps/frappe/frappe/core/doctype/communication/communication.js +42,Close,Zatvori
+apps/frappe/frappe/templates/print_formats/standard_macros.html +39,Sr,Rb
+DocType: Contact,Purchase Master Manager,Direktor nabavke
+DocType: User,Last Login,Poslednja prijava
+apps/frappe/frappe/core/doctype/file/file.py +268,Folder {0} is not empty,Folder {0} nije prazan
+DocType: Custom DocPerm,Report,Izvještaj
+apps/frappe/frappe/utils/response.py +162,You don't have permission to access this file,Немате дозволу да приступите овој датотеци.
+DocType: Communication,User Tags,Korisnički tagovi
+apps/frappe/frappe/public/js/frappe/form/link_selector.js +106,Make a new {0},Napravite novi {0}
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html +49,Assigned To Me,Dodijeljeno meni
+DocType: User,Email Settings,Podešavanje emaila
+,Role Permissions Manager,Menadžer prava pristupa rolama
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js +663,Delete comment?,Obriši komentar?
+DocType: Contact,Purchase Manager,Menadžer nabavke
+DocType: About Us Settings,About Us Settings,Podešavanja o nama
+apps/frappe/frappe/website/doctype/website_settings/website_settings.js +3,View Website,Pogledaj sajt
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +9,Add a New Role,Dodaj novu rolu
+apps/frappe/frappe/public/js/frappe/roles_editor.js +30,Add all roles,Dodaj sve role
+apps/frappe/frappe/public/js/frappe/form/toolbar.js +153,Reload,Učitaj ponovo
+DocType: ToDo,Low,Nizak
+DocType: Prepared Report,Completed,Završeno
+apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html +28,Apply,Primijeni
+apps/frappe/frappe/public/js/frappe/misc/pretty_date.js +51,Yesterday,Juče
+apps/frappe/frappe/desk/query_report.py +331,Total,Ukupno
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +614,Show Totals,Prikaži ukupno
+apps/frappe/frappe/public/js/frappe/ui/messages.js +215,Enter your password,Unesite lozinku
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js +512,Like,Kao
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js +840,Export Report: ,Izvoz izvještaja:
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js +229,New Kanban Board,Nova Kanban prikaz
+DocType: DocType,Image View,Prikaz slike
+apps/frappe/frappe/desk/doctype/event/event.py +121,Events In Today's Calendar,Događaji u kalendaru na današnji dan.
+DocType: Workflow State,remove,Ukloni
+DocType: Auto Repeat,Start Date,Datum početka
+apps/frappe/frappe/email/doctype/email_group/email_group.js +45,New Newsletter,Novi newsletter
+DocType: Activity Log,Message,Poruka
+apps/frappe/frappe/www/login.html +91,Back to Login,Vrati se na prijavu
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html +32,Kanban,Kanban
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js +145,Loading,Učitavanje
+apps/frappe/frappe/public/js/frappe/views/reports/reportview_footer.html +9,Show all data,Prikaži sve podatke
+DocType: Auto Repeat,Weekly,Nedeljni
+apps/frappe/frappe/public/js/frappe/roles_editor.js +194,Role Permissions,Prava pristupa rolama
+DocType: Communication,From,Od
+apps/frappe/frappe/core/doctype/file/test_file.py +241,Home/Test Folder 1/Test Folder 3,Naslovna / Test Folder1 / Test Folder3
+DocType: Workflow State,share,Podijeli
+apps/frappe/frappe/core/doctype/file/file.py +195,Same file has already been attached to the record,Isti fajl je već dodijeljen nekom zapisu
+apps/frappe/frappe/desk/doctype/auto_repeat/auto_repeat.py +285,New {0}: #{1},Novi {0}: # {1}
+apps/frappe/frappe/core/doctype/user/user.js +74,Set Desktop Icons,Podesi ikonice na radnoj površini
+apps/frappe/frappe/public/js/frappe/form/controls/link.js +185,Advanced Search,Napredna pretraga
+DocType: Communication,Error,Greška
+DocType: Address,Warehouse,Skladište
+DocType: Workflow State,Upload,Priloži
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +216,You can't set 'Translatable' for field {0},Не можете поставити 'Може се превести' за поље {0}
+DocType: Workflow,States,Države
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html +52,Go,Traži
+apps/frappe/frappe/public/js/frappe/misc/pretty_date.js +52,{0} days ago,prije {0} dana
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js +405,Y Axis Fields,Поља на Y-oси
+apps/frappe/frappe/public/js/frappe/form/grid.js +72,Add Row,Dodaj red
+DocType: File,Is Home Folder,Da li je folder naslovna
+apps/frappe/frappe/desk/doctype/todo/todo_list.js +9,To Do,To Do
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js +15,Not In,Nije u
+apps/frappe/frappe/public/js/frappe/form/footer/assign_to.js +134,Add to To Do,Dodaj u To Do
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js +178,Created,Kreirano
+apps/frappe/frappe/public/js/frappe/form/link_selector.js +125,Added {0} ({1}),Dodato {0} ({1})
+DocType: OAuth Client, Advanced Settings,Napredna podešavanja
+DocType: Address,Address,Adresa
+DocType: Email Account,Email Addresses,Email adrese
+apps/frappe/frappe/public/js/frappe/views/treeview.js +89,{0} Tree,{0} stablo
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js +10,Equals,Jednak
+apps/frappe/frappe/public/js/frappe/views/reports/grid_report.js +284,Loading Report,Učitavanje izvještaja
+DocType: Address,Address Line 1,Adresa 1
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html +4,Add a column,Dodaj kolonu
+,Background Jobs,Pozadinski procesi
+DocType: Activity Log,Login,Prijava
+DocType: Chat Message,Chat,Poruke
+apps/frappe/frappe/config/setup.py +146,Deleted Documents,Obrisana dokumenta
+apps/frappe/frappe/public/js/frappe/form/print.js +284,With Letter head,Sa zaglavljem
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js +512,Not Like,Nije kao
+DocType: DocType,Setup,Podešavanje
+DocType: Data Import,Import Status,Status uvoza
+apps/frappe/frappe/core/doctype/user/user.js +136,Create User Email,Kreiraj korisnički Email
+DocType: Address,Address Line 2,Adresa 2
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js +530,{0} from {1} to {2},{0} od {1} za {2}
+DocType: Auto Repeat,Draft,Na čekanju
+DocType: Contact,Maintenance Manager,Menadžer održavanja
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js +67,Ctrl + Down,Ctrl + down
+DocType: Data Import,Data Import,Uvoz podataka
+apps/frappe/frappe/desk/reportview.py +110,{0} is saved,{0} je sačuvan
+DocType: DocField,Datetime,Datum vrijeme
+DocType: Email Group,Email Group,Email grupa
+apps/frappe/frappe/core/page/desktop/desktop.py +14,Add Employees to Manage Them,"Dodaj zaposlenog u ""Manage them"""
+apps/frappe/frappe/core/doctype/data_import/exporter.py +69,You can only upload upto 5000 records in one go. (may be less in some cases),Можете поднети највише 5000 записа одједном. (некада може бити и мање)
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +112,{0} Report,Izvještaj {0}
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html +10,Reports,Izvještaji
+DocType: Post,Comments,Komentari
+DocType: Workflow State,folder-open,folder-otvori
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +27,You can use Customize Form to set levels on fields.,Можете користити Прилагоди Формулар да подесите нивое на пољима.
+apps/frappe/frappe/public/js/frappe/model/model.js +541,Merge with existing,Spoji sa postojećim
+DocType: Print Settings,Send Print as PDF,Štampaj u PDF
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html +28,My Settings,Moja podešavanja
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js +250,Email Inbox,Email primljene
+apps/frappe/frappe/www/list.html +4,{0} List,{0} Lista
+DocType: Report,Letter Head,Zaglavlje
+DocType: Auto Repeat,Series,Vrsta dokumenta
+DocType: Workflow State,Home,Naslovna
+apps/frappe/frappe/public/js/frappe/list/list_filter.js +102,Duplicate Filter Name,Ime filtera već postoji
+apps/frappe/frappe/public/js/frappe/desk.js +402,Session Expired,Sesija je istekla
+DocType: Communication,Received,Primljeno
+DocType: User,Login After,Prijava nakon
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js +895,PDF,PDF
+DocType: Contact,Mobile No,Mobilni br.
+apps/frappe/frappe/public/js/frappe/ui/sort_selector.js +182,Most Used,Najviše korišćeno
+apps/frappe/frappe/email/doctype/email_account/email_account.js +183,"You are selecting Sync Option as ALL, It will resync all \
+				read as well as unread message from server. This may also cause the duplication\
+				of Communication (emails).","Постављате Начин усклађивања на СВЕ, што ће поново усклатиди све прочитане и непрочитане поруке са сервера. Ово може изазвати дупликате комуникација (мејлова)."
+apps/frappe/frappe/utils/data.py +654,{0} or {1},{0} {1} ili
+DocType: File,Is Attachments Folder,Da li je prilog folder
+DocType: Contact,Gender,Pol
+apps/frappe/frappe/templates/pages/integrations/payment-cancel.html +3,Payment Cancelled,Plaćenje otkazano
+DocType: DocField,Report Hide,Sakrij izvještaj
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +131,Setup Auto Email,Podešavanje auto e-mail-a
+apps/frappe/frappe/contacts/doctype/address/address.py +137,Addresses,Adrese
+DocType: ToDo,Assigned By,Dodijelio od strane
+DocType: Contact,All,Svi
+DocType: Auto Email Report,Report Filters,Filteri na izvještaju
+apps/frappe/frappe/public/js/frappe/misc/pretty_date.js +54,{0} months ago,Prije {0} mjeseci
+DocType: Web Form,Allow Comments,Dozvoli komentare
+DocType: User,Login Before,Prijava prije
+apps/frappe/frappe/public/js/frappe/form/share.js +115,Share With,Podijeli sa
+apps/frappe/frappe/core/page/desktop/desktop.py +15,"Add your Employees so you can manage leaves, expenses and payroll","Dodaj Vaše zaposlene, tako da možete da upravljate odsustvom, troškovima i platnim spiskovima"
+apps/frappe/frappe/public/js/frappe/model/model.js +544,Rename,Reimenuj
+DocType: Address,Links,Linkovi
+DocType: Contact,Is Primary Contact,Je primarni kontakt
+apps/frappe/frappe/public/js/frappe/form/share.js +27,Shared with everyone,Podijeljeno sa svima
+apps/frappe/frappe/core/doctype/error_log/error_log_list.js +12,Clear Error Logs,Očisti Log grešaka
+DocType: DocShare,Everyone,Svi
+apps/frappe/frappe/public/js/frappe/views/treeview.js +319,You are not allowed to print this report,Немате дозволу да штампате овај извештај
+,Download Backups,Preuzmi rezervne kopije programa
+apps/frappe/frappe/public/js/frappe/ui/upload.html +4,Browse,Izaberi
+apps/frappe/frappe/public/js/frappe/form/link_selector.js +151,{0} added,Dodao je {0}
+apps/frappe/frappe/public/js/frappe/form/link_selector.js +142,Set,Set
+apps/frappe/frappe/desk/report/todo/todo.py +20,Assigned To/Owner,Dodijeljeno / Vlasnik
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +749,Save As,Sačuvaj kao
+apps/frappe/frappe/model/naming.py +85,Naming Series mandatory,Vrsta dokumenta je obavezna
+apps/frappe/frappe/core/doctype/file/test_file.py +249,Test_Folder,Test_folder
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +723,Select File Type,Odaberite tip datoteke
+apps/frappe/frappe/public/js/frappe/views/reports/reportview.js +867,Add Column,Dodaj kolonu
+DocType: Communication,Unshared,Nije podijeljen
+DocType: Help Article,Knowledge Base Editor,Urednik baze znanja
+DocType: Prepared Report,Report Name,Naziv izvještaja
+DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesija ističe u satima npr. 06:00
+DocType: Report,Report Builder,Generator izvještaja
+apps/frappe/frappe/desk/report/todo/todo.py +19,ID,ID
+DocType: Custom DocPerm,Cancel,Otkaži
+DocType: Contact,Sales Master Manager,Direktor prodaje
+DocType: Kanban Board Column,yellow,жуто
+DocType: DocField,Currency,Valuta
+DocType: Workflow State,Print,Štampaj
+DocType: Workflow State,Primary,Primarni
+DocType: ToDo,Medium,Srednji
+DocType: Workflow State,barcode,barkod
+DocType: Address,Reference,Vezni dokumenti
+DocType: Custom Role,Custom Role,Prilagođjena rola
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js +559,{0} from {1} to {2} in row #{3},{0} od {1} do {2} na poziciji # {3}
+apps/frappe/frappe/public/js/frappe/upload.js +232,Uploading,Prilaganje datoteke
+DocType: Workflow State,User,Korisnik
+apps/frappe/frappe/public/js/frappe/desk.js +406,Please Enter Your Password to Continue,Za nastavak unesite lozinku
+DocType: File,File Size,Veličina fajla
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html +62,About,O Nama
+apps/frappe/frappe/public/js/frappe/views/communication.js +539,You are not allowed to send emails related to this document,Немате дозволу да шаљете мејлове у вези са овим документом

--- a/frappe/translations/sr_ba.csv
+++ b/frappe/translations/sr_ba.csv
@@ -1,0 +1,460 @@
+apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Dodijelio drugima
+apps/frappe/frappe/desk/doctype/note/note_list.js,Notes,Bilješke
+DocType: Desktop Icon,_doctype,_doctype
+DocType: Desktop Icon,List,Lista
+DocType: Report,Report Type,Vrsta izvještaja
+DocType: System Settings,Session Expiry,Sesija ističe
+DocType: DocShare,DocShare,Dijeljenje dokumenta
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Add Filter,Dodaj filter
+DocType: Address,Contacts,Kontakti
+apps/frappe/frappe/public/js/frappe/form/save.js,Submitting,Potvrđivanje
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Editing Row,Izmjena u redu
+apps/frappe/frappe/public/js/frappe/form/print.js,You are not allowed to print this document,Немате дозволу да штампате овај документ
+DocType: Auto Repeat,End Date,Datum završetka
+DocType: ToDo,Allocated To,Dodijeljeno je
+DocType: Custom DocPerm,Delete,Obriši
+apps/frappe/frappe/app.py,You do not have enough permissions to complete the action,Немате дозволу да завршите ову акцију.
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Project,Projekti
+DocType: ToDo,Due Date,Datum dospijeća
+apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Dodijeljeno prema
+apps/frappe/frappe/model/rename_doc.py,renamed from {0} to {1},Preimenuj iz {0} u {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,Submit this document to confirm,Potvrdi ovaj dokument da bi ga zaključio
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Можете тражити ствари претрагом ""тражи наранџасто у купцима"""
+DocType: Note Seen By,Note Seen By,Bilješku je vidio
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Prikaži tagove
+apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Pređi na radnu površinu
+apps/frappe/frappe/public/js/frappe/dom.js,Confirm,Potvrdi
+apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Assign to me,Dodijeljeno meni
+apps/frappe/frappe/public/js/frappe/roles_editor.js,Clear all roles,Obriši sve role
+DocType: Address,Sales User,Korisnik prodaje
+DocType: Custom DocPerm,Set User Permissions,Postavite korisnička prava
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Between,Između
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,e.g.:,npr:
+DocType: Country,Country Name,Ime države
+DocType: Workflow State,Download,Preuzmi
+apps/frappe/frappe/handler.py,You have been successfully logged out,Успешно сте се одјавили
+apps/frappe/frappe/website/doctype/web_form/web_form.py,You don't have the permissions to access this document,Немате дозволу да приступите овом документу.
+DocType: Website Settings,Brand Image,Slika brenda
+apps/frappe/frappe/utils/bot.py,show,Prikaži
+DocType: Page,Yes,Da
+DocType: Custom DocPerm,Role,Uloga
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Totals,Ukupno
+apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,Немате дозволу да приступите овоме. Молимо јавите се свом менаџеру да добијете приступ.
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Dodaj podređeni
+apps/frappe/frappe/core/doctype/user/user.py,Invalid Password: ,Pogrešna lozinka:
+DocType: System Settings,System Settings,Sistemska podešavanja
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,Можете да додате динамичке вредности из документа помоћу Jinja шаблона.
+DocType: Chat Profile,Offline,Van mreže (offline)
+DocType: Assignment Rule,System Manager,Menadžer sistema
+apps/frappe/frappe/www/update-password.html,New Password,Nova lozinka
+apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Немате дозволу да добијете извештај о: {0}
+DocType: User,Middle Name (Optional),Srednje ime (opciono)
+apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Share,Može dijeliti
+apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,Nadzorna ploča
+DocType: Contact,Last Name,Prezime
+apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! You are not permitted to view this page.,Niste autorizovani za prikaz ove stranice.
+DocType: Web Form,Success Message,Poruka o uspjehu
+apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} created this {1},{1} {0} je kreirao/la ovo.
+DocType: Chat Profile,Online,Na mreži
+apps/frappe/frappe/core/doctype/file/file.py,Folder {0} does not exist,Folder {0} ne postoji
+DocType: Auto Repeat,Subject,Naslov
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Unesi naziv foldera
+DocType: Workflow State,Tags,Tagovi
+apps/frappe/frappe/patches/v6_19/comment_feed_communication.py,Assignment,Dodjeljivanje
+DocType: Workflow State,move,Kretanje
+DocType: Language,Language,Jezik
+apps/frappe/frappe/public/js/frappe/form/form.js,Permanently Submit {0}?,Trajno potvrdi {0} ?
+DocType: Address,Maintenance User,Korisnik održavanja
+DocType: Contact,Image,Slika
+apps/frappe/frappe/public/js/frappe/model/model.js,Rename {0},Preimenuj {0}
+apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload,Dodavanje fajla
+DocType: Report,Add Total Row,Dodaj red ukupno bez PDV-a
+,Setup Wizard,Čarobnjak za postavke
+DocType: Data Import,Amended From,Izmijenjena iz
+apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,Ikona na radnoj površini već postoji
+DocType: Comment,Attachment Removed,Prilog uklonjen
+DocType: Assignment Rule,Users,Korisnici
+DocType: Data Import,Import Log,Log uvoza
+apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Add a comment,Dodaj komentar
+apps/frappe/frappe/public/js/frappe/model/model.js,Permanently delete {0}?,Trajno obriši dokument {0} ?
+DocType: Custom DocPerm,Export,Izvezi
+DocType: Comment,Cancelled,Otkazan
+DocType: Contact,Open,Otvoren
+apps/frappe/frappe/public/js/frappe/web_form/webform_script.js,You are not permitted to access this page.,Немате дозволу да приступите овој страници.
+DocType: File,Attached To DocType,Priložen u vrstu dokumetu
+apps/frappe/frappe/public/js/frappe/request.js,You are not connected to Internet. Retry after sometime.,Нисте повезани са Интернетом. Покушајте касније.
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Collapse All,Skupi sve
+apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,Poruke i ostala obavještenja.
+apps/frappe/frappe/website/doctype/blog_post/blog_post.py,{0} comments,{0} komentara
+apps/frappe/frappe/public/js/frappe/socketio_client.js,Upload Failed,Dodavanje priloga neuspješno
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Customize,Prilagodite
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Users with role {0}:,Korisnici sa rolom {0} :
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not add,Nije dodato
+apps/frappe/frappe/config/desk.py,Files,Fajlovi
+DocType: Communication,Opened,Otvoreno
+apps/frappe/frappe/desk/reportview.py,No Tags,Nema tag-ova
+DocType: Workflow State,picture,Slika
+DocType: Workflow State,Edit,Izmijeni
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New {0},Novi {0}
+apps/frappe/frappe/email/doctype/email_group/email_group.js,View,Pogledaj
+DocType: Notification,Print Settings,Podešavanje štampanja
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Pretražite ili otkucajte komandu
+DocType: About Us Team Member,Image Link,Link za sliku
+DocType: Letter Head,Default Letter Head,Podrazumijevano zaglavlje
+DocType: Workflow State,folder-close,Folder-zatvori
+DocType: List Filter,Filter Name,Naziv filtera
+DocType: Calendar View,Subject Field,Polje naslova
+apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1,Naslovna / Test Folder1
+DocType: Chat Token,Country,Država
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,New Folder,Novi folder
+DocType: Communication,Email,Email
+apps/frappe/frappe/public/js/frappe/form/save.js,Mandatory fields required in {0},Obavezna polja koja se moraju unijeti u dijelu {0}
+DocType: Chat Message Attachment,Attachment,Prilog
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not equals,Nije jednak
+DocType: Help Article,Knowledge Base Contributor,Saradnik zs bazu znanja
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Help on Search,Pomoć oko pretrage
+apps/frappe/frappe/public/js/frappe/ui/page.html,Menu,Meni
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No {0} mail,{0} email nije nađen
+DocType: Email Account,Attachment Limit (MB),Prilog limitiran na (MB)
+DocType: Error Snapshot,Error Snapshot,Snimak grešaka (snapshot)
+apps/frappe/frappe/public/js/frappe/model/model.js,Document Status,Status dokumenta
+apps/frappe/frappe/public/js/frappe/form/save.js,Saving,Čuvanje
+DocType: About Us Settings,Website,Web sajt
+apps/frappe/frappe/config/core.py,Script or Query reports,Skripte ili query izvještaji
+apps/frappe/frappe/utils/file_manager.py,Added {0},Dodatо {0}
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,Немате дозволу да правите колоне
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Gantt,Gantogram
+DocType: Contact,First Name,Ime
+apps/frappe/frappe/templates/emails/new_user.html,You can also copy-paste this link in your browser,Можете и да копирате и налепите овај линк у свој претраживач.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions,Prava pristupa korisnika
+DocType: Contact,More Information,Više informacija
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Confirm Your Email,Potvrdi tvoj E mail
+DocType: Auto Repeat,Accounts Manager,Menadžer računa
+apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Created On,Kreirano
+DocType: Email Account,Yandex.Mail,Yandex.Mail
+apps/frappe/frappe/website/doctype/blog_post/blog_post.py,1 comment,1 komentar
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Date Range,Opseg datuma
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Expand All,Proširi sve
+apps/frappe/frappe/website/doctype/web_form/web_form.py,You are not allowed to update this Web Form Document,Немате дозволу да ажурирате овај Документ Веб Форме
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New,Novi
+apps/frappe/frappe/core/doctype/file/file.py,Cannot delete Home and Attachments folders,Ne možete brisati foldere Naslovna i prilozi
+DocType: User,Desktop Background,Pozadina radne površine
+apps/frappe/frappe/core/doctype/data_import/data_import.js,Attach File,Priloži dokument
+DocType: ToDo,High,Visok
+apps/frappe/frappe/www/printview.py,No {0} permission,{0} Nema dozvolu
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Delete {0} items permanently?,Trajno obriši stavke{0} ?
+DocType: Address,Postal Code,Poštanski broj
+apps/frappe/frappe/workflow/doctype/workflow/workflow_list.js,Not active,Nije aktivna
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Add,Dodaj
+DocType: Email Account,Add Signature,Dodaj potpis
+apps/frappe/frappe/public/js/frappe/list/list_filter.js,Save Filter,Sačuvaj filter
+DocType: Deleted Document,New Name,Novi naziv
+DocType: User,Enabled,Aktivan
+DocType: ToDo,ToDo,To Do
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Report {0},Izvještaj {0}
+apps/frappe/frappe/public/js/frappe/views/communication.js,New Email,Novi email
+apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Dodaj još
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Odaberi kolone
+DocType: Footer Item,Company,Preduzeće
+DocType: Address,Purchase User,Korisnik u nabavci
+apps/frappe/frappe/public/js/frappe/model/model.js,Created By,Kreirao
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export Report: {0},Izvoz izvještaja: {0}
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Insert Below,Ubacite ispod
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Assign To,Dodijeli
+apps/frappe/frappe/www/update-password.html,Invalid Password,Pogrešna lozinka
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Dropbox podešavanje
+apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Share {0} with,Podijeli {0} sa
+,Addresses And Contacts,Adrese i kontakti
+DocType: Auto Repeat,Accounts User,Računi korisnik
+DocType: File,File Name,Naziv dokumenta
+DocType: Has Role,Has Role,Ima ulogu
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,Podijeljeno sa
+DocType: Contact,Contact,Kontakt
+apps/frappe/frappe/desk/page/activity/activity_row.html,{0} {1} to {2},{0} {1} do {2}
+apps/frappe/frappe/templates/includes/comments/comments.html,Add Comment,Dodaj komentar
+DocType: Error Log,Title,Naslov
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Assign,Dodijeli
+DocType: Note,Note,Bilješke
+apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} nije nadjen
+DocType: Email Group,Newsletter Manager,Menadžer newsletter-a
+apps/frappe/frappe/core/doctype/communication/communication.js,Add Contact,Dodaj kontakt
+apps/frappe/frappe/core/doctype/version/version.js,Show all Versions,Prikaži sve verzije
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Insert Above,Ubacite iznad
+apps/frappe/frappe/core/doctype/version/version_view.html,New Value,Nova vrijednost
+apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,Plaćanje nije uspjelo
+apps/frappe/frappe/desk/doctype/todo/todo_list.js,Open {0},Otvoren {0}
+DocType: Customize Form,Sort Order,Sortiranje
+DocType: DocField,Password,Lozinka
+DocType: Post,Post,Pošalji
+DocType: DocType,Image Field,Polje sa slikom
+apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with {0},Podijeljeno sa {0}
+apps/frappe/frappe/public/js/frappe/form/toolbar.js,Duplicate,Dupliraj
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},"Не можете искључити ""Само за читање"" за поље {0}"
+DocType: Blog Category,Blogger,Blogger
+DocType: User,Change Password,Promjena lozinke
+apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Prikaz liste
+DocType: Communication,Delivery Status,Status isporuke
+DocType: Translation,Saved,Sačuvano
+DocType: Workflow State,share-alt,Podijeli-alt
+apps/frappe/frappe/public/js/frappe/ui/upload.html,Web Link,Url adresa
+DocType: Web Form,Amount,Vrijednost
+,Address and Contacts,Adresa i kontakti
+apps/frappe/frappe/config/desk.py,Event and other calendars.,Događaji i ostali kalendari.
+apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Ctrl+Enter to add comment,Ctrl + enter da dodate komentar
+DocType: Workflow State,Comment,Komentar
+DocType: User,Timezone,Vremenska zona
+DocType: Workflow State,Refresh,Osvježi
+apps/frappe/frappe/desk/query_report.py,You don't have access to Report: {0},Немате дозволу да приступите Извештају: {0}
+apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,Немате дозволу за брисање стандардне Вебсајт Теме
+apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 2,Nalovna/ Test Folder2
+DocType: Contact Us Settings,Email ID,Email adresa
+DocType: Auto Repeat,Status,Status
+apps/frappe/frappe/desk/query_report.py,Report {0} is disabled,Izvještaj {0} јe onemogućen
+apps/frappe/frappe/config/desktop.py,Tools,Alati
+DocType: Comment,Deleted,Obrisan
+DocType: System Settings,Setup Complete,Podešavanje završeno
+apps/frappe/frappe/core/doctype/user/user.js,Reset Password,Resetuju lozinku
+DocType: Contact,Salutation,Titula
+DocType: Activity Log,Date,Datum
+,Desktop,Radna površina
+apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Share this document with,Podijelite ovaj dokument sa
+apps/frappe/frappe/templates/pages/integrations/braintree_checkout.html,Pay,Plati
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Images,Slike
+,Document Share Report,Izvještaj o dijeljenim dokumentima
+apps/frappe/frappe/public/js/frappe/form/sidebar/form_viewers.js,{0} is currently viewing this document,{0} trenutno gleda ovaj dokumenat
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Tree,Stablo
+DocType: Chat Message,Type,Tip
+DocType: DocField,Attach Image,Dodajte sliku
+DocType: Custom DocPerm,Submit,Potvrdi
+apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Polja koja nisu unešena
+DocType: Website Settings,Brand,Brend
+apps/frappe/frappe/public/js/frappe/chat.js,You don't have any messages yet.,Још увек немате порука.
+DocType: Email Queue,Attachments,Prilozi
+DocType: Contact,Sales Manager,Menadžer prodaje
+DocType: Report,Report Manager,Menadžer za izvještaje
+DocType: Desktop Icon,Desktop Icon,Ikone na radnoj površini
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Get Items,Dodaj stavke
+apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Last Modified On,Poslednji put izmijenjeno
+apps/frappe/frappe/public/js/frappe/form/save.js,"Mandatory fields required in table {0}, Row {1}","Obavezna polja koja se moraju unijeti u tabeli {0}, Red {1}"
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,You can use wildcard %,Можете да користите џокер %
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Added,Dodato
+DocType: Workflow,Is Active,Je aktivan
+apps/frappe/frappe/www/login.html,Forgot Password,Zaboravili ste lozinku
+DocType: Page,No,Ne
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,New Report name,Novi naziv izvještaja
+apps/frappe/frappe/www/login.py,Mobile Number,Mobilni br. telefona
+apps/frappe/frappe/public/js/frappe/model/indicator.js,Not Saved,Nije sačuvano
+apps/frappe/frappe/public/js/frappe/views/interaction.js,Add Attachment,Dodaj prilog
+apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Week,Nedelja
+DocType: Activity Log,Full Name,Puno ime
+apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Edit in full page,Izmijeni u punoj strani
+apps/frappe/frappe/public/js/frappe/form/form.js,Permanently Cancel {0}?,Trajno otkaži {0} ?
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Notes:,Bilješke :
+DocType: Notification,Save,Sačuvaj
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,File Manager,Fajlovi
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,; not allowed in condition,; није дозвољенa у услову
+DocType: File,Folder,Folder
+apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoć
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Attach Your Picture,Priložite svoju fotografiju
+DocType: Assignment Rule,Disabled,Neaktivni
+DocType: Communication,Email Account,Email nalog
+apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Dodaj više
+DocType: Custom DocPerm,Import,Uvoz
+DocType: User,Security Settings,Bezbjedonosna podešavanja
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Search term,Pretraga
+apps/frappe/frappe/www/login.py,Email Address,Email adresa
+DocType: Google Maps Settings,Home Address,Kućna adresa
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Up,Ctrl + up
+DocType: Comment,Assigned,Dodijeljeno
+DocType: Desktop Icon,_report,_izvještaj
+apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Vrati ili trajno obriši dokument.
+DocType: Comment,Website Manager,Menadžer za web sajt
+DocType: GCalendar Settings,State,Država (USA)
+DocType: Activity Log,Closed,Zatvoreno
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Korisnik '{0}' već sarži rolu  '{1}'
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Create a new {0},Kreirajte {0}
+apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Učitavanje ...
+apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} edited this {1},{1} {0} je izmijenio/la ovo
+DocType: Error Log,Error Log,Log grešaka
+DocType: Assignment Rule,Description,Opis
+DocType: Newsletter,Newsletter,Newsletter
+apps/frappe/frappe/desk/moduleview.py,Standard Reports,Standardni izvještaji
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Change,Kusur
+apps/frappe/frappe/templates/pages/integrations/payment-success.html,Payment Success,Plaćanje uspješno
+DocType: User,Reset Password Key,Resetuj ključ lozinke
+,Activity,Aktivnost
+DocType: Comment,Submitted,Potvrđen
+DocType: File,Is Folder,Da li je Folder
+DocType: Page,Roles,Role
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,You are not permitted to view the newsletter.,Немате дозволу да видите овај билтен.
+DocType: Auto Repeat,Active,Aktivan
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"You can change Submitted documents by cancelling them and then, amending them.",Можете да измените потврђене документе тако што ћете их поништити а затим изменити.
+DocType: Workflow State,Calendar,Kalendar
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Import Zip,Uvoz zip arhive
+DocType: Custom DocPerm,Amend,Izmijeni
+apps/frappe/frappe/public/js/frappe/form/layout.js,Hide Details,Sakrij detalje
+apps/frappe/frappe/core/doctype/version/version_view.html,Success,Uspješno
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Šablon za uvoz podataka
+apps/frappe/frappe/public/js/frappe/form/formatters.js,{0} to {1},{0} do {1}
+DocType: User,Background Image,Pozadinska slika
+DocType: Web Form,Payments,Plaćanja
+apps/frappe/frappe/core/doctype/communication/communication.js,Close,Zatvori
+apps/frappe/frappe/public/js/frappe/web_form/web_form_list.js,Sr,Rb
+DocType: Contact,Purchase Master Manager,Direktor nabavke
+DocType: User,Last Login,Poslednja prijava
+apps/frappe/frappe/core/doctype/file/file.py,Folder {0} is not empty,Folder {0} nije prazan
+DocType: Custom DocPerm,Report,Izvještaj
+apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Немате дозволу да приступите овој датотеци.
+DocType: Communication,User Tags,Korisnički tagovi
+DocType: User,Email Settings,Podešavanje emaila
+,Role Permissions Manager,Menadžer prava pristupa rolama
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Delete comment?,Obriši komentar?
+DocType: Contact,Purchase Manager,Menadžer nabavke
+DocType: About Us Settings,About Us Settings,Podešavanja o nama
+apps/frappe/frappe/website/doctype/website_settings/website_settings.js,View Website,Pogledaj sajt
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Add a New Role,Dodaj novu rolu
+apps/frappe/frappe/public/js/frappe/roles_editor.js,Add all roles,Dodaj sve role
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Reload,Učitaj ponovo
+DocType: ToDo,Low,Nizak
+DocType: Auto Repeat,Completed,Završeno
+apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Primijeni
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Juče
+apps/frappe/frappe/desk/query_report.py,Total,Ukupno
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,Prikaži ukupno
+apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter your password,Unesite lozinku
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Like,Kao
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Export Report: ,Izvoz izvještaja:
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,New Kanban Board,Nova Kanban prikaz
+DocType: Customize Form,Image View,Prikaz slike
+apps/frappe/frappe/desk/doctype/event/event.py,Events In Today's Calendar,Događaji u kalendaru na današnji dan.
+DocType: Workflow State,remove,Ukloni
+DocType: Auto Repeat,Start Date,Datum početka
+apps/frappe/frappe/email/doctype/email_group/email_group.js,New Newsletter,Novi newsletter
+DocType: Auto Repeat,Message,Poruka
+apps/frappe/frappe/www/login.html,Back to Login,Vrati se na prijavu
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Kanban,Kanban
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Loading,Učitavanje
+DocType: Auto Repeat,Weekly,Nedeljni
+apps/frappe/frappe/public/js/frappe/roles_editor.js,Role Permissions,Prava pristupa rolama
+DocType: Communication,From,Od
+apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Naslovna / Test Folder1 / Test Folder3
+DocType: Workflow State,share,Podijeli
+apps/frappe/frappe/core/doctype/file/file.py,Same file has already been attached to the record,Isti fajl je već dodijeljen nekom zapisu
+apps/frappe/frappe/public/js/frappe/form/controls/link.js,Advanced Search,Napredna pretraga
+DocType: Communication,Error,Greška
+DocType: Address,Warehouse,Skladište
+DocType: Workflow State,Upload,Priloži
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Не можете поставити 'Може се превести' за поље {0}
+DocType: Workflow,States,Države
+apps/frappe/frappe/public/js/frappe/form/toolbar.js,Go,Traži
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} days ago,prije {0} dana
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Поља на Y-oси
+apps/frappe/frappe/public/js/frappe/form/grid.js,Add Row,Dodaj red
+DocType: File,Is Home Folder,Da li je folder naslovna
+apps/frappe/frappe/desk/doctype/todo/todo_list.js,To Do,To Do
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Nije u
+apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Add to To Do,Dodaj u To Do
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Created,Kreirano
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,Added {0} ({1}),Dodato {0} ({1})
+DocType: OAuth Client, Advanced Settings,Napredna podešavanja
+DocType: Address,Address,Adresa
+DocType: Email Account,Email Addresses,Email adrese
+apps/frappe/frappe/public/js/frappe/views/treeview.js,{0} Tree,{0} stablo
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Jednak
+DocType: Address,Address Line 1,Adresa 1
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html,Add a column,Dodaj kolonu
+,Background Jobs,Pozadinski procesi
+DocType: Activity Log,Login,Prijava
+DocType: Chat Message,Chat,Poruke
+apps/frappe/frappe/config/settings.py,Deleted Documents,Obrisana dokumenta
+apps/frappe/frappe/public/js/frappe/form/print.js,With Letter head,Sa zaglavljem
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Not Like,Nije kao
+DocType: DocType,Setup,Podešavanje
+DocType: Data Import,Import Status,Status uvoza
+apps/frappe/frappe/core/doctype/user/user.js,Create User Email,Kreiraj korisnički Email
+DocType: Address,Address Line 2,Adresa 2
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} from {1} to {2},{0} od {1} za {2}
+apps/frappe/frappe/public/js/frappe/model/indicator.js,Draft,Na čekanju
+DocType: Contact,Maintenance Manager,Menadžer održavanja
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Down,Ctrl + down
+DocType: Data Import,Data Import,Uvoz podataka
+apps/frappe/frappe/desk/reportview.py,{0} is saved,{0} je sačuvan
+DocType: DocField,Datetime,Datum vrijeme
+DocType: Email Group,Email Group,Email grupa
+apps/frappe/frappe/core/doctype/data_export/exporter.py,You can only upload upto 5000 records in one go. (may be less in some cases),Можете поднети највише 5000 записа одједном. (некада може бити и мање)
+apps/frappe/frappe/public/js/frappe/utils/utils.js,{0} Report,Izvještaj {0}
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Reports,Izvještaji
+DocType: Post,Comments,Komentari
+DocType: Workflow State,folder-open,folder-otvori
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,You can use Customize Form to set levels on fields.,Можете користити Прилагоди Формулар да подесите нивое на пољима.
+apps/frappe/frappe/public/js/frappe/model/model.js,Merge with existing,Spoji sa postojećim
+DocType: Print Settings,Send Print as PDF,Štampaj u PDF
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,My Settings,Moja podešavanja
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Email Inbox,Email primljene
+apps/frappe/frappe/core/page/dashboard/dashboard.js,{0} List,{0} Lista
+DocType: Report,Letter Head,Zaglavlje
+DocType: Workflow State,Home,Naslovna
+apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,Ime filtera već postoji
+apps/frappe/frappe/config/desktop.py,Users and Permissions,Korisnici i dozvole
+apps/frappe/frappe/public/js/frappe/desk.js,Session Expired,Sesija je istekla
+DocType: Communication,Received,Primljeno
+DocType: User,Login After,Prijava nakon
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,PDF,PDF
+DocType: Contact,Mobile No,Mobilni br.
+apps/frappe/frappe/public/js/frappe/ui/sort_selector.js,Most Used,Najviše korišćeno
+apps/frappe/frappe/email/doctype/email_account/email_account.js,"You are selecting Sync Option as ALL, It will resync all \
+				read as well as unread message from server. This may also cause the duplication\
+				of Communication (emails).","Постављате Начин усклађивања на СВЕ, што ће поново усклатиди све прочитане и непрочитане поруке са сервера. Ово може изазвати дупликате комуникација (мејлова)."
+apps/frappe/frappe/utils/data.py,{0} or {1},{0} {1} ili
+DocType: File,Is Attachments Folder,Da li je prilog folder
+DocType: Contact,Gender,Pol
+apps/frappe/frappe/templates/pages/integrations/payment-cancel.html,Payment Cancelled,Plaćenje otkazano
+DocType: DocField,Report Hide,Sakrij izvještaj
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Setup Auto Email,Podešavanje auto e-mail-a
+apps/frappe/frappe/contacts/doctype/address/address.py,Addresses,Adrese
+DocType: ToDo,Assigned By,Dodijelio od strane
+DocType: Contact,All,Svi
+DocType: Auto Email Report,Report Filters,Filteri na izvještaju
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,Prije {0} mjeseci
+DocType: Web Form,Allow Comments,Dozvoli komentare
+DocType: User,Login Before,Prijava prije
+apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Share With,Podijeli sa
+apps/frappe/frappe/public/js/frappe/model/model.js,Rename,Reimenuj
+DocType: Address,Links,Linkovi
+DocType: Contact,Is Primary Contact,Je primarni kontakt
+apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with everyone,Podijeljeno sa svima
+apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Clear Error Logs,Očisti Log grešaka
+DocType: DocShare,Everyone,Svi
+apps/frappe/frappe/public/js/frappe/views/treeview.js,You are not allowed to print this report,Немате дозволу да штампате овај извештај
+,Download Backups,Preuzmi rezervne kopije programa
+apps/frappe/frappe/public/js/frappe/ui/upload.html,Browse,Izaberi
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,Dodao je {0}
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Set,Set
+apps/frappe/frappe/desk/report/todo/todo.py,Assigned To/Owner,Dodijeljeno / Vlasnik
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Save As,Sačuvaj kao
+apps/frappe/frappe/model/naming.py,Naming Series mandatory,Vrsta dokumenta je obavezna
+apps/frappe/frappe/core/doctype/file/test_file.py,Test_Folder,Test_folder
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Select File Type,Odaberite tip datoteke
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Add Column,Dodaj kolonu
+DocType: Comment,Unshared,Nije podijeljen
+DocType: Help Article,Knowledge Base Editor,Urednik baze znanja
+DocType: Prepared Report,Report Name,Naziv izvještaja
+DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesija ističe u satima npr. 06:00
+DocType: Report,Report Builder,Generator izvještaja
+apps/frappe/frappe/desk/report/todo/todo.py,ID,ID
+DocType: Custom DocPerm,Cancel,Otkaži
+DocType: Contact,Sales Master Manager,Direktor prodaje
+DocType: Kanban Board Column,yellow,жуто
+DocType: DocField,Currency,Valuta
+DocType: Workflow State,Print,Štampaj
+DocType: Workflow State,Primary,Primarni
+DocType: ToDo,Medium,Srednji
+DocType: Workflow State,barcode,barkod
+DocType: Address,Reference,Vezni dokumenti
+DocType: Custom Role,Custom Role,Prilagođjena rola
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} from {1} to {2} in row #{3},{0} od {1} do {2} na poziciji # {3}
+DocType: Workflow State,User,Korisnik
+apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Za nastavak unesite lozinku
+DocType: File,File Size,Veličina fajla
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,About,O Nama
+apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,Немате дозволу да шаљете мејлове у вези са овим документом


### PR DESCRIPTION
After setting language code as `sr_SP`, the user used to get the following error while navigating to Global Defaults because `sr_SP` code is not supported by Babel(python package).
```
File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/__init__.py", line 90, in get_lang_dict
    return get_dict(fortype, name)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/translate.py", line 121, in get_dict
    message_dict.update(get_dict_from_hooks(fortype, name))
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/translate.py", line 139, in get_dict_from_hooks
    translated_dict.update(frappe.get_attr(method)())
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/geo/country_info.py", line 34, in get_translated_dict
    locale = Locale.parse(frappe.local.lang, sep="-")
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/babel/core.py", line 331, in parse
    raise UnknownLocaleError(input_id)
babel.core.UnknownLocaleError: unknown locale 'sr_SP'

```
Solution: Use sr_BA instead which is supported by Babel