### PR TITLE
fix: Error while customizing desk

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -227,7 +227,6 @@ def get_config(app, module):
 		items = []
 		for item in section["items"]:
 			if item["type"]=="report" and frappe.db.get_value("Report", item["name"], "disabled")==1:
-				section["items"].remove(item)
 				continue
 			if not item.get("label"):
 				item["label"] = _(item["name"])

--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -324,7 +324,8 @@ def get_desktop_settings():
 		all_links = get_links(module.app, module.module_name)
 		module_links_by_label = {}
 		for link in all_links:
-			module_links_by_label[link['label']] = link
+			if link.get('label'):
+				module_links_by_label[link['label']] = link
 
 		if module.module_name in user_saved_links_by_module:
 			user_links = frappe.parse_json(user_saved_links_by_module[module.module_name])

--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -228,7 +228,7 @@ def get_config(app, module):
 			if item["type"]=="report" and frappe.db.get_value("Report", item["name"], "disabled")==1:
 				section["items"].remove(item)
 				continue
-			if not "label" in item:
+			if not item.get("label"):
 				item["label"] = _(item["name"])
 
 	return sections
@@ -324,8 +324,7 @@ def get_desktop_settings():
 		all_links = get_links(module.app, module.module_name)
 		module_links_by_label = {}
 		for link in all_links:
-			if link.get('label'):
-				module_links_by_label[link['label']] = link
+			module_links_by_label[link['label']] = link
 
 		if module.module_name in user_saved_links_by_module:
 			user_links = frappe.parse_json(user_saved_links_by_module[module.module_name])

--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -224,12 +224,15 @@ def get_config(app, module):
 	sections = [s for s in config if s.get("condition", True)]
 
 	for section in sections:
+		items = []
 		for item in section["items"]:
 			if item["type"]=="report" and frappe.db.get_value("Report", item["name"], "disabled")==1:
 				section["items"].remove(item)
 				continue
 			if not item.get("label"):
 				item["label"] = _(item["name"])
+			items.append(item)
+		section['items'] = items
 
 	return sections
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/desk/moduleview.py", line 339, in get_desktop_settings
    for m in user_modules if modules_by_name.get(m)]
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/desk/moduleview.py", line 339, in 
    for m in user_modules if modules_by_name.get(m)]
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/desk/moduleview.py", line 327, in apply_user_saved_links
    module_links_by_label[link['label']] = link
KeyError: 'label'
```