### PR TITLE
fix: Allow only owner or admin to delete comment

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -370,11 +370,8 @@ frappe.ui.form.Timeline = class Timeline {
 		c["delete"] = "";
 		c["edit"] = "";
 		if(c.communication_type=="Comment" && (c.comment_type || "Comment") === "Comment") {
-			if(frappe.model.can_delete("Comment")) {
-				c["delete"] = '<a class="close delete-comment" title="Delete"  href="#"><i class="octicon octicon-x"></i></a>';
-			}
-
 			if(frappe.user.name == c.sender || (frappe.user.name == 'Administrator')) {
+				c["delete"] = '<a class="close delete-comment" title="Delete"  href="#"><i class="octicon octicon-x"></i></a>';
 				c["edit"] = '<a class="edit-comment text-muted" title="Edit" href="#">Edit</a>';
 			}
 		}


### PR DESCRIPTION
Problem:
Currently, anyone can delete any other person's comment irrespective of the role. 
`can_delete` does not consider `if_owner` permission

Solution:
Delete and Edit should have same permissions, only the owner and Administrator should be allowed to delete the comment.