### PR TITLE
fix: Duplicate items in menu dropdown

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -380,14 +380,16 @@ frappe.ui.Page = Class.extend({
 	* @param {string} selector - CSS Selector of the button to be searched for. By default, it is `li`.
 	* @param {string} label - Label of the button
 	*/
-	is_in_group_button_dropdown: function(parent, selector, label){
+	is_in_group_button_dropdown: function(parent, selector, label) {
+
 		if (!selector) selector = 'li';
 
 		if (!label || !parent) return false;
 
 		const result = $(parent).find(`${selector}:contains('${label}')`)
 			.filter(function() {
-				return $(this).text() === label;
+				let item = $(this).html();
+				return $(item).attr('data-label') === label;
 			});
 		return result.length > 0;
 	},


### PR DESCRIPTION
After addition of keyboard shortcuts innerText of menu items changed due to which duplicate items were not filtered properly

Used data-label attribute to compare labels

Befor:
![Screenshot 2019-08-15 at 11 31 38 AM](https://user-images.githubusercontent.com/42651287/63075705-38a2e800-bf50-11e9-98fd-0bd96b1f35a3.png)

After: 
![Screenshot 2019-08-15 at 11 12 40 AM](https://user-images.githubusercontent.com/42651287/63075710-3c366f00-bf50-11e9-8502-cd0a23e3946f.png)
