### PR TITLE
fix: Use fieldname instead of name for preview_fields

### DIFF
--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -13,7 +13,7 @@ def get_preview_data(doctype, docname):
 
 	# no preview fields defined, build list from mandatory fields
 	if not preview_fields:
-		preview_fields = [field.name for field in meta.fields if field.reqd]
+		preview_fields = [field.fieldname for field in meta.fields if field.reqd]
 
 	title_field = meta.get_title_field()
 	image_field = meta.image_field


### PR DESCRIPTION
backport of: https://github.com/frappe/frappe/pull/8175

Also fixes: https://github.com/frappe/erpnext/issues/18724

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/desk/link_preview.py", line 27, in get_preview_data
    }, fields=preview_fields, limit=1)
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/__init__.py", line 1264, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/model/db_query.py", line 95, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/model/db_query.py", line 129, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/home/frappe/benches/bench-2019-08-14/apps/frappe/frappe/database/database.py", line 171, in sql
    self._cursor.execute(query)
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2019-08-14/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column '499712c122' in 'field list'")
```