### PR TITLE
fix(ListView): trigger primary function on btn-new-doc

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -984,7 +984,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	setup_new_doc_event() {
-		this.$no_result.find('.btn-new-doc').click(() => this.make_new_doc());
+		this.$no_result.find('.btn-new-doc').click(() => {
+			if (this.settings.primary_action) {
+				this.settings.primary_action();
+			} else {
+				this.make_new_doc();
+			}
+		});
 	}
 
 	setup_tag_event() {


### PR DESCRIPTION
`.btn-new-doc` in listview did not trigger primary_action mentioned in `_list.js`

#### before fix:
- The `.btn-new-doc` did not trigger primary action mentioned in `_list.js`.
![commm-f-b](https://user-images.githubusercontent.com/7310479/63143232-e96dbd80-c00a-11e9-92f9-1a7df3a84f9f.gif)

#### after fix:
- The `.btn-new-doc` now triggers primary action mentioned in `_list.js` else triggers new_doc.
![commm-f](https://user-images.githubusercontent.com/7310479/63143103-546ac480-c00a-11e9-965a-3f05761065b7.gif)
