### PR TITLE
fix(minor): Changed error message display in printview

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -1,31 +1,31 @@
 // Copyright (c) 2017, Frappe Technologies and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on("Print Format", "onload", function(frm) {
+frappe.ui.form.on("Print Format", "onload", function (frm) {
 	frm.add_fetch("doc_type", "module", "module");
 });
 
 frappe.ui.form.on("Print Format", {
-	refresh: function(frm) {
+	refresh: function (frm) {
 		frm.set_intro("");
 		frm.toggle_enable(["html", "doc_type", "module"], false);
-		if (frappe.session.user==="Administrator" || frm.doc.standard==="No") {
+		if (frappe.session.user === "Administrator" || frm.doc.standard === "No") {
 			frm.toggle_enable(["html", "doc_type", "module"], true);
 			frm.enable_save();
 		}
 
-		if(frm.doc.standard==="Yes" && frappe.session.user !== "Administrator") {
+		if (frm.doc.standard === "Yes" && frappe.session.user !== "Administrator") {
 			frm.set_intro(__("Please duplicate this to make changes"));
 		}
 		frm.trigger('render_buttons');
 		frm.toggle_display('standard', frappe.boot.developer_mode);
 	},
-	render_buttons: function(frm) {
+	render_buttons: function (frm) {
 		frm.page.clear_inner_toolbar();
-		if(!frm.is_new()) {
-			if(!frm.doc.custom_format) {
-				frm.add_custom_button(__("Edit Format"), function() {
-					if(!frm.doc.doc_type) {
+		if (!frm.is_new()) {
+			if (!frm.doc.custom_format) {
+				frm.add_custom_button(__("Edit Format"), function () {
+					if (!frm.doc.doc_type) {
 						frappe.msgprint(__("Please select DocType first"));
 						return;
 					}
@@ -35,7 +35,7 @@ frappe.ui.form.on("Print Format", {
 			else if (frm.doc.custom_format && !frm.doc.raw_printing) {
 				frm.set_df_property("html", "reqd", 1);
 			}
-			frm.add_custom_button(__("Make Default"), function() {
+			frm.add_custom_button(__("Make Default"), function () {
 				frappe.call({
 					method: "frappe.printing.doctype.print_format.print_format.make_default",
 					args: {
@@ -45,8 +45,8 @@ frappe.ui.form.on("Print Format", {
 			});
 		}
 	},
-	custom_format: function(frm) {
-		var value = frm.doc.custom_format ? 0:1;
+	custom_format: function (frm) {
+		var value = frm.doc.custom_format ? 0 : 1;
 		frm.set_value('align_labels_right', value);
 		frm.set_value('show_section_headings', value);
 		frm.set_value('line_breaks', value);

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -32,6 +32,9 @@ frappe.ui.form.on("Print Format", {
 					frappe.set_route("print-format-builder", frm.doc.name);
 				});
 			}
+			else if (frm.doc.custom_format && !frm.doc.raw_printing) {
+				frm.set_df_property("html", "reqd", 1);
+			}
 			frm.add_custom_button(__("Make Default"), function() {
 				frappe.call({
 					method: "frappe.printing.doctype.print_format.print_format.make_default",

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -11,8 +11,6 @@ from frappe.utils.jinja import validate_template
 
 from frappe.model.document import Document
 
-class MissingHTML(frappe.ValidationError): pass
-
 class PrintFormat(Document):
 	def validate(self):
 		if (self.standard=="Yes"
@@ -33,10 +31,11 @@ class PrintFormat(Document):
 		if self.html and self.print_format_type != 'JS':
 			validate_template(self.html)
 
-		if self.custom_format and not self.raw_printing and not self.html:
-			frappe.throw(_
-				("Enabling Custom Format without Raw Printing requires some HTML. Please populate the HTML field."),
-					MissingHTML)
+		if self.custom_format and self.raw_printing and not self.raw_commands:
+			frappe.throw(_('{0} are required').format(frappe.bold(_('Raw Commands'))), frappe.MandatoryError)
+
+		if self.custom_format and not self.html:
+			frappe.throw(_('{0} is required').format(frappe.bold(_('HTML'))), frappe.MandatoryError)
 
 	def extract_images(self):
 		from frappe.core.doctype.file.file import extract_images_from_html

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -6,9 +6,12 @@ from __future__ import unicode_literals
 import frappe
 import frappe.utils
 import json
+from frappe import _
 from frappe.utils.jinja import validate_template
 
 from frappe.model.document import Document
+
+class MissingHTML(frappe.ValidationError): pass
 
 class PrintFormat(Document):
 	def validate(self):
@@ -29,6 +32,11 @@ class PrintFormat(Document):
 
 		if self.html and self.print_format_type != 'JS':
 			validate_template(self.html)
+
+		if self.custom_format and not self.raw_printing and not self.html:
+			frappe.throw(_
+				("Enabling Custom Format without Raw Printing requires some HTML. Please populate the HTML field."),
+					MissingHTML)
 
 	def extract_images(self):
 		from frappe.core.doctype.file.file import extract_images_from_html

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -200,7 +200,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 		var me = this;
 		this.get_print_html(out => {
 			if (!out.html) {
-				out.html = this.get_no_preview_html()
+				out.html = this.get_no_preview_html();
 			}
 			const $print_format = me.wrapper.find(".print-format");
 			$print_format.html(out.html);
@@ -313,7 +313,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 		if (print_format.raw_printing) {
 			callback({
 				html: this.get_no_preview_html()
-			})
+			});
 			return;
 		}
 		if (this._req) {
@@ -337,7 +337,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 	get_no_preview_html() {
 		return `<div class="text-muted text-center" style="font-size: 1.2em;">
 			${__("No Preview Available")}
-		</div>`
+		</div>` ;
 	},
 	get_raw_commands: function (callback) {
 		// fetches rendered raw commands from the server for the current print format.

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -198,7 +198,10 @@ frappe.ui.form.PrintPreview = Class.extend({
 	},
 	preview: function () {
 		var me = this;
-		this.get_print_html(function (out) {
+		this.get_print_html(out => {
+			if (!out.html) {
+				out.html = this.get_no_preview_html()
+			}
 			const $print_format = me.wrapper.find(".print-format");
 			$print_format.html(out.html);
 			me.show_footer();
@@ -306,6 +309,13 @@ frappe.ui.form.PrintPreview = Class.extend({
 		}
 	},
 	get_print_html: function (callback) {
+		let print_format = this.get_print_format();
+		if (print_format.raw_printing) {
+			callback({
+				html: this.get_no_preview_html()
+			})
+			return;
+		}
 		if (this._req) {
 			this._req.abort();
 		}
@@ -323,6 +333,11 @@ frappe.ui.form.PrintPreview = Class.extend({
 				}
 			}
 		});
+	},
+	get_no_preview_html() {
+		return `<div class="text-muted text-center" style="font-size: 1.2em;">
+			${__("No Preview Available")}
+		</div>`
 	},
 	get_raw_commands: function (callback) {
 		// fetches rendered raw commands from the server for the current print format.

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -254,14 +254,8 @@ def get_print_format(doctype, print_format):
 		elif print_format.raw_commands and print_format.raw_printing:
 			return print_format.raw_commands
 		else:
-			return """
-			<html>
-			<div class="text-muted text-center" style="font-size: 2em; margin-top: 80px;">
-			<p>No HTML Template found</p>
-			<p>Please add some HTML code in the current Print Format</p>
-			</div>
-			</html>
-			"""
+			frappe.throw(_("No template found at path: {0}").format(path),
+				frappe.TemplateNotFoundError)
 
 def make_layout(doc, meta, format_data=None):
 	"""Builds a hierarchical layout object from the fields list to be rendered

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -185,16 +185,15 @@ def get_html_and_style(doc, name=None, print_format=None, meta=None,
 
 	print_format = get_print_format_doc(print_format, meta=meta or frappe.get_meta(doc.doctype))
 
-	if print_format and print_format.raw_printing:
-		return {
-			"html": '<div class="text-muted text-center" style="font-size: 2em; margin-top: 80px;">'
-		+ _("No Preview Available")
-		+ '</div>'
-		}
+	try:
+		html = get_rendered_template(doc, name=name, print_format=print_format, meta=meta,
+			no_letterhead=no_letterhead, trigger_print=trigger_print)
+	except frappe.TemplateNotFoundError:
+		frappe.clear_last_message()
+		html = None
 
 	return {
-		"html": get_rendered_template(doc, name=name, print_format=print_format, meta=meta,
-	no_letterhead=no_letterhead, trigger_print=trigger_print),
+		"html": html,
 		"style": get_print_style(style=style, print_format=print_format)
 	}
 
@@ -249,13 +248,13 @@ def get_print_format(doctype, print_format):
 		with open(path, "r") as pffile:
 			return pffile.read()
 	else:
-		if print_format.html and not print_format.raw_printing:
-			return print_format.html
-		elif print_format.raw_commands and print_format.raw_printing:
+		if print_format.raw_printing:
 			return print_format.raw_commands
-		else:
-			frappe.throw(_("No template found at path: {0}").format(path),
-				frappe.TemplateNotFoundError)
+		if print_format.html:
+			return print_format.html
+
+		frappe.throw(_("No template found at path: {0}").format(path),
+			frappe.TemplateNotFoundError)
 
 def make_layout(doc, meta, format_data=None):
 	"""Builds a hierarchical layout object from the fields list to be rendered

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -254,8 +254,14 @@ def get_print_format(doctype, print_format):
 		elif print_format.raw_commands and print_format.raw_printing:
 			return print_format.raw_commands
 		else:
-			frappe.throw(_("No template found at path: {0}").format(path),
-				frappe.TemplateNotFoundError)
+			return """
+			<html>
+			<div class="text-muted text-center" style="font-size: 2em; margin-top: 80px;">
+			<p>No HTML Template found</p>
+			<p>Please add some HTML code in the current Print Format</p>
+			</div>
+			</html>
+			"""
 
 def make_layout(doc, meta, format_data=None):
 	"""Builds a hierarchical layout object from the fields list to be rendered


### PR DESCRIPTION
Error will be prompted in the printview of selected print format rather than a pop-up with the file path in it.
![image](https://user-images.githubusercontent.com/25857446/63246223-d6175800-c27f-11e9-8b8b-5bb109026d4c.png)
