### PR TITLE
fix: fix reverse list order on firefox

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -125,9 +125,10 @@ frappe.views.ListGroupBy = class ListGroupBy {
 		return frappe.call('frappe.desk.listview.get_group_by_count', args).then((r) => {
 			let field_counts = r.message || [];
 			field_counts = field_counts.filter(f => f.count !== 0);
-			if (field === 'assigned_to') {
-				field_counts = field_counts.filter(f => !['Guest', 'Administrator'].includes(f.name));
-			}
+			let current_user = field_counts.find(f => f.name === frappe.session.user);
+			field_counts = field_counts.filter(f => !['Guest', 'Administrator', frappe.session.user].includes(f.name));
+			// Set frappe.session.user on top of the list
+			if(current_user) field_counts.unshift(current_user);
 			return field_counts;
 		});
 	}
@@ -152,9 +153,6 @@ frappe.views.ListGroupBy = class ListGroupBy {
 				<input type="text" placeholder="${__('Search')}" class="form-control dropdown-search-input input-xs">
 			</div>
 		`;
-
-		// Sort and set frappe.session.user on top of the list
-		fields.sort((item) => item.name ===  frappe.session.user ? -1 : 1);
 
 		let dropdown_html = standard_html + fields.map(get_dropdown_html).join('');
 		dropdown.html(dropdown_html);

--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -128,7 +128,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 			let current_user = field_counts.find(f => f.name === frappe.session.user);
 			field_counts = field_counts.filter(f => !['Guest', 'Administrator', frappe.session.user].includes(f.name));
 			// Set frappe.session.user on top of the list
-			if(current_user) field_counts.unshift(current_user);
+			if (current_user) field_counts.unshift(current_user);
 			return field_counts;
 		});
 	}


### PR DESCRIPTION
Order is now descending:

![Screen Shot 2019-08-19 at 12 59 41 PM](https://user-images.githubusercontent.com/19775888/63246879-4d012080-c281-11e9-938e-00ce5eb37984.png)
