### PR TITLE
feat: Add events for Workflow Action

### DIFF
--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -90,12 +90,18 @@ frappe.ui.form.States = Class.extend({
 				if(frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function() {
-						frappe.xcall('frappe.model.workflow.apply_workflow',
-							{doc: me.frm.doc, action: d.action})
-							.then((doc) => {
-								frappe.model.sync(doc);
-								me.frm.refresh();
-							});
+						// set the workflow_action for use in form scripts
+						me.frm.selected_workflow_action = d.action;
+						me.frm.script_manager.trigger('before_workflow_action').then(() => {
+							frappe.xcall('frappe.model.workflow.apply_workflow',
+								{doc: me.frm.doc, action: d.action})
+								.then((doc) => {
+									frappe.model.sync(doc);
+									me.frm.refresh();
+									me.frm.selected_workflow_action = null;
+									me.frm.script_manager.trigger("after_workflow_action");
+								});
+						});
 					});
 				}
 			});


### PR DESCRIPTION
Documents that have workflow active don't fire the `before_submit` and related events. This PR adds two events for workflow actions.

- before_workflow_action
- after_workflow_action
- frm.selected_workflow_action contains the name of the Workflow Action that is triggered

![image](https://user-images.githubusercontent.com/9355208/63273856-5bb8f900-c2bc-11e9-91d4-0999db4d79c9.png)
