### PR TITLE
feat: Support wkhtmltopdf options "page-size" and "orientation"

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -116,9 +116,13 @@ def read_options_from_html(html):
 	toggle_visible_pdf(soup)
 
 	# use regex instead of soup-parser
-	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size", "header-spacing"):
+	for attr in (("page-size",), ("orientation",), 
+		     ("margin-top", "mm"), ("margin-bottom", "mm"), ("margin-left", "mm"), 
+		     ("margin-right", "mm"), ("header-spacing", "mm")):
+		unit = attr[1] if len(attr) == 2 else ""
+		attr = attr[0]
 		try:
-			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
+			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(" + str(unit) + r";)")
 			match = pattern.findall(html)
 			if match:
 				options[attr] = str(match[-1][3]).strip()

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -116,9 +116,9 @@ def read_options_from_html(html):
 	toggle_visible_pdf(soup)
 
 	# use regex instead of soup-parser
-	for attr in (("page-size",), ("orientation",), 
-		     ("margin-top", "mm"), ("margin-bottom", "mm"), ("margin-left", "mm"), 
-		     ("margin-right", "mm"), ("header-spacing", "mm")):
+	for attr in (("page-size",), ("orientation",),
+		     ("page-width", "mm"), ("page-height", "mm"), ("header-spacing", "mm")
+		     ("margin-top", "mm"), ("margin-bottom", "mm"), ("margin-left", "mm"), ("margin-right", "mm")):
 		unit = attr[1] if len(attr) == 2 else ""
 		attr = attr[0]
 		try:


### PR DESCRIPTION
This change consists of two parts:
1. Fix the hardcoded regex that assumes unit "mm" for all options. This is not a valid unit for "page-size" (A4, A5, A6...)
2. Add support for option "orientation": Landscape | Portrait (default)
