### PR TITLE
fix: Response fix in chat message seen function

### DIFF
--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -148,7 +148,7 @@ def seen(message, user = None):
 		mess.add_seen(user)
 		mess.load_from_db()
 		room = mess.room
-		resp = dict(message = message, data = dict(seen = json.loads(mess._seen)))
+		resp = dict(message = message, data = dict(seen = json.loads(mess._seen) if mess._seen else []))
 
 		frappe.publish_realtime('frappe.chat.message:update', resp, room = room, after_commit = True)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/chat/doctype/chat_message/chat_message.py", line 151, in seen
    resp = dict(message = message, data = dict(seen = json.loads(mess._seen)))
  File "/usr/lib64/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'NoneType'
```