### PR TITLE
feat: check email account while pulling email inbox and show distinct messages on timeline

### DIFF
--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -150,7 +150,8 @@ class TestCommunication(unittest.TestCase):
 			"doctype": "Communication",
 			"communication_type": "Communication",
 			"content": "Test Get Communication Data 1",
-			"communication_medium": "Email"
+			"communication_medium": "Email",
+			"message_id": frappe.generate_hash()
 		}).insert(ignore_permissions=True)
 
 		comm_note_1.add_link(link_doctype="Note", link_name=note.name, autosave=True)
@@ -159,7 +160,8 @@ class TestCommunication(unittest.TestCase):
 			"doctype": "Communication",
 			"communication_type": "Communication",
 			"content": "Test Get Communication Data 2",
-			"communication_medium": "Email"
+			"communication_medium": "Email",
+			"message_id": frappe.generate_hash()
 		}).insert(ignore_permissions=True)
 
 		comm_note_2.add_link(link_doctype="Note", link_name=note.name, autosave=True)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -161,7 +161,7 @@ def get_communication_data(doctype, name, start=0, limit=20, after=None, fields=
 	'''Returns list of communications for a given document'''
 	if not fields:
 		fields = '''
-			distinct C.message_id, C.name, C.communication_type, C.communication_medium,
+			C.message_id, C.name, C.communication_type, C.communication_medium,
 			C.comment_type, C.communication_date, C.content,
 			C.sender, C.sender_full_name, C.cc, C.bcc,
 			C.creation AS creation, C.subject, C.delivery_status,
@@ -199,6 +199,11 @@ def get_communication_data(doctype, name, start=0, limit=20, after=None, fields=
 		AND `tabCommunication Link`.link_doctype = %(doctype)s AND `tabCommunication Link`.link_name = %(name)s
 		{conditions}
 	'''.format(fields=fields, conditions=conditions)
+
+	#add goup by to pull distinct communications
+
+	if not group_by:
+		group_by = 'group by message_id'
 
 	communications = frappe.db.sql('''
 		SELECT *

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -161,7 +161,7 @@ def get_communication_data(doctype, name, start=0, limit=20, after=None, fields=
 	'''Returns list of communications for a given document'''
 	if not fields:
 		fields = '''
-			C.name, C.communication_type, C.communication_medium,
+			distinct C.message_id, C.name, C.communication_type, C.communication_medium,
 			C.comment_type, C.communication_date, C.content,
 			C.sender, C.sender_full_name, C.cc, C.bcc,
 			C.creation AS creation, C.subject, C.delivery_status,

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -346,9 +346,9 @@ class EmailAccount(Document):
 		if email.message_id:
 			# https://stackoverflow.com/a/18367248
 			names = frappe.db.sql("""SELECT DISTINCT `name`, `creation` FROM `tabCommunication`
-				WHERE `message_id`='{message_id}'
+				WHERE `message_id`='{message_id}' and email_account='{email_account}'
 				ORDER BY `creation` DESC LIMIT 1""".format(
-					message_id=email.message_id
+					message_id=email.message_id, email_account=self.name
 				), as_dict=True)
 
 			if names:

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -11,6 +11,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, split_emails
 from frappe.utils.background_jobs import enqueue
+from rq.timeouts import JobTimeoutException
 from botocore.exceptions import ClientError
 
 class S3BackupSettings(Document):


### PR DESCRIPTION
## Scenario 1:  Consider Email Account while pulling emails

**Case**: We have three users User A, User B and User C. Out of these three users, User B and User C have configured Email Inbox. User A had sent email to User B and User C. 

**Issue**: As we only check Message-Id while syncing, the system creates only one communication record perhaps only one user able to see an email in their Inbox.

*User B Gmail Inbox:*
<img width="1045" alt="Screen Shot 2019-08-20 at 1 16 46 PM" src="https://user-images.githubusercontent.com/3784093/63327950-dc273a80-c34c-11e9-9173-039833ed19de.png">

*User B's Inbox in Frappe:*
<img width="996" alt="Screen Shot 2019-08-20 at 1 15 25 PM" src="https://user-images.githubusercontent.com/3784093/63327989-ecd7b080-c34c-11e9-9e2b-2b44f067a66b.png">

*User C Gmail Inbox:*
<img width="1038" alt="Screen Shot 2019-08-20 at 1 17 04 PM" src="https://user-images.githubusercontent.com/3784093/63328026-00831700-c34d-11e9-967e-f814bcc45eba.png">

*User C's Inbox in Frappe:*
<img width="958" alt="Screen Shot 2019-08-20 at 1 15 10 PM" src="https://user-images.githubusercontent.com/3784093/63328036-0678f800-c34d-11e9-8a9f-e8a391dc1359.png">


**Resolution**: Check Email Account while syncing messages. 

*User B's Inbox in Frappe:*
<img width="973" alt="Screen Shot 2019-08-20 at 1 22 41 PM" src="https://user-images.githubusercontent.com/3784093/63328405-bb131980-c34d-11e9-8b2e-3c4af76b5170.png">

*User C's Inbox in Frappe:*
<img width="977" alt="Screen Shot 2019-08-20 at 1 22 59 PM" src="https://user-images.githubusercontent.com/3784093/63328420-c1a19100-c34d-11e9-9e86-e17d27ed5d9c.png">

---

## Scenario 2: Show distinct communications on a timeline

**Issue**: As now the system syncs the same message for multiple inboxes, this affects timeline representation by showing the same message multiple time.

<img width="483" alt="Screen Shot 2019-08-20 at 1 28 38 PM" src="https://user-images.githubusercontent.com/3784093/63331996-6b841c00-c354-11e9-8424-c82f27494296.png">

**Resolution**: Group communications based on the Message-ID

<img width="638" alt="Screen Shot 2019-08-20 at 2 11 07 PM" src="https://user-images.githubusercontent.com/3784093/63332075-89ea1780-c354-11e9-8640-3cc70d13d85a.png">






