### PR TITLE
fix: Underline anchor tags in msgprint

### DIFF
--- a/frappe/public/less/common.less
+++ b/frappe/public/less/common.less
@@ -161,6 +161,10 @@ a.badge-hover& {
 	pre {
 		text-align: left;
 	}
+
+	a:not(.btn) {
+		text-decoration: underline;
+	}
 }
 
 .centered {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9355208/63349770-ba907800-c379-11e9-8c3f-8e0f2e43d8bd.png)
