### PR TITLE
fix: web_view section disabled on checking custom field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -397,6 +397,7 @@
    "oldfieldtype": "Check"
   },
   {
+   "depends_on": "eval:doc.custom===0",
    "fieldname": "web_view",
    "fieldtype": "Section Break",
    "label": "Web View"
@@ -449,15 +450,15 @@
    "label": "Is Tree"
   },
   {
+   "depends_on": "is_tree",
    "fieldname": "nsm_parent_field",
    "fieldtype": "Data",
-   "label": "Parent Field (Tree)",
-   "depends_on": "is_tree"
+   "label": "Parent Field (Tree)"
   }
  ],
  "icon": "fa fa-bolt",
  "idx": 6,
- "modified": "2019-09-02 05:52:29.411525",
+ "modified": "2019-09-07 14:28:05.392490",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",


### PR DESCRIPTION
`Custom` Field:
![Screenshot 2019-09-07 at 3 49 03 PM](https://user-images.githubusercontent.com/36654812/64473724-ca84c600-d187-11e9-94bb-8cd25ba995cc.png)

`Custom` field is checked:
![Screenshot 2019-09-07 at 3 48 19 PM](https://user-images.githubusercontent.com/36654812/64473653-14b97780-d187-11e9-9b29-e75806d1b8a6.png)

`Custom` field is unchecked:
![Screenshot 2019-09-07 at 3 48 40 PM](https://user-images.githubusercontent.com/36654812/64473654-14b97780-d187-11e9-93b5-180056b9fd0c.png)

