### PR TITLE
fix: Add date for last period if results exists

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -137,7 +137,7 @@ def add_missing_values(data, timegrain, from_date, to_date):
 			next_expected_date = get_next_expected_date(next_expected_date, timegrain)
 
 	# add date for the last period (if missing)
-	if get_period_ending(to_date, timegrain) > result[-1][0]:
+	if result and get_period_ending(to_date, timegrain) > result[-1][0]:
 		result.append([get_period_ending(to_date, timegrain), 0.0])
 
 	return result


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/core/page/dashboard/dashboard.py", line 20, in wrapper
    results = generate_and_cache_results(chart_name, function, cache_key)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/core/page/dashboard/dashboard.py", line 25, in generate_and_cache_results
    results = function(chart_name)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py", line 60, in get
    result = add_missing_values(result, timegrain, from_date, to_date)
  File "/home/frappe/benches/bench-version-12-2019-08-13/apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py", line 140, in add_missing_values
    if get_period_ending(to_date, timegrain) > result[-1][0]:
IndexError: list index out of range
```
