### PR TITLE
[v11] feat: check email account while pulling email inbox and show distinct messages on timeline

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -71,12 +71,7 @@ def make(doctype=None, name=None, content=None, subject=None, sent_or_received =
 		"message_id":get_message_id().strip(" <>"),
 		"read_receipt":read_receipt,
 		"has_attachment": 1 if attachments else 0
-	})
-	comm.insert(ignore_permissions=True)
-
-	if not doctype:
-		# if no reference given, then send it against the communication
-		comm.db_set(dict(reference_doctype='Communication', reference_name=comm.name))
+	}).insert(ignore_permissions=True)
 
 	if isinstance(attachments, string_types):
 		attachments = json.loads(attachments)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -144,7 +144,7 @@ def get_communication_data(doctype, name, start=0, limit=20, after=None, fields=
 			timeline_doctype, timeline_name,
 			reference_doctype, reference_name,
 			link_doctype, link_name, read_by_recipient,
-			rating, "Communication" as doctype'''
+			rating, "Communication" as doctype, message_id'''
 
 	conditions = '''communication_type in ("Communication", "Comment", "Feedback")
 			and (
@@ -158,6 +158,9 @@ def get_communication_data(doctype, name, start=0, limit=20, after=None, fields=
 					and comment_type in ("Created", "Updated", "Submitted", "Cancelled", "Deleted")
 				)))
 			)'''
+
+	if not group_by:
+		group_by = 'group by message_id'
 
 
 	if after:

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -344,9 +344,9 @@ class EmailAccount(Document):
 
 		if email.message_id:
 			names = frappe.db.sql("""select distinct name from tabCommunication
-				where message_id='{message_id}'
+				where message_id='{message_id}' and email_account='{email_account}'
 				order by creation desc limit 1""".format(
-					message_id=email.message_id
+					message_id=email.message_id, email_account=self.name
 				), as_dict=True)
 
 			if names:


### PR DESCRIPTION
## Scenario 1:  Consider Email Account while pulling emails

**Case**: We have three users User A, User B and User C. Out of these three users, User B and User C have configured Email Inbox. User A had sent email to User B and User C. 

**Issue**: As we only check Message-Id while syncing, the system creates only one communication record perhaps only one user able to see an email in their Inbox.

*User B Gmail Inbox:*
<img width="1045" alt="Screen Shot 2019-08-20 at 1 16 46 PM" src="https://user-images.githubusercontent.com/3784093/63327950-dc273a80-c34c-11e9-9173-039833ed19de.png">

*User B's Inbox in Frappe:*
<img width="996" alt="Screen Shot 2019-08-20 at 1 15 25 PM" src="https://user-images.githubusercontent.com/3784093/63327989-ecd7b080-c34c-11e9-9e2b-2b44f067a66b.png">

*User C Gmail Inbox:*
<img width="1038" alt="Screen Shot 2019-08-20 at 1 17 04 PM" src="https://user-images.githubusercontent.com/3784093/63328026-00831700-c34d-11e9-967e-f814bcc45eba.png">

*User C's Inbox in Frappe:*
<img width="958" alt="Screen Shot 2019-08-20 at 1 15 10 PM" src="https://user-images.githubusercontent.com/3784093/63328036-0678f800-c34d-11e9-8a9f-e8a391dc1359.png">


**Resolution**: Check Email Account while syncing messages. 

*User B's Inbox in Frappe:*
<img width="973" alt="Screen Shot 2019-08-20 at 1 22 41 PM" src="https://user-images.githubusercontent.com/3784093/63328405-bb131980-c34d-11e9-8b2e-3c4af76b5170.png">

*User C's Inbox in Frappe:*
<img width="977" alt="Screen Shot 2019-08-20 at 1 22 59 PM" src="https://user-images.githubusercontent.com/3784093/63328420-c1a19100-c34d-11e9-9e86-e17d27ed5d9c.png">

---

## Scenario 2: Show distinct communications on a timeline

**Issue**: As now the system syncs the same message for multiple inboxes, this affects timeline representation by showing the same message multiple time.

<img width="483" alt="Screen Shot 2019-08-20 at 1 28 38 PM" src="https://user-images.githubusercontent.com/3784093/63331996-6b841c00-c354-11e9-8424-c82f27494296.png">

**Resolution**: Group communications based on the Message-ID

<img width="638" alt="Screen Shot 2019-08-20 at 2 11 07 PM" src="https://user-images.githubusercontent.com/3784093/63332075-89ea1780-c354-11e9-8640-3cc70d13d85a.png">
