### PR TITLE
feat: allow toggle sidebar to be persistent using local storage

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -3,7 +3,6 @@ frappe.provide('frappe.views');
 frappe.views.BaseList = class BaseList {
 	constructor(opts) {
 		Object.assign(this, opts);
-		this.show_sidebar = JSON.parse(localStorage.show_sidebar || 'true');
 	}
 
 	show() {
@@ -200,15 +199,15 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	toggle_side_bar() {
-		this.show_sidebar = !this.show_sidebar
-		localStorage.show_sidebar = this.show_sidebar;
+		let show_sidebar = JSON.parse(localStorage.show_sidebar || 'true');
+		show_sidebar = !show_sidebar
+		localStorage.show_sidebar = show_sidebar;
 		this.show_or_hide_sidebar()
 	}
 
 	show_or_hide_sidebar() {
-		this.list_sidebar.parent.toggleClass('hide', !this.show_sidebar);
-		cur_list.page.current_view.find('.layout-main-section-wrapper').toggleClass('col-md-10', this.show_sidebar)
-		cur_list.page.current_view.find('.layout-main-section-wrapper').toggleClass('col-md-12', this.show_sidebar)
+		let show_sidebar = JSON.parse(localStorage.show_sidebar || 'true');
+		$(document.body).toggleClass('no-sidebar', !show_sidebar);
 	}
 
 	setup_main_section() {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -200,9 +200,9 @@ frappe.views.BaseList = class BaseList {
 
 	toggle_side_bar() {
 		let show_sidebar = JSON.parse(localStorage.show_sidebar || 'true');
-		show_sidebar = !show_sidebar
+		show_sidebar = !show_sidebar;
 		localStorage.show_sidebar = show_sidebar;
-		this.show_or_hide_sidebar()
+		this.show_or_hide_sidebar();
 	}
 
 	show_or_hide_sidebar() {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -3,6 +3,7 @@ frappe.provide('frappe.views');
 frappe.views.BaseList = class BaseList {
 	constructor(opts) {
 		Object.assign(this, opts);
+		this.show_sidebar = JSON.parse(localStorage.show_sidebar || 'true');
 	}
 
 	show() {
@@ -199,13 +200,26 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	toggle_side_bar() {
-		this.list_sidebar.parent.toggleClass('hide');
-		this.page.current_view.find('.layout-main-section-wrapper').toggleClass('col-md-10 col-md-12');
+		this.show_sidebar = !this.show_sidebar
+		localStorage.show_sidebar = this.show_sidebar;
+		this.list_sidebar.parent.toggle(this.show_sidebar);
+		this.set_list_width()
+	}
+
+	set_list_width() {
+		if (!this.show_sidebar) {
+			cur_list.page.current_view.find('.layout-main-section-wrapper').removeClass('col-md-10')
+			cur_list.page.current_view.find('.layout-main-section-wrapper').addClass('col-md-12')
+		} else {
+			cur_list.page.current_view.find('.layout-main-section-wrapper').removeClass('col-md-12')
+			cur_list.page.current_view.find('.layout-main-section-wrapper').addClass('col-md-10')
+		}
 	}
 
 	setup_main_section() {
 		return frappe.run_serially([
 			this.setup_list_wrapper,
+			this.set_list_width,
 			this.setup_filter_area,
 			this.setup_sort_selector,
 			this.setup_result_area,

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -202,24 +202,19 @@ frappe.views.BaseList = class BaseList {
 	toggle_side_bar() {
 		this.show_sidebar = !this.show_sidebar
 		localStorage.show_sidebar = this.show_sidebar;
-		this.list_sidebar.parent.toggle(this.show_sidebar);
-		this.set_list_width()
+		this.show_or_hide_sidebar()
 	}
 
-	set_list_width() {
-		if (!this.show_sidebar) {
-			cur_list.page.current_view.find('.layout-main-section-wrapper').removeClass('col-md-10')
-			cur_list.page.current_view.find('.layout-main-section-wrapper').addClass('col-md-12')
-		} else {
-			cur_list.page.current_view.find('.layout-main-section-wrapper').removeClass('col-md-12')
-			cur_list.page.current_view.find('.layout-main-section-wrapper').addClass('col-md-10')
-		}
+	show_or_hide_sidebar() {
+		this.list_sidebar.parent.toggleClass('hide', !this.show_sidebar);
+		cur_list.page.current_view.find('.layout-main-section-wrapper').toggleClass('col-md-10', this.show_sidebar)
+		cur_list.page.current_view.find('.layout-main-section-wrapper').toggleClass('col-md-12', this.show_sidebar)
 	}
 
 	setup_main_section() {
 		return frappe.run_serially([
 			this.setup_list_wrapper,
-			this.set_list_width,
+			this.show_or_hide_sidebar,
 			this.setup_filter_area,
 			this.setup_sort_selector,
 			this.setup_result_area,

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -22,6 +22,8 @@ frappe.views.ListSidebar = class ListSidebar {
 		this.sidebar = $('<div class="list-sidebar overlay-sidebar hidden-xs hidden-sm"></div>')
 			.html(sidebar_content)
 			.appendTo(this.page.sidebar.empty());
+		let show_sidebar = JSON.parse(localStorage.show_sidebar || 'true');
+		this.sidebar.toggle(show_sidebar)
 
 		this.setup_reports();
 		this.setup_list_filter();

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -22,8 +22,6 @@ frappe.views.ListSidebar = class ListSidebar {
 		this.sidebar = $('<div class="list-sidebar overlay-sidebar hidden-xs hidden-sm"></div>')
 			.html(sidebar_content)
 			.appendTo(this.page.sidebar.empty());
-		let show_sidebar = JSON.parse(localStorage.show_sidebar || 'true');
-		this.sidebar.toggle(show_sidebar)
 
 		this.setup_reports();
 		this.setup_list_filter();

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -1081,6 +1081,18 @@ body.full-width {
 	}
 }
 
+body.no-sidebar {
+	@media (min-width: @screen-md) {
+		.layout-side-section {
+			display: none;
+		}
+
+		.layout-main-section-wrapper {
+			width: 100% !important;
+		}
+	}
+}
+
 // utilities
 
 .whitespace-nowrap {


### PR DESCRIPTION
Sidebar toggle state will be stored in local storage of the browser and will persist on refresh. This will happen across all doctypes and reports


Co-authored-by: Sahil Khan <sahilkhan28297@gmail.com>
