### PR TITLE
feat: Bring full width to version-11

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -43,7 +43,9 @@ frappe.Application = Class.extend({
 		this.load_user_permissions();
 		this.make_nav_bar();
 		this.set_favicon();
+		this.set_fullwidth_if_enabled();		
 		this.setup_analytics();
+		
 		frappe.ui.keys.setup();
 		this.set_rtl();
 
@@ -506,6 +508,10 @@ frappe.Application = Class.extend({
 				"$email": frappe.session.user
 			});
 		}
+	},
+	
+	set_fullwidth_if_enabled() {
+		frappe.ui.toolbar.set_fullwidth_if_enabled();
 	},
 
 	show_notes: function() {

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -31,6 +31,9 @@
 					    {%= __("Reload") %}</a></li>
 					<li><a href="/index" target="_blank" rel="noopener noreferrer">
 						{%= __("View Website") %}</a></li>
+					<li class="navbar-toggle-full-width">
+						<a href="#" onclick="return false">{%= __("Toggle Full Width") %}</a>
+					</li>
 					<li><a href="#background_jobs">
 						{%= __("Background Jobs") %}</a></li>
 					<li class="divider"></li>

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -203,6 +203,16 @@ $.extend(frappe.ui.toolbar, {
 		</li>`).get(0);
 
 		parent_element.insertBefore(new_element, parent_element.children[index]);
+	},
+	toggle_full_width() {
+		let fullwidth = JSON.parse(localStorage.container_fullwidth || 'false');
+		fullwidth = !fullwidth;
+		localStorage.container_fullwidth = fullwidth;
+		frappe.ui.toolbar.set_fullwidth_if_enabled();
+	},
+	set_fullwidth_if_enabled() {
+		let fullwidth = JSON.parse(localStorage.container_fullwidth || 'false');
+		$(document.body).toggleClass('full-width', fullwidth);
 	}
 });
 

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -1039,3 +1039,11 @@ img.img-loading:after {
 	font-family: 'Octicons';
 	content: "\f00b";
 }
+
+body.full-width {
+	@media (min-width: @screen-md) {
+		.container {
+			width: 90%;
+		}
+	}
+}


### PR DESCRIPTION
I know that new features should be set in version 13, but in big screens will be a good feature to have full width config on version 11.

Before:

![image](https://user-images.githubusercontent.com/1592496/63468738-d3eefe00-c425-11e9-8a99-c7c4ebd153e1.png)

After:
![image](https://user-images.githubusercontent.com/1592496/63468775-e8cb9180-c425-11e9-8531-25a915e0a091.png)


