### PR TITLE
fix: Include font-awesome in website.scss

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -10,7 +10,6 @@
 		"node_modules/frappe-datatable/dist/frappe-datatable.css"
 	],
 	"css/frappe-web-b4.css": [
-		"public/css/font-awesome.css",
 		"public/less/indicator.less",
 		"public/scss/website.scss"
 	],

--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -1,4 +1,5 @@
 @import "variables";
+@import "frappe/public/css/font-awesome";
 @import "~bootstrap/scss/bootstrap";
 @import "multilevel-dropdown";
 @import "website-image";


### PR DESCRIPTION
The standard theme includes `font-awesome.css` via `build.json`, but it is not included when a Custom Theme is created.