### PR TITLE
fix: remove 'Install App' menu item on module page js (v11)

### DIFF
--- a/frappe/desk/page/modules/modules.js
+++ b/frappe/desk/page/modules/modules.js
@@ -18,12 +18,6 @@ frappe.pages['modules'].on_page_load = function(wrapper) {
 			.show(frappe.session.user);
 	});
 
-	if(frappe.user.has_role('System Manager')) {
-		page.add_menu_item(__('Install Apps'), function() {
-			frappe.set_route("applications");
-		});
-	}
-
 	page.get_page_modules = () => {
 		return frappe.get_desktop_icons(true)
 			.filter(d => d.type==='module' && !d.blocked)


### PR DESCRIPTION
Remove 'Install App' menu item on module page js becouse install app was deprecated:

https://discuss.erpnext.com/t/no-application-page/34150

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.