### PR TITLE
fix: When autoname is not set, treat it as hash

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -319,7 +319,7 @@ class BaseDocument(object):
 				), list(d.values()))
 		except Exception as e:
 			if frappe.db.is_primary_key_violation(e):
-				if self.meta.autoname=="hash":
+				if not self.meta.autoname or self.meta.autoname=="hash":
 					# hash collision? try again
 					self.name = None
 					self.db_insert()


### PR DESCRIPTION
During collision it only checks for 'hash', but it can be unset too.


Port of https://github.com/frappe/frappe/pull/8259 for develop