### PR TITLE
fix: Escape html in timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -598,6 +598,7 @@ frappe.ui.form.Timeline = class Timeline {
 					return parts.length < 3;
 				});
 				if(parts.length) {
+					parts = parts.map(frappe.utils.escape_html);
 					out.push(me.get_version_comment(version, __("changed value of {0}", [parts.join(', ').bold()])));
 				}
 			}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9355208/63680600-a7febe80-c811-11e9-8091-bfb4478fcd88.png)
