### PR TITLE
fix: do not check empty string check for date type fields

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -60,7 +60,7 @@ def update_last_reset_password_date():
 		SET
 			last_password_reset_date = %s
 		WHERE
-			last_password_reset_date is null or last_password_reset_date = ''""", today())
+			last_password_reset_date is null""", today())
 
 @frappe.whitelist()
 def load():


### PR DESCRIPTION
In MariaDB, if date type field is empty system sets default value as Null. Thus empty string check is failing while saving system settings after changing value for the field `last_password_reset_date`

```
Traceback (most recent call last):
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 271, in save
    return self._save(*args, **kwargs)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 324, in _save
    self.run_post_save_methods()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 917, in run_post_save_methods
    self.run_method("on_update")
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 786, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 1055, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 1038, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 780, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/core/doctype/system_settings/system_settings.py", line 56, in on_update
    update_last_reset_password_date()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/core/doctype/system_settings/system_settings.py", line 63, in update_last_reset_password_date
    last_password_reset_date is null or last_password_reset_date = ''""", today())
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 516, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 727, in _read_query_result
    result.read()
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1066, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 683, in _read_packet
    packet.check_error()
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1292, u"Incorrect datetime value: ''")
```