### PR TITLE
fix: enabled translation for desk card categories

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -2,6 +2,8 @@
 // MIT License. See license.txt
 /* eslint-disable no-console */
 
+// __('Modules') __('Domains') __('Places') __('Administration') # for translation, don't remove
+
 frappe.start_app = function() {
 	if(!frappe.Application)
 		return;

--- a/frappe/public/js/frappe/views/components/DeskSection.vue
+++ b/frappe/public/js/frappe/views/components/DeskSection.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="section-header level text-muted">
-      <div class="module-category h6 uppercase">{{ category }}</div>
+      <div class="module-category h6 uppercase">{{ __(this.category) }}</div>
     </div>
 
     <div class="modules-container" :class="{'dragging': dragging}" ref="modules-container">

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -117,12 +117,6 @@ def get_dict(fortype, name=None):
 			messages += frappe.db.sql("select 'Role:', name from tabRole")
 			messages += frappe.db.sql("select 'Module:', name from `tabModule Def`")
 
-			# Adding module labels
-			messages.append(('sites/assets/js/desk.min.js', 'Modules'))
-			messages.append(('sites/assets/js/desk.min.js', 'Domains'))
-			messages.append(('sites/assets/js/desk.min.js', 'Places'))
-			messages.append(('sites/assets/js/desk.min.js', 'Administration'))
-
 		message_dict = make_dict_from_messages(messages)
 		message_dict.update(get_dict_from_hooks(fortype, name))
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -117,6 +117,12 @@ def get_dict(fortype, name=None):
 			messages += frappe.db.sql("select 'Role:', name from tabRole")
 			messages += frappe.db.sql("select 'Module:', name from `tabModule Def`")
 
+			# Adding module labels
+			messages.append(('sites/assets/js/desk.min.js', 'Modules'))
+			messages.append(('sites/assets/js/desk.min.js', 'Domains'))
+			messages.append(('sites/assets/js/desk.min.js', 'Places'))
+			messages.append(('sites/assets/js/desk.min.js', 'Administration'))
+
 		message_dict = make_dict_from_messages(messages)
 		message_dict.update(get_dict_from_hooks(fortype, name))
 


### PR DESCRIPTION
Translations for category label on the desk was not enabled.
The `get_messages_from_file` function would fetch words from desk.min.js but this did not include the Vue files or the category labels. This PR fixes it.

### Preview 
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/18097732/63918781-fe127280-ca5a-11e9-8dfd-0042b92d6bfb.png">
