### PR TITLE
fix: Disable caching for respond_as_web_page response

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1152,7 +1152,7 @@ def compare(val1, condition, val2):
 
 def respond_as_web_page(title, html, success=None, http_status_code=None,
 	context=None, indicator_color=None, primary_action='/', primary_label = None, fullpage=False,
-	width=None, template='message'):
+	width=None, template='message', no_cache=0):
 	"""Send response as a web page with a message rather than JSON. Used to show permission errors etc.
 
 	:param title: Page title and heading.
@@ -1162,15 +1162,18 @@ def respond_as_web_page(title, html, success=None, http_status_code=None,
 	:param context: web template context
 	:param indicator_color: color of indicator in title
 	:param primary_action: route on primary button (default is `/`)
-	:param primary_label: label on primary button (defaut is "Home")
+	:param primary_label: label on primary button (default is "Home")
 	:param fullpage: hide header / footer
 	:param width: Width of message in pixels
 	:param template: Optionally pass view template
+	:param no_cache: Template will always be re-rendered i.e., no caching.
 	"""
 	local.message_title = title
 	local.message = html
 	local.response['type'] = 'page'
 	local.response['route'] = template
+	local.no_cache = no_cache
+
 	if http_status_code:
 		local.response['http_status_code'] = http_status_code
 
@@ -1190,6 +1193,7 @@ def respond_as_web_page(title, html, success=None, http_status_code=None,
 	context['primary_action'] = primary_action
 	context['error_code'] = http_status_code
 	context['fullpage'] = fullpage
+	context['no_cache'] = no_cache
 	if width:
 		context['card_width'] = width
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1166,7 +1166,6 @@ def respond_as_web_page(title, html, success=None, http_status_code=None,
 	:param fullpage: hide header / footer
 	:param width: Width of message in pixels
 	:param template: Optionally pass view template
-	:param no_cache: Template will always be re-rendered i.e., no caching.
 	"""
 	local.message_title = title
 	local.message = html
@@ -1193,7 +1192,6 @@ def respond_as_web_page(title, html, success=None, http_status_code=None,
 	context['primary_action'] = primary_action
 	context['error_code'] = http_status_code
 	context['fullpage'] = fullpage
-	context['no_cache'] = no_cache
 	if width:
 		context['card_width'] = width
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1152,7 +1152,7 @@ def compare(val1, condition, val2):
 
 def respond_as_web_page(title, html, success=None, http_status_code=None,
 	context=None, indicator_color=None, primary_action='/', primary_label = None, fullpage=False,
-	width=None, template='message', no_cache=0):
+	width=None, template='message'):
 	"""Send response as a web page with a message rather than JSON. Used to show permission errors etc.
 
 	:param title: Page title and heading.
@@ -1172,7 +1172,7 @@ def respond_as_web_page(title, html, success=None, http_status_code=None,
 	local.message = html
 	local.response['type'] = 'page'
 	local.response['route'] = template
-	local.no_cache = no_cache
+	local.no_cache = 1
 
 	if http_status_code:
 		local.response['http_status_code'] = http_status_code

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -121,8 +121,7 @@ def return_action_confirmation_page(doc, action, action_link, alert_doc_change=F
 		html=None,
 		indicator_color='blue',
 		template='confirm_workflow_action',
-		context=template_params,
-		no_cache=True)
+		context=template_params)
 
 def return_link_expired_page(doc, doc_workflow_state):
 	frappe.respond_as_web_page(_("Link Expired"),

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -94,7 +94,8 @@ def confirm_action(doctype, docname, user, action):
 	return_success_page(newdoc)
 
 	# reset session user
-	frappe.set_user(logged_in_user)
+	if logged_in_user == 'Guest':
+		frappe.set_user(logged_in_user)
 
 def return_success_page(doc):
 	frappe.respond_as_web_page(_("Success"),
@@ -116,10 +117,12 @@ def return_action_confirmation_page(doc, action, action_link, alert_doc_change=F
 
 	template_params['pdf_link'] = get_pdf_link(doc.get('doctype'), doc.get('name'))
 
-	frappe.respond_as_web_page(None, None,
-		indicator_color="blue",
-		template="confirm_workflow_action",
-		context=template_params)
+	frappe.respond_as_web_page(None,
+		None,
+		indicator_color='blue',
+		template='confirm_workflow_action',
+		context=template_params,
+		no_cache=True)
 
 def return_link_expired_page(doc, doc_workflow_state):
 	frappe.respond_as_web_page(_("Link Expired"),

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -117,8 +117,8 @@ def return_action_confirmation_page(doc, action, action_link, alert_doc_change=F
 
 	template_params['pdf_link'] = get_pdf_link(doc.get('doctype'), doc.get('name'))
 
-	frappe.respond_as_web_page(None,
-		None,
+	frappe.respond_as_web_page(title=None,
+		html=None,
 		indicator_color='blue',
 		template='confirm_workflow_action',
 		context=template_params,


### PR DESCRIPTION
Workflow confirmation page always used to show old cached document approval page if multiple links are clicked simultaneously for approval.

**Solution:** Disable caching for respond_as_web_page response