### PR TITLE
refactor: added logged in status in body tag

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -52,7 +52,7 @@
 		window.socketio_port = {{ frappe.socketio_port }};
     </script>
 </head>
-<body data-path="{{ path | e }}" {%- if template and template.endswith('.md') %} frappe-content-type="markdown" {% endif -%}>
+<body frappe-session-status="{{ 'logged-in' if frappe.session.user != 'Guest' else 'logged-out'}}" data-path="{{ path | e }}" {%- if template and template.endswith('.md') %} frappe-content-type="markdown" {% endif -%}>
 	{%- block banner -%}
 		{% include "templates/includes/banner_extension.html" ignore missing %}
 


### PR DESCRIPTION
Added `frappe-session-status` data attribute in body tag. This can be used to hide certain elements on the website using CSS when a user is logged in.

For example
```
body[frappe-session-status="logged-in"] a[data-navbar-label="Sign Up"] {
	display: none;
}
```