### PR TITLE
fix: Do not throw error while reloading doctypes

### DIFF
--- a/frappe/patches/v7_2/set_in_standard_filter_property.py
+++ b/frappe/patches/v7_2/set_in_standard_filter_property.py
@@ -16,5 +16,5 @@ def execute():
 			pass
 		except frappe.db.DataError:
 			pass
-		except pymysql.err.InternalError:
+		except Exception:
 			pass

--- a/frappe/patches/v7_2/set_in_standard_filter_property.py
+++ b/frappe/patches/v7_2/set_in_standard_filter_property.py
@@ -16,5 +16,5 @@ def execute():
 			pass
 		except frappe.db.DataError:
 			pass
-		except pymysql.err.InternalError
+		except pymysql.err.InternalError:
 			pass

--- a/frappe/patches/v7_2/set_in_standard_filter_property.py
+++ b/frappe/patches/v7_2/set_in_standard_filter_property.py
@@ -16,3 +16,5 @@ def execute():
 			pass
 		except frappe.db.DataError:
 			pass
+		except pymysql.err.InternalError
+			pass


### PR DESCRIPTION
Any schema changes in tables of erpnext causes this patches to fail since the patch that handles the schema change is executed after all patches in frappe are executed.
 
![Screenshot 2019-08-29 at 11 37 29 AM](https://user-images.githubusercontent.com/42651287/63914648-82f88e80-ca51-11e9-8d77-f082bc5888fd.png)
