### PR TITLE
fix: handle data too long exception

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -166,7 +166,7 @@ def update_comments_in_parent(reference_doctype, reference_name, _comments):
 			frappe.local._comments = (getattr(frappe.local, "_comments", [])
 				+ [(reference_doctype, reference_name, _comments)])
 
-		elif frappe.db.data_too_long(e):
+		elif frappe.db.is_data_too_long(e):
 			raise frappe.DataTooLongException
 
 		else:

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -165,6 +165,10 @@ def update_comments_in_parent(reference_doctype, reference_name, _comments):
 			# missing column and in request, add column and update after commit
 			frappe.local._comments = (getattr(frappe.local, "_comments", [])
 				+ [(reference_doctype, reference_name, _comments)])
+
+		elif frappe.db.data_too_long(e):
+			raise frappe.DataTooLongException
+
 		else:
 			raise ImplicitCommitError
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -169,6 +169,10 @@ class MariaDBDatabase(Database):
 	def is_syntax_error(e):
 		return e.args[0] == ER.PARSE_ERROR
 
+	@staticmethod
+	def data_too_long(e):
+		return e.args[0] == ER.DATA_TOO_LONG
+
 	def is_primary_key_violation(self, e):
 		return self.is_duplicate_entry(e) and 'PRIMARY' in cstr(e.args[1])
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -170,7 +170,7 @@ class MariaDBDatabase(Database):
 		return e.args[0] == ER.PARSE_ERROR
 
 	@staticmethod
-	def data_too_long(e):
+	def is_data_too_long(e):
 		return e.args[0] == ER.DATA_TOO_LONG
 
 	def is_primary_key_violation(self, e):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -170,7 +170,7 @@ class PostgresDatabase(Database):
 		return e.pgcode == '42701'
 
 	@staticmethod
-	def data_too_long(e):
+	def is_data_too_long(e):
 		return e.pgcode == '22001'
 
 	def create_auth_table(self):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -169,6 +169,10 @@ class PostgresDatabase(Database):
 	def is_duplicate_fieldname(e):
 		return e.pgcode == '42701'
 
+	@staticmethod
+	def data_too_long(e):
+		return e.pgcode == '22001'
+
 	def create_auth_table(self):
 		self.sql_ddl("""create table if not exists "__Auth" (
 				"doctype" VARCHAR(140) NOT NULL,

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -83,3 +83,4 @@ class SecurityException(Exception): pass
 class InvalidColumnName(ValidationError): pass
 class IncompatibleApp(ValidationError): pass
 class InvalidDates(ValidationError): pass
+class DataTooLongException(ValidationError): pass


### PR DESCRIPTION
<img width="415" alt="Screen Shot 2019-08-01 at 2 23 43 PM" src="https://user-images.githubusercontent.com/3784093/62279587-067d8a80-b468-11e9-9ce8-322ffe104b68.png">

- instead of data too long exception, the system used to raise ImplicitCommitError.