### PR TITLE
fix: Markup when using links in footer items

### DIFF
--- a/frappe/templates/includes/footer/footer_items.html
+++ b/frappe/templates/includes/footer/footer_items.html
@@ -18,7 +18,7 @@
                 {%- endfor -%}
                 </ul>
             {%- else -%}
-            <div class="footer-group-label">{{ page.label }}<div>
+            <div class="footer-group-label">{{ page.label }}</div>
             </a>
             {%- endif -%}
             </div>


### PR DESCRIPTION
Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.

This is a bugfix for the item footer: because the ending tag was coded wrongly, in v12 only half of the screen is used. 

Steps to reproduce: enable footer items in Webpage Settings. Observe that i.e. in Firefox only the left half of the footer is used and a syntx error is shown in the console (wrong nesting of tags). This correction solves this.

Test cases: no test cases affected.