### PR TITLE
fix: Remove extra 'List' in the awesome bar option

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -152,9 +152,15 @@ frappe.search.utils = {
 
 		var level, target;
 		var option = function(type, route, order) {
+			// check to skip extra list in the text
+			// eg. Price List List should be only Price List
+			let skip_list = type === 'List' && target.endsWith('List');
+			let label = me.bolden_match_part(__(target), keywords);
+			label += skip_list ? '' : ` ${__(type)}`;
+
 			return {
 				type: type,
-				label: me.bolden_match_part(__(target), keywords) + " " + __(type),
+				label: label,
 				value: __(target + " " + type),
 				index: level + order,
 				match: target,


### PR DESCRIPTION
**Before** 
<img width="1179" alt="Screenshot 2019-08-29 at 7 58 40 PM" src="https://user-images.githubusercontent.com/13928957/63949227-afcf9480-ca97-11e9-9f3f-6a84d0d5750d.png">
**After**
<img width="1180" alt="Screenshot 2019-08-29 at 7 56 04 PM" src="https://user-images.githubusercontent.com/13928957/63949264-be1db080-ca97-11e9-9029-294e9fd7126e.png">

---

**Before**
<img width="1182" alt="Screenshot 2019-08-29 at 7 59 24 PM" src="https://user-images.githubusercontent.com/13928957/63949332-db527f00-ca97-11e9-9a6b-8a032478c35a.png">
**After**
<img width="1185" alt="Screenshot 2019-08-29 at 8 02 07 PM" src="https://user-images.githubusercontent.com/13928957/63949402-fd4c0180-ca97-11e9-99a4-52d8eee3a3b1.png">
