### PR TITLE
fix(Desk): Alignment

### DIFF
--- a/frappe/public/css/desk-rtl.css
+++ b/frappe/public/css/desk-rtl.css
@@ -109,5 +109,5 @@ ul.tree-children {
   direction: ltr;
 }
 .section-header {
-  direction: ltr !important;
+  direction: ltr;
 }

--- a/frappe/public/css/desk-rtl.css
+++ b/frappe/public/css/desk-rtl.css
@@ -108,3 +108,6 @@ ul.tree-children {
 .data-table {
   direction: ltr;
 }
+.section-header {
+  direction: ltr !important;
+}


### PR DESCRIPTION
- In Arabic, then name of the section was overlapping 'Show / Hide Cards'.
- Before fix
   ![Screenshot 2019-08-30 at 12 29 40 PM](https://user-images.githubusercontent.com/7310479/63999778-e0f4a700-cb21-11e9-9894-5d5c0b4bfbbe.png)
- After fix
   ![Screenshot 2019-08-30 at 12 28 21 PM](https://user-images.githubusercontent.com/7310479/63999772-dd612000-cb21-11e9-8b9a-926d51fffb10.png)