### PR TITLE
fix(UX): Make User field mandatory in review dialog

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/review.js
+++ b/frappe/public/js/frappe/form/sidebar/review.js
@@ -79,6 +79,7 @@ frappe.ui.form.Review = class Review {
 				fieldname: 'to_user',
 				fieldtype: 'Autocomplete',
 				label: __('To User'),
+				reqd: 1,
 				options: user_options,
 				description: __('Only users involved in the document are listed')
 			}, {


### PR DESCRIPTION
Make User field mandatory in review dialog to avoid the following error:
<img width="515" alt="Screenshot 2019-09-02 at 8 23 03 AM" src="https://user-images.githubusercontent.com/13928957/64087639-89da1680-cd5b-11e9-9ba0-0587deb5c239.png">

