### PR TITLE
fix: Load doc before save in db_set as well

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -984,6 +984,7 @@ class Document(BaseDocument):
 			self.set("modified", now())
 			self.set("modified_by", frappe.session.user)
 
+		self.load_doc_before_save()
 		# to trigger notification on value change
 		self.run_method('before_change')
 


### PR DESCRIPTION
- Because db_set internally triggers `on_change` event
and `on_change` handlers might expect doc_before_save for data processing.

