### PR TITLE
fix: add a edge case to correct email format for validate_email m…

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -124,12 +124,12 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 				email_list.forEach(function(email) {
 					// The email format is something like 'Jack Ma <JackMa@alibaba.com>'
 					let email_address = '';
-					if (email.includes("<") && email.includes(">")){
+					if (email.includes("<") && email.includes(">")) {
 						let left_sign = email.indexOf("<");
 						let right_sign = email.indexOf(">");
 						email_address = email.substring(left_sign+1, right_sign);
-					}else {
-						email_address = email
+					} else {
+						email_address = email;
 					}
 					// email_address now will look like 'JackMa@alibaba.com'
 					if (!validate_email(email_address)) {

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -122,8 +122,18 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 			} else {
 				var invalid_email = false;
 				email_list.forEach(function(email) {
-					if (!validate_email(email)) {
-						frappe.msgprint(__("Invalid Email: {0}", [email]));
+					// The email format is something like 'Jack Ma <JackMa@alibaba.com>'
+					let email_address = '';
+					if (email.includes("<") && email.includes(">")){
+						let left_sign = email.indexOf("<");
+						let right_sign = email.indexOf(">");
+						email_address = email.substring(left_sign+1, right_sign);
+					}else {
+						email_address = email
+					}
+					// email_address now will look like 'JackMa@alibaba.com'
+					if (!validate_email(email_address)) {
+						frappe.msgprint(__("Invalid Email: {0}", [email_address]));
 						invalid_email = true;
 					}
 				});


### PR DESCRIPTION
The email format in some edge cases could be something like 'Jack Ma \<JackMa@alibaba.com\>'.
So it will give an error message saying "Invalid Email: Jack Ma".

The changes I made is trying to extract the email address.
Based on assuming inside the "<>" is the email address that needed to pass into validate_email method.

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.