### PR TITLE
fix: submit and cancel actions in bulk update when workflow is setup

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1146,12 +1146,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		// Bulk submit
-		if (frappe.model.is_submittable(doctype) && has_submit_permission(doctype)) {
+		if (frappe.model.is_submittable(doctype) && has_submit_permission(doctype) && !(frappe.model.has_workflow(doctype))) {
 			actions_menu_items.push(bulk_submit());
 		}
 
 		// Bulk cancel
-		if (frappe.model.can_cancel(doctype)) {
+		if (frappe.model.can_cancel(doctype) && !(frappe.model.has_workflow(doctype))) {
 			actions_menu_items.push(bulk_cancel());
 		}
 


### PR DESCRIPTION
**Problem:**
- When workflow is setup, during bulk update the Actions menu in List View used to show Submit and Cancel options.
![workflow-state-1](https://user-images.githubusercontent.com/24353136/64148837-fd565380-ce41-11e9-98b4-7a056043ece7.png)
- If docs are directly submitted instead of following the workflow states, it updates the docstatus as 1, but not the workflow state
![docstatus](https://user-images.githubusercontent.com/24353136/64148981-5cb46380-ce42-11e9-9cbf-61f1f227bfb1.png)

**Fix:**
- Submit and Cancel options are hidden when workflow is setup. User has to follow the workflow to update the documents.

![workflow-state-fix](https://user-images.githubusercontent.com/24353136/64148838-fe878080-ce41-11e9-99c0-97548c07e510.png)
