### PR TITLE
fix: check if field is_tree exists

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -34,8 +34,13 @@ def get_controller(doctype):
 	global _classes
 
 	if not doctype in _classes:
-		module_name, custom, is_tree = frappe.db.get_value("DocType", doctype, ("module", "custom", "is_tree"), cache=True) \
-			or ["Core", False, False]
+		is_tree = False
+
+		module_name, custom = frappe.db.get_value("DocType", doctype, ("module", "custom"), cache=True) \
+			or ["Core", False]
+
+		if frappe.db.field_exists(doctype, "is_tree"):
+			is_tree = frappe.db.get_value("DocType", doctype, ("is_tree"), cache=True)
 
 		if custom:
 			_class = NestedSet if is_tree else Document

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -34,15 +34,14 @@ def get_controller(doctype):
 	global _classes
 
 	if not doctype in _classes:
-		is_tree = False
-
 		module_name, custom = frappe.db.get_value("DocType", doctype, ("module", "custom"), cache=True) \
 			or ["Core", False]
 
-		if frappe.db.field_exists(doctype, "is_tree"):
-			is_tree = frappe.db.get_value("DocType", doctype, ("is_tree"), cache=True)
-
 		if custom:
+			if frappe.db.field_exists(doctype, "is_tree"):
+				is_tree = frappe.db.get_value("DocType", doctype, ("is_tree"), cache=True)
+			else:
+				is_tree = False
 			_class = NestedSet if is_tree else Document
 		else:
 			module = load_doctype_module(doctype, module_name)


### PR DESCRIPTION
```
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/app.py", line 60, in application
13:01:42 web.1            |     response = frappe.api.handle()
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/api.py", line 55, in handle
13:01:42 web.1            |     return frappe.handler.handle()
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/handler.py", line 21, in handle
13:01:42 web.1            |     data = execute_cmd(cmd)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
13:01:42 web.1            |     return frappe.call(method, **frappe.form_dict)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/__init__.py", line 1036, in call
13:01:42 web.1            |     return fn(*args, **newargs)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/__init__.py", line 511, in wrapper_fn
13:01:42 web.1            |     retval = fn(*args, **get_newargs(fn, kwargs))
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/desk/notifications.py", line 16, in get_notifications
13:01:42 web.1            |     not frappe.db.get_single_value('System Settings', 'setup_complete')):
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/database/database.py", line 555, in get_single_value
13:01:42 web.1            |     df = frappe.get_meta(doctype).get_field(fieldname)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/__init__.py", line 759, in get_meta
13:01:42 web.1            |     return frappe.model.meta.get_meta(doctype, cached=cached)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/meta.py", line 35, in get_meta
13:01:42 web.1            |     meta = Meta(meta)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/meta.py", line 77, in __init__
13:01:42 web.1            |     super(Meta, self).__init__(doctype)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 113, in __init__
13:01:42 web.1            |     super(Document, self).__init__(kwargs)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 61, in __init__
13:01:42 web.1            |     self.update(d)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 84, in update
13:01:42 web.1            |     self.set(key, value)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 131, in set
13:01:42 web.1            |     self.extend(key, value)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 168, in extend
13:01:42 web.1            |     self.append(key, v)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 145, in append
13:01:42 web.1            |     value = self._init_child(value, key)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 184, in _init_child
13:01:42 web.1            |     value = get_controller(value["doctype"])(value)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 37, in get_controller
13:01:42 web.1            |     module_name, custom, is_tree = frappe.db.get_value("DocType", doctype, ("module", "custom", "is_tree"), cache=True) \
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/database/database.py", line 400, in get_value
13:01:42 web.1            |     order_by, cache=cache)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/database/database.py", line 444, in get_values
13:01:42 web.1            |     out = self._get_values_from_table(fields, filters, doctype, as_dict, debug, order_by, update)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/database/database.py", line 591, in _get_values_from_table
13:01:42 web.1            |     as_dict=as_dict, debug=debug, update=update)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/database/database.py", line 156, in sql
13:01:42 web.1            |     self._cursor.execute(query, values)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
13:01:42 web.1            |     result = self._query(query)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
13:01:42 web.1            |     conn.query(q)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 516, in query
13:01:42 web.1            |     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 727, in _read_query_result
13:01:42 web.1            |     result.read()
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1066, in read
13:01:42 web.1            |     first_packet = self.connection._read_packet()
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 683, in _read_packet
13:01:42 web.1            |     packet.check_error()
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
13:01:42 web.1            |     err.raise_mysql_exception(self._data)
13:01:42 web.1            |   File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
13:01:42 web.1            |     raise errorclass(errno, errval)
13:01:42 web.1            | InternalError: (1054, u"Unknown column 'is_tree' in 'field list'")
```