### PR TITLE
fix: doc_update was sent only once per session

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -161,6 +161,7 @@ frappe.socketio = {
 	doc_close: function(doctype, docname) {
 		// notify that the user has closed this doc
 		frappe.socketio.socket.emit('doc_close', doctype, docname);
+		frappe.socketio.last_doc = [];
 	},
 
 	setup_listeners: function() {


### PR DESCRIPTION
make sure that the user gets notified about someone else opening the same doc, even after that someone else closed and reopened it. This also fixes a bug that caused no more doc_open notifications to be sent when a user opened a doc this session already.
