### PR TITLE
feat: Make sure we also display rooms that have been opened

### DIFF
--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1421,7 +1421,7 @@ class extends Component {
 			const state     = [ ]
 
 			for (const room of rooms)
-				if ( ["Group", "Visitor"].includes(room.type) || room.owner === frappe.session.user || room.last_message ) {
+				  if ( ["Group", "Visitor"].includes(room.type) || room.owner === frappe.session.user || room.last_message || room.users.includes(frappe.session.user)) {
 					frappe.log.info(`Adding ${room.name} to component.`)
 					state.push(room)
 				}


### PR DESCRIPTION
Make sure we also display rooms that have been opened, even if there are no chatmessages yet. If that is not so, Alice and Bob can get into the situation that the direct chat between them was opened by Alice, but if Alice didn't write anything to Bob yet, Bob will never be able to chat with Alice

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.