### PR TITLE
fix(nestedset): check if meta has nsm_parent_field

### DIFF
--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -184,7 +184,7 @@ def validate_loop(doctype, name, lft, rgt):
 
 class NestedSet(Document):
 	def __setup__(self):
-		if self.meta.nsm_parent_field:
+		if self.meta.get("nsm_parent_field"):
 			self.nsm_parent_field = self.meta.nsm_parent_field
 
 	def on_update(self):


### PR DESCRIPTION
Error
```
Traceback (most recent call last):
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/commands/init.py”, line 25, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/commands/site.py”, line 233, in migrate
migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/migrate.py”, line 48, in migrate
frappe.modules.patch_handler.run_all(skip_failing)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 41, in run_all
run_patch(patch)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 30, in run_patch
if not run_single(patchmodule = patch):
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 71, in run_single
return execute_patch(patchmodule, method, methodargs)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 91, in execute_patch
frappe.get_attr(patchmodule.split()[0] + “.execute”)()
File “/home/ubuntu/frappe-bench/apps/erpnext/erpnext/patches/v12_0/add_default_dashboards.py”, line 8, in execute
add_dashboards()
File “/home/ubuntu/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/operations/install_fixtures.py”, line 505, in add_dashboards
dashboard_data = get_default_dashboards()
File “/home/ubuntu/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/data/dashboard_charts.py”, line 7, in get_default_dashboards
company = frappe.get_doc(“Company”, frappe.defaults.get_defaults().company)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/init.py”, line 734, in get_doc
doc = frappe.model.document.get_doc(*args, **kwargs)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/model/document.py”, line 69, in get_doc
return controller(*args, **kwargs)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/model/document.py”, line 104, in init
self.load_from_db()
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/model/document.py”, line 149, in load_from_db
super(Document, self).init(d)
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/model/base_document.py”, line 69, in init
self.setup()
File “/home/ubuntu/frappe-bench/apps/frappe/frappe/utils/nestedset.py”, line 187, in setup
if self.meta.nsm_parent_field:
AttributeError: ‘Meta’ object has no attribute ‘nsm_parent_field’
```
fixes: https://github.com/frappe/frappe/issues/8329

https://discuss.erpnext.com/t/on-latest-bench-update-meta-object-has-no-attribute-nsm-parent-field/52448

