### PR TITLE
fix(Customize Form): Strip column name in search field list

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -169,11 +169,17 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 
 def get_std_fields_list(meta, key):
 	# get additional search fields
-	sflist = meta.search_fields and meta.search_fields.split(",") or []
-	title_field = [meta.title_field] if (meta.title_field and meta.title_field not in sflist) else []
-	sflist = ['name'] + sflist + title_field
-	if not key in sflist:
-		sflist = sflist + [key]
+	sflist = ["name"]
+	if meta.search_fields:
+		for d in meta.search_fields.split(","):
+			if d.strip() not in sflist:
+				sflist.append(d.strip())
+
+	if meta.title_field and meta.title_field not in sflist:
+		sflist.append(meta.title_field)
+
+	if key not in sflist:
+		sflist.append(key)
 
 	return sflist
 


### PR DESCRIPTION
Whitespaces were not stripped when sf_list in `Customize Form` was split on `,`
![Screenshot 2019-09-04 at 4 13 57 PM](https://user-images.githubusercontent.com/7310479/64248598-302a4580-cf2f-11e9-890b-68406323a43c.png)
