### PR TITLE
fix: Key Error while opening report

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -119,7 +119,7 @@ def save_report():
 def export_query():
 	"""export from report builder"""
 	title = frappe.form_dict.title
-	frappe.form_dict.pop('title')
+	frappe.form_dict.pop('title', None)
 
 	form_params = get_form_params()
 	form_params["limit_page_length"] = None


### PR DESCRIPTION
Pop title safely to avoid Key Error
<img width="641" alt="Screenshot 2019-09-05 at 8 49 57 AM" src="https://user-images.githubusercontent.com/13928957/64309505-45988180-cfba-11e9-99be-d551da475d65.png">


This error introduced through https://github.com/frappe/frappe/pull/8314