### PR TITLE
fix(login): ldap_settings not defined

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -91,6 +91,7 @@ def get_icon_html(icon, small=False):
 		u"(\ud83c[\udde0-\uddff])"
 		"+", flags=re.UNICODE)
 
+	icon = icon or ""
 	if icon and emoji_pattern.match(icon):
 		return '<span class="text-muted">' + icon + '</span>'
 


### PR DESCRIPTION
If a Social Login Key is created with `enable_social_login` and without `icon` then visiting `/login` throws the following error.

```jinja
  {%- if not disable_signup -%}
    <p class="text-center sign-up-message">
      <a href="#signup" style="margin-top: -2px;">{{ _("Don't have an account? Sign up") }}</a>
    </p>
  {%- endif -%}
  <p class="text-center forgot-password-message">
    <a href="#forgot">{{ _("Forgot Password?") }}</a></p>
  </div>
</section>
<section class='for-signup'>
  <div class="login-content page-card" style="margin-top: 20px;">
  <form class="form-signin form-signup hide" role="form">
    <div class="page-card-head">
      <span class="indicator blue" data-text="{{ _("Sign Up") }}"></span>
    </div>
    <input type="text" id="signup_fullname"
      class="form-control" placeholder="{{ _('Full Name') }}" required autofocus>
    <input type="email" id="signup_email"
      class="form-control" placeholder="{{ _('Email address') }}" required>
    <button class="btn btn-sm btn-primary btn-block btn-signup" type="submit">{{ _("Sign up") }}</button>
  </form>
  </div>
  <div class='form-footer'>
    <a href="#login" class="blue">{{ _("Have an account? Login") }}</a>
  </div>
</section>

<section class='for-forgot'>
  <div class="login-content page-card" style="margin-top: 20px;">
  <form class="form-signin form-forgot hide" role="form">
    <div class="page-card-head">
      <span class="indicator blue" data-text="{{ _("Forgot Password") }}"></span></div>
    <input type="email" id="forgot_email"
      class="form-control" placeholder="{{ _('Email address') }}" required autofocus>
    <button class="btn btn-sm btn-primary btn-block btn-forgot" type="submit">{{ _("Reset Password") }}</button>
  </form>
  </div>
  <div class='form-footer'>
    <a href="#login">{{ _("Back to Login") }}</a>
  </div>
</section>
</div>
{% endblock %}

{% block script %}
  <script>{% include "templates/includes/login/login.js" %}</script>
{% endblock %}

{% block sidebar %}{% endblock %}
</pre><pre>Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/jinja.py", line 78, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 1, in top-level template code
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 1, in top-level template code
    {% extends base_template_path %}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/base.html", line 87, in top-level template code
    {%- block script %}{%- endblock %}
  File "<template>", line 101, in block "script"
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/includes/login/login.js", line 69, in top-level template code
    {% if ldap_settings.enabled %}
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/sandbox.py", line 385, in getattr
    value = getattr(obj, attribute)
UndefinedError: 'ldap_settings' is undefined
</pre>
```