### PR TITLE
fix: use doc in webform save

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -97,20 +97,18 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		);
 	}
 
-	get_values(ignore_errors) {
-		let values = super.get_values(ignore_errors);
-		values.doctype = this.doc_type;
-		values.name = this.doc_name;
-		values.web_form_name = this.name;
-		return values;
-	}
-
 	save() {
 		this.validate && this.validate();
 
+		// small validation hack
+		super.get_values(this.allow_incomplete);
+
+		if (window.saving) return;
 		let for_payment = Boolean(this.accept_payment && !this.doc.paid);
-		let data = this.get_values(this.allow_incomplete);
-		if (!data || window.saving) return;
+
+		this.doc.doctype = this.doc_type;
+		this.doc.name = this.doc_name;
+		this.doc.web_form_name = this.name;
 
 		// Save
 		window.saving = true;
@@ -120,7 +118,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			type: "POST",
 			method: "frappe.website.doctype.web_form.web_form.accept",
 			args: {
-				data: data,
+				data: this.doc,
 				web_form: this.name,
 				docname: this.doc.name,
 				for_payment

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -168,13 +168,11 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		const success_dialog = new frappe.ui.Dialog({
 			title: __("Saved Successfully"),
 			secondary_action: () => {
-				if (this.login_required) {
-					if (this.route_to_success_link) {
-						window.location.pathname = this.success_url;
-					} else {
-						window.location.href =
-							window.location.pathname + "?name=" + data.name;
-					}
+				if (this.success_url) {
+					window.location.pathname = this.success_url;
+				} else if(this.login_required) {
+					window.location.href =
+						window.location.pathname + "?name=" + data.name;
 				}
 			}
 		});

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -100,7 +100,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	save() {
 		this.validate && this.validate();
 
-		// small validation hack
+		// validation hack: get_values will check for missing data
 		super.get_values(this.allow_incomplete);
 
 		if (window.saving) return;


### PR DESCRIPTION
Use doc object instead of values in webform when saving it. This allows updating the form values in after_load or validate events. 
