### PR TITLE
fix: Quotes at Jinja expression in Login Form

### DIFF
--- a/frappe/translations/es.csv
+++ b/frappe/translations/es.csv
@@ -70,7 +70,7 @@ DocType: Auto Repeat,Monthly,Mensual
 DocType: Address,Uttarakhand,Uttarakhand
 DocType: Email Account,Enable Incoming,Habilitar correos entrantes
 apps/frappe/frappe/core/doctype/version/version_view.html,Danger,Peligro
-apps/frappe/frappe/www/login.py,Email Address,Dirección de correo electrónico
+apps/frappe/frappe/www/login.py,Email address,Dirección de correo electrónico
 DocType: Workflow State,th-large,th-large
 DocType: Communication,Unread Notification Sent,Envíar una notificación al no ser leído
 apps/frappe/frappe/public/js/frappe/utils/tools.js,Export not allowed. You need {0} role to export.,Exportación no permitida. Se necesita el rol {0} para exportar.

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -13,12 +13,12 @@
 	<div class="login-content page-card" style="margin-top: 30px;">
 		<form class="form-signin form-login" role="form">
 			<div class="page-card-head">
-				<span class="indicator blue" data-text="{{ _("Login") }}"></span>
+				<span class="indicator blue" data-text="{{ _('Login') }}"></span>
 			</div>
 
 			<input type="text" id="login_email"
 				class="form-control"
-				placeholder="{% if login_name_placeholder %}{{ login_name_placeholder  }}{% else %}{{ _("Email address") }}{% endif %}"
+				placeholder="{% if login_name_placeholder %}{{ login_name_placeholder  }}{% else %}{{ _('Email address') }}{% endif %}"
 				required autofocus>
 
 			<div class="password-field" style="position: relative;">


### PR DESCRIPTION
Fix the placeholder translation of _Email Address_ field in the Login Form.