### PR TITLE
fix: Properly escape values passed in contact migration query

### DIFF
--- a/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
+++ b/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
@@ -9,22 +9,23 @@ def execute():
 	for contact_detail in contact_details:
 		contact_name = contact_detail.name
 
-		frappe.db.sql("""
+		if contact_detail.email_id:
+			frappe.db.sql("""
 				INSERT INTO `tabContact Email`
-						(`idx`, `name`, `email_id`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
+					(`idx`, `name`, `email_id`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
 				VALUES (1, %s, %s, 'email_ids', 'Contact', %s, 1, %s, %s, %s)
-		""", (frappe.generate_hash(contact_detail.email_id, 10), contact_detail.email_id, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
+			""", (frappe.generate_hash(contact_detail.email_id, 10), contact_detail.email_id, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
 
 		if contact_detail.phone:
 			frappe.db.sql("""
-					INSERT INTO `tabContact Phone`
-							(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
-					VALUES (1, %s, %s, 'phone_nos', 'Contact', %s, 1, %s, %s, %s)
+				INSERT INTO `tabContact Phone`
+					(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
+				VALUES (1, %s, %s, 'phone_nos', 'Contact', %s, 1, %s, %s, %s)
 			""", (frappe.generate_hash(contact_detail.phone, 10), contact_detail.phone, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
 
 		if contact_detail.mobile_no:
 			frappe.db.sql("""
-					INSERT INTO `tabContact Phone`
-							(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
-					VALUES (1, %s, %s, 'phone_nos', 'Contact', %s, 1, %s, %s, %s)
+				INSERT INTO `tabContact Phone`
+					(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
+				VALUES (1, %s, %s, 'phone_nos', 'Contact', %s, 1, %s, %s, %s)
 			""", (frappe.generate_hash(contact_detail.mobile_no, 10), contact_detail.mobile_no, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))

--- a/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
+++ b/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
@@ -7,25 +7,24 @@ def execute():
 	frappe.reload_doc("contacts", "doctype", "contact")
 
 	for contact_detail in contact_details:
-		contact_name = frappe.db.escape(contact_detail.name)
+		contact_name = contact_detail.name
 
-		if contact_detail.email_id:
-			frappe.db.sql("""
+		frappe.db.sql("""
 				INSERT INTO `tabContact Email`
-					(`idx`, `name`, `email_id`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
-				VALUES (1, '{0}', '{1}', 'email_ids', 'Contact', {2}, 1, '{3}', '{4}', '{5}')
-			""".format(frappe.generate_hash(contact_detail.email_id, 10), contact_detail.email_id, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
+						(`idx`, `name`, `email_id`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
+				VALUES (1, %s, %s, 'email_ids', 'Contact', %s, 1, %s, %s, %s)
+		""", (frappe.generate_hash(contact_detail.email_id, 10), contact_detail.email_id, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
 
 		if contact_detail.phone:
 			frappe.db.sql("""
-				INSERT INTO `tabContact Phone`
-					(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
-				VALUES (1, '{0}', '{1}', 'phone_nos', 'Contact', {2}, 1, '{3}', '{4}', '{5}')
-			""".format(frappe.generate_hash(contact_detail.phone, 10), contact_detail.phone, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
+					INSERT INTO `tabContact Phone`
+							(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
+					VALUES (1, %s, %s, 'phone_nos', 'Contact', %s, 1, %s, %s, %s)
+			""", (frappe.generate_hash(contact_detail.phone, 10), contact_detail.phone, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
 
 		if contact_detail.mobile_no:
 			frappe.db.sql("""
-				INSERT INTO `tabContact Phone`
-					(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
-				VALUES (2, '{0}', '{1}', 'phone_nos', 'Contact', {2}, 0, '{3}', '{4}', '{5}')
-			""".format(frappe.generate_hash(contact_detail.mobile_no, 10), contact_detail.mobile_no, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))
+					INSERT INTO `tabContact Phone`
+							(`idx`, `name`, `phone`, `parentfield`, `parenttype`, `parent`, `is_primary`, `creation`, `modified`, `modified_by`)
+					VALUES (1, %s, %s, 'phone_nos', 'Contact', %s, 1, %s, %s, %s)
+			""", (frappe.generate_hash(contact_detail.mobile_no, 10), contact_detail.mobile_no, contact_name, contact_detail.creation, contact_detail.modified, contact_detail.modified_by))


### PR DESCRIPTION
Escape values passed in query