### PR TITLE
fix: Fetch fullname from User then Contact

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -176,7 +176,7 @@ class Communication(Document):
 					first_name, last_name = frappe.db.get_value('Contact',
 						filters={'email_id': sender_email},
 						fieldname=['first_name', 'last_name']
-					)
+					) or [None, None]
 					self.sender_full_name = (first_name or '') + (last_name or '')
 
 				if not self.sender_full_name:

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -161,11 +161,26 @@ class Communication(Document):
 			else:
 				if self.sent_or_received=='Sent':
 					validate_email_add(self.sender, throw=True)
+
 				sender_name, sender_email = parse_addr(self.sender)
 				if sender_name == sender_email:
 					sender_name = None
+
 				self.sender = sender_email
-				self.sender_full_name = sender_name or frappe.db.exists("Contact", {"email_id": sender_email}) or sender_email
+				self.sender_full_name = sender_name
+
+				if not self.sender_full_name:
+					self.sender_full_name = frappe.db.get_value('User', self.sender, 'full_name')
+
+				if not self.sender_full_name:
+					first_name, last_name = frappe.db.get_value('Contact',
+						filters={'email_id': sender_email},
+						fieldname=['first_name', 'last_name']
+					)
+					self.sender_full_name = (first_name or '') + (last_name or '')
+
+				if not self.sender_full_name:
+					self.sender_full_name = sender_email
 
 	def send(self, print_html=None, print_format=None, attachments=None,
 		send_me_a_copy=False, recipients=None):


### PR DESCRIPTION
Let's say we have a Contact with the Email ID `test@example.com` and a User `test@example.com`.

Now, if the User `test@example.com` writes a comment, his name is fetched from `Contact`. 

This change will fetch the full name from User first and then look for the Contact.