### PR TITLE
fix: Overflowing values for Text, Small Text

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -560,7 +560,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					data-filter="${fieldname},=,${value}">
 					${_value}
 				</a>`;
-			} else if (df.fieldtype === 'Text Editor') {
+			} else if (['Text Editor', 'Text', 'Small Text'].includes(df.fieldtype)) {
 				html = `<span class="text-muted ellipsis">
 					${_value}
 				</span>`;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/9355208/64478794-5409b780-d1cb-11e9-8f98-4e252de96b43.png)

After:

![image](https://user-images.githubusercontent.com/9355208/64478799-68e64b00-d1cb-11e9-92d4-85156b7205b8.png)
