### PR TITLE
fix: Check istable using meta

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -556,7 +556,10 @@ frappe.ui.form.Form = class FrappeForm {
 			resolve();
 		};
 
-		var fail = () => {
+		var fail = (e) => {
+			if (e) {
+				console.error(e)
+			}
 			btn && $(btn).prop("disabled", false);
 			if(on_error) {
 				on_error();

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -147,7 +147,8 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			}
 
 			if (error_fields.length) {
-				if (doc.parenttype) {
+				let meta = frappe.get_meta(doc.doctype);
+				if (meta.istable) {
 					var message = __('Mandatory fields required in table {0}, Row {1}',
 						[__(frappe.meta.docfield_map[doc.parenttype][doc.parentfield].label).bold(), doc.idx]);
 				} else {

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -80,8 +80,10 @@ $.extend(frappe.model, {
 
 		locals[doc.doctype][doc.name] = doc;
 
+		let meta = frappe.get_meta(doc.doctype);
+		let is_table = meta ? meta.istable : doc.parentfield;
 		// add child docs to locals
-		if(!doc.parentfield) {
+		if (!is_table) {
 			for(var i in doc) {
 				var value = doc[i];
 


### PR DESCRIPTION
To check if a document is a child table document or not, `doc.parentfield` is checked. This is not foolproof. For e.g, if a Parent DocType is added as a Table in other DocType, the fields `parentfield`, `parent` and `parenttype` are added.

To fix this, we check for table using `meta.istable`