### PR TITLE
fix: Use .get() to avoid attribute error

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -122,7 +122,7 @@ def apply(doc, method):
 
 	# multiple auto assigns
 	for d in assignment_rules:
-		assignment_rule_docs.append(frappe.get_doc('Assignment Rule', d.name))
+		assignment_rule_docs.append(frappe.get_doc('Assignment Rule', d.get('name')))
 
 	if not assignment_rule_docs:
 		return
@@ -138,7 +138,7 @@ def apply(doc, method):
 			clear = assignment_rule.apply_unassign(doc, assignments)
 			if clear: break
 
-	# apply rule only if there are no exisiting assignments
+	# apply rule only if there are no existing assignments
 	if clear:
 		for assignment_rule in assignment_rule_docs:
 			if assignment_rule.apply_assign(doc): break


### PR DESCRIPTION
<img width="356" alt="Screenshot 2019-09-09 at 9 55 39 AM" src="https://user-images.githubusercontent.com/13928957/64503315-1cdcf880-d2e8-11e9-889d-bbcb83457dd5.png">

This happens when system tries to get data from cache because `frappe.cache_manager.get_doctype_map` internally uses `json.loads` and the dict returned from it does not support dot notation to access data. 