### PR TITLE
fix: Handle error on bulk deletion

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -226,22 +226,29 @@ def delete_items():
 	"""delete selected items"""
 	import json
 
-	il = sorted(json.loads(frappe.form_dict.get('items')), reverse=True)
+	items = sorted(json.loads(frappe.form_dict.get('items')), reverse=True)
 	doctype = frappe.form_dict.get('doctype')
 
-	failed = []
+	if len(items) > 10:
+		frappe.enqueue('frappe.desk.reportview.delete_bulk',
+			doctype=doctype, items=items)
+	else:
+		delete_bulk(doctype, items)
 
-	for i, d in enumerate(il):
+def delete_bulk(doctype, items):
+	for i, d in enumerate(items):
 		try:
 			frappe.delete_doc(doctype, d)
-			if len(il) >= 5:
+			if len(items) >= 5:
 				frappe.publish_realtime("progress",
-					dict(progress=[i+1, len(il)], title=_('Deleting {0}').format(doctype), description=d),
+					dict(progress=[i+1, len(items)], title=_('Deleting {0}').format(doctype), description=d),
 						user=frappe.session.user)
+			# Commit after successful deletion
+			frappe.db.commit()
 		except Exception:
-			failed.append(d)
-
-	return failed
+			# rollback if any record failed to delete
+			# if not rollbacked, queries get committed on after_request method in app.py
+			frappe.db.rollback()
 
 @frappe.whitelist()
 @frappe.read_only()

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -79,9 +79,6 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 					doc.flags.in_delete = True
 					doc.run_method('on_change')
 
-				frappe.enqueue('frappe.model.delete_doc.delete_dynamic_links', doctype=doc.doctype, name=doc.name,
-					is_async=False if frappe.flags.in_test else True)
-
 				# check if links exist
 				if not force:
 					check_if_doc_is_linked(doc)
@@ -93,6 +90,14 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 
 			# delete attachments
 			remove_all(doctype, name, from_delete=True)
+
+			if not for_reload:
+				# Enqueued at the end, because it gets committed
+				# All the linked docs should be checked beforehand
+				frappe.enqueue('frappe.model.delete_doc.delete_dynamic_links',
+					doctype=doc.doctype, name=doc.name,
+					is_async=False if frappe.flags.in_test else True)
+
 
 		# delete global search entry
 		delete_for_document(doc)


### PR DESCRIPTION
- On deletion of items from List view, if any error raised, it must be rollbacked. Otherwise, it gets committed on after_request method in app.py.

- Deletion of dynamic links - enqueued at the end to avoid commit in case of any other error.