### PR TITLE
fix: Remove !important to allow style override

### DIFF
--- a/frappe/public/less/website.less
+++ b/frappe/public/less/website.less
@@ -38,7 +38,7 @@ h1, h2, h3, h4, h5, h6 {
 
 	// anchor inside header should not be styled
 	a {
-		color: inherit !important;
+		color: inherit;
 		text-decoration: none;
 	}
 


### PR DESCRIPTION
Users were not able to override color for `<a>` inside `<h1>`. 

**Case:**
User added a website description for Item with yellow color heading from item master.
On the website, user was not able to see that yellow color for his description heading.