### PR TITLE
fix: fix legends on charts on user profile page

### DIFF
--- a/frappe/desk/page/user_profile/user_profile.js
+++ b/frappe/desk/page/user_profile/user_profile.js
@@ -179,6 +179,7 @@ class UserProfile {
 						labels: chart.labels,
 						datasets: chart.datasets
 					},
+					truncateLegends: 1,
 					barOptions: {
 						height: 11,
 						depth: 1


### PR DESCRIPTION
Truncate legends to avoid this:

<img width="965" alt="Screenshot 2019-09-10 at 1 46 26 PM" src="https://user-images.githubusercontent.com/19775888/64596405-74a35e80-d3d1-11e9-84e2-f97f16cf0791.png">
