### PR TITLE
fix(patch): Skip name column from duplicate index check

### DIFF
--- a/frappe/patches/v12_0/delete_duplicate_indexes.py
+++ b/frappe/patches/v12_0/delete_duplicate_indexes.py
@@ -19,6 +19,7 @@ def execute():
 				non_unique
 			FROM information_schema.STATISTICS
 			WHERE table_name=%s
+			AND column_name!='name'
 			AND non_unique=0
 			ORDER BY index_name;
 		""", table, as_dict=1)


### PR DESCRIPTION
Since `name` is the Primary column. Also avoids following error
<img width="989" alt="Screenshot 2019-09-10 at 2 39 30 PM" src="https://user-images.githubusercontent.com/13928957/64600761-55103400-d3d9-11e9-9f34-48981eb09244.png">
