### PR TITLE
fix: empty comments added

### DIFF
--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -60,7 +60,7 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 
 	update_state() {
 		const value = this.get_value();
-		if (strip_html(value)) {
+		if (strip_html(value).trim() != "") {
 			this.button.removeClass('btn-default').addClass('btn-primary');
 		} else {
 			this.button.addClass('btn-default').removeClass('btn-primary');

--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -30,7 +30,7 @@ frappe.ui.form.Timeline = class Timeline {
 			render_input: true,
 			only_input: true,
 			on_submit: (val) => {
-				if(strip_html(val)) {
+				if(strip_html(val).trim() != "") {
 					this.insert_comment(val, this.comment_area.button);
 				}
 			}


### PR DESCRIPTION
- Comments consisting of only whitespaces should not be inserted.
- **Comment** button should not become primary when comments of the above type are created.