### PR TITLE
fix: Improper "bold text" in timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -562,37 +562,36 @@ frappe.ui.form.Timeline = class Timeline {
 	build_version_comments(docinfo, out) {
 		var me = this;
 		docinfo.versions.forEach(function(version) {
-			if(!version.data) return;
+			if (!version.data) return;
 			var data = JSON.parse(version.data);
 
 			// comment
-			if(data.comment) {
+			if (data.comment) {
 				out.push(me.get_version_comment(version, data.comment, data.comment_type));
 				return;
 			}
 
 			// value changed in parent
-			if(data.changed && data.changed.length) {
-				var parts = [];
-				data.changed.every(function(p) {
-					if(p[0]==='docstatus') {
-						if(p[2]==1) {
+			if (data.changed && data.changed.length) {
+				const parts = [];
+				data.changed.every(function (p) {
+					if (p[0] === 'docstatus') {
+						if (p[2] == 1) {
 							out.push(me.get_version_comment(version, __('submitted this document')));
-						} else if (p[2]==2) {
+						} else if (p[2] == 2) {
 							out.push(me.get_version_comment(version, __('cancelled this document')));
 						}
 					} else {
-
-						var df = frappe.meta.get_docfield(me.frm.doctype, p[0], me.frm.docname);
-
+						p = p.map(frappe.utils.escape_html);
+						const df = frappe.meta.get_docfield(me.frm.doctype, p[0], me.frm.docname);
 						if (df && !df.hidden) {
-							var field_display_status = frappe.perm.get_field_display_status(df, null,
+							const field_display_status = frappe.perm.get_field_display_status(df, null,
 								me.frm.perm);
 							if (field_display_status === 'Read' || field_display_status === 'Write') {
 								parts.push(__('{0} from {1} to {2}', [
 									__(df.label),
-									(frappe.ellipsis(frappe.utils.html2text(p[1]), 40) || '""'),
-									(frappe.ellipsis(frappe.utils.html2text(p[2]), 40) || '""')
+									(frappe.ellipsis(frappe.utils.html2text(p[1]), 40) || '""').bold(),
+									(frappe.ellipsis(frappe.utils.html2text(p[2]), 40) || '""').bold()
 								]));
 							}
 						}
@@ -600,8 +599,7 @@ frappe.ui.form.Timeline = class Timeline {
 					return parts.length < 3;
 				});
 				if (parts.length) {
-					parts = parts.map(frappe.utils.escape_html);
-					out.push(me.get_version_comment(version, __("changed value of {0}", [parts.join(', ').bold()])));
+					out.push(me.get_version_comment(version, __('changed value of {0}', [parts.join(', ')])));
 				}
 			}
 

--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -585,21 +585,21 @@ frappe.ui.form.Timeline = class Timeline {
 
 						var df = frappe.meta.get_docfield(me.frm.doctype, p[0], me.frm.docname);
 
-						if(df && !df.hidden) {
+						if (df && !df.hidden) {
 							var field_display_status = frappe.perm.get_field_display_status(df, null,
 								me.frm.perm);
-							if(field_display_status === 'Read' || field_display_status === 'Write') {
+							if (field_display_status === 'Read' || field_display_status === 'Write') {
 								parts.push(__('{0} from {1} to {2}', [
 									__(df.label),
-									(frappe.ellipsis(frappe.utils.html2text(p[1]), 40) || '""').bold(),
-									(frappe.ellipsis(frappe.utils.html2text(p[2]), 40) || '""').bold()
+									(frappe.ellipsis(frappe.utils.html2text(p[1]), 40) || '""'),
+									(frappe.ellipsis(frappe.utils.html2text(p[2]), 40) || '""')
 								]));
 							}
 						}
 					}
 					return parts.length < 3;
 				});
-				if(parts.length) {
+				if (parts.length) {
 					parts = parts.map(frappe.utils.escape_html);
 					out.push(me.get_version_comment(version, __("changed value of {0}", [parts.join(', ').bold()])));
 				}


### PR DESCRIPTION
**Before:**
<img width="965" alt="Screenshot 2019-09-11 at 9 38 12 AM" src="https://user-images.githubusercontent.com/13928957/64668064-c30c3800-d479-11e9-9400-a78665d84f9d.png">

**After**
<img width="937" alt="Screenshot 2019-09-11 at 9 45 47 AM" src="https://user-images.githubusercontent.com/13928957/64668080-ce5f6380-d479-11e9-89da-0ff20738a92b.png">
