### PR TITLE
fix(PostgreSQL): if not db host then localhost

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -17,7 +17,7 @@ def setup_database(force, source_sql, verbose):
 	subprocess_env['PGPASSWORD'] = str(frappe.conf.db_password)
 	# bootstrap db
 	subprocess.check_output([
-		'psql', frappe.conf.db_name, '-h', frappe.conf.db_host, '-U',
+		'psql', frappe.conf.db_name, '-h', frappe.conf.db_host or 'localhost', '-U',
 		frappe.conf.db_name, '-f',
 		os.path.join(os.path.dirname(__file__), 'framework_postgres.sql')
 	], env=subprocess_env)


### PR DESCRIPTION
- If `frappe.conf.db_host` is None then site creation in postgres breaks
```Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/himanshuwarekar/Frappe/version-12/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/himanshuwarekar/Frappe/version-12/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/himanshuwarekar/Frappe/version-12/env/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/himanshuwarekar/Frappe/version-12/env/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/himanshuwarekar/Frappe/version-12/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/himanshuwarekar/Frappe/version-12/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/himanshuwarekar/Frappe/version-12/env/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/himanshuwarekar/Frappe/version-12/env/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/himanshuwarekar/Frappe/version-12/apps/frappe/frappe/commands/site.py", line 32, in new_site
    db_type=db_type)
  File "/Users/himanshuwarekar/Frappe/version-12/apps/frappe/frappe/commands/site.py", line 69, in _new_site
    source_sql=source_sql, force=force, reinstall=reinstall, db_type=db_type)
  File "/Users/himanshuwarekar/Frappe/version-12/apps/frappe/frappe/installer.py", line 34, in install_db
    setup_database(force, source_sql, verbose)
  File "/Users/himanshuwarekar/Frappe/version-12/apps/frappe/frappe/database/__init__.py", line 13, in setup_database
    return frappe.database.postgres.setup_db.setup_database(force, source_sql, verbose)
  File "/Users/himanshuwarekar/Frappe/version-12/apps/frappe/frappe/database/postgres/setup_db.py", line 23, in setup_database
    ], env=subprocess_env)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 1453, in _execute_child
    restore_signals, start_new_session, preexec_fn)
TypeError: expected str, bytes or os.PathLike object, not NoneType```