### PR TITLE
fix(Role): Don't return admin and guest placeholder email

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -31,7 +31,7 @@ def get_emails_from_role(role):
 
 	for user in users:
 		user_email, enabled = frappe.db.get_value("User", user.parent, ["email", "enabled"])
-		if enabled:
+		if enabled and user_email not in ["admin@example.com", "guest@example.com"]:
 			emails.append(user_email)
 
 	return emails

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -309,9 +309,7 @@ def evaluate_alert(doc, alert, event):
 				else:
 					raise
 			db_value = parse_val(db_value)
-			if (doc.get(alert.value_changed) == db_value) or \
-				(not db_value and not doc.get(alert.value_changed)):
-
+			if (doc.get(alert.value_changed) == db_value) or (not db_value and not doc.get(alert.value_changed)):
 				return # value not changed
 
 		if event != "Value Change" and not doc.is_new():


### PR DESCRIPTION
- When getting emails from role, do not return admin@example.com and guest@example.com placeholder email addresses