### PR TITLE
fix: Validate invalid fieldnames

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -488,6 +488,12 @@ def validate_fields(meta):
 	def check_illegal_characters(fieldname):
 		validate_column_name(fieldname)
 
+	def check_invalid_fieldnames(docname, fieldname):
+		invalid_fields = ('doctype',)
+		if fieldname in invalid_fields:
+			frappe.throw(_("{0}: Fieldname cannot one of {1}")
+				.format(docname, ", ".join(invalid_fields)))
+
 	def check_unique_fieldname(docname, fieldname):
 		duplicates = list(filter(None, map(lambda df: df.fieldname==fieldname and str(df.idx) or None, fields)))
 		if len(duplicates) > 1:
@@ -719,6 +725,7 @@ def validate_fields(meta):
 			d.fieldname = d.fieldname.lower()
 
 		check_illegal_characters(d.fieldname)
+		check_invalid_fieldnames(meta.get("name"), d.fieldname)
 		check_unique_fieldname(meta.get("name"), d.fieldname)
 		check_fieldname_length(d.fieldname)
 		check_illegal_mandatory(meta.get("name"), d)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -491,8 +491,8 @@ def validate_fields(meta):
 	def check_invalid_fieldnames(docname, fieldname):
 		invalid_fields = ('doctype',)
 		if fieldname in invalid_fields:
-			frappe.throw(_("{0}: Fieldname cannot one of {1}")
-				.format(docname, ", ".join(invalid_fields)))
+			frappe.throw(_("{0}: Fieldname cannot be one of {1}")
+				.format(docname, ", ".join([frappe.bold(d) for d in invalid_fields])))
 
 	def check_unique_fieldname(docname, fieldname):
 		duplicates = list(filter(None, map(lambda df: df.fieldname==fieldname and str(df.idx) or None, fields)))


### PR DESCRIPTION
`doctype` is an invalid fieldname, it overwrites `doctype` property of `get_doc`