### PR TITLE
fix: Skip get_table_fields of Custom Field if field_doctype is Custom Field

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -161,6 +161,9 @@ def delete_from_table(doctype, name, ignore_doctypes, doc):
 
 	else:
 		def get_table_fields(field_doctype):
+			if field_doctype == 'Custom Field':
+				return []
+
 			return [r[0] for r in frappe.get_all(field_doctype,
 				fields='options',
 				filters={


### PR DESCRIPTION
Skip get_table_fields of Custom Field if field_doctype is Custom Field. This avoids following error while migrating https://github.com/frappe/frappe/pull/8399.

```
Updating DocTypes for frappe        : [=                                       ]Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 50, in migrate
    frappe.model.sync.sync_all(verbose=verbose)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/sync.py", line 19, in sync_all
    sync_for(app, force, verbose=verbose, reset_permissions=reset_permissions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/sync.py", line 56, in sync_for
    reset_permissions=reset_permissions, for_sync=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 66, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 132, in import_doc
    frappe.delete_doc(doc.doctype, doc.name, force=1, ignore_doctypes=ignore, for_reload=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 777, in delete_doc
    ignore_permissions, flags, ignore_on_trash, ignore_missing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 76, in delete_doc
    delete_from_table(doctype, name, ignore_doctypes, None)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 175, in delete_from_table
    tables += get_table_fields("Custom Field")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 170, in get_table_fields
    as_list=1
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1293, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1266, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 95, in execute
    result = self.build_and_run()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 109, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 136, in prepare_args
    self.build_conditions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 323, in build_conditions
    self.build_filter_conditions(self.filters, self.conditions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 344, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 351, in prepare_filter_condition
    f = get_filter(self.doctype, f)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/data.py", line 898, in get_filter
    meta = frappe.get_meta(f.doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 759, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 37, in get_meta
    meta = Meta(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 84, in __init__
    super(Meta, self).__init__("DocType", doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 104, in __init__
    self.load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 89, in load_from_db
    super(Meta, self).load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 147, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType Custom Field not found
```