### PR TITLE
fix: show scheduler inactive only for production

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -135,7 +135,7 @@ frappe.Application = Class.extend({
 			frappe.call({
 				method: 'frappe.core.page.background_jobs.background_jobs.get_scheduler_status',
 				callback: function(r) {
-					if (r.message[0] == __("Inactive")) {
+					if (r.message[0] == __("Inactive") && !frappe.boot.developer_mode) {
 						frappe.msgprint({
 							title: __("Scheduler Inactive"),
 							indicator: "red",


### PR DESCRIPTION
do not show the popup when the site is in developer_mode