### PR TITLE
refactor: convert link field to autocomplete

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -48,7 +48,7 @@ def sanitize_searchfield(searchfield):
 				_raise_exception(searchfield)
 
 # this is called by the Link Field
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def search_link(doctype, txt, query=None, filters=None, page_length=20, searchfield=None, reference_doctype=None, ignore_user_permissions=False):
 	search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters, reference_doctype=reference_doctype, ignore_user_permissions=ignore_user_permissions)
 	frappe.response['results'] = build_for_autosuggest(frappe.response["values"])

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -48,7 +48,7 @@ def sanitize_searchfield(searchfield):
 				_raise_exception(searchfield)
 
 # this is called by the Link Field
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def search_link(doctype, txt, query=None, filters=None, page_length=20, searchfield=None, reference_doctype=None, ignore_user_permissions=False):
 	search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters, reference_doctype=reference_doctype, ignore_user_permissions=ignore_user_permissions)
 	frappe.response['results'] = build_for_autosuggest(frappe.response["values"])

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -100,7 +100,9 @@ frappe.ready(function() {
 
 					return df;
 				}
-				if (df.fieldtype === "Link") df.only_select = true;
+				if (df.fieldtype === "Link") {
+					df.only_select = true;
+				}
 			});
 
 			return form_data;

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -527,6 +527,14 @@ def get_form_data(doctype, docname=None, web_form_name=None):
 			field.fields = get_in_list_view_fields(field.options)
 			out.update({field.fieldname: field.fields})
 
+		if field.fieldtype == "Link":
+			field.fieldtype = "Autocomplete"
+			field.options = get_link_options(
+				web_form_name,
+				field.options,
+				field.allow_read_on_all_link_options
+			)
+
 	return out
 
 @frappe.whitelist()


### PR DESCRIPTION
For webforms with links for fields like country, the search_link API is not open to guests. This PR changes that.

Since the appropriated doc permissions apply anyway, exposing this method will not cause any security issue