### PR TITLE
feat(Contact): Show address related to doctype in child

### DIFF
--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -48,7 +48,6 @@ frappe.ui.form.on("Contact", {
 				args: {links: frm.doc.links},
 				callback: function(r) {
 					if (r && r.message) {
-						console.log(r.message);
 						frm.set_query("address", function () {
 							return {
 								filters: {

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -41,6 +41,25 @@ frappe.ui.form.on("Contact", {
 			}
 		});
 		frm.refresh_field("links");
+
+		if (frm.doc.links.length > 0) {
+			frappe.call({
+				method: "frappe.contacts.doctype.contact.contact.address_query",
+				args: {links: frm.doc.links},
+				callback: function(r) {
+					if (r && r.message) {
+						console.log(r.message);
+						frm.set_query("address", function () {
+							return {
+								filters: {
+									name: ["in", r.message],
+								}
+							}
+						});
+					}
+				}
+			});
+		}
 	},
 	validate: function(frm) {
 		// clear linked customer / supplier / sales partner on saving...

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -206,6 +206,9 @@ def address_query(links):
 	result = []
 
 	for link in links:
+		if not frappe.has_permission(doctype=link.get("link_doctype"), ptype="read", doc=link.get("link_name")):
+			continue
+
 		res = frappe.db.sql("""
 			SELECT `tabAddress`.name
 			FROM `tabAddress`, `tabDynamic Link`

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -198,6 +198,29 @@ def contact_query(doctype, txt, searchfield, start, page_len, filters):
 			'link_doctype': link_doctype
 		})
 
+@frappe.whitelist()
+def address_query(links):
+	import json
+
+	links = [{"link_doctype": d.get("link_doctype"), "link_name": d.get("link_name")} for d in json.loads(links)]
+	result = []
+
+	for link in links:
+		res = frappe.db.sql("""
+			SELECT `tabAddress`.name
+			FROM `tabAddress`, `tabDynamic Link`
+			WHERE `tabDynamic Link`.parenttype='Address'
+				AND `tabDynamic Link`.parent=`tabAddress`.name
+				AND `tabDynamic Link`.link_doctype = %(link_doctype)s
+				AND `tabDynamic Link`.link_name = %(link_name)s
+		""", {
+			"link_doctype": link.get("link_doctype"),
+			"link_name": link.get("link_name"),
+		}, as_dict=True)
+
+		result.extend([l.name for l in res])
+
+	return result
 
 def get_contact_with_phone_number(number):
 	if not number: return


### PR DESCRIPTION
- If an Address is related to any doctype in Contact Links, the address field in Contacts will be filtered based on that
- Filtered Address for Contact with Links
![add_filt](https://user-images.githubusercontent.com/7310479/64919609-a26e1600-d7ca-11e9-80e6-c0717a58d894.gif)

- Unfiltered Address for Contact without Links
![add_filt_un](https://user-images.githubusercontent.com/7310479/64919611-a5690680-d7ca-11e9-96a7-6df514a57f11.gif)
