### PR TITLE
fix: v11 patch breaking as v11 dint have google contacts

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -42,7 +42,7 @@ class Contact(Document):
 		if self.email_id and not self.image:
 			self.image = has_gravatar(self.email_id)
 
-		if self.sync_with_google_contacts and not self.google_contacts:
+		if self.get("sync_with_google_contacts") and not self.get("google_contacts"):
 			frappe.throw(_("Select Google Contacts to which contact should be synced."))
 
 		deduplicate_dynamic_links(self)


### PR DESCRIPTION
- use `.get()` to check for google contacts parameters in Contacts