### PR TITLE
feat: click on currently viewing user to open chat with that user

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_viewers.js
+++ b/frappe/public/js/frappe/form/sidebar/form_viewers.js
@@ -1,34 +1,33 @@
-function openChatWith(viewer){
-		function displayRoom(room){
-				// frappe.chatter.render({room: room});
-				/* The above may be the way to go to display the chat,
-					 but it inserts a completely new chat into the dom
-					 which will lead to issues with toggeling the chat
-					 using the normal toggle function in the page header
-				*/
-				//Ugly, but I don't find a better way
-				frappe.chat.widget.props.children[0].attributes.click(room);
-		}
+function openChatWith (viewer) {
+	function displayRoom (room) {
+		/* The following line may be the way to go to display the chat,
+			 but it inserts a completely new chat into the dom
+			 which will lead to issues with toggeling the chat
+			 using the normal toggle function in the page header
+		*/
+		// frappe.chatter.render({room: room});
 
-		frappe.chat.widget.toggle(true);				// display Chat
-		frappe.chat.room.get().then(
-				function (rooms) {
-						if (! Array.isArray(rooms)){
-								rooms = [rooms];
-						}
-						let directChatsWithViewer = rooms.filter(function(room) {
-								return room.type === "Direct" &&
-										(room.owner === viewer || room.users.includes(viewer));
-						});
-						if (directChatsWithViewer.length > 0){
-								displayRoom(directChatsWithViewer[0]);
-						} else {
-								frappe.chat.room.create("Direct", null, viewer).then(room => displayRoom(room));
-						}
-				});
-		return false;	 /*  Becuase we execute this method onClick, it is very important to disable the
-											 onClick listeners to bubble up by returning false.
-											 The document onClick would trigger and make the chat widget invisible again */
+		//Ugly, but I don't find a better way
+		frappe.chat.widget.props.children[0].attributes.click(room);
+	}
+	frappe.chat.widget.toggle(true);				// display Chat
+	frappe.chat.room.get().then(
+		function (rooms) {
+			if (!Array.isArray(rooms)) {
+				rooms = [rooms];
+			}
+			let directChatsWithViewer = rooms.filter(function(room) {
+				return room.type === "Direct" && (room.owner === viewer || room.users.includes(viewer));
+			});
+			if (directChatsWithViewer.length > 0) {
+				displayRoom(directChatsWithViewer[0]);
+			} else {
+				frappe.chat.room.create("Direct", null, viewer).then(room => displayRoom(room));
+			}
+		});
+	return false;	 /*  Becuase we execute this method onClick, it is very important to disable the
+										 onClick listeners to bubble up by returning false.
+										 The document onClick would trigger and make the chat widget invisible again */
 }
 
 
@@ -78,7 +77,7 @@ frappe.ui.form.Viewers = Class.extend({
 			this.parent.parent().removeClass("hidden");
 			this.parent.append(frappe.render_template("users_in_sidebar", {"users": users}));
 			this.parent.find(".avatar").on("click", function(e) {
-					return openChatWith($(e.currentTarget).data('username'));
+				return openChatWith($(e.currentTarget).data('username'));
 			});
 
 		} else {

--- a/frappe/public/js/frappe/form/templates/users_in_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/users_in_sidebar.html
@@ -1,7 +1,7 @@
 {% for (var i=0, l=users.length; i < l; i++) {
 	var u = users[i];
 %}
-	<span class="avatar avatar-small {{ u.avatar_class || "" }}" title="{{ u.title }}">
+  <span class="avatar avatar-small {{ u.avatar_class || "" }}" {% if(u.username) { %} data-username ="{{ u.username }}" {% }  %}title="{{ u.title }}">
 	{% if (u.icon) { %}
 		<i class="{{ u.icon }}"></i>
 	{% } else if(u.image) { %}


### PR DESCRIPTION
When two users are working on the same document it makes sense for them to talk about whatever they want to do as they would create conflicts anyway (the one who saves the document first, will force the other one to redo all his/her changes).
To make it easy for them to get into contact, we added a shortcut to open a chat