### PR TITLE
fix: assignments reflect after removing on sidebar

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -110,7 +110,7 @@ def close_all_assignments(doctype, name):
 
 @frappe.whitelist()
 def remove(doctype, name, assign_to):
-	set_status(doctype, name, assign_to, status="Cancelled")
+	return set_status(doctype, name, assign_to, status="Cancelled")
 
 def set_status(doctype, name, assign_to, status="Cancelled"):
 	"""remove from todo"""


### PR DESCRIPTION
On removing an assignment from a form, the existing assignments would not be returned. So assignments on sidebar would be blank until refreshed. This PR fixes that.
