### PR TITLE
fix: fix non-ascii characters in HTTP headers.

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -115,12 +115,12 @@ def build_response(path, data, http_status_code, headers=None):
 	response = Response()
 	response.data = set_content_type(response, data, path)
 	response.status_code = http_status_code
-	response.headers["X-Page-Name"] = path.encode("utf-8")
+	response.headers["X-Page-Name"] = path.encode("ascii", errors="xmlcharrefreplace")
 	response.headers["X-From-Cache"] = frappe.local.response.from_cache or False
 
 	if headers:
 		for key, val in iteritems(headers):
-			response.headers[key] = val.encode("utf-8")
+			response.headers[key] = val.encode("ascii", errors="xmlcharrefreplace")
 
 	return response
 


### PR DESCRIPTION
HTTP headers need to be ascii or Gunicorn throws an exception.
The error handler 'xmlcharrefreplace' is chosen for no particular
reason.

See example of an error here:
frappe/erpnext#17536

I had the same problem with an Item page that had a non-ascii character in the URL - it went in the X-Page-Name header value and broke everything.