### PR TITLE
fix(report-view): show export all checkbox only if total row count ex…

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1231,23 +1231,27 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				action: () => {
 					const args = this.get_args();
 					const selected_items = this.get_checked_items(true);
+					let fields = [
+						{
+							fieldtype: 'Select',
+							label: __('Select File Type'),
+							fieldname:'file_format_type',
+							options: ['Excel', 'CSV'],
+							default: 'Excel'
+						}
+					]
+
+					if (this.total_count > args.page_length) {
+						fields.push({
+							fieldtype: 'Check',
+							fieldname: 'export_all_rows',
+							label: __('Export All {0} rows?', [(this.total_count + "").bold()])
+						});
+					}
 
 					const d = new frappe.ui.Dialog({
 						title: __("Export Report: {0}",[__(this.doctype)]),
-						fields: [
-							{
-								fieldtype: 'Select',
-								label: __('Select File Type'),
-								fieldname:'file_format_type',
-								options: ['Excel', 'CSV'],
-								default: 'Excel'
-							},
-							{
-								fieldtype: 'Check',
-								fieldname: 'export_all_rows',
-								label: __('Export All {0} rows?', [(this.total_count + "").bold()])
-							}
-						],
+						fields: fields,
 						primary_action_label: __('Download'),
 						primary_action: (data) => {
 							args.cmd = 'frappe.desk.reportview.export_query';

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1239,7 +1239,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							options: ['Excel', 'CSV'],
 							default: 'Excel'
 						}
-					]
+					];
 
 					if (this.total_count > args.page_length) {
 						fields.push({


### PR DESCRIPTION
Problem:
- The **Export All rows** checkbox is for exporting all filtered rows if they are exceeding the page length. But it even shows up if the row count is not exceeding the page length.

Fix:
- Don't show the checkbox when page length is not getting exceeded
Case 1: not exceeding
![export_row](https://user-images.githubusercontent.com/24353136/65063039-08a99300-d99b-11e9-9182-f1ee043334d9.png)
Case 2: exceeding
![export_row_exceed_page_length](https://user-images.githubusercontent.com/24353136/65063040-09dac000-d99b-11e9-83c9-d38603327d3e.png)

- Another reason to do this
shows **1 rows** and not **1 row** But there is no need for that checkbox
![export_report_1_rows](https://user-images.githubusercontent.com/24353136/65063422-d9dfec80-d99b-11e9-9b90-2595b5cd8155.png)





