### PR TITLE
fix: Dont delete controller files on doctype delete

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -75,7 +75,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 
 			delete_from_table(doctype, name, ignore_doctypes, None)
 
-			if not (frappe.flags.in_migrate or frappe.flags.in_install or frappe.flags.in_test):
+			if not (for_reload or frappe.flags.in_migrate or frappe.flags.in_install or frappe.flags.in_test):
 				try:
 					delete_controllers(name, doc.module)
 				except (FileNotFoundError, OSError):


### PR DESCRIPTION
`reload_doc` calls `delete_doc` which deletes controller files. This does more harm than good, so removing.