### PR TITLE
chore: Squash PRs when squash label is added

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,3 +11,16 @@ pull_request_rules:
     actions:
       merge:
         method: merge
+  - name: Automatic squash on CI success and review
+    conditions:
+      - status-success=Codacy/PR Quality Review
+      - status-success=Semantic Pull Request
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=security/snyk - package.json (frappe)
+      - status-success=security/snyk - requirements.txt (frappe)
+      - label!=don't-merge
+      - label=squash
+      - "#approved-reviews-by>=1"
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
Mergify used to **Merge** all PRs. This is for PRs that needs to be squashed.

Reviewers should add the squash label and then approve the PR.