### PR TITLE
fix: User Permission issue in Reports

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -562,7 +562,7 @@ def get_linked_doctypes(columns, data):
 	for idx, col in enumerate(columns):
 		df = columns_dict[idx]
 		if df.get("fieldtype")=="Link":
-			if isinstance(col, string_types):
+			if data and isinstance(data[0], (list, tuple)):
 				linked_doctypes[df["options"]] = idx
 			else:
 				# dict


### PR DESCRIPTION
Data was not getting filtered properly because the `get_linked_doctype`
was returning empty for some reports.

**Before:**
<img width="1173" alt="Screenshot 2019-09-18 at 2 28 14 PM" src="https://user-images.githubusercontent.com/13928957/65133681-a7c49e00-da20-11e9-9a3f-e423ef117bd2.png">


**After:**
<img width="1169" alt="Screenshot 2019-09-18 at 2 26 38 PM" src="https://user-images.githubusercontent.com/13928957/65133699-b01cd900-da20-11e9-889b-2bac3b93589e.png">


**Note:** User had user permission on warehouse **Stores - FB**