### PR TITLE
fix: use getfullargspec for type annotations

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1039,7 +1039,13 @@ def get_newargs(fn, kwargs):
 	if hasattr(fn, 'fnargs'):
 		fnargs = fn.fnargs
 	else:
-		fnargs, varargs, varkw, defaults = inspect.getargspec(fn)
+		try:
+			fnargs, varargs, varkw, defaults = inspect.getargspec(fn)
+		except ValueError:
+			fnargs = inspect.getfullargspec(fn).args
+			varargs = inspect.getfullargspec(fn).varargs
+			varkw = inspect.getfullargspec(fn).varkw
+			defaults = inspect.getfullargspec(fn).defaults
 
 	newargs = {}
 	for a in kwargs:

--- a/frappe/desk/form/run_method.py
+++ b/frappe/desk/form/run_method.py
@@ -31,7 +31,14 @@ def runserverobj(method, docs=None, dt=None, dn=None, arg=None, args=None):
 		except ValueError:
 			args = args
 
-		fnargs, varargs, varkw, defaults = inspect.getargspec(getattr(doc, method))
+		try:
+			fnargs, varargs, varkw, defaults = inspect.getargspec(getattr(doc, method))
+		except ValueError:
+			fnargs = inspect.getfullargspec(getattr(doc, method)).args
+			varargs = inspect.getfullargspec(getattr(doc, method)).varargs
+			varkw = inspect.getfullargspec(getattr(doc, method)).varkw
+			defaults = inspect.getfullargspec(getattr(doc, method)).defaults
+
 		if not fnargs or (len(fnargs)==1 and fnargs[0]=="self"):
 			r = doc.run_method(method)
 


### PR DESCRIPTION
- `inspect.getargspec()` doesn't support type annotations.
- `inspect.getfullargspec()` is used to support it.
- Currently `inspect.getargspec()` breaks if we put type hints
```
    def foo(bar: list = None):
        pass
```
- [typing — Support for type hints](https://docs.python.org/3.6/library/typing.html)