### PR TITLE
fix(Session): Check ip restriction before resuming session

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -51,8 +51,6 @@ def application(request):
 
 		init_request(request)
 
-		frappe.recorder.record()
-
 		if frappe.local.form_dict.cmd:
 			response = frappe.handler.handle()
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -24,7 +24,6 @@ from frappe.middlewares import StaticDataMiddleware
 from frappe.utils.error import make_error_snapshot
 from frappe.core.doctype.comment.comment import update_comments_in_parent_after_request
 from frappe import _
-import frappe.recorder
 
 local_manager = LocalManager([frappe.local])
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -24,6 +24,7 @@ from frappe.middlewares import StaticDataMiddleware
 from frappe.utils.error import make_error_snapshot
 from frappe.core.doctype.comment.comment import update_comments_in_parent_after_request
 from frappe import _
+import frappe.recorder
 
 local_manager = LocalManager([frappe.local])
 
@@ -49,6 +50,8 @@ def application(request):
 		rollback = True
 
 		init_request(request)
+
+		frappe.recorder.record()
 
 		if frappe.local.form_dict.cmd:
 			response = frappe.handler.handle()

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -407,10 +407,10 @@ def validate_ip_address(user):
 	enabled = int(frappe.get_system_settings('enable_two_factor_auth') or 0)
 	if enabled:
 		#check if bypass restrict ip is enabled for all users
-		bypass_restrict_ip_check = int(frappe.get_system_settings('bypass_restrict_ip_check_if_2fa_enabled') or 0)
+		bypass_restrict_ip_check = int(frappe.get_system_settings('bypass_restrict_ip_check_if_2fa_enabled')) or 0
 		if not bypass_restrict_ip_check:
 			#check if bypass restrict ip is enabled for login user
-			bypass_restrict_ip_check = int(frappe.db.get_value('User', user, 'bypass_restrict_ip_check_if_2fa_enabled') or 0)
+			bypass_restrict_ip_check = user.bypass_restrict_ip_check_if_2fa_enabled or 0
 	for ip in ip_list:
 		if frappe.local.request_ip.startswith(ip) or bypass_restrict_ip_check:
 			return

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -18,7 +18,6 @@ from frappe.utils.password import check_password, delete_login_failed_cache
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
 from frappe.twofactor import (should_run_2fa, authenticate_for_2factor,
 	confirm_otp_token, get_cached_user_pass)
-import frappe.recorder
 from six.moves.urllib.parse import quote
 
 

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -18,7 +18,7 @@ from frappe.utils.password import check_password, delete_login_failed_cache
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
 from frappe.twofactor import (should_run_2fa, authenticate_for_2factor,
 	confirm_otp_token, get_cached_user_pass)
-
+import frappe.recorder
 from six.moves.urllib.parse import quote
 
 
@@ -400,11 +400,17 @@ def check_consecutive_login_attempts(user, doc):
 def validate_ip_address(user):
 	"""check if IP Address is valid"""
 	user = frappe.get_cached_doc("User", user)
+	if frappe.flags.in_test:
+		user = frappe.get_doc("User", user)
+
 	ip_list = user.get_restricted_ip_list()
 	if not ip_list:
 		return
 
 	system_settings = frappe.get_cached_doc("System Settings")
+	if frappe.flags.in_test:
+		system_settings = frappe.get_doc("System Settings")
+
 	bypass_restrict_ip_check = None
 
 	# check if two factor auth is enabled

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -47,6 +47,8 @@ class HTTPRequest:
 		# set db
 		self.connect()
 
+		frappe.recorder.record()
+
 		# login
 		frappe.local.login_manager = LoginManager()
 
@@ -397,22 +399,21 @@ def check_consecutive_login_attempts(user, doc):
 
 def validate_ip_address(user):
 	"""check if IP Address is valid"""
-	user = frappe.get_doc("User", user)
+	user = frappe.get_cached_doc("User", user)
 	ip_list = user.get_restricted_ip_list()
 	if not ip_list:
 		return
 
-	bypass_restrict_ip_check = 0
+	system_settings = frappe.get_cached_doc("System Settings")
+	bypass_restrict_ip_check = None
+
 	# check if two factor auth is enabled
-	enabled = int(frappe.get_system_settings('enable_two_factor_auth') or 0)
-	if enabled:
-		#check if bypass restrict ip is enabled for all users
-		bypass_restrict_ip_check = int(frappe.get_system_settings('bypass_restrict_ip_check_if_2fa_enabled')) or 0
-		if not bypass_restrict_ip_check:
-			#check if bypass restrict ip is enabled for login user
-			bypass_restrict_ip_check = user.bypass_restrict_ip_check_if_2fa_enabled or 0
+	if system_settings.enable_two_factor_auth and not system_settings.bypass_restrict_ip_check_if_2fa_enabled:
+		# check if bypass restrict ip is enabled for all users or check if bypass restrict ip is enabled for login user
+		bypass_restrict_ip_check = user.bypass_restrict_ip_check_if_2fa_enabled
+
 	for ip in ip_list:
 		if frappe.local.request_ip.startswith(ip) or bypass_restrict_ip_check:
 			return
 
-	frappe.throw(_("Not allowed from this IP Address"), frappe.AuthenticationError)
+	frappe.throw(_("Access not allowed from this IP Address"), frappe.AuthenticationError)

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -18,6 +18,7 @@ from frappe.utils.password import check_password, delete_login_failed_cache
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
 from frappe.twofactor import (should_run_2fa, authenticate_for_2factor,
 	confirm_otp_token, get_cached_user_pass)
+
 from six.moves.urllib.parse import quote
 
 

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -403,11 +403,12 @@ def validate_ip_address(user):
 		return
 
 	system_settings = frappe.get_cached_doc("System Settings") if not frappe.flags.in_test else frappe.get_single("System Settings")
-	bypass_restrict_ip_check = None
+	# check if bypass restrict ip is enabled for all users
+	bypass_restrict_ip_check = system_settings.bypass_restrict_ip_check_if_2fa_enabled
 
 	# check if two factor auth is enabled
-	if system_settings.enable_two_factor_auth and not system_settings.bypass_restrict_ip_check_if_2fa_enabled:
-		# check if bypass restrict ip is enabled for all users or check if bypass restrict ip is enabled for login user
+	if system_settings.enable_two_factor_auth and not bypass_restrict_ip_check:
+		# check if bypass restrict ip is enabled for login user
 		bypass_restrict_ip_check = user.bypass_restrict_ip_check_if_2fa_enabled
 
 	for ip in ip_list:

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -138,7 +138,7 @@ class LoginManager:
 
 	def post_login(self):
 		self.run_trigger('on_login')
-		self.validate_ip_address()
+		validate_ip_address(self.user)
 		self.validate_hour()
 		self.get_user_info()
 		self.make_session()
@@ -271,28 +271,6 @@ class LoginManager:
 		for method in frappe.get_hooks().get(event, []):
 			frappe.call(frappe.get_attr(method), login_manager=self)
 
-	def validate_ip_address(self):
-		"""check if IP Address is valid"""
-		user = frappe.get_doc("User", self.user)
-		ip_list = user.get_restricted_ip_list()
-		if not ip_list:
-			return
-
-		bypass_restrict_ip_check = 0
-		# check if two factor auth is enabled
-		enabled = int(frappe.get_system_settings('enable_two_factor_auth') or 0)
-		if enabled:
-			#check if bypass restrict ip is enabled for all users
-			bypass_restrict_ip_check = int(frappe.get_system_settings('bypass_restrict_ip_check_if_2fa_enabled') or 0)
-			if not bypass_restrict_ip_check:
-				#check if bypass restrict ip is enabled for login user
-				bypass_restrict_ip_check = int(frappe.db.get_value('User', self.user, 'bypass_restrict_ip_check_if_2fa_enabled') or 0)
-		for ip in ip_list:
-			if frappe.local.request_ip.startswith(ip) or bypass_restrict_ip_check:
-				return
-
-		frappe.throw(_("Not allowed from this IP Address"), frappe.AuthenticationError)
-
 	def validate_hour(self):
 		"""check if user is logging in during restricted hours"""
 		login_before = int(frappe.db.get_value('User', self.user, 'login_before', ignore=True) or 0)
@@ -416,3 +394,25 @@ def check_consecutive_login_attempts(user, doc):
 				.format(doc.allow_login_after_fail), frappe.SecurityException)
 		else:
 			delete_login_failed_cache(user)
+
+def validate_ip_address(user):
+	"""check if IP Address is valid"""
+	user = frappe.get_doc("User", user)
+	ip_list = user.get_restricted_ip_list()
+	if not ip_list:
+		return
+
+	bypass_restrict_ip_check = 0
+	# check if two factor auth is enabled
+	enabled = int(frappe.get_system_settings('enable_two_factor_auth') or 0)
+	if enabled:
+		#check if bypass restrict ip is enabled for all users
+		bypass_restrict_ip_check = int(frappe.get_system_settings('bypass_restrict_ip_check_if_2fa_enabled') or 0)
+		if not bypass_restrict_ip_check:
+			#check if bypass restrict ip is enabled for login user
+			bypass_restrict_ip_check = int(frappe.db.get_value('User', user, 'bypass_restrict_ip_check_if_2fa_enabled') or 0)
+	for ip in ip_list:
+		if frappe.local.request_ip.startswith(ip) or bypass_restrict_ip_check:
+			return
+
+	frappe.throw(_("Not allowed from this IP Address"), frappe.AuthenticationError)

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -397,18 +397,12 @@ def check_consecutive_login_attempts(user, doc):
 
 def validate_ip_address(user):
 	"""check if IP Address is valid"""
-	user = frappe.get_cached_doc("User", user)
-	if frappe.flags.in_test:
-		user = frappe.get_doc("User", user)
-
+	user = frappe.get_cached_doc("User", user) if not frappe.flags.in_test else frappe.get_doc("User", user)
 	ip_list = user.get_restricted_ip_list()
 	if not ip_list:
 		return
 
-	system_settings = frappe.get_cached_doc("System Settings")
-	if frappe.flags.in_test:
-		system_settings = frappe.get_doc("System Settings")
-
+	system_settings = frappe.get_cached_doc("System Settings") if not frappe.flags.in_test else frappe.get_single("System Settings")
 	bypass_restrict_ip_check = None
 
 	# check if two factor auth is enabled

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -47,8 +47,6 @@ class HTTPRequest:
 		# set db
 		self.connect()
 
-		frappe.recorder.record()
-
 		# login
 		frappe.local.login_manager = LoginManager()
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -502,10 +502,7 @@ class User(Document):
 		if not self.restrict_ip:
 			return
 
-		ip_list = self.restrict_ip.replace(",", "\n").split('\n')
-		ip_list = [i.strip() for i in ip_list]
-
-		return ip_list
+		return [i.strip() for i in self.restrict_ip.split(",")]
 
 @frappe.whitelist()
 def get_timezones():

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -254,13 +254,14 @@ class Session:
 	def resume(self):
 		"""non-login request: load a session"""
 		import frappe
-
+		from frappe.auth import validate_ip_address
 		data = self.get_session_record()
 
 		if data:
 			# set language
 			self.data.update({'data': data, 'user':data.user, 'sid': self.sid})
 			self.user = data.user
+			validate_ip_address(self.user)
 			self.device = data.device
 		else:
 			self.start_as_guest()

--- a/frappe/tests/test_twofactor.py
+++ b/frappe/tests/test_twofactor.py
@@ -140,18 +140,18 @@ class TestTwoFactor(unittest.TestCase):
 		user.save()
 		enable_2fa(bypass_restrict_ip_check=0)
 		with self.assertRaises(frappe.AuthenticationError):
-			validate_ip_address()
+			validate_ip_address(self.user)
 
 		#2
 		enable_2fa(bypass_restrict_ip_check=1)
-		self.assertIsNone(validate_ip_address())
+		self.assertIsNone(validate_ip_address(self.user))
 
 		#3
 		user = frappe.get_doc('User', self.user)
 		user.bypass_restrict_ip_check_if_2fa_enabled = 1
 		user.save()
 		enable_2fa()
-		self.assertIsNone(validate_ip_address())
+		self.assertIsNone(validate_ip_address(self.user))
 
 def create_http_request():
 	'''Get http request object.'''

--- a/frappe/tests/test_twofactor.py
+++ b/frappe/tests/test_twofactor.py
@@ -9,7 +9,7 @@ from frappe.tests import set_request
 from frappe.twofactor import (should_run_2fa, authenticate_for_2factor, get_cached_user_pass,
 	two_factor_is_enabled_for_, confirm_otp_token, get_otpsecret_for_, get_verification_obj,
 	render_string_template)
-
+from frappe.auth import validate_ip_address
 import time
 
 class TestTwoFactor(unittest.TestCase):
@@ -140,18 +140,18 @@ class TestTwoFactor(unittest.TestCase):
 		user.save()
 		enable_2fa(bypass_restrict_ip_check=0)
 		with self.assertRaises(frappe.AuthenticationError):
-			self.login_manager.validate_ip_address()
+			validate_ip_address()
 
 		#2
 		enable_2fa(bypass_restrict_ip_check=1)
-		self.assertIsNone(self.login_manager.validate_ip_address())
+		self.assertIsNone(validate_ip_address())
 
 		#3
 		user = frappe.get_doc('User', self.user)
 		user.bypass_restrict_ip_check_if_2fa_enabled = 1
 		user.save()
 		enable_2fa()
-		self.assertIsNone(self.login_manager.validate_ip_address())
+		self.assertIsNone(validate_ip_address())
 
 def create_http_request():
 	'''Get http request object.'''


### PR DESCRIPTION
- If a session is created using an ip in restrict_ip, and then resumed from ip address not being present in restrict_ip, no error is raised.
- After fix whenever a session is being resumed, ip address will be validated.