### PR TITLE
fix: focus on first control after navigating to next document

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -117,7 +117,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 	add_nav_keyboard_shortcuts() {
 		frappe.ui.keys.add_shortcut({
-			shortcut: 'shift+>',
+			shortcut: 'shift+ctrl+>',
 			action: () => this.navigate_records(0),
 			page: this.page,
 			description: __('Go to next record'),
@@ -126,7 +126,7 @@ frappe.ui.form.Form = class FrappeForm {
 		});
 
 		frappe.ui.keys.add_shortcut({
-			shortcut: 'shift+<',
+			shortcut: 'shift+ctrl+<',
 			action: () => this.navigate_records(1),
 			page: this.page,
 			description: __('Go to previous record'),
@@ -839,10 +839,14 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.call('frappe.desk.form.utils.get_next', args).then(r => {
 			if (r.message) {
 				frappe.set_route('Form', this.doctype, r.message);
-				let $first_input_el = $(frappe.container.page).find('.frappe-control:visible').eq(0);
-				$first_input_el.find('input, select, textarea').focus();
+				this.focus_on_first_input();
 			}
 		});
+	}
+
+	focus_on_first_input() {
+		let $first_input_el = $(frappe.container.page).find('.frappe-control:visible').eq(0);
+		$first_input_el.find('input, select, textarea').focus();
 	}
 
 	rename_doc() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -121,6 +121,7 @@ frappe.ui.form.Form = class FrappeForm {
 			action: () => this.navigate_records(0),
 			page: this.page,
 			description: __('Go to next record'),
+			ignore_inputs: true,
 			condition: () => !this.is_new()
 		});
 
@@ -129,6 +130,7 @@ frappe.ui.form.Form = class FrappeForm {
 			action: () => this.navigate_records(1),
 			page: this.page,
 			description: __('Go to previous record'),
+			ignore_inputs: true,
 			condition: () => !this.is_new()
 		});
 	}
@@ -837,6 +839,8 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.call('frappe.desk.form.utils.get_next', args).then(r => {
 			if (r.message) {
 				frappe.set_route('Form', this.doctype, r.message);
+				let $first_input_el = $(frappe.container.page).find('.frappe-control:visible').eq(0);
+				$first_input_el.find('input, select, textarea').focus();
 			}
 		});
 	}


### PR DESCRIPTION
![next-prev](https://user-images.githubusercontent.com/19775888/65234431-2ccbb800-daf2-11e9-8036-5b8be9e3e3ef.gif)

Changed the keyboard shortcut for navigation to : **Ctrl + Shift + <**