### PR TITLE
fix(Report View): Error on setting Is Set filter for date fields

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -458,18 +458,6 @@ class DatabaseQuery(object):
 				value = get_between_date_filter(f.value, df)
 				fallback = "'0001-01-01 00:00:00'"
 
-			elif df and df.fieldtype=="Date":
-				value = frappe.db.format_date(f.value)
-				fallback = "'0001-01-01'"
-
-			elif (df and df.fieldtype=="Datetime") or isinstance(f.value, datetime):
-				value = frappe.db.format_datetime(f.value)
-				fallback = "'0001-01-01 00:00:00'"
-
-			elif df and df.fieldtype=="Time":
-				value = get_time(f.value).strftime("%H:%M:%S.%f")
-				fallback = "'00:00:00'"
-
 			elif f.operator.lower() == "is":
 				if f.value == 'set':
 					f.operator = '!='
@@ -482,6 +470,18 @@ class DatabaseQuery(object):
 
 				if 'ifnull' not in column_name:
 					column_name = 'ifnull({}, {})'.format(column_name, fallback)
+
+			elif df and df.fieldtype=="Date":
+				value = frappe.db.format_date(f.value)
+				fallback = "'0001-01-01'"
+
+			elif (df and df.fieldtype=="Datetime") or isinstance(f.value, datetime):
+				value = frappe.db.format_datetime(f.value)
+				fallback = "'0001-01-01 00:00:00'"
+
+			elif df and df.fieldtype=="Time":
+				value = get_time(f.value).strftime("%H:%M:%S.%f")
+				fallback = "'00:00:00'"
 
 			elif f.operator.lower() in ("like", "not like") or (isinstance(f.value, string_types) and
 				(not df or df.fieldtype not in ["Float", "Int", "Currency", "Percent", "Check"])):


### PR DESCRIPTION
**Problem:**
- Error on setting **Is Set** filter on a date field because in db_query.py it was checking for date condition before the set operator condition. Hence it was considering 'set' as a date.
<img width="1195" alt="is_set_field_problem" src="https://user-images.githubusercontent.com/24353136/65257369-bbeec500-db1e-11e9-8f6e-2c086c05efb3.png">
