### PR TITLE
feat: added flag to skip redirect on error for quick entry

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -186,7 +186,9 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 					}
 				},
 				error: function() {
-					me.open_doc();
+					if (!me.skip_redirect_on_error) {
+						me.open_doc();
+					}
 				},
 				always: function() {
 					me.dialog.working = false;


### PR DESCRIPTION
**New flag:** skip_redirect_on_error

If this flag is enabled quick entry will not be redirected to the form if any error occurs.