### PR TITLE
fix: sync_single_doctype method in utils.py

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -119,7 +119,7 @@ def sync_customizations_for_doctype(data, folder):
 					custom_doctype, doctype_fieldname), doc_type)
 
 				for d in data[key]:
-					_insert(data)
+					_insert(d)
 
 			else:
 				for d in data[key]:


### PR DESCRIPTION
Property Setters from custom json files (from the Export Customizations button) got deleted on bench migrate and haven't been readded, because data was passed instead of d.

Now, when running bench migrate, the fields get deleted, and readded, as it should.