### PR TITLE
chore: fix docstring (docname and description)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1404,8 +1404,9 @@ def publish_progress(*args, **kwargs):
 
 	:param percent: Percent progress
 	:param title: Title
-	:param doctype: Optional, for DocType
-	:param name: Optional, for Document name
+	:param doctype: Optional, for document type
+	:param docname: Optional, for document name
+	:param description: Optional description
 	"""
 	import frappe.realtime
 	return frappe.realtime.publish_progress(*args, **kwargs)


### PR DESCRIPTION
Fix Docstring:

* Correct `name` to `docname`
* Add `description`