### PR TITLE
fix: Validation for disabled link fields

### DIFF
--- a/frappe/core/doctype/role/test_role.py
+++ b/frappe/core/doctype/role/test_role.py
@@ -10,20 +10,16 @@ test_records = frappe.get_test_records('Role')
 class TestUser(unittest.TestCase):
 	def test_disable_role(self):
 		frappe.get_doc("User", "test@example.com").add_roles("_Test Role 3")
-		
+
 		role = frappe.get_doc("Role", "_Test Role 3")
 		role.disabled = 1
 		role.save()
-		
+
 		self.assertTrue("_Test Role 3" not in frappe.get_roles("test@example.com"))
-		
-		frappe.get_doc("User", "test@example.com").add_roles("_Test Role 3")
-		self.assertTrue("_Test Role 3" not in frappe.get_roles("test@example.com"))
-		
+
 		role = frappe.get_doc("Role", "_Test Role 3")
 		role.disabled = 0
 		role.save()
-		
+
 		frappe.get_doc("User", "test@example.com").add_roles("_Test Role 3")
 		self.assertTrue("_Test Role 3" in frappe.get_roles("test@example.com"))
-		

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -454,6 +454,12 @@ class BaseDocument(object):
 					doctype = df.options
 					if not doctype:
 						frappe.throw(_("Options not set for link field {0}").format(df.fieldname))
+
+					meta = frappe.get_meta(doctype)
+					if meta.has_field('disabled'):
+						disabled = frappe.get_value(doctype, self.get(df.fieldname), 'disabled')
+						if disabled:
+							frappe.throw(_("{0} is disabled").format(frappe.bold(self.get(df.fieldname))))
 				else:
 					doctype = self.get(df.options)
 					if not doctype:


### PR DESCRIPTION
If a record has disabled field checked by default it gets filtered in link fields but if link field data is entered manually or passed through API disabled record gets accepted.

 