### PR TITLE
fix: set default value in set_value as None to avoid error.

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -607,7 +607,7 @@ class Database(object):
 		"""Update multiple values. Alias for `set_value`."""
 		return self.set_value(*args, **kwargs)
 
-	def set_value(self, dt, dn, field, val, modified=None, modified_by=None,
+	def set_value(self, dt, dn, field, val=None, modified=None, modified_by=None,
 		update_modified=True, debug=False):
 		"""Set a single value in the database, do not call the ORM triggers
 		but update the modified timestamp (unless specified not to).


### PR DESCRIPTION
```
frappe.db.set_value('Call Log', log.name, {
			fieldname: doc.name,
			display_name_field: doc.get_title()
		}, update_modified=False)
```
This code should not fail if `value` is not pass because value is passed in the dict.

Currently, it fails...
![image](https://user-images.githubusercontent.com/13928957/65418713-ac22f980-de1a-11e9-92f5-b045079490a0.png)
