### PR TITLE
feat: Energy Points for assigned users on a document

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1234,12 +1234,12 @@ class Document(BaseDocument):
 
 	def get_assigned_users(self):
 		assignments = frappe.get_all('ToDo',
-				fields=['owner'],
-				filters={
-					'reference_type': self.doctype,
-					'reference_name': self.name,
-					'status': ('!=', 'Cancelled'),
-				})
+			fields=['owner'],
+			filters={
+				'reference_type': self.doctype,
+				'reference_name': self.name,
+				'status': ('!=', 'Cancelled'),
+			})
 
 		users = set([assignment.owner for assignment in assignments])
 		return users

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1232,6 +1232,18 @@ class Document(BaseDocument):
 				frappe.bold(self.meta.get_label(from_date_field)),
 			), frappe.exceptions.InvalidDates)
 
+	def get_assigned_users(self):
+		assignments = frappe.get_all('ToDo',
+				fields=['owner'],
+				filters={
+					'reference_type': self.doctype,
+					'reference_name': self.name,
+					'status': ('!=', 'Cancelled'),
+				})
+
+		users = set([assignment.owner for assignment in assignments])
+		return users
+
 def execute_action(doctype, name, action, **kwargs):
 	'''Execute an action on a document (called by background worker)'''
 	doc = frappe.get_doc(doctype, name)

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.json
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.json
@@ -12,6 +12,7 @@
   "for_doc_event",
   "condition",
   "points",
+  "for_assigned_users",
   "user_field",
   "multiplier_field",
   "max_points"
@@ -56,6 +57,7 @@
    "reqd": 1
   },
   {
+   "depends_on": "eval:!doc.for_assigned_users || doc.for_doc_event==='New'",
    "description": "The user from this field will be rewarded points",
    "fieldname": "user_field",
    "fieldtype": "Select",
@@ -84,9 +86,16 @@
    "fieldtype": "Select",
    "label": "For Document Event",
    "options": "New\nSubmit\nCancel\nCustom"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.for_doc_event !=='New'",
+   "fieldname": "for_assigned_users",
+   "fieldtype": "Check",
+   "label": "Allot Points To Assigned Users"
   }
  ],
- "modified": "2019-09-05 14:22:27.664645",
+ "modified": "2019-09-19 17:45:58.137148",
  "modified_by": "Administrator",
  "module": "Social",
  "name": "Energy Point Rule",

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.json
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.json
@@ -61,8 +61,7 @@
    "description": "The user from this field will be rewarded points",
    "fieldname": "user_field",
    "fieldtype": "Select",
-   "label": "User Field",
-   "reqd": 1
+   "label": "User Field"
   },
   {
    "fieldname": "multiplier_field",
@@ -71,7 +70,7 @@
   },
   {
    "depends_on": "eval:doc.multiplier_field",
-   "description": "Maximum points allowed after multiplying points with the multiplier value\n(Note: For no limit set value as 0)",
+   "description": "Maximum points allowed after multiplying points with the multiplier value\n(Note: For no limit leave this field empty or set 0)",
    "fieldname": "max_points",
    "fieldtype": "Int",
    "label": "Maximum Points"
@@ -90,12 +89,13 @@
   {
    "default": "0",
    "depends_on": "eval:doc.for_doc_event !=='New'",
+   "description": "Users assigned to the reference document will get points.",
    "fieldname": "for_assigned_users",
    "fieldtype": "Check",
    "label": "Allot Points To Assigned Users"
   }
  ],
- "modified": "2019-09-19 17:45:58.137148",
+ "modified": "2019-09-20 11:26:26.101557",
  "modified_by": "Administrator",
  "module": "Social",
  "name": "Energy Point Rule",

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -31,21 +31,24 @@ class EnergyPointRule(Document):
 
 			reference_doctype = doc.doctype
 			reference_name = doc.name
-			user = doc.get(self.user_field)
+			users = []
+			if self.for_assigned_users:
+				users = doc.get_assigned_users()
+			else:
+				users = [doc.get(self.user_field)]
 			rule = self.name
 
 			# incase of zero as result after roundoff
 			if not points: return
 
-			# if user_field has no value
-			if not user or user == 'Administrator': return
-
 			try:
-				create_energy_points_log(reference_doctype, reference_name, {
-					'points': points,
-					'user': user,
-					'rule': rule
-				})
+				for user in users:
+					if not user or user == 'Administrator': continue
+					create_energy_points_log(reference_doctype, reference_name, {
+						'points': points,
+						'user': user,
+						'rule': rule
+					})
 			except Exception as e:
 				frappe.log_error(frappe.get_traceback(), 'apply_energy_point')
 


### PR DESCRIPTION
Ability to allot energy points to the assigned users in the reference document.

<img width="954" alt="Screenshot 2019-09-23 at 4 24 38 PM" src="https://user-images.githubusercontent.com/13928957/65420471-e0001e00-de1e-11e9-8a2c-31ba8bff1d89.png">

