### PR TITLE
fix: dont check for "is_disabled" in case of data import/migrate

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -457,9 +457,15 @@ class BaseDocument(object):
 
 					meta = frappe.get_meta(doctype)
 					if meta.has_field('disabled'):
-						disabled = frappe.get_value(doctype, self.get(df.fieldname), 'disabled')
-						if disabled:
-							frappe.throw(_("{0} is disabled").format(frappe.bold(self.get(df.fieldname))))
+						if not (
+							frappe.flags.in_import
+							or frappe.flags.in_migrate
+							or frappe.flags.in_install
+							or frappe.flags.in_patch
+						):
+							disabled = frappe.get_value(doctype, self.get(df.fieldname), 'disabled')
+							if disabled:
+								frappe.throw(_("{0} is disabled").format(frappe.bold(self.get(df.fieldname))))
 				else:
 					doctype = self.get(df.options)
 					if not doctype:


### PR DESCRIPTION
Traceback on migrate/restore:

```
Traceback (most recent call last):
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 56, in migrate
    frappe.get_doc('Portal Settings', 'Portal Settings').sync_menu()
  File "/home/travis/frappe-bench/apps/frappe/frappe/website/doctype/portal_settings/portal_settings.py", line 37, in sync_menu
    self.save()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 271, in save
    return self._save(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 306, in _save
    self._validate_links()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 748, in _validate_links
    result = d.get_invalid_links(is_submittable=self.meta.is_submittable)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/base_document.py", line 462, in get_invalid_links
    frappe.throw(_("{0} is disabled").format(frappe.bold(self.get(df.fieldname))))
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: <b>Patient</b> is disabled

```