### PR TITLE
fix(Translation): Load Custom Translations

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -193,6 +193,9 @@ def load_translations(bootinfo):
 	for name in bootinfo.user.all_reports:
 		messages[name] = frappe._(name)
 
+	for t in frappe.get_list("Translation", fields=["source_name", "target_name"]):
+		messages[t.source_name] = t.target_name
+
 	# only untranslated
 	messages = {k:v for k, v in iteritems(messages) if k!=v}
 


### PR DESCRIPTION
- Load Custom Translations from Translation DocType when initialising `boot`.
- `frappe.msgprint()` triggered from js and whose translation is present in Translation DocType wasn't loaded in boot.
    ![Screenshot 2019-09-23 at 7 52 22 PM](https://user-images.githubusercontent.com/7310479/65434191-05e7eb80-de3c-11e9-85af-613cc86e467f.png)

- Before Fix:
   ![Screenshot 2019-09-23 at 7 50 56 PM](https://user-images.githubusercontent.com/7310479/65433937-940fa200-de3b-11e9-9850-9d4b60996753.png)
- After Fix:
    ![Screenshot 2019-09-23 at 7 47 34 PM](https://user-images.githubusercontent.com/7310479/65434080-d3d68980-de3b-11e9-89ab-6be43251f7e5.png)
