### PR TITLE
fix: Duplicate review point allocation

### DIFF
--- a/frappe/social/doctype/energy_point_settings/energy_point_settings.py
+++ b/frappe/social/doctype/energy_point_settings/energy_point_settings.py
@@ -21,16 +21,20 @@ def allocate_review_points():
 		settings.point_allocation_periodicity):
 		return
 
+	user_point_map = {}
+
 	for level in settings.review_levels:
-		create_review_points(level)
+		users = get_users_with_role(level.role)
+		for user in users:
+			user_point_map.setdefault(user, 0)
+			# to avoid duplicate point allocation
+			user_point_map[user] = max([user_point_map[user], level.review_points])
+
+	for user, points in user_point_map.items():
+		create_review_points_log(user, points)
 
 	settings.last_point_allocation_date = today()
 	settings.save(ignore_permissions=True)
-
-def create_review_points(level):
-	users = get_users_with_role(level.role)
-	for user in users:
-		create_review_points_log(user, level.review_points)
 
 def can_allocate_today(last_date, periodicity):
 	if not last_date:


### PR DESCRIPTION
<img width="1154" alt="Screenshot 2019-09-23 at 10 34 05 PM" src="https://user-images.githubusercontent.com/13928957/65446613-59fdca80-de52-11e9-9dac-4500464e5605.png">

Suppose a user had both roles **Reviewer** and **Employee**, then the previous system would have granted him/her 350 review point i.e., 300 from **Reviewer** role and 50 from **Employee** role.

Now the user will only get maximum point i.e., 300 through **Reviewer** role 