### PR TITLE
fix: document.title reset while updating modules

### DIFF
--- a/frappe/public/js/frappe/views/components/Modules.vue
+++ b/frappe/public/js/frappe/views/components/Modules.vue
@@ -41,7 +41,7 @@ export default {
   methods: {
     update_current_module() {
       let route = frappe.get_route()
-      if (route[0] === 'modules' || !route[0]) {
+      if (route[0] === 'modules') {
         this.route = route
         let module = this.modules_list.filter(m => m.module_name == route[1])[0]
         let module_name = module && (module.label || module.module_name)


### PR DESCRIPTION
![Screenshot 2019-09-24 at 5 11 23 PM](https://user-images.githubusercontent.com/25369014/65508713-75b6ae80-deee-11e9-83ff-b6da350b2cd8.png)

When navigating backwards (`triggers route change event`) to Desk Page which has empty route `""` the page title is set as `undefined`. This happens because `!route[0]` is true and the `module` associated with `""` is `undefined`. In the end `title` gets `undefined`