### PR TITLE
fix: setup doc before creating webform

### DIFF
--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -56,18 +56,18 @@ frappe.ready(function() {
 				window.location.replace(window.location.pathname + "?new=1");
 				return;
 			}
-			let doc = r.message.doc || build_doc(r.message)
+			let doc = r.message.doc || build_doc(r.message);
 			web_form.prepare(web_form_doc, doc);
 			web_form.make();
 			web_form.set_default_values();
 		})
 
 		function build_doc(form_data) {
-			let doc = {}
+			let doc = {};
 			form_data.web_form.web_form_fields.forEach(df => {
-				if (df.default) return doc[df.fieldname] = df.default
-			})
-			return doc
+				if (df.default) return doc[df.fieldname] = df.default;
+			});
+			return doc;
 		}
 
 		function get_data() {

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -56,11 +56,19 @@ frappe.ready(function() {
 				window.location.replace(window.location.pathname + "?new=1");
 				return;
 			}
-
-			web_form.prepare(web_form_doc, r.message.doc || {});
+			let doc = r.message.doc || build_doc(r.message)
+			web_form.prepare(web_form_doc, doc);
 			web_form.make();
 			web_form.set_default_values();
 		})
+
+		function build_doc(form_data) {
+			let doc = {}
+			form_data.web_form.web_form_fields.forEach(df => {
+				if (df.default) return doc[df.fieldname] = df.default
+			})
+			return doc
+		}
 
 		function get_data() {
 			return frappe.call({


### PR DESCRIPTION
Fix `doc` would not have default value when a webform for new doc is created.

On the desk side, the defaults are available in `frappe.model`, which is not available on the portal, `doc`. This PR fixes by making the doc object with defaults before initalizing the webform 