### PR TITLE
fix: desk freeze on updating multiple documents

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -19,13 +19,14 @@ context('List View', () => {
 			cy.route({
 				method: 'POST',
 				url:'api/method/frappe.model.workflow.bulk_workflow_approval'
-			}).as('bulk-approval');
-			cy.route({
-				method: 'GET',
-				url:'api/method/frappe.desk.reportview.get*'
-			}).as('update-list');
+			}).then(()=> {
+				cy.route({
+					method: 'POST',
+					url:'api/method/frappe.desk.reportview.get'
+				})
+			}).as('update-view');
 			cy.wrap(elements).contains('Approve').click();
-			cy.wait(['@bulk-approval', '@update-list']);
+			cy.wait('@update-view');
 			cy.get('.list-row-container:visible').should('contain', 'Approved');
 		});
 	});

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -19,14 +19,13 @@ context('List View', () => {
 			cy.route({
 				method: 'POST',
 				url:'api/method/frappe.model.workflow.bulk_workflow_approval'
-			}).then(()=> {
-				cy.route({
-					method: 'POST',
-					url:'api/method/frappe.desk.reportview.get'
-				})
-			}).as('update-view');
+			}).as('bulk-approval');
+			cy.route({
+				method: 'POST',
+				url:'api/method/frappe.desk.reportview.get'
+			}).as('real-time-update');
 			cy.wrap(elements).contains('Approve').click();
-			cy.wait('@update-view');
+			cy.wait(['@bulk-approval', '@real-time-update']);
 			cy.get('.list-row-container:visible').should('contain', 'Approved');
 		});
 	});

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -19,13 +19,14 @@ context('List View', () => {
 			cy.route({
 				method: 'POST',
 				url:'api/method/frappe.model.workflow.bulk_workflow_approval'
-			}).as('bulk-approval');
-			cy.route({
-				method: 'GET',
-				url:'api/method/frappe.desk.reportview.get*'
-			}).as('update-list');
+			}).then(()=> {
+				cy.route({
+					method: 'GET',
+					url:'api/method/frappe.desk.reportview.get'
+				})
+			}).as('update-view');
 			cy.wrap(elements).contains('Approve').click();
-			cy.wait(['@bulk-approval', '@update-list']);
+			cy.wait('@update-view');
 			cy.get('.list-row-container:visible').should('contain', 'Approved');
 		});
 	});

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -124,7 +124,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		const actions = this.actions_menu_items.concat(this.workflow_action_menu_items);
 		actions.map(item => {
-			const $item = this.page.add_actions_menu_item(item.label, item.action, item.standard);
+			let action = () => {
+				frappe.run_serially([
+					this.toggle_auto_refresh(false),
+					item.action,
+					this.toggle_auto_refresh(true)
+				])
+			}
+			const $item = this.page.add_actions_menu_item(item.label, action, item.standard);
 			if (item.class) {
 				$item.addClass(item.class);
 			}
@@ -133,6 +140,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				this.workflow_action_items[item.name] = $item;
 			}
 		});
+	}
+
+	toggle_auto_refresh(state) {
+		this.list_view_settings.disable_auto_refresh = !state;
 	}
 
 	show_restricted_list_indicator_if_applicable() {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1041,7 +1041,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						// in the listview according to filters applied
 						// let's remove it manually
 						this.data = this.data.filter(d => d.name !== name);
-						this.$result.find('.list-row-container').remove();
 						this.render_list();
 						return;
 					}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1064,6 +1064,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						return return_value;
 					});
 					this.toggle_result_area();
+					this.render_list();
 				});
 		});
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -129,7 +129,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					this.toggle_auto_refresh(false),
 					item.action,
 					this.toggle_auto_refresh(true)
-				])
+				]);
 			}
 			const $item = this.page.add_actions_menu_item(item.label, action, item.standard);
 			if (item.class) {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -391,6 +391,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	render() {
+		this.render_list();
+		this.on_row_checked();
+		this.render_count();
+		this.render_tags();
+	}
+
+	render_list() {
+		// clear rows
 		this.$result.find('.list-row-container').remove();
 		if (this.data.length > 0) {
 			// append rows
@@ -401,9 +409,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				}).join('')
 			);
 		}
-		this.on_row_checked();
-		this.render_count();
-		this.render_tags();
 	}
 
 	render_count() {
@@ -1036,7 +1041,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						// in the listview according to filters applied
 						// let's remove it manually
 						this.data = this.data.filter(d => d.name !== name);
-						this.render();
+						this.$result.find('.list-row-container').remove();
+						this.render_list();
 						return;
 					}
 
@@ -1070,7 +1076,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						return return_value;
 					});
 					this.toggle_result_area();
-					this.render();
 				});
 		});
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -124,14 +124,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		const actions = this.actions_menu_items.concat(this.workflow_action_menu_items);
 		actions.map(item => {
-			let action = () => {
-				frappe.run_serially([
-					this.toggle_auto_refresh(false),
-					item.action,
-					this.toggle_auto_refresh(true)
-				]);
-			}
-			const $item = this.page.add_actions_menu_item(item.label, action, item.standard);
+			const $item = this.page.add_actions_menu_item(item.label, item.action, item.standard);
 			if (item.class) {
 				$item.addClass(item.class);
 			}
@@ -140,10 +133,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				this.workflow_action_items[item.name] = $item;
 			}
 		});
-	}
-
-	toggle_auto_refresh(state) {
-		this.list_view_settings.disable_auto_refresh = !state;
 	}
 
 	show_restricted_list_indicator_if_applicable() {

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -59,7 +59,7 @@ def create_todo_records():
 
 @frappe.whitelist()
 def setup_workflow():
-  from frappe.workflow.doctype.workflow.test_workflow import create_todo_workflow
-  create_todo_workflow()
-  create_todo_records()
-  frappe.clear_cache()
+	from frappe.workflow.doctype.workflow.test_workflow import create_todo_workflow
+	create_todo_workflow()
+	create_todo_records()
+	frappe.clear_cache()

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -33,19 +33,33 @@ def create_if_not_exists(doc):
 
 @frappe.whitelist()
 def create_todo_records():
-	frappe.db.sql("DELETE FROM `tabToDo` WHERE name!=''")
+	if frappe.db.get_all('ToDo', {'description': 'this is first todo'}):
+		return
 
-	for number in range(1, 5):
-		frappe.get_doc({
-			"doctype": "ToDo",
-			"date": add_to_date(now(), days=3),
-			"description": "this is {} todo".format(number)
-		}).insert()
-
+	frappe.get_doc({
+		"doctype": "ToDo",
+		"date": add_to_date(now(), days=3),
+		"description": "this is first todo"
+	}).insert()
+	frappe.get_doc({
+		"doctype": "ToDo",
+		"date": add_to_date(now(), days=-3),
+		"description": "this is second todo"
+	}).insert()
+	frappe.get_doc({
+		"doctype": "ToDo",
+		"date": add_to_date(now(), months=2),
+		"description": "this is third todo"
+	}).insert()
+	frappe.get_doc({
+		"doctype": "ToDo",
+		"date": add_to_date(now(), months=-2),
+		"description": "this is fourth todo"
+	}).insert()
 
 @frappe.whitelist()
 def setup_workflow():
-	from frappe.workflow.doctype.workflow.test_workflow import create_todo_workflow
-	create_todo_workflow()
-	create_todo_records()
-	frappe.clear_cache()
+  from frappe.workflow.doctype.workflow.test_workflow import create_todo_workflow
+  create_todo_workflow()
+  create_todo_records()
+  frappe.clear_cache()

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -33,33 +33,19 @@ def create_if_not_exists(doc):
 
 @frappe.whitelist()
 def create_todo_records():
-	if frappe.db.get_all('ToDo', {'description': 'this is first todo'}):
-		return
+	frappe.db.sql("DELETE FROM `tabToDo` WHERE name!=''")
 
-	frappe.get_doc({
-		"doctype": "ToDo",
-		"date": add_to_date(now(), days=3),
-		"description": "this is first todo"
-	}).insert()
-	frappe.get_doc({
-		"doctype": "ToDo",
-		"date": add_to_date(now(), days=-3),
-		"description": "this is second todo"
-	}).insert()
-	frappe.get_doc({
-		"doctype": "ToDo",
-		"date": add_to_date(now(), months=2),
-		"description": "this is third todo"
-	}).insert()
-	frappe.get_doc({
-		"doctype": "ToDo",
-		"date": add_to_date(now(), months=-2),
-		"description": "this is fourth todo"
-	}).insert()
+	for number in range(1, 5):
+		frappe.get_doc({
+			"doctype": "ToDo",
+			"date": add_to_date(now(), days=3),
+			"description": "this is {} todo".format(number)
+		}).insert()
+
 
 @frappe.whitelist()
 def setup_workflow():
-  from frappe.workflow.doctype.workflow.test_workflow import create_todo_workflow
-  create_todo_workflow()
-  create_todo_records()
-  frappe.clear_cache()
+	from frappe.workflow.doctype.workflow.test_workflow import create_todo_workflow
+	create_todo_workflow()
+	create_todo_records()
+	frappe.clear_cache()


### PR DESCRIPTION
### Issue:
 - Browser sends `n` requests for updating `n` documents to update and awaits responses.
 - Browser sends another `n` requests for updating document count in the `list_view` and awaits responses respectively.

----------------------------------
### Solution:
 - Render lists as needed
 - Refresh total count and list view after requests are sent

----------------------------------
### Scenario:
Updating a simple field check of 100 items

#### Before
**Number of requests:** ~200
**Reason:** Real time updates + count update
**Consequence:** the CPU usage gets 100+ and memory usage spikes 2-3 times. The tab freezes for a few minutes. It's usually faster to kill the tab and reload.

#### After
**Number of requests:** ~100 + 1
**Reason:** Real time updates + 1 count update
**Consequence:** You have plenty time left to worry about other problems