### PR TITLE
fix: duplicate contacts being pushed on creation

### DIFF
--- a/frappe/integrations/doctype/google_contacts/google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.py
@@ -231,7 +231,7 @@ def update_contacts_to_google_contacts(doc, method=None):
 	"""
 	# Workaround to avoid triggering updation when Event is being inserted since
 	# creation and modified are same when inserting doc
-	if not frappe.db.exists("Google Contacts", {"name": doc.google_contacts}) or doc.is_new() \
+	if not frappe.db.exists("Google Contacts", {"name": doc.google_contacts}) or doc.modified == doc.creation \
 		or not doc.sync_with_google_contacts:
 		return
 


### PR DESCRIPTION
- Duplicate Google Contacts were created as `on_update` is called twice while inserting a new doc