### PR TITLE
feat: Added 'Allow Import (via Data Import Tool)' checkbox in Customize Form

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -7,15 +7,20 @@ frappe.ui.form.on('Data Import', {
 			frm.set_value("action", "");
 		}
 
-		frm.set_query("reference_doctype", function() {
-			return {
-				"filters": {
-					"issingle": 0,
-					"istable": 0,
-					"name": ['in', frappe.boot.user.can_import]
-				}
-			};
-		});
+		frappe.call({
+			method: "frappe.core.doctype.data_import.data_import.get_importable_doc",
+			callback: function (r) {
+				frm.set_query("reference_doctype", function () {
+					return {
+						"filters": {
+							"issingle": 0,
+							"istable": 0,
+							"name": ['in', r.message]
+						}
+					};
+				});
+			}
+		}),
 
 		// should never check public
 		frm.fields_dict["import_file"].df.is_private = 1;

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -30,6 +30,11 @@ class DataImport(Document):
 
 
 @frappe.whitelist()
+def get_importable_doc():
+	import_lst = frappe.cache().hget("can_import", frappe.session.user)
+	return import_lst
+
+@frappe.whitelist()
 def import_data(data_import):
 	frappe.db.set_value("Data Import", data_import, "import_status", "In Progress", update_modified=False)
 	frappe.publish_realtime("data_import_progress", {"progress": "0",

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -180,7 +180,7 @@
  "icon": "fa fa-glass",
  "idx": 1,
  "issingle": 1,
- "modified": "2019-09-27 00:01:19.609039",
+ "modified": "2019-10-08 11:16:36.698006",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -18,6 +18,7 @@
   "track_changes",
   "track_views",
   "allow_auto_repeat",
+  "allow_import",
   "image_view",
   "column_break_5",
   "title_field",
@@ -167,13 +168,19 @@
    "fieldname": "allow_auto_repeat",
    "fieldtype": "Check",
    "label": "Allow Auto Repeat"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_import",
+   "fieldtype": "Check",
+   "label": "Allow Import (via Data Import Tool)"
   }
  ],
  "hide_toolbar": 1,
  "icon": "fa fa-glass",
  "idx": 1,
  "issingle": 1,
- "modified": "2019-07-01 22:50:50.372465",
+ "modified": "2019-09-27 00:01:19.609039",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -30,7 +30,8 @@ doctype_properties = {
 	'max_attachments': 'Int',
 	'track_changes': 'Check',
 	'track_views': 'Check',
-	'allow_auto_repeat': 'Check'
+	'allow_auto_repeat': 'Check',
+	'allow_import': 'Check'
 }
 
 docfield_properties = {

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -157,8 +157,11 @@ class UserPermissions:
 				self.can_read.remove(dt)
 
 		if "System Manager" in self.get_roles():
-			self.can_import = list(filter(lambda d: d in self.can_create,
-				frappe.db.sql_list("""select name from `tabDocType` where allow_import = 1""")))
+			docs = [x['name'] for x in frappe.get_all("DocType", "name")]
+			frappe.clear_cache()
+			for docname in docs:
+				if frappe.get_meta(docname).allow_import == 1:
+					self.can_import.append(docname)
 
 	def get_defaults(self):
 		import frappe.defaults

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -157,11 +157,11 @@ class UserPermissions:
 				self.can_read.remove(dt)
 
 		if "System Manager" in self.get_roles():
-			docs = [x['name'] for x in frappe.get_all("DocType", "name")]
-			frappe.clear_cache()
+			docs = [x["name"] for x in frappe.get_all("DocType", "name")]
 			for docname in docs:
-				if frappe.get_meta(docname).allow_import == 1:
+				if frappe.get_meta(docname, cached=False).allow_import == 1:
 					self.can_import.append(docname)
+			frappe.cache().hset("can_import", frappe.session.user, self.can_import)
 
 	def get_defaults(self):
 		import frappe.defaults


### PR DESCRIPTION
- Checkbox will let users enable DocTypes in Data Import
- Document Type Link Field in Data Import will fetch Importable DocTypes from meta

![Screenshot 2019-09-27 at 1 14 54 PM](https://user-images.githubusercontent.com/25857446/65751766-04af0b00-e129-11e9-9a8c-7df8fb1de1f6.png)
