### PR TITLE
feat: Fully customizable query reports

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -470,7 +470,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 	}
 });
 
-frappe.ui.get_print_settings = function (pdf, callback, letter_head) {
+frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_columns) {
 	var print_settings = locals[":Print Settings"]["Print Settings"];
 
 	var default_letter_head = locals[":Company"] && frappe.defaults.get_default('company')
@@ -498,6 +498,27 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head) {
 		],
 		default: "Landscape"
 	}];
+
+	if (pick_columns) {
+		columns.push(
+			{
+				label: __("Pick Columns"),
+				fieldtype: "Check",
+				fieldname: "pick_columns",
+			},
+			{
+				label: __("Select Columns"),
+				fieldtype: "MultiCheck",
+				fieldname: "columns",
+				depends_on: "pick_columns",
+				columns: 2,
+				options: pick_columns.map(df => ({
+					label: __(df.label),
+					value: df.fieldname
+				}))
+			}
+		)
+	}
 
 	return frappe.prompt(columns, function (data) {
 		var data = $.extend(print_settings, data);

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -517,7 +517,7 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 					value: df.fieldname
 				}))
 			}
-		)
+		);
 	}
 
 	return frappe.prompt(columns, function (data) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -836,7 +836,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const custom_format = this.report_settings.html_format || null;
 		const filters_html = this.get_filters_html_for_print();
 		const landscape = print_settings.orientation == 'Landscape';
-		let columns = []
+		let columns = [];
 
 		if (print_settings.columns) {
 			columns = this.get_columns_for_print().filter(column =>
@@ -867,8 +867,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const print_css = frappe.boot.print_css;
 		const landscape = print_settings.orientation == 'Landscape';
 
-		let columns = []
-
+		let columns = [];
 
 		if (print_settings.columns) {
 			columns = this.get_columns_for_print().filter(column =>
@@ -1083,15 +1082,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 											.filter(frappe.model.is_value_type)
 											.map(df => ({ label: df.label, value: df.fieldname }));
 
-										d.set_df_property('field', 'options', options.sort(function(a,b) {
-												if (a.label < b.label) {
-													return -1;
-												}
-												if (a.label > b.label) {
-													return 1;
-												}
-												return 0;
-											})
+										d.set_df_property('field', 'options', options.sort(function(a, b) {
+											if (a.label < b.label) {
+												return -1;
+											}
+											if (a.label > b.label) {
+												return 1;
+											}
+											return 0;
+										})
 										);
 									});
 								}

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -836,16 +836,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const custom_format = this.report_settings.html_format || null;
 		const filters_html = this.get_filters_html_for_print();
 		const landscape = print_settings.orientation == 'Landscape';
-		let columns = [];
-
-		if (print_settings.columns) {
-			columns = this.get_columns_for_print().filter(column =>
-				print_settings.columns.includes(column.fieldname)
-			);
-		}
-		else {
-			columns = custom_format ? this.columns : this.get_columns_for_print();
-		}
 
 		this.make_access_log('Print', 'PDF');
 		frappe.render_grid({
@@ -856,7 +846,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			landscape: landscape,
 			filters: this.get_filter_values(),
 			data: this.get_data_for_print(),
-			columns: columns,
+			columns: this.get_columns_for_print(print_settings, custom_format),
 			original_data: this.data,
 			report: this
 		});
@@ -866,17 +856,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const base_url = frappe.urllib.get_base_url();
 		const print_css = frappe.boot.print_css;
 		const landscape = print_settings.orientation == 'Landscape';
-
-		let columns = [];
-
-		if (print_settings.columns) {
-			columns = this.get_columns_for_print().filter(column =>
-				print_settings.columns.includes(column.fieldname)
-			);
-		}
-		else {
-			columns = custom_format ? this.columns : this.get_columns_for_print();
-		}
 
 		const custom_format = this.report_settings.html_format || null;
 		const data = this.get_data_for_print();
@@ -889,7 +868,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			filters: applied_filters,
 			data: data,
 			original_data: this.data,
-			columns: columns,
+			columns: this.get_columns_for_print(print_settings, custom_format),
 			report: this
 		});
 
@@ -1007,8 +986,18 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		return rows;
 	}
 
-	get_columns_for_print() {
-		return this.get_visible_columns();
+	get_columns_for_print(print_settings, custom_format) {
+		let columns = [];
+
+		if (print_settings && print_settings.columns) {
+			columns = this.get_visible_columns().filter(column =>
+				print_settings.columns.includes(column.fieldname)
+			);
+		} else {
+			columns = custom_format ? this.columns : this.get_visible_columns();
+		}
+
+		return columns;
 	}
 
 	get_menu_items() {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1083,8 +1083,16 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 											.filter(frappe.model.is_value_type)
 											.map(df => ({ label: df.label, value: df.fieldname }));
 
-										d.set_df_property('field', 'options', options);
-
+										d.set_df_property('field', 'options', options.sort(function(a,b) {
+												if (a.label < b.label) {
+													return -1;
+												}
+												if (a.label > b.label) {
+													return 1;
+												}
+												return 0;
+											})
+										);
 									});
 								}
 							},
@@ -1127,7 +1135,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 									d.hide();
 								}
 							});
-							this.show_save = true;
 							this.set_menu_items();
 						}
 					})
@@ -1155,7 +1162,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								args: {
 									reference_report: this.report_name,
 									report_name: values.report_name,
-									columns: this.columns
+									columns: this.get_visible_columns()
 								},
 								callback: function(r) {
 									this.show_save = false;
@@ -1167,7 +1174,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					});
 					d.show();
 				},
-				condition: () => this.show_save,
 				standard: true
 			},
 			{


### PR DESCRIPTION
- Save Report after deleting and changing column positions
![Delete Column](https://user-images.githubusercontent.com/42651287/65836800-c7f13880-e30f-11e9-9d1a-f4e8db75ebd7.gif)

- Some reports in ERPNext like Accounts Receivable have standard print formats and the report has 21 columns so while printing custom columns are not printed and the entire report also cannot be printed.So this PR will allow users to pick columns while printing 
![Pick Columns](https://user-images.githubusercontent.com/42651287/65836859-0dae0100-e310-11e9-827a-6280c567b8ea.gif)
