### PR TITLE
fix: webhook data

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -12,7 +12,7 @@ frappe.webhook = {
 					} else if (d.fieldtype === 'Currency' || d.fieldtype === 'Float') {
 						return { label: d.label, value: d.fieldname };
 					} else {
-						return { label: d.label + ' (' + d.fieldtype + ')', value: d.fieldname };
+						return {  label: `${__(d.label)} (${d.fieldtype})`, value: d.fieldname };
 					}
 				});
 
@@ -21,7 +21,7 @@ frappe.webhook = {
 					if (field.fieldname == "name") {
 						fields.unshift({ label: "Name (Doc Name)", value: "name" });
 					} else {
-						fields.push({ label: field.label + ' (' + field.fieldtype + ')', value: field.fieldname });
+						fields.push({ label: `${__(field.label)} (${field.fieldtype})`, value: field.fieldname });
 					}
 				}
 

--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -8,11 +8,11 @@ frappe.webhook = {
 				// get doctype fields
 				let fields = $.map(frappe.get_doc("DocType", frm.doc.webhook_doctype).fields, (d) => {
 					if (frappe.model.no_value_type.includes(d.fieldtype) || frappe.model.table_fields.includes(d.fieldtype)) {
-						return { label: d.label + ' (' + d.fieldtype + ')', value: d.fieldname };
+						return null;
 					} else if (d.fieldtype === 'Currency' || d.fieldtype === 'Float') {
 						return { label: d.label, value: d.fieldname };
 					} else {
-						return null;
+						return { label: d.label + ' (' + d.fieldtype + ')', value: d.fieldname };
 					}
 				});
 


### PR DESCRIPTION
Webhook Data table gives `no_value_type` fields (Section Break, Column Break, Button, Image, etc) and `table_fields` as options for fieldname and does not give Data type fields as options:

![webhook_data_why_section](https://user-images.githubusercontent.com/24353136/65859291-771c2700-e385-11e9-9a8a-b2a012806f05.png)

It should be the other way around
