### PR TITLE
fix(notifications): do not send emails if no recipients

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -143,6 +143,8 @@ def get_context(context):
 
 		attachments = self.get_attachment(doc)
 		recipients, cc, bcc = self.get_list_of_recipients(doc, context)
+		if not recipients:
+			return
 		sender = None
 		if self.sender and self.sender_email:
 			sender = formataddr((self.sender, self.sender_email))


### PR DESCRIPTION
notifications triggered through hooks have no checks for recipients, if no recipients exist, sending mails shouldn't be attempted