### PR TITLE
fix: Prevent long review text from busting out of the body

### DIFF
--- a/frappe/public/less/sidebar.less
+++ b/frappe/public/less/sidebar.less
@@ -465,6 +465,7 @@ body[data-route^="Module"] .main-menu {
 	}
 	.subject, .body {
 		padding: 12px;
+		overflow-wrap: break-word;
 	}
 }
 


### PR DESCRIPTION
**Before:**
<img width="250" alt="Screenshot 2019-10-02 at 10 35 56 AM" src="https://user-images.githubusercontent.com/13928957/66019660-08b0a380-e502-11e9-9cf6-f312a1119b31.png">

**After:**
<img width="233" alt="Screenshot 2019-10-02 at 10 36 54 AM" src="https://user-images.githubusercontent.com/13928957/66019680-17975600-e502-11e9-9813-272d9dbc0b2d.png">

