### PR TITLE
fix: validate conditions for raw printing

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -34,7 +34,7 @@ class PrintFormat(Document):
 		if self.custom_format and self.raw_printing and not self.raw_commands:
 			frappe.throw(_('{0} are required').format(frappe.bold(_('Raw Commands'))), frappe.MandatoryError)
 
-		if self.custom_format and not self.html:
+		if self.custom_format and not self.html and not self.raw_printing:
 			frappe.throw(_('{0} is required').format(frappe.bold(_('HTML'))), frappe.MandatoryError)
 
 	def extract_images(self):


### PR DESCRIPTION
Fixes: https://github.com/frappe/frappe/issues/8439

The last condition would trigger and would ask for HTML format even if the selected format is Raw Printing