### PR TITLE
fix: Show maximum 5 values for a field in filter description

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -278,7 +278,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	},
 
 	merge_duplicates(results) {
-		// in case of result like this 
+		// in case of result like this
 		// [{value: 'Manufacturer 1', 'description': 'mobile part 1'},
 		// 	{value: 'Manufacturer 1', 'description': 'mobile part 2'}]
 		// suggestion list has two items with same value (docname) & description
@@ -329,6 +329,11 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			let fieldname = filter[1];
 			let docfield = frappe.meta.get_docfield(doctype, fieldname);
 			let label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
+
+			if (filter[3] && Array.isArray(filter[3]) && filter[3].length > 5) {
+				filter[3] = filter[3].slice(0, 5);
+				filter[3].push('...');
+			}
 
 			let value = filter[3] == null || filter[3] === ''
 				? __('empty')


### PR DESCRIPTION
Fix For:
![image](https://user-images.githubusercontent.com/42651287/66042834-336b1e00-e53b-11e9-9aba-3d16bb674347.png)
