### PR TITLE
fix: run specific code only if auto linking is onn

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -381,6 +381,9 @@ def parse_email(communication, email_strings):
 		a doctype and docname ie in the format `admin+doctype+docname@example.com`,
 		the email is parsed and doctype and docname is extracted and timeline link is added.
 	"""
+	if not frappe.get_list("Email Account", filters={"enable_automatic_linking": 1}):
+		return
+
 	delimiter = "+"
 
 	for email_string in email_strings:
@@ -388,9 +391,12 @@ def parse_email(communication, email_strings):
 			for email in email_string.split(","):
 				if delimiter in email:
 					email = email.split("@")[0]
+					email_local_parts = email.split(delimiter)
+					if not len(email_local_parts) == 3:
+						continue
 
-					doctype = unquote(email.split(delimiter)[1])
-					docname = unquote(email.split(delimiter)[2])
+					doctype = unquote(email_local_parts[1])
+					docname = unquote(email_local_parts[2])
 
 					if doctype and docname and frappe.db.exists(doctype, docname):
 						communication.add_link(doctype, docname)
@@ -400,6 +406,9 @@ def get_email_without_link(email):
 		returns email address without doctype links
 		returns admin@example.com for email admin+doctype+docname@example.com
 	"""
+	if not frappe.get_list("Email Account", filters={"enable_automatic_linking": 1}):
+		return email
+
 	email_id = email.split("@")[0].split("+")[0]
 	email_host = email.split("@")[1]
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -179,6 +179,8 @@ class TestCommunication(unittest.TestCase):
 	def test_link_in_email(self):
 		frappe.delete_doc_if_exists("Note", "test document link in email")
 
+		create_email_account()
+
 		note = frappe.get_doc({
 			"doctype": "Note",
 			"title": "test document link in email",
@@ -198,3 +200,33 @@ class TestCommunication(unittest.TestCase):
 			doc_links.append((timeline_link.link_doctype, timeline_link.link_name))
 
 		self.assertIn(("Note", note.name), doc_links)
+
+def create_email_account():
+	frappe.flags.mute_emails = False
+	frappe.flags.sent_mail = None
+
+	email_account = frappe.get_doc({
+		"is_default": 1,
+		"is_global": 1,
+		"doctype": "Email Account",
+		"domain":"example.com",
+		"append_to": "ToDo",
+		"email_account_name": "_Test Comm Account 1",
+		"enable_outgoing": 1,
+		"smtp_server": "test.example.com",
+		"email_id": "test@example.com",
+		"password": "password",
+		"add_signature": 1,
+		"signature": "\nBest Wishes\nTest Signature",
+		"enable_auto_reply": 1,
+		"auto_reply_message": "",
+		"enable_incoming": 1,
+		"notify_if_unreplied": 1,
+		"unreplied_for_mins": 20,
+		"send_notification_to": "test_unreplied@example.com",
+		"pop3_server": "pop.test.example.com",
+		"no_remaining":"0",,
+		"enable_automatic_linking": 1
+	}).insert(ignore_permissions=True)
+
+	return email_account

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -225,7 +225,7 @@ def create_email_account():
 		"unreplied_for_mins": 20,
 		"send_notification_to": "test_unreplied@example.com",
 		"pop3_server": "pop.test.example.com",
-		"no_remaining":"0",,
+		"no_remaining":"0",
 		"enable_automatic_linking": 1
 	}).insert(ignore_permissions=True)
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -214,7 +214,7 @@ def create_email_account():
 		"email_account_name": "_Test Comm Account 1",
 		"enable_outgoing": 1,
 		"smtp_server": "test.example.com",
-		"email_id": "test@example.com",
+		"email_id": "test_comm@example.com",
 		"password": "password",
 		"add_signature": 1,
 		"signature": "\nBest Wishes\nTest Signature",
@@ -223,7 +223,7 @@ def create_email_account():
 		"enable_incoming": 1,
 		"notify_if_unreplied": 1,
 		"unreplied_for_mins": 20,
-		"send_notification_to": "test_unreplied@example.com",
+		"send_notification_to": "test_comm@example.com",
 		"pop3_server": "pop.test.example.com",
 		"no_remaining":"0",
 		"enable_automatic_linking": 1

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -16,8 +16,8 @@ frappe.patches.v8_0.drop_is_custom_from_docperm
 execute:frappe.reload_doc('core', 'doctype', 'module_def') #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'version') #2017-04-01
 execute:frappe.reload_doc('email', 'doctype', 'document_follow')
-execute:frappe.reload_doc('core', 'doctype', 'communication_link')
-execute:frappe.reload_doc('core', 'doctype', 'communication')
+execute:frappe.reload_doc('core', 'doctype', 'communication_link') #2019-10-02
+execute:frappe.reload_doc('core', 'doctype', 'communication') #2019-10-02
 frappe.patches.v11_0.replicate_old_user_permissions
 frappe.patches.v11_0.reload_and_rename_view_log #2019-01-03
 frappe.patches.v7_1.rename_scheduler_log_to_error_log


### PR DESCRIPTION
- Do not run `automatic_email_linking` code if it is disabled.
- Reload `communication_links` and `communication` doctype again as it did not run for some users