### PR TITLE
fix: return default user permission as the leading element

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -143,7 +143,11 @@ def get_applicable_for_doctype_list(doctype, txt, searchfield, start, page_len, 
 	return return_list
 
 def get_permitted_documents(doctype):
-	return [d.get('doc') for d in get_user_permissions().get(doctype, []) \
+	''' Returns permitted documents from the given doctype for the session user '''
+	# sort permissions in a way to make the first permission in the list to be default
+	user_perm_list = sorted(get_user_permissions().get(doctype, []), key=lambda x: x.get('is_default'), reverse=True)
+
+	return [d.get('doc') for d in user_perm_list \
 		if d.get('doc')]
 
 @frappe.whitelist()


### PR DESCRIPTION
Returns: a list of user permission with the first element as the default user permission. This function is used at multiple places where the first element is applied as the default user permission.