### PR TITLE
fix: Link field validation via set_value

### DIFF
--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -203,8 +203,11 @@ _f.Frm.prototype.watch_model_updates = function() {
 			} else {
 				me.dirty();
 			}
-			me.fields_dict[fieldname]
-				&& me.fields_dict[fieldname].refresh(fieldname);
+			let field = me.fields_dict[fieldname];
+			field && field.refresh(fieldname);
+
+			// Validate value for link field explicitly
+			field && field.df.fieldtype === "Link" && field.validate && field.validate(value);
 
 			me.layout.refresh_dependency();
 			let object = me.script_manager.trigger(fieldname, doc.doctype, doc.name);

--- a/frappe/public/js/legacy/form.js
+++ b/frappe/public/js/legacy/form.js
@@ -207,7 +207,7 @@ _f.Frm.prototype.watch_model_updates = function() {
 			field && field.refresh(fieldname);
 
 			// Validate value for link field explicitly
-			field && field.df.fieldtype === "Link" && field.validate && field.validate(value);
+			field && ["Link", "Dynamic Link"].includes(field.df.fieldtype) && field.validate && field.validate(value);
 
 			me.layout.refresh_dependency();
 			let object = me.script_manager.trigger(fieldname, doc.doctype, doc.name);


### PR DESCRIPTION
- Link fields used to set any other dependent field values in the form when set via UI
- The same did not happen when set via **set_value** method 
- **What fix does:** Updates fields dependent on Link field via Fetch From when Link Field is set through set_value.