### PR TITLE
fix: pdf report js issues

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -865,7 +865,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		const filters_html = this.get_filters_html_for_print();
 		const template =
-			print_settings.columns && custom_format ? 'print_grid' : custom_format;
+			print_settings.columns || !custom_format ? 'print_grid' : custom_format;
 		const content = frappe.render_template(template, {
 			title: __(this.report_name),
 			subtitle: filters_html,

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -859,17 +859,20 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const landscape = print_settings.orientation == 'Landscape';
 
 		const custom_format = this.report_settings.html_format || null;
+		const columns = this.get_columns_for_print(print_settings, custom_format);
 		const data = this.get_data_for_print();
 		const applied_filters = this.get_filter_values();
 
 		const filters_html = this.get_filters_html_for_print();
-		const content = frappe.render_template(print_settings.columns ? 'print_grid' : custom_format, {
+		const template =
+			print_settings.columns && custom_format ? 'print_grid' : custom_format;
+		const content = frappe.render_template(template, {
 			title: __(this.report_name),
 			subtitle: filters_html,
 			filters: applied_filters,
 			data: data,
 			original_data: this.data,
-			columns: this.get_columns_for_print(print_settings, custom_format),
+			columns: columns,
 			report: this
 		});
 


### PR DESCRIPTION
This PR attempts to fixes two things - 

1. A _TypeError_ because `custom_format` can be _null_, here https://github.com/frappe/frappe/blob/e32efa295e05e94cc938515f0386690831b60fa2/frappe/public/js/frappe/views/reports/query_report.js#L861-L867
2. A _ReferenceError_ for `columns`, here
https://github.com/frappe/frappe/blob/e32efa295e05e94cc938515f0386690831b60fa2/frappe/public/js/frappe/views/reports/query_report.js#L877-L885