### PR TITLE
fix: report the DocType's name when its associated table is missing

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -854,7 +854,7 @@ class Database(object):
 		"""Returns list of column names from given doctype."""
 		columns = self.get_db_table_columns('tab' + doctype)
 		if not columns:
-			raise self.TableMissingError
+			raise self.TableMissingError('DocType', doctype)
 		return columns
 
 	def has_column(self, doctype, column):


### PR DESCRIPTION
Reported here https://discuss.erpnext.com/t/bench-migrate-fails-with-pymysql-err-programmingerror-it-doesnt-print-what-is-the-error/53540

Please read the [Pull Request Checklist](https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist) to ensure you have everything that is needed to get your contribution merged.