### PR TITLE
fix: rate auto changing from 3.9 to 39

### DIFF
--- a/frappe/public/js/frappe/form/controls/currency.js
+++ b/frappe/public/js/frappe/form/controls/currency.js
@@ -1,12 +1,23 @@
 frappe.ui.form.ControlCurrency = frappe.ui.form.ControlFloat.extend({
 	eval_expression: function(value) {
 		if (typeof value === 'string' 
-			&& value.match(/^[0-9+-/* ]+$/)
-			// paresFloat('1,44,000') returns 1.0
-			// 1,44,000 are being passed when we paste rows from excel sheet to a table
-			&& value.includes(',')) {
-			return value.replace(",", "");
+			&& value.match(/^[0-9+-/* ]+$/)) {
+			if (value.includes(',')) {
+				// paresFloat('1,44,000') returns 1.0
+				// 1,44,000 are being passed when we paste rows from excel sheet to a table)
+
+				const regex = new RegExp("\\,", "g");
+				value = value.replace(regex, "");
+			}
+
+			try {
+				return eval(value);
+			} catch(e) {
+				return value;
+			}
 		}
+
+		// If not string
 		return value;
 	},
 

--- a/frappe/public/js/frappe/form/controls/currency.js
+++ b/frappe/public/js/frappe/form/controls/currency.js
@@ -12,7 +12,7 @@ frappe.ui.form.ControlCurrency = frappe.ui.form.ControlFloat.extend({
 
 			try {
 				return eval(value);
-			} catch(e) {
+			} catch (e) {
 				return value;
 			}
 		}


### PR DESCRIPTION
**Issue**

User has put the value as 3.9 in the rate field on item price. But system has automatically converted it into 39

Here number format is #.###,##

![image](https://user-images.githubusercontent.com/8780500/66313009-3eed8900-e92f-11e9-98c5-1e45d0408f77.png)


**After Fix**
<img width="956" alt="Screenshot 2019-10-07 at 6 08 27 PM" src="https://user-images.githubusercontent.com/8780500/66312986-31380380-e92f-11e9-9c89-345385ea276e.png">
