### PR TITLE
Fix: lock click version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ babel==2.6.0
 ipython
 html2text==2016.9.19
 email_reply_parser
-click
+click==7.0
 num2words==0.5.5
 watchdog==0.8.0
 bleach==2.1.4


### PR DESCRIPTION
- On updating old instance (v11->v12), the click version is not getting updated to version 7. This gives the following error:
```TypeError: __init__() got an unexpected keyword argument 'case_sensitive' erpnext```
https://github.com/frappe/frappe/blob/217e321fc29175993c1181ff834be9102017a7f1/frappe/commands/utils.py#L300 
- Click version 7 has added option for case_sensitive in choice here: https://github.com/pallets/click/pull/887

