### PR TITLE
fix: comma in rate field not changing to dot for the number format #.###,##

### DIFF
--- a/frappe/public/js/frappe/form/controls/currency.js
+++ b/frappe/public/js/frappe/form/controls/currency.js
@@ -1,5 +1,10 @@
 frappe.ui.form.ControlCurrency = frappe.ui.form.ControlFloat.extend({
 	eval_expression: function(value) {
+		if (typeof value === 'string' && value.includes(',')
+			&& frappe.sys_defaults.number_format.startsWith("#.")) {
+			return value;
+		}
+
 		if (typeof value === 'string' 
 			&& value.match(/^[0-9+-/* ]+$/)) {
 			if (value.includes(',')) {


### PR DESCRIPTION
**Issue**

User has set the value as "3,9" in the rate field which has changed to "39,000"
Number Format = "#.###,##"

<img width="969" alt="Screenshot 2019-10-09 at 1 09 32 PM" src="https://user-images.githubusercontent.com/8780500/66461255-411e2780-ea96-11e9-9b6a-c1afcebbbc7b.png">


**After Fix**

<img width="989" alt="Screenshot 2019-10-09 at 1 08 38 PM" src="https://user-images.githubusercontent.com/8780500/66461268-467b7200-ea96-11e9-876b-ace25d6e48d3.png">


