### PR TITLE
fix: notification not working if recipients not set but cc is set

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -139,7 +139,7 @@ def get_context(context):
 
 		attachments = self.get_attachment(doc)
 		recipients, cc, bcc = self.get_list_of_recipients(doc, context)
-		if not recipients:
+		if not (recipients or cc or bcc):
 			return
 		sender = None
 		if self.sender and self.sender_email:


### PR DESCRIPTION
**Issue:**

Notification is not working if Email By Document Field is not set and cc is set

<img width="949" alt="Screenshot 2019-10-09 at 2 47 25 PM" src="https://user-images.githubusercontent.com/8780500/66468627-1c30b100-eaa4-11e9-92bb-6867cb9205aa.png">

