### PR TITLE
fix: None type object has no attribute options

### DIFF
--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -383,7 +383,7 @@
  ],
  "icon": "fa fa-comment",
  "idx": 1,
- "modified": "2019-09-05 14:22:27.664645",
+ "modified": "2019-10-09 14:22:27.664645",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Communication",


### PR DESCRIPTION
**Issue**

In some account "Timeline Links" field has not added in the communication doctype thefore user getting an error "None type object has no attribute options" while sending an email