### PR TITLE
chore: make communication list exception helpful

### DIFF
--- a/frappe/public/js/frappe/views/inbox/inbox_view.js
+++ b/frappe/public/js/frappe/views/inbox/inbox_view.js
@@ -17,9 +17,7 @@ frappe.views.InboxView = class InboxView extends frappe.views.ListView {
 			frappe.set_route("List", "Communication", "Inbox", email_account);
 			return true;
 		} else if (!route[3] || (route[3] !== "All Accounts" && !is_valid(route[3]))) {
-			frappe.msgprint(__('Invalid Email Account'));
-			window.history.back();
-			return true;
+			frappe.throw(__('No email account associated with the User. Please add an account under User > Email Inbox.'));
 		}
 		return false;
 


### PR DESCRIPTION
* fixes infinite error recursion caused by window.history.back();
* throw an actually useful message instead of using msgprint
