### PR TITLE
fix: Miscellaneous Fixes

### DIFF
--- a/frappe/contacts/doctype/contact/contact.json
+++ b/frappe/contacts/doctype/contact/contact.json
@@ -193,7 +193,7 @@
   {
    "fieldname": "phone_nos",
    "fieldtype": "Table",
-   "label": "Numbers",
+   "label": "Contact Numbers",
    "options": "Contact Phone"
   },
   {
@@ -245,7 +245,7 @@
  "icon": "fa fa-user",
  "idx": 1,
  "image_field": "image",
- "modified": "2019-09-24 17:48:26.790985",
+ "modified": "2019-10-10 22:04:41.070479",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Contact",

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -32,7 +32,6 @@ class Contact(Document):
 		self.set_primary_email()
 		self.set_primary("phone")
 		self.set_primary("mobile_no")
-		self.check_if_primary_phone_and_mobile_no_same()
 
 		self.set_user()
 
@@ -118,11 +117,6 @@ class Contact(Document):
 			if d.get(field_name) == 1:
 				setattr(self, fieldname, d.phone)
 				break
-
-	def check_if_primary_phone_and_mobile_no_same(self):
-		if self.phone and self.mobile_no and self.phone == self.mobile_no:
-			number = frappe.bold(self.phone)
-			frappe.throw(_("Number {0} cannot be set as primary for Phone as well as Mobile No.").format(number))
 
 def get_default_contact(doctype, name):
 	'''Returns default contact for the given doctype, name'''

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -33,37 +33,6 @@ class TestContact(unittest.TestCase):
 		self.assertEqual(contact.phone, "+91 0000000002")
 		self.assertEqual(contact.mobile_no, "+91 0000000003")
 
-	def test_same_phone_and_mobile(self):
-		phones = [
-			{"phone": "+91 0000000000", "is_primary_phone": 1, "is_primary_mobile_no": 1},
-		]
-		contact = create_contact("Phone", "Mr", phones=phones, save=False)
-		self.assertRaises(ValidationError, contact.save)
-
-	def test_no_primary_set(self):
-		emails = [
-			{"email": "test1@example.com", "is_primary": 0},
-			{"email": "test2@example.com", "is_primary": 0},
-			{"email": "test3@example.com", "is_primary": 0},
-			{"email": "test4@example.com", "is_primary": 0},
-			{"email": "test5@example.com", "is_primary": 0},
-		]
-		phones = [
-			{"phone": "+91 0000000000", "is_primary_phone": 0, "is_primary_mobile_no": 0},
-			{"phone": "+91 0000000001", "is_primary_phone": 0, "is_primary_mobile_no": 0},
-			{"phone": "+91 0000000002", "is_primary_phone": 1, "is_primary_mobile_no": 1},
-			{"phone": "+91 0000000003", "is_primary_phone": 0, "is_primary_mobile_no": 0},
-		]
-
-		contact_email = create_contact("Default", "Mr", emails=emails, phones=phones, save=False)
-		contact_phone = create_contact("Default", "Mr", emails=emails, phones=phones, save=False)
-
-		# No default set for emails if many emails are passed as params
-		self.assertRaises(ValidationError, contact_email.save)
-
-		# No default set for phones if many phones are passed as params
-		self.assertRaises(ValidationError, contact_phone.save)
-
 def create_contact(name, salutation, emails=None, phones=None, save=True):
 	doc = frappe.get_doc({
 			"doctype": "Contact",

--- a/frappe/core/doctype/dynamic_link/dynamic_link.json
+++ b/frappe/core/doctype/dynamic_link/dynamic_link.json
@@ -13,7 +13,7 @@
    "fieldname": "link_doctype",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Link DocType",
+   "label": "Link Document Type",
    "options": "DocType",
    "reqd": 1
   },
@@ -34,7 +34,7 @@
   }
  ],
  "istable": 1,
- "modified": "2019-05-16 19:54:31.400026",
+ "modified": "2019-10-10 22:05:54.736093",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Dynamic Link",

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.json
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.json
@@ -10,12 +10,12 @@
   {
    "fieldname": "allowed_in_global_search",
    "fieldtype": "Table",
-   "label": "Document Types",
+   "label": "Search Priorities",
    "options": "Global Search DocType"
   }
  ],
  "issingle": 1,
- "modified": "2019-09-18 18:00:17.388486",
+ "modified": "2019-10-10 22:05:02.692689",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Global Search Settings",

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -127,9 +127,9 @@ frappe.views.CommunicationComposer = Class.extend({
 		this.setup_last_edited_communication();
 		this.setup_email_template();
 
-		this.dialog.fields_dict.recipients.set_value(this.recipients || '');
-		this.dialog.fields_dict.cc.set_value(this.cc || '');
-		this.dialog.fields_dict.bcc.set_value(this.bcc || '');
+		this.dialog.set_value("recipients", this.recipients || '');
+		this.dialog.set_value("cc", this.cc || '');
+		this.dialog.set_value("bcc", this.bcc || '');
 
 		if(this.dialog.fields_dict.sender) {
 			this.dialog.fields_dict.sender.set_value(this.sender || '');
@@ -180,6 +180,10 @@ frappe.views.CommunicationComposer = Class.extend({
 					this.subject = `${__(this.frm.doctype)}: ${title}`;
 				}
 			}
+		}
+
+		if (!this.recipients) {
+			this.recipients = this.frm.doc[this.frm.email_field];
 		}
 	},
 
@@ -690,6 +694,7 @@ frappe.views.CommunicationComposer = Class.extend({
 		}
 		fields.content.set_value(content);
 	},
+
 	html2text: function(html) {
 		// convert HTML to text and try and preserve whitespace
 		var d = document.createElement( 'div' );


### PR DESCRIPTION
- If the frm has email_field, then set it to recipient.
- Rename Dynamic Link field label to `Link Document Type`
- Remove unnecessary validation
- Rename Global Search Doctype label