### PR TITLE
fix(patch): auto commit if too many writes

### DIFF
--- a/frappe/patches/v12_0/setup_comments_from_communications.py
+++ b/frappe/patches/v12_0/setup_comments_from_communications.py
@@ -3,26 +3,32 @@ from __future__ import unicode_literals
 import frappe
 
 def execute():
-    frappe.reload_doctype("Comment")
+	frappe.reload_doctype("Comment")
 
-    for comment in frappe.get_all('Communication', fields = ['*'],
-        filters = dict(communication_type = 'Comment')):
+	if frappe.db.count('Communication', filters = dict(communication_type = 'Comment')) > 20000:
+			frappe.db.auto_commit_on_many_writes = True
 
-        new_comment = frappe.new_doc('Comment')
-        new_comment.comment_type = comment.comment_type
-        new_comment.comment_email = comment.sender
-        new_comment.comment_by = comment.sender_full_name
-        new_comment.subject = comment.subject
-        new_comment.content = comment.content or comment.subject
-        new_comment.reference_doctype = comment.reference_doctype
-        new_comment.reference_name = comment.reference_name
-        new_comment.link_doctype = comment.link_doctype
-        new_comment.link_name = comment.link_name
-        new_comment.creation = comment.creation
-        new_comment.modified = comment.modified
-        new_comment.owner = comment.owner
-        new_comment.modified_by = comment.modified_by
-        new_comment.db_insert()
+	for comment in frappe.get_all('Communication', fields = ['*'],
+		filters = dict(communication_type = 'Comment')):
 
-    # clean up
-    frappe.db.sql("delete from `tabCommunication` where communication_type = 'Comment'")
+		new_comment = frappe.new_doc('Comment')
+		new_comment.comment_type = comment.comment_type
+		new_comment.comment_email = comment.sender
+		new_comment.comment_by = comment.sender_full_name
+		new_comment.subject = comment.subject
+		new_comment.content = comment.content or comment.subject
+		new_comment.reference_doctype = comment.reference_doctype
+		new_comment.reference_name = comment.reference_name
+		new_comment.link_doctype = comment.link_doctype
+		new_comment.link_name = comment.link_name
+		new_comment.creation = comment.creation
+		new_comment.modified = comment.modified
+		new_comment.owner = comment.owner
+		new_comment.modified_by = comment.modified_by
+		new_comment.db_insert()
+
+	if frappe.db.auto_commit_on_many_writes:
+		frappe.db.auto_commit_on_many_writes = False
+
+	# clean up
+	frappe.db.sql("delete from `tabCommunication` where communication_type = 'Comment'")

--- a/frappe/patches/v12_0/setup_comments_from_communications.py
+++ b/frappe/patches/v12_0/setup_comments_from_communications.py
@@ -6,7 +6,7 @@ def execute():
 	frappe.reload_doctype("Comment")
 
 	if frappe.db.count('Communication', filters = dict(communication_type = 'Comment')) > 20000:
-			frappe.db.auto_commit_on_many_writes = True
+		frappe.db.auto_commit_on_many_writes = True
 
 	for comment in frappe.get_all('Communication', fields = ['*'],
 		filters = dict(communication_type = 'Comment')):


### PR DESCRIPTION
```
Executing frappe.patches.v12_0.setup_comments_from_communications
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 48, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/patches/v12_0/setup_comments_from_communications.py", line 25, in execute
    new_comment.db_insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 324, in db_insert
    ), list(d.values()))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 125, in sql
    self.check_transaction_status(query)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 260, in check_transaction_status
    frappe.throw(_("Too many writes in one request. Please send smaller requests"), frappe.ValidationError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Too many writes in one request. Please send smaller requests
```