### PR TITLE
fix: Set link fields with same fieldname from one doc to other

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1369,6 +1369,8 @@ frappe.ui.form.Form = class FrappeForm {
 				frappe.get_meta(doctype).fields.forEach(function(df) {
 					if(df.fieldtype==='Link' && df.options===me.doctype) {
 						new_doc[df.fieldname] = me.doc.name;
+					} else if (df.fieldtype==='Link' || 'Dynamic Link' && me.doc[df.fieldname]) {
+						new_doc[df.fieldname] = me.doc[df.fieldname];
 					}
 				});
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1369,7 +1369,7 @@ frappe.ui.form.Form = class FrappeForm {
 				frappe.get_meta(doctype).fields.forEach(function(df) {
 					if(df.fieldtype==='Link' && df.options===me.doctype) {
 						new_doc[df.fieldname] = me.doc.name;
-					} else if (df.fieldtype==='Link' || 'Dynamic Link' && me.doc[df.fieldname]) {
+					} else if (['Link', 'Dynamic Link'].includes(df.fieldtype) && me.doc[df.fieldname]) {
 						new_doc[df.fieldname] = me.doc[df.fieldname];
 					}
 				});


### PR DESCRIPTION
When a new document is created using dashboard (+) button the field with options same as the source doctype only gets set but the source and the target doctype might have multiple common fields which don't get set