### PR TITLE
fix(Email): poplib.error_proto exception

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -86,8 +86,8 @@ class EmailServer:
 			frappe.msgprint(_('Invalid Mail Server. Please rectify and try again.'))
 			raise
 
-		except poplib.error_proto as e:
-			if self.is_temporary_system_problem(e):
+		except poplib.error_proto, details:
+			if self.is_temporary_system_problem(details):
 				return False
 
 			else:
@@ -298,7 +298,7 @@ class EmailServer:
 			"Connection timed out",
 		)
 		for message in messages:
-			if message in strip(cstr(e.message)) or message in strip(cstr(getattr(e, 'strerror', ''))):
+			if message in strip(cstr(e)) or message in strip(cstr(getattr(e, 'strerror', ''))):
 				return True
 		return False
 


### PR DESCRIPTION
**Problem:** 
AttributeError: 'error_proto' object has no attribute 'message'

**Fix**: 
The reason for this exception is passed to the constructor as a string. Passed the details string to is_temporary_system_problem function