### PR TITLE
fix: font size showing small after upgrade wkhtmltopdf to 0.12.5

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -17,6 +17,7 @@ def get_pdf(html, options=None, output = None):
 	options.update({
 		"disable-javascript": "",
 		"disable-local-file-access": "",
+		"disable-smart-shrinking": ""
 	})
 
 	try:


### PR DESCRIPTION
**Issue**
![image](https://user-images.githubusercontent.com/8780500/66749898-aadc6e00-eea8-11e9-8819-20681fa08cd7.png)

**After Fix**
![image](https://user-images.githubusercontent.com/8780500/66749905-af088b80-eea8-11e9-9465-9c965a55cb3a.png)


Reference 
https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3241