### PR TITLE
fix: font size showing small after upgrade wkhtmltopdf to 0.12.5

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -16,6 +16,7 @@ def get_pdf(html, options=None, output=None):
 	options.update({
 		"disable-javascript": "",
 		"disable-local-file-access": "",
+		"disable-smart-shrinking": ""
 	})
 
 	filedata = ''


### PR DESCRIPTION
Port https://github.com/frappe/frappe/pull/8598