### PR TITLE
Revert "fix: Provision to ignore disabled link validations in a doctype"

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -464,7 +464,7 @@ class BaseDocument(object):
 							or frappe.flags.in_patch
 						):
 							disabled = frappe.get_value(doctype, self.get(df.fieldname), 'disabled')
-							if disabled and (not self.flags.ignore_disabled):
+							if disabled:
 								frappe.throw(_("{0} is disabled").format(frappe.bold(self.get(df.fieldname))))
 				else:
 					doctype = self.get(df.options)


### PR DESCRIPTION
Reverts frappe/frappe#8572

Using a flag this way is an anti-pattern, especially bad since it is used in base_document.
Disabled is a frappe framework convention, it should not be messed with