### PR TITLE
fix: remove bad disabled check

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -454,18 +454,6 @@ class BaseDocument(object):
 					doctype = df.options
 					if not doctype:
 						frappe.throw(_("Options not set for link field {0}").format(df.fieldname))
-
-					meta = frappe.get_meta(doctype)
-					if meta.has_field('disabled'):
-						if not (
-							frappe.flags.in_import
-							or frappe.flags.in_migrate
-							or frappe.flags.in_install
-							or frappe.flags.in_patch
-						):
-							disabled = frappe.get_value(doctype, self.get(df.fieldname), 'disabled')
-							if disabled and (not self.flags.ignore_disabled):
-								frappe.throw(_("{0} is disabled").format(frappe.bold(self.get(df.fieldname))))
 				else:
 					doctype = self.get(df.options)
 					if not doctype:


### PR DESCRIPTION
Reverts the following PRs

https://github.com/frappe/frappe/pull/8606
https://github.com/frappe/frappe/pull/8476

The following problems exists with the following PR
1. It breaks one of the core Document convention of frappe (i.e. what disabled means).
1. Using flags for such a thing is an anti-pattern (particularly stupid given it is in base document)
1. Flags are not accessible when to enqueued jobs, will breaking things like importing (the heck it's already breaking stuff)
1. It is a breaking change, a new branch must have been created.
1. The original problem could easily have been fixed in ERPNext. Altering the behavior of Frappe Framework was not required. 