### PR TITLE
feat: add hyperlinks to Link fields in auto email reports

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -166,10 +166,19 @@ class Report(Document):
 
 			_columns = []
 
-			for column in columns:
-				meta = frappe.get_meta(column[1])
-				field = [meta.get_field(column[0]) or frappe._dict(label=meta.get_label(column[0]), fieldname=column[0])]
-				_columns.extend(field)
+			for (fieldname, doctype) in columns:
+				meta = frappe.get_meta(doctype)
+
+				if meta.get_field(fieldname):
+					field = meta.get_field(fieldname)
+				else:
+					field = frappe._dict(fieldname=fieldname, label=meta.get_label(fieldname))
+					# since name is the primary key for a document, it will always be a Link datatype
+					if fieldname == "name":
+						field.fieldtype = "Link"
+						field.options = doctype
+
+				_columns.append(field)
 			columns = _columns
 
 			out = out + [list(d) for d in result]

--- a/frappe/email/doctype/auto_email_report/test_auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/test_auto_email_report.py
@@ -3,9 +3,12 @@
 # See license.txt
 from __future__ import unicode_literals
 
+import json
+import unittest
+
 import frappe
-import unittest, json
-from frappe.utils import get_link_to_form, today, add_to_date
+from frappe.utils import add_to_date, get_link_to_form, today
+from frappe.utils.data import is_html
 
 # test_records = frappe.get_test_records('Auto Email Report')
 
@@ -17,7 +20,8 @@ class TestAutoEmailReport(unittest.TestCase):
 
 		data = auto_email_report.get_report_content()
 
-		self.assertTrue('<td>'+str(get_link_to_form('Module Def', 'Core'))+'</td>' in data)
+		self.assertTrue(is_html(data))
+		self.assertTrue(str(get_link_to_form('Module Def', 'Core')) in data)
 
 		auto_email_report.format = 'CSV'
 

--- a/frappe/templates/emails/auto_email_report.html
+++ b/frappe/templates/emails/auto_email_report.html
@@ -39,7 +39,11 @@
 					</td>
 				{% else %}
 					<td {{- get_alignment(col) }}>
-						{{- frappe.format(row[col.fieldname], col, row) -}}
+						{% if col.fieldtype in ("Link", "Dynamic Link") and col.options %}
+							{{- frappe.utils.get_link_to_form(col.options, row[col.fieldname]) }}
+						{% else %}
+							{{- frappe.format(row[col.fieldname], col, row) -}}
+						{% endif %}
 					</td>
 				{% endif %}
 			{% endfor %}

--- a/frappe/templates/emails/auto_email_report.html
+++ b/frappe/templates/emails/auto_email_report.html
@@ -39,11 +39,7 @@
 					</td>
 				{% else %}
 					<td {{- get_alignment(col) }}>
-						{% if col.fieldtype in ("Link", "Dynamic Link") and col.options %}
-							{{- frappe.utils.get_link_to_form(col.options, row[col.fieldname]) }}
-						{% else %}
-							{{- frappe.format(row[col.fieldname], col, row) -}}
-						{% endif %}
+						{{- frappe.format(row[col.fieldname], col, row) -}}
 					</td>
 				{% endif %}
 			{% endfor %}


### PR DESCRIPTION
**Problem:**

Auto-email HTML reports for "Report Builder" reports do not send out the data with hyperlinks, making the email less useful to interact with, especially if there is significant data.

**Changes:**

- Table rows now include hyperlinks to the relevant document form, if available.