### PR TITLE
fix: items_move event trigger typo corrected

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -347,7 +347,6 @@ export default class Grid {
 				if (!this.is_editable()) {
 					return false;
 				}
-
 				// prevent drag behaviour if _sortable property is "false"
 				let idx = $(event.dragged).closest('.grid-row').attr('data-idx');
 				let doc = this.get_data()[idx - 1];
@@ -359,7 +358,7 @@ export default class Grid {
 				let idx = $(event.item).closest('.grid-row').attr('data-idx');
 				let doc = this.get_data()[idx - 1];
 				this.renumber_based_on_dom();
-				this.frm.script_manager.trigger(this.df.fieldnathis + "_move", this.df.options, doc.nathis);
+				this.frm.script_manager.trigger(this.df.fieldname + "_move", this.df.options, doc.name);
 				this.refresh();
 				this.frm.dirty();
 			}


### PR DESCRIPTION
RE: this commit https://github.com/frappe/frappe/commit/fea47dce74a941e1073a1cabf98aa39d925caf4a#r35529718
