### PR TITLE
fix: allow bold and underline tags while adding comment

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -10,8 +10,8 @@ def clean_html(html):
 		return html
 
 	return bleach.clean(clean_script_and_style(html),
-		tags=['div', 'p', 'br', 'ul', 'ol', 'li', 'b', 'i', 'em',
-                'table', 'thead', 'tbody', 'td', 'tr'],
+		tags=['div', 'p', 'br', 'ul', 'ol', 'li', 'strong', 'b', 'em', 'i', 'u',
+			'table', 'thead', 'tbody', 'td', 'tr'],
 		attributes=[],
 		styles=['color', 'border', 'border-color'],
 		strip=True, strip_comments=True)
@@ -21,7 +21,7 @@ def clean_email_html(html):
 		return html
 
 	return bleach.clean(clean_script_and_style(html),
-		tags=['div', 'p', 'br', 'ul', 'ol', 'li', 'b', 'i', 'em', 'a',
+		tags=['div', 'p', 'br', 'ul', 'ol', 'li', 'strong', 'b', 'em', 'i', 'u', 'a',
 			'table', 'thead', 'tbody', 'td', 'tr', 'th', 'pre', 'code',
 			'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'button', 'img'],
 		attributes=['border', 'colspan', 'rowspan',


### PR DESCRIPTION
**Screenshots / GIFs:**

**Before:**

![comment-fix-before](https://user-images.githubusercontent.com/13396535/67085424-6dcfee80-f1bc-11e9-84b4-1281acffa3cf.gif)

**After:**

![comment-fix-after](https://user-images.githubusercontent.com/13396535/67085428-6e688500-f1bc-11e9-999a-647c1c9149fe.gif)