### PR TITLE
fix(style): navbar css for ipad screen

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -50,8 +50,7 @@
 				<a class="dropdown-toggle" data-toggle="dropdown" href="#"
 					onclick="return false;"  style="height: 40px;">
 					<span class="hidden-xs hidden-sm" style="line-height: 24px;">{{ __("Help") }} <b class="caret"></b></span>
-					<span class="visible-xs visible-sm standard-image"
-						style="padding: 50% 7px; font-size: 17px; background-color: #fafbfc; font-weight: 100;">?</span>
+					<span class="visible-xs visible-sm standard-image help-icon">?</span>
 				</a>
 				<ul class="dropdown-menu" id="toolbar-help" role="menu">
 					<li id="help-links"></li>

--- a/frappe/public/less/navbar.less
+++ b/frappe/public/less/navbar.less
@@ -82,6 +82,13 @@
 		padding: 8px 0 !important;
 		margin-left: 0 !important;
 	}
+
+	.help-icon {
+		margin-top: 1px;
+		padding: 10px 5px;
+		background-color: #fafbfc;
+		font-weight: 100;
+	}
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Before:
<img width="835" alt="Screenshot 2019-10-19 at 2 24 04 PM" src="https://user-images.githubusercontent.com/19775888/67140902-8273bb80-f27c-11e9-89dc-10cc0f0d1567.png">


After:
<img width="887" alt="Screenshot 2019-10-19 at 2 19 52 PM" src="https://user-images.githubusercontent.com/19775888/67140918-8bfd2380-f27c-11e9-9fae-440474ffb270.png">
