### PR TITLE
fix: Throttle clear cache

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -225,19 +225,16 @@ $.extend(frappe.ui.toolbar, {
 	},
 });
 
-frappe.ui.toolbar.clear_cache = function() {
+frappe.ui.toolbar.clear_cache = frappe.utils.throttle(function() {
 	frappe.assets.clear_local_storage();
-	frappe.call({
-		method: 'frappe.sessions.clear',
-		callback: function(r) {
-			if(!r.exc) {
-				frappe.show_alert({message:r.message, indicator:'green'});
-				location.reload(true);
-			}
-		}
+	frappe.xcall('frappe.sessions.clear').then(message => {
+		frappe.show_alert({
+			message: message,
+			indicator: 'green'
+		});
+		location.reload(true);
 	});
-	return false;
-};
+}, 10000);
 
 frappe.ui.toolbar.show_about = function() {
 	try {


### PR DESCRIPTION
Throttle clear cache function for 10s to avoid repeated "clear cache" on pressing and holding `cmd + r`

**Issue:**

![clear-cache](https://user-images.githubusercontent.com/13928957/67178700-4dd54080-f3f1-11e9-98a6-41fcdcaa1bf7.gif)
