### PR TITLE
fix: missing arguments

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -123,10 +123,10 @@ frappe.ui.form.Toolbar = Class.extend({
 								doctype,
 								docname,
 								title_field,
-								old_title: me.frm.doc[title_field],
-								new_title: args.title,
-								old_name: docname,
-								new_name: args.name
+								old_title: me.frm.doc[title_field] || "",
+								new_title: args.title || "",
+								old_name: docname || "",
+								new_name: args.name | ""
 							},
 							btn: d.get_primary_btn()
 						}).then((res) => {


### PR DESCRIPTION
- new_title and old_title field was not undefined for DocType
![Screenshot 2019-10-21 at 8 48 31 PM](https://user-images.githubusercontent.com/7310479/67218672-6458b780-f444-11e9-88c6-7fa0a0040952.png)
