### PR TITLE
fix: Ignore ImportError for Notification Settings

### DIFF
--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -44,7 +44,7 @@ def get_subscribed_documents():
 	try:
 		doc = frappe.get_doc('Notification Settings', frappe.session.user)
 		subscribed_documents = [item.document for item in doc.subscribed_documents]
-	except frappe.DoesNotExistError:
+	except (frappe.DoesNotExistError, ImportError):
 		subscribed_documents = []
 
 	return subscribed_documents


### PR DESCRIPTION
During migrate, Notification Settings are fetched which doesn't exist yet. It is safe to ignore it because Notification Settings are not created anyway for any user.