### PR TITLE
fix: quill editor's tooltip

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -278,6 +278,10 @@ frappe.ui.form.Timeline = class Timeline {
 				e.preventDefault();
 				var name = $timeline_item.data('name');
 
+				// fix quill editor's tooltip
+				$timeline_item.attr('style', 'overflow: visible;');
+				$timeline_item.find('.timeline-content-show').attr('style', 'overflow: visible;');
+
 				if($timeline_item.hasClass('is-editing')) {
 					me.current_editing_area.submit();
 				} else {


### PR DESCRIPTION
Before:
![Screenshot 2019-10-22 at 2 22 19 PM](https://user-images.githubusercontent.com/25369014/67271069-7b94b500-f4d7-11e9-836f-7c6b552d6f8b.png)

After:
![Screenshot 2019-10-22 at 2 21 58 PM](https://user-images.githubusercontent.com/25369014/67271078-7df70f00-f4d7-11e9-80ec-5ef9f8ecabe2.png)
