### PR TITLE
fix: home_settings should be hidden in User DocType

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -416,6 +416,7 @@
   {
    "fieldname": "home_settings",
    "fieldtype": "Code",
+   "hidden": 1,
    "label": "Home Settings"
   },
   {
@@ -585,7 +586,7 @@
  "idx": 413,
  "image_field": "user_image",
  "max_attachments": 5,
- "modified": "2019-09-18 14:14:01.233124",
+ "modified": "2019-10-22 14:16:34.810223",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",


### PR DESCRIPTION
The home settings are changed when we use show/hide cards or reorder the cards hence it should be hidden in User DocType to avoid editing and thereby overriding **Allow Modules** configurations.

![stock module issue](https://user-images.githubusercontent.com/24353136/67271175-a7179f80-f4d7-11e9-843a-f23f88b6409c.png)
