### PR TITLE
feat: allow internal links from parent document to show in dashboard

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -370,15 +370,28 @@ frappe.ui.form.Dashboard = Class.extend({
 				});
 
 				// update from internal links
-				$.each(me.data.internal_links, function(doctype, link) {
-					var table_fieldname = link[0], link_fieldname = link[1];
-					var names = [];
-					(me.frm.doc[table_fieldname] || []).forEach(function(d) {
-						var value = d[link_fieldname];
-						if(value && names.indexOf(value)===-1) {
-							names.push(value);
-						}
-					});
+				$.each(me.data.internal_links, (doctype, link) => {
+					let table_fieldname, link_fieldname;
+					if (typeof link === 'string' || link instanceof String) {
+						// get reference field from parent document
+						link_fieldname = link;
+					} else if (Array.isArray(link)) {
+						// get reference field from child documents
+						[table_fieldname, link_fieldname] = link;
+					}
+
+					let names = [];
+					if (!table_fieldname && link_fieldname) {
+						// get internal links in parent document
+						let value = me.frm.doc[link_fieldname];
+						if (value && !names.includes(value)) { names.push(value); }
+					} else {
+						// get internal links in child documents
+						(me.frm.doc[table_fieldname] || []).forEach((d) => {
+							let value = d[link_fieldname];
+							if (value && !names.includes(value)) { names.push(value); }
+						});
+					}
 					me.frm.dashboard.set_badge_count(doctype, 0, names.length, names);
 				});
 

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -371,22 +371,14 @@ frappe.ui.form.Dashboard = Class.extend({
 
 				// update from internal links
 				$.each(me.data.internal_links, (doctype, link) => {
-					let table_fieldname, link_fieldname;
-					if (typeof link === 'string' || link instanceof String) {
-						// get reference field from parent document
-						link_fieldname = link;
-					} else if (Array.isArray(link)) {
-						// get reference field from child documents
-						[table_fieldname, link_fieldname] = link;
-					}
-
 					let names = [];
-					if (!table_fieldname && link_fieldname) {
+					if (typeof link === 'string' || link instanceof String) {
 						// get internal links in parent document
-						let value = me.frm.doc[link_fieldname];
+						let value = me.frm.doc[link];
 						if (value && !names.includes(value)) { names.push(value); }
-					} else {
+					} else if (Array.isArray(link)) {
 						// get internal links in child documents
+						let [table_fieldname, link_fieldname] = link;
 						(me.frm.doc[table_fieldname] || []).forEach((d) => {
 							let value = d[link_fieldname];
 							if (value && !names.includes(value)) { names.push(value); }

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -375,13 +375,17 @@ frappe.ui.form.Dashboard = Class.extend({
 					if (typeof link === 'string' || link instanceof String) {
 						// get internal links in parent document
 						let value = me.frm.doc[link];
-						if (value && !names.includes(value)) { names.push(value); }
+						if (value && !names.includes(value)) {
+							names.push(value);
+						}
 					} else if (Array.isArray(link)) {
 						// get internal links in child documents
 						let [table_fieldname, link_fieldname] = link;
-						(me.frm.doc[table_fieldname] || []).forEach((d) => {
+						(me.frm.doc[table_fieldname] || []).forEach(d => {
 							let value = d[link_fieldname];
-							if (value && !names.includes(value)) { names.push(value); }
+							if (value && !names.includes(value)) {
+								names.push(value);
+							}
 						});
 					}
 					me.frm.dashboard.set_badge_count(doctype, 0, names.length, names);


### PR DESCRIPTION
**Ref:** https://discuss.erpnext.com/t/dashboard-doctype-linking/24736

<hr>

**Changes:**

You can now include fields in the parent document to provide internal links. For example:

```python
dashboard_data = {
	...
	internal_links: {
		'doctype_1': ['table_fieldname', 'link_fieldname'],  # already exists
		'doctype_2': 'link_fieldname'  # added in this PR
	},
	...
}
```

**Screenshots / GIFs:**

![dashboard](https://user-images.githubusercontent.com/13396535/67287193-45b3f880-f4f8-11e9-8b49-5e691e09e714.gif)