### PR TITLE
fix: PDF print overlapping text content for the table header

### DIFF
--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -166,6 +166,6 @@ table td div {
 	max-height: 150px;
 }
 
-.print-format [data-fieldtype="Table"] {
+.print-preview [data-fieldtype="Table"] {
 	overflow: auto;
 }


### PR DESCRIPTION
**Issue**

<img width="756" alt="Screenshot 2019-10-23 at 1 26 25 PM" src="https://user-images.githubusercontent.com/8780500/67372811-1ce53f00-f59c-11e9-9e9a-b01a7a29b843.png">


**After Fix**

<img width="723" alt="Screenshot 2019-10-23 at 1 26 44 PM" src="https://user-images.githubusercontent.com/8780500/67372804-1a82e500-f59c-11e9-8961-cabfbb3a70b8.png">
