### PR TITLE
fix(notifications): Add notification_config to global_cache_keys

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -10,7 +10,7 @@ from frappe.desk.notifications import (delete_notification_count_for,
 
 common_default_keys = ["__default", "__global"]
 
-global_cache_keys = ("app_hooks", "installed_apps",
+global_cache_keys = ("app_hooks", "installed_apps", "notification_config",
 		"app_modules", "module_app", "system_settings",
 		'scheduler_events', 'time_zone', 'webhooks', 'active_domains',
 		'active_modules', 'assignment_rule', 'server_script_map')


### PR DESCRIPTION
bench migrate breaks with the following error

```python-traceback
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 40, in migrate
    clear_global_cache()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/cache_manager.py", line 48, in clear_global_cache
    clear_website_cache()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 295, in clear_cache
    frappe.clear_cache("Guest")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 563, in clear_cache
    frappe.cache_manager.clear_user_cache(user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/cache_manager.py", line 31, in clear_user_cache
    clear_notifications(user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/notifications.py", line 121, in clear_notifications
    config = get_notification_config()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/notifications.py", line 199, in get_notification_config
    return frappe.cache().hget("notification_config", frappe.session.user, _get)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/redis_wrapper.py", line 172, in hget
    value = super(RedisWrapper, self).hget(_name, key)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/redis/client.py", line 1963, in hget
    return self.execute_command('HGET', name, key)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/redis/client.py", line 668, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/redis/client.py", line 680, in parse_response
    response = connection.read_response()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/redis/connection.py", line 629, in read_response
    raise response
redis.exceptions.ResponseError: WRONGTYPE Operation against a key holding the wrong kind of value
```

Co-authored-by: prssanna <prssud@gmail.com>

