### PR TITLE
fix: remove disable-smart-shrinking. 

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -15,8 +15,7 @@ def get_pdf(html, options=None, output=None):
 
 	options.update({
 		"disable-javascript": "",
-		"disable-local-file-access": "",
-		"disable-smart-shrinking": ""
+		"disable-local-file-access": ""
 	})
 
 	filedata = ''


### PR DESCRIPTION
this change was proposed for a fix when manually updating wkpdftohtml. because of this change in a normal PIP install (VMWARE - wkhtmltopdf 0.12.3 (with patched qt)) all background pdf (letterheads) become 20% larger wich is unfixable by css.

please remove and suggest other solution!
#8660