### PR TITLE
fix: search tag on click

### DIFF
--- a/frappe/public/js/frappe/ui/tags.js
+++ b/frappe/public/js/frappe/ui/tags.js
@@ -100,17 +100,22 @@ frappe.ui.Tags = class {
 
 	getTag(label) {
 		let $tag = $(`<div class="frappe-tag btn-group" data-tag-label="${label}">
-		<button class="btn btn-default btn-xs toggle-tag"
-			title="${ __("toggle Tag") }"
-			data-tag-label="${label}">${label}
-		</button>
-		<button class="btn btn-default btn-xs remove-tag"
-			title="${ __("Remove Tag") }"
-			data-tag-label="${label}">
-			<i class="fa fa-remove text-muted"></i>
-		</button></div>`);
+			<button class="btn btn-default btn-xs toggle-tag"
+				title="${ __("toggle Tag") }"
+				data-tag-label="${label}">#${label}
+			</button>
+			<button class="btn btn-default btn-xs remove-tag"
+				title="${ __("Remove Tag") }"
+				data-tag-label="${label}">
+				<i class="fa fa-remove text-muted"></i>
+			</button></div>`);
 
+		let $searchTag = $tag.find(".toggle-tag");
 		let $removeTag = $tag.find(".remove-tag");
+
+		$searchTag.on("click", () => {
+			frappe.searchdialog.search.init_search("#".concat($searchTag.attr('data-tag-label')), "tags");
+		});
 
 		$removeTag.on("click", () => {
 			this.removeTag($removeTag.attr('data-tag-label'));


### PR DESCRIPTION
- Display `#` before tag name in form sidebar.
- Search for documents linked with Tag onclick.
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/7310479/67412611-3a86c880-f5dd-11e9-8928-b01f70211c56.gif)
