### PR TITLE
fix: Rename Document Fix

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -16,11 +16,11 @@ def update_document_title(doctype, docname, title_field=None, old_title=None, ne
 	"""
 		Update title from header in form view
 	"""
-	if new_title and old_title != new_title:
+	if old_title and new_title and not old_title == new_title:
 		frappe.db.set_value(doctype, docname, title_field, new_title)
 		frappe.msgprint(_('Saved'), alert=True, indicator='green')
 
-	if new_name and old_name != new_name:
+	if old_name and new_name and not old_name == new_name:
 		return rename_doc(doctype, old_name, new_name)
 
 	return old_name

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -12,7 +12,7 @@ from frappe.model.utils.user_settings import sync_user_settings, update_user_set
 
 
 @frappe.whitelist()
-def update_document_title(doctype, docname, title_field, old_title, new_title, old_name, new_name):
+def update_document_title(doctype, docname, title_field=None, old_title=None, new_title=None, old_name=None, new_name=None):
 	"""
 		Update title from header in form view
 	"""


### PR DESCRIPTION
- Fix missing required positional arguments
- Either `old_title, new_title` or `old_name, new_name` are passed for renaming document
![Screenshot 2019-10-23 at 10 29 31 PM](https://user-images.githubusercontent.com/7310479/67416570-b0daf900-f5e4-11e9-8a06-94478105cfaa.png)
