### PR TITLE
fix: hide file browser for web forms

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -23,7 +23,7 @@
 							:accept="restrictions.allowed_file_types.join(', ')"
 						>
 					</label>
-					<span v-if="file_browser_enabled">
+					<span v-if="!disable_file_browser">
 						{{ __('choose an') }}
 						<a href="#" class="text-primary bold"
 							@click.stop.prevent="show_file_browser = true"
@@ -107,7 +107,7 @@
 		</div>
 		<FileBrowser
 			ref="file_browser"
-			v-if="show_file_browser && file_browser_enabled"
+			v-if="show_file_browser && !disable_file_browser"
 			@hide-browser="show_file_browser = false"
 		/>
 		<WebLink
@@ -129,8 +129,8 @@ export default {
 		show_upload_button: {
 			default: true
 		},
-		file_browser_enabled: {
-			default: true
+		disable_file_browser: {
+			default: false
 		},
 		allow_multiple: {
 			default: true

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -23,12 +23,14 @@
 							:accept="restrictions.allowed_file_types.join(', ')"
 						>
 					</label>
-					{{ __('choose an') }}
-					<a href="#" class="text-primary bold"
-						@click.stop.prevent="show_file_browser = true"
-					>
-						{{ __('uploaded file') }}
-					</a>
+					<span v-if="file_browser_enabled">
+						{{ __('choose an') }}
+						<a href="#" class="text-primary bold"
+							@click.stop.prevent="show_file_browser = true"
+						>
+							{{ __('uploaded file') }}
+						</a>
+					</span>
 					{{ __('or attach a') }}
 					<a class="text-primary bold" href
 						@click.stop.prevent="show_web_link = true"
@@ -105,7 +107,7 @@
 		</div>
 		<FileBrowser
 			ref="file_browser"
-			v-if="show_file_browser"
+			v-if="show_file_browser && file_browser_enabled"
 			@hide-browser="show_file_browser = false"
 		/>
 		<WebLink
@@ -186,6 +188,9 @@ export default {
 				&& this.files.every(
 					file => file.total !== 0 && file.progress === file.total);
 		},
+		file_browser_enabled() {
+			return !Boolean(frappe.web_form)
+		}
 	},
 	methods: {
 		dragover() {

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -129,6 +129,9 @@ export default {
 		show_upload_button: {
 			default: true
 		},
+		file_browser_enabled: {
+			default: true
+		},
 		allow_multiple: {
 			default: true
 		},
@@ -187,9 +190,6 @@ export default {
 			return this.files.length > 0
 				&& this.files.every(
 					file => file.total !== 0 && file.progress === file.total);
-		},
-		file_browser_enabled() {
-			return !Boolean(frappe.web_form)
 		}
 	},
 	methods: {

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -12,7 +12,8 @@ export default class FileUploader {
 		restrictions,
 		upload_notes,
 		allow_multiple,
-		as_dataurl
+		as_dataurl,
+		disable_file_browser,
 	} = {}) {
 		if (!wrapper) {
 			this.make_dialog();
@@ -33,7 +34,8 @@ export default class FileUploader {
 					restrictions,
 					upload_notes,
 					allow_multiple,
-					as_dataurl
+					as_dataurl,
+					disable_file_browser,
 				}
 			})
 		});

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -71,7 +71,6 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 		if (this.df.options) {
 			Object.assign(options, this.df.options);
 		}
-
 		this.upload_options = options;
 	},
 

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -113,7 +113,7 @@ frappe.ready(function() {
 				}
 				if (["Attach", "Attach Image"].includes(df.fieldtype)) {
 					if (!df.options)
-						df.options = {}
+						df.options = {};
 					df.options.disable_file_browser = true;
 				}
 			});

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -114,7 +114,7 @@ frappe.ready(function() {
 				if (["Attach", "Attach Image"].includes(df.fieldtype)) {
 					if (!df.options)
 						df.options = {}
-					df.options.file_browser_enabled = false;
+					df.options.disable_file_browser = true;
 				}
 			});
 

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -111,6 +111,11 @@ frappe.ready(function() {
 				if (df.fieldtype === "Link") {
 					df.only_select = true;
 				}
+				if (["Attach", "Attach Image"].includes(df.fieldtype)) {
+					if (!df.options)
+						df.options = {}
+					df.options.file_browser_enabled = false;
+				}
 			});
 
 			return form_data;


### PR DESCRIPTION
File browser was not hidden in web forms previously. This PR changes that!

Added a `disable_file_browser` prop.
Set the value in options in `webform_script.js`