### PR TITLE
fix: include items with hyphen in global search irrespective of query

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -462,17 +462,20 @@ frappe.search.utils = {
 
 		// **Specific use-case step**
 		keywords = keywords || '';
+		var item = __(_item || '');
+		var item_without_hyphen = item.replace(/-/g, " ")
 
-		var item = __(_item || '').replace(/-/g, " ");
-
-		var ilen = item.length;
-		var klen = keywords.length;
-		var length_ratio = klen/ilen;
+		var item_length = item.length;
+		var query_length = keywords.length;
+		var length_ratio = query_length / item_length;
 		var max_skips = 3, max_mismatch_len = 2;
 
-		if (klen > ilen) {	return 0;  }
+		if (query_length > item_length) { return 0; }
 
-		if(keywords === item || item.toLowerCase().indexOf(keywords) === 0) {
+		// check for perfect string matches or
+		// matches that start with the keyword
+		if ([item, item_without_hyphen].includes(keywords)
+				|| [item, item_without_hyphen].some((txt) => txt.toLowerCase().indexOf(keywords) === 0)) {
 			return 10 + length_ratio;
 		}
 
@@ -488,12 +491,12 @@ frappe.search.utils = {
 		}
 
 		var skips = 0, mismatches = 0;
-		outer: for (var i = 0, j = 0; i < klen; i++) {
-			if(mismatches !== 0) skips++;
-			if(skips > max_skips) return 0;
+		outer: for (var i = 0, j = 0; i < query_length; i++) {
+			if (mismatches !== 0) skips++;
+			if (skips > max_skips) return 0;
 			var k_ch = keywords.charCodeAt(i);
 			mismatches = 0;
-			while (j < ilen) {
+			while (j < item_length) {
 				if (item.charCodeAt(j++) === k_ch) {
 					continue outer;
 				}


### PR DESCRIPTION
**Before:**

![batch-wise-before](https://user-images.githubusercontent.com/13396535/67466264-5e412180-f664-11e9-89c7-4b4b88c66471.gif)

**After:**

![batch-wise-fix](https://user-images.githubusercontent.com/13396535/67465866-a9a70000-f663-11e9-9b51-735381cbdc5e.gif)