### PR TITLE
fix(Notifications): Improvements for Notifications

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -8,7 +8,8 @@ from frappe import _
 import json
 from frappe.model.document import Document
 from frappe.core.doctype.user.user import extract_mentions
-from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
+from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
+	get_truncated_title
 from frappe.utils import get_fullname
 from frappe.website.render import clear_cache
 from frappe.database.schema import add_column
@@ -51,9 +52,7 @@ class Comment(Document):
 				return
 
 			sender_fullname = get_fullname(frappe.session.user)
-			title_field = frappe.get_meta(self.reference_doctype).get_title_field()
-			title = self.reference_name if title_field == "name" else \
-				frappe.db.get_value(self.reference_doctype, self.reference_name, title_field)
+			title = get_truncated_title(self.reference_doctype, self.reference_name, truncate_length=100)
 
 			recipients = [frappe.db.get_value("User", {"enabled": 1, "name": name, "user_type": "System User", "allowed_in_mentions": 1}, "email")
 				for name in mentions]

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -9,7 +9,7 @@ import json
 from frappe.model.document import Document
 from frappe.core.doctype.user.user import extract_mentions
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
-	get_truncated_title
+	get_title, get_title_html
 from frappe.utils import get_fullname
 from frappe.website.render import clear_cache
 from frappe.database.schema import add_column
@@ -52,13 +52,13 @@ class Comment(Document):
 				return
 
 			sender_fullname = get_fullname(frappe.session.user)
-			title = get_truncated_title(self.reference_doctype, self.reference_name, truncate_length=100)
+			title = get_title(self.reference_doctype, self.reference_name)
 
 			recipients = [frappe.db.get_value("User", {"enabled": 1, "name": name, "user_type": "System User", "allowed_in_mentions": 1}, "email")
 				for name in mentions]
 
 			notification_message = _('''{0} mentioned you in a comment in {1} {2}''')\
-				.format(frappe.bold(sender_fullname), frappe.bold(self.reference_doctype), frappe.bold(title))
+				.format(frappe.bold(sender_fullname), frappe.bold(self.reference_doctype), get_title_html(title))
 
 			notification_doc = {
 				'type': 'Mention',

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -50,7 +50,7 @@ def make_notification_logs(doc, users):
 					_doc.update(doc)
 					_doc.for_user = user
 					_doc.subject = _doc.subject.replace('<div>', '').replace('</div>', '')
-					if _doc.for_user != _doc.from_user:
+					if _doc.for_user != _doc.from_user or doc.type == 'Energy Point':
 						_doc.insert(ignore_permissions=True)
 
 def send_notification_email(doc):

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -88,6 +88,15 @@ def get_email_header(doc):
 	}[doc.type or 'Default']
 
 
+def get_truncated_title(doctype, docname, title_field=None, truncate_length=None):
+	if not title_field:
+		title_field = frappe.get_meta(doctype).get_title_field()
+	title = docname if title_field == "name" else \
+		frappe.db.get_value(doctype, docname, title_field)
+	if truncate_length:
+		title = (title[:truncate_length] + '..') if len(title) > truncate_length else title
+	return title
+
 @frappe.whitelist()
 def mark_as_seen(docname):
 	if docname:

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -89,9 +89,11 @@ def get_email_header(doc):
 
 
 @frappe.whitelist()
-def mark_as_seen(docnames):
-	docnames = frappe.parse_json(docnames)
-	if docnames:
-		filters = {'name': ['in', docnames]}
-		frappe.db.set_value('Notification Log', filters, 'seen', 1, update_modified=False)
-		frappe.publish_realtime('seen_notification', after_commit=True, user=frappe.session.user)
+def mark_as_seen(docname):
+	if docname:
+		frappe.db.set_value('Notification Log', docname, 'seen', 1, update_modified=False)
+
+
+@frappe.whitelist()
+def trigger_indicator_hide():
+	frappe.publish_realtime('indicator_hide', user=frappe.session.user)

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -50,7 +50,8 @@ def make_notification_logs(doc, users):
 					_doc.update(doc)
 					_doc.for_user = user
 					_doc.subject = _doc.subject.replace('<div>', '').replace('</div>', '')
-					_doc.insert(ignore_permissions=True)
+					if _doc.for_user != _doc.from_user:
+						_doc.insert(ignore_permissions=True)
 
 def send_notification_email(doc):
 	is_type_enabled = is_email_notifications_enabled_for_type(doc.for_user, doc.type)

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -58,6 +58,9 @@ def send_notification_email(doc):
 	if not is_type_enabled:
 		return
 
+	if doc.type == 'Energy Point' and doc.email_content is None:
+		return
+
 	from frappe.utils import get_url_to_form, strip_html
 
 	doc_link = get_url_to_form(doc.document_type, doc.document_name)

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -89,14 +89,15 @@ def get_email_header(doc):
 	}[doc.type or 'Default']
 
 
-def get_truncated_title(doctype, docname, title_field=None, truncate_length=None):
+def get_title(doctype, docname, title_field=None):
 	if not title_field:
 		title_field = frappe.get_meta(doctype).get_title_field()
 	title = docname if title_field == "name" else \
 		frappe.db.get_value(doctype, docname, title_field)
-	if truncate_length:
-		title = (title[:truncate_length] + '..') if len(title) > truncate_length else title
 	return title
+
+def get_title_html(title):
+	return '<b class="subject-title">{0}</b>'.format(title)
 
 @frappe.whitelist()
 def mark_as_seen(docname):

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.desk.form.document_follow import follow_document
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
-	get_truncated_title
+	get_title, get_title_html
 import frappe.utils
 import frappe.share
 
@@ -161,15 +161,15 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 
 	# Search for email address in description -- i.e. assignee
 	user_name = frappe.get_cached_value('User', frappe.session.user, 'full_name')
-	title = get_truncated_title(doc_type, doc_name, truncate_length=100)
+	title = get_title(doc_type, doc_name)
 	description_html =  "<div>{0}</div>".format(description) if description else None
 
 	if action=='CLOSE':
-		subject = _('Your assignment on {0} {1} has been removed').format(frappe.bold(doc_type), frappe.bold(title))
+		subject = _('Your assignment on {0} {1} has been removed').format(frappe.bold(doc_type), get_title_html(title))
 	else:
 		user_name = frappe.bold(user_name)
 		document_type = frappe.bold(doc_type)
-		title = frappe.bold(title)
+		title = get_title_html(title)
 		subject = _('{0} assigned a new task {1} {2} to you').format(user_name, document_type, title)
 
 	notification_doc = {

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -7,7 +7,8 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.desk.form.document_follow import follow_document
-from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
+from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
+	get_truncated_title
 import frappe.utils
 import frappe.share
 
@@ -160,9 +161,7 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 
 	# Search for email address in description -- i.e. assignee
 	user_name = frappe.get_cached_value('User', frappe.session.user, 'full_name')
-	title_field = frappe.get_meta(doc_type).get_title_field()
-	title = doc_name if title_field == "name" else \
-		frappe.db.get_value(doc_type, doc_name, title_field)
+	title = get_truncated_title(doc_type, doc_name, truncate_length=100)
 	description_html =  "<div>{0}</div>".format(description) if description else None
 
 	if action=='CLOSE':

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -288,6 +288,8 @@ frappe.ui.Notifications = class Notifications {
 		);
 		let seen_class = field.seen ? '' : 'unseen';
 		let message = field.subject;
+		let title = message.match(/<b class="subject-title">(.*?)<\/b>/);
+		message = title ? message.replace(title[1], frappe.ellipsis(title[1], 100)): message;
 		let message_html = `<div class="message">${message}</div>`;
 		let user = field.from_user;
 		let user_avatar = frappe.avatar(user, 'avatar-small user-avatar');
@@ -309,18 +311,18 @@ frappe.ui.Notifications = class Notifications {
 	render_dropdown_headers() {
 		this.categories = [
 			{
-				label: __('Notifications'),
-				value: 'Notifications'
+				label: __("Notifications"),
+				value: "Notifications"
 			},
 			{
-				label: __('Today\'s Events'),
-				value: 'Todays Events',
-				action: 'render_todays_events'
+				label: __("Today's Events"),
+				value: "Todays Events",
+				action: "render_todays_events"
 			},
 			{
-				label: __('Open Documents'),
-				value: 'Open Documents',
-				action: 'get_open_document_config'
+				label: __("Open Documents"),
+				value: "Open Documents",
+				action: "get_open_document_config"
 			}
 		];
 

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -24,8 +24,8 @@ frappe.ui.Notifications = class Notifications {
 		this.$open_docs = this.$dropdown_list.find(
 			'.category-list[data-category="Open Documents"]'
 		);
-		this.$upcoming_events = this.$dropdown_list.find(
-			'.category-list[data-category="Upcoming Events"]'
+		this.$today_events = this.$dropdown_list.find(
+			'.category-list[data-category="Todays Events"]'
 		);
 
 		frappe.utils.bind_actions_with_object(this.$dropdown_list, this);
@@ -44,19 +44,15 @@ frappe.ui.Notifications = class Notifications {
 		});
 	}
 
-	render_upcoming_events(e, $target) {
+	render_todays_events(e, $target) {
 		let hide = $target.next().hasClass('in');
 		if (!hide) {
 			let today = frappe.datetime.get_today();
-			let tomorrow = frappe.datetime.add_days(today, 1);
-			frappe.db.get_list('Event', {
-				fields: ['name', 'subject', 'starts_on'],
-				filters: [
-					{'starts_on': ['between', today, tomorrow]},
-					{'ends_on': ['>=', frappe.datetime.now_datetime()]},
-					{'owner': frappe.session.user}
-				]
-			}).then(event_list => {
+			frappe.xcall('frappe.desk.doctype.event.event.get_events', {
+					start: today,
+					end: today
+			})
+			.then(event_list => {
 				this.render_events_html(event_list);
 			});
 		}
@@ -75,11 +71,11 @@ frappe.ui.Notifications = class Notifications {
 			html = event_list.map(get_event_html).join('');
 		} else {
 			html = `<li class="recent-item text-center">
-					<span class="text-muted">${__('No Upcoming Events')}</span>
+					<span class="text-muted">${__('No Events Today')}</span>
 				</li>`;
 		}
 
-		this.$upcoming_events.html(html);
+		this.$today_events.html(html);
 	}
 
 	get_open_document_config(e) {
@@ -222,9 +218,9 @@ frappe.ui.Notifications = class Notifications {
 	change_activity_status() {
 		if (this.$dropdown_list.find('.activity-status')) {
 			this.$dropdown_list.find('.activity-status').replaceWith(
-				`<a class="recent-item text-center text-muted full-log-btn" 
+				`<a class="recent-item text-center text-muted" 
 					href="#List/Notification Log">
-					${__('View Full Log')}
+					<div class="full-log-btn">${__('View Full Log')}</div>
 				</a>`
 			);
 		}
@@ -270,9 +266,9 @@ frappe.ui.Notifications = class Notifications {
 					let item_html = this.get_dropdown_item_html(field);
 					if (item_html) body_html += item_html;
 				});
-				view_full_log_html = `<a class="recent-item text-center text-muted full-log-btn"
+				view_full_log_html = `<a class="recent-item text-center text-muted"
 					href="#List/Notification Log">
-						${__('View Full Log')}
+						<div class="full-log-btn">${__('View Full Log')}</div>
 					</a>`;
 			} else {
 				body_html += `<li class="recent-item text-center activity-status">
@@ -297,7 +293,7 @@ frappe.ui.Notifications = class Notifications {
 		let user = field.from_user;
 		let user_avatar = frappe.avatar(user, 'avatar-small user-avatar');
 		let timestamp = frappe.datetime.comment_when(field.creation, true);
-		let item_html = `<a class="recent-item ${seen_class}" href = "${doc_link}" data-name="${field.name}">
+		let item_html = `<a class="recent-item ${seen_class}" href="${doc_link}" data-name="${field.name}">
 				${user_avatar}
 				${message_html}
 				<div class="notification-timestamp text-muted">
@@ -318,9 +314,9 @@ frappe.ui.Notifications = class Notifications {
 				value: 'Notifications'
 			},
 			{
-				label: __('Upcoming Events'),
-				value: 'Upcoming Events',
-				action: 'render_upcoming_events'
+				label: __('Today\'s Events'),
+				value: 'Todays Events',
+				action: 'render_todays_events'
 			},
 			{
 				label: __('Open Documents'),
@@ -421,7 +417,7 @@ frappe.ui.Notifications = class Notifications {
 	setup_dropdown_events() {
 		this.$dropdown_list
 			.find(
-				'[data-category="Notifications"], [data-category="Upcoming Events"], [data-category="Open Documents"]'
+				'[data-category="Notifications"], [data-category="Todays Events"], [data-category="Open Documents"]'
 			)
 			.collapse({
 				toggle: false
@@ -434,7 +430,7 @@ frappe.ui.Notifications = class Notifications {
 					.collapse('show');
 				this.$dropdown_list
 					.find(
-						'[data-category="Upcoming Events"], [data-category="Open Documents"]'
+						'[data-category="Todays Events"], [data-category="Open Documents"]'
 					)
 					.collapse('hide');
 			}

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -49,10 +49,9 @@ frappe.ui.Notifications = class Notifications {
 		if (!hide) {
 			let today = frappe.datetime.get_today();
 			frappe.xcall('frappe.desk.doctype.event.event.get_events', {
-					start: today,
-					end: today
-			})
-			.then(event_list => {
+				start: today,
+				end: today
+			}).then(event_list => {
 				this.render_events_html(event_list);
 			});
 		}
@@ -232,7 +231,7 @@ frappe.ui.Notifications = class Notifications {
 			{ docname: docname }
 		).then(()=> {
 			$el.removeClass('unseen');
-		})
+		});
 	}
 
 	explicitly_mark_as_seen(e, $target) {

--- a/frappe/public/less/notifications.less
+++ b/frappe/public/less/notifications.less
@@ -100,15 +100,6 @@ a.unseen:hover .mark-read {
 	margin-bottom: 10px;
 }
 
-.divider-dot {
-	height: 5px;
-	width: 5px;
-	margin: 0 2px;
-    background-color: #99a4af;
-    border-radius: 50%;
-    display: inline-block;
-}
-
 .user-avatar {
 	float: left;
 	margin-right: 10px;

--- a/frappe/public/less/notifications.less
+++ b/frappe/public/less/notifications.less
@@ -45,7 +45,7 @@
 }
 
 .dropdown-notifications .recent-item {
-	padding: 10px 14px;
+	padding: 15px 14px 0 14px;
     white-space: normal;
 	text-decoration: none;
 	font-weight: normal;
@@ -56,25 +56,23 @@ a.recent-item:hover {
 	background-color: #f0f4f7; 
 }
 
-.dropdown-energy-points .energy-points-icon {
-	height: 40px;
-	font-size: 14px;
-	text-align: center;
+a.unseen:hover .mark-read {
+	display: inline-block;
+}
+
+.mark-read {
+	display: none;
+	margin-left: 10px;
+}
+
+.mark-read:hover {
+	text-decoration: underline;
 }
 
 .notifications-list {
 	width: 450px;
 	max-height: 480px;
 	overflow-y: auto;
-}
-
-.energy-points-notification {
-	font-size: 7px;
-	position: absolute;
-	top: 4px;
-	right: 8px;
-	color: @indicator-orange;
-	display: none;
 }
 
 .date-range {
@@ -89,6 +87,16 @@ a.recent-item:hover {
 .notification-timestamp {
 	margin-top: 5px;
 	font-size: 11px;
+	display: inline-block;
+}
+
+.divider-dot {
+	height: 5px;
+	width: 5px;
+	margin: 0 2px;
+    background-color: #99a4af;
+    border-radius: 50%;
+    display: inline-block;
 }
 
 .user-avatar {

--- a/frappe/public/less/notifications.less
+++ b/frappe/public/less/notifications.less
@@ -45,11 +45,19 @@
 }
 
 .dropdown-notifications .recent-item {
-	padding: 15px 14px 0 14px;
+	padding: 10px 14px;
     white-space: normal;
 	text-decoration: none;
 	font-weight: normal;
 	display: flow-root;
+}
+
+.category-list[data-category="Notifications"] .recent-item {
+	padding: 15px 14px 0 14px;
+}
+
+.full-log-btn {
+	padding-bottom: 10px;
 }
 
 a.recent-item:hover {
@@ -63,6 +71,7 @@ a.unseen:hover .mark-read {
 .mark-read {
 	display: none;
 	margin-left: 10px;
+	font-size: 11px;
 }
 
 .mark-read:hover {
@@ -88,6 +97,7 @@ a.unseen:hover .mark-read {
 	margin-top: 5px;
 	font-size: 11px;
 	display: inline-block;
+	margin-bottom: 10px;
 }
 
 .divider-dot {

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.desk.form.document_follow import follow_document
-from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
+from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
+	get_truncated_title
 from frappe.utils import cint
 
 @frappe.whitelist()
@@ -152,9 +153,7 @@ def notify_assignment(shared_by, doctype, doc_name, everyone):
 
 	from frappe.utils import get_fullname
 
-	title_field = frappe.get_meta(doctype).get_title_field()
-	title = doc_name if title_field == "name" else \
-		frappe.db.get_value(doctype, doc_name, title_field)
+	title = get_truncated_title(doctype, doc_name, truncate_length=100)
 
 	reference_user = get_fullname(frappe.session.user)
 	notification_message = _('{0} shared a document {1} {2} with you').format(

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _
 from frappe.desk.form.document_follow import follow_document
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
-	get_truncated_title
+	get_title, get_title_html
 from frappe.utils import cint
 
 @frappe.whitelist()
@@ -153,11 +153,11 @@ def notify_assignment(shared_by, doctype, doc_name, everyone):
 
 	from frappe.utils import get_fullname
 
-	title = get_truncated_title(doctype, doc_name, truncate_length=100)
+	title = get_title(doctype, doc_name)
 
 	reference_user = get_fullname(frappe.session.user)
 	notification_message = _('{0} shared a document {1} {2} with you').format(
-		frappe.bold(reference_user), frappe.bold(doctype), frappe.bold(title))
+		frappe.bold(reference_user), frappe.bold(doctype), get_title_html(title))
 
 	notification_doc = {
 		'type': 'Share',

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -39,7 +39,7 @@ class EnergyPointLog(Document):
 				'document_name': self.reference_name,
 				'subject': get_notification_message(self),
 				'from_user': reference_user,
-				'email_content': '<div>{}</div>'.format(self.reason)
+				'email_content': '<div>{}</div>'.format(self.reason) if self.reason else None
 			}
 
 			enqueue_create_notification(self.user, notification_doc)

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -8,7 +8,7 @@ from frappe import _
 import json
 from frappe.model.document import Document
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
-	get_truncated_title
+	get_title, get_title_html
 from frappe.utils import cint, get_fullname, getdate, get_link_to_form
 
 class EnergyPointLog(Document):
@@ -47,7 +47,7 @@ class EnergyPointLog(Document):
 def get_notification_message(doc):
 	owner_name = get_fullname(doc.owner)
 	points = doc.points
-	title = get_truncated_title(doc.reference_doctype, doc.reference_name, truncate_length=100)
+	title = get_title(doc.reference_doctype, doc.reference_name)
 
 	if doc.type == 'Auto':
 		owner_name = frappe.bold('You')
@@ -55,26 +55,26 @@ def get_notification_message(doc):
 			message = _('{0} gained {1} point for {2} {3}')
 		else:
 			message = _('{0} gained {1} points for {2} {3}')
-		message = message.format(owner_name, frappe.bold(points), doc.rule, frappe.bold(title))
+		message = message.format(owner_name, frappe.bold(points), doc.rule, get_title_html(title))
 	elif doc.type == 'Appreciation':
 		if points == 1:
 			message = _('{0} appreciated your work on {1} with {2} point')
 		else:
 			message = _('{0} appreciated your work on {1} with {2} points')
-		message = message.format(frappe.bold(owner_name), frappe.bold(title), frappe.bold(points))
+		message = message.format(frappe.bold(owner_name), get_title_html(title), frappe.bold(points))
 	elif doc.type == 'Criticism':
 		if points == 1:
 			message = _('{0} criticized your work on {1} with {2} point')
 		else:
 			message = _('{0} criticized your work on {1} with {2} points')
 
-		message = message.format(frappe.bold(owner_name), frappe.bold(title), frappe.bold(points))
+		message = message.format(frappe.bold(owner_name), get_title_html(title), frappe.bold(points))
 	elif doc.type == 'Revert':
 		if points == 1:
 			message = _('{0} reverted your point on {1}')
 		else:
 			message = _('{0} reverted your points on {1}')
-		message = message.format(frappe.bold(owner_name), frappe.bold(title))
+		message = message.format(frappe.bold(owner_name), get_title_html(title))
 
 	return message
 

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -7,7 +7,8 @@ import frappe
 from frappe import _
 import json
 from frappe.model.document import Document
-from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
+from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
+	get_truncated_title
 from frappe.utils import cint, get_fullname, getdate, get_link_to_form
 
 class EnergyPointLog(Document):
@@ -46,9 +47,7 @@ class EnergyPointLog(Document):
 def get_notification_message(doc):
 	owner_name = get_fullname(doc.owner)
 	points = doc.points
-	title_field = frappe.get_meta(doc.reference_doctype).get_title_field()
-	title = doc.reference_name if title_field == "name" else \
-		frappe.db.get_value(doc.reference_doctype, doc.reference_name, title_field)
+	title = get_truncated_title(doc.reference_doctype, doc.reference_name, truncate_length=100)
 
 	if doc.type == 'Auto':
 		owner_name = frappe.bold('You')


### PR DESCRIPTION
Changes:

<img width="473" alt="Screenshot 2019-10-24 at 1 55 32 PM" src="https://user-images.githubusercontent.com/19775888/67467343-3488fa00-f666-11e9-9bb1-7fc409c11f23.png">


- Notification is marked as seen only when visited or explicitly marked as read

- Renamed Upcoming Events to Today's Events

- Truncate document titles

- Disallowed notifications to self
