### PR TITLE
fix(printview): Make before_print hookable

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -84,8 +84,7 @@ def get_rendered_template(doc, name=None, print_format=None, meta=None,
 		if doc.docstatus==2 and not cint(print_settings.allow_print_for_cancelled):
 			frappe.throw(_("Not allowed to print cancelled documents"), frappe.PermissionError)
 
-	if hasattr(doc, "before_print"):
-		doc.before_print()
+	doc.run_method("before_print")
 
 	if not hasattr(doc, "print_heading"): doc.print_heading = None
 	if not hasattr(doc, "sub_heading"): doc.sub_heading = None


### PR DESCRIPTION
Minor change to allow hooks on `before_print`

`doc.run_method("before_print")` instead of `doc.before_print()`