### PR TITLE
Patch(Tags): Check if column exists

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -968,7 +968,7 @@ class Database(object):
 				frappe.flags.touched_tables = set()
 			frappe.flags.touched_tables.update(tables)
 
-	def bulk_insert(self, doctype, fields, values):
+	def bulk_insert(self, doctype, fields, values, ignore_duplicates=False):
 		"""
 			Insert multiple records at a time
 
@@ -982,7 +982,8 @@ class Database(object):
 		for idx, value in enumerate(values):
 			insert_list.append(tuple(value))
 			if idx and (idx%10000 == 0 or idx < len(values)-1):
-				self.sql("""INSERT IGNORE INTO `tab{doctype}` ({fields}) VALUES {values}""".format(
+				self.sql("""INSERT {ignore_duplicates} INTO `tab{doctype}` ({fields}) VALUES {values}""".format(
+						ignore_duplicates="IGNORE" if ignore_duplicates else "",
 						doctype=doctype,
 						fields=fields,
 						values=", ".join(['%s'] * len(insert_list))

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -982,7 +982,7 @@ class Database(object):
 		for idx, value in enumerate(values):
 			insert_list.append(tuple(value))
 			if idx and (idx%10000 == 0 or idx < len(values)-1):
-				self.sql("""INSERT INTO `tab{doctype}` ({fields}) VALUES {values}""".format(
+				self.sql("""INSERT IGNORE INTO `tab{doctype}` ({fields}) VALUES {values}""".format(
 						doctype=doctype,
 						fields=fields,
 						values=", ".join(['%s'] * len(insert_list))

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -254,3 +254,4 @@ frappe.patches.v12_0.delete_duplicate_indexes
 frappe.patches.v12_0.set_default_incoming_email_port
 frappe.patches.v12_0.update_global_search
 execute:frappe.reload_doc('desk', 'doctype', 'notification_settings')
+frappe.patches.v12_0.setup_tags

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -15,11 +15,13 @@ def execute():
 			continue
 
 		for _user_tags in frappe.db.sql("select `name`, `_user_tags` from `tab{0}`".format(doctype.name), as_dict=True):
-			if not dt_tags.get("_user_tags"):
+			if not _user_tags.get("_user_tags"):
 				continue
 
-			tags = dt_tags.get("_user_tags").split(",") if dt_tags.get("_user_tags") else None
-			for tag in tags:
+			for tag in _user_tags.get("_user_tags").split(",") if _user_tags.get("_user_tags") else []:
+				if not tag:
+					continue
+
 				tag_name = frappe.db.escape(tag.strip())
 				tag_link_name = frappe.generate_hash(_user_tags.name + tag.strip() + doctype.name, 10)
 

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -8,6 +8,7 @@ def execute():
 	frappe.reload_doc("desk", "doctype", "tag_link")
 
 	time = frappe.utils.get_datetime()
+	frappe.db.auto_commit_on_many_writes = True
 
 	for doctype in frappe.get_list("DocType", filters={"istable": 0, "issingle": 0}):
 		if not (frappe.db.count(doctype.name) or frappe.db.has_column(doctype.name, "_user_tags")):
@@ -24,6 +25,9 @@ def execute():
 
 				insert_tag(tag_name, time, time, "Administrator")
 				insert_tag_link(tag_link_name, doctype.name, _user_tags.name, tag_name, time, time, "Administrator")
+
+	if frappe.db.auto_commit_on_many_writes:
+		frappe.db.auto_commit_on_many_writes = False
 
 def insert_tag(name, creation, modified, modified_by):
 	doc = frappe.new_doc("Tag")

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -7,8 +7,9 @@ def execute():
 	frappe.reload_doc("desk", "doctype", "tag")
 	frappe.reload_doc("desk", "doctype", "tag_link")
 
+	tag_list = []
+	tag_links = []
 	time = frappe.utils.get_datetime()
-	frappe.db.auto_commit_on_many_writes = True
 
 	for doctype in frappe.get_list("DocType", filters={"istable": 0, "issingle": 0}):
 		if not frappe.db.count(doctype.name) or not frappe.db.has_column(doctype.name, "_user_tags"):
@@ -22,37 +23,11 @@ def execute():
 				if not tag:
 					continue
 
-				tag_name = frappe.db.escape(tag.strip())
+				tag_list.append((tag.strip(), time, time, 'Administrator'))
+
 				tag_link_name = frappe.generate_hash(_user_tags.name + tag.strip() + doctype.name, 10)
+				tag_links.append((tag_link_name, doctype.name, _user_tags.name, tag.strip(), time, time, 'Administrator'))
 
-				insert_tag(tag_name, time, time, "Administrator")
-				insert_tag_link(tag_link_name, doctype.name, _user_tags.name, tag_name, time, time, "Administrator")
 
-	frappe.db.auto_commit_on_many_writes = False
-
-def insert_tag(name, creation, modified, modified_by):
-	if frappe.db.exists("Tag", name):
-		return
-
-	doc = frappe.new_doc("Tag")
-	doc.name = name
-	doc.creation = creation
-	doc.modified = modified
-	doc.modified_by = modified_by
-	doc.db_insert()
-
-def insert_tag_link(name, document_type, document_name, tag, creation, modified, modified_by):
-	if frappe.db.exists("Tag", {"document_type": document_type, "document_name": document_name, "tag": tag}):
-		return
-
-	doc = frappe.new_doc("Tag Link")
-	doc.name = name
-	doc.document_type = document_type
-	doc.document_name = document_name
-	doc.tag = tag
-	doc.parenttype = document_type
-	doc.parent = document_name
-	doc.creation = creation
-	doc.modified = modified
-	doc.modified_by = modified_by
-	doc.db_insert()
+	frappe.db.bulk_insert("Tag", fields=["name", "creation", "modified", "modified_by"], values=set(tag_list))
+	frappe.db.bulk_insert("Tag Link", fields=["name", "document_type", "document_name", "tag", "creation", "modified", "modified_by"], values=set(tag_links))

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -32,6 +32,9 @@ def execute():
 		frappe.db.auto_commit_on_many_writes = False
 
 def insert_tag(name, creation, modified, modified_by):
+	if frappe.db.exists("Tag", name):
+		return
+
 	doc = frappe.new_doc("Tag")
 	doc.name = name
 	doc.creation = creation
@@ -40,6 +43,9 @@ def insert_tag(name, creation, modified, modified_by):
 	doc.db_insert()
 
 def insert_tag_link(name, document_type, document_name, tag, creation, modified, modified_by):
+	if frappe.db.exists("Tag", {"document_type": document_type, "document_name": document_name, "tag": tag}):
+		return
+
 	doc = frappe.new_doc("Tag Link")
 	doc.name = name
 	doc.document_type = document_type

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -11,7 +11,7 @@ def execute():
 	frappe.db.auto_commit_on_many_writes = True
 
 	for doctype in frappe.get_list("DocType", filters={"istable": 0, "issingle": 0}):
-		if not (frappe.db.count(doctype.name) or frappe.db.has_column(doctype.name, "_user_tags")):
+		if not frappe.db.count(doctype.name) or not frappe.db.has_column(doctype.name, "_user_tags"):
 			continue
 
 		for _user_tags in frappe.db.sql("select `name`, `_user_tags` from `tab{0}`".format(doctype.name), as_dict=True):

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -28,8 +28,7 @@ def execute():
 				insert_tag(tag_name, time, time, "Administrator")
 				insert_tag_link(tag_link_name, doctype.name, _user_tags.name, tag_name, time, time, "Administrator")
 
-	if frappe.db.auto_commit_on_many_writes:
-		frappe.db.auto_commit_on_many_writes = False
+	frappe.db.auto_commit_on_many_writes = False
 
 def insert_tag(name, creation, modified, modified_by):
 	if frappe.db.exists("Tag", name):

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -29,5 +29,5 @@ def execute():
 				tag_links.append((tag_link_name, doctype.name, _user_tags.name, tag.strip(), time, time, 'Administrator'))
 
 
-	frappe.db.bulk_insert("Tag", fields=["name", "creation", "modified", "modified_by"], values=set(tag_list))
-	frappe.db.bulk_insert("Tag Link", fields=["name", "document_type", "document_name", "tag", "creation", "modified", "modified_by"], values=set(tag_links))
+	frappe.db.bulk_insert("Tag", fields=["name", "creation", "modified", "modified_by"], values=set(tag_list), ignore_duplicates=True)
+	frappe.db.bulk_insert("Tag Link", fields=["name", "document_type", "document_name", "tag", "creation", "modified", "modified_by"], values=set(tag_links), ignore_duplicates=True)


### PR DESCRIPTION
- Initial patch did not check if `_user_tags` column existed in the table and used to break if there isn't one, so the patch was excluded.