### PR TITLE
fix(Desk): show/hide cards not working after changing order of cards

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -364,6 +364,10 @@ def update_hidden_modules(category_map):
 		saved_hidden_modules += config.removed or []
 		saved_hidden_modules = [d for d in saved_hidden_modules if d not in (config.added or [])]
 
+		if home_settings.get('modules_by_category') and home_settings.modules_by_category.get(category):
+			module_placement = [d for d in (config.added or []) if d not in home_settings.modules_by_category[category]]
+			home_settings.modules_by_category[category] += module_placement
+
 	home_settings.hidden_modules = saved_hidden_modules
 	set_home_settings(home_settings)
 


### PR DESCRIPTION
**Problem**:
- Hide a module
- Change the order of modules
- Unhide that module
 Does not work
![Module_show_hide](https://user-images.githubusercontent.com/24353136/67742282-9fa94680-fa41-11e9-9f01-e2f9157fe972.gif)

**After fix:**
![Module_show_hide_fixed](https://user-images.githubusercontent.com/24353136/67742283-a20ba080-fa41-11e9-8ebd-e16ef2b85fb5.gif)
