### PR TITLE
refactor: add data and int to group by

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -227,12 +227,12 @@ frappe.ui.GroupBy = class {
 
 	get_group_by_fields() {
 		let group_by_fields = {};
-		let fields = this.report_view.meta.fields.filter(f => ["Select", "Link"].includes(f.fieldtype));
+		let fields = this.report_view.meta.fields.filter(f => ["Select", "Link", "Data", "Int"].includes(f.fieldtype));
 		group_by_fields[this.doctype] = fields;
 
 		const standard_fields_filter = df =>
 			!in_list(frappe.model.no_value_type, df.fieldtype) && !df.report_hide;
-		
+
 		const table_fields = frappe.meta.get_table_fields(this.doctype)
 			.filter(df => !df.hidden);
 


### PR DESCRIPTION
This PR enables `Data` and `Int` fieldtype in **Group By** filters