### PR TITLE
fix: build filter metadata before allowing user to send email (develop)

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -78,6 +78,9 @@ frappe.ui.form.on('Auto Email Report', {
 
 			if(report_filters && report_filters.length > 0) {
 				frm.set_value('filter_meta', JSON.stringify(report_filters));
+				if (frm.is_dirty()) {
+					frm.save();
+				}
 			}
 
 			var report_filters_list = []


### PR DESCRIPTION
**Problem:**

Although there is a check for unset filters in Auto Email Report, the database is not updated with the required filter data for the check (it saves the document first to get report metadata, and then builds the filter data).

We now do a check for unsaved changes and update the database.

**Traceback:**

```diff
Traceback (most recent call last):
  File "/home/rohan/erpn/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 171, in send_now
    auto_email_report.send()
  File "/home/rohan/erpn/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 126, in send
    data = self.get_report_content()
  File "/home/rohan/erpn/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 66, in get_report_content
    filters = self.filters, as_dict=True)
  File "/home/rohan/erpn/apps/frappe/frappe/core/doctype/report/report.py", line 101, in get_data
    data = frappe.desk.query_report.run(self.name, filters=filters, user=user)
  File "/home/rohan/erpn/apps/frappe/frappe/__init__.py", line 511, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/rohan/erpn/apps/frappe/frappe/desk/query_report.py", line 201, in run
    result = generate_report_result(report, filters, user)
  File "/home/rohan/erpn/apps/frappe/frappe/desk/query_report.py", line 76, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/rohan/erpn/apps/erpnext/erpnext/selling/report/sales_analytics/sales_analytics.py", line 12, in execute
    return Analytics(filters).run()
  File "/home/rohan/erpn/apps/erpnext/erpnext/selling/report/sales_analytics/sales_analytics.py", line 23, in run
    self.get_columns()
  File "/home/rohan/erpn/apps/erpnext/erpnext/selling/report/sales_analytics/sales_analytics.py", line 30, in get_columns
    "label": _(self.filters.tree_type + " ID"),
TypeError: unsupported operand type(s) for +: 'NoneType' and 'unicode'
```

<hr>

**Screenshots / GIFs:**

**Before:**

![auto-email-before](https://user-images.githubusercontent.com/13396535/67747747-6b3c8700-fa4f-11e9-89d5-aae0ead0932e.gif)

**After:**

![auto-email-fix](https://user-images.githubusercontent.com/13396535/67747151-2cf29800-fa4e-11e9-8f54-daf03e11db5d.gif)