### PR TITLE
refactor: allow hiding of columns in query report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -457,7 +457,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.datatable.refresh(data, this.columns);
 		} else {
 			let datatable_options = {
-				columns: this.columns,
+				columns: this.columns.filter((col) => !col.hidden),
 				data: data,
 				inlineFilters: true,
 				treeView: this.tree_report,


### PR DESCRIPTION
Setting `hidden: 1` at the python configuration of a query_report column will hide the column in the datatable