### PR TITLE
fix(Select): specify top for dropdown arrow

### DIFF
--- a/frappe/public/less/controls.less
+++ b/frappe/public/less/controls.less
@@ -152,7 +152,7 @@
 
 	.octicon-chevron-down {
 		position: absolute;
-		top: 10px;
+		top: 8px;
 		height: 15px;
 		right: 12px;
 	}

--- a/frappe/public/less/controls.less
+++ b/frappe/public/less/controls.less
@@ -152,6 +152,7 @@
 
 	.octicon-chevron-down {
 		position: absolute;
+		top: 10px;
 		height: 15px;
 		right: 12px;
 	}


### PR DESCRIPTION
- Before
![image](https://user-images.githubusercontent.com/7310479/67760826-06d9f180-fa68-11e9-9af9-cd1440238974.png)

- Dropdown arrow was broken on Dialog
![Screenshot 2019-10-29 at 4 20 08 PM](https://user-images.githubusercontent.com/7310479/67760799-fb86c600-fa67-11e9-973a-9b34399cf104.png)
