### PR TITLE
fix: decode non-ascii characters for formataddr

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -10,6 +10,7 @@ from .html_utils import sanitize_html
 import frappe
 from frappe.utils.identicon import Identicon
 from email.utils import parseaddr, formataddr
+from email.header import decode_header, make_header
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *
 from six.moves.urllib.parse import quote
@@ -65,7 +66,7 @@ def get_formatted_email(user):
 	"""get Email Address of user formatted as: `John Doe <johndoe@example.com>`"""
 	fullname = get_fullname(user)
 	mail = get_email_address(user)
-	return formataddr((fullname, mail))
+	return cstr(make_header(decode_header(formataddr((fullname, mail)))))
 
 def extract_email_id(email):
 	"""fetch only the email part of the Email Address"""


### PR DESCRIPTION
formataddr[1] by default encodes non-ascii characters to `=?utf-8?q`, which needs to be decoded to a human-readable string format. using decode_header and make_header we can decode the string back to human-readable format.

before:

```python-console
In [1]: formataddr(("Tèst", "notifications@erpnext.com"))
Out[1]: '=?utf-8?b?VMOoc3Q=?= <notifications@erpnext.com>'
```

after:

```python-console
In [2]: make_header(decode_header(formataddr(("Tèst", "notifications@erpnext.com"))))
Out[2]: 'Tèst <notifications@erpnext.com>'
```

references:
[1]: https://docs.python.org/3/library/email.utils.html#email.utils.formataddr
