### PR TITLE
fix: ascii check for route

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -307,6 +307,8 @@ def extract_comment_tag(source, tag):
 	else:
 		return None
 
+def remove_non_ascii(text):
+	return "".join(filter(lambda x: ord(x)<128, text))
 
 def add_missing_headers():
 	'''Walk and add missing headers in docs (to be called from bench execute)'''

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
-from frappe.website.utils import cleanup_page_name
+from frappe.website.utils import cleanup_page_name, remove_non_ascii
 from frappe.website.render import clear_cache
 from frappe.modules import get_module_name
 
@@ -50,7 +50,7 @@ class WebsiteGenerator(Document):
 		route/title'''
 		from_title = self.scrubbed_title()
 		if self.meta.route:
-			return self.meta.route + '/' + from_title
+			return self.meta.route + '/' + remove_non_ascii(from_title)
 		else:
 			return from_title
 


### PR DESCRIPTION
Non ASCII characters like emDash or any character that is not a part of ASCII character set when added to title would make a route that breaks gunicorn, causing an Internal Server Error.

This PR fixes this