### PR TITLE
fix: add support for utf-8 characters in pdf filename during downloads

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -90,7 +90,8 @@ def as_json():
 def as_pdf():
 	response = Response()
 	response.mimetype = "application/pdf"
-	response.headers["Content-Disposition"] = ("filename=\"%s\"" % frappe.response['filename'].replace(' ', '_')).encode("utf-8")
+	encoded_filename = quote(frappe.response['filename'].replace(' ', '_'), encoding='utf-8')
+	response.headers["Content-Disposition"] = ("filename=\"%s\"" % frappe.response['filename'].replace(' ', '_') + ";filename*=utf-8''%s" % encoded_filename).encode("utf-8")
 	response.data = frappe.response['filecontent']
 	return response
 


### PR DESCRIPTION
After updating to Python 3 I noticed I can no longer save pdf filenames correctly. They get replaced by unreadable characters. This commit will add support for the `content-disposition` header attribute `filename*` which can allow for a utf8 filename

Closes #8714 
<!--Previously issue at https://github.com/frappe/erpnext/issues/19440 -->
