### PR TITLE
fix: smtp rfc compliance and line endings for exchange 2016/RFC email servers.

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -405,7 +405,7 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 
 			message = prepare_message(email, recipient.recipient, recipients_list)
 			if not frappe.flags.in_test:
-				smtpserver.sess.sendmail(email.sender, recipient.recipient, encode(message))
+				smtpserver.sess.sendmail(email.sender, recipient.recipient, str(message))
 
 			recipient.status = "Sent"
 			frappe.db.sql("""update `tabEmail Queue Recipient` set status='Sent', modified=%s where name=%s""",

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -404,8 +404,10 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False, from_test=Fals
 				continue
 
 			message = prepare_message(email, recipient.recipient, recipients_list)
+			message = message.replace('\n', '\r\n')
 			if not frappe.flags.in_test:
-				smtpserver.sess.sendmail(email.sender, recipient.recipient, str(message))
+
+				smtpserver.sess.sendmail(email.sender, recipient.recipient, encode(message))
 
 			recipient.status = "Sent"
 			frappe.db.sql("""update `tabEmail Queue Recipient` set status='Sent', modified=%s where name=%s""",

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -516,28 +516,27 @@ def prepare_message(email, recipient, recipients_list):
 		return message
 
 	# On-demand attachments
-    from email.parser import Parser
-    from email.policy import EmailPolicy, SMTP as SMTP_policy
+	from email.parser import Parser
+	from email.policy import EmailPolicy, SMTP as SMTP_policy
 
-    MSG_ID_HEADERS = {'message-id', 'in-reply-to', 'references', 'resent-msg-id'}
+	MSG_ID_HEADERS = {'message-id', 'in-reply-to', 'references', 'resent-msg-id'}
 
 
-    class MsgIdExemptPolicy(EmailPolicy):
-        def _fold(self, name, value, *args, **kwargs):
-            if (name.lower() in MSG_ID_HEADERS and
-                    self.max_line_length < 998 and
-                    self.max_line_length - len(name) - 2 < len(value)):
-                # RFC 5322, section 2.1.1: "Each line of characters MUST be no
+	class MsgIdExemptPolicy(EmailPolicy):
+		def _fold(self, name, value, *args, **kwargs):
+			if (name.lower() in MSG_ID_HEADERS and
+                self.max_line_length < 998 and
+                self.max_line_length - len(name) - 2 < len(value)):
+				# RFC 5322, section 2.1.1: "Each line of characters MUST be no
                 # more than 998 characters, and SHOULD be no more than 78
                 # characters, excluding the CRLF.". To avoid msg-id tokens from being folded
                 # by means of RFC2047, fold identifier lines to the max length instead.
-                return self.clone(max_line_length=998)._fold(name, value, *args, **kwargs)
-            return super()._fold(name, value, *args, **kwargs)
+				return self.clone(max_line_length=998)._fold(name, value, *args, **kwargs)
+			return super()._fold(name, value, *args, **kwargs)
 
+	our_policy = MsgIdExemptPolicy() + SMTP_policy
 
-    our_policy = MsgIdExemptPolicy() + SMTP_policy
-
-    msg_obj = Parser(policy=our_policy).parsestr(message)
+	msg_obj = Parser(policy=our_policy).parsestr(message)
 	attachments = json.loads(email.attachments)
 
 	for attachment in attachments:

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -12,7 +12,7 @@ from frappe.email.smtp import SMTPServer, get_outgoing_email_account
 from frappe.email.email_body import get_email, get_formatted_html, add_attachment
 from frappe.utils.verified_command import get_signed_params, verify_request
 from html2text import html2text
-from frappe.utils import get_url, nowdate, encode, now_datetime, add_days, split_emails, cstr, cint
+from frappe.utils import get_url, nowdate, now_datetime, add_days, split_emails, cstr, cint
 from rq.timeouts import JobTimeoutException
 from frappe.utils.scheduler import log
 from six import text_type, string_types

--- a/frappe/email/rfc5322policy.py
+++ b/frappe/email/rfc5322policy.py
@@ -6,7 +6,7 @@ class RFC5322Policy(EmailPolicy):
 		self._msg_id_headers = {'message-id', 'in-reply-to', 'references', 'resent-msg-id'}
 		super().__init__(**kwargs)
 
-	def _fold(self, name, value, refold_binary):
+	def _fold(self, name, value, refold_binary=False):
 		if name.lower() in self._msg_id_headers and \
 				self.max_line_length < 998 and \
 				self.max_line_length - len(name) - 2 < len(value):

--- a/frappe/email/rfc5322policy.py
+++ b/frappe/email/rfc5322policy.py
@@ -4,13 +4,15 @@ from email.policy import EmailPolicy
 class RFC5322Policy(EmailPolicy):
 	def __init__(self, **kwargs):
 		self._msg_id_headers = {'message-id', 'in-reply-to', 'references', 'resent-msg-id'}
-		return super().__init__(**kwargs)
+		super().__init__(**kwargs)
 
-	def _fold(self, name, value, *args, **kwargs):
-		if name.lower() in self._msg_id_headers and self.max_line_length < 998 and self.max_line_length - len(name) - 2 < len(value):
+	def _fold(self, name, value, refold_binary):
+		if name.lower() in self._msg_id_headers and \
+				self.max_line_length < 998 and \
+				self.max_line_length - len(name) - 2 < len(value):
 			# RFC 5322, section 2.1.1: "Each line of characters MUST be no
 			# more than 998 characters, and SHOULD be no more than 78
 			# characters, excluding the CRLF.". To avoid msg-id tokens from being folded
 			# by means of RFC2047, fold identifier lines to the max length instead.
-			return self.clone(max_line_length=998)._fold(name, value, *args, **kwargs)
-		return super()._fold(name, value, *args, **kwargs)
+			return self.clone(max_line_length=998)._fold(name, value, refold_binary=refold_binary)
+		return super()._fold(name, value, refold_binary=refold_binary)

--- a/frappe/email/rfc5322policy.py
+++ b/frappe/email/rfc5322policy.py
@@ -1,0 +1,16 @@
+from email.policy import EmailPolicy
+
+
+class RFC5322Policy(EmailPolicy):
+	def __init__(self, **kwargs):
+		self._msg_id_headers = {'message-id', 'in-reply-to', 'references', 'resent-msg-id'}
+		return super().__init__(**kwargs)
+
+	def _fold(self, name, value, *args, **kwargs):
+		if name.lower() in self._msg_id_headers and self.max_line_length < 998 and self.max_line_length - len(name) - 2 < len(value):
+			# RFC 5322, section 2.1.1: "Each line of characters MUST be no
+			# more than 998 characters, and SHOULD be no more than 78
+			# characters, excluding the CRLF.". To avoid msg-id tokens from being folded
+			# by means of RFC2047, fold identifier lines to the max length instead.
+			return self.clone(max_line_length=998)._fold(name, value, *args, **kwargs)
+		return super()._fold(name, value, *args, **kwargs)


### PR DESCRIPTION
As raised in thread https://discuss.erpnext.com/t/equal-sign-in-emails/52597/23
https://discuss.erpnext.com/t/erpnext-python-3/33492/56
Fixes a number of issues with non RFC5322 compliant issues, which are related to smtplib bug as well.

Ensures that end of line chars are \r\n as needed by RFC5322.
Ensures that headers in the email message are wrapped at 998 chars, instead of the default 76
Removes double encoding of message

https://bugs.python.org/issue35805

This was needed since exchange 2016 will reject the message since it is not complying to standards.
Tested on exchange 2016 and dovecot/sendmail.

Please note that this is python3 ONLY compatible. - Is 2.7 support dropped for v12?


