### PR TITLE
fix: convert number to string if title_field is Int

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -30,7 +30,7 @@ frappe.ui.form.Toolbar = Class.extend({
 	},
 	set_title: function() {
 		if(this.frm.meta.title_field) {
-			let title_field = (this.frm.doc[this.frm.meta.title_field].toString() || "").trim();
+			let title_field = (this.frm.doc[this.frm.meta.title_field] || "").toString().trim();
 			var title = strip_html(title_field || this.frm.docname);
 			if(this.frm.doc.__islocal || title === this.frm.docname || this.frm.meta.autoname==="hash") {
 				this.page.set_title_sub("");

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -30,7 +30,8 @@ frappe.ui.form.Toolbar = Class.extend({
 	},
 	set_title: function() {
 		if(this.frm.meta.title_field) {
-			var title = strip_html((this.frm.doc[this.frm.meta.title_field] || "").trim() || this.frm.docname);
+			let title_field = (this.frm.doc[this.frm.meta.title_field].toString() || "").trim();
+			var title = strip_html(title_field || this.frm.docname);
 			if(this.frm.doc.__islocal || title === this.frm.docname || this.frm.meta.autoname==="hash") {
 				this.page.set_title_sub("");
 			} else {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -719,7 +719,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		let user = frappe.session.user;
 		let subject_field = this.columns[0].df;
 		let value = doc[subject_field.fieldname] || doc.name;
-		let subject = strip_html(value);
+		let subject = strip_html(value.toString());
 		let escaped_subject = frappe.utils.escape_html(subject);
 
 		const liked_by = JSON.parse(doc._liked_by || '[]');


### PR DESCRIPTION
- Form and ListView rendering breaks if the field set for `title_field` is of type `Int`
- DocType
![Screenshot 2019-10-30 at 10 57 09 AM](https://user-images.githubusercontent.com/7310479/67831390-2f172e00-fb04-11e9-9b2f-7c0f4a21f74b.png)

- ListView
![Screenshot 2019-10-30 at 10 57 28 AM](https://user-images.githubusercontent.com/7310479/67831368-1eff4e80-fb04-11e9-8dbe-2d9a6af24de1.png)

- FormView
![Screenshot 2019-10-30 at 10 58 02 AM](https://user-images.githubusercontent.com/7310479/67831399-35a5a580-fb04-11e9-971a-047e2afeda50.png)

