### PR TITLE
fix: Reroute to doctype if custom doctype

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -244,7 +244,7 @@ frappe.ui.form.Toolbar = Class.extend({
 
 				if (me.frm.meta.custom) {
 					frappe.set_route('Form', 'DocType', me.frm.doctype);
-				} else if (!me.frm.meta.custom) {
+				} else {
 					frappe.set_route('Form', 'Customize Form', {
 						doc_type: me.frm.doctype
 					});

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -240,9 +240,8 @@ frappe.ui.form.Toolbar = Class.extend({
 
 		if(frappe.user_roles.includes("System Manager") && me.frm.meta.issingle === 0) {
 			this.page.add_menu_item(__("Customize"), function() {
-				if (!me.frm.meta) return;
 
-				if (me.frm.meta.custom) {
+				if (me.frm.meta && me.frm.meta.custom) {
 					frappe.set_route('Form', 'DocType', me.frm.doctype);
 				} else {
 					frappe.set_route('Form', 'Customize Form', {

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -240,9 +240,15 @@ frappe.ui.form.Toolbar = Class.extend({
 
 		if(frappe.user_roles.includes("System Manager") && me.frm.meta.issingle === 0) {
 			this.page.add_menu_item(__("Customize"), function() {
-				frappe.set_route("Form", "Customize Form", {
-					doc_type: me.frm.doctype
-				})
+				if (!me.frm.meta) return;
+
+				if (me.frm.meta.custom) {
+					frappe.set_route('Form', 'DocType', me.frm.doctype);
+				} else if (!me.frm.meta.custom) {
+					frappe.set_route('Form', 'Customize Form', {
+						doc_type: me.frm.doctype
+					});
+				}
 			}, true);
 
 			if (frappe.boot.developer_mode===1) {


### PR DESCRIPTION
- In FormView, if you click on Customise from Menu, it'll redirect you to `Customize Form` even if that doctype is a Custom DocType.