### PR TITLE
feat: Utilities for Cordova Chat App

### DIFF
--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -59,7 +59,6 @@ def get_chat_assets(build_version):
 
 	include_js = [
 		'assets/js/moment-bundle.min.js',
-		'assets/js/libs.min.js',
 		'assets/js/chat-bundle.js',
 	]
 	include_css = [

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -4,39 +4,91 @@ from   frappe.chat.util import filter_dict, safe_json_loads
 
 from   frappe.sessions  import get_geo_ip_country
 
+import os
+import re
+from frappe.www.desk import get_build_version
+
 @frappe.whitelist(allow_guest = True)
 def settings(fields = None):
-    fields    = safe_json_loads(fields)
+	fields	= safe_json_loads(fields)
 
-    dsettings = frappe.get_single('Website Settings')
-    response  = dict(
-        socketio         = dict(
-            port         = frappe.conf.socketio_port
-        ),
-        enable           = bool(dsettings.chat_enable),
-        enable_from      = dsettings.chat_enable_from,
-        enable_to        = dsettings.chat_enable_to,
-        room_name        = dsettings.chat_room_name,
-        welcome_message  = dsettings.chat_welcome_message,
-        operators        = [
-            duser.user for duser in dsettings.chat_operators
-        ]
-    )
+	dsettings = frappe.get_single('Website Settings')
+	response  = dict(
+		socketio		 = dict(
+			port		 = frappe.conf.socketio_port
+		),
+		enable		   = bool(dsettings.chat_enable),
+		enable_from	  = dsettings.chat_enable_from,
+		enable_to		= dsettings.chat_enable_to,
+		room_name		= dsettings.chat_room_name,
+		welcome_message  = dsettings.chat_welcome_message,
+		operators		= [
+			duser.user for duser in dsettings.chat_operators
+		]
+	)
 
-    if fields:
-        response = filter_dict(response, fields)
+	if fields:
+		response = filter_dict(response, fields)
 
-    return response
+	return response
 
 @frappe.whitelist(allow_guest = True)
 def token():
-    dtoken             = frappe.new_doc('Chat Token')
+	dtoken			 = frappe.new_doc('Chat Token')
 
-    dtoken.token       = frappe.generate_hash()
-    dtoken.ip_address  = frappe.local.request_ip
-    country            = get_geo_ip_country(dtoken.ip_address)
-    if country:
-        dtoken.country = country['iso_code']
-    dtoken.save(ignore_permissions = True)
+	dtoken.token	   = frappe.generate_hash()
+	dtoken.ip_address  = frappe.local.request_ip
+	country			= get_geo_ip_country(dtoken.ip_address)
+	if country:
+		dtoken.country = country['iso_code']
+	dtoken.save(ignore_permissions = True)
 
-    return dtoken.token
+	return dtoken.token
+
+
+@frappe.whitelist(allow_guest=True)
+def get_chat_assets(build_version):
+	try:
+		boot = frappe.sessions.get()
+	except Exception as e:
+		boot = frappe._dict(status='failed', error = str(e))
+		print(frappe.get_traceback())
+
+	csrf_token = frappe.sessions.get_csrf_token()
+	frappe.db.commit()
+
+	boot_json = frappe.as_json(boot)
+	boot_json = re.sub("\<script\>[^<]*\</script\>", "", boot_json)
+
+	include_js = ['assets/js/frappe-web.min.js', 'assets/js/chat.js']
+	include_css = []
+	local_build_version = get_build_version()
+
+	"""Get chat assets to be loaded for mobile app"""
+	assets = [{"type": "js", "data": ""}, {"type": "css", "data": ""}]
+
+	if build_version != local_build_version:
+		# new build, send assets
+		for path in include_js:
+			if path.startswith('/assets/'):
+				path = path.replace('/assets/', 'assets/')
+			try:
+				with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
+					assets[0]["data"] = assets[0]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
+			except IOError:
+				pass
+
+		for path in include_css:
+			if path.startswith('/assets/'):
+				path = path.replace('/assets/', 'assets/')
+			try:
+				with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
+					assets[1]["data"] = assets[1]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
+			except IOError:
+				pass
+
+	return {
+		"build_version": local_build_version,
+		"boot": boot_json,
+		"assets": assets
+	}

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -59,6 +59,7 @@ def get_chat_assets(build_version):
 
 	include_js = [
 		'assets/js/moment-bundle.min.js',
+		'assets/js/libs.min.js',
 		'assets/js/chat-bundle.js',
 	]
 	include_css = [

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -57,17 +57,13 @@ def get_chat_assets(build_version):
 	csrf_token = frappe.sessions.get_csrf_token()
 	frappe.db.commit()
 
-	boot_json = frappe.as_json(boot)
-	boot_json = re.sub("\<script\>[^<]*\</script\>", "", boot_json)
-
 	include_js = [
-		'assets/js/frappe-web.min.js',
-		'assets/js/bootstrap-4-web.min.js',
-		'assets/js/dialog.min.js',
-		'assets/js/control.min.js'
-		'assets/js/chat.js',
+		'assets/js/moment-bundle.min.js',
+		'assets/js/chat-bundle.js',
 	]
-	include_css = []
+	include_css = [
+		'assets/css/desk.min.css'
+	]
 	local_build_version = get_build_version()
 
 	"""Get chat assets to be loaded for mobile app"""
@@ -95,6 +91,6 @@ def get_chat_assets(build_version):
 
 	return {
 		"build_version": local_build_version,
-		"boot": boot_json,
+		"boot": boot,
 		"assets": assets
 	}

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -60,7 +60,13 @@ def get_chat_assets(build_version):
 	boot_json = frappe.as_json(boot)
 	boot_json = re.sub("\<script\>[^<]*\</script\>", "", boot_json)
 
-	include_js = ['assets/js/frappe-web.min.js', 'assets/js/chat.js']
+	include_js = [
+		'assets/js/frappe-web.min.js',
+		'assets/js/bootstrap-4-web.min.js',
+		'assets/js/dialog.min.js',
+		'assets/js/control.min.js'
+		'assets/js/chat.js',
+	]
 	include_css = []
 	local_build_version = get_build_version()
 

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -5,7 +5,6 @@ from   frappe.chat.util import filter_dict, safe_json_loads
 from   frappe.sessions  import get_geo_ip_country
 
 import os
-import re
 from frappe.www.desk import get_build_version
 
 @frappe.whitelist(allow_guest = True)

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -53,9 +53,6 @@ def get_chat_assets(build_version):
 		boot = frappe._dict(status='failed', error = str(e))
 		print(frappe.get_traceback())
 
-	csrf_token = frappe.sessions.get_csrf_token()
-	frappe.db.commit()
-
 	include_js = [
 		'assets/js/moment-bundle.min.js',
 		'assets/js/chat-bundle.js',

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -62,7 +62,7 @@ def get_chat_assets(build_version):
 	]
 	local_build_version = get_build_version()
 
-	"""Get chat assets to be loaded for mobile app"""
+	# Get chat assets to be loaded for mobile app
 	assets = [{"type": "js", "data": ""}, {"type": "css", "data": ""}]
 
 	if build_version != local_build_version:

--- a/frappe/chat/website/__init__.py
+++ b/frappe/chat/website/__init__.py
@@ -1,46 +1,45 @@
 from __future__ import unicode_literals
 import frappe
-from   frappe.chat.util import filter_dict, safe_json_loads
-
-from   frappe.sessions  import get_geo_ip_country
+from frappe.chat.util import filter_dict, safe_json_loads
+from frappe.sessions import get_geo_ip_country
 
 import os
-from frappe.www.desk import get_build_version
+from frappe.www.desk import get_build_version, get_assets_data
 
-@frappe.whitelist(allow_guest = True)
-def settings(fields = None):
-	fields	= safe_json_loads(fields)
+
+@frappe.whitelist(allow_guest=True)
+def settings(fields=None):
+	fields = safe_json_loads(fields)
 
 	dsettings = frappe.get_single('Website Settings')
-	response  = dict(
-		socketio		 = dict(
-			port		 = frappe.conf.socketio_port
-		),
-		enable		   = bool(dsettings.chat_enable),
-		enable_from	  = dsettings.chat_enable_from,
-		enable_to		= dsettings.chat_enable_to,
-		room_name		= dsettings.chat_room_name,
-		welcome_message  = dsettings.chat_welcome_message,
-		operators		= [
-			duser.user for duser in dsettings.chat_operators
-		]
-	)
+	response = {
+		"socketio": {
+			"port": frappe.conf.socketio_port
+		},
+		"enable": bool(dsettings.chat_enable),
+		"enable_from": dsettings.chat_enable_from,
+		"enable_to": dsettings.chat_enable_to,
+		"room_name": dsettings.chat_room_name,
+		"welcome_message": dsettings.chat_welcome_message,
+		"operators": [duser.user for duser in dsettings.chat_operators]
+	}
 
 	if fields:
 		response = filter_dict(response, fields)
 
 	return response
 
-@frappe.whitelist(allow_guest = True)
-def token():
-	dtoken			 = frappe.new_doc('Chat Token')
 
-	dtoken.token	   = frappe.generate_hash()
-	dtoken.ip_address  = frappe.local.request_ip
-	country			= get_geo_ip_country(dtoken.ip_address)
+@frappe.whitelist(allow_guest=True)
+def token():
+	dtoken = frappe.new_doc('Chat Token')
+
+	dtoken.token = frappe.generate_hash()
+	dtoken.ip_address = frappe.local.request_ip
+	country = get_geo_ip_country(dtoken.ip_address)
 	if country:
 		dtoken.country = country['iso_code']
-	dtoken.save(ignore_permissions = True)
+	dtoken.save(ignore_permissions=True)
 
 	return dtoken.token
 
@@ -53,37 +52,21 @@ def get_chat_assets(build_version):
 		boot = frappe._dict(status='failed', error = str(e))
 		print(frappe.get_traceback())
 
-	include_js = [
-		'assets/js/moment-bundle.min.js',
-		'assets/js/chat-bundle.js',
-	]
-	include_css = [
-		'assets/css/desk.min.css'
-	]
-	local_build_version = get_build_version()
+	data = {
+		'include_js': [
+			'assets/js/moment-bundle.min.js',
+			'assets/js/chat-bundle.js',
+		],
+		'include_css': [
+			'assets/css/desk.min.css'
+		]
+	}
 
 	# Get chat assets to be loaded for mobile app
+	local_build_version = get_build_version()
 	assets = [{"type": "js", "data": ""}, {"type": "css", "data": ""}]
-
 	if build_version != local_build_version:
-		# new build, send assets
-		for path in include_js:
-			if path.startswith('/assets/'):
-				path = path.replace('/assets/', 'assets/')
-			try:
-				with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
-					assets[0]["data"] = assets[0]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
-			except IOError:
-				pass
-
-		for path in include_css:
-			if path.startswith('/assets/'):
-				path = path.replace('/assets/', 'assets/')
-			try:
-				with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
-					assets[1]["data"] = assets[1]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
-			except IOError:
-				pass
+		get_assets_data(data)
 
 	return {
 		"build_version": local_build_version,

--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -14,6 +14,8 @@
 		"public/js/frappe/class.js",
 		"public/js/frappe/provide.js",
 		"public/js/frappe/request.js",
+		"public/js/frappe/dom.js",
+		"public/js/lib/bootstrap.min.js",
 		"public/js/frappe/format.js",
 		"public/js/frappe/utils/number_format.js",
 		"public/js/frappe/form/formatters.js",
@@ -27,6 +29,9 @@
 		"public/js/frappe/form/controls/control.js",
 		"public/js/frappe/ui/messages.js",
 		"public/js/frappe/query_string.js",
+		"public/js/frappe/model/meta.js",
+		"public/js/frappe/model/model.js",
+		"public/js/frappe/model/perm.js",
 		"public/js/frappe/socketio_client.js",
 		"public/js/frappe/chat.js"
 	],

--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -32,6 +32,7 @@
 		"public/js/frappe/model/meta.js",
 		"public/js/frappe/model/model.js",
 		"public/js/frappe/model/perm.js",
+		"public/js/frappe/model/sync.js",
 		"public/js/frappe/socketio_client.js",
 		"public/js/frappe/chat.js"
 	],

--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -10,6 +10,26 @@
 	"js/chat.js": [
 		"public/js/frappe/chat.js"
 	],
+	"js/chat-bundle.js": [
+		"public/js/frappe/class.js",
+		"public/js/frappe/provide.js",
+		"public/js/frappe/request.js",
+		"public/js/frappe/format.js",
+		"public/js/frappe/utils/number_format.js",
+		"public/js/frappe/form/formatters.js",
+		"public/js/frappe/utils/utils.js",
+		"public/js/frappe/utils/common.js",
+		"public/js/frappe/utils/pretty_date.js",
+		"public/js/frappe/utils/user.js",
+		"public/js/frappe/ui/dialog.js",
+		"public/js/frappe/translate.js",
+		"public/js/frappe/ui/capture.js",
+		"public/js/frappe/form/controls/control.js",
+		"public/js/frappe/ui/messages.js",
+		"public/js/frappe/query_string.js",
+		"public/js/frappe/socketio_client.js",
+		"public/js/frappe/chat.js"
+	],
 	"js/frappe-recorder.min.js": [
 		"public/js/frappe/recorder/recorder.js"
 	],

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1015,11 +1015,12 @@ frappe.provide('frappe.chat.sound')
  */
 frappe.chat.sound.play  = function (name, volume = 0.1) {
 	// frappe._.play_sound(`chat-${name}`)
-	const $audio = $(`<audio class="chat-audio"/>`)
-	$audio.attr('volume', volume)
+	let $audio = $("audio.chat-audio")
 
-	if  ( frappe._.is_empty($audio) )
-		$(document).append($audio)
+	if  ( !$audio.length ) {
+		$audio = $(`<audio class="chat-audio"/>`)
+		$("body").append($audio)
+	}
 
 	if  ( !$audio.paused ) {
 		frappe.log.info('Stopping sound playing.')
@@ -1028,6 +1029,7 @@ frappe.chat.sound.play  = function (name, volume = 0.1) {
 	}
 
 	frappe.log.info('Playing sound.')
+	$audio.attr('volume', volume)
 	$audio.attr('src', `${frappe.chat.sound.PATH}/chat-${name}.mp3`)
 	$audio[0].play()
 }

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1031,7 +1031,7 @@ frappe.chat.sound.play  = function (name, volume = 0.1) {
 	$audio.attr('src', `${frappe.chat.sound.PATH}/chat-${name}.mp3`)
 	$audio[0].play()
 }
-frappe.chat.sound.PATH  = '/assets/frappe/sounds'
+frappe.chat.sound.PATH  = 'assets/frappe/sounds'
 
 // frappe.chat.emoji
 frappe.chat.emojis = [ ]
@@ -2617,7 +2617,7 @@ frappe._.platform   = () => {
  */
 frappe.provide('frappe.assets')
 frappe.assets.image = (image, app = 'frappe') => {
-	const  path     = `/assets/${app}/images/${image}`
+	const  path     = `assets/${app}/images/${image}`
 	return path
 }
 

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -1605,6 +1605,7 @@ class extends Component {
 				{
 					  label: __("New"),
 					onclick: function ( ) {
+						const has_user_perm = frappe.perm.has_perm("User", 0, 'read');
 						const dialog = new frappe.ui.Dialog({
 							  title: __("New Chat"),
 							 fields: [
@@ -1639,8 +1640,8 @@ class extends Component {
 								 {
 										 label: __("User"),
 									 fieldname: "user",
-									 fieldtype: "Link",
-									   options: "User",
+									 fieldtype: has_user_perm ? "Link" : "Data",
+									   options: has_user_perm ? "User" : null,
 									depends_on: "eval:doc.type == 'Direct Chat'"
 								 }
 							 ],

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -101,7 +101,7 @@ frappe.socketio = {
 		}
 	},
 	get_host: function(port = 3000) {
-		var host = window.location.origin;
+		var host = (window.cordova && frappe.base_url) || window.location.origin;
 		if(window.dev_server) {
 			var parts = host.split(":");
 			port = frappe.boot.socketio_port || port.toString() || '3000';

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -52,28 +52,8 @@ def get_desk_assets(build_version):
 	"""Get desk assets to be loaded for mobile app"""
 	data = get_context({"for_mobile": True})
 	assets = [{"type": "js", "data": ""}, {"type": "css", "data": ""}]
-
 	if build_version != data["build_version"]:
-		# new build, send assets
-		for path in data["include_js"]:
-			# assets path shouldn't start with /
-			# as it points to different location altogether
-			if path.startswith('/assets/'):
-				path = path.replace('/assets/', 'assets/')
-			try:
-				with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
-					assets[0]["data"] = assets[0]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
-			except IOError:
-				pass
-
-		for path in data["include_css"]:
-			if path.startswith('/assets/'):
-				path = path.replace('/assets/', 'assets/')
-			try:
-				with open(os.path.join(frappe.local.sites_path, path) ,"r") as f:
-					assets[1]["data"] = assets[1]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
-			except IOError:
-				pass
+		assets = get_assets_data(data)
 
 	return {
 		"build_version": data["build_version"],
@@ -88,3 +68,29 @@ def get_build_version():
 		# .build can sometimes not exist
 		# this is not a major problem so send fallback
 		return frappe.utils.random_string(8)
+
+def get_assets_data(data):
+	# new build, send assets
+	assets = [{"type": "js", "data": ""}, {"type": "css", "data": ""}]
+
+	for path in data["include_js"]:
+		# assets path shouldn't start with /
+		# as it points to different location altogether
+		if path.startswith('/assets/'):
+			path = path.replace('/assets/', 'assets/')
+		try:
+			with open(os.path.join(frappe.local.sites_path, path), "r") as f:
+				assets[0]["data"] = assets[0]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
+		except IOError:
+			pass
+
+	for path in data["include_css"]:
+		if path.startswith('/assets/'):
+			path = path.replace('/assets/', 'assets/')
+		try:
+			with open(os.path.join(frappe.local.sites_path, path), "r") as f:
+				assets[1]["data"] = assets[1]["data"] + "\n" + frappe.safe_decode(f.read(), "utf-8")
+		except IOError:
+			pass
+
+	return assets


### PR DESCRIPTION
Features:
* `frappe.chat.website.get_chat_assets`
* `chat-bundle.js` in `build.json`

Fixes:
* `frappe.chat.sound.play` wasn't working
* `frappe.socketio.get_host` to use `frappe.base_url` if in Cordova environment
* Create new chat room dialog use Data field rather than Link field if no permission to read `User`

Cordova Chat App: https://github.com/SaiFi0102/mobile/tree/chat

Test Server: https://chatapp.mocha.pk
Test User: test@test.com
Test Password: 123
Prebuilt Debug Android APK (you can build your own if you don't want to use this): https://drive.google.com/open?id=1P723EHBXFDb5FOjWfZhJ1rbIuTOtWfRq

You can send me a message at User: saifi0102@gmail.com
Please feel free to register if you need another User

-------

![image](https://user-images.githubusercontent.com/328330/67855738-d613be00-fb34-11e9-9bab-a90765e70bbd.png)

---------

![image](https://user-images.githubusercontent.com/328330/67855810-f93e6d80-fb34-11e9-894e-2242869147f0.png)
