### PR TITLE
fix: number format issue while parsing float values

### DIFF
--- a/frappe/public/js/frappe/form/controls/currency.js
+++ b/frappe/public/js/frappe/form/controls/currency.js
@@ -19,6 +19,11 @@ frappe.ui.form.ControlCurrency = frappe.ui.form.ControlFloat.extend({
 		return isNaN(parseFloat(value)) ? "" : formatted_value;
 	},
 
+	get_number_format: function() {
+		var currency = frappe.meta.get_field_currency(this.df, this.get_doc());
+		return get_number_format(currency);
+	},
+
 	get_precision: function() {
 		// always round based on field precision or currency's precision
 		// this method is also called in this.parse()

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -1,9 +1,10 @@
 frappe.ui.form.ControlFloat = frappe.ui.form.ControlInt.extend({
 	parse: function(value) {
 		value = this.eval_expression(value);
-		// For #'###.## number format, if we enter 45'00 then it gets parsed as 45.00
-		// becoz number format isn't provided to flt()
-		return isNaN(parseFloat(value)) ? null : flt(value, this.get_precision(), this.get_number_format());
+		return isNaN(parseFloat(value)) ? null : flt(value, this.get_precision(), 
+			// While parsing currency, get_number_format passes currency's number_format
+			// In case of parsing float, it passes global number_format
+			this.get_number_format());
 	},
 
 	format_for_input: function(value) {
@@ -15,10 +16,9 @@ frappe.ui.form.ControlFloat = frappe.ui.form.ControlInt.extend({
 		return isNaN(parseFloat(value)) ? "" : formatted_value;
 	},
 
-	// even a float field can be formatted based on currency format instead of float format
 	get_number_format: function() {
-		var currency = frappe.meta.get_field_currency(this.df, this.get_doc());
-		return get_number_format(currency);
+		// In case of 'Float' field currency's number_format shouldn't be used for formatting
+		return get_number_format();
 	},
 
 	get_precision: function() {


### PR DESCRIPTION
**Problem:** Incase of different global currency and global number format float values were getting parsed using global currency's `number_format`. 
**Fix:** Currency and Float controls now have different `get_number_format()`