### PR TITLE
fix(patch): update status and set auto repeat as not submittable

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -55,11 +55,15 @@ class AutoRepeat(Document):
 			frappe.db.set_value(self.reference_doctype, self.reference_document, 'auto_repeat', '')
 
 	def validate_reference_doctype(self):
-		if not frappe.flags.in_test:
-			if not frappe.get_meta(self.reference_doctype).allow_auto_repeat:
-				frappe.throw(_("Enable Allow Auto Repeat for the doctype {0} in Customize Form").format(self.reference_doctype))
+		if frappe.flags.in_test or frappe.flags.in_patch:
+			return
+		if not frappe.get_meta(self.reference_doctype).allow_auto_repeat:
+			frappe.throw(_("Enable Allow Auto Repeat for the doctype {0} in Customize Form").format(self.reference_doctype))
 
 	def validate_dates(self):
+		if frappe.flags.in_patch:
+			return
+
 		if self.end_date:
 			self.validate_from_to_dates('start_date', 'end_date')
 
@@ -81,7 +85,7 @@ class AutoRepeat(Document):
 	def update_auto_repeat_id(self):
 		#check if document is already on auto repeat
 		auto_repeat = frappe.db.get_value(self.reference_doctype, self.reference_document, "auto_repeat")
-		if auto_repeat and auto_repeat != self.name:
+		if auto_repeat and auto_repeat != self.name and not frappe.flags.in_patch:
 			frappe.throw(_("The {0} is already on auto repeat {1}").format(self.reference_document, auto_repeat))
 		else:
 			frappe.db.set_value(self.reference_doctype, self.reference_document, "auto_repeat", self.name)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -255,3 +255,4 @@ frappe.patches.v12_0.set_default_incoming_email_port
 frappe.patches.v12_0.update_global_search
 execute:frappe.reload_doc('desk', 'doctype', 'notification_settings')
 frappe.patches.v12_0.setup_tags
+frappe.patches.v12_0.update_auto_repeat_status_and_not_submittable

--- a/frappe/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
+++ b/frappe/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
@@ -1,0 +1,25 @@
+from __future__ import unicode_literals
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+
+def execute():
+	#auto repeat is not submittable in v12
+	frappe.reload_doc("automation", "doctype", "Auto Repeat")
+	frappe.db.sql("update `tabDocPerm` set submit=0, cancel=0, amend=0 where parent='Auto Repeat'")
+	frappe.db.sql("update `tabAuto Repeat` set docstatus=0 where docstatus=1 or docstatus=2")
+
+	for entry in frappe.get_all("Auto Repeat"):
+		doc = frappe.get_doc("Auto Repeat", entry.name)
+
+		#create custom field for allow auto repeat
+		fields = frappe.get_meta(doc.reference_doctype).fields
+		insert_after = fields[len(fields) - 1].fieldname
+		df = dict(fieldname="auto_repeat", label="Auto Repeat", fieldtype="Link", insert_after=insert_after,
+			options="Auto Repeat", hidden=1, print_hide=1, read_only=1) 
+		create_custom_field(doc.reference_doctype, df)
+
+		if doc.status in ['Draft', 'Stopped', 'Cancelled']:
+			doc.disabled = 1
+
+		#updates current status as Active, Disabled or Completed on validate
+		doc.save()

--- a/frappe/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
+++ b/frappe/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
@@ -15,10 +15,10 @@ def execute():
 		fields = frappe.get_meta(doc.reference_doctype).fields
 		insert_after = fields[len(fields) - 1].fieldname
 		df = dict(fieldname="auto_repeat", label="Auto Repeat", fieldtype="Link", insert_after=insert_after,
-			options="Auto Repeat", hidden=1, print_hide=1, read_only=1) 
+			options="Auto Repeat", hidden=1, print_hide=1, read_only=1)
 		create_custom_field(doc.reference_doctype, df)
 
-		if doc.status in ['Draft', 'Stopped', 'Cancelled']:
+		if doc.status in ["Draft", "Stopped", "Cancelled"]:
 			doc.disabled = 1
 
 		#updates current status as Active, Disabled or Completed on validate


### PR DESCRIPTION
- **Problem**: Auto Repeat Permission and docstatus issue after upgrading to v12
![auto_repeat_submit_perm_issue](https://user-images.githubusercontent.com/24353136/67867190-0a48a800-fb50-11e9-9105-4017b5eb442d.png)
**Fix**: Update DocPerm and docstatus for older auto repeat as Auto Repeat is not submittable in v12.

- **Problem**: Old Auto Repeat not working after upgrade to v12 (due to different statuses)
Statuses in v11: Active, Stopped, Cancelled, Draft, Expired, Disabled
Statuses in v12: Active, Disabled, Completed
**Fix**: Set Draft, Cancelled and Stopped as Disabled, Expired set to Completed on save and remaining set to Active

**In v11:**
![auto-repeat-v12-issues](https://user-images.githubusercontent.com/24353136/67867380-53006100-fb50-11e9-874c-0bdce5cd37eb.png)

**After upgrading to v12:**
![auto_repeat_after_upgrade_to_v12](https://user-images.githubusercontent.com/24353136/67867386-55fb5180-fb50-11e9-9c6d-435f03dbb0cf.png)

**After patch:**
![after_patch](https://user-images.githubusercontent.com/24353136/67867389-572c7e80-fb50-11e9-831c-e972bc948768.png)

