### PR TITLE
feat: add indicator option for cancelled doc

### DIFF
--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -55,7 +55,7 @@ frappe.get_indicator = function(doc, doctype) {
 	}
 
 	// cancelled
-	if(is_submittable && doc.docstatus==2) {
+	if(is_submittable && doc.docstatus==2 && !settings.has_indicator_for_cancelled) {
 		return [__("Cancelled"), "red", "docstatus,=,2"];
 	}
 


### PR DESCRIPTION
Addition for custom app to determine color of cancelled doc.

Usefull when not all cancelled doc require attention (red is an 'error' color but when an for example order is amended this can also look strange.