### PR TITLE
fix(Query Report View): Do not force set filters from URL Args

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -287,12 +287,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	refresh() {
 		this.toggle_message(true);
 		let filters = this.get_filter_values(true);
-		let query = frappe.utils.get_query_string(frappe.get_route_str());
-
-		if(query) {
-			let obj = frappe.utils.get_query_params(query);
-			filters = Object.assign(filters || {}, obj);
-		}
 
 		// only one refresh at a time
 		if (this.last_ajax) {


### PR DESCRIPTION
No need to force set filters from URL Args
It is already set in the method `set_route_filters` to the Query Report's model

Currently if there are URL Arguments then even if you change the filters in the report view, the URL Args will override them.