### PR TITLE
fix: Ensure naming of files/folders is correct.

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -56,9 +56,7 @@ class File(Document):
 
 	def get_name_based_on_parent_folder(self):
 		if self.folder:
-			path = get_breadcrumbs(self.folder)
-			folder_name = frappe.get_value("File", self.folder, "file_name")
-			return "/".join([d.file_name for d in path] + [folder_name, self.file_name])
+			return "/".join([self.folder, self.file_name])
 
 	def autoname(self):
 		"""Set name for folder"""
@@ -583,19 +581,6 @@ def make_home_folder():
 		"file_name": _("Attachments")
 	}).insert()
 
-@frappe.whitelist()
-def get_breadcrumbs(folder):
-	"""returns name, file_name of parent folder"""
-	path = folder.split('/')
-
-	folders = []
-	for i, _ in enumerate(path):
-		indexes = range(0, i)
-		folder = '/'.join([path[i] for i in indexes])
-		if folder:
-			folders.append(folder)
-
-	return [frappe._dict(file_name=f) for f in folders]
 
 @frappe.whitelist()
 def create_new_folder(file_name, folder):

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -225,6 +225,23 @@ class TestFile(unittest.TestCase):
 
 		self.assertEqual(_("Home/Test Folder 2"), file.folder)
 
+	def test_folder_depth(self):
+		result1 = self.get_folder("d1", "Home")
+		self.assertEqual(result1.name, "Home/d1")
+		result2 = self.get_folder("d2", "Home/d1")
+		self.assertEqual(result2.name, "Home/d1/d2")
+		result3 = self.get_folder("d3", "Home/d1/d2")
+		self.assertEqual(result3.name, "Home/d1/d2/d3")
+		result4 = self.get_folder("d4", "Home/d1/d2/d3")
+		_file = frappe.get_doc({
+			"doctype": "File",
+			"file_name": "folder_copy.txt",
+			"attached_to_name": "",
+			"attached_to_doctype": "",
+			"folder": result4.name,
+			"content": "Testing folder copy example"})
+		_file.save()
+
 
 	def test_folder_copy(self):
 		folder = self.get_folder("Test Folder 2", "Home")


### PR DESCRIPTION
Fixes bug in file/folders.

when creating folders great than 2 in depth, it was appending the root folder name twice.

Test inserted to first of all locate the bug, and then fix it.

Thanks