### PR TITLE
fix(Notifications): Fix for 'New Document Shared' notifications

### DIFF
--- a/frappe/desk/doctype/notification_log/test_notification_log.py
+++ b/frappe/desk/doctype/notification_log/test_notification_log.py
@@ -28,7 +28,7 @@ class TestNotificationLog(unittest.TestCase):
 		todo = get_todo()
 		user = get_user()
 
-		frappe.share.add('ToDo', todo.name, user)
+		frappe.share.add('ToDo', todo.name, user, notify=1)
 		log_type = frappe.db.get_value('Notification Log', {
 			'document_type': 'ToDo',
 			'document_name': todo.name

--- a/frappe/public/js/frappe/form/sidebar/share.js
+++ b/frappe/public/js/frappe/form/sidebar/share.js
@@ -141,6 +141,7 @@ frappe.ui.form.Share = Class.extend({
 					read: $(d.body).find(".add-share-read").prop("checked") ? 1 : 0,
 					write: $(d.body).find(".add-share-write").prop("checked") ? 1 : 0,
 					share: $(d.body).find(".add-share-share").prop("checked") ? 1 : 0,
+					notify: 1,
 				},
 				btn: this,
 				callback: function(r) {

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -299,7 +299,7 @@ frappe.ui.Notifications = class Notifications {
 				<div class="notification-timestamp text-muted">
 					${timestamp}
 				</div>
-				<span class="mark-read text-muted" data-action="explicitly_mark_as_seen">
+				<span class="mark-read text-muted hidden-xs" data-action="explicitly_mark_as_seen">
 					${__('Mark as Read')}
 				</span>
 			</a>`;

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -10,7 +10,7 @@ from frappe.desk.doctype.notification_log.notification_log import enqueue_create
 from frappe.utils import cint
 
 @frappe.whitelist()
-def add(doctype, name, user=None, read=1, write=0, share=0, everyone=0, flags=None):
+def add(doctype, name, user=None, read=1, write=0, share=0, everyone=0, flags=None, notify=0):
 	"""Share the given document with a user."""
 	if not user:
 		user = frappe.session.user
@@ -42,7 +42,7 @@ def add(doctype, name, user=None, read=1, write=0, share=0, everyone=0, flags=No
 	})
 
 	doc.save(ignore_permissions=True)
-	notify_assignment(user, doctype, name, everyone)
+	notify_assignment(user, doctype, name, everyone, notify=notify)
 
 	follow_document(doctype, name, user)
 
@@ -147,9 +147,9 @@ def check_share_permission(doctype, name):
 	if not frappe.has_permission(doctype, ptype="share", doc=name):
 		frappe.throw(_("No permission to {0} {1} {2}".format("share", doctype, name)), frappe.PermissionError)
 
-def notify_assignment(shared_by, doctype, doc_name, everyone):
+def notify_assignment(shared_by, doctype, doc_name, everyone, notify=0):
 
-	if not (shared_by and doctype and doc_name) or everyone: return
+	if not (shared_by and doctype and doc_name) or everyone or not notify: return
 
 	from frappe.utils import get_fullname
 

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -149,7 +149,8 @@ def check_share_permission(doctype, name):
 
 def notify_assignment(shared_by, doctype, doc_name, everyone, notify=0):
 
-	if not (shared_by and doctype and doc_name) or everyone or not notify: return
+	if not (shared_by and doctype and doc_name) or everyone or not notify:
+		return
 
 	from frappe.utils import get_fullname
 


### PR DESCRIPTION
- Added notify param to `notifiy_assignment` in share.py to prevent sending emails for new logins/signups:

<img width="1048" alt="Screenshot 2019-11-04 at 11 32 16 PM" src="https://user-images.githubusercontent.com/19775888/68145237-600bbe80-ff5b-11e9-839c-00f302a845ca.png">

- Hide "Mark as Read" on mobile screens
