### PR TITLE
fix: skip filters is not in dict

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -276,7 +276,7 @@ def get_open_count(doctype, name, items=[]):
 		filters = get_filters_for(d)
 		fieldname = links.get('non_standard_fieldnames', {}).get(d, links.fieldname)
 		data = {'name': d}
-		if filters:
+		if filters and type(filters) is dict:
 			# get the fieldname for the current document
 			# we only need open documents related to the current document
 			filters[fieldname] = name


### PR DESCRIPTION
For certain custom apps it is not possible
to set direct links only simple open count. This checks for a correct dict before trying to load the filters.

Does no harm to the orignal and is not problematic for other users.