### PR TITLE
chore: Fix typo in docstring

### DIFF
--- a/frappe/core/utils.py
+++ b/frappe/core/utils.py
@@ -41,7 +41,7 @@ def find(list_of_dict, match_function):
 	Usage:
 		list_of_dict = [{'name': 'Suraj'}, {'name': 'Aditya'}]
 
-		required_dict = find(list_of_dict, lamda d: d['name'] == 'Aditya')
+		required_dict = find(list_of_dict, lambda d: d['name'] == 'Aditya')
 	'''
 
 	for entry in list_of_dict:
@@ -60,7 +60,7 @@ def find_all(list_of_dict, match_function):
 			{'color': 'blue', 'shape': 'triangle'}
 		]
 
-		red_shapes = find_all(colored_shapes, lamda d: d['color'] == 'red')
+		red_shapes = find_all(colored_shapes, lambda d: d['color'] == 'red')
 	'''
 	found = []
 	for entry in list_of_dict:


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

This PR is a minor typo fix in the documentation of find() and find_all() functions in frappe/core/utils.py
