### PR TITLE
fix(Tags): Global Tags fixes

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -256,3 +256,4 @@ frappe.patches.v12_0.update_global_search
 execute:frappe.reload_doc('desk', 'doctype', 'notification_settings')
 frappe.patches.v12_0.setup_tags
 frappe.patches.v12_0.update_auto_repeat_status_and_not_submittable
+frappe.patches.v12_0.copy_to_parent_for_tags

--- a/frappe/patches/v12_0/copy_to_parent_for_tags.py
+++ b/frappe/patches/v12_0/copy_to_parent_for_tags.py
@@ -1,0 +1,6 @@
+import frappe
+
+def execute():
+
+	frappe.db.sql("UPDATE `tabTag Link` SET parenttype=document_type")
+	frappe.db.sql("UPDATE `tabTag Link` SET parent=document_name")

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -177,7 +177,7 @@ frappe.ui.Filter = class {
 		if (doctype === "Tag Link" || fieldname === "_user_tags") {
 			original_docfield = {fieldname: "tag", fieldtype: "Data", label: "Tags", parent: "Tag Link"};
 			doctype = "Tag Link";
-			condition = "=";
+			condition = condition;
 		}
 
 		if(!original_docfield) {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -177,7 +177,6 @@ frappe.ui.Filter = class {
 		if (doctype === "Tag Link" || fieldname === "_user_tags") {
 			original_docfield = {fieldname: "tag", fieldtype: "Data", label: "Tags", parent: "Tag Link"};
 			doctype = "Tag Link";
-			condition = condition;
 		}
 
 		if(!original_docfield) {


### PR DESCRIPTION
- Copies document_type to parenttype and parent=document_name
- Allow all conditions in filters other than `Equals`.