### PR TITLE
fix: fix for "IN" type filters not being saved

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -101,6 +101,9 @@ frappe.ui.form.ControlAutocomplete = frappe.ui.form.ControlData.extend({
 
 	validate(value) {
 		let valid_values = this.awesomplete._list.map(d => d.value);
+		if (!valid_values.length) {
+			return value;
+		}
 		if (valid_values.includes(value)) {
 			return value;
 		} else {


### PR DESCRIPTION
"IN" type list filters were not being saved because `validate_list` in `validate` was empty. 

Before:
![filters fix before](https://user-images.githubusercontent.com/19775888/68301654-708c7800-00c6-11ea-9592-d30489832d1e.gif)


After:
![filters fix](https://user-images.githubusercontent.com/19775888/68301702-869a3880-00c6-11ea-85a4-43014b06d09d.gif)
