### PR TITLE
fix: email account permission issue while sending an email

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -381,7 +381,7 @@ def parse_email(communication, email_strings):
 		a doctype and docname ie in the format `admin+doctype+docname@example.com`,
 		the email is parsed and doctype and docname is extracted and timeline link is added.
 	"""
-	if not frappe.get_list("Email Account", filters={"enable_automatic_linking": 1}):
+	if not frappe.get_all("Email Account", filters={"enable_automatic_linking": 1}):
 		return
 
 	delimiter = "+"
@@ -406,7 +406,7 @@ def get_email_without_link(email):
 		returns email address without doctype links
 		returns admin@example.com for email admin+doctype+docname@example.com
 	"""
-	if not frappe.get_list("Email Account", filters={"enable_automatic_linking": 1}):
+	if not frappe.get_all("Email Account", filters={"enable_automatic_linking": 1}):
 		return email
 
 	email_id = email.split("@")[0].split("+")[0]


### PR DESCRIPTION
While sending an email user getting below error.
```
Traceback (most recent call last):
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/app.py", line 60, in application
response = frappe.api.handle()
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/api.py", line 55, in handle
return frappe.handler.handle()
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 22, in handle
data = execute_cmd(cmd)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 61, in execute_cmd
return frappe.call(method, **frappe.form_dict)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 1038, in call
return fn(*args, **newargs)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/core/doctype/communication/email.py", line 73, in make
}).insert(ignore_permissions=True)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 229, in insert
self.run_before_save_methods()
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 888, in run_before_save_methods
self.run_method("validate")
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 787, in run_method
out = Document.hook(fn)(self, *args, **kwargs)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 1058, in composer
return composed(self, method, *args, **kwargs)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 1041, in runner
add_to_return_value(self, fn(self, *args, **kwargs))
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 781, in <lambda>
fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/core/doctype/communication/communication.py", line 64, in validate
self.parse_email_for_timeline_links()
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/core/doctype/communication/communication.py", line 257, in parse_email_for_timeline_links
parse_email(self, [self.recipients, self.cc, self.bcc])
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/core/doctype/communication/communication.py", line 384, in parse_email
if not frappe.get_list("Email Account", filters={"enable_automatic_linking": 1}):
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 1274, in get_list
return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/db_query.py", line 43, in execute
raise frappe.PermissionError(self.doctype)
frappe.exceptions.PermissionError: Email Account
```