### PR TITLE
fix: do not process server script or energy points if site is in migrate state

### DIFF
--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -31,6 +31,9 @@ def run_server_script_for_doc_event(doc, event):
 	if frappe.flags.in_install:
 		return
 
+	if frappe.flags.in_migrate:
+		return
+
 	scripts = get_server_script_map().get(doc.doctype, {}).get(EVENT_MAP[event], None)
 	if scripts:
 		# run all scripts for this doctype + event

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -82,7 +82,10 @@ class EnergyPointRule(Document):
 def process_energy_points(doc, state):
 	if (frappe.flags.in_patch
 		or frappe.flags.in_install
-		or not is_energy_point_enabled()):
+		or frappe.flags.in_migrate):
+		return
+
+	if not is_energy_point_enabled():
 		return
 
 	old_doc = doc.get_doc_before_save()


### PR DESCRIPTION
1. do not run server-side script if a site is in migrate state
```
~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in reload_doc(module, dt, dn, force, reset_permissions)
    799 
    800 	import frappe.modules
--> 801 	return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
    802 
    803 def rename_doc(*args, **kwargs):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/utils.py in reload_doc(module, dt, dn, force, reset_permissions)
    172 def reload_doc(module, dt=None, dn=None, force=False, reset_permissions=False):
    173 	from frappe.modules.import_file import import_files
--> 174 	return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
    175 
    176 def export_doc(doctype, name, module=None):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_files(module, dt, dn, force, pre_process, reset_permissions)
     25 	else:
     26 		return import_file(module, dt, dn, force=force, pre_process=pre_process,
---> 27 			reset_permissions=reset_permissions)
     28 
     29 def import_file(module, dt, dn, force=False, pre_process=None, reset_permissions=False):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_file(module, dt, dn, force, pre_process, reset_permissions)
     30 	"""Sync a file from txt if modifed, return false if not updated"""
     31 	path = get_file_path(module, dt, dn)
---> 32 	ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
     33 	return ret
     34 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_file_by_path(path, force, data_import, pre_process, ignore_version, reset_permissions, for_sync)
     64 			frappe.flags.in_import = True
     65 			import_doc(doc, force=force, data_import=data_import, pre_process=pre_process,
---> 66 				ignore_version=ignore_version, reset_permissions=reset_permissions)
     67 			frappe.flags.in_import = False
     68 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_doc(docdict, force, data_import, pre_process, ignore_version, reset_permissions)
    139 		doc.flags.ignore_mandatory = True
    140 
--> 141 	doc.insert()
    142 
    143 	frappe.flags.in_import = False

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in insert(self, ignore_permissions, ignore_links, ignore_if_duplicate, ignore_mandatory)
    220 		self.set_docstatus()
    221 		self.check_if_latest()
--> 222 		self.run_method("before_insert")
    223 		self._validate_links()
    224 		self.set_new_name()

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in run_method(self, method, *args, **kwargs)
    789 		self.run_notifications(method)
    790 		run_webhooks(self, method)
--> 791 		run_server_script_for_doc_event(self, method)
    792 
    793 		return out

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/core/doctype/server_script/server_script_utils.py in run_server_script_for_doc_event(doc, event)
     32 		return
     33 
---> 34 	scripts = get_server_script_map().get(doc.doctype, {}).get(EVENT_MAP[event], None)
     35 	if scripts:
     36 		# run all scripts for this doctype + event

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/core/doctype/server_script/server_script_utils.py in get_server_script_map()
     55 		script_map = {}
     56 		for script in frappe.get_all('Server Script', ('name', 'reference_doctype', 'doctype_event',
---> 57 			'api_method', 'script_type')):
     58 			if script.script_type == 'DocType Event':
     59 				script_map.setdefault(script.reference_doctype, {}).setdefault(script.doctype_event, []).append(script.name)

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in get_all(doctype, *args, **kwargs)
   1299 	if not "limit_page_length" in kwargs:
   1300 		kwargs["limit_page_length"] = 0
-> 1301 	return get_list(doctype, *args, **kwargs)
   1302 
   1303 def get_value(*args, **kwargs):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in get_list(doctype, *args, **kwargs)
   1272 	"""
   1273 	import frappe.model.db_query
-> 1274 	return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
   1275 
   1276 def get_all(doctype, *args, **kwargs):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/db_query.py in execute(self, query, fields, filters, or_filters, docstatus, group_by, order_by, limit_start, limit_page_length, as_list, with_childnames, debug, ignore_permissions, user, with_comment_count, join, distinct, start, page_length, limit, ignore_ifnull, save_user_settings, save_user_settings_fields, update, add_total_row, user_settings, reference_doctype, return_query, strict)
     94 			result = self.run_custom_query(query)
     95 		else:
---> 96 			result = self.build_and_run()
     97 			if return_query:
     98 				return result

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/db_query.py in build_and_run(self)
    108 
    109 	def build_and_run(self):
--> 110 		args = self.prepare_args()
    111 		args.limit = self.add_limit()
    112 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/db_query.py in prepare_args(self)
    134 		self.sanitize_fields()
    135 		self.extract_tables()
--> 136 		self.set_optional_columns()
    137 		self.build_conditions()
    138 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/db_query.py in set_optional_columns(self)
    292 	def set_optional_columns(self):
    293 		"""Removes optional columns like `_user_tags`, `_comments` etc. if not in table"""
--> 294 		columns = get_table_columns(self.doctype)
    295 
    296 		# remove from fields

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/meta.py in get_table_columns(doctype)
     47 
     48 def get_table_columns(doctype):
---> 49 	return frappe.db.get_table_columns(doctype)
     50 
     51 def load_doctype_from_file(doctype):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py in get_table_columns(self, doctype)
    862 		columns = self.get_db_table_columns('tab' + doctype)
    863 		if not columns:
--> 864 			raise self.TableMissingError('DocType', doctype)
    865 		return columns
    866 

ProgrammingError: ('DocType', 'Server Script')
```


2. do not process energy points if a site is in migrate state
```
ModuleNotFoundError                       Traceback (most recent call last)
~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/utils.py in load_doctype_module(doctype, module, prefix, suffix)
    203 		if key not in doctype_python_modules:
--> 204 			doctype_python_modules[key] = frappe.get_module(module_name)
    205 	except ImportError as e:

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in get_module(modulename)
    809 	"""Returns a module object for given Python module name using `importlib.import_module`."""
--> 810 	return importlib.import_module(modulename)
    811 

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/__init__.py in import_module(name, package)
    125             level += 1
--> 126     return _bootstrap._gcd_import(name[level:], package, level)
    127 

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/_bootstrap.py in _gcd_import(name, package, level)

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/_bootstrap.py in _find_and_load(name, import_)

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/_bootstrap.py in _find_and_load_unlocked(name, import_)

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/_bootstrap.py in _call_with_frames_removed(f, *args, **kwds)

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/_bootstrap.py in _gcd_import(name, package, level)

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/_bootstrap.py in _find_and_load(name, import_)

~/benches/bench-version-12-2019-10-30/env/lib64/python3.6/importlib/_bootstrap.py in _find_and_load_unlocked(name, import_)

ModuleNotFoundError: No module named 'frappe.core.doctype.energy_point_settings'

During handling of the above exception, another exception occurred:

ImportError                               Traceback (most recent call last)
~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/commands/utils.py in <module>
----> 1 frappe.reload_doc('setup', 'doctype', 'global_defaults')

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in reload_doc(module, dt, dn, force, reset_permissions)
    799 
    800 	import frappe.modules
--> 801 	return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
    802 
    803 def rename_doc(*args, **kwargs):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/utils.py in reload_doc(module, dt, dn, force, reset_permissions)
    172 def reload_doc(module, dt=None, dn=None, force=False, reset_permissions=False):
    173 	from frappe.modules.import_file import import_files
--> 174 	return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
    175 
    176 def export_doc(doctype, name, module=None):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_files(module, dt, dn, force, pre_process, reset_permissions)
     25 	else:
     26 		return import_file(module, dt, dn, force=force, pre_process=pre_process,
---> 27 			reset_permissions=reset_permissions)
     28 
     29 def import_file(module, dt, dn, force=False, pre_process=None, reset_permissions=False):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_file(module, dt, dn, force, pre_process, reset_permissions)
     30 	"""Sync a file from txt if modifed, return false if not updated"""
     31 	path = get_file_path(module, dt, dn)
---> 32 	ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
     33 	return ret
     34 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_file_by_path(path, force, data_import, pre_process, ignore_version, reset_permissions, for_sync)
     64 			frappe.flags.in_import = True
     65 			import_doc(doc, force=force, data_import=data_import, pre_process=pre_process,
---> 66 				ignore_version=ignore_version, reset_permissions=reset_permissions)
     67 			frappe.flags.in_import = False
     68 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/import_file.py in import_doc(docdict, force, data_import, pre_process, ignore_version, reset_permissions)
    139 		doc.flags.ignore_mandatory = True
    140 
--> 141 	doc.insert()
    142 
    143 	frappe.flags.in_import = False

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in insert(self, ignore_permissions, ignore_links, ignore_if_duplicate, ignore_mandatory)
    257 			self.copy_attachments_from_amended_from()
    258 
--> 259 		self.run_post_save_methods()
    260 		self.flags.in_insert = False
    261 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in run_post_save_methods(self)
    927 			self.run_method("on_update_after_submit")
    928 
--> 929 		self.run_method('on_change')
    930 
    931 		self.clear_cache()

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in run_method(self, method, *args, **kwargs)
    785 
    786 		fn.__name__ = str(method)
--> 787 		out = Document.hook(fn)(self, *args, **kwargs)
    788 
    789 		self.run_notifications(method)

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in composer(self, *args, **kwargs)
   1056 
   1057 			composed = compose(f, *hooks)
-> 1058 			return composed(self, method, *args, **kwargs)
   1059 
   1060 		return composer

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in runner(self, method, *args, **kwargs)
   1041 				add_to_return_value(self, fn(self, *args, **kwargs))
   1042 				for f in hooks:
-> 1043 					add_to_return_value(self, f(self, method, *args, **kwargs))
   1044 
   1045 				return self._return_value

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py in process_energy_points(doc, state)
     83 	if (frappe.flags.in_patch
     84 		or frappe.flags.in_install
---> 85 		or not is_energy_point_enabled()):
     86 		return
     87 

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.py in is_energy_point_enabled()
     13 
     14 def is_energy_point_enabled():
---> 15 	return frappe.get_cached_value('Energy Point Settings', None, 'enabled')
     16 
     17 def allocate_review_points():

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in get_cached_value(doctype, name, fieldname, as_dict)
    706 
    707 def get_cached_value(doctype, name, fieldname, as_dict=False):
--> 708 	doc = get_cached_doc(doctype, name)
    709 	if isinstance(fieldname, string_types):
    710 		if as_dict:

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in get_cached_doc(*args, **kwargs)
    691 
    692 	# database
--> 693 	doc = get_doc(*args, **kwargs)
    694 
    695 	return doc

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py in get_doc(*args, **kwargs)
    734 	"""
    735 	import frappe.model.document
--> 736 	doc = frappe.model.document.get_doc(*args, **kwargs)
    737 
    738 	# set in cache

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py in get_doc(*args, **kwargs)
     66 			raise ValueError('"doctype" is a required key')
     67 
---> 68 	controller = get_controller(doctype)
     69 	if controller:
     70 		return controller(*args, **kwargs)

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/base_document.py in get_controller(doctype)
     45 			_class = NestedSet if is_tree else Document
     46 		else:
---> 47 			module = load_doctype_module(doctype, module_name)
     48 			classname = doctype.replace(" ", "").replace("-", "")
     49 			if hasattr(module, classname):

~/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/utils.py in load_doctype_module(doctype, module, prefix, suffix)
    204 			doctype_python_modules[key] = frappe.get_module(module_name)
    205 	except ImportError as e:
--> 206 		raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))
    207 
    208 	return doctype_python_modules[key]

ImportError: Module import failed for Energy Point Settings (frappe.core.doctype.energy_point_settings.energy_point_settings Error: No module named 'frappe.core.doctype.energy_point_settings')

```

