### PR TITLE
fix: Name of Contact cannot be Contact error while creating communication for incoming emails

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -356,13 +356,13 @@ def get_contacts(email_strings):
 			first_name = frappe.unscrub(email_parts[0])
 
 			try:
+				contact_name = '{0}-{1}'.format(first_name, email_parts[1]) if first_name == 'Contact' else first_name
 				contact = frappe.get_doc({
 					"doctype": "Contact",
-					"first_name": first_name,
+					"first_name": contact_name,
+					"name": contact_name
 				})
 				contact.add_email(email_id=email, is_primary=True)
-				contact.name = ('{0}-{1}'.format(first_name, email_parts[1])
-					if first_name == 'Contact' else first_name)
 				contact.insert(ignore_permissions=True)
 				contact_name = contact.name
 			except Exception:

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -351,16 +351,26 @@ def get_contacts(email_strings):
 		email = get_email_without_link(email)
 		contact_name = get_contact_name(email)
 
-		if not contact_name:
-			contact = frappe.get_doc({
-				"doctype": "Contact",
-				"first_name": frappe.unscrub(email.split("@")[0]),
-			})
-			contact.add_email(email_id=email, is_primary=True)
-			contact.insert(ignore_permissions=True)
-			contact_name = contact.name
+		if not contact_name and email:
+			email_parts = email.split("@")
+			first_name = frappe.unscrub(email_parts[0])
 
-		contacts.append(contact_name)
+			try:
+				contact = frappe.get_doc({
+					"doctype": "Contact",
+					"first_name": first_name,
+				})
+				contact.add_email(email_id=email, is_primary=True)
+				contact.name = ('{0}-{1}'.format(first_name, email_parts[1])
+					if first_name == 'Contact' else first_name)
+				contact.insert(ignore_permissions=True)
+				contact_name = contact.name
+			except Exception:
+				traceback = frappe.get_traceback()
+				frappe.log_error(traceback)
+
+		if contact_name:
+			contacts.append(contact_name)
 
 	return contacts
 


### PR DESCRIPTION
Incoming emails are not fetched because of below error

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 280, in receive
    communication = self.insert_communication(msg, args=args)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 392, in insert_communication
    communication.insert(ignore_permissions=True)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 228, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 886, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 786, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 1056, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 1039, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 780, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/core/doctype/communication/communication.py", line 65, in validate
    self.set_timeline_links()
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/core/doctype/communication/communication.py", line 261, in set_timeline_links
    contacts = get_contacts([self.sender, self.recipients, self.cc, self.bcc])
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/core/doctype/communication/communication.py", line 360, in get_contacts
    contact.insert(ignore_permissions=True)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 223, in insert
    self.set_new_name()
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/document.py", line 391, in set_new_name
    set_new_name(self)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/naming.py", line 57, in set_new_name
    frappe.get_meta(doc.doctype).get_field("name_case")
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/model/naming.py", line 212, in validate_name
    frappe.throw(_("Name of {0} cannot be {1}").format(doctype, name), frappe.NameError)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.NameError: Name of Contact cannot be Contact
```