### PR TITLE
fix: Ignore links while saving auto repeat doc

### DIFF
--- a/frappe/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
+++ b/frappe/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
@@ -21,5 +21,6 @@ def execute():
 		if doc.status in ["Draft", "Stopped", "Cancelled"]:
 			doc.disabled = 1
 
+		doc.flags.ignore_links = 1
 		#updates current status as Active, Disabled or Completed on validate
 		doc.save()


### PR DESCRIPTION
```
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/deepesh/test-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/deepesh/test-bench/apps/frappe/frappe/patches/v12_0/update_auto_repeat_status_and_not_submittable.py", line 25, in execute
    doc.save()
  File "/Users/deepesh/test-bench/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/Users/deepesh/test-bench/apps/frappe/frappe/model/document.py", line 307, in _save
    self._validate_links()
  File "/Users/deepesh/test-bench/apps/frappe/frappe/model/document.py", line 756, in _validate_links
    frappe.LinkValidationError)
  File "/Users/deepesh/test-bench/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/Users/deepesh/test-bench/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/Users/deepesh/test-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.LinkValidationError: Could not find Reference Document: SINV-RET-00012
```
