### PR TITLE
fix: error while enqueuing jobs related to notification log

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -25,6 +25,16 @@ def get_permission_query_conditions(for_user):
 
 	return '''(`tabNotification Log`.for_user = '{user}')'''.format(user=for_user)
 
+def get_title(doctype, docname, title_field=None):
+	if not title_field:
+		title_field = frappe.get_meta(doctype).get_title_field()
+	title = docname if title_field == "name" else \
+		frappe.db.get_value(doctype, docname, title_field)
+	return title
+
+def get_title_html(title):
+	return '<b class="subject-title">{0}</b>'.format(title)
+
 def enqueue_create_notification(users, doc):
 	'''
 	During installation of new site, enqueue_create_notification tries to connect to Redis.
@@ -100,16 +110,6 @@ def get_email_header(doc):
 		'Energy Point': _('Energy Point Update'),
 	}[doc.type or 'Default']
 
-
-def get_title(doctype, docname, title_field=None):
-	if not title_field:
-		title_field = frappe.get_meta(doctype).get_title_field()
-	title = docname if title_field == "name" else \
-		frappe.db.get_value(doctype, docname, title_field)
-	return title
-
-def get_title_html(title):
-	return '<b class="subject-title">{0}</b>'.format(title)
 
 @frappe.whitelist()
 def mark_as_seen(docname):


### PR DESCRIPTION
Problem:
While deleting 10+ items from a list, jobs get enqueued then on executing those jobs, facing this error:

![Screenshot 2019-11-08 at 4 02 19 PM](https://user-images.githubusercontent.com/25369014/68469980-34315700-0241-11ea-9444-07b3e3bbc56e.png)

Following lines had circular dependencies:
![Screenshot 2019-11-08 at 4 02 10 PM](https://user-images.githubusercontent.com/25369014/68470033-4a3f1780-0241-11ea-9b8a-4de55826817d.png)

Loop starts by `boot.py` importing `is_energy_point_enabled()`
then going through other imports finally same function gets imported again in `notification_log.py` (line 61)

Solution:
Moved the functions to be imported before circular dependencies happen.



