### PR TITLE
fix: Hide default arrow from select field in webforms

### DIFF
--- a/frappe/public/less/controls.less
+++ b/frappe/public/less/controls.less
@@ -150,6 +150,13 @@
 .frappe-control[data-fieldtype="Select"] .control-input {
 	position: relative;
 
+	select {
+		/* for Firefox */
+		-moz-appearance: none;
+		/* for Chrome */
+		-webkit-appearance: none;
+	}
+
 	.octicon-chevron-down {
 		position: absolute;
 		top: 8px;


### PR DESCRIPTION
Before:
![Screenshot 2019-11-09 at 9 41 18 PM](https://user-images.githubusercontent.com/42651287/68531852-db46e900-033c-11ea-872a-986f0cfac02f.png)

After:
![Screenshot 2019-11-09 at 9 59 07 PM](https://user-images.githubusercontent.com/42651287/68531856-e26df700-033c-11ea-849b-d1c79019add9.png)
