### PR TITLE
fix: poplib.error_proto exception (v11)

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -298,7 +298,7 @@ class EmailServer:
 			"Connection timed out",
 		)
 		for message in messages:
-			if message in strip(cstr(e.message)) or message in strip(cstr(getattr(e, 'strerror', ''))):
+			if message in strip(cstr(e)) or message in strip(cstr(getattr(e, 'strerror', ''))):
 				return True
 		return False
 


### PR DESCRIPTION
Backport: https://github.com/frappe/frappe/pull/8596
Problem:
AttributeError: 'error_proto' object has no attribute 'message'

Fix:
The reason for this exception is passed to the constructor as a string, so there is no message attribute