### PR TITLE
fix(Report): do not validate Script Manager role for Report Builder type

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -30,7 +30,7 @@ class Report(Document):
 
 		if self.is_standard == "No":
 			# allow only script manager to edit scripts
-			if frappe.session.user!="Administrator":
+			if self.report_type == 'Script Report' and frappe.conf.server_script_enabled and frappe.session.user != "Administrator":
 				frappe.only_for('Script Manager', True)
 
 			if frappe.db.get_value("Report", self.name, "is_standard") == "Yes":

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -30,7 +30,7 @@ class Report(Document):
 
 		if self.is_standard == "No":
 			# allow only script manager to edit scripts
-			if self.report_type == 'Script Report' and frappe.conf.server_script_enabled and frappe.session.user != "Administrator":
+			if self.report_type != 'Report Builder' and frappe.session.user != "Administrator":
 				frappe.only_for('Script Manager', True)
 
 			if frappe.db.get_value("Report", self.name, "is_standard") == "Yes":

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -30,7 +30,7 @@ class Report(Document):
 
 		if self.is_standard == "No":
 			# allow only script manager to edit scripts
-			if self.report_type != 'Report Builder' and frappe.session.user != "Administrator":
+			if self.report_type != 'Report Builder':
 				frappe.only_for('Script Manager', True)
 
 			if frappe.db.get_value("Report", self.name, "is_standard") == "Yes":


### PR DESCRIPTION
Script Manager role should only be validated for Script Report, Custom Report, Query Report. Not for Report Builder type

![validation_for_script_manager](https://user-images.githubusercontent.com/24353136/68653749-6816c000-0552-11ea-9bcd-20a11d179ac3.png)
