### PR TITLE
fix: formatting for chart tooltip

### DIFF
--- a/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py
+++ b/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py
@@ -242,7 +242,6 @@ class RazorpaySettings(Document):
 
 		redirect_to = data.get('redirect_to') or None
 		redirect_message = data.get('redirect_message') or None
-
 		if self.flags.status_changed_to in ("Authorized", "Verified", "Completed"):
 			if self.data.reference_doctype and self.data.reference_docname:
 				custom_redirect_to = None

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -500,10 +500,11 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			axisOptions: {
 				shortenYAxisNumbers: 1
 			},
-
-			format_tooltip_x: value => value.doc.name,
-			format_tooltip_y:
-				value => frappe.format(value, get_df(value.field), { always_show_decimals: true, inline: true }, get_doc(value.doc))
+			tooltipOptions: {
+				formatTooltipY: value => {
+					return frappe.format(value, get_df(this.chart_args.y_axes[0]), { always_show_decimals: true, inline: true }, get_doc(value.doc))
+				}
+			}
 		});
 	}
 

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -501,9 +501,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				shortenYAxisNumbers: 1
 			},
 			tooltipOptions: {
-				formatTooltipY: value => {
-					return frappe.format(value, get_df(this.chart_args.y_axes[0]), { always_show_decimals: true, inline: true }, get_doc(value.doc))
-				}
+				formatTooltipY: value => frappe.format(value, get_df(this.chart_args.y_axes[0]), { always_show_decimals: true, inline: true }, get_doc(value.doc))
 			}
 		});
 	}


### PR DESCRIPTION
Enable formatting for tooltips in report view

<img width="319" alt="Screenshot 2019-11-12 at 5 37 12 PM" src="https://user-images.githubusercontent.com/18097732/68670501-1cc0d980-0573-11ea-9dd8-e419b89f680a.png">
