### PR TITLE
fix: int eval_expression only checks for comma

### DIFF
--- a/frappe/public/js/frappe/form/controls/currency.js
+++ b/frappe/public/js/frappe/form/controls/currency.js
@@ -1,21 +1,6 @@
 frappe.ui.form.ControlCurrency = frappe.ui.form.ControlFloat.extend({
-	eval_expression: function(value) {
-		if (typeof value ==='string' && value.match(/^[0-9+-/* ]+$/)) {
-			// Removes seperator
-			value = strip_number_groups(value, this.get_number_format());
-
-			try {
-				return eval(value);
-			} catch (e) {
-				return value;
-			}
-		}
-		// If not string
-		return value;
-	},
-
 	format_for_input: function(value) {
-		var formatted_value = format_number(parseFloat(value), this.get_number_format(), this.get_precision());
+		var formatted_value = format_number(value, this.get_number_format(), this.get_precision());
 		return isNaN(parseFloat(value)) ? "" : formatted_value;
 	},
 

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -1,7 +1,7 @@
 frappe.ui.form.ControlFloat = frappe.ui.form.ControlInt.extend({
 	parse: function(value) {
 		value = this.eval_expression(value);
-		return isNaN(parseFloat(value)) ? null : flt(value, this.get_precision(), 
+		return isNaN(parseFloat(value)) ? null : flt(value, this.get_precision(),
 			// While parsing currency, get_number_format passes currency's number_format
 			// In case of parsing float, it passes global number_format
 			this.get_number_format());
@@ -12,7 +12,7 @@ frappe.ui.form.ControlFloat = frappe.ui.form.ControlInt.extend({
 		if (this.df.fieldtype==="Float" && this.df.options && this.df.options.trim()) {
 			number_format = this.get_number_format();
 		}
-		var formatted_value = format_number(parseFloat(value), number_format, this.get_precision());
+		var formatted_value = format_number(value, number_format, this.get_precision());
 		return isNaN(parseFloat(value)) ? "" : formatted_value;
 	},
 

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -20,11 +20,10 @@ frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
 			});
 	},
 	eval_expression: function(value) {
-		if (typeof value==='string'
-			&& value.match(/^[0-9+-/* ]+$/)
-			// strings with commas are evaluated incorrectly
-			// for e.g 47,186.00 -> 186
-			&& !value.includes(',')) {
+		// Removes seperators of any number format
+		value = strip_number_groups(value, this.get_number_format());
+		if (typeof value==='string' && value.match(/^[0-9+-/* ]+$/)) {
+			// If it is a string containing operators
 			try {
 				return eval(value);
 			} catch (e) {

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -20,19 +20,23 @@ frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
 			});
 	},
 	eval_expression: function(value) {
-		// Removes seperators of any number format
-		value = strip_number_groups(value, this.get_number_format());
-		if (typeof value==='string' && value.match(/^[0-9+-/* ]+$/)) {
-			// If it is a string containing operators
-			try {
-				return eval(value);
-			} catch (e) {
-				// bad expression
-				return value;
+		if (typeof value==='string') {
+			// Removes seperators of any number format
+			value = this.get_number_format ? strip_number_groups(value, this.get_number_format())
+				// for integer there's no get_number_format
+				: strip_number_groups(value);
+
+			if (value.match(/^[0-9+-/* ]+$/)) {
+				// If it is a string containing operators
+				try {
+					return eval(value);
+				} catch (e) {
+					// bad expression
+					return value;
+				}
 			}
-		} else {
-			return value;
 		}
+		return value;
 	},
 	parse: function(value) {
 		return cint(this.eval_expression(value), null);

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -20,13 +20,8 @@ frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
 			});
 	},
 	eval_expression: function(value) {
-		if (typeof value==='string') {
-			// Removes seperators of any number format
-			value = this.get_number_format ? strip_number_groups(value, this.get_number_format())
-				// for integer there's no get_number_format
-				: strip_number_groups(value);
-
-			if (value.match(/^[0-9+-/* ]+$/)) {
+		if (typeof value === 'string') {
+			if (value.match(/^[0-9\+\-\/\* ]+$/)) {
 				// If it is a string containing operators
 				try {
 					return eval(value);


### PR DESCRIPTION
Problem: expressions of other country number formats not evaluating correctly.