### PR TITLE
fix: deadlock issue on load of company

### DIFF
--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -80,7 +80,6 @@ def get_monthly_goal_graph_data(title, doctype, docname, goal_value_field, goal_
 		if filter_str:
 			doc_filter += ' and ' + filter_str if doc_filter else filter_str
 		month_to_value_dict = get_monthly_results(goal_doctype, goal_field, date_field, doc_filter, aggregation)
-		frappe.db.set_value(doctype, docname, goal_history_field, json.dumps(month_to_value_dict))
 
 	month_to_value_dict[current_month_year] = current_month_value
 


### PR DESCRIPTION
**Issue**

Get and set, on load causing the deadlock issue
We have already wrote method which update the monthly sales data through daily hooks
https://github.com/frappe/erpnext/blob/develop/erpnext/hooks.py#L295

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 1038, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/utils/goal.py", line 83, in get_monthly_goal_graph_data
    frappe.db.set_value(doctype, docname, goal_history_field, json.dumps(month_to_value_dict))
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 652, in set_value
    values, debug=debug)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1213, 'Deadlock found when trying to get lock; try restarting transaction')
```