### PR TITLE
fix: update sidebar tags on changing list filters (develop)

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -261,17 +261,24 @@ def delete_bulk(doctype, items):
 @frappe.whitelist()
 @frappe.read_only()
 def get_sidebar_stats(stats, doctype, filters=[]):
+	_user_tags = []
+	data = frappe._dict(frappe.local.form_dict)
+	filters = json.loads(data["filters"])
 
-	if not frappe.cache().hget("tags_count", doctype):
-		tags = [tag.name for tag in frappe.get_list("Tag")]
-		_user_tags = []
-		for tag in tags:
-			count = frappe.db.count("Tag Link", filters={"document_type": doctype, "tag": tag})
-			if count > 0:
-				_user_tags.append([tag, count])
-		frappe.cache().hset("tags_count", doctype, _user_tags)
+	if not frappe.cache().hget("Tags", doctype):
+		tags = set([tag.tag for tag in frappe.get_list("Tag Link", filters={"document_type": doctype}, fields=["tag"])])
+		frappe.cache().hset("Tags", doctype, tags)
 
-	return {"stats": {"_user_tags": frappe.cache().hget("tags_count", doctype)}}
+	for tag in list(frappe.cache().hget("Tags", doctype)):
+		tag_filters = []
+		tag_filters.extend(filters)
+		tag_filters.extend([['Tag Link', 'tag', '=', tag]])
+
+		count = frappe.get_all(doctype, filters=tag_filters, fields=["count(*)"])
+		if count[0].get("count(*)") > 0:
+			_user_tags.append([tag, count[0].get("count(*)")])
+
+	return {"stats": {"_user_tags": _user_tags}}
 
 @frappe.whitelist()
 @frappe.read_only()

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -402,7 +402,7 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	after_render() {
-
+		this.list_sidebar.reload_stats();
 	}
 
 	render() {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -402,7 +402,7 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	after_render() {
-		this.list_sidebar.reload_stats();
+
 	}
 
 	render() {

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -386,8 +386,8 @@ frappe.views.ListSidebar = class ListSidebar {
 	}
 
 	reload_stats() {
-		this.sidebar.find(".sidebar-stat").remove();
-		this.sidebar.find(".list-tag-preview").remove();
+		this.sidebar.find(".stat-link").remove();
+		this.sidebar.find(".stat-no-records").remove();
 		this.get_stats();
 	}
 

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -285,7 +285,8 @@ frappe.views.ListSidebar = class ListSidebar {
 			args: {
 				stats: me.stats,
 				doctype: me.doctype,
-				filters: me.default_filters || []
+				// wait for list filter area to be generated before getting filters, or fallback to default filters
+				filters: (me.list_view.filter_area ? me.list_filter.get_current_filters() : me.default_filters) || []
 			},
 			callback: function(r) {
 				me.render_stat("_user_tags", (r.message.stats || {})["_user_tags"]);
@@ -386,6 +387,7 @@ frappe.views.ListSidebar = class ListSidebar {
 
 	reload_stats() {
 		this.sidebar.find(".sidebar-stat").remove();
+		this.sidebar.find(".list-tag-preview").remove();
 		this.get_stats();
 	}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -390,6 +390,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		});
 	}
 
+	after_render() {
+		this.list_sidebar.reload_stats();
+	}
+
 	render() {
 		this.render_list();
 		this.on_row_checked();

--- a/frappe/public/less/sidebar.less
+++ b/frappe/public/less/sidebar.less
@@ -400,7 +400,9 @@ body[data-route^="Module"] .main-menu {
 		max-height: 300px;
 		overflow-y: auto;
 		max-width: 250px;
+		z-index: 100;
 	}
+
 	.dropdown-search {
 		padding: 8px;
 	}


### PR DESCRIPTION
**Problem:**

If a user applies filters to a DocType with tagged documents, the system considers all the documents in the doctype and ignores the filters completely.

**Solution:**

If filters are applied to tagged documents, the system reloads the tags to only include the filtered documents.

<hr>

**Screenshots / GIFs:**

![ezgif com-video-to-gif(5)](https://user-images.githubusercontent.com/7310479/69231780-bdd11500-0baf-11ea-8c00-7a04b8251fc2.gif)

