### PR TITLE
fix(eps): Allow creation of new point log if old logs were reverted

### DIFF
--- a/frappe/social/doctype/energy_point_log/energy_point_log.js
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.js
@@ -21,14 +21,15 @@ frappe.ui.form.on('Energy Point Log', {
 				reqd: 1
 			}],
 			primary_action: (values) => {
-				return frappe.xcall('frappe.social.doctype.energy_point_log.energy_point_log.revert', {
-					'name': frm.doc.name,
+				return frm.call('revert', {
 					'reason': values.reason
-				}).then(revert_log => {
+				}).then(res => {
+					let revert_log = res.message;
 					revert_dialog.hide();
 					revert_dialog.clear();
 					frappe.model.docinfo[frm.doc.reference_doctype][frm.doc.reference_name].energy_point_logs.unshift(revert_log);
-				}).catch(() => {});
+					frm.refresh();
+				});
 			},
 			primary_action_label: __('Submit')
 		});

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -44,6 +44,35 @@ class EnergyPointLog(Document):
 
 			enqueue_create_notification(self.user, notification_doc)
 
+	def on_trash(self):
+		if self.type == 'Revert':
+			reference_log = frappe.get_doc('Energy Point Log', self.revert_of)
+			reference_log.reverted = 0
+			reference_log.save()
+
+	def revert(self, reason):
+		frappe.only_for('System Manager')
+		if self.type != 'Auto':
+			frappe.throw(_('This document cannot be reverted'))
+
+		if self.reverted: return
+
+		self.reverted = 1
+		self.save(ignore_permissions=True)
+
+		revert_log = frappe.get_doc({
+			'doctype': 'Energy Point Log',
+			'points': -(self.points),
+			'type': 'Revert',
+			'user': self.user,
+			'reason': reason,
+			'reference_doctype': self.reference_doctype,
+			'reference_name': self.reference_name,
+			'revert_of': self.name
+		}).insert(ignore_permissions=True)
+
+		return revert_log
+
 def get_notification_message(doc):
 	owner_name = get_fullname(doc.owner)
 	points = doc.points
@@ -258,32 +287,6 @@ def get_reviews(doctype, docname):
 		'type': ['in', ('Appreciation', 'Criticism')],
 	}, fields=['points', 'owner', 'type', 'user', 'reason', 'creation'])
 
-@frappe.whitelist()
-def revert(name, reason):
-	frappe.only_for('System Manager')
-	doc_to_revert = frappe.get_doc('Energy Point Log', name)
-
-	if doc_to_revert.type != 'Auto':
-		frappe.throw(_('This document cannot be reverted'))
-
-	if doc_to_revert.reverted: return
-
-	doc_to_revert.reverted = 1
-	doc_to_revert.save(ignore_permissions=True)
-
-	revert_log = frappe.get_doc({
-		'doctype': 'Energy Point Log',
-		'points': -(doc_to_revert.points),
-		'type': 'Revert',
-		'user': doc_to_revert.user,
-		'reason': reason,
-		'reference_doctype': doc_to_revert.reference_doctype,
-		'reference_name': doc_to_revert.reference_name,
-		'revert_of': doc_to_revert.name
-	}).insert(ignore_permissions=True)
-
-	return revert_log
-
 def send_weekly_summary():
 	send_summary('Weekly')
 
@@ -326,5 +329,3 @@ def get_footer_message(timespan):
 		return _("Stats based on last month's performance (from {0} to {1})")
 	else:
 		return _("Stats based on last week's performance (from {0} to {1})")
-
-

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -55,7 +55,8 @@ class EnergyPointLog(Document):
 		if self.type != 'Auto':
 			frappe.throw(_('This document cannot be reverted'))
 
-		if self.get('reverted'): return
+		if self.get('reverted'):
+			return
 
 		self.reverted = 1
 		self.save(ignore_permissions=True)

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -55,7 +55,7 @@ class EnergyPointLog(Document):
 		if self.type != 'Auto':
 			frappe.throw(_('This document cannot be reverted'))
 
-		if self.reverted: return
+		if self.get('reverted'): return
 
 		self.reverted = 1
 		self.save(ignore_permissions=True)

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -149,7 +149,8 @@ def check_if_log_exists(ref_doctype, ref_name, rule, user=None):
 	filters = frappe._dict({
 		'rule': rule,
 		'reference_doctype': ref_doctype,
-		'reference_name': ref_name
+		'reference_name': ref_name,
+		'reverted': 0
 	})
 
 	if user:

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -8,7 +8,7 @@ from frappe import _
 import frappe.cache_manager
 from frappe.model.document import Document
 from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
-from frappe.social.doctype.energy_point_log.energy_point_log import create_energy_points_log, revert
+from frappe.social.doctype.energy_point_log.energy_point_log import create_energy_points_log
 
 class EnergyPointRule(Document):
 	def on_update(self):
@@ -106,7 +106,7 @@ def revert_points_for_cancelled_doc(doc):
 		'type': 'Auto'
 	})
 	for log in energy_point_logs:
-		revert(log.name, _('Reference document has been cancelled'))
+		frappe.get_doc('Energy Point Log', log.name).revert(_('Reference document has been cancelled'))
 
 
 def get_energy_point_doctypes():

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -8,7 +8,8 @@ from frappe import _
 import frappe.cache_manager
 from frappe.model.document import Document
 from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
-from frappe.social.doctype.energy_point_log.energy_point_log import create_energy_points_log
+from frappe.social.doctype.energy_point_log.energy_point_log import \
+	create_energy_points_log
 
 class EnergyPointRule(Document):
 	def on_update(self):
@@ -106,7 +107,8 @@ def revert_points_for_cancelled_doc(doc):
 		'type': 'Auto'
 	})
 	for log in energy_point_logs:
-		frappe.get_doc('Energy Point Log', log.name).revert(_('Reference document has been cancelled'))
+		reference_log = frappe.get_doc('Energy Point Log', log.name)
+		reference_log.revert(_('Reference document has been cancelled'))
 
 
 def get_energy_point_doctypes():


### PR DESCRIPTION
- Allow creation of new point log if old logs were reverted
(Previously, once the point log is created against a doc, the was no way to create a log for the same user again even if the previous log was reverted)
- Moved revert functionality to the controller
