### PR TITLE
fix: update sidebar tags on changing list filters (v11)

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -400,7 +400,7 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	after_render() {
-		this.list_sidebar.reload_stats();
+
 	}
 
 	render() {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -400,7 +400,7 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	after_render() {
-
+		this.list_sidebar.reload_stats();
 	}
 
 	render() {

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -263,7 +263,8 @@ frappe.views.ListSidebar = class ListSidebar {
 			args: {
 				stats: me.stats,
 				doctype: me.doctype,
-				filters: me.default_filters || []
+				// wait for list filter area to be generated before getting filters, or fallback to default filters
+				filters: (me.list_view.filter_area ? me.list_filter.get_current_filters() : me.default_filters) || []
 			},
 			callback: function(r) {
 				me.defined_category = r.message;
@@ -383,6 +384,7 @@ frappe.views.ListSidebar = class ListSidebar {
 
 	reload_stats() {
 		this.sidebar.find(".sidebar-stat").remove();
+		this.sidebar.find(".list-tag-preview").remove();
 		this.get_stats();
 	}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -348,6 +348,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		});
 	}
 
+	after_render() {
+		this.list_sidebar.reload_stats();
+	}
+
 	render() {
 		this.$result.find('.list-row-container').remove();
 		if (this.data.length > 0) {


### PR DESCRIPTION
**Problem:**

If a user applies filters to a DocType with tagged documents, the system considers all the documents in the doctype and ignores the filters completely.

**Solution:**

If filters are applied to tagged documents, the system reloads the tags to only include the filtered documents.

<hr>

**Screenshots / GIFs:**

![tag-filters](https://user-images.githubusercontent.com/13396535/68850592-4e17e180-06fa-11ea-8cc2-b7e3be5641c6.gif)