### PR TITLE
fix(pdf): Remove unnecessary argument

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -90,7 +90,7 @@ def as_json():
 def as_pdf():
 	response = Response()
 	response.mimetype = "application/pdf"
-	encoded_filename = quote(frappe.response['filename'].replace(' ', '_'), encoding='utf-8')
+	encoded_filename = quote(frappe.response['filename'].replace(' ', '_'))
 	response.headers["Content-Disposition"] = ("filename=\"%s\"" % frappe.response['filename'].replace(' ', '_') + ";filename*=utf-8''%s" % encoded_filename).encode("utf-8")
 	response.data = frappe.response['filecontent']
 	return response


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/8707 trying to generate PDF from Report throws following error on Python 2
![photo_2019-11-15_15-47-53](https://user-images.githubusercontent.com/8528887/68935908-656cd280-07bf-11ea-9cc8-62c466294b2a.jpg)
