### PR TITLE
fix: Cache can_import for all users and not just System Managers

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -3,19 +3,20 @@
 
 frappe.ui.form.on('Data Import', {
 	onload: function(frm) {
-		if(frm.doc.__islocal) {
+		if (frm.doc.__islocal) {
 			frm.set_value("action", "");
 		}
 
 		frappe.call({
-			method: "frappe.core.doctype.data_import.data_import.get_importable_doc",
+			method: "frappe.core.doctype.data_import.data_import.get_importable_doctypes",
 			callback: function (r) {
+				let importable_doctypes = r.message;
 				frm.set_query("reference_doctype", function () {
 					return {
 						"filters": {
 							"issingle": 0,
 							"istable": 0,
-							"name": ['in', r.message]
+							"name": ['in', importable_doctypes]
 						}
 					};
 				});

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -30,9 +30,8 @@ class DataImport(Document):
 
 
 @frappe.whitelist()
-def get_importable_doc():
-	import_lst = frappe.cache().hget("can_import", frappe.session.user)
-	return import_lst
+def get_importable_doctypes():
+	return frappe.cache().hget("can_import", frappe.session.user)
 
 @frappe.whitelist()
 def import_data(data_import):

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -161,7 +161,8 @@ class UserPermissions:
 			for docname in docs:
 				if frappe.get_meta(docname, cached=True).allow_import == 1:
 					self.can_import.append(docname)
-			frappe.cache().hset("can_import", frappe.session.user, self.can_import)
+
+		frappe.cache().hset("can_import", frappe.session.user, self.can_import)
 
 	def get_defaults(self):
 		import frappe.defaults


### PR DESCRIPTION
Users who are not System Managers were not able to see any doctype in the Data Import page even if they had rights to import.
![image](https://user-images.githubusercontent.com/13928957/68941140-0319cf00-07cb-11ea-8582-f58a6001dbba.png)


