### PR TITLE
fix: Handle overflow in version info

### DIFF
--- a/frappe/core/doctype/version/version.css
+++ b/frappe/core/doctype/version/version.css
@@ -1,3 +1,7 @@
+.version-info {
+	overflow: auto;
+}
+
 .version-info pre {
 	border: 0px;
 	margin: 0px;


### PR DESCRIPTION
Added `overflow: auto` to the container.

Before:

![image](https://user-images.githubusercontent.com/9355208/69004556-4eeb8600-093b-11ea-8321-fac600831370.png)


After:

![image](https://user-images.githubusercontent.com/9355208/69004555-3ed3a680-093b-11ea-899b-8d0af8db5224.png)
