### PR TITLE
feat: new field type Link multi select

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -108,7 +108,7 @@
    "no_copy": 0,
    "oldfieldname": "fieldtype",
    "oldfieldtype": "Select",
-   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRead Only\nRating\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
+   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nImage\nInt\nLink\nLink MultiSelect\nLong Text\nMarkdown Editor\nPassword\nPercent\nRead Only\nRating\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
    "permlevel": 0,
    "print_hide": 0,
    "print_hide_if_no_value": 0,

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -45,6 +45,7 @@ class MariaDBDatabase(Database):
 			'Text':			('text', ''),
 			'Data':			('varchar', self.VARCHAR_LEN),
 			'Link':			('varchar', self.VARCHAR_LEN),
+			'Link MultiSelect':	('varchar', self.VARCHAR_LEN),
 			'Dynamic Link':	('varchar', self.VARCHAR_LEN),
 			'Password':		('varchar', self.VARCHAR_LEN),
 			'Select':		('varchar', self.VARCHAR_LEN),

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -50,6 +50,7 @@ class PostgresDatabase(Database):
 			'Text':			('text', ''),
 			'Data':			('varchar', self.VARCHAR_LEN),
 			'Link':			('varchar', self.VARCHAR_LEN),
+			'Link MultiSelect':	('varchar', self.VARCHAR_LEN),
 			'Dynamic Link':	('varchar', self.VARCHAR_LEN),
 			'Password':		('varchar', self.VARCHAR_LEN),
 			'Select':		('varchar', self.VARCHAR_LEN),

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -24,6 +24,7 @@ data_fieldtypes = (
 	'Text',
 	'Data',
 	'Link',
+	'Link MultiSelect',
 	'Dynamic Link',
 	'Password',
 	'Select',

--- a/frappe/public/js/frappe/form/controls/control.js
+++ b/frappe/public/js/frappe/form/controls/control.js
@@ -34,6 +34,7 @@ import './barcode';
 import './geolocation';
 import './multiselect';
 import './multicheck';
+import './link_multiselect';
 import './table_multiselect';
 import './multiselect_pills';
 import './multiselect_list';

--- a/frappe/public/js/frappe/form/controls/link_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/link_multiselect.js
@@ -1,0 +1,133 @@
+frappe.ui.form.ControlLinkMultiSelect = frappe.ui.form.ControlLink.extend({
+	make_input() {
+		this._super();
+
+		this.$input_area.addClass('form-control table-multiselect');
+		this.$input.removeClass('form-control');
+
+		this.$input.on("awesomplete-selectcomplete", () => {
+			this.$input.val('').focus();
+		});		
+		// used as an internal model to store values
+		this.rows = [];
+
+		this.$input_area.on('click', (e) => {
+			if (e.target === this.$input_area.get(0)) {
+				this.$input.focus();
+			}
+		});
+
+		this.$input_area.on('click', '.btn-remove', (e) => {
+			const $target = $(e.currentTarget);
+			const $value = $target.closest('.tb-selected-value');
+
+			const value = decodeURIComponent($value.data().value);
+			this.rows = this.rows.filter(row => row !== value);
+
+			this.parse_validate_and_set_in_model('');
+		});
+		this.$input_area.on('click', '.btn-link-to-form', (e) => {
+			const $target = $(e.currentTarget);
+			const $value = $target.closest('.tb-selected-value');
+
+			const value = decodeURIComponent($value.data().value);
+			frappe.set_route('Form', this.df.options, value);
+		});
+		this.$input.on('keydown', e => {
+			// if backspace key pressed on empty input, delete last value
+			if (e.keyCode == frappe.ui.keyCode.BACKSPACE && e.target.value === '') {
+				this.rows = this.rows.slice(0, this.rows.length - 1);
+				this.parse_validate_and_set_in_model('');
+			}
+		});
+	},
+	setup_buttons() {
+		this.$input_area.find('.link-btn').remove();
+	},
+
+	parse(value) {
+		if (value) {
+			this.rows.push(value);
+		}
+		return this.rows.join(",");
+	},
+
+	validate(value) {
+		if (value === "") return;
+		if (typeof value === "string") value = value.split(",")
+
+		const rows = (value || []).slice();
+
+		if (rows.length === 0) {
+			return rows;
+		}
+
+		const all_rows_except_last = rows.slice(0, rows.length - 1);
+		const last_value = rows[rows.length - 1];
+
+		// falsy value
+		if (!last_value) {
+			return all_rows_except_last;
+		}
+
+		// duplicate value
+		if (all_rows_except_last.includes(last_value)) {
+			return all_rows_except_last;
+		}
+
+		return rows.join(",");
+	},
+	
+	set_formatted_input(value) {
+		if (typeof value === "string") value = value.split(",")
+		this.rows = value || [];
+		this.set_pill_html(this.rows);
+	},
+	set_pill_html(values) {
+		const html = values
+			.map(value => this.get_pill_html(value))
+			.join('');
+
+		this.$input_area.find('.tb-selected-value').remove();
+		this.$input_area.prepend(html);
+	},
+	get_pill_html(value) {
+		const encoded_value = encodeURIComponent(value);
+		return `<div class="btn-group tb-selected-value" data-value="${encoded_value}">
+			<button class="btn btn-default btn-xs btn-link-to-form">${__(value)}</button>
+			<button class="btn btn-default btn-xs btn-remove">
+				<i class="fa fa-remove text-muted"></i>
+			</button>
+		</div>`;
+	},
+
+	get_value() {
+		return this.rows;
+	},
+
+	get_values() {
+		return this.rows;
+	},
+
+	get_data() {
+		let data;
+		if(this.df.get_data) {
+			data = this.df.get_data();
+			if (data && data.then) {
+				data.then((r) => {
+					this.set_data(r);
+				});
+				data = this.get_value();
+			} else {
+				this.set_data(data);
+			}
+		} else {
+			data = this._super();
+		}
+		const values = this.get_values() || [];
+
+		// return values which are not already selected
+		if (data) data.filter(d => !values.includes(d));
+		return data;
+	}
+});


### PR DESCRIPTION
The recently introduced new table multi select field type is great,  to use the new table multi select field, it is needed to create a separate doctype(table) with only one link field, then reference this new doctype as option. because currently the frappe core does not support grand child( child under child), so the new table multi select field can not be used in child doctype.

This new Link MultiSelect field type works like the existing Link field, but support selecting multi link values(like the table multi select), the multi selected value is stored in database as comma(,) separated pure text.
![multi select doctype definition](https://user-images.githubusercontent.com/12823863/69020460-8451ab80-09ef-11ea-997f-4e4fbe482fdd.PNG)
Fig 1: field definition
![multi select](https://user-images.githubusercontent.com/12823863/69020471-8a478c80-09ef-11ea-8b9f-ba47b3b80a7a.PNG)
Fig 2: how it can be used in child table in form
![multi select stored data](https://user-images.githubusercontent.com/12823863/69020476-903d6d80-09ef-11ea-9fe1-82651f456ed4.PNG)
Fig 3: how the data stored in database

LinkMultiSelect change log
1. model/__init__.py
	line 27 add 'Link MultiSelect', after link as part of data_fieldtypes
	
2. add public/js/frappe/form/controls/multi_linkselect.js

3. line 37 add import './link_multiselect';  in public/js/frappe/form/controls.control.js

4. core/doctype/docfield add Link MultiSelect as options for fieldtype

5. database/mariadb/database.py line 48 add 'Link MultiSelect':	('varchar', self.VARCHAR_LEN),

6. database/postgresql/database.py line 53 add 'Link MultiSelect':	('varchar', self.VARCHAR_LEN),





