### PR TITLE
fix: layout & api for message print

### DIFF
--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -101,6 +101,10 @@ h4.modal-title {
   font-size: 1em;
 }
 
+h5.modal-title {
+  margin: 0px !important;
+}
+
 .col-xs-1 { @extend .col-1; }
 .col-xs-2 { @extend .col-2; }
 .col-xs-3 { @extend .col-3; }

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -132,12 +132,12 @@ $.extend(frappe, {
 
 		if (data._server_messages) {
 			var server_messages = JSON.parse(data._server_messages || '[]');
-			server_messages = $.map(server_messages, function(v) {
+			server_messages.map((msg) => {
 				// temp fix for messages sent as dict
 				try {
-					return JSON.parse(v).message;
+					return JSON.parse(msg);
 				} catch (e) {
-					return v;
+					return msg;
 				}
 			}).join('<br>');
 


### PR DESCRIPTION

## Layout Fix

Before
<img width="516" alt="Screenshot 2019-11-18 at 1 13 43 PM" src="https://user-images.githubusercontent.com/18097732/69033669-7870e400-0a05-11ea-85fd-3178d5b04994.png">

After
<img width="508" alt="Screenshot 2019-11-18 at 1 14 33 PM" src="https://user-images.githubusercontent.com/18097732/69033666-7870e400-0a05-11ea-9344-4eb54fefc540.png">

## API fix
- Enabled using title in msgprint in `process_response`