### PR TITLE
feat: Handle server and client side primary action in msgprint

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -290,7 +290,7 @@ def log(msg):
 
 	debug_log.append(as_unicode(msg))
 
-def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None, alert=False):
+def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None, alert=False, primary_action=None):
 	"""Print a message to the user (via HTTP response).
 	Messages are sent in the `__server_messages` property in the
 	response JSON and shown in a pop-up / modal.
@@ -299,6 +299,7 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None,
 	:param title: [optional] Message title.
 	:param raise_exception: [optional] Raise given exception and show message.
 	:param as_table: [optional] If `msg` is a list of lists, render as HTML table.
+	:param primary_action: [optional] Bind a primary server/client side action.
 	"""
 	from frappe.utils import encode
 
@@ -337,6 +338,9 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None,
 
 	if alert:
 		out.alert = 1
+
+	if primary_action:
+		out.primary_action = primary_action
 
 	message_log.append(json.dumps(out))
 

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -150,7 +150,7 @@ frappe.msgprint = function(msg, title) {
 				__(data.primary_action.label || "Done"),
 				data.primary_action.action
 			);
-	}
+		}
 
 		// class "msgprint" is used in tests
 		frappe.msg_dialog.msg_area = $('<div class="msgprint">')

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -123,15 +123,14 @@ frappe.msgprint = function(msg, title) {
 		// setup and bind an action to the primary button
 		if (data.primary_action) {
 			if (data.primary_action.server_action && typeof data.primary_action.server_action === 'string') {
-				frappe.msg_dialog.set_primary_action(__(data.primary_action.label || "Done"),
-					() => {
-						frappe.call({
-							method: data.primary_action.server_action,
-							args: {
-								args: data.primary_action.args
-							}
-						});
+				data.primary_action.action = () => {
+					frappe.call({
+						method: data.primary_action.server_action,
+						args: {
+							args: data.primary_action.args
+						}
 					});
+				}
 			}
 
 			if (data.primary_action.client_action && typeof data.primary_action.client_action === 'string') {
@@ -140,19 +139,18 @@ frappe.msgprint = function(msg, title) {
 				for (let part of parts) {
 					obj = obj[part];
 				}
-				frappe.msg_dialog.set_primary_action(
-					__(data.primary_action.label || "Done"),
-					() => {
-						if (typeof obj === 'function') {
-							obj(data.primary_action.args);
-						}
+				data.primary_action.action = () => {
+					if (typeof obj === 'function') {
+						obj(data.primary_action.args);
 					}
-				);
-			} else {
-				frappe.msg_dialog.set_primary_action(__(data.primary_action.label || "Done"),
-				data.primary_action.action);
+				}
 			}
-		}
+
+			frappe.msg_dialog.set_primary_action(
+				__(data.primary_action.label || "Done"),
+				data.primary_action.action
+			);
+	}
 
 		// class "msgprint" is used in tests
 		frappe.msg_dialog.msg_area = $('<div class="msgprint">')

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -122,8 +122,36 @@ frappe.msgprint = function(msg, title) {
 
 		// setup and bind an action to the primary button
 		if (data.primary_action) {
-			frappe.msg_dialog.set_primary_action(__(data.primary_action.label || "Done"),
+			if (data.primary_action.server_action && typeof data.primary_action.server_action === 'string') {
+				frappe.msg_dialog.set_primary_action(__(data.primary_action.label || "Done"),
+					() => {
+						frappe.call({
+							method: data.primary_action.server_action,
+							args: {
+								args: data.primary_action.args
+							}
+						});
+					});
+			}
+
+			if (data.primary_action.client_action && typeof data.primary_action.client_action === 'string') {
+				let parts = data.primary_action.client_action.split('.');
+				let obj = window;
+				for (let part of parts) {
+					obj = obj[part];
+				}
+				frappe.msg_dialog.set_primary_action(
+					__(data.primary_action.label || "Done"),
+					() => {
+						if (typeof obj === 'function') {
+							obj(data.primary_action.args);
+						}
+					}
+				);
+			} else {
+				frappe.msg_dialog.set_primary_action(__(data.primary_action.label || "Done"),
 				data.primary_action.action);
+			}
 		}
 
 		// class "msgprint" is used in tests


### PR DESCRIPTION
- Added provision to pass 'primary action' from server side **msgprint** method
- **msgprint**  on client side handles server side and client side methods as primary actions
- **Usage (Server side)**:
```python
        frappe.msgprint(msg, title, 
             primary_action={
                'label': 'Do Something',
                'server_action': 'dotted.path.to.method',
	        'client_action': 'dotted_path.to_method',
	        'args': args 
        })
```

- **Use Case:** Routing to an adjustment Journal Voucher (with JV data) via msgprint called from the server side.
![Screenshot 2019-11-18 at 3 30 47 PM](https://user-images.githubusercontent.com/25857446/69043030-487f0c00-0a18-11ea-9510-83ccb9195331.png)
