### PR TITLE
fix: permission issue for activity

### DIFF
--- a/frappe/core/doctype/activity_log/feed.py
+++ b/frappe/core/doctype/activity_log/feed.py
@@ -81,9 +81,9 @@ def get_feed_match_conditions(user=None, doctype='Comment'):
 
 		if user_permissions:
 			can_read_docs = []
-			for doctype, obj in user_permissions.items():
+			for dt, obj in user_permissions.items():
 				for n in obj:
-					can_read_docs.append('{}|{}'.format(doctype, frappe.db.escape(n.get('doc', ''))))
+					can_read_docs.append('{}|{}'.format(frappe.db.escape(dt), frappe.db.escape(n.get('doc', ''))))
 
 			if can_read_docs:
 				conditions.append("concat_ws('|', `tab{doctype}`.reference_doctype, `tab{doctype}`.reference_name) in ({values})".format(


### PR DESCRIPTION
Fixes: ``` File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column 'tabCompany.reference_doctype' in 'where clause'")```