### PR TITLE
feat(Contacts): Show is Billing Contact tagging for contacts

### DIFF
--- a/frappe/contacts/doctype/contact/contact.json
+++ b/frappe/contacts/doctype/contact/contact.json
@@ -34,6 +34,7 @@
   "phone_nos",
   "contact_details",
   "is_primary_contact",
+  "is_billing_contact",
   "links",
   "more_info",
   "department",
@@ -240,12 +241,18 @@
    "fieldname": "company_name",
    "fieldtype": "Data",
    "label": "Company Name"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_billing_contact",
+   "fieldtype": "Check",
+   "label": "Is Billing Contact"
   }
  ],
  "icon": "fa fa-user",
  "idx": 1,
  "image_field": "image",
- "modified": "2019-10-10 22:04:41.070479",
+ "modified": "2019-11-15 10:38:59.623989",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Contact",

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -33,6 +33,20 @@ class TestContact(unittest.TestCase):
 		self.assertEqual(contact.phone, "+91 0000000002")
 		self.assertEqual(contact.mobile_no, "+91 0000000003")
 
+	def test_primary_and_billing(self):
+		test_contacts = [
+			{"first_name": "Jane", "salutation": "Ms", "is_primary_contact": 0, "is_billing_contact": 1},
+			{"first_name": "Joe", "salutation": "Mr", "is_primary_contact": 1, "is_billing_contact": 1},
+			{"first_name": "Jason", "salutation": "Dr", "is_primary_contact": 1, "is_billing_contact": 0}
+		]
+		for contact in test_contacts:
+			doc_contact = create_contact(contact.get("first_name"), contact.get("salutation"))
+			doc_contact.is_primary_contact = contact.get("is_primary_contact")
+			doc_contact.is_billing_contact = contact.get("is_billing_contact")
+			doc_contact.save()
+			self.assertEqual(doc_contact.is_primary_contact, contact.get("is_primary_contact"))
+			self.assertEqual(doc_contact.is_billing_contact, contact.get("is_billing_contact"))
+
 def create_contact(name, salutation, emails=None, phones=None, save=True):
 	doc = frappe.get_doc({
 			"doctype": "Contact",


### PR DESCRIPTION
Most of the time, point of contact are different from sale, invoicing and on different aspect/phase of the transaction. This feature is to have contacts that are identified for billing.

![Screen Shot 2019-11-18 at 5 31 51 PM](https://user-images.githubusercontent.com/44422325/69040951-aec05a80-0a29-11ea-8851-ad2a7ec7d2c5.png)

### Unit Test
![Screen Shot 2019-11-19 at 10 29 01 AM](https://user-images.githubusercontent.com/44422325/69111133-926aff00-0ab7-11ea-82dd-849b46faceb8.png)


### Creating new Contact with is Billing Contact
![core is billing contact new contact](https://user-images.githubusercontent.com/44422325/69040973-b4b63b80-0a29-11ea-97f7-1f46272e7a63.gif)


### Usage:

Billing contact will be retrieved during creation of Invoice as point of contact at this stage is different from sale or other aspect/stage of the transaction.

![core is billing contact](https://user-images.githubusercontent.com/44422325/69041081-dd3e3580-0a29-11ea-9f4a-d2f891602aa9.gif)
