### PR TITLE
fix: revert "unique" fields in chat_token and chat_profile

### DIFF
--- a/frappe/chat/doctype/chat_profile/chat_profile.json
+++ b/frappe/chat/doctype/chat_profile/chat_profile.json
@@ -22,8 +22,7 @@
    "fieldtype": "Link",
    "label": "User",
    "options": "User",
-   "reqd": 1,
-   "unique": 1
+   "reqd": 1
   },
   {
    "default": "Online",

--- a/frappe/chat/doctype/chat_token/chat_token.json
+++ b/frappe/chat/doctype/chat_token/chat_token.json
@@ -16,8 +16,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Token",
-   "reqd": 1,
-   "unique": 1
+   "reqd": 1
   },
   {
    "fieldname": "ip_address",


### PR DESCRIPTION
![Screenshot 2019-11-19 at 9 35 41 AM](https://user-images.githubusercontent.com/36654812/69117119-c09b0f80-0ab4-11ea-9076-d04fa6aac641.png)
