### PR TITLE
fix(List): standard filters with default value are saved when changed

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -646,11 +646,11 @@ class FilterArea {
 		for (let key in fields_dict) {
 			let field = fields_dict[key];
 			let value = field.get_value();
-			let default_value = (field.df.fieldtype === 'Link')
-				? frappe.defaults.get_user_default(field.df.options)
-				: null;
-			if (['__default', '__global'].includes(default_value)) {	
-				default_value = null;	
+			let default_value = (field.df.fieldtype === 'Link') ?
+				frappe.defaults.get_user_default(field.df.options) : null;
+
+			if (['__default', '__global'].includes(default_value)) {
+				default_value = null;
 			}
 
 			if (value) {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -649,6 +649,9 @@ class FilterArea {
 			let default_value = (field.df.fieldtype === 'Link')
 				? frappe.defaults.get_user_default(field.df.options)
 				: null;
+			if (['__default', '__global'].includes(default_value)) {	
+				default_value = null;	
+			}
 
 			if (value) {
 				if (field.df.condition === 'like' && !value.includes('%')) {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -625,17 +625,13 @@ class FilterArea {
 					options = options.join("\n");
 				}
 			}
-			let default_value = (fieldtype === 'Link') ? frappe.defaults.get_user_default(options) : null;
-			if (['__default', '__global'].includes(default_value)) {
-				default_value = null;
-			}
+
 			return {
 				fieldtype: fieldtype,
 				label: __(df.label),
 				options: options,
 				fieldname: df.fieldname,
 				condition: condition,
-				default: default_value,
 				onchange: () => this.refresh_list_view(),
 				ignore_link_validation: fieldtype === 'Dynamic Link'
 			};
@@ -650,6 +646,10 @@ class FilterArea {
 		for (let key in fields_dict) {
 			let field = fields_dict[key];
 			let value = field.get_value();
+			let default_value = (field.df.fieldtype === 'Link')
+				? frappe.defaults.get_user_default(field.df.options)
+				: null;
+
 			if (value) {
 				if (field.df.condition === 'like' && !value.includes('%')) {
 					value = '%' + value + '%';
@@ -659,6 +659,13 @@ class FilterArea {
 					field.df.fieldname,
 					field.df.condition || '=',
 					value
+				]);
+			} else if (default_value) {
+				filters.push([
+					this.list_view.doctype,
+					field.df.fieldname,
+					field.df.condition,
+					default_value
 				]);
 			}
 		}


### PR DESCRIPTION
Standard filter fields that had a default value, would be reset to that value on refresh even if changed:

![std-filter](https://user-images.githubusercontent.com/19775888/69133398-d53ece00-0adb-11ea-8741-153f027e2d45.gif)


After:

![std-filter-after](https://user-images.githubusercontent.com/19775888/69133419-de2f9f80-0adb-11ea-8045-c8ecf46b4e16.gif)



If no value is set, then the default value is set