### PR TITLE
feat(ux): added noscript for login page

### DIFF
--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -11,8 +11,8 @@
 <div style='min-height: 360px'>
 	<noscript>
 		<div class="text-center my-5">
-			<h4>Javascript is disabled on your browser</h4>
-			<p class="text-muted">You need to enable JavaScript for your app to work. <br>To enable it follow the instructions in the following link: <a href="https://enable-javascript.com/">enable-javascript.com</a></p>
+			<h4>{{ _("Javascript is disabled on your browser") }}</h4>
+			<p class="text-muted">{{ _("You need to enable JavaScript for your app to work.") }}<br>{{ _("To enable it follow the instructions in the following link: {0}").format("<a href='https://enable-javascript.com/'>enable-javascript.com</a></p>") }}
 		</div>
 	</noscript>
 <section class='for-login'>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -9,6 +9,12 @@
 {% block page_content %}
 <!-- {{ for_test }} -->
 <div style='min-height: 360px'>
+	<noscript>
+		<div class="text-center my-5">
+			<h4>Javascript is disabled on your browser</h4>
+			<p class="text-muted">You need to enable JavaScript for your app to work. <br>To enable it follow the instructions in the following link: <a href="https://enable-javascript.com/">enable-javascript.com</a></p>
+		</div>
+	</noscript>
 <section class='for-login'>
 	<div class="login-content page-card" style="margin-top: 30px;">
 		<form class="form-signin form-login" role="form">


### PR DESCRIPTION
Added `<noscript>` message for login page. [[ref](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript)]

<img width="1228" alt="Screenshot 2019-11-19 at 3 07 16 PM" src="https://user-images.githubusercontent.com/18097732/69135117-92322a00-0ade-11ea-88b5-f69f9ee1b3d0.png">
