### PR TITLE
fix: change code type to data in standard filter

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -614,7 +614,7 @@ class FilterArea {
 			let options = df.options;
 			let condition = '=';
 			let fieldtype = df.fieldtype;
-			if (['Text', 'Small Text', 'Text Editor', 'Data'].includes(fieldtype)) {
+			if (['Text', 'Small Text', 'Text Editor', 'Data', 'Code'].includes(fieldtype)) {
 				fieldtype = 'Data';
 				condition = 'like';
 			}


### PR DESCRIPTION
Code field in standard fields would add ace editor field, breaking the entire view.

## Preview for the Fix

Before
<img width="1230" alt="Screenshot 2019-11-19 at 3 41 02 PM" src="https://user-images.githubusercontent.com/18097732/69137568-07076300-0ae3-11ea-9f54-46e0559216fb.png">

After
<img width="1234" alt="Screenshot 2019-11-19 at 3 41 30 PM" src="https://user-images.githubusercontent.com/18097732/69137587-1090cb00-0ae3-11ea-93e5-c7188bb80e71.png">
