### PR TITLE
fix: value not being set in webform

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -40,7 +40,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	}
 
 	set_field_values() {
-		if (this.doc_name) this.set_values(this.doc);
+		if (this.doc.name) this.set_values(this.doc);
 		else return;
 	}
 


### PR DESCRIPTION
`this.doc_name` is no longer used, the set value could rely on `doc.name` instead.