### PR TITLE
fix(web-forms): view addresses only by session user

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -145,30 +145,10 @@ def get_list_context(context=None):
 def get_address_list(doctype, txt, filters, limit_start, limit_page_length = 20, order_by = None):
 	from frappe.www.list import get_list
 	user = frappe.session.user
-	ignore_permissions = False
-	if is_website_user():
-		if not filters: filters = []
-		add_name = []
-		contact = frappe.db.sql("""
-			select
-				address.name
-			from
-				`tabDynamic Link` as link
-			join
-				`tabAddress` as address on link.parent = address.name
-			where
-				link.parenttype = 'Address' and
-				link_name in(
-				   select
-					   link.link_name from `tabContact` as contact
-				   join
-					   `tabDynamic Link` as link on contact.name = link.parent
-				   where
-					   contact.user = %s)""",(user))
-		for c in contact:
-			add_name.append(c[0])
-		filters.append(("Address", "name", "in", add_name))
-		ignore_permissions = True
+	ignore_permissions = True
+
+	if not filters: filters = []
+	filters.append(("Address", "owner", "=", user))
 
 	return get_list(doctype, txt, filters, limit_start, limit_page_length, ignore_permissions=ignore_permissions)
 


### PR DESCRIPTION
reverts https://github.com/frappe/frappe/pull/3678 (not functional anymore)

**This Functionality:** Only show users addresses they've added