### PR TITLE
fix: PDF generation from print view

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -90,7 +90,7 @@ def as_json():
 def as_pdf():
 	response = Response()
 	response.mimetype = "application/pdf"
-	encoded_filename = quote(frappe.response['filename'].replace(' ', '_'), encoding='utf-8')
+	encoded_filename = quote(frappe.response['filename'].replace(' ', '_').encode('utf-8'))
 	response.headers["Content-Disposition"] = ("filename=\"%s\"" % frappe.response['filename'].replace(' ', '_') + ";filename*=utf-8''%s" % encoded_filename).encode("utf-8")
 	response.data = frappe.response['filecontent']
 	return response


### PR DESCRIPTION
Changes of [this PR](https://github.com/frappe/frappe/pull/8707/) use to fail in Python 2.7

While creating PDF from print view, a user would have got the following error instead of PDF.

```
Traceback (most recent call last):
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 33, in handle
    return build_response("json")
  File "/Users/sps/benches/develop/apps/frappe/frappe/utils/response.py", line 53, in build_response
    return response_type_map[frappe.response.get('type') or response_type]()
  File "/Users/sps/benches/develop/apps/frappe/frappe/utils/response.py", line 93, in as_pdf
    encoded_filename = quote(frappe.response['filename'].replace(' ', '_'), encoding='utf-8')
TypeError: quote() got an unexpected keyword argument 'encoding'
```