### PR TITLE
fix: MultiSelect backspace on input

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -61,6 +61,9 @@ frappe.ui.form.ControlMultiSelectList = frappe.ui.form.ControlData.extend({
 		});
 
 		this.$list_wrapper.on('keydown', e => {
+			if ($(e.target).is('input')) {
+				return;
+			}
 			if (e.key === 'Backspace') {
 				this.set_value([]);
 			}


### PR DESCRIPTION
- Dont clear values if backspace is pressed on input

![captured](https://user-images.githubusercontent.com/9355208/69229289-2e296780-0bab-11ea-9696-25733be4db57.gif)
