### PR TITLE
fix(Communication): allow creation of new email

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -182,7 +182,7 @@ frappe.views.CommunicationComposer = Class.extend({
 			}
 		}
 
-		if (!this.recipients) {
+		if (this.frm && !this.recipients) {
 			this.recipients = this.frm.doc[this.frm.email_field];
 		}
 	},


### PR DESCRIPTION
Now checks that the `frm` object exists, which prevented a new email from being created on the  `version-12` branch. 

This issue existed on both self-hosted and erpnext's self hosted instances of erpnext as of 20/11/2019 when creating a new email.  

GIF can be found [here](https://i.imgur.com/MR0m1qn.gif)

Closes #8857 