### PR TITLE
fix: Allow to delete custom doctype with custom module

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -80,8 +80,8 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 			if not (for_reload or frappe.flags.in_migrate or frappe.flags.in_install or frappe.flags.in_test):
 				try:
 					delete_controllers(name, doc.module)
-				except (FileNotFoundError, OSError):
-					# in case a doctype doesnt have any controller code
+				except (FileNotFoundError, OSError, KeyError):
+					# in case a doctype doesnt have any controller code  nor any app and module
 					pass
 
 		else:


### PR DESCRIPTION
A doctype was created solely with the UI with a "artificial" module name also created in the UI. Without that fix, such a doctype can not be deleted, as the code searches for a modules.txt. 
Just added a catch clause. Even if that catch is not most descriptive )its an index error), I think its an appropriate solution.

No tests sorry.
