### PR TITLE
fix: Throw error on reaching max attachment limit

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -139,11 +139,14 @@ frappe.ui.form.Attachments = Class.extend({
 			}
 		});
 	},
-	new_attachment: function(fieldname) {
-		var me = this;
+	new_attachment: function() {
 		if (this.dialog) {
 			// remove upload dialog
 			this.dialog.$wrapper.remove();
+		}
+
+		if (this.max_reached()) {
+			frappe.throw(__("Maximum attachment limit for this record reached."));
 		}
 
 		new frappe.ui.FileUploader({


### PR DESCRIPTION
There were no checks on max attachment allowed for a doc.
<img width="1200" alt="Screenshot 2019-11-21 at 2 51 25 PM" src="https://user-images.githubusercontent.com/13928957/69324515-9f7e1e80-0c6e-11ea-9c2c-da2d09c32615.png">
