### PR TITLE
fix: Typo in email account doctype

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -184,7 +184,7 @@ frappe.ui.form.on("Email Account", {
 				read as well as unread message from server. This may also cause the duplication\
 				of Communication (emails).");
 			frappe.confirm(msg, null, function() {
-				frm.set_value("email_sync_option", "UNSEEN");
+				frm.set_value("email_sync_option", "ALL");
 			});
 		}
 	}


### PR DESCRIPTION
When previously selecting **ALL** in the email sync option like below, only **UNREAD** emails would get synced. This was an irritating issue as you would be unable to see **ALL**.  With this fix, all emails are synced, as it should be.

![image](https://user-images.githubusercontent.com/13621738/69332370-73eb3c00-0c4e-11ea-99c6-a04779303e8a.png)

I can only presume this was a typo. 👍 
