### PR TITLE
fix: patch

### DIFF
--- a/frappe/patches/v12_0/create_notification_settings_for_user.py
+++ b/frappe/patches/v12_0/create_notification_settings_for_user.py
@@ -4,6 +4,7 @@ from frappe.desk.doctype.notification_settings.notification_settings import crea
 
 def execute():
 	frappe.reload_doc('desk', 'doctype', 'notification_settings')
+	frappe.reload_doc('desk', 'doctype', 'notification_subscribed_document')
 
 	users = frappe.db.get_all('User', fields=['name'])
 	for user in users:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 48, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v12_0/create_notification_settings_for_user.py", line 10, in execute
    create_notification_settings(user.name)
  File "/home/travis/frappe-bench/apps/frappe/frappe/desk/doctype/notification_settings/notification_settings.py", line 38, in create_notification_settings
    _doc.insert(ignore_permissions=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 218, in insert
    self._set_defaults()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 613, in _set_defaults
    new_doc = frappe.new_doc(df.options, as_dict=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 670, in new_doc
    return get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/create_new.py", line 21, in get_new_doc
    frappe.local.new_doc_templates[doctype] = make_new_doc(doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/create_new.py", line 39, in make_new_doc
    "docstatus": 0
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 736, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 68, in get_doc
    controller = get_controller(doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/base_document.py", line 47, in get_controller
    module = load_doctype_module(doctype, module_name)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/utils.py", line 206, in load_doctype_module
    raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))
ImportError: Module import failed for Notification Subscribed Document (frappe.core.doctype.notification_subscribed_document.notification_subscribed_document Error: No module named notification_subscribed_document.notification_subscribed_document)
```