### PR TITLE
feat: Add all time in dashboard charts

### DIFF
--- a/frappe/core/page/dashboard/dashboard.py
+++ b/frappe/core/page/dashboard/dashboard.py
@@ -44,5 +44,7 @@ def get_from_date_from_timespan(to_date, timespan):
 		months = -3
 	elif "Last Year" == timespan:
 		years = -1
+	elif "All Time" == timespan:
+		years = -50
 	return add_to_date(to_date, years=years, months=months, days=days,
 		as_datetime=True)

--- a/frappe/core/page/dashboard/dashboard.py
+++ b/frappe/core/page/dashboard/dashboard.py
@@ -36,15 +36,15 @@ def generate_and_cache_results(chart, chart_name, function, cache_key):
 
 def get_from_date_from_timespan(to_date, timespan):
 	days = months = years = 0
-	if "Last Week" == timespan:
+	if timespan == "Last Week":
 		days = -7
-	if "Last Month" == timespan:
+	if timespan == "Last Month":
 		months = -1
-	elif "Last Quarter" == timespan:
+	elif timespan == "Last Quarter":
 		months = -3
-	elif "Last Year" == timespan:
+	elif timespan == "Last Year":
 		years = -1
-	elif "All Time" == timespan:
+	elif timespan == "All Time":
 		years = -50
 	return add_to_date(to_date, years=years, months=months, days=days,
 		as_datetime=True)

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -41,6 +41,7 @@ frappe.ui.form.on('Dashboard Chart', {
 	timespan: function(frm) {
 		const time_interval_options = {
 			"Select Date Range": ["Quarterly", "Monthly", "Weekly", "Daily"],
+			"All Time": ["Yearly", "Monthly"],
 			"Last Year": ["Quarterly", "Monthly", "Weekly", "Daily"],
 			"Last Quarter": ["Monthly", "Weekly", "Daily"],
 			"Last Month": ["Weekly", "Daily"],

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -82,14 +82,14 @@
    "fieldname": "timespan",
    "fieldtype": "Select",
    "label": "Timespan",
-   "options": "Last Year\nLast Quarter\nLast Month\nLast Week\nSelect Date Range"
+   "options": "All Time\nLast Year\nLast Quarter\nLast Month\nLast Week\nSelect Date Range"
   },
   {
    "depends_on": "timeseries",
    "fieldname": "time_interval",
    "fieldtype": "Select",
    "label": "Time Interval",
-   "options": "Quarterly\nMonthly\nWeekly\nDaily"
+   "options": "Yearly\nQuarterly\nMonthly\nWeekly\nDaily"
   },
   {
    "default": "0",
@@ -187,7 +187,7 @@
    "label": "To Date"
   }
  ],
- "modified": "2019-11-04 12:32:14.525409",
+ "modified": "2019-11-18 16:20:11.529496",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -132,8 +132,9 @@ def get_aggregate_function(chart_type):
 		"Average": "AVG",
 	}[chart_type]
 
+
 def convert_to_dates(data, timegrain):
-	''' Converts individual dates within data to the end of period '''
+	""" Converts individual dates within data to the end of period """
 	result = []
 	for d in data:
 		if timegrain == 'Daily':
@@ -141,11 +142,11 @@ def convert_to_dates(data, timegrain):
 		elif timegrain == 'Weekly':
 			result.append([add_to_date(add_to_date('{:d}-01-01'.format(int(d[0])), weeks = d[1] + 1), days = -1), d[2]])
 		elif timegrain == 'Monthly':
-			result.append([add_to_date(add_to_date('{:d}-01-01'.format(int(d[0])), months = d[1]), days = -1), d[2]])
+			result.append([add_to_date(add_to_date('{:d}-01-01'.format(int(d[0])), months=d[1]), days = -1), d[2]])
 		elif timegrain == 'Quarterly':
-			result.append([add_to_date(add_to_date('{:d}-01-01'.format(int(d[0])), months = d[1] * 3), days = -1), d[2]])
+			result.append([add_to_date(add_to_date('{:d}-01-01'.format(int(d[0])), months=d[1] * 3), days = -1), d[2]])
 		elif timegrain == 'Yearly':
-			result.append([add_to_date(add_to_date('{:d}-01-01'.format(int(d[0])), months = 12), days = -1), d[2]])
+			result.append([add_to_date(add_to_date('{:d}-01-01'.format(int(d[0])), months=12), days = -1), d[2]])
 		result[-1][0] = getdate(result[-1][0])
 
 	return result
@@ -165,7 +166,7 @@ def get_unit_function(datefield, timegrain):
 
 	return unit_function
 
-def add_missing_values(data, timegrain, from_date, to_date, timespan):
+def add_missing_values(data, timegrain, timespan, from_date, to_date):
 	# add missing intervals
 	result = []
 
@@ -213,15 +214,15 @@ def get_next_expected_date(date, timegrain):
 
 def get_period_ending(date, timegrain):
 	date = getdate(date)
-	if timegrain=='Daily':
+	if timegrain == 'Daily':
 		pass
-	elif timegrain=='Weekly':
+	elif timegrain == 'Weekly':
 		date = get_week_ending(date)
-	elif timegrain=='Monthly':
+	elif timegrain == 'Monthly':
 		date = get_month_ending(date)
-	elif timegrain=='Quarterly':
+	elif timegrain == 'Quarterly':
 		date = get_quarter_ending(date)
-	elif timegrain=='Yearly':
+	elif timegrain == 'Yearly':
 		date = get_year_ending(date)
 
 	return getdate(date)
@@ -234,7 +235,7 @@ def get_week_ending(date):
 	# first day of next week
 	date = add_to_date('{}-01-01'.format(date.year), weeks = week_of_the_year + 1)
 	# last day of this week
-	return add_to_date(date, days = -1)
+	return add_to_date(date, days=-1)
 
 def get_month_ending(date):
 	month_of_the_year = int(date.strftime('%m'))
@@ -242,7 +243,7 @@ def get_month_ending(date):
 
 	date = add_to_date('{}-01-01'.format(date.year), months = month_of_the_year)
 	# last day of this month
-	return add_to_date(date, days = -1)
+	return add_to_date(date, days=-1)
 
 def get_quarter_ending(date):
 	date = getdate(date)
@@ -260,14 +261,15 @@ def get_quarter_ending(date):
 
 def get_year_ending(date):
 	''' returns year ending of the given date '''
-	year = int(date.strftime('%y'))
 
 	# first day of next year (note year starts from 1)
 	date = add_to_date('{}-01-01'.format(date.year), months = 12)
 	# last day of this month
-	return add_to_date(date, days = -1)
+	return add_to_date(date, days=-1)
+
 
 class DashboardChart(Document):
+
 	def on_update(self):
 		frappe.cache().delete_key('chart-data:{}'.format(self.name))
 

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -36,6 +36,9 @@ class TestDashboardChart(unittest.TestCase):
 		self.assertEqual(get_period_ending('2019-10-01', 'Quarterly'),
 			getdate('2019-12-31'))
 
+		self.assertEqual(get_period_ending('2019-10-01', 'Yearly'),
+			getdate('2019-12-31'))
+
 	def test_dashboard_chart(self):
 		if frappe.db.exists('Dashboard Chart', 'Test Dashboard Chart'):
 			frappe.delete_doc('Dashboard Chart', 'Test Dashboard Chart')


### PR DESCRIPTION
Currently, dashboard charts don't support the view of yearly deviations, this PR proposes a change to add timespan for 'All Time' period along with yearly and monthly data time-grains in those periods.

Dashboard [Documentation Link](https://erpnext.com/docs/user/manual/en/customize-erpnext/dashboard)
