### PR TITLE
fix: REST API utf-8 decoding on creates/updates

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -82,7 +82,7 @@ def handle():
 
 				if frappe.local.request.method=="PUT":
 					if frappe.local.form_dict.data is None:
-						data = json.loads(frappe.local.request.get_data().decode('utf-8'))
+						data = json.loads(frappe.safe_decode(frappe.local.request.get_data()))
 					else:
 						data = json.loads(frappe.local.form_dict.data)
 					doc = frappe.get_doc(doctype, name)
@@ -117,7 +117,7 @@ def handle():
 
 				if frappe.local.request.method=="POST":
 					if frappe.local.form_dict.data is None:
-						data = json.loads(frappe.local.request.get_data().decode('utf-8'))
+						data = json.loads(frappe.safe_decode(frappe.local.request.get_data()))
 					else:
 						data = json.loads(frappe.local.form_dict.data)
 					data.update({

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -82,7 +82,7 @@ def handle():
 
 				if frappe.local.request.method=="PUT":
 					if frappe.local.form_dict.data is None:
-						data = json.loads(frappe.local.request.get_data())
+						data = json.loads(frappe.local.request.get_data().decode('utf-8'))
 					else:
 						data = json.loads(frappe.local.form_dict.data)
 					doc = frappe.get_doc(doctype, name)
@@ -117,7 +117,7 @@ def handle():
 
 				if frappe.local.request.method=="POST":
 					if frappe.local.form_dict.data is None:
-						data = json.loads(frappe.local.request.get_data())
+						data = json.loads(frappe.local.request.get_data().decode('utf-8'))
 					else:
 						data = json.loads(frappe.local.form_dict.data)
 					data.update({


### PR DESCRIPTION
Creating or updating a document via the REST API would generate an error of:

`TypeError: the JSON object must be str, not 'bytes'`

Because get_data() returns bytes which must be explicitly converted to a string before parsing as JSON.

Defect introduced by efe94886a and a71a92341e

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
