### PR TITLE
fix: Escape HTML for the value of field with fieldtype HTML Editor

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -577,7 +577,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					data-filter="${fieldname},=,${value}">
 					${_value}
 				</a>`;
-			} else if (['Text Editor', 'Text', 'Small Text'].includes(df.fieldtype)) {
+			} else if (['Text Editor', 'Text', 'Small Text', 'HTML Editor'].includes(df.fieldtype)) {
 				html = `<span class="text-muted ellipsis">
 					${_value}
 				</span>`;
@@ -589,7 +589,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			}
 
 			return `<span class="ellipsis"
-				title="${__(label) + ': ' + _value}">
+				title="${__(label)}: ${escape(_value)}">
 				${html}
 			</span>`;
 		};


### PR DESCRIPTION
**Before:**
<img width="974" alt="Screenshot 2019-11-25 at 9 15 19 AM" src="https://user-images.githubusercontent.com/13928957/69510923-a655ab80-0f64-11ea-8974-9eeed6ae1eef.png">


**After:**
<img width="989" alt="Screenshot 2019-11-25 at 9 13 05 AM" src="https://user-images.githubusercontent.com/13928957/69510930-ab1a5f80-0f64-11ea-8e8d-7f9baad17f8d.png">

- Escaped text in the title to avoid HTML/style bleed from the title

**Before:**
<img width="976" alt="Screenshot 2019-11-25 at 9 16 46 AM" src="https://user-images.githubusercontent.com/13928957/69510944-af467d00-0f64-11ea-861b-743b69560a1f.png">

**After:**
<img width="989" alt="Screenshot 2019-11-25 at 9 13 05 AM" src="https://user-images.githubusercontent.com/13928957/69510959-bd949900-0f64-11ea-9399-5345bc718a42.png">
