### PR TITLE
fix: Desktop UI issues

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -234,8 +234,11 @@ def get_config(app, module):
 		for item in section["items"]:
 			if item["type"]=="report" and item["name"] in disabled_reports:
 				continue
+			# some module links might not have name
+			if not item.get("name"):
+				item["name"] = item.get("label")
 			if not item.get("label"):
-				item["label"] = _(item["name"])
+				item["label"] = _(item.get("name"))
 			items.append(item)
 		section['items'] = items
 
@@ -297,7 +300,7 @@ def get_onboard_items(app, module):
 
 @frappe.whitelist()
 def get_links_for_module(app, module):
-	return [l.get('label') for l in get_links(app, module)]
+	return [{'value': l.get('name'), 'label': l.get('label')} for l in get_links(app, module)]
 
 def get_links(app, module):
 	try:
@@ -330,13 +333,13 @@ def get_desktop_settings():
 	def apply_user_saved_links(module):
 		module = frappe._dict(module)
 		all_links = get_links(module.app, module.module_name)
-		module_links_by_label = {}
+		module_links_by_name = {}
 		for link in all_links:
-			module_links_by_label[link['label']] = link
+			module_links_by_name[link['name']] = link
 
 		if module.module_name in user_saved_links_by_module:
 			user_links = frappe.parse_json(user_saved_links_by_module[module.module_name])
-			module.links = [module_links_by_label[l] for l in user_links if l in module_links_by_label]
+			module.links = [module_links_by_name[l] for l in user_links if l in module_links_by_name]
 
 		return module
 

--- a/frappe/public/js/frappe/views/components/DeskModuleBox.vue
+++ b/frappe/public/js/frappe/views/components/DeskModuleBox.vue
@@ -63,7 +63,7 @@ export default {
       }
 	},
 	dropdown_links() {
-		return this.links.length > 0 ? this.links
+		return this.type === 'module' ? this.links
 			.filter(link => !link.hidden)
 			.concat([
 				{ label: __('Customize'), action: () => this.$emit('customize'), class: 'border-top' }

--- a/frappe/public/js/frappe/views/components/DeskSection.vue
+++ b/frappe/public/js/frappe/views/components/DeskSection.vue
@@ -26,7 +26,8 @@ export default {
 	},
 	data() {
 		return {
-			dragging: false
+			dragging: false,
+			fetched_module_links: {}
 		}
 	},
 	mounted() {
@@ -53,6 +54,7 @@ export default {
 			})
 		},
 		show_module_card_customize_dialog(module) {
+			const me = this;
 			const d = new frappe.ui.Dialog({
 				title: __('Customize Shortcuts'),
 				fields: [
@@ -60,11 +62,19 @@ export default {
 						label: __('Shortcuts'),
 						fieldname: 'links',
 						fieldtype: 'MultiSelectPills',
-						get_data() {
-							return frappe.call('frappe.desk.moduleview.get_links_for_module', {
-								app: module.app,
-								module: module.module_name,
-							}).then(r => r.message);
+						get_data: () => {
+							const module_links = me.fetched_module_links[module.module_name];
+							if (!module_links) {
+								return frappe.xcall('frappe.desk.moduleview.get_links_for_module', {
+									app: module.app,
+									module: module.module_name,
+								}).then(links => {
+									me.fetched_module_links[module.module_name] = links;
+									return links;
+								});
+							} else {
+								return module_links;
+							}
 						},
 						default: module.links.filter(l => !l.hidden).map(l => l.name)
 					}
@@ -73,7 +83,7 @@ export default {
 				primary_action: ({ links }) => {
 					frappe.call('frappe.desk.moduleview.update_links_for_module', {
 						module_name: module.module_name,
-						links
+						links: links || []
 					}).then(r => {
 						this.$emit('update-desktop-settings', r.message);
 					});


### PR DESCRIPTION
-  Filter links based on the name of the link config,
because the label can be different if the user switches the language.

**Issue:**
![2019-11-25 13-14-52 2019-11-25 13_22_12](https://user-images.githubusercontent.com/13928957/69522559-aca94f00-0f87-11ea-88d1-bc46560a406f.gif)

- Return the value instead of the label while updating links for module
- Show Customize option in DeskModuleBox even if there are no links selected by the user.
- Handle error when the user tries to remove all the links for a module.
<img width="448" alt="Screenshot 2019-11-25 at 12 28 09 PM" src="https://user-images.githubusercontent.com/13928957/69521585-5a672e80-0f85-11ea-860f-4d7b5b928f59.png">



