### PR TITLE
fix: Suppress quill warnings

### DIFF
--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -1,7 +1,7 @@
 import Quill from 'quill';
 import Mention from './quill-mention/quill.mention';
 
-Quill.register('modules/mention', Mention);
+Quill.register('modules/mention', Mention, true);
 
 frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 	make_wrapper() {

--- a/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
@@ -35,4 +35,4 @@ MentionBlot.blotName = 'mention';
 MentionBlot.tagName = 'span';
 MentionBlot.className = 'mention';
 
-Quill.register(MentionBlot);
+Quill.register(MentionBlot, true);

--- a/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
@@ -361,6 +361,6 @@ class Mention {
   }
 }
 
-Quill.register('modules/mention', Mention);
+Quill.register('modules/mention', Mention, true);
 
 export default Mention;

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -36,7 +36,7 @@ class MyLink extends Link {
 	}
 }
 
-Quill.register(MyLink);
+Quill.register(MyLink, true);
 
 // image uploader
 const Uploader = Quill.import('modules/uploader');


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2019-11-24 at 6 46 22 PM" src="https://user-images.githubusercontent.com/13928957/69527812-1418cc00-0f93-11ea-9db4-e74a97da8835.png">

Suppress quill warnings for a cleaner console.