### PR TITLE
fix(security): Make all Prepared Report file attachments private

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -81,7 +81,7 @@ def create_json_gz_file(data, dt, dn):
 		dt=dt,
 		dn=dn,
 		folder=None,
-		is_private=False)
+		is_private=True)
 
 
 @frappe.whitelist()

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -237,3 +237,4 @@ execute:frappe.delete_doc('Page', 'applications', ignore_missing=True)
 frappe.patches.v11_0.set_missing_creation_and_modified_value_for_user_permissions
 frappe.patches.v11_0.remove_doctype_user_permissions_for_page_and_report #2019-05-01
 frappe.patches.v11_0.apply_customization_to_custom_doctype
+frappe.patches.v11_0.make_all_prepared_report_attachments_private

--- a/frappe/patches/v11_0/make_all_prepared_report_attachments_private.py
+++ b/frappe/patches/v11_0/make_all_prepared_report_attachments_private.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+import frappe
+
+
+def execute():
+	files = frappe.get_all("File", filters={"attached_to_doctype": "Prepared Report", "is_private": 0})
+	for file_name in files:
+		file_doc = frappe.get_doc("File", file_name)
+		file_doc.is_private = 1
+		file_doc.save()


### PR DESCRIPTION
Backporting https://github.com/frappe/frappe/pull/8884