### PR TITLE
fix: parameterize link name when clearing timeline references

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -333,7 +333,7 @@ def clear_references(doctype, reference_doctype, reference_name,
 
 def clear_timeline_references(link_doctype, link_name):
 	frappe.db.sql("""delete from `tabCommunication Link`
-		where `tabCommunication Link`.link_doctype='{0}' and `tabCommunication Link`.link_name='{1}'""".format(link_doctype, link_name)) # nosec
+		where `tabCommunication Link`.link_doctype='{0}' and `tabCommunication Link`.link_name=%s""".format(link_doctype), (link_name)) # nosec
 
 def insert_feed(doc):
 	from frappe.utils import get_fullname

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -332,8 +332,8 @@ def clear_references(doctype, reference_doctype, reference_name,
 		(reference_doctype, reference_name))
 
 def clear_timeline_references(link_doctype, link_name):
-	frappe.db.sql("""delete from `tabCommunication Link`
-		where `tabCommunication Link`.link_doctype='{0}' and `tabCommunication Link`.link_name=%s""".format(link_doctype), (link_name)) # nosec
+	frappe.db.sql("""DELETE FROM `tabCommunication Link`
+		WHERE `tabCommunication Link`.link_doctype=%s AND `tabCommunication Link`.link_name=%s""", (link_doctype, link_name))
 
 def insert_feed(doc):
 	from frappe.utils import get_fullname


### PR DESCRIPTION
link_name could potentially include an apostrophe and cause:

`"mysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax"`

Adjusted the query to parameterize it