### PR TITLE
fix: don't allow standard fieldnames

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -194,6 +194,10 @@ class DocType(Document):
 					else:
 						d.fieldname = d.fieldtype.lower().replace(" ","_") + "_" + str(d.idx)
 
+				else:
+					if d.fieldname in restricted:
+						frappe.throw(_("Fieldname {0} is restricted").format(d.fieldname), InvalidFieldNameError)
+
 				d.fieldname = re.sub('''['",./%@()<>{}]''', '', d.fieldname)
 
 				# fieldnames should be lowercase


### PR DESCRIPTION
If entered manually, doctype would accept the restricted fieldname.

This PR adds a validation for that