### PR TITLE
fix checkbox behavior in rtl view when clicking on label to check

### DIFF
--- a/frappe/public/css/desk.css
+++ b/frappe/public/css/desk.css
@@ -998,7 +998,7 @@ li.user-progress .progress-bar {
 
 input[type="checkbox"] {
   position: relative;
-  visibility: hidden;
+  left: -999999px;
 }
 input[type="checkbox"]:before {
   position: absolute;
@@ -1016,7 +1016,7 @@ input[type="checkbox"]:before {
   -webkit-transition: 150ms color;
   -o-transition: 150ms color;
   transition: 150ms color;
-  left: 0px;
+  left: 999999px;
 }
 input[type="checkbox"]:focus:before {
   color: #8D99A6;

--- a/frappe/public/css/desk.css
+++ b/frappe/public/css/desk.css
@@ -998,7 +998,7 @@ li.user-progress .progress-bar {
 
 input[type="checkbox"] {
   position: relative;
-  left: -999999px;
+  visibility: hidden;
 }
 input[type="checkbox"]:before {
   position: absolute;
@@ -1016,7 +1016,7 @@ input[type="checkbox"]:before {
   -webkit-transition: 150ms color;
   -o-transition: 150ms color;
   transition: 150ms color;
-  left: 999999px;
+  left: 0px;
 }
 input[type="checkbox"]:focus:before {
   color: #8D99A6;

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -771,7 +771,7 @@ li.user-progress {
 // custom font awesome checkbox
 input[type="checkbox"] {
 	position: relative;
-	left: -999999px;
+	visibility: hidden;
 
 	&:before {
 		position: absolute;
@@ -787,7 +787,7 @@ input[type="checkbox"] {
 		font-size: 14px;
 		color: @text-extra-muted;
 		.transition(150ms color);
-		left: 999999px;
+		left: 0px;
 	}
 
 	&:focus:before {


### PR DESCRIPTION
Checkbox crashes all desk view when clicking on its label in RTL View

**Output of bench version**

frappe 12.0.20
Although its an old problem which occurs in all versions.

**Steps to reproduce the issue**

Open Desk in any rtl language, for example arabic.
Go to any doctype that has a checkbox in it.
Press on the label instead of the checkbox itself.

**Observed result**
All desk content is shifted and no longer visible, you can only see the checkbox original box sitting there alone in a white spaced page.

**Expected result**
The checkbox should be checked or unchecked without any unexpected change in view.

**A photo of the issue:**
![checkbox-problem](https://user-images.githubusercontent.com/9443874/69633676-5c9abd00-1059-11ea-8ef4-225d1bb13303.gif)

**After implementing the fix:**
![checkbox-solution](https://user-images.githubusercontent.com/9443874/69633703-6c1a0600-1059-11ea-9882-df61e8ad8ef9.gif)
