### PR TITLE
fix: list view group by filter ambiguous column name

### DIFF
--- a/frappe/desk/listview.py
+++ b/frappe/desk/listview.py
@@ -48,7 +48,7 @@ def get_group_by_count(doctype, current_filters, field):
 	else:
 		return frappe.db.get_list(doctype,
 			filters=current_filters,
-			group_by=field,
+			group_by='`tab{0}`.{1}'.format(doctype, field),
 			fields=['count(*) as count', '`{}` as name'.format(field)],
 			order_by='count desc',
 			limit=50,

--- a/frappe/tests/test_listview.py
+++ b/frappe/tests/test_listview.py
@@ -6,7 +6,7 @@ import unittest
 import frappe
 import json
 
-from frappe.desk.listview import get_list_settings, set_list_settings
+from frappe.desk.listview import get_list_settings, set_list_settings, get_group_by_count
 
 class TestListView(unittest.TestCase):
 	def setUp(self):
@@ -51,3 +51,13 @@ class TestListView(unittest.TestCase):
 		self.assertEqual(settings.disable_count, 0)
 		self.assertEqual(settings.disable_sidebar_stats, 0)
 
+	def test_list_view_child_table_filter_with_created_by_filter(self):
+		if frappe.db.exists("Note", "Test created by filter with child table filter"):
+			frappe.delete_doc("Note", "Test created by filter with child table filter")
+
+		doc = frappe.get_doc({"doctype": "Note", "title": "Test created by filter with child table filter", "public": 1})
+		doc.append("seen_by", {"user": "Administrator"})
+		doc.insert()
+
+		data = {d.name: d.count for d in get_group_by_count('Note', '[["Note Seen By","user","=","Administrator"]]', 'owner')}
+		self.assertEqual(data['Administrator'], 1)


### PR DESCRIPTION
**Problem**:

When created by filter is applied with a filter on child table, it throws an ambiguous column name error.

![list_filter_problem](https://user-images.githubusercontent.com/24353136/69707692-368c2000-1120-11ea-8a7f-529ec66fc802.png)

**After fix:**

![list_view_fix](https://user-images.githubusercontent.com/24353136/69707837-794df800-1120-11ea-9a32-06e3db01daaf.png)

