### PR TITLE
fix: Pass prepared_report_name as filter if exists

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -17,6 +17,7 @@ frappe.ui.form.ControlMultiSelectList = frappe.ui.form.ControlData.extend({
 
 		this.$list_wrapper = $(template);
 		this.$input = $('<input>');
+		this.input = this.$input.get(0);
 		this.$list_wrapper.prependTo(this.input_area);
 		this.$filter_input = this.$list_wrapper.find('input');
 		this.$list_wrapper.on('click', '.dropdown-menu', e => {


### PR DESCRIPTION
Query Report used to break on clicking "Show Report" from Prepared Report.

**Before:**
![prepared_report_bug](https://user-images.githubusercontent.com/13928957/69784785-a2cc5980-11dc-11ea-93cf-548b49a0c908.gif)

**After:**
![prepared_report_fix](https://user-images.githubusercontent.com/13928957/69784793-a7910d80-11dc-11ea-9b1f-058d23bd5380.gif)

The bug was introduced with [this PR](https://github.com/frappe/frappe/pull/8740)

