### PR TITLE
Fix error when rename something

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -217,7 +217,13 @@ def get_open_count(doctype, name, items=[]):
 			"count": []
 		}
 
-	frappe.has_permission(doc=frappe.get_doc(doctype, name), throw=True)
+	try:
+		frappe.has_permission(doc=frappe.get_doc(doctype, name), throw=True)
+	except frappe.DoesNotExistError:
+		frappe.clear_messages()
+		return {
+			'count': []
+		}
 
 	meta = frappe.get_meta(doctype)
 	links = meta.get_dashboard_data()


### PR DESCRIPTION
fix(renaming error): Fix error when rename something

When I make a rename of a document frappe performs two refreshes: one on the old document and another one on the new one to change it. When it refreshes the old document and tries to execute 'has_permission' it creates an error on the document that no longer exists.

I created a small fix to avoid the error.

