### PR TITLE
fix: next schedule date in auto repeat should be set on or after current date

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -106,10 +106,6 @@ class AutoRepeat(Document):
 		schedule_details = []
 		start_date = getdate(self.start_date)
 		end_date = getdate(self.end_date)
-		today = frappe.utils.datetime.date.today()
-
-		if start_date < today:
-			start_date = today
 
 		if not self.end_date:
 			start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day)
@@ -131,7 +127,6 @@ class AutoRepeat(Document):
 				}
 				schedule_details.append(row)
 				start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, end_date)
-
 
 		return schedule_details
 
@@ -283,6 +278,11 @@ def get_next_schedule_date(start_date, frequency, repeat_on_day, repeat_on_last_
 	else:
 		days = 7 if frequency == 'Weekly' else 1
 		next_date = add_days(start_date, days)
+
+	# next schedule date should be after or on current date
+	while getdate(next_date) < getdate(today()):
+		next_date = get_next_schedule_date(
+			next_date, frequency, repeat_on_day, repeat_on_last_day, end_date)
 
 	return next_date
 

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -45,10 +45,11 @@ class AutoRepeat(Document):
 		frappe.get_doc(self.reference_doctype, self.reference_document).notify_update()
 
 	def set_dates(self):
-		if self.disabled:
-			self.next_schedule_date = None
-		else:
-			self.next_schedule_date = get_next_schedule_date(self.start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, self.end_date)
+		if not frappe.flags.in_patch:
+			if self.disabled:
+				self.next_schedule_date = None
+			else:
+				self.next_schedule_date = get_next_schedule_date(self.start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, self.end_date)
 
 	def unlink_if_applicable(self):
 		if self.status == 'Completed' or self.disabled:
@@ -307,7 +308,7 @@ def create_repeated_entries(data):
 		current_date = getdate(today())
 		schedule_date = getdate(doc.next_schedule_date)
 
-		while schedule_date <= current_date and not doc.disabled:
+		if schedule_date == current_date and not doc.disabled:
 			doc.create_documents()
 			schedule_date = get_next_schedule_date(schedule_date, doc.frequency, doc.repeat_on_day, doc.repeat_on_last_day, doc.end_date)
 

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -96,6 +96,20 @@ class TestAutoRepeat(unittest.TestCase):
 		linked_comm = frappe.db.exists("Communication", dict(reference_doctype="ToDo", reference_name=new_todo))
 		self.assertTrue(linked_comm)
 
+	def test_next_schedule_date(self):
+		current_date = getdate(today())
+		todo = frappe.get_doc(
+			dict(doctype='ToDo', description='test next schedule date todo', assigned_by='Administrator')).insert()
+		doc = make_auto_repeat(frequency='Monthly',	reference_document=todo.name, start_date=add_months(today(), -2))
+
+		#check next_schedule_date is set as per current date
+		#it should not be a previous month's date
+		self.assertEqual(doc.next_schedule_date, current_date)
+		data = get_auto_repeat_entries(current_date)
+		create_repeated_entries(data)
+		docnames = frappe.get_all(doc.reference_doctype, {'auto_repeat': doc.name})
+		#the original doc + the repeated doc
+		self.assertEqual(len(docnames), 2)
 
 def make_auto_repeat(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
- Skip setting next schedule date if in patch https://github.com/frappe/frappe/pull/8721.
Because next schedule date is set according to the start date on validate and then its updated every time a repeated document is created.
- Also, since creation of repeated documents was under a while loop, after upgrade to v12, as the next_schedule_date was already reset due to the patch and was an older date, it created repeated docs until the next schedule date became equal to the current date. So, replaced while loop by if condition.
version-12-hotfix - https://github.com/frappe/frappe/pull/8917