### PR TITLE
fix: auto repeat next schedule date should be on or after the current date

### DIFF
--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -96,6 +96,21 @@ class TestAutoRepeat(unittest.TestCase):
 		linked_comm = frappe.db.exists("Communication", dict(reference_doctype="ToDo", reference_name=new_todo))
 		self.assertTrue(linked_comm)
 
+	def test_next_schedule_date(self):
+		current_date = getdate(today())
+		todo = frappe.get_doc(
+			dict(doctype='ToDo', description='test next schedule date todo', assigned_by='Administrator')).insert()
+		doc = make_auto_repeat(frequency='Monthly',	reference_document=todo.name, start_date=add_months(today(), -2))
+
+		#check next_schedule_date is set as per current date
+		#it should not be a previous month's date
+		self.assertEqual(doc.next_schedule_date, current_date)
+		data = get_auto_repeat_entries(current_date)
+		create_repeated_entries(data)
+		docnames = frappe.get_all(doc.reference_doctype, {'auto_repeat': doc.name})
+		#the original doc + the repeated doc
+		self.assertEqual(len(docnames), 2)
+
 
 def make_auto_repeat(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
- Next schedule date was calculated and changed on validate. So if auto repeat was set up on an older date, next schedule date was set as a date which has already passed.

**Before:**
![next_schedule_date_auto_repeat](https://user-images.githubusercontent.com/24353136/69870821-19e61880-12d7-11ea-8d0c-a254d3b74f4e.gif)

**After:**
![next_schedule_date_auto_repeat_fix](https://user-images.githubusercontent.com/24353136/69870825-1c487280-12d7-11ea-8310-21e375f5af8f.gif)

- Also, since creation of repeated documents was under a while loop, if next_schedule_date was an older date, it created repeated docs until the next schedule date became equal to the current date. So, replaced while loop by if condition. 

- Added a test for next schedule date