### PR TITLE
fix: auto repeat next schedule date should be on or after the current date

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -105,10 +105,6 @@ class AutoRepeat(Document):
 		schedule_details = []
 		start_date = getdate(self.start_date)
 		end_date = getdate(self.end_date)
-		today = frappe.utils.datetime.date.today()
-
-		if start_date < today:
-			start_date = today
 
 		if not self.end_date:
 			start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day)
@@ -121,7 +117,8 @@ class AutoRepeat(Document):
 			start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day)
 
 		if self.end_date:
-			start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day)
+			start_date = start_date = get_next_schedule_date(
+					start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, end_date, for_full_schedule=True)
 			while (getdate(start_date) < getdate(end_date)):
 				row = {
 					"reference_document" : self.reference_document,
@@ -129,7 +126,8 @@ class AutoRepeat(Document):
 					"next_scheduled_date" : start_date
 				}
 				schedule_details.append(row)
-				start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, end_date)
+				start_date = start_date = get_next_schedule_date(
+					start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, end_date, for_full_schedule=True)
 
 
 		return schedule_details
@@ -271,17 +269,27 @@ class AutoRepeat(Document):
 		)
 
 
-def get_next_schedule_date(start_date, frequency, repeat_on_day, repeat_on_last_day = False, end_date = None):
+def get_next_schedule_date(start_date, frequency, repeat_on_day, repeat_on_last_day=False, end_date=None, for_full_schedule=False):
 	month_count = month_map.get(frequency)
+	day_count = 0
 	if month_count and repeat_on_last_day:
 		next_date = get_next_date(start_date, month_count, 31)
+		day_count = 31
+		next_date = get_next_date(start_date, month_count, day_count)
 	elif month_count and repeat_on_day:
 		next_date = get_next_date(start_date, month_count, repeat_on_day)
+		day_count = repeat_on_day
+		next_date = get_next_date(start_date, month_count, day_count)
 	elif month_count:
 		next_date = get_next_date(start_date, month_count)
 	else:
 		days = 7 if frequency == 'Weekly' else 1
 		next_date = add_days(start_date, days)
+
+	# next schedule date should be after or on current date
+	if not for_full_schedule:
+		while getdate(next_date) < getdate(today()):
+			next_date = get_next_date(next_date, month_count, day_count)
 
 	return next_date
 
@@ -307,7 +315,7 @@ def create_repeated_entries(data):
 		current_date = getdate(today())
 		schedule_date = getdate(doc.next_schedule_date)
 
-		while schedule_date <= current_date and not doc.disabled:
+		if schedule_date == current_date and not doc.disabled:
 			doc.create_documents()
 			schedule_date = get_next_schedule_date(schedule_date, doc.frequency, doc.repeat_on_day, doc.repeat_on_last_day, doc.end_date)
 

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -96,6 +96,21 @@ class TestAutoRepeat(unittest.TestCase):
 		linked_comm = frappe.db.exists("Communication", dict(reference_doctype="ToDo", reference_name=new_todo))
 		self.assertTrue(linked_comm)
 
+	def test_next_schedule_date(self):
+		current_date = getdate(today())
+		todo = frappe.get_doc(
+			dict(doctype='ToDo', description='test next schedule date todo', assigned_by='Administrator')).insert()
+		doc = make_auto_repeat(frequency='Monthly',	reference_document=todo.name, start_date=add_months(today(), -2))
+
+		#check next_schedule_date is set as per current date
+		#it should not be a previous month's date
+		self.assertEqual(doc.next_schedule_date, current_date)
+		data = get_auto_repeat_entries(current_date)
+		create_repeated_entries(data)
+		docnames = frappe.get_all(doc.reference_doctype, {'auto_repeat': doc.name})
+		#the original doc + the repeated doc
+		self.assertEqual(len(docnames), 2)
+
 
 def make_auto_repeat(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
- Next schedule date was calculated and changed on validate. So if auto repeat was set up on an older date, next schedule date was set as a date which has already passed.

**Before:**
![next_schedule_date_auto_repeat](https://user-images.githubusercontent.com/24353136/69870821-19e61880-12d7-11ea-8d0c-a254d3b74f4e.gif)

**After:**
![next_schedule_date_auto_repeat_fix](https://user-images.githubusercontent.com/24353136/69870825-1c487280-12d7-11ea-8310-21e375f5af8f.gif)

- Also, since creation of repeated documents was under a while loop, if next_schedule_date was an older date, it created repeated docs until the next schedule date became equal to the current date. So, replaced while loop by if condition. 

- Added a test for next schedule date

Version-12-hotfix: #8924