### PR TITLE
test: Fix list_view test by removing clear-cache code

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -5,7 +5,13 @@ context('List View', () => {
 		cy.window().its('frappe').then(frappe => {
 			frappe.call("frappe.tests.ui_test_helpers.setup_workflow");
 		});
+		cy.server();
+		cy.route({
+			method: 'POST',
+			url: 'frappe.sessions.clear'
+		}).as('clear-cache');
 		cy.clear_cache();
+		cy.wait(['@clear-cache']);
 	});
 	it('enables "Actions" button', () => {
 		const actions = ['Approve', 'Reject', 'Edit', 'Assign To', 'Apply Assignment Rule', 'Print', 'Delete'];

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -2,16 +2,9 @@ context('List View', () => {
 	before(() => {
 		cy.login();
 		cy.visit('/desk');
-		cy.window().its('frappe').then(frappe => {
-			frappe.call("frappe.tests.ui_test_helpers.setup_workflow");
+		return cy.window().its('frappe').then(frappe => {
+			return frappe.xcall("frappe.tests.ui_test_helpers.setup_workflow");
 		});
-		cy.server();
-		cy.route({
-			method: 'POST',
-			url: 'frappe.sessions.clear'
-		}).as('clear-cache');
-		cy.clear_cache();
-		cy.wait(['@clear-cache']);
 	});
 	it('enables "Actions" button', () => {
 		const actions = ['Approve', 'Reject', 'Edit', 'Assign To', 'Apply Assignment Rule', 'Print', 'Delete'];

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -162,9 +162,15 @@ Cypress.Commands.add('go_to_list', (doctype) => {
 });
 
 Cypress.Commands.add('clear_cache', () => {
+	cy.server();
+	cy.route({
+		method: 'POST',
+		url: 'frappe.sessions.clear'
+	}).as('clear-cache');
 	cy.window().its('frappe').then(frappe => {
 		frappe.ui.toolbar.clear_cache();
 	});
+	cy.wait(['@clear-cache']);
 });
 
 Cypress.Commands.add('dialog', (opts) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -162,15 +162,9 @@ Cypress.Commands.add('go_to_list', (doctype) => {
 });
 
 Cypress.Commands.add('clear_cache', () => {
-	cy.server();
-	cy.route({
-		method: 'POST',
-		url: 'frappe.sessions.clear'
-	}).as('clear-cache');
 	cy.window().its('frappe').then(frappe => {
 		frappe.ui.toolbar.clear_cache();
 	});
-	cy.wait(['@clear-cache']);
 });
 
 Cypress.Commands.add('dialog', (opts) => {


### PR DESCRIPTION
Cache gets cleared in `setup_workflow` method. No need to do it again.