### PR TITLE
fix: Restrict DocTypes in Bulk Update Tool

### DIFF
--- a/frappe/desk/doctype/bulk_update/bulk_update.js
+++ b/frappe/desk/doctype/bulk_update/bulk_update.js
@@ -3,6 +3,16 @@
 
 frappe.ui.form.on('Bulk Update', {
 	refresh: function(frm) {
+		frm.set_query("document_type", function() {
+			return {
+				filters: [
+					['DocType', 'issingle', '=', 0],
+					['DocType', 'name', 'not in', frappe.model.core_doctypes_list],
+					['DocType', 'restrict_to_domain', 'in', frappe.boot.active_domains]
+				]
+			};
+		});
+
 		frm.page.set_primary_action(__('Update'), function() {
 			if (!frm.doc.update_value) {
 				frappe.throw(__('Field "value" is mandatory. Please specify value to be updated'));

--- a/frappe/desk/doctype/bulk_update/bulk_update.js
+++ b/frappe/desk/doctype/bulk_update/bulk_update.js
@@ -7,8 +7,7 @@ frappe.ui.form.on('Bulk Update', {
 			return {
 				filters: [
 					['DocType', 'issingle', '=', 0],
-					['DocType', 'name', 'not in', frappe.model.core_doctypes_list],
-					['DocType', 'restrict_to_domain', 'in', frappe.boot.active_domains]
+					['DocType', 'name', 'not in', frappe.model.core_doctypes_list]
 				]
 			};
 		});


### PR DESCRIPTION
Filter out:
- Single
- Core DocTypes like DocType, DocField, etc.

in the Bulk Update Tool