### PR TITLE
global search does not return all matches

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -479,7 +479,7 @@ def search(text, start=0, limit=20, doctype=""):
 		for index, r in enumerate(results):
 			if r.doctype == priority:
 				tmp_result.extend([r])
-				results.pop(index)
+				#results.pop(index)     doesnt that modify the list we iterate over?!
 
 		sorted_results.extend(tmp_result)
 


### PR DESCRIPTION
pop() modifies the list , in my case it dropped subsequent results in the list. I assume it was just a performance optimization?

Sorry, no testcase.
