### PR TITLE
fix: use hasattr to verify links

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -433,7 +433,7 @@ class Meta(Document):
 
 	def add_doctype_links(self, data):
 		'''add `links` child table in standard link dashboard format'''
-		if self.links:
+		if hasattr(self, 'links'):
 			if not data.transactions:
 				# init groups
 				data.transactions = []

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -433,7 +433,7 @@ class Meta(Document):
 
 	def add_doctype_links(self, data):
 		'''add `links` child table in standard link dashboard format'''
-		if hasattr(self, 'links') and len(self.links):
+		if hasattr(self, 'links') and self.links:
 			if not data.transactions:
 				# init groups
 				data.transactions = []

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -433,7 +433,7 @@ class Meta(Document):
 
 	def add_doctype_links(self, data):
 		'''add `links` child table in standard link dashboard format'''
-		if hasattr(self, 'links'):
+		if hasattr(self, 'links') and len(self.links):
 			if not data.transactions:
 				# init groups
 				data.transactions = []


### PR DESCRIPTION
When the child table is empty, `self.links` returns an attribute error `AttributeError: 'Meta' object has no attribute 'links'`

This PR makes the verification explicit for both attribute as well as length of links.

ref PR: https://github.com/frappe/frappe/pull/8486

P.S. Squash and Merge this