### PR TITLE
fix: Show default currency as a fallback for currency fieldtype

### DIFF
--- a/frappe/tests/test_formatter.py
+++ b/frappe/tests/test_formatter.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import frappe
+from frappe import format
+import unittest
+
+class TestFormatter(unittest.TestCase):
+	def test_currency_formatting(self):
+		df = frappe._dict({
+			'fieldname': 'amount',
+			'fieldtype': 'Currency',
+			'options': 'currency'
+		})
+
+		doc = frappe._dict({
+			'amount': 5
+		})
+		frappe.db.set_default("currency", 'INR')
+
+		# if currency field is not passed then default currency should be used.
+		self.assertEqual(format(100, df, doc), '₹ 100.00')
+
+		doc.currency = 'USD'
+		self.assertEqual(format(100, df, doc), "$ 100.00")
+
+		frappe.db.set_default("currency", None)

--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -55,12 +55,15 @@ def format_value(value, df=None, doc=None, currency=None, translated=False):
 		# this is required to show 0 as blank in table columns
 		return ""
 
-	elif df.get("fieldtype") == "Currency" or (df.get("fieldtype")=="Float" and (df.options or "").strip()):
-		return fmt_money(value, precision=get_field_precision(df, doc),
-			currency=currency if currency else (get_field_currency(df, doc) if doc else None))
+	elif df.get("fieldtype") == "Currency":
+		default_currency = frappe.db.get_default("currency")
+		currency = currency or get_field_currency(df, doc) or default_currency
+		return fmt_money(value, precision=get_field_precision(df, doc), currency=currency)
 
 	elif df.get("fieldtype") == "Float":
 		precision = get_field_precision(df, doc)
+		# I don't know why we support currency option for float
+		currency = currency or get_field_currency(df, doc)
 
 		# show 1.000000 as 1
 		# options should not specified
@@ -69,7 +72,7 @@ def format_value(value, df=None, doc=None, currency=None, translated=False):
 			if len(temp)==1 or cint(temp[1])==0:
 				precision = 0
 
-		return fmt_money(value, precision=precision)
+		return fmt_money(value, precision=precision, currency=currency)
 
 	elif df.get("fieldtype") == "Percent":
 		return "{}%".format(flt(value, 2))


### PR DESCRIPTION
Previously, there was no default currency fallback if currency field had no options set. Now if currency is explicitly not passed via options or argument then the default currency will be used as a fallback.
