### PR TITLE
fix: query report chart options

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -507,6 +507,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				})
 			};
 		}
+		options.axisOptions = {
+			shortenYAxisNumbers: 1
+		}
 
 		return options;
 	}
@@ -561,7 +564,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	get_possible_chart_options() {
 		const columns = this.columns;
 		const rows =  this.raw_data.result.filter(value => Object.keys(value).length);
-		const first_row = Array.isArray(rows[0]) ? rows[0] : Object.values(rows[0]);
+		const first_row = Array.isArray(rows[0]) ? rows[0] : columns.map(col => rows[0][col.fieldname]);
 		const me = this
 
 		const indices = first_row.reduce((accumulator, current_value, current_index) => {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -509,7 +509,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 		options.axisOptions = {
 			shortenYAxisNumbers: 1
-		}
+		};
 
 		return options;
 	}


### PR DESCRIPTION
Ok, here's why we need that change.

## The problem
The following is the code the makes the chart dialog box
```javascript
get_possible_chart_options() {
	const columns = this.columns;
	const rows =  this.raw_data.result.filter(value => Object.keys(value).length);
	const first_row = Array.isArray(rows[0]) ? rows[0] : Object.values(rows[0]);
	const me = this

	const indices = first_row.reduce((accumulator, current_value, current_index) => {
		if (Number.isFinite(current_value)) {
			accumulator.push(current_index);
		}
		return accumulator;
	}, []);

	// Some Code

	const numeric_fields = columns.filter((col, i) => indices.includes(i));
	const non_numeric_fields = columns.filter((col, i) => !indices.includes(i))

	const dialog = new frappe.ui.Dialog({
		// Dialog Configuration
	});

	dialog.show();

	// load preview after dialog animation
	setTimeout(preview_chart, 500);
}
```

So for a report say Sales Analytics in ERPNext the columns is a list of dictionary in a specific order.
``` javascript
>> columns.map(col => col.fieldname)
["entity", "entity_name", "apr_2019", "may_2019", "jun_2019", "jul_2019", ... , "feb_2020", "mar_2020", "total"]
```

Now the next two declarations take all the rows and return a list of values for the first row.

```javascript
const rows =  this.raw_data.result.filter(value => Object.keys(value).length);
const first_row = Array.isArray(rows[0]) ? rows[0] : Object.values(rows[0]);
```

This happens in two steps
1. Get all the rows
1. Check if the row is already an array, if it's not an array then it is assumed to be an object and the values are extracted


The third section returns the indices of all numeric values from the rows
```javascript
const indices = first_row.reduce((accumulator, current_value, current_index) => {
		if (Number.isFinite(current_value)) {
			accumulator.push(current_index);
		}
		return accumulator;
	}, []);
```

The ideal case would be that `columns` and `first_row` are in the same order as ever.
```
["entity", "entity_name", "apr_2019", "may_2019", "jun_2019", "jul_2019", ... , "feb_2020", "mar_2020", "total"]
["frappe", "Frappe Tech", 1200, 1200, 1200, 1200, ...1200, 1200, 14400]
```
In this case indices would return `[2,3,4,5,6,7,8,9,10,11,12,13,14]` and would skip `0` and `1`

But here's the catch `Object.values(rows[0])` does not return values in order. 
To check just console log the row[0] on your browser
```javascript
>> rows[0]
{total: 14400, indent: 0, aug_2019: 1200.00, apr_2019: 1200.00, mar_2020: 1200.00, …}
```

`Object.values` will return that values in that order, and `columns` and `first_row` will never match and indices will produce the wrong values

## Implications
The X and Y axis data pickers get their data from the following two variables that rely on indices.
```javascript
const numeric_fields = columns.filter((col, i) => indices.includes(i));
const non_numeric_fields = columns.filter((col, i) => !indices.includes(i))
```

So if indices are wrong, the chart picker will show the wrong columns. 

<details>
<summary>The problem in all it's glory (Screenshots)</summary>
 <img width="607" alt="Screenshot 2019-12-04 at 1 00 51 PM" src="https://user-images.githubusercontent.com/18097732/70122211-377bff00-1696-11ea-9bf2-081c88588b98.png">
 <img width="612" alt="Screenshot 2019-12-04 at 1 00 43 PM" src="https://user-images.githubusercontent.com/18097732/70122212-38149580-1696-11ea-8245-f8b7134a0e9b.png">
</details>

## The fix
Once the problem was understood, the fix was pretty straight forward.
I know the order of columns specifically. Thanks to the fact that browsers don't mess up the orders of array, I can create the first row myself using the order from columns.

```javascript
columns.map(col => rows[0][col.fieldname])
```

I loop over `columns` and return the value corresponding to the current column from `row[0]`

P.S. I have also enabled shortening of Y Axis Numbers