### PR TITLE
fix(Leaderboard): Leaderboard timespan options

### DIFF
--- a/frappe/desk/page/leaderboard/leaderboard.css
+++ b/frappe/desk/page/leaderboard/leaderboard.css
@@ -19,6 +19,14 @@
 	background: #f0f4f7;
 }
 
+.from-date-field .clearfix{
+	display: none;
+}
+
+.from-date-field {
+	margin-left: 10px;
+}
+
 .select-time:focus, .select-doctype:focus, .select-filter:focus, .select-sort:focus {
 	background: #f0f4f7;
 }

--- a/frappe/desk/page/leaderboard/leaderboard.js
+++ b/frappe/desk/page/leaderboard/leaderboard.js
@@ -43,7 +43,7 @@ class Leaderboard {
 			}
 			this.timespans = [
 				"This Week", "This Month", "This Quarter", "This Year",
-				"Last Week", "Last Quarter", "Last Year",
+				"Last Week", "Last Month", "Last Quarter", "Last Year",
 				"All Time", "Select From Date"
 			];
 

--- a/frappe/desk/page/leaderboard/leaderboard.js
+++ b/frappe/desk/page/leaderboard/leaderboard.js
@@ -41,7 +41,7 @@ class Leaderboard {
 					return field;
 				});
 			}
-			this.timespans = ["Week", "Month", "Quarter", "Year", "All Time"];
+			this.timespans = ["Last Week", "This Month", "Last Quarter", "This Year", "All Time", "Select From Date"];
 
 			// for saving current selected filters
 			const _initial_doctype = frappe.get_route()[1] || this.doctypes[0];
@@ -103,7 +103,8 @@ class Leaderboard {
 			this.timespans.map(d => {
 				return {"label": __(d), value: d };
 			})
-		);
+		);		
+		this.create_from_date_field();
 
 		this.type_select = this.page.add_select(__("Field"),
 			this.options.selected_filter.map(d => {
@@ -113,12 +114,39 @@ class Leaderboard {
 
 		this.timespan_select.on("change", (e) => {
 			this.options.selected_timespan = e.currentTarget.value;
-			this.make_request();
+			if (this.options.selected_timespan === 'Select From Date') {
+				this.from_date_field.show();
+			} else {
+				this.from_date_field.hide();
+				this.make_request();
+			}
 		});
 
 		this.type_select.on("change", (e) => {
 			this.options.selected_filter_item = e.currentTarget.value;
 			this.make_request();
+		});
+	}
+
+	create_from_date_field() {
+		let timespan_field = $(this.parent).find(`.frappe-control[data-original-title='Timespan']`);
+		this.from_date_field = $(`<div class="from-date-field"></div>`).insertAfter(timespan_field).hide();
+
+		let date_field = frappe.ui.form.make_control({
+			df: {
+				fieldtype: 'Date',
+				fieldname: 'selected_from_date',
+				placeholder: 'From Date',
+				default: frappe.datetime.month_start(),
+				input_class: 'input-sm',
+				reqd: 1,
+				change: () => {
+					this.selected_from_date = date_field.get_value();
+					if (this.selected_from_date) this.make_request();
+				}
+			},
+			parent: $(this.parent).find('.from-date-field'),
+			render_input: 1
 		});
 	}
 
@@ -361,14 +389,16 @@ class Leaderboard {
 		let timespan = this.options.selected_timespan.toLowerCase();
 		let current_date = frappe.datetime.now_date();
 		let date = '';
-		if (timespan === "month") {
-			date = frappe.datetime.add_months(current_date, -1);
-		} else if (timespan === "quarter") {
+		if (timespan === "this month") {
+			date = frappe.datetime.month_start();
+		} else if (timespan === "last quarter") {
 			date = frappe.datetime.add_months(current_date, -3);
-		} else if (timespan === "year") {
-			date = frappe.datetime.add_months(current_date, -12);
-		} else if (timespan === "week") {
+		} else if (timespan === "this year") {
+			date = frappe.datetime.year_start();
+		} else if (timespan === "last week") {
 			date = frappe.datetime.add_days(current_date, -7);
+		} else if (timespan === 'select from date') {
+			date = this.selected_from_date;
 		}
 		return date;
 	}

--- a/frappe/desk/page/leaderboard/leaderboard.js
+++ b/frappe/desk/page/leaderboard/leaderboard.js
@@ -43,7 +43,7 @@ class Leaderboard {
 			}
 			this.timespans = [
 				"This Week", "This Month", "This Quarter", "This Year",
-				"Last Week", "Last Quarter","Last Year",
+				"Last Week", "Last Quarter", "Last Year",
 				"All Time", "Select From Date"
 			];
 

--- a/frappe/desk/page/leaderboard/leaderboard.js
+++ b/frappe/desk/page/leaderboard/leaderboard.js
@@ -41,7 +41,11 @@ class Leaderboard {
 					return field;
 				});
 			}
-			this.timespans = ["Last Week", "This Month", "Last Quarter", "This Year", "All Time", "Select From Date"];
+			this.timespans = [
+				"This Week", "This Month", "This Quarter", "This Year",
+				"Last Week", "Last Quarter","Last Year",
+				"All Time", "Select From Date"
+			];
 
 			// for saving current selected filters
 			const _initial_doctype = frappe.get_route()[1] || this.doctypes[0];
@@ -136,7 +140,7 @@ class Leaderboard {
 			df: {
 				fieldtype: 'Date',
 				fieldname: 'selected_from_date',
-				placeholder: 'From Date',
+				placeholder: frappe.datetime.month_start(),
 				default: frappe.datetime.month_start(),
 				input_class: 'input-sm',
 				reqd: 1,
@@ -235,7 +239,6 @@ class Leaderboard {
 			this.leaderboard_config[this.options.selected_doctype].method,
 			{
 				'from_date': this.get_from_date(),
-				'timespan': this.options.selected_timespan,
 				'company': this.options.selected_company,
 				'field': this.options.selected_filter_item,
 				'limit': this.leaderboard_limit,
@@ -388,19 +391,20 @@ class Leaderboard {
 	get_from_date() {
 		let timespan = this.options.selected_timespan.toLowerCase();
 		let current_date = frappe.datetime.now_date();
-		let date = '';
-		if (timespan === "this month") {
-			date = frappe.datetime.month_start();
-		} else if (timespan === "last quarter") {
-			date = frappe.datetime.add_months(current_date, -3);
-		} else if (timespan === "this year") {
-			date = frappe.datetime.year_start();
-		} else if (timespan === "last week") {
-			date = frappe.datetime.add_days(current_date, -7);
-		} else if (timespan === 'select from date') {
-			date = this.selected_from_date;
+		let get_from_date = {
+			"this week": frappe.datetime.week_start(),
+			"this month": frappe.datetime.month_start(),
+			"this quarter": frappe.datetime.quarter_start(),
+			"this year": frappe.datetime.year_start(),
+			"last week": frappe.datetime.add_days(current_date, -7),
+			"last month": frappe.datetime.add_months(current_date, -1),
+			"last quarter": frappe.datetime.add_months(current_date, -3),
+			"last year": frappe.datetime.add_months(current_date, -12),
+			"all time": "",
+			"select from date": this.selected_from_date || frappe.datetime.month_start()
 		}
-		return date;
+
+		return get_from_date[timespan];
 	}
 
 }

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -90,6 +90,14 @@ $.extend(frappe.datetime, {
 		return moment().endOf("month").format();
 	},
 
+	quarter_start: function() {
+		return moment().startOf("quarter").format();
+	},
+
+	quarter_end: function() {
+		return moment().endOf("quarter").format();
+	},
+
 	year_start: function(){
 		return moment().startOf("year").format();
 	},


### PR DESCRIPTION
- Added timespan options **This Week**, **This Month**, **This Quarter**, **This Year**:
<img width="148" alt="Screenshot 2019-12-11 at 2 30 13 PM" src="https://user-images.githubusercontent.com/19775888/70606636-ec786380-1c22-11ea-99e6-95aa9a3b986d.png">

- Added a **Select From Date** option to select the from date:

<img width="1190" alt="Screenshot 2019-12-04 at 11 57 57 PM" src="https://user-images.githubusercontent.com/19775888/70170580-f6660800-16f2-11ea-8691-ff0eaea8b9ee.png">

