### PR TITLE
fix(email): try to encode email part to utf-8

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -457,9 +457,9 @@ class Email:
 	def show_attached_email_headers_in_content(self, part):
 		# get the multipart/alternative message
 		try:
-		    from html import escape  # python 3.x
+			from html import escape  # python 3.x
 		except ImportError:
-		    from cgi import escape  # python 2.x
+			from cgi import escape  # python 2.x
 
 		message = list(part.walk())[1]
 		headers = []
@@ -481,7 +481,7 @@ class Email:
 		"""Detect chartset."""
 		charset = part.get_content_charset()
 		if not charset:
-			charset = chardet.detect(frappe.safe_encode(part))['encoding']
+			charset = chardet.detect(cstr(part))['encoding']
 
 		return charset
 
@@ -515,7 +515,7 @@ class Email:
 				'fcontent': fcontent,
 			})
 
-			cid = (part.get("Content-Id") or "").strip("><")
+			cid = (cstr(part.get("Content-Id")) or "").strip("><")
 			if cid:
 				self.cid_map[fname] = cid
 


### PR DESCRIPTION
fixes issues with class objects other than str

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 281, in receive
    communication = self.insert_communication(msg, args=args)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 338, in insert_communication
    email = Email(raw)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/receive.py", line 372, in __init__
    self.parse()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/receive.py", line 393, in parse
    self.process_part(part)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/receive.py", line 445, in process_part
    self.text_content += self.get_payload(part)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/receive.py", line 489, in get_payload
    charset = self.get_charset(part)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/receive.py", line 484, in get_charset
    charset = chardet.detect(frappe.safe_encode(part))['encoding']
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/chardet/__init__.py", line 34, in detect
    '{0}'.format(type(byte_str)))
TypeError: Expected object of type bytes or bytearray, got: <class 'email.message.Message'>
```
