### PR TITLE
fix (ui/ux): change log modal on boot

### DIFF
--- a/frappe/public/js/frappe/change_log.html
+++ b/frappe/public/js/frappe/change_log.html
@@ -6,11 +6,13 @@
             {{ app_info.title }}
 			<small>{{ __("updated to {0}", [app_info.version]) }}</small>
 		</h2>
-		{% for (var x=0, y=app_info.change_log.length; x < y; x++) {
-            var version_info = app_info.change_log[x];
-            if(version_info) { %}
-    			<p>{{ frappe.markdown(version_info[1]) }}</p>
-		    {% }
-        } %}
+		<div class="app-change-log-body">
+			{% for (var x=0, y=app_info.change_log.length; x < y; x++) {
+	            var version_info = app_info.change_log[x];
+	            if(version_info) { %}
+	    			<p>{{ frappe.markdown(version_info[1]) }}</p>
+			    {% }
+	        } %}
+	    </div>
 	</div>
 {% } %}

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -463,12 +463,34 @@ frappe.Application = Class.extend({
 
 	show_change_log: function() {
 		var me = this;
-		var d = frappe.msgprint(
-			frappe.render_template("change_log", {"change_log": frappe.boot.change_log}),
-			__("Updated To New Version")
-		);
-		d.keep_open = true;
-		d.custom_onhide = function() {
+		let change_log = frappe.boot.change_log;
+
+		// frappe.boot.change_log = [{
+		// 	"change_log": [
+		// 		[<version>, <change_log in markdown>],
+		// 		[<version>, <change_log in markdown>],
+		// 	],
+		// 	"description": "ERP made simple",
+		// 	"title": "ERPNext",
+		// 	"version": "12.2.0"
+		// }];
+
+		// Iterate over changelog
+		change_log.forEach(log => {
+			log.change_log.forEach(version_info => {
+				version_info[1] = version_info[1].replace(/#/, '##')
+				// replace all # with ## for rendering them as <h2>
+			})
+		})
+
+		var change_log_dialog = frappe.msgprint({
+			message: frappe.render_template("change_log", {"change_log": change_log}),
+			title: __("Updated To New Version 🎉"),
+			wide: true,
+			scroll: true
+		});
+		change_log_dialog.keep_open = true;
+		change_log_dialog.custom_onhide = function() {
 			frappe.call({
 				"method": "frappe.utils.change_log.update_last_known_versions"
 			});

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -478,10 +478,10 @@ frappe.Application = Class.extend({
 		// Iterate over changelog
 		change_log.forEach(log => {
 			log.change_log.forEach(version_info => {
-				version_info[1] = version_info[1].replace(/#/, '##')
+				version_info[1] = version_info[1].replace(/#/, '##');
 				// replace all # with ## for rendering them as <h2>
-			})
-		})
+			});
+		});
 
 		var change_log_dialog = frappe.msgprint({
 			message: frappe.render_template("change_log", {"change_log": change_log}),

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -475,14 +475,6 @@ frappe.Application = Class.extend({
 		// 	"version": "12.2.0"
 		// }];
 
-		// Iterate over changelog
-		change_log.forEach(log => {
-			log.change_log.forEach(version_info => {
-				version_info[1] = version_info[1].replace(/#/, '##');
-				// replace all # with ## for rendering them as <h2>
-			});
-		});
-
 		var change_log_dialog = frappe.msgprint({
 			message: frappe.render_template("change_log", {"change_log": change_log}),
 			title: __("Updated To New Version 🎉"),

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -207,6 +207,15 @@ frappe.msgprint = function(msg, title) {
 		frappe.msg_dialog.wrapper.classList.add('msgprint-dialog');
 	}
 
+	if (data.scroll) {
+		// limit modal height and allow scrolling instead
+		frappe.msg_dialog.body.classList.add('msgprint-scroll');
+	} else {
+		if (frappe.msg_dialog.body.classList.contains('msgprint-scroll')) {
+			frappe.msg_dialog.body.classList.remove('msgprint-scroll');
+		}
+	}
+
 
 	if(msg_exists) {
 		frappe.msg_dialog.msg_area.append("<hr>");

--- a/frappe/public/less/common.less
+++ b/frappe/public/less/common.less
@@ -153,6 +153,11 @@ a.badge-hover& {
 	}
 }
 
+.msgprint-scroll {
+	max-height: 36em;
+	overflow: scroll;
+}
+
 .msgprint {
 	// margin: 15px 0px;
 	// text-align: center;

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -1124,3 +1124,9 @@ body.no-sidebar {
 .alt-pressed .alt-underline {
 	text-decoration: underline;
 }
+
+.app-change-log-body {
+	h1 {
+		font-size: 20px;
+	}
+}


### PR DESCRIPTION
Port of https://github.com/frappe/frappe/pull/8970

This PR brings the following changes
- Fixes the narrow modal for showing change log
- Adds a scroll option to msgprint API that sets the max height of the modal and sets the overflow to scroll
- Replaces all `#` from change-log markdown to `##` for design consistency

## Preview
<details>
<summary>Before</summary>

![Screenshot_2019-12-06 Home(6)](https://user-images.githubusercontent.com/18097732/70314647-e7d83780-183d-11ea-9b2c-6c31c54d62cf.png)

</details>

<details>
<summary>After </summary>

![Screenshot_2019-12-06 Home(4)](https://user-images.githubusercontent.com/18097732/70314303-346f4300-183d-11ea-9297-a1f3cc5ad3a0.png)

</details>