### PR TITLE
fix: padding for progress bar in dashboard

### DIFF
--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -239,6 +239,18 @@
 .progress-area {
 	padding-top: 15px;
 	padding-bottom: 15px;
+
+	.progress-chart {
+		padding-top: 20px;
+	}
+
+	.progress {
+		margin-bottom: 5px;
+	}
+
+	.progress-message {
+		margin-top: 0px;
+	}
 }
 
 .form-links {

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -241,7 +241,7 @@
 	padding-bottom: 15px;
 
 	.progress-chart {
-		padding-top: 20px;
+		padding-top: 15px;
 	}
 
 	.progress {


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/8780500/70322098-29251300-184f-11ea-8a78-28ce734df0a5.png)


**After**

![image](https://user-images.githubusercontent.com/8780500/70322008-ef540c80-184e-11ea-9604-49cb704488d2.png)
