### PR TITLE
fix: patch

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -6,11 +6,11 @@ frappe.patches.v8_0.update_global_search_table
 frappe.patches.v7_0.update_auth
 frappe.patches.v8_0.drop_in_dialog #2017-09-22
 frappe.patches.v7_2.remove_in_filter
-frappe.patches.v11_0.drop_column_apply_user_permissions
 execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'docfield', force=True) #2018-02-20
 execute:frappe.reload_doc('core', 'doctype', 'doctype_action', force=True) #2019-09-23
 execute:frappe.reload_doc('core', 'doctype', 'doctype_link', force=True) #2019-09-23
+frappe.patches.v11_0.drop_column_apply_user_permissions
 execute:frappe.reload_doc('core', 'doctype', 'custom_docperm')
 execute:frappe.reload_doc('core', 'doctype', 'docperm') #2018-05-29
 execute:frappe.reload_doc('core', 'doctype', 'comment')

--- a/frappe/patches/v11_0/drop_column_apply_user_permissions.py
+++ b/frappe/patches/v11_0/drop_column_apply_user_permissions.py
@@ -10,7 +10,6 @@ def execute():
 			if column in frappe.db.get_table_columns(doctype):
 				frappe.db.sql("alter table `tab{0}` drop column {1}".format(doctype, column))
 
-	frappe.reload_doc('core', 'doctype', 'doctype_link', force=True)
 	frappe.reload_doc('core', 'doctype', 'docperm', force=True)
 	frappe.reload_doc('core', 'doctype', 'custom_docperm', force=True)
 


### PR DESCRIPTION
**Issue**

```
Executing frappe.patches.v11_0.drop_column_apply_user_permissions in test_site (test_frappe)
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 49, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v11_0/drop_column_apply_user_permissions.py", line 14, in execute
    frappe.reload_doc('core', 'doctype', 'docperm', force=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 804, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/utils.py", line 174, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 27, in import_files
    reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 32, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 66, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 132, in import_doc
    frappe.delete_doc(doc.doctype, doc.name, force=1, ignore_doctypes=ignore, for_reload=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 782, in delete_doc
    ignore_permissions, flags, ignore_on_trash, ignore_missing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 78, in delete_doc
    delete_from_table(doctype, name, ignore_doctypes, None)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 187, in delete_from_table
    frappe.db.sql("delete from `tab%s` where parenttype=%s and parent = %s" % (t, '%s', '%s'), (doctype, name))
  File "/home/travis/frappe-bench/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1146, u"Table 'test_frappe.tabDocType Action' doesn't exist")
```