### PR TITLE
fix: use get_status for rq job status

### DIFF
--- a/frappe/core/page/background_jobs/background_jobs.html
+++ b/frappe/core/page/background_jobs/background_jobs.html
@@ -11,7 +11,7 @@
 		<tbody>
 			{% for j in jobs %}
 			<tr>
-				<td><span class="indicator {{ j.color }}" title="{{ j.status }}">{{ j.queue.split(".").slice(-1)[0] }}</span></td>
+				<td><span class="indicator {{ j.color }}" title="{{ j.get_status() }}">{{ j.queue.split(".").slice(-1)[0] }}</span></td>
 				<td style="overflow: auto;">
 					<div>
 						{{ frappe.utils.encode_tags(j.job_name) }}

--- a/frappe/core/page/background_jobs/background_jobs.py
+++ b/frappe/core/page/background_jobs/background_jobs.py
@@ -29,9 +29,9 @@ def get_info(show_failed=False):
 			jobs.append({
 				'job_name': j.kwargs.get('kwargs', {}).get('playbook_method') \
 					or str(j.kwargs.get('job_name')),
-				'status': j.status, 'queue': name,
+				'status': j.get_status(), 'queue': name,
 				'creation': format_datetime(convert_utc_to_user_timezone(j.created_at)),
-				'color': colors[j.status]
+				'color': colors[j.get_status()]
 			})
 			if j.exc_info:
 				jobs[-1]['exc_info'] = j.exc_info


### PR DESCRIPTION
`job.status` has been replaced with `job.get_status()` in the latest rq release (1.0)

https://github.com/rq/rq/releases/tag/v1.0