### PR TITLE
fix: not able to download XML file

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -210,7 +210,7 @@ def send_private_file(path):
 	blacklist = ['.svg', '.html', '.htm', '.xml']
 
 	if extension.lower() in blacklist:
-		response.headers.add(b'Content-Disposition', b'attachment', filename=filename.encode("utf-8"))
+		response.headers.add('Content-Disposition', 'attachment', filename=filename.encode("utf-8"))
 
 	response.mimetype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.utils.response.download_private_file(request.path)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/utils/response.py", line 185, in download_private_file
    return send_private_file(path.split("/private", 1)[1])
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/utils/response.py", line 213, in send_private_file
    response.headers.add(b'Content-Disposition', b'attachment', filename=filename.encode("utf-8"))
  File "/home/frappe/benches/bench-12-2019-11-26/env/lib/python3.6/site-packages/werkzeug/datastructures.py", line 1172, in add
    _value = _options_header_vkw(_value, kw)
  File "/home/frappe/benches/bench-12-2019-11-26/env/lib/python3.6/site-packages/werkzeug/datastructures.py", line 907, in _options_header_vkw
    value, dict((k.replace("_", "-"), v) for k, v in kw.items())
  File "/home/frappe/benches/bench-12-2019-11-26/env/lib/python3.6/site-packages/werkzeug/http.py", line 275, in dump_options_header
    return "; ".join(segments)
TypeError: sequence item 0: expected str instance, bytes found
```