### PR TITLE
fix(security): invalidate reset_password_key on password reset

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -97,7 +97,9 @@ class User(Document):
 		self.share_with_self()
 		clear_notifications(user=self.name)
 		frappe.clear_cache(user=self.name)
-		self.send_password_notification(self.__new_password)
+		if self.__new_password:
+			self.send_password_notification(self.__new_password)
+			self.reset_password_key = ''
 		create_contact(self, ignore_mandatory=True)
 		if self.name not in ('Administrator', 'Guest') and not self.user_image:
 			frappe.enqueue('frappe.core.doctype.user.user.update_gravatar', name=self.name)


### PR DESCRIPTION
currently there is no way to invalidate `reset_password_key` on updating password through the user settings. so whenever the user sets a new password we'll invalidate the `reset_password_key`, so that existing links to reset user passwords cannot be used.

port-of: https://github.com/frappe/frappe/pull/8982