### PR TITLE
fix(requirements): Pin faker version to avoid test failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ google-api-python-client
 google-auth
 google-auth-httplib2
 google-auth-oauthlib
-faker
+Faker==2.0.4
 stripe
 coverage
 urllib3


### PR DESCRIPTION
Pip used to install the latest Faker(3.0) which had breaking API. This resulted in some test failures.
