### PR TITLE
fix: Missing results in global search

### DIFF
--- a/frappe/desk/doctype/global_search_doctype/global_search_doctype.py
+++ b/frappe/desk/doctype/global_search_doctype/global_search_doctype.py
@@ -3,10 +3,8 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-import frappe
+# import frappe
 from frappe.model.document import Document
 
 class GlobalSearchDocType(Document):
-
-	def on_doctype_update():
-		frappe.db.add_index("Global Search DocType", ["document_type"])
+	pass

--- a/frappe/desk/doctype/global_search_doctype/global_search_doctype.py
+++ b/frappe/desk/doctype/global_search_doctype/global_search_doctype.py
@@ -3,8 +3,10 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class GlobalSearchDocType(Document):
-	pass
+
+	def on_doctype_update():
+		frappe.db.add_index("Global Search DocType", ["document_type"])

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -29,7 +29,6 @@ class GlobalSearchSettings(Document):
 			repeated_dts = (", ".join([frappe.bold(dt) for dt in repeated_dts]))
 			frappe.throw(_("Document Type {0} has been repeated.").format(repeated_dts))
 
-	def on_update(self):
 		set_doctypes_for_global_search()
 
 def set_doctypes_for_global_search():

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -29,20 +29,16 @@ class GlobalSearchSettings(Document):
 			repeated_dts = (", ".join([frappe.bold(dt) for dt in repeated_dts]))
 			frappe.throw(_("Document Type {0} has been repeated.").format(repeated_dts))
 
-		set_doctypes_for_global_search()
+		# reset cache
+		frappe.cache().hdel('global_search', 'search_priorities')
 
-def set_doctypes_for_global_search():
-	doctypes = frappe.get_list("Global Search DocType", fields=["document_type"], order_by="idx ASC")
-	if not doctypes:
-		return []
+def get_doctypes_for_global_search():
+	def get_from_db():
+		doctypes = frappe.get_list("Global Search DocType", fields=["document_type"], order_by="idx ASC")
+		return [d.document_type for d in doctypes] or []
 
-	priorities = [d.document_type for d in doctypes]
-	allowed_doctypes = ",".join(["'{0}'".format(dt) for dt in priorities])
+	return frappe.cache().hget("global_search", "search_priorities", get_from_db)
 
-	frappe.cache().hset("global_search", "search_priorities", priorities)
-	frappe.cache().hset("global_search", "allowed_doctypes", allowed_doctypes)
-
-	return priorities, allowed_doctypes
 
 @frappe.whitelist()
 def reset_global_search_settings_doctypes():

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -30,9 +30,9 @@ class GlobalSearchSettings(Document):
 			frappe.throw(_("Document Type {0} has been repeated.").format(repeated_dts))
 
 	def on_update(self):
-		get_doctypes_for_global_search()
+		set_doctypes_for_global_search()
 
-def get_doctypes_for_global_search():
+def set_doctypes_for_global_search():
 	doctypes = frappe.get_list("Global Search DocType", fields=["document_type"], order_by="idx ASC")
 	if not doctypes:
 		return []

--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -80,7 +80,7 @@ class TestGlobalSearch(unittest.TestCase):
 		make_property_setter(doctype, "repeat_on", "in_global_search", 1, "Int")
 		global_search.rebuild_for_doctype(doctype)
 		results = global_search.search('Monthly')
-		self.assertEqual(len(results), 2)
+		self.assertEqual(len(results), 3)
 
 	def test_delete_doc(self):
 		self.insert_test_events()

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -477,7 +477,6 @@ def search(text, start=0, limit=20, doctype=""):
 					frappe.clear_messages()
 
 				sorted_results.extend([r])
-				results.pop(index)
 
 	return sorted_results or results
 

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -415,7 +415,7 @@ def search(text, start=0, limit=20, doctype=""):
 	:param limit: number of results to return, default 20
 	:return: Array of result objects
 	"""
-	from frappe.desk.doctype.global_search_settings.global_search_settings import get_doctypes_for_global_search
+	from frappe.desk.doctype.global_search_settings.global_search_settings import set_doctypes_for_global_search
 
 	results = []
 	sorted_results = []
@@ -424,7 +424,7 @@ def search(text, start=0, limit=20, doctype=""):
 	allowed_doctypes = frappe.cache().hget("global_search", "allowed_doctypes")
 
 	if not priorities or not allowed_doctypes:
-		priorities, allowed_doctypes = get_doctypes_for_global_search()
+		priorities, allowed_doctypes = set_doctypes_for_global_search()
 
 	for text in set(text.split('&')):
 		text = text.strip()

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -442,7 +442,7 @@ def search(text, start=0, limit=20, doctype=""):
 			values['doctype'] = doctype
 		elif allowed_doctypes:
 			conditions = '`doctype` IN %(allowed_doctypes)s'
-			values['allowed_doctypes'] = allowed_doctypes
+			values['allowed_doctypes'] = tuple(allowed_doctypes)
 
 		if int(start) > 0:
 			offset = 'OFFSET {}'.format(start)

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -478,7 +478,7 @@ def search(text, start=0, limit=20, doctype=""):
 
 				sorted_results.extend([r])
 
-	return sorted_results or results
+	return sorted_results
 
 @frappe.whitelist(allow_guest=True)
 def web_search(text, scope=None, start=0, limit=20):


### PR DESCRIPTION
- Global search used to skip some of the results
- Global Search takes more than 10s to search for larger DBS.
- Cached Global Search DocTypes and optimized code
- Global Search time down to ~4s

port-of: #8706