### PR TITLE
fix: add hourly long frequency to scheduled job type

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -60,7 +60,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Frequency",
-   "options": "All\nHourly\nDaily\nDaily Long\nWeekly\nWeekly Long\nMonthly\nMonthly Long\nCron\nYearly\nAnnual",
+   "options": "All\nHourly\nHourly Long\nDaily\nDaily Long\nWeekly\nWeekly Long\nMonthly\nMonthly Long\nCron\nYearly\nAnnual",
    "read_only": 1,
    "reqd": 1
   }
@@ -72,7 +72,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2019-09-27 12:19:23.259989",
+ "modified": "2019-12-09 11:10:21.259929",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/project/develop-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/migrate.py", line 54, in migrate
    sync_jobs()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 120, in sync_jobs
    insert_events(all_events, scheduler_events)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 130, in insert_events
    insert_event_list(events, event_type, all_events)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 142, in insert_event_list
    insert_single_event(frequency, event)
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 150, in insert_single_event
    frequency = frequency
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 230, in insert
    self._validate()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/document.py", line 461, in _validate
    self._validate_selects()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/model/base_document.py", line 537, in _validate_selects
    value, comma_options))
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/__init__.py", line 363, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/__init__.py", line 349, in msgprint
    _raise_exception()
  File "/Users/saurabh/project/develop-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError:  Frequency cannot be "Hourly Long". It should be one of "All", "Hourly", "Daily", "Daily Long", "Weekly", "Weekly Long", "Monthly", "Monthly Long", "Cron", "Yearly", "Annual"

```