### PR TITLE
fix: Allow field of submitted doc to edit if field has allow_on_submit enabled

### DIFF
--- a/cypress/fixtures/custom_submittable_doctype.js
+++ b/cypress/fixtures/custom_submittable_doctype.js
@@ -1,5 +1,5 @@
 export default {
-	name: 'Custom Submittable Doctype',
+	name: 'Custom Submittable DocType',
 	custom: 1,
 	actions: [],
 	is_submittable: 1,
@@ -41,7 +41,9 @@ export default {
 			read: 1,
 			role: 'System Manager',
 			share: 1,
-			write: 1
+			write: 1,
+			submit: 1,
+			cancel: 1
 		}
 	],
 	quick_entry: 1,

--- a/cypress/fixtures/custom_submittable_doctype.js
+++ b/cypress/fixtures/custom_submittable_doctype.js
@@ -1,0 +1,51 @@
+export default {
+	name: 'Custom Submittable Doctype',
+	custom: 1,
+	actions: [],
+	is_submittable: 1,
+	creation: '2019-12-10 06:29:07.215072',
+	doctype: 'DocType',
+	editable_grid: 1,
+	engine: 'InnoDB',
+	fields: [
+		{
+			fieldname: 'enabled',
+			fieldtype: 'Check',
+			label: 'Enabled',
+			allow_on_submit: 1,
+			reqd: 1
+		},
+		{
+			fieldname: 'title',
+			fieldtype: 'Data',
+			label: 'title',
+			reqd: 1
+		},
+		{
+			fieldname: 'description',
+			fieldtype: 'Text Editor',
+			label: 'Description'
+		}
+	],
+	links: [],
+	modified: '2019-12-10 14:40:53.127615',
+	modified_by: 'Administrator',
+	module: 'Custom',
+	owner: 'Administrator',
+	permissions: [
+		{
+			create: 1,
+			delete: 1,
+			email: 1,
+			print: 1,
+			read: 1,
+			role: 'System Manager',
+			share: 1,
+			write: 1
+		}
+	],
+	quick_entry: 1,
+	sort_field: 'modified',
+	sort_order: 'ASC',
+	track_changes: 1
+};

--- a/cypress/integration/report_view.js
+++ b/cypress/integration/report_view.js
@@ -15,7 +15,7 @@ context('Report View', () => {
 		}, true);
 
 	});
-	it('Field with enabled allow_on_edit should be editable.', () => {
+	it('Field with enabled allow_on_submit should be editable.', () => {
 		cy.server();
 		cy.route('POST', 'api/method/frappe.client.set_value').as('value-update');
 		cy.visit(`/desk#List/${doctype_name}/Report`);

--- a/cypress/integration/report_view.js
+++ b/cypress/integration/report_view.js
@@ -12,7 +12,7 @@ context('Report View', () => {
 			'enabled': 0,
 			// submit document
 			'docstatus': 1
-		}, true);
+		}, true).as('doc');
 
 	});
 	it('Field with enabled allow_on_submit should be editable.', () => {
@@ -25,5 +25,16 @@ context('Report View', () => {
 		cell.find('input[data-fieldname="enabled"]').check({force: true});
 		cy.get('.dt-row-0 > .dt-cell--col-4').click();
 		cy.wait('@value-update');
+		cy.get('@doc').then(doc => {
+			cy.call('frappe.client.get_value', {
+				doctype: doc.doctype,
+				filters: {
+					name: doc.name,
+				},
+				fieldname: 'enabled'
+			}).then(r => {
+				expect(r.message.enabled).to.equals(1);
+			});
+		});
 	});
 });

--- a/cypress/integration/report_view.js
+++ b/cypress/integration/report_view.js
@@ -6,6 +6,7 @@ context('Report View', () => {
 		cy.login();
 		cy.visit('/desk');
 		cy.insert_doc('DocType', custom_submittable_doctype, true);
+		cy.clear_cache();
 		cy.insert_doc(doctype_name, {
 			'title': 'Doc 1',
 			'description': 'Random Text',
@@ -13,7 +14,6 @@ context('Report View', () => {
 			// submit document
 			'docstatus': 1
 		}, true).as('doc');
-
 	});
 	it('Field with enabled allow_on_submit should be editable.', () => {
 		cy.server();

--- a/cypress/integration/report_view.js
+++ b/cypress/integration/report_view.js
@@ -1,0 +1,29 @@
+import custom_submittable_doctype from '../fixtures/custom_submittable_doctype';
+const doctype_name = custom_submittable_doctype.name;
+
+context('Report View', () => {
+	before(() => {
+		cy.login();
+		cy.visit('/desk');
+		cy.insert_doc('DocType', custom_submittable_doctype, true);
+		cy.insert_doc(doctype_name, {
+			'title': 'Doc 1',
+			'description': 'Random Text',
+			'enabled': 0,
+			// submit document
+			'docstatus': 1
+		}, true);
+
+	});
+	it('Field with enabled allow_on_edit should be editable.', () => {
+		cy.server();
+		cy.route('POST', 'api/method/frappe.client.set_value').as('value-update');
+		cy.visit(`/desk#List/${doctype_name}/Report`);
+		let cell = cy.get('.dt-row-0 > .dt-cell--col-3');
+		// select the cell
+		cell.dblclick();
+		cell.find('input[data-fieldname="enabled"]').check({force: true});
+		cy.get('.dt-row-0 > .dt-cell--col-4').click();
+		cy.wait('@value-update');
+	});
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -207,7 +207,7 @@ Cypress.Commands.add('insert_doc', (doctype, args, ignore_duplicate) => {
 						status_codes.push(409);
 					}
 					expect(res.status).to.be.oneOf(status_codes);
-					return res.body;
+					return res.body.data;
 				});
 		});
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -183,3 +183,31 @@ Cypress.Commands.add('hide_dialog', () => {
 	cy.get_open_dialog().find('.btn-modal-close').click();
 	cy.get('.modal:visible').should('not.exist');
 });
+
+Cypress.Commands.add('insert_doc', (doctype, args, ignore_duplicate) => {
+	return cy
+		.window()
+		.its('frappe.csrf_token')
+		.then(csrf_token => {
+			return cy
+				.request({
+					method: 'POST',
+					url: `/api/resource/${doctype}`,
+					body: args,
+					headers: {
+						Accept: 'application/json',
+						'Content-Type': 'application/json',
+						'X-Frappe-CSRF-Token': csrf_token
+					},
+					failOnStatusCode: !ignore_duplicate
+				})
+				.then(res => {
+					let status_codes = [200];
+					if (ignore_duplicate) {
+						status_codes.push(409);
+					}
+					expect(res.status).to.be.oneOf(status_codes);
+					return res.body;
+				});
+		});
+});

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -615,15 +615,18 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	is_editable(df, data) {
-		if (!df || data.docstatus !== 0) return false;
-		const is_standard_field = frappe.model.std_fields_list.includes(df.fieldname);
-		const can_edit = !(
-			is_standard_field
-			|| df.read_only
-			|| df.hidden
-			|| !frappe.model.can_write(this.doctype)
-		);
-		return can_edit;
+		if (df
+			&& frappe.model.can_write(this.doctype)
+			// not a submitted doc or field is allowed to edit after submit
+			&& (data.docstatus !== 1 || df.allow_on_submit)
+			// not a cancelled doc
+			&& data.docstatus !== 2
+			&& !df.read_only
+			&& !df.hidden
+			// not a standard field i.e., owner, modified_by, etc.
+			&& !frappe.model.std_fields_list.includes(df.fieldname))
+			return true;
+		return false;
 	}
 
 	get_data(values) {


### PR DESCRIPTION
Previously, Users were not able to edit (from report view) field value of a submitted document even if that field had **allow_on_submit** enabled.