### PR TITLE
fix(filters): set default id to empty string instead of 0

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -501,6 +501,10 @@ class DatabaseQuery(object):
 				value = f.value or "''"
 				fallback = "''"
 
+			elif f.fieldname == 'name':
+				value = f.value or "''"
+				fallback = "''"
+
 			else:
 				value = flt(f.value)
 				fallback = 0


### PR DESCRIPTION
fixes issue where "undefined" value gets set to 0 in postgres, which causes ProgrammingError since the expected value is of type str and not int