### PR TITLE
fix: User permission issue in query report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -510,7 +510,7 @@ def has_match(row, linked_doctypes, doctype_match_filters, ref_doctype, if_owner
 					cell_value = None
 					if isinstance(row, dict):
 						cell_value = row.get(idx)
-					elif isinstance(row, list):
+					elif isinstance(row, (list, tuple)):
 						cell_value = row[idx]
 
 					if dt in match_filters and cell_value not in match_filters.get(dt) and frappe.db.exists(dt, cell_value):


### PR DESCRIPTION
Previously, for reports, user permissions were not getting checked properly if the row data was in a tuple.

**Note:** Query report result data can be `list of dicts`, `list of lists` or `list of tuples`