### PR TITLE
Avoid clickjacking attacks sending X-Frame-Options HTTP header in response

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -127,6 +127,7 @@ def build_response(path, data, http_status_code, headers=None):
 	response.status_code = http_status_code
 	response.headers["X-Page-Name"] = path.encode("ascii", errors="xmlcharrefreplace")
 	response.headers["X-From-Cache"] = frappe.local.response.from_cache or False
+	response.headers["X-Frame-Options"] = "sameorigin"
 
 	if headers:
 		for key, val in iteritems(headers):


### PR DESCRIPTION
After test my app for a penetration test with OWASP ZAP 2.8.0, I was suggested to add the X-Frame-Options header to avoid other domains using my site inside a frame:

![Screenshot from 2019-12-11 11-20-56](https://user-images.githubusercontent.com/47140294/70614651-32293200-1c0b-11ea-91b2-af312e649172.png)

Header set to "sameorigin" (The page can only be displayed in a frame on the same origin as the page itself)

More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options