### PR TITLE
fix(chat): refactor code to make chat work

### DIFF
--- a/frappe/chat/doctype/chat_room/chat_room.py
+++ b/frappe/chat/doctype/chat_room/chat_room.py
@@ -94,13 +94,14 @@ class ChatRoom(Document):
 				frappe.publish_realtime('frappe.chat.room:update', update, room = self.name, after_commit = True)
 
 @frappe.whitelist(allow_guest=True)
-def get(token, rooms=None, fields=None, filters=None):
+def get(user=None, token=None, rooms=None, fields=None, filters=None):
 	# There is this horrible bug out here.
 	# Looks like if frappe.call sends optional arguments (not in right order), the argument turns to an empty string.
 	# I'm not even going to think searching for it.
 	# Hence, the hack was get_if_empty (previous assign_if_none)
 	# - Achilles Rasquinha achilles@frappe.io
-	authenticate(token)
+	data = user or token
+	authenticate(data)
 
 	rooms, fields, filters = safe_json_loads(rooms, fields, filters)
 
@@ -201,7 +202,7 @@ def create(kind, token, users=None, name=None):
 
 	room.save(ignore_permissions = True)
 
-	room  = get(token, rooms=room.name)
+	room  = get(token=token, rooms=room.name)
 	if room:
 		users = [room.owner] + [u for u in room.users]
 

--- a/frappe/chat/doctype/chat_room/chat_room.py
+++ b/frappe/chat/doctype/chat_room/chat_room.py
@@ -162,8 +162,8 @@ def create(kind, token, users=None, name=None):
 		room = squashify(frappe.db.sql("""
 			SELECT name
 			FROM   `tabChat Room`
-			WHERE  owner = "{owner}"
-		""".format(owner=frappe.session.user), as_dict=True))
+			WHERE  owner=%s
+			""", (frappe.session.user), as_dict=True))
 
 		if room:
 			room   = frappe.get_doc('Chat Room', room.name)

--- a/frappe/chat/doctype/chat_room/chat_room.py
+++ b/frappe/chat/doctype/chat_room/chat_room.py
@@ -1,17 +1,14 @@
 from __future__ import unicode_literals
 
-# imports - standard imports
-import json
-
 # imports - module imports
-from   frappe.model.document import Document
-from   frappe import _
+from frappe.model.document import Document
+from frappe import _
 import frappe
 
 # imports - frappe module imports
-from frappe.chat 						 import authenticate
+from frappe.chat import authenticate
 from frappe.core.doctype.version.version import get_diff
-from frappe.chat.doctype.chat_message	 import chat_message
+from frappe.chat.doctype.chat_message import chat_message
 from frappe.chat.util import (
 	safe_json_loads,
 	dictify,
@@ -22,13 +19,14 @@ from frappe.chat.util import (
 
 session = frappe.session
 
-def is_direct(owner, other, bidirectional = False):
+
+def is_direct(owner, other, bidirectional=False):
 	def get_room(owner, other):
-		room = frappe.get_all('Chat Room', filters = [
-			['Chat Room', 	   'type' , 'in', ('Direct', 'Visitor')],
-			['Chat Room', 	   'owner', '=' , owner],
-			['Chat Room User', 'user' , '=' , other]
-		], distinct = True)
+		room = frappe.get_all('Chat Room', filters=[
+			['Chat Room', 'type', 'in', ('Direct', 'Visitor')],
+			['Chat Room', 'owner', '=', owner],
+			['Chat Room User', 'user', '=', other]
+		], distinct=True)
 
 		return room
 
@@ -38,7 +36,8 @@ def is_direct(owner, other, bidirectional = False):
 
 	return exists
 
-def get_chat_room_user_set(users, filter_ = None):
+
+def get_chat_room_user_set(users, filter_=None):
 	seen, uset = set(), list()
 
 	for u in users:
@@ -48,12 +47,13 @@ def get_chat_room_user_set(users, filter_ = None):
 
 	return uset
 
+
 class ChatRoom(Document):
 	def validate(self):
 		if self.is_new():
-			users = get_chat_room_user_set(self.users, filter_ = lambda u: u.user != session.user)
+			users = get_chat_room_user_set(self.users, filter_=lambda u: u.user != session.user)
 			self.update(dict(
-				users = users
+				users=users
 			))
 
 		if self.type == "Direct":
@@ -63,7 +63,7 @@ class ChatRoom(Document):
 			other = squashify(self.users)
 
 			if self.is_new():
-				if is_direct(self.owner, other.user, bidirectional = True):
+				if is_direct(self.owner, other.user, bidirectional=True):
 					frappe.throw(_('Direct room with {0} already exists.').format(other.user))
 
 		if self.type == "Group" and not self.room_name:
@@ -74,29 +74,32 @@ class ChatRoom(Document):
 			before = self.get_doc_before_save()
 			if not before: return
 
-			after  = self
-			diff   = dictify(get_diff(before, after))
+			after = self
+			diff = dictify(get_diff(before, after))
 			if diff:
-				update = { }
+				update = {}
 				for changed in diff.changed:
 					field, old, new = changed
 
 					if field == 'last_message':
 						new = chat_message.get(new)
 
-					update.update({ field: new })
+					update.update({field: new})
 
 				if diff.added or diff.removed:
-					update.update(dict(users = [u.user for u in self.users]))
+					update.update(dict(users=[u.user for u in self.users]))
 
-				update = dict(room = self.name, data = update)
+				update = dict(room=self.name, data=update)
 
-				frappe.publish_realtime('frappe.chat.room:update', update, room = self.name, after_commit = True)
+				frappe.publish_realtime('frappe.chat.room:update', update, room=self.name,
+						after_commit=True)
+
 
 @frappe.whitelist(allow_guest=True)
 def get(user=None, token=None, rooms=None, fields=None, filters=None):
 	# There is this horrible bug out here.
-	# Looks like if frappe.call sends optional arguments (not in right order), the argument turns to an empty string.
+	# Looks like if frappe.call sends optional arguments (not in right order),
+	# the argument turns to an empty string.
 	# I'm not even going to think searching for it.
 	# Hence, the hack was get_if_empty (previous assign_if_none)
 	# - Achilles Rasquinha achilles@frappe.io
@@ -105,10 +108,10 @@ def get(user=None, token=None, rooms=None, fields=None, filters=None):
 
 	rooms, fields, filters = safe_json_loads(rooms, fields, filters)
 
-	rooms   = listify(get_if_empty(rooms,  [ ]))
-	fields  = listify(get_if_empty(fields, [ ]))
+	rooms = listify(get_if_empty(rooms, []))
+	fields = listify(get_if_empty(fields, []))
 
-	const   = [ ] # constraints
+	const = []  # constraints
 	if rooms:
 		const.append(['Chat Room', 'name', 'in', rooms])
 	if filters:
@@ -118,24 +121,24 @@ def get(user=None, token=None, rooms=None, fields=None, filters=None):
 			const.append(filters)
 
 	default = ['name', 'type', 'room_name', 'creation', 'owner', 'avatar']
-	handle  = ['users', 'last_message']
+	handle = ['users', 'last_message']
 
-	param   = [f for f in fields if f not in handle]
+	param = [f for f in fields if f not in handle]
 
-	rooms   = frappe.get_all('Chat Room',
-		or_filters = [
-			['Chat Room', 'owner', '=', frappe.session.user],
-			['Chat Room User', 'user', '=', frappe.session.user]
-		],
-		filters  = const,
-		fields   = param + ['name'] if param else default,
-		distinct = True
-	)
+	rooms = frappe.get_all('Chat Room',
+			or_filters=[
+				['Chat Room', 'owner', '=', frappe.session.user],
+				['Chat Room User', 'user', '=', frappe.session.user]
+			],
+			filters=const,
+			fields=param + ['name'] if param else default,
+			distinct=True
+		)
 
 	if not fields or 'users' in fields:
 		for i, r in enumerate(rooms):
 			droom = frappe.get_doc('Chat Room', r.name)
-			rooms[i]['users'] = [ ]
+			rooms[i]['users'] = []
 
 			for duser in droom.users:
 				rooms[i]['users'].append(duser.user)
@@ -152,11 +155,12 @@ def get(user=None, token=None, rooms=None, fields=None, filters=None):
 
 	return rooms
 
+
 @frappe.whitelist(allow_guest=True)
 def create(kind, token, users=None, name=None):
 	authenticate(token)
 
-	users  = safe_json_loads(users)
+	users = safe_json_loads(users)
 	create = True
 
 	if kind == 'Visitor':
@@ -167,7 +171,7 @@ def create(kind, token, users=None, name=None):
 			""", (frappe.session.user), as_dict=True))
 
 		if room:
-			room   = frappe.get_doc('Chat Room', room.name)
+			room = frappe.get_doc('Chat Room', room.name)
 			create = False
 
 	if create:
@@ -176,11 +180,11 @@ def create(kind, token, users=None, name=None):
 		room.owner = frappe.session.user
 		room.room_name = name
 
-	dusers = [ ]
+	dusers = []
 
 	if kind != 'Visitor':
 		if users:
-			users  = listify(users)
+			users = listify(users)
 			for user in users:
 				duser = frappe.new_doc('Chat Room User')
 				duser.user = user
@@ -191,7 +195,7 @@ def create(kind, token, users=None, name=None):
 		dsettings = frappe.get_single('Website Settings')
 		room.room_name = dsettings.chat_room_name
 
-		users          = [user for user in room.users] if hasattr(room, 'users') else [ ]
+		users = [user for user in room.users] if hasattr(room, 'users') else []
 
 		for user in dsettings.chat_operators:
 			if user.user not in users:
@@ -200,9 +204,9 @@ def create(kind, token, users=None, name=None):
 				chat_room_user = {"doctype": "Chat Room User", "user": user.user}
 				room.append('users', chat_room_user)
 
-	room.save(ignore_permissions = True)
+	room.save(ignore_permissions=True)
 
-	room  = get(token=token, rooms=room.name)
+	room = get(token=token, rooms=room.name)
 	if room:
 		users = [room.owner] + [u for u in room.users]
 
@@ -211,14 +215,15 @@ def create(kind, token, users=None, name=None):
 
 	return room
 
-@frappe.whitelist(allow_guest = True)
-def history(room, user, fields = None, limit = 10, start = None, end = None):
+
+@frappe.whitelist(allow_guest=True)
+def history(room, user, fields=None, limit=10, start=None, end=None):
 	if frappe.get_doc('Chat Room', room).type != 'Visitor':
 		authenticate(user)
 
 	fields = safe_json_loads(fields)
 
-	mess   = chat_message.history(room, limit = limit, start = start, end = end)
-	mess   = squashify(mess)
+	mess = chat_message.history(room, limit=limit, start=start, end=end)
+	mess = squashify(mess)
 
 	return dictify(mess)

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -781,7 +781,7 @@ frappe.chat.room.get = function (names, fields, fn) {
 
 	return new Promise(resolve => {
 		frappe.call("frappe.chat.doctype.chat_room.chat_room.get",
-			{ token: frappe.session.user, rooms: names, fields: fields },
+			{ user: frappe.session.user, rooms: names, fields: fields },
 				response => {
 					let rooms = response.message
 					if ( rooms ) { // frappe.api BOGZ! (emtpy arrays are falsified, not good design).

--- a/frappe/public/js/frappe/chat.js
+++ b/frappe/public/js/frappe/chat.js
@@ -718,7 +718,7 @@ frappe.chat.room.create = function (kind, owner, users, name, fn) {
 
 	return new Promise(resolve => {
 		frappe.call("frappe.chat.doctype.chat_room.chat_room.create",
-			{ kind: kind, owner: owner || frappe.session.user, users: users, name: name },
+			{ kind: kind, token: owner || frappe.session.user, users: users, name: name },
 			r => {
 				let room = r.message
 				room     = { ...room, creation: new frappe.datetime.datetime(room.creation) }
@@ -781,7 +781,7 @@ frappe.chat.room.get = function (names, fields, fn) {
 
 	return new Promise(resolve => {
 		frappe.call("frappe.chat.doctype.chat_room.chat_room.get",
-			{ user: frappe.session.user, rooms: names, fields: fields },
+			{ token: frappe.session.user, rooms: names, fields: fields },
 				response => {
 					let rooms = response.message
 					if ( rooms ) { // frappe.api BOGZ! (emtpy arrays are falsified, not good design).


### PR DESCRIPTION
fixes issues with token being wrongly passed as the owner, instead of current session user (ie. `frappe.session.user`), which in turn causes the following issue:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/chat/doctype/chat_room/chat_room.py", line 203, in create
    room.save(ignore_permissions = True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 295, in _save
    self.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 223, in insert
    self._validate_links()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 756, in _validate_links
    frappe.LinkValidationError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 364, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 350, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 316, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.LinkValidationError: Could not find Owner: 0a4d6eb7763ef2065f44ece0653d829a1ba189f753562ab9ac261620
```

also fixes issue where the chat rooms do not load because of wrongly passed parameters
