### PR TITLE
fix(file): Public-private issue

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -398,7 +398,7 @@ def get_bcc(doc, recipients=None, fetched_from_email_account=False):
 	return bcc
 
 def add_attachments(name, attachments):
-	'''Add attachments to the given Communiction'''
+	'''Add attachments to the given Communication'''
 	# loop through attachments
 	for a in attachments:
 		if isinstance(a, string_types):
@@ -411,7 +411,9 @@ def add_attachments(name, attachments):
 				"file_url": attach.file_url,
 				"attached_to_doctype": "Communication",
 				"attached_to_name": name,
-				"folder": "Home/Attachments"})
+				"folder": "Home/Attachments",
+				"is_private": attach.is_private
+			})
 			_file.save(ignore_permissions=True)
 
 def filter_email_list(doc, email_list, exclude, is_cc=False, is_bcc=False):

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -89,8 +89,9 @@ class File(Document):
 
 	def validate(self):
 		if self.is_new():
+			self.set_is_private()
+			self.set_file_name()
 			self.validate_duplicate_entry()
-			self.validate_file_name()
 		self.validate_folder()
 
 		if not self.file_url and not self.flags.ignore_file_validate:
@@ -133,6 +134,10 @@ class File(Document):
 					frappe.db.set_value(self.attached_to_doctype, self.attached_to_name,
 						self.attached_to_field, self.file_url)
 
+		if (self.is_private and not self.file_url.startswith('/private')
+			or not self.is_private and self.file_url.startswith('/private')):
+			frappe.throw(_('Invalid file URL. Please contact System Administrator.'))
+
 	def set_folder_name(self):
 		"""Make parent folders if not exists based on reference doctype and name"""
 		if self.attached_to_doctype and not self.folder:
@@ -157,9 +162,11 @@ class File(Document):
 
 	def validate_duplicate_entry(self):
 		if not self.flags.ignore_duplicate_entry_error and not self.is_folder:
-			# check duplicate name
+			if not self.content_hash:
+				self.generate_content_hash()
 
-			# check duplicate assignement
+			# check duplicate name
+			# check duplicate assignment
 			filters = {
 				'content_hash': self.content_hash,
 				'is_private': self.is_private,
@@ -184,7 +191,7 @@ class File(Document):
 					else:
 						self.file_url = duplicate_file.file_url
 
-	def validate_file_name(self):
+	def set_file_name(self):
 		if not self.file_name and self.file_url:
 			self.file_name = self.file_url.split('/')[-1]
 
@@ -192,13 +199,12 @@ class File(Document):
 		if self.content_hash or not self.file_url:
 			return
 
-		if self.file_url.startswith("/files/"):
-			try:
-				with open(get_files_path(self.file_name.lstrip("/")), "rb") as f:
-					self.content_hash = get_content_hash(f.read())
-			except IOError:
-				frappe.msgprint(_("File {0} does not exist").format(self.file_url))
-				raise
+		try:
+			with open(get_files_path(self.file_name.lstrip("/")), "rb") as f:
+				self.content_hash = get_content_hash(f.read())
+		except IOError:
+			frappe.msgprint(_("File {0} does not exist").format(self.file_url))
+			raise
 
 	def on_trash(self):
 		if self.is_home_folder or self.is_attachments_folder:
@@ -563,6 +569,9 @@ class File(Document):
 			except frappe.DoesNotExistError:
 				frappe.clear_messages()
 
+	def set_is_private(self):
+		if self.file_url:
+			self.is_private = self.file_url.startswith('/private')
 
 def on_doctype_update():
 	frappe.db.add_index("File", ["attached_to_doctype", "attached_to_name"])

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -570,7 +570,7 @@ class File(Document):
 
 	def set_is_private(self):
 		if self.file_url:
-			self.is_private = self.file_url.startswith('/private')
+			self.is_private = cint(self.file_url.startswith('/private'))
 
 def on_doctype_update():
 	frappe.db.add_index("File", ["attached_to_doctype", "attached_to_name"])

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -134,9 +134,10 @@ class File(Document):
 					frappe.db.set_value(self.attached_to_doctype, self.attached_to_name,
 						self.attached_to_field, self.file_url)
 
-		if (self.is_private and not self.file_url.startswith('/private')
-			or not self.is_private and self.file_url.startswith('/private')):
-			frappe.throw(_('Invalid file URL. Please contact System Administrator.'))
+		if self.file_url:
+			if (self.is_private and not self.file_url.startswith('/private'))
+				or (not self.is_private and self.file_url.startswith('/private')):
+				frappe.throw(_('Invalid file URL. Please contact System Administrator.'))
 
 	def set_folder_name(self):
 		"""Make parent folders if not exists based on reference doctype and name"""

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -195,11 +195,11 @@ class File(Document):
 			self.file_name = self.file_url.split('/')[-1]
 
 	def generate_content_hash(self):
-		if self.content_hash or not self.file_url:
+		if self.content_hash or not self.file_url or self.file_url.startswith('http'):
 			return
 
 		try:
-			with open(get_files_path(self.file_name.lstrip("/")), "rb") as f:
+			with open(get_files_path(self.file_name.lstrip("/"), is_private=self.is_private), "rb") as f:
 				self.content_hash = get_content_hash(f.read())
 		except IOError:
 			frappe.msgprint(_("File {0} does not exist").format(self.file_url))

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -134,10 +134,8 @@ class File(Document):
 					frappe.db.set_value(self.attached_to_doctype, self.attached_to_name,
 						self.attached_to_field, self.file_url)
 
-		if self.file_url:
-			if (self.is_private and not self.file_url.startswith('/private'))
-				or (not self.is_private and self.file_url.startswith('/private')):
-				frappe.throw(_('Invalid file URL. Please contact System Administrator.'))
+		if self.file_url and (self.is_private != self.file_url.startswith('/private')):
+			frappe.throw(_('Invalid file URL. Please contact System Administrator.'))
 
 	def set_folder_name(self):
 		"""Make parent folders if not exists based on reference doctype and name"""


### PR DESCRIPTION
While creating a new file doc from an existing file document, `is_private` was not getting set properly.


Co-authored-by: Chinmay Pai <chinmaydpai@gmail.com>