### PR TITLE
feat: Custom url

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1021,7 +1021,7 @@ def read_file(path, raise_not_found=False):
 	else:
 		return None
 
-def get_attr(method_string):
+def get_attr(method_string, args=[]):
 	"""Get python method object from its name."""
 	app_name = method_string.split(".")[0]
 	if not local.flags.in_install and app_name not in get_installed_apps():
@@ -1029,7 +1029,11 @@ def get_attr(method_string):
 
 	modulename = '.'.join(method_string.split('.')[:-1])
 	methodname = method_string.split('.')[-1]
-	return getattr(get_module(modulename), methodname)
+	if args:
+		method = getattr(get_module(modulename), methodname)(args)
+	else:
+		method = getattr(get_module(modulename), methodname)
+	return method
 
 def call(fn, *args, **kwargs):
 	"""Call a function and match arguments."""

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1021,7 +1021,7 @@ def read_file(path, raise_not_found=False):
 	else:
 		return None
 
-def get_attr(method_string, args=[]):
+def get_attr(method_string, args=None):
 	"""Get python method object from its name."""
 	app_name = method_string.split(".")[0]
 	if not local.flags.in_install and app_name not in get_installed_apps():

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -151,7 +151,7 @@ def get_request(request):
 	"""
 	request = frappe.get_hooks("request", {}).get(request)
 	if len(request) > 1:
-		frappe.throw("Multiple methods registered for the same endpoint")
+		frappe.throw(_("Multiple methods registered for the same endpoint"))
 	return request[0]
 
 

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -133,9 +133,8 @@ def handle():
 	elif get_request(call):
 		cmd = get_request(call)
 		parts = frappe.request.path[1:].split("/")
-		frappe.local.form_dict.uri_params = parts[2:]
 		frappe.local.form_dict.cmd = cmd
-		return frappe.handler.handle()
+		return frappe.handler.handle(parts[2:])
 
 	else:
 		raise frappe.DoesNotExistError

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -38,7 +38,7 @@ def handle():
 	validate_oauth()
 	validate_auth_via_api_keys()
 
-	parts = frappe.request.path[1:].split("/")
+	parts = frappe.request.path[1:].split("/", 3)
 	call = doctype = name = None
 
 	if len(parts) > 1:
@@ -132,6 +132,7 @@ def handle():
 
 	elif get_request(call):
 		cmd = get_request(call)
+		parts = frappe.request.path[1:].split("/")
 		frappe.local.form_dict.uri_params = parts[2:]
 		frappe.local.form_dict.cmd = cmd
 		return frappe.handler.handle()

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -13,13 +13,13 @@ from frappe.core.doctype.server_script.server_script_utils import run_server_scr
 from werkzeug.wrappers import Response
 from six import string_types
 
-def handle():
+def handle(args=[]):
 	"""handle request"""
 	cmd = frappe.local.form_dict.cmd
 	data = None
 
 	if cmd!='login':
-		data = execute_cmd(cmd)
+		data = execute_cmd(cmd, args=args)
 
 	# data can be an empty string or list which are valid responses
 	if data is not None:
@@ -32,7 +32,7 @@ def handle():
 
 	return build_response("json")
 
-def execute_cmd(cmd, from_async=False):
+def execute_cmd(cmd, args=[], from_async=False):
 	"""execute a request as python module"""
 	for hook in frappe.get_hooks("override_whitelisted_methods", {}).get(cmd, []):
 		# override using the first hook
@@ -58,7 +58,7 @@ def execute_cmd(cmd, from_async=False):
 
 	is_whitelisted(method)
 
-	return frappe.call(method, **frappe.form_dict)
+	return frappe.call(method, *args, **frappe.form_dict)
 
 
 def is_whitelisted(method):
@@ -199,10 +199,10 @@ def upload_file():
 		return ret
 
 
-def get_attr(cmd):
+def get_attr(cmd, args=[]):
 	"""get method object from cmd"""
 	if '.' in cmd:
-		method = frappe.get_attr(cmd)
+		method = frappe.get_attr(cmd, args)
 	else:
 		method = globals()[cmd]
 	frappe.log("method:" + cmd)

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -13,7 +13,7 @@ from frappe.core.doctype.server_script.server_script_utils import run_server_scr
 from werkzeug.wrappers import Response
 from six import string_types
 
-def handle(args=[]):
+def handle(args=None):
 	"""handle request"""
 	cmd = frappe.local.form_dict.cmd
 	data = None
@@ -32,7 +32,7 @@ def handle(args=[]):
 
 	return build_response("json")
 
-def execute_cmd(cmd, args=[], from_async=False):
+def execute_cmd(cmd, args=None, from_async=False):
 	"""execute a request as python module"""
 	for hook in frappe.get_hooks("override_whitelisted_methods", {}).get(cmd, []):
 		# override using the first hook
@@ -199,7 +199,7 @@ def upload_file():
 		return ret
 
 
-def get_attr(cmd, args=[]):
+def get_attr(cmd, args=None):
 	"""get method object from cmd"""
 	if '.' in cmd:
 		method = frappe.get_attr(cmd, args)
@@ -207,7 +207,3 @@ def get_attr(cmd, args=[]):
 		method = globals()[cmd]
 	frappe.log("method:" + cmd)
 	return method
-
-@frappe.whitelist(allow_guest = True)
-def ping():
-	return "pong"

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -57,9 +57,10 @@ def execute_cmd(cmd, args=None, from_async=False):
 		method = method.queue
 
 	is_whitelisted(method)
-
-	return frappe.call(method, *args, **frappe.form_dict)
-
+	if args:
+		return frappe.call(method, *args, **frappe.form_dict)
+	else:
+		return frappe.call(method, **frappe.form_dict)
 
 def is_whitelisted(method):
 	# check if whitelisted


### PR DESCRIPTION
## Example: /api/test/hello/world
Register test request url in hooks.py with function which needs to be executed.
request = {"test": "frappe.api.ping"}
whatever comes after test in url is converted to list and sent as uri_params to the method
hello, world will be args/kwargs (type: list) to registered method as uri_params
uri_params = ['hello', 'world']

uri_params is optional argument to ping

#### eg whitelisted method
def ping(uri_params):
   print(uri_params) # output ---->  ['hello', 'world']




hooks.py
![image](https://user-images.githubusercontent.com/11792643/70709763-b363f000-1d03-11ea-8ba0-edd7f2f6241f.png)




![image](https://user-images.githubusercontent.com/11792643/70709368-c5915e80-1d02-11ea-97bc-c3a93f35a5cd.png)

uri_params can be accessed by following methods
## Access uri_params as argument
![image](https://user-images.githubusercontent.com/11792643/70709266-7f3bff80-1d02-11ea-8304-818e02d38e9c.png)

## Access uri_params as kwargs
![image](https://user-images.githubusercontent.com/11792643/70709514-07baa000-1d03-11ea-9373-d2b3cc89310a.png)

