### PR TITLE
fix: link field search taking trailing and leading spaces

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -50,7 +50,7 @@ def sanitize_searchfield(searchfield):
 # this is called by the Link Field
 @frappe.whitelist()
 def search_link(doctype, txt, query=None, filters=None, page_length=20, searchfield=None, reference_doctype=None, ignore_user_permissions=False):
-	search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters, reference_doctype=reference_doctype, ignore_user_permissions=ignore_user_permissions)
+	search_widget(doctype, txt.strip(), query, searchfield=searchfield, page_length=page_length, filters=filters, reference_doctype=reference_doctype, ignore_user_permissions=ignore_user_permissions)
 	frappe.response['results'] = build_for_autosuggest(frappe.response["values"])
 	del frappe.response["values"]
 


### PR DESCRIPTION

Link Field taking space while searching like below
![image](https://user-images.githubusercontent.com/26349035/70714596-76512b00-1d0e-11ea-8afb-beeb9f2ccb10.png)


After Removing spaces

![image](https://user-images.githubusercontent.com/26349035/70714693-abf61400-1d0e-11ea-8dd9-5dfc3acbee3a.png)
