### PR TITLE
fix: Add a patch to fix all user's home settings

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -258,3 +258,4 @@ frappe.patches.v12_0.update_auto_repeat_status_and_not_submittable
 frappe.patches.v12_0.copy_to_parent_for_tags
 frappe.patches.v12_0.create_notification_settings_for_user
 frappe.patches.v11_0.make_all_prepared_report_attachments_private #2019-11-26
+frappe.patches.v12_0.fix_home_settings_for_all_users

--- a/frappe/patches/v12_0/fix_home_settings_for_all_users.py
+++ b/frappe/patches/v12_0/fix_home_settings_for_all_users.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.config import get_modules_from_all_apps_for_user
 import json
 def execute():
-	users = frappe.get_all('User', fields=['name', 'home_settings'], limit=2)
+	users = frappe.get_all('User', fields=['name', 'home_settings'])
 
 	for user in users:
 

--- a/frappe/patches/v12_0/fix_home_settings_for_all_users.py
+++ b/frappe/patches/v12_0/fix_home_settings_for_all_users.py
@@ -1,0 +1,41 @@
+import frappe
+from frappe.config import get_modules_from_all_apps_for_user
+import json
+def execute():
+	users = frappe.get_all('User', fields=['name', 'home_settings'], limit=2)
+
+	for user in users:
+
+		if not user.home_settings:
+			continue
+
+		home_settings = json.loads(user.home_settings)
+
+		modules_by_category = home_settings.get('modules_by_category')
+		if not modules_by_category:
+			continue
+		visible_modules = []
+		category_to_check = []
+
+		for category, modules in modules_by_category.items():
+			visible_modules += modules
+			category_to_check.append(category)
+
+		all_modules = get_modules_from_all_apps_for_user(user.name)
+		all_modules = set([m.get('name') or m.get('module_name') or m.get('label') \
+			for m in all_modules if m.get('category') in category_to_check])
+
+		hidden_modules = home_settings['hidden_modules']
+
+		modules_in_home_settings = set(visible_modules + hidden_modules)
+
+		all_modules = all_modules.union(modules_in_home_settings)
+
+		missing_modules = all_modules - modules_in_home_settings
+
+		if missing_modules:
+			home_settings['hidden_modules'] += missing_modules
+			home_settings = json.dumps(home_settings)
+			frappe.set_value('User', user.name, 'home_settings', home_settings)
+
+	frappe.cache().delete_key('home_settings')


### PR DESCRIPTION
Patch to fix home settings for all users.

Few users were complaining that they are not able to view some modules even if it was checked on the "Show / Hide" modal.

**Reason:** Few modules were not present in hidden_modules or in module_by_category (of home_settings). So since the module was not in hidden_modules, it was showing checked on the "Show / Hide" modal and since the module was not in module_by_category, that module was not visible to the user.

This patch will add missing modules to hidden_modules of home_setting.

port-of: https://github.com/frappe/frappe/pull/9037