### PR TITLE
fix(grid): Empty row validation

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -53,6 +53,8 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			return frappe.model.is_table(d.doctype);
 		});
 
+		let modified_table_fields = [];
+
 		tables.map(
 			function(doc){
 				const cells = frappe.meta.docfield_list[doc.doctype] || [];
@@ -72,9 +74,14 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 
 				if (is_empty_row(in_list_view_cells)) {
 					frappe.model.clear_doc(doc.doctype, doc.name);
+					modified_table_fields.push(doc.parentfield);
 				}
 			}
 		);
+
+		modified_table_fields.forEach(field => {
+			frm.refresh_field(field);
+		});
 	};
 
 	var cancel = function () {

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -41,43 +41,41 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 	};
 
 	var remove_empty_rows = function() {
-		/**
-		This function removes empty rows. Note that in this function, a row is considered
-		empty if the fields with `in_list_view: 1` are undefined or falsy because that's
-		what users also consider to be an empty row
-		 */
+		/*
+			This function removes empty rows. Note that in this function, a row is considered
+			empty if the fields with `in_list_view: 1` are undefined or falsy because that's
+			what users also consider to be an empty row
+		*/
 		const docs = frappe.model.get_all_docs(frm.doc);
 
 		// we should only worry about table data
-		const tables = docs.filter(function(d){
+		const tables = docs.filter(d => {
 			return frappe.model.is_table(d.doctype);
 		});
 
 		let modified_table_fields = [];
 
-		tables.map(
-			function(doc){
-				const cells = frappe.meta.docfield_list[doc.doctype] || [];
+		tables.map(doc => {
+			const cells = frappe.meta.docfield_list[doc.doctype] || [];
 
-				const in_list_view_cells = cells.filter(function(df) {
-					return cint(df.in_list_view) === 1;
-				});
+			const in_list_view_cells = cells.filter((df) => {
+				return cint(df.in_list_view) === 1;
+			});
 
-				var is_empty_row = function(cells) {
-					for (var i=0; i < cells.length; i++){
-						if(locals[doc.doctype][doc.name][cells[i].fieldname]){
-							return false;
-						}
+			const is_empty_row = function(cells) {
+				for (let i = 0; i < cells.length; i++) {
+					if (locals[doc.doctype][doc.name][cells[i].fieldname]) {
+						return false;
 					}
-					return true;
 				}
+				return true;
+			};
 
-				if (is_empty_row(in_list_view_cells)) {
-					frappe.model.clear_doc(doc.doctype, doc.name);
-					modified_table_fields.push(doc.parentfield);
-				}
+			if (is_empty_row(in_list_view_cells)) {
+				frappe.model.clear_doc(doc.doctype, doc.name);
+				modified_table_fields.push(doc.parentfield);
 			}
-		);
+		});
 
 		modified_table_fields.forEach(field => {
 			frm.refresh_field(field);


### PR DESCRIPTION
Refresh parent field after removing an empty row (while validation) from the grid.

**Issue:**
![empty_row_bug](https://user-images.githubusercontent.com/13928957/70865752-08636880-1f87-11ea-9a09-63c7d51b8e61.gif)

**After Fix:**
![empty_row_bug_fix](https://user-images.githubusercontent.com/13928957/70865754-0c8f8600-1f87-11ea-9621-cdca349300a3.gif)



Co-authored-by: Faris Ansari <netchampfaris@users.noreply.github.com>

port-of: https://github.com/frappe/frappe/pull/9044