### PR TITLE
feat(server-scripts): Support Before/After Save for submitted document

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "Prompt",
  "creation": "2019-09-30 11:56:57.943241",
  "doctype": "DocType",
@@ -43,7 +44,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Save\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete"
+   "options": "Before Insert\nBefore Save\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -73,7 +74,8 @@
    "fieldtype": "Section Break"
   }
  ],
- "modified": "2019-10-09 15:08:40.085059",
+ "links": [],
+ "modified": "2019-12-17 12:55:07.389775",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -14,6 +14,8 @@ EVENT_MAP = {
 	'on_cancel': 'After Cancel',
 	'on_trash': 'Before Delete',
 	'after_delete': 'After Delete',
+	'before_update_after_submit': 'Before Save (Submitted Document)',
+	'on_update_after_submit': 'After Save (Submitted Document)'
 }
 
 def run_server_script_api(method):


### PR DESCRIPTION
Support Before/After Save for submitted document

[Documentation Link](https://github.com/frappe/erpnext_com/pull/620)
