### PR TITLE
fix: user default value for Link fields

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -61,7 +61,9 @@ def set_user_and_static_default_values(doc):
 
 			user_default_value = get_user_default_value(df, defaults, doctype_user_permissions, allowed_records, default_doc)
 			if user_default_value is not None:
-				doc.set(df.fieldname, user_default_value)
+				# if fieldtype is link check if doc exists
+				if not df.fieldtype == "Link" or frappe.db.exists(df.options, user_default_value):
+					doc.set(df.fieldname, user_default_value)
 
 			else:
 				if df.fieldname != doc.meta.title_field:


### PR DESCRIPTION
While creating a new document, before setting user default value for a Link field, check if the doc exists.
Example - Contact has a field with name company which is linked to Customer. In this case while inserting a new Contact, default company should not be set in the company field.

port-of: #9062