### PR TITLE
fix(login): Get guest's config if session.user is None

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -172,8 +172,8 @@ def get_notification_info():
 	return out
 
 def get_notification_config():
-	if not frappe.session.user:
-		return frappe._dict()
+	user = frappe.session.user or 'Guest'
+
 	def _get():
 		subscribed_documents = get_subscribed_documents()
 		config = frappe._dict()
@@ -196,8 +196,8 @@ def get_notification_config():
 					else:
 						config[key].update(nc.get(key, {}))
 		return config
-	print(frappe.cache().hget("notification_config", frappe.session.user))
-	return frappe.cache().hget("notification_config", frappe.session.user, _get)
+
+	return frappe.cache().hget("notification_config", user, _get)
 
 def get_filters_for(doctype):
 	'''get open filters for doctype'''

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -196,7 +196,7 @@ def get_notification_config():
 					else:
 						config[key].update(nc.get(key, {}))
 		return config
-	print(frappe.cache().hget("notification_config", frappe.session.user))
+
 	return frappe.cache().hget("notification_config", frappe.session.user, _get)
 
 def get_filters_for(doctype):

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -172,6 +172,8 @@ def get_notification_info():
 	return out
 
 def get_notification_config():
+	if not frappe.session.user:
+		return frappe._dict()
 	def _get():
 		subscribed_documents = get_subscribed_documents()
 		config = frappe._dict()
@@ -194,7 +196,7 @@ def get_notification_config():
 					else:
 						config[key].update(nc.get(key, {}))
 		return config
-
+	print(frappe.cache().hget("notification_config", frappe.session.user))
 	return frappe.cache().hget("notification_config", frappe.session.user, _get)
 
 def get_filters_for(doctype):


### PR DESCRIPTION
redis-py 3.0 has stopped accepting `None` as a key.
https://github.com/andymccurdy/redis-py#encoding-of-user-input


Co-authored-by: Sahil Khan <sahilkhan28297@gmail.com>
Co-authored-by: Shivam Mishra <scmmishra@users.noreply.github.com>

**Error while logging:**
```
Traceback (most recent call last):
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 52, in application
    init_request(request)
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 117, in init_request
    frappe.local.http_request = frappe.auth.HTTPRequest()
  File "/Users/sps/benches/develop/apps/frappe/frappe/auth.py", line 51, in __init__
    frappe.local.login_manager = LoginManager()
  File "/Users/sps/benches/develop/apps/frappe/frappe/auth.py", line 105, in __init__
    if self.login()==False: return
  File "/Users/sps/benches/develop/apps/frappe/frappe/auth.py", line 124, in login
    frappe.clear_cache(user = frappe.form_dict.get('usr'))
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 567, in clear_cache
    frappe.cache_manager.clear_user_cache(user)
  File "/Users/sps/benches/develop/apps/frappe/frappe/cache_manager.py", line 31, in clear_user_cache
    clear_notifications(user)
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/notifications.py", line 120, in clear_notifications
    config = get_notification_config()
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/notifications.py", line 199, in get_notification_config
    print(frappe.cache().hget("notification_config", frappe.session.user))
  File "/Users/sps/benches/develop/apps/frappe/frappe/utils/redis_wrapper.py", line 172, in hget
    value = super(RedisWrapper, self).hget(_name, key)
  File "/Users/sps/benches/develop/env/lib/python2.7/site-packages/redis/client.py", line 2713, in hget
    return self.execute_command('HGET', name, key)
  File "/Users/sps/benches/develop/env/lib/python2.7/site-packages/redis/client.py", line 838, in execute_command
    conn.send_command(*args)
  File "/Users/sps/benches/develop/env/lib/python2.7/site-packages/redis/connection.py", line 686, in send_command
    self.send_packed_command(self.pack_command(*args),
  File "/Users/sps/benches/develop/env/lib/python2.7/site-packages/redis/connection.py", line 737, in pack_command
    for arg in imap(self.encoder.encode, args):
  File "/Users/sps/benches/develop/env/lib/python2.7/site-packages/redis/connection.py", line 118, in encode
    "byte, string or number first." % typename)
DataError: Invalid input of type: 'NoneType'. Convert to a byte, string or number first.
```

**Note:**
This is just to fix the code. Users using this version i.e., v12, should not face the above issue as the Redis version has been pinned to `redis==2.10.6`