### PR TITLE
fix: on image remove event remove attach file.

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -32,7 +32,7 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 		if(this.frm) {
 			me.parse_validate_and_set_in_model(null);
 			me.refresh();
-			me.frm.attachments.remove_attachment_by_filename(me.value || me.frm.doc[me.frm.meta.image_field], function() {
+			me.frm.attachments.remove_attachment_by_filename(me.value, function() {
 				me.parse_validate_and_set_in_model(null);
 				me.refresh();
 				me.frm.doc.docstatus == 1 ? me.frm.save('Update') : me.frm.save();

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -32,7 +32,7 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 		if(this.frm) {
 			me.parse_validate_and_set_in_model(null);
 			me.refresh();
-			me.frm.attachments.remove_attachment_by_filename(me.value, function() {
+			me.frm.attachments.remove_attachment_by_filename(me.value || me.frm.doc[me.frm.meta.image_field], function() {
 				me.parse_validate_and_set_in_model(null);
 				me.refresh();
 				me.frm.doc.docstatus == 1 ? me.frm.save('Update') : me.frm.save();

--- a/frappe/public/js/frappe/form/sidebar/user_image.js
+++ b/frappe/public/js/frappe/form/sidebar/user_image.js
@@ -88,6 +88,7 @@ frappe.ui.form.setup_user_image_event = function(frm) {
 			}
 			field.$input.trigger('click');
 		} else {
+			/// on remove event for a sidebar image wrapper remove attach file.
 			frm.attachments.remove_attachment_by_filename(frm.doc[frm.meta.image_field] , function() {
 				field.set_value('').then(() => frm.save());
 			});

--- a/frappe/public/js/frappe/form/sidebar/user_image.js
+++ b/frappe/public/js/frappe/form/sidebar/user_image.js
@@ -88,7 +88,9 @@ frappe.ui.form.setup_user_image_event = function(frm) {
 			}
 			field.$input.trigger('click');
 		} else {
-			field.set_value('').then(() => frm.save());
+			frm.attachments.remove_attachment_by_filename(frm.doc[frm.meta.image_field] , function() {
+				field.set_value('').then(() => frm.save());
+			});
 		}
 	});
 }

--- a/frappe/public/js/frappe/form/sidebar/user_image.js
+++ b/frappe/public/js/frappe/form/sidebar/user_image.js
@@ -89,7 +89,7 @@ frappe.ui.form.setup_user_image_event = function(frm) {
 			field.$input.trigger('click');
 		} else {
 			/// on remove event for a sidebar image wrapper remove attach file.
-			frm.attachments.remove_attachment_by_filename(frm.doc[frm.meta.image_field] , function() {
+			frm.attachments.remove_attachment_by_filename(frm.doc[frm.meta.image_field], function() {
 				field.set_value('').then(() => frm.save());
 			});
 		}


### PR DESCRIPTION
As a user, if I remove a file from a document, it should remove it from the attached files for that document as well

Before:
![frappe2](https://user-images.githubusercontent.com/6947417/71059509-0f59c900-2189-11ea-9860-9ac280092bec.gif)

After:
![frappe1](https://user-images.githubusercontent.com/6947417/71059520-12ed5000-2189-11ea-8f8d-a1a10a1e8798.gif)
