### PR TITLE
fix: Make "Restriction" text translatable and fix style

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -291,7 +291,7 @@ frappe.get_modal = function(title, content) {
 			<div class="modal-content">
 				<div class="modal-header">
 					<div class="flex justify-between">
-						<div class="fill-width">
+						<div class="fill-width flex">
 							<span class="indicator hidden"></span>
 							<h4 class="modal-title" style="font-weight: bold;">${title}</h4>
 						</div>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -137,8 +137,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	show_restricted_list_indicator_if_applicable() {
 		const match_rules_list = frappe.perm.get_match_rules(this.doctype);
-		if(match_rules_list.length) {
-			this.restricted_list = $('<button class="restricted-list form-group">Restricted</button>')
+		if (match_rules_list.length) {
+			this.restricted_list = $(`<button class="restricted-list form-group">${__('Restricted')}</button>`)
 				.prepend('<span class="octicon octicon-lock"></span>')
 				.click(() => this.show_restrictions(match_rules_list))
 				.appendTo(this.page.page_form);
@@ -148,7 +148,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	show_restrictions(match_rules_list=[]) {
 		frappe.msgprint(frappe.render_template('list_view_permission_restrictions', {
 			condition_list: match_rules_list
-		}), 'Restrictions');
+		}), __('Restrictions'));
 	}
 
 	set_fields() {

--- a/frappe/public/less/indicator.less
+++ b/frappe/public/less/indicator.less
@@ -76,7 +76,6 @@
 }
 
 .modal-header .indicator {
-	float: left;
 	margin-top: 7.5px;
 	margin-right: 3px;
 }

--- a/frappe/public/less/list.less
+++ b/frappe/public/less/list.less
@@ -293,7 +293,7 @@ input.list-check-all, input.list-row-checkbox {
 		border-radius:  5px;
 		background: lightyellow;
 		color: @text-light;
-		margin-left:  auto;
+		margin: auto 0 auto auto;
 		font-size: @text-small;
 		margin-top: 3px;
 		outline: 0;
@@ -301,6 +301,13 @@ input.list-check-all, input.list-row-checkbox {
 			padding-right: 5px;
 			font-size: 12px;
 		}
+	}
+}
+
+.frappe-rtl {
+	.restricted-list {
+		margin: auto auto auto 0;
+		direction: ltr;
 	}
 }
 

--- a/frappe/public/less/page.less
+++ b/frappe/public/less/page.less
@@ -124,17 +124,16 @@
 }
 
 .page-form {
-	margin: 0px;
-	padding-right: 15px;
-	padding-top: 10px;
+	margin: 0;
+	padding: 10px 15px;
 	display: flex;
 	flex-wrap: wrap;
 	border-bottom: 1px solid @border-color;
 	background-color: @panel-bg;
 
 	.form-group {
-		padding-right: 0px;
-		margin-bottom: 10px;
+		padding: 0px;
+		margin: 0px;
 	}
 	.checkbox {
 		margin-top: 4px;


### PR DESCRIPTION
Make "Restriction" text translatable and fix the "Restricted" button CSS for RTL users.

**Before:**
<img width="972" alt="Screenshot 2019-12-19 at 1 00 32 PM" src="https://user-images.githubusercontent.com/13928957/71153745-ee17dc00-225f-11ea-94a5-9ba1d54a8094.png">
**After:**
<img width="980" alt="Screenshot 2019-12-19 at 11 25 21 AM" src="https://user-images.githubusercontent.com/13928957/71153645-a4c78c80-225f-11ea-88f8-225cf15b4167.png">

---

**Before:**
<img width="427" alt="Screenshot 2019-12-19 at 1 00 41 PM" src="https://user-images.githubusercontent.com/13928957/71153764-fa039e00-225f-11ea-8502-659a41188f18.png">

**After:**
<img width="519" alt="Screenshot 2019-12-19 at 1 02 15 PM" src="https://user-images.githubusercontent.com/13928957/71153816-1a335d00-2260-11ea-8095-cb6236fe7001.png">

