### PR TITLE
fix: patch home_settings_for_all_users

### DIFF
--- a/frappe/patches/v12_0/fix_home_settings_for_all_users.py
+++ b/frappe/patches/v12_0/fix_home_settings_for_all_users.py
@@ -25,7 +25,7 @@ def execute():
 		all_modules = set([m.get('name') or m.get('module_name') or m.get('label') \
 			for m in all_modules if m.get('category') in category_to_check])
 
-		hidden_modules = home_settings['hidden_modules']
+		hidden_modules = home_settings.get("hidden_modules", [])
 
 		modules_in_home_settings = set(visible_modules + hidden_modules)
 


### PR DESCRIPTION
**Issue**

```
Executing frappe.patches.v12_0.fix_home_settings_for_all_users in restore_db_hotfix (a2fb786d4eb8d296)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/migrate.py", line 48, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/patches/v12_0/fix_home_settings_for_all_users.py", line 29, in execute
    hidden_modules = home_settings['hidden_modules']
KeyError: 'hidden_modules'
```