### PR TITLE
fix: List filter area style

### DIFF
--- a/frappe/public/less/list.less
+++ b/frappe/public/less/list.less
@@ -293,9 +293,8 @@ input.list-check-all, input.list-row-checkbox {
 		border-radius:  5px;
 		background: lightyellow;
 		color: @text-light;
-		margin: auto 0 auto auto;
+		margin: auto 5px auto auto;
 		font-size: @text-small;
-		margin-top: 3px;
 		outline: 0;
 		.octicon {
 			padding-right: 5px;
@@ -306,7 +305,7 @@ input.list-check-all, input.list-row-checkbox {
 
 .frappe-rtl {
 	.restricted-list {
-		margin: auto auto auto 0;
+		margin: auto auto auto 5px;
 		direction: ltr;
 	}
 }

--- a/frappe/public/less/page.less
+++ b/frappe/public/less/page.less
@@ -125,7 +125,7 @@
 
 .page-form {
 	margin: 0;
-	padding: 10px 15px;
+	padding: 5px 10px;
 	display: flex;
 	flex-wrap: wrap;
 	border-bottom: 1px solid @border-color;
@@ -133,7 +133,7 @@
 
 	.form-group {
 		padding: 0px;
-		margin: 0px;
+		margin: 5px;
 	}
 	.checkbox {
 		margin-top: 4px;


### PR DESCRIPTION
**Before:**
<img width="1182" alt="Screenshot 2019-12-20 at 8 38 26 AM" src="https://user-images.githubusercontent.com/13928957/71227190-6801a100-2304-11ea-9e5e-575ca6156007.png">

**After:**
<img width="1196" alt="Screenshot 2019-12-20 at 8 40 02 AM" src="https://user-images.githubusercontent.com/13928957/71227275-a13a1100-2304-11ea-966f-ec33413e4656.png">

The issue was introduced after:
https://github.com/frappe/frappe/pull/9073
