### PR TITLE
fix: TypeError in home_settings patch

### DIFF
--- a/frappe/patches/v12_0/fix_home_settings_for_all_users.py
+++ b/frappe/patches/v12_0/fix_home_settings_for_all_users.py
@@ -34,7 +34,7 @@ def execute():
 		missing_modules = all_modules - modules_in_home_settings
 
 		if missing_modules:
-			home_settings['hidden_modules'] = hidden_modules + missing_modules
+			home_settings['hidden_modules'] = hidden_modules + list(missing_modules)
 			home_settings = json.dumps(home_settings)
 			frappe.set_value('User', user.name, 'home_settings', home_settings)
 


### PR DESCRIPTION
Convert set to list before concatenation

fixes: https://github.com/frappe/frappe/issues/9067

