### PR TITLE
fix(UX): Warn user about irreversible change while merging documents

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -80,10 +80,12 @@ frappe.ui.form.Toolbar = Class.extend({
 		const title_field = this.frm.meta.title_field || '';
 		const doctype = this.frm.doctype;
 
+		let confirm_message=null;
+
 		if (new_name) {
 			const warning = __("This cannot be undone");
 			const message = __("Are you sure you want to merge {0} with {1}?", [docname.bold(), new_name.bold()]);
-			const confirm_message = message + "<br><b>" + warning + "<b>";
+			confirm_message = `${message}<br><b>${warning}<b>`;
 		}
 
 		let rename_document = () => {
@@ -109,7 +111,9 @@ frappe.ui.form.Toolbar = Class.extend({
 				this.show_unchanged_document_alert();
 				resolve();
 			} else if (merge) {
-				frappe.confirm(confirm_message, function() { rename_document().then(resolve).catch(reject) }, reject);
+				frappe.confirm(confirm_message, () => {
+					rename_document().then(resolve).catch(reject);
+				}, reject);
 			} else {
 				rename_document().then(resolve).catch(reject);
 			}

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -69,23 +69,61 @@ frappe.ui.form.Toolbar = Class.extend({
 	can_rename: function() {
 		return this.frm.perm[0].write && this.frm.meta.allow_rename && !this.frm.doc.__islocal;
 	},
+	show_unchanged_document_alert: function() {
+		frappe.show_alert({
+			indicator: "yellow",
+			message: __("Unchanged")
+		});
+	},
+	rename_document_title(new_name, new_title, merge=false) {
+		const docname = this.frm.doc.name;
+		const title_field = this.frm.meta.title_field || '';
+		const doctype = this.frm.doctype;
+
+		const warning = __("This cannot be undone");
+		const message = __("Are you sure you want to merge {0} with {1}?", [docname.bold(), new_name.bold()]);
+		const confirm_message = message + "<br><b>" + warning + "<b>";
+
+		let rename_document = () => {
+			return frappe.xcall("frappe.model.rename_doc.update_document_title", {
+				doctype,
+				docname,
+				title_field,
+				old_title: this.frm.doc[title_field],
+				new_name: new_name,
+				new_title: new_title,
+				merge: merge
+			}).then(new_docname => {
+				if (new_name != docname) {
+					$(document).trigger("rename", [doctype, docname, new_docname || new_name]);
+					if (locals[doctype] && locals[doctype][docname]) delete locals[doctype][docname];
+				}
+			});
+		};
+
+		return new Promise((resolve, reject) => {
+			if (new_title === this.frm.doc[title_field] && new_name === docname) {
+				this.show_unchanged_document_alert();
+				resolve();
+			} else if (merge) {
+				frappe.confirm(confirm_message, () => {
+					rename_document().then(resolve).catch(reject);
+				}, reject);
+			} else {
+				rename_document().then(resolve).catch(reject);
+			}
+		});
+
+	},
 	setup_editable_title: function () {
 		let me = this;
 
-		function document_unchanged(){
-			frappe.show_alert({
-				indicator: "yellow",
-				message: __("Unchanged")
-			})
-		}
-
 		this.page.$title_area.find(".title-text").on("click", () => {
 			let fields = [];
-			let doctype = me.frm.doctype;
 			let docname = me.frm.doc.name;
 			let title_field = me.frm.meta.title_field || '';
 
-			// check if title is updateable
+			// check if title is updatable
 			if (me.is_title_editable()) {
 				let title_field_label = me.frm.get_docfield(title_field).label;
 
@@ -98,7 +136,7 @@ frappe.ui.form.Toolbar = Class.extend({
 				});
 			}
 
-			// check if docname is updateable
+			// check if docname is updatable
 			if (me.can_rename()) {
 				fields.push(...[{
 					label: __("New Name"),
@@ -121,45 +159,15 @@ frappe.ui.form.Toolbar = Class.extend({
 					fields: fields
 				});
 				d.show();
-
-				d.set_primary_action(__("Rename"), function () {
-					let args = d.get_values();
-					if (args.title != me.frm.doc[title_field] || args.name != docname) {
-						if (args.merge) {
-							let warning = __("This cannot be undone");
-							let message = __("Are you sure you want to merge {0} with {1}?", [docname.bold(), args.name.bold()])
-							let confirm_message = message + "<br><b>" + warning + "<b>";
-
-							frappe.confirm(
-								confirm_message,
-								function() {
-									frappe.call({
-										method: "frappe.model.rename_doc.update_document_title",
-										args: {
-											doctype,
-											docname,
-											title_field,
-											old_title: me.frm.doc[title_field],
-											new_title: args.title,
-											new_name: args.name,
-											merge: args.merge
-										},
-										btn: d.get_primary_btn()
-									}).then((res) => {
-										me.frm.reload_doc();
-										if (!res.exc && (args.name != docname)) {
-											$(document).trigger("rename", [doctype, docname, res.message || args.name]);
-											if (locals[doctype] && locals[doctype][docname]) delete locals[doctype][docname];
-										}
-									})
-								},
-								document_unchanged
-							);
-						}
-					} else {
-						document_unchanged()
-					}
-					d.hide();
+				d.set_primary_action(__("Rename"), (values) => {
+					d.disable_primary_action();
+					this.rename_document_title(values.name, values.title, values.merge)
+						.then(() => {
+							d.hide();
+						})
+						.catch(() => {
+							d.enable_primary_action();
+						});
 				});
 			}
 		});

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -550,13 +550,18 @@ $.extend(frappe.model, {
 	},
 
 	rename_doc: function(doctype, docname, callback) {
+			let message = __("Merge with existing");
+			let warning = __("This cannot be undone");
+			let merge_label = message + " <b>(" + warning + ")</b>";
+
 		var d = new frappe.ui.Dialog({
 			title: __("Rename {0}", [__(docname)]),
 			fields: [
 				{label:__("New Name"), fieldname: "new_name", fieldtype:"Data", reqd:1, "default": docname},
-				{label:__("Merge with existing"), fieldtype:"Check", fieldname:"merge"},
+				{label:merge_label, fieldtype:"Check", fieldname:"merge"},
 			]
 		});
+
 		d.set_primary_action(__("Rename"), function() {
 			var args = d.get_values();
 			if(!args) return;

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -557,8 +557,8 @@ $.extend(frappe.model, {
 		var d = new frappe.ui.Dialog({
 			title: __("Rename {0}", [__(docname)]),
 			fields: [
-				{label:__("New Name"), fieldname: "new_name", fieldtype:"Data", reqd:1, "default": docname},
-				{label:merge_label, fieldtype:"Check", fieldname:"merge"},
+				{label: __("New Name"), fieldname: "new_name", fieldtype: "Data", reqd: 1, "default": docname},
+				{label: merge_label, fieldtype: "Check", fieldname: "merge"},
 			]
 		});
 


### PR DESCRIPTION
**Added:**
 - frappe.confirm in case of merging documents via toolbar document rename `frappe.call(update_document_title)`

![2019-12-23 11 21 24](https://user-images.githubusercontent.com/36654812/71339176-c0d96f80-2578-11ea-8b26-88dd53a2db15.gif)

 - added warning for merging via `frappe.model.rename_doc` JS API

![2019-12-23 11 33 48](https://user-images.githubusercontent.com/36654812/71339167-bb7c2500-2578-11ea-9bc5-36689f50901e.gif)

**Miscellaneous Changes:**
 - fixed symlinking fails on `bench build`  [moved to #9184] 