### PR TITLE
fix: allow to format currency for guest users

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -130,7 +130,7 @@ function format_currency(v, currency, decimals) {
 
 function get_currency_symbol(currency) {
 	if (frappe.boot) {
-		if (frappe.boot.sysdefaults.hide_currency_symbol == "Yes")
+		if (frappe.boot.sysdefaults && frappe.boot.sysdefaults.hide_currency_symbol == "Yes")
 			return null;
 
 		if (!currency)


### PR DESCRIPTION
Checks if frappe boot has sysdefaults before fetching flag for the hiding currency symbol

port-of: https://github.com/frappe/frappe/pull/9096