### PR TITLE
fix: Pass key to get_user_settings to avoid TypeError

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -858,7 +858,7 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	navigate_records(prev) {
-		let list_settings = frappe.get_user_settings(this.doctype)['List'];
+		let list_settings = frappe.get_user_settings(this.doctype, 'List');
 		let args = {
 			doctype: this.doctype,
 			value: this.docname,


### PR DESCRIPTION
If the user settings for List is not set then the list view
should not throw `TypeError` error

Passing key to `get_user_settings` returns an empty object even if
there are no default settings and hence avoids the TypeError
