### PR TITLE
fix: don't create filter tag if no filter is applied

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -287,6 +287,7 @@ frappe.ui.Filter = class {
 	}
 
 	make_tag() {
+		if (!this.field) return;
 		this.$filter_tag = this.get_filter_tag_element()
 			.insertAfter(this.parent.find(".active-tag-filters .clear-filters"));
 		this.set_filter_button_text();


### PR DESCRIPTION
To prevent this :

<img width="976" alt="Screenshot 2019-12-24 at 12 19 45 PM" src="https://user-images.githubusercontent.com/19775888/71398865-dd90a880-2647-11ea-8fbb-8838bbe0dbd5.png">

 