### PR TITLE
fix: Treat html editor as data field in standard filter

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -614,7 +614,7 @@ class FilterArea {
 			let options = df.options;
 			let condition = '=';
 			let fieldtype = df.fieldtype;
-			if (['Text', 'Small Text', 'Text Editor', 'Data', 'Code'].includes(fieldtype)) {
+			if (['Text', 'Small Text', 'Text Editor', 'HTML Editor', 'Data', 'Code'].includes(fieldtype)) {
 				fieldtype = 'Data';
 				condition = 'like';
 			}


### PR DESCRIPTION
HTML Editor field can be treated as normal data field and be filtered with Data fieldtype and condition 'like'

port-of: https://github.com/frappe/frappe/pull/9059