### PR TITLE
fix: File duplicate check

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -311,39 +311,6 @@ class File(Document):
 		exists = os.path.exists(self.get_full_path())
 		return exists
 
-	def upload(self):
-		# get record details
-		self.attached_to_doctype = frappe.form_dict.doctype
-		self.attached_to_name = frappe.form_dict.docname
-		self.attached_to_field = frappe.form_dict.docfield
-		self.file_url = frappe.form_dict.file_url
-		self.file_name = frappe.form_dict.filename
-		frappe.form_dict.is_private = cint(frappe.form_dict.is_private)
-
-		if not self.file_name and not self.file_url:
-			frappe.msgprint(_("Please select a file or url"),
-				raise_exception=True)
-
-		file_doc = self.get_file_doc()
-
-		comment = {}
-		if self.attached_to_doctype and self.attached_to_name:
-			comment = frappe.get_doc(self.attached_to_doctype, self.attached_to_name).add_comment("Attachment",
-			_	("added {0}").format("<a href='{file_url}' target='_blank'>{file_name}</a>{icon}".format(**{
-					"icon": ' <i class="fa fa-lock text-warning"></i>' \
-						if file_doc.is_private else "",
-					"file_url": file_doc.file_url.replace("#", "%23") \
-						if file_doc.file_name else file_doc.file_url,
-					"file_name": file_doc.file_name or file_doc.file_url
-				})))
-
-		return {
-			"name": file_doc.name,
-			"file_name": file_doc.file_name,
-			"file_url": file_doc.file_url,
-			"is_private": file_doc.is_private,
-			"comment": comment.as_dict() if comment else {}
-		}
 
 	def get_content(self):
 		"""Returns [`file_name`, `content`] for given file name `fname`"""

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -197,9 +197,9 @@ class File(Document):
 	def generate_content_hash(self):
 		if self.content_hash or not self.file_url or self.file_url.startswith('http'):
 			return
-
+		file_name = self.file_url.split('/')[-1]
 		try:
-			with open(get_files_path(self.file_name.lstrip("/"), is_private=self.is_private), "rb") as f:
+			with open(get_files_path(file_name, is_private=self.is_private), "rb") as f:
 				self.content_hash = get_content_hash(f.read())
 		except IOError:
 			frappe.msgprint(_("File {0} does not exist").format(self.file_url))


### PR DESCRIPTION
Generate content hash by passing file_name from file_url instead of file_name in the file doc because file_name can be different from the actual file
if the same file (same content) is uploaded twice with different names.

**fixes:**

```
Traceback (most recent call last):
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 1041, in call
    return fn(*args, **newargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 295, in _save
    self.insert()
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 257, in insert
    self.copy_attachments_from_amended_from()
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 344, in copy_attachments_from_amended_from
    _file.save()
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 295, in _save
    self.insert()
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 229, in insert
    self.run_before_save_methods()
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 888, in run_before_save_methods
    self.run_method("validate")
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 781, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/core/doctype/file/file.py", line 94, in validate
    self.validate_duplicate_entry()
  File "/Users/sps/benches/develop/apps/frappe/frappe/core/doctype/file/file.py", line 165, in validate_duplicate_entry
    self.generate_content_hash()
  File "/Users/sps/benches/develop/apps/frappe/frappe/core/doctype/file/file.py", line 202, in generate_content_hash
    with open(get_files_path(self.file_name.lstrip("/"), is_private=self.is_private), "rb") as f:
IOError: [Errno 2] No such file or directory: u'./erpnext-develop/private/files/a1ba249'
```


Steps to replicate:

1. Attach file `a` to doc `x`
2. Rename file `a` to `b` and attach/upload to doc `y` (save and submit)
3. Now cancel `y` and amend the doc. On saving the amended document, the system used to throw the above error.