### PR TITLE
fix(email): Do not encode smtp_server value

### DIFF
--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import validate_email_address ,cint
+from frappe.utils import validate_email_address ,cint, cstr
 import imaplib,poplib,smtplib
 from frappe.email.utils import get_port
 
@@ -51,7 +51,7 @@ class EmailDomain(Document):
 			try:
 				if self.use_tls and not self.smtp_port:
 					self.smtp_port = 587
-				sess = smtplib.SMTP((self.smtp_server or ""), cint(self.smtp_port) or None)
+				sess = smtplib.SMTP(cstr(self.smtp_server or ""), cint(self.smtp_port) or None)
 				sess.quit()
 			except Exception:
 				frappe.throw(_("Outgoing email account not correct"))

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -51,7 +51,7 @@ class EmailDomain(Document):
 			try:
 				if self.use_tls and not self.smtp_port:
 					self.smtp_port = 587
-				sess = smtplib.SMTP((self.smtp_server or "").encode('utf-8'), cint(self.smtp_port) or None)
+				sess = smtplib.SMTP((self.smtp_server or ""), cint(self.smtp_port) or None)
 				sess.quit()
 			except Exception:
 				frappe.throw(_("Outgoing email account not correct"))

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -8,7 +8,7 @@ import smtplib
 import email.utils
 import _socket, sys
 from frappe import _
-from frappe.utils import cint, parse_addr
+from frappe.utils import cint, cstr, parse_addr
 
 def send(email, append_to=None, retry=1):
 	"""Deprecated: Send the message or add it to Outbox Email"""
@@ -202,7 +202,7 @@ class SMTPServer:
 			if self.use_tls and not self.port:
 				self.port = 587
 
-			self._sess = smtplib.SMTP((self.server or "").encode('utf-8'),
+			self._sess = smtplib.SMTP(cstr(self.server or ""),
 				cint(self.port) or None)
 
 			if not self._sess:


### PR DESCRIPTION
The following error occurs while creating new Email Domain in python 3 instance.

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 308, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 888, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 781, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 73, in validate
    self.check_smtp()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 141, in check_smtp
    server.sess
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/smtp.py", line 206, in sess
    cint(self.port) or None)
  File "/usr/lib64/python3.6/smtplib.py", line 251, in __init__
    (code, msg) = self.connect(host, port)
  File "/usr/lib64/python3.6/smtplib.py", line 324, in connect
    if not port and (host.find(':') == host.rfind(':')):
TypeError: a bytes-like object is required, not 'str'
```

Removed encoding as it seems useless here.



