### PR TITLE
fix: formatting for check in prints

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -84,7 +84,7 @@ frappe.form.formatters = {
 	},
 	Check: function(value) {
 		if(value) {
-			return '<i class="octicon octicon-check" style="margin-right: 3px;"></i>';
+			return '<i class="fa fa-check" style="margin-right: 3px;"></i>';
 		} else {
 			return '<i class="fa fa-square disabled-check"></i>';
 		}

--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -50,7 +50,7 @@
 }
 
 .disabled-check {
-	color: #eee !important;
+	color: #eee;
 }
 
 .data-field {

--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -49,6 +49,10 @@
 	}
 }
 
+.disabled-check {
+	color: #eee !important;
+}
+
 .data-field {
 	margin-top: 5px;
 	margin-bottom: 5px;


### PR DESCRIPTION
Fix check box formatting for print format

This PR has the following changes
1. Replace octicon with font-awesome, octicon is not available in print
2. Set style explicitly for disabled check in `standard.css`

Before

![image](https://user-images.githubusercontent.com/18097732/71477007-bf74a500-280d-11ea-9b7e-831ed97a6f06.png)

After

<img width="734" alt="image" src="https://user-images.githubusercontent.com/18097732/71477052-f8ad1500-280d-11ea-9399-b3be39a850f7.png">
