### PR TITLE
fix: Fix non translatable text for edit/delete comments in doctypes timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -313,11 +313,11 @@ frappe.ui.form.Timeline = class Timeline {
 		c["edit"] = "";
 		if(c.communication_type=="Comment" && (c.comment_type || "Comment") === "Comment") {
 			if(frappe.model.can_delete("Communication")) {
-				c["delete"] = '<a class="close delete-comment" title="Delete"  href="#"><i class="octicon octicon-x"></i></a>';
+				c["delete"] = `<a class="close delete-comment" title="${__('Delete')}"  href="#"><i class="octicon octicon-x"></i></a>`;
 			}
 
 			if(frappe.user.name == c.sender || (frappe.user.name == 'Administrator')) {
-				c["edit"] = '<a class="edit-comment text-muted" title="Edit" href="#">Edit</a>';
+				c["edit"] = `<a class="edit-comment text-muted" title="${__('Edit')}" href="#">${__('Edit')}</a>`;
 			}
 		}
 		let communication_date = c.communication_date || c.creation;


### PR DESCRIPTION
Added missed translatable text for comments edit/delete actions in doctype timeline:
 
![Screenshot from 2019-12-26 12-39-01](https://user-images.githubusercontent.com/47140294/71474648-cdf69880-27dc-11ea-925f-0f781fc8ad34.png)
