### PR TITLE
fix: no data fallback on filters

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -90,7 +90,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 					this.render_dropdown_items(field_count_list, dropdown);
 					this.sidebar.setup_dropdown_search(dropdown, '.group-by-value');
 				} else {
-					dropdown.find('.group-by-loading').hide();
+					dropdown.find('.group-by-loading').html(`${__("No filters found")}`);
 				}
 			});
 		});


### PR DESCRIPTION
**Problem:**

If a user tries to apply filters on a doctype with no unique values, the system would just not show any feedback to indicate that, which leads to bad UX.

**Before:**

![image](https://user-images.githubusercontent.com/13396535/71504279-d31c1c00-289e-11ea-8d12-71f6cf86fc4c.png)

**After:**

![image](https://user-images.githubusercontent.com/13396535/71504228-9cde9c80-289e-11ea-8f4c-cad47be8f811.png)