### PR TITLE
fix(email): handle case where cstr returns text_type of str

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -480,7 +480,7 @@ class Email:
 		"""Detect chartset."""
 		charset = part.get_content_charset()
 		if not charset:
-			charset = chardet.detect(cstr(part))['encoding']
+			charset = chardet.detect(safe_encode(cstr(part)))['encoding']
 
 		return charset
 


### PR DESCRIPTION
chardet requires input to be `bytes` or `bytesarray`, but sometimes `cstr()` returns unicode text_type which needs to be encoded to bytes before using `chardet.detect()`.

a [similar issue has been fixed before](https://github.com/frappe/frappe/pull/8965) where `safe_encode` was replaced with `cstr`, which ensures that the data is at least converted into `text_type`, which then needs to be passed through `safe_encode` to make sure that the data gets converted to bytes.

---

Traceback:

```python-traceback
Traceback (most recent call last):                                                                                               File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 280, in   receive                                                                                                                          communication = self.insert_communication(msg, args=args)                                                                    File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 337, in   insert_communication                                                                                                             email = Email(raw)                                                                                                           File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 372, in __init__                        self.parse()                                                                                                                 File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 393, in parse                           self.process_part(part)                                                                                                      File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 445, in process_part                    self.text_content += self.get_payload(part)                                                                                  File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 489, in get_payload                     charset = self.get_charset(part)                                                                                             File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 484, in get_charset                     charset = chardet.detect(cstr(part))['encoding']                                                                             File \"/home/frappe/benches/bench-2019-12-20/env/lib/python3.6/site-packages/chardet/__init__.py\", line 34, in detect           '{0}'.format(type(byte_str)))                                                                                              TypeError: Expected object of type bytes or bytearray, got: <class 'str'>                                                                                                                                                                                     Traceback (most recent call last):                                                                                               File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 280, in   receive                                                                                                                          communication = self.insert_communication(msg, args=args)                                                                    File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 337, in   insert_communication
    email = Email(raw)
  File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 372, in __init__
    self.parse()
  File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 393, in parse
    self.process_part(part)
  File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 445, in process_part
    self.text_content += self.get_payload(part)
  File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 489, in get_payload
    charset = self.get_charset(part)
  File \"/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/email/receive.py\", line 484, in get_charset
    charset = chardet.detect(cstr(part))['encoding']
  File \"/home/frappe/benches/bench-2019-12-20/env/lib/python3.6/site-packages/chardet/__init__.py\", line 34, in detect
    '{0}'.format(type(byte_str)))
TypeError: Expected object of type bytes or bytearray, got: <class 'str'>
```