### PR TITLE
fix: update docstatus of documents if docstatus value is changed in w…

### DIFF
--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -88,6 +88,20 @@ class TestWorkflow(unittest.TestCase):
 		self.assertEqual(workflow_actions[0].status, 'Completed')
 		frappe.set_user('Administrator')
 
+	def test_update_docstatus(self):
+		todo = create_new_todo()
+		apply_workflow(todo, 'Approve')
+
+		self.workflow.states[1].doc_status = 0
+		self.workflow.save()
+		todo.reload()
+		self.assertEqual(todo.docstatus, 0)
+		self.workflow.states[1].doc_status = 1
+		self.workflow.save()
+		todo.reload()
+		self.assertEqual(todo.docstatus, 1)
+
+
 def create_todo_workflow():
 	if frappe.db.exists('Workflow', 'Test ToDo'):
 		return frappe.get_doc('Workflow', 'Test ToDo').save(ignore_permissions=True)

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -58,6 +58,10 @@ class Workflow(Document):
 				docstatus_map[d.doc_status] = d.state
 
 	def update_doc_status(self):
+		'''
+			Checks if the docstatus of a state was updated. 
+			If yes then the docstatus of the document with same state will be updated
+		'''
 		doc_before_save = self.get_doc_before_save()
 		before_save_states, new_states = {}, {}
 		if doc_before_save:
@@ -69,14 +73,12 @@ class Workflow(Document):
 			for key in new_states:
 				if key in before_save_states:
 					if not new_states[key].doc_status == before_save_states[key].doc_status:
-						frappe.db.set_value(self.document_type,
-							{
+						frappe.db.set_value(self.document_type, {
 								self.workflow_state_field: before_save_states[key].state
 							},
 							'docstatus',
 							new_states[key].doc_status,
-							update_modified = False
-						)
+							update_modified = False)
 
 	def validate_docstatus(self):
 		def get_state(state):

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -59,13 +59,14 @@ class Workflow(Document):
 
 	def update_doc_status(self):
 		doc_before_save = self.get_doc_before_save()
-		for current_doc_state, doc_before_save_state in zip(self.states, doc_before_save.states):
-			if not doc_before_save_state.doc_status == current_doc_state.doc_status:
-				frappe.db.set_value(self.document_type,
-					{self.workflow_state_field: doc_before_save_state.state},
-					'docstatus',
-					current_doc_state.doc_status
-				)
+		if doc_before_save:
+			for current_doc_state, doc_before_save_state in zip(self.states, doc_before_save.states):
+				if not doc_before_save_state.doc_status == current_doc_state.doc_status:
+					frappe.db.set_value(self.document_type,
+						{self.workflow_state_field: doc_before_save_state.state},
+						'docstatus',
+						current_doc_state.doc_status
+					)
 
 	def validate_docstatus(self):
 		def get_state(state):


### PR DESCRIPTION
Update document status of existing documents if the docstatus value is changed for a state in a Workflow to prevent this:

<img width="567" alt="Screenshot 2019-12-30 at 4 59 42 PM" src="https://user-images.githubusercontent.com/19775888/71580229-cb21dd80-2b25-11ea-8581-374f2e78a74b.png">
