### PR TITLE
fix: allow tables to be sent with dates in webhook (develop)

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -106,16 +106,12 @@ def get_webhook_headers(doc, webhook):
 
 def get_webhook_data(doc, webhook):
 	data = {}
+	doc = doc.as_dict(convert_dates_to_str=True)
+
 	if webhook.webhook_data:
-		for w in webhook.webhook_data:
-			value = doc.get(w.fieldname)
-			if isinstance(value, datetime.datetime):
-				value = frappe.utils.get_datetime_str(value)
-			if isinstance(value, list):
-				serialize_doc = lambda val: val.as_dict() if isinstance(val, Document) else val
-				value = list(map(serialize_doc, value))
-			data[w.key] = value
+		data = {w.key: doc.get(w.fieldname) for w in webhook.webhook_data}
 	elif webhook.webhook_json:
 		data = frappe.render_template(webhook.webhook_json, get_context(doc))
 		data = json.loads(data)
+
 	return data

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -111,6 +111,9 @@ def get_webhook_data(doc, webhook):
 			value = doc.get(w.fieldname)
 			if isinstance(value, datetime.datetime):
 				value = frappe.utils.get_datetime_str(value)
+			if isinstance(value, list):
+				serialize_doc = lambda val: val.as_dict() if isinstance(val, Document) else val
+				value = list(map(serialize_doc, value))
 			data[w.key] = value
 	elif webhook.webhook_json:
 		data = frappe.render_template(webhook.webhook_json, get_context(doc))

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -275,7 +275,7 @@ class BaseDocument(object):
 		doc["doctype"] = self.doctype
 		for df in self.meta.get_table_fields():
 			children = self.get(df.fieldname) or []
-			doc[df.fieldname] = [d.as_dict(no_nulls=no_nulls) for d in children]
+			doc[df.fieldname] = [d.as_dict(convert_dates_to_str=convert_dates_to_str, no_nulls=no_nulls) for d in children]
 
 		if no_nulls:
 			for k in list(doc):


### PR DESCRIPTION
**Ref:** https://discuss.erpnext.com/t/webhook-json-serializable-error-on-salesinvoiceitem/56452

<hr>

**Changes:**
- Improve data mapping for webhook payload
- Serialize date objects in child tables