### PR TITLE
fix(requirements): remove psycopg2 from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ pdfkit==0.6.1
 Pillow==6.2.1
 premailer==3.6.1
 psycopg2-binary==2.8.4
-psycopg2==2.8.4
 pyasn1==0.4.7
 Pygments==2.2.0
 PyJWT==1.7.1


### PR DESCRIPTION
apparently, since version 2.8, psycopg2 does not install the binary version by default (read source), and hence fails on setup with the error:
```
Error: pg_config executable not found
```
since nobody can really be arsed to compile this binary on their own, we'll stick to using psycopg2-binary instead.

source: [pgsql mailing list](https://www.postgresql.org/message-id/CA%2Bmi_8bd6kJHLTGkuyHSnqcgDrJ1uHgQWvXCKQFD3tPQBUa2Bw%40mail.gmail.com).
