### PR TITLE
fix(requirements): remove psycopg2 from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,6 @@ stripe
 coverage
 urllib3
 GitPython==2.1.11
-psycopg2==2.8.4
 psycopg2-binary==2.8.4
 sqlparse==0.2.4
 Pygments==2.2.0


### PR DESCRIPTION
apparently, since version 2.8, psycopg2 does not install the binary version by default (read source), and hence fails on setup with the error:
```
Error: pg_config executable not found
```
since nobody can really be arsed to compile this binary on their own, we'll stick to using psycopg2-binary instead.

source: [pgsql mailing list](https://www.postgresql.org/message-id/CA%2Bmi_8bd6kJHLTGkuyHSnqcgDrJ1uHgQWvXCKQFD3tPQBUa2Bw%40mail.gmail.com).


port of: #9175 
