### PR TITLE
fix(Auto Repeat): derive next date from start date and offset

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -9,7 +9,7 @@ from frappe.desk.form import assign_to
 from frappe.utils.jinja import validate_template
 from dateutil.relativedelta import relativedelta
 from frappe.utils.user import get_system_managers
-from frappe.utils import cstr, getdate, split_emails, add_days, today, get_last_day, get_first_day
+from frappe.utils import cstr, getdate, split_emails, add_days, today, get_last_day, get_first_day, month_diff
 from frappe.model.document import Document
 from frappe.core.doctype.communication.email import make
 from frappe.utils.background_jobs import get_jobs
@@ -48,7 +48,7 @@ class AutoRepeat(Document):
 		if self.disabled:
 			self.next_schedule_date = None
 		else:
-			self.next_schedule_date = get_next_schedule_date(self.start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, self.end_date)
+			self.next_schedule_date = get_next_schedule_date(self.start_date, self.frequency, self.start_date, self.repeat_on_day, self.repeat_on_last_day, self.end_date)
 
 	def unlink_if_applicable(self):
 		if self.status == 'Completed' or self.disabled:
@@ -107,27 +107,27 @@ class AutoRepeat(Document):
 		end_date = getdate(self.end_date)
 
 		if not self.end_date:
-			start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day)
+			next_date = get_next_schedule_date(start_date, self.frequency, self.start_date, self.repeat_on_day, self.repeat_on_last_day)
 			row = {
 				"reference_document": self.reference_document,
 				"frequency": self.frequency,
-				"next_scheduled_date": start_date
+				"next_scheduled_date": next_date
 			}
 			schedule_details.append(row)
-			start_date = get_next_schedule_date(start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day)
 
 		if self.end_date:
-			start_date = get_next_schedule_date(
-				start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, for_full_schedule=True)
-			while (getdate(start_date) < getdate(end_date)):
+			next_date = get_next_schedule_date(
+				start_date, self.frequency, self.start_date, self.repeat_on_day, self.repeat_on_last_day, for_full_schedule=True)
+
+			while (getdate(next_date) < getdate(end_date)):
 				row = {
 					"reference_document" : self.reference_document,
 					"frequency" : self.frequency,
-					"next_scheduled_date" : start_date
+					"next_scheduled_date" : next_date
 				}
 				schedule_details.append(row)
-				start_date = get_next_schedule_date(
-					start_date, self.frequency, self.repeat_on_day, self.repeat_on_last_day, end_date, for_full_schedule=True)
+				next_date = get_next_schedule_date(
+					next_date, self.frequency, self.start_date, self.repeat_on_day, self.repeat_on_last_day, end_date, for_full_schedule=True)
 
 		return schedule_details
 
@@ -268,8 +268,12 @@ class AutoRepeat(Document):
 		)
 
 
-def get_next_schedule_date(start_date, frequency, repeat_on_day, repeat_on_last_day=False, end_date=None, for_full_schedule=False):
-	month_count = month_map.get(frequency)
+def get_next_schedule_date(schedule_date, frequency, start_date, repeat_on_day=None, repeat_on_last_day=False, end_date=None, for_full_schedule=False):
+	if month_map.get(frequency):
+		month_count = month_map.get(frequency) + month_diff(schedule_date, start_date) - 1
+	else:
+		month_count = 0
+
 	day_count = 0
 	if month_count and repeat_on_last_day:
 		next_date = get_next_date(start_date, month_count, 31)
@@ -288,7 +292,9 @@ def get_next_schedule_date(start_date, frequency, repeat_on_day, repeat_on_last_
 	# next schedule date should be after or on current date
 	if not for_full_schedule:
 		while getdate(next_date) < getdate(today()):
-			next_date = get_next_date(next_date, month_count, day_count)
+			if month_count:
+				month_count += month_map.get(frequency)
+			next_date = get_next_date(start_date, month_count, day_count)
 
 	return next_date
 
@@ -316,8 +322,7 @@ def create_repeated_entries(data):
 
 		if schedule_date == current_date and not doc.disabled:
 			doc.create_documents()
-			schedule_date = get_next_schedule_date(schedule_date, doc.frequency, doc.repeat_on_day, doc.repeat_on_last_day, doc.end_date)
-
+			schedule_date = get_next_schedule_date(schedule_date, doc.frequency, doc.start_date, doc.repeat_on_day, doc.repeat_on_last_day, doc.end_date)
 			if schedule_date and not doc.disabled:
 				frappe.db.set_value('Auto Repeat', doc.name, 'next_schedule_date', schedule_date)
 


### PR DESCRIPTION
**Problem:**

As the next schedule date was getting calculated based on current schedule date, the date after 29-2-2020 is set as 29-3-2020 but it should be 31-3-2020 and so on:

![auto_repeat_edge_case_prob](https://user-images.githubusercontent.com/24353136/71622260-8320ba80-2bfa-11ea-9045-0d5b5e374cc5.png)

**Fix:**

Compute next schedule date based on start date and months offset (if frequency involves months)
Month count will be calculated as:

`month_count = month_map.get(frequency) + month_diff(schedule_date, start_date) - 1`

![auto_repeat_edge_case_fix](https://user-images.githubusercontent.com/24353136/71622258-80be6080-2bfa-11ea-999e-06f80b495ee3.png)