### PR TITLE
fix: Use _ for translation since frappe._ is not supported

### DIFF
--- a/frappe/templates/emails/energy_points_summary.html
+++ b/frappe/templates/emails/energy_points_summary.html
@@ -2,7 +2,7 @@
 <h3>{{ _('Top Performer') }} 🏆 </h3>
 <p> {{ frappe.get_fullname(top_performer.user) }}
 	<span class="text-muted">
-		{{ frappe._('gained {0} points').format(frappe.utils.cint(top_performer.energy_points)) }}
+		{{ _('gained {0} points').format(frappe.utils.cint(top_performer.energy_points)) }}
 	</span>
 </p>
 {% endif %}
@@ -11,7 +11,7 @@
 <h3>{{ _('Top Reviewer') }} ❤️ </h3>
 <p> {{ frappe.get_fullname(top_reviewer.user) }}
 	<span class="text-muted">
-		{{ frappe._('gave {0} points').format(frappe.utils.cint(top_reviewer.given_points)) }}
+		{{ _('gave {0} points').format(frappe.utils.cint(top_reviewer.given_points)) }}
 	</span>
 </p>
 
@@ -24,9 +24,9 @@
 <table class='table table-bordered'>
 	<tr>
 		<th> # </th>
-		<th style='width: 70%'>{{ frappe._('User') }}</th>
-		<th style='width: 15%'>{{ frappe._('Energy Points') }}</th>
-		<th style='width: 15%'>{{ frappe._('Points Given') }}</th>
+		<th style='width: 70%'>{{ _('User') }}</th>
+		<th style='width: 15%'>{{ _('Energy Points') }}</th>
+		<th style='width: 15%'>{{ _('Points Given') }}</th>
 	</tr>
 	{% for user in standings %}
 	<tr>

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -46,8 +46,6 @@ def get_safe_globals():
 		json = json,
 		dict = dict,
 		frappe =  frappe._dict(
-			_ = frappe._,
-			_dict = frappe._dict,
 			flags = frappe.flags,
 
 			format = frappe.format_value,
@@ -86,6 +84,7 @@ def get_safe_globals():
 		get_toc =  get_toc,
 		get_next_link = get_next_link,
 		_ =  frappe._,
+		_dict = frappe._dict,
 		get_shade = get_shade,
 		scrub =  scrub,
 		guess_mimetype = mimetypes.guess_type,


### PR DESCRIPTION
- Remove _ & _dict from frappe dict in `get_safe_globals` because it anyway gets ignored in `add_module_properties`. Instead users can directly use `_` and `_dict`

[Documentation Link](https://github.com/frappe/erpnext_com/commit/3867790a738414259661ec43cd50aea179f2b74c#diff-cc91d8507d8b7773025b0e291367b3e0)

- Fixes Energy Point Summary

Error
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 73, in execute
    frappe.get_attr(self.method)()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py", line 295, in send_monthly_summary
    send_summary('Monthly')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py", line 324, in send_summary
    'footer_message': get_footer_message(timespan).format(from_date, to_date)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 457, in sendmail
    message, text_content = get_email_from_template(template, args)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/jinja.py", line 32, in get_email_from_template
    message = get_template('templates/emails/' + name + '.html').render(args)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/emails/energy_points_summary.html", line 5, in top-level template code
    {{ frappe._('gained {0} points').format(frappe.utils.cint(top_performer.energy_points)) }}
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/sandbox.py", line 438, in call
    if not __self.is_safe_callable(__obj):
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/jinja2/sandbox.py", line 340, in is_safe_callable
    return not (getattr(obj, 'unsafe_callable', False) or
jinja2.exceptions.SecurityError: access to attribute '_' of '_dict' object is unsafe.
```

port-of: https://github.com/frappe/frappe/pull/9180