### PR TITLE
fix: allow setting custom database schema in site_config

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -107,7 +107,7 @@ class PostgresDatabase(Database):
 			from information_schema.tables
 			where table_catalog='{0}'
 				and table_type = 'BASE TABLE'
-				and table_schema='{1}'""".format(frappe.conf.db_name, frappe.conf.db_schema if frappe.conf.db_schema else 'public'))]
+				and table_schema='{1}'""".format(frappe.conf.db_name, frappe.conf.get("db_schema", "public")))]
 
 	def format_date(self, date):
 		if not date:

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -107,7 +107,7 @@ class PostgresDatabase(Database):
 			from information_schema.tables
 			where table_catalog='{0}'
 				and table_type = 'BASE TABLE'
-				and table_schema='public'""".format(frappe.conf.db_name))]
+				and table_schema='{1}'""".format(frappe.conf.db_name, frappe.conf.db_schema if frappe.conf.db_schema else 'public'))]
 
 	def format_date(self, date):
 		if not date:


### PR DESCRIPTION
Current situation : 
- If I have the same name for role, database and schema, then the bench migrate will not be able to fetch the tables from my schema because it always fetch the tables from the public schema

Suggested solution : 
- Allow the user to change the default name of the schema "public" by adding a new record in site config as stated below 
- "db_schema" : "XXX",
- Where xxx is the name of the schema
- In this case if the user has a role, database and schema which have the same name and the name is erpnext_db then the developer can add the following lines in the site_config file:
{
 "db_name": "erpnext_db",
 "db_schema" : "erpnext_db",
 "db_password": "XXX",
 "db_type": "postgres"
}