### PR TITLE
fix: global search index breaking on long titles

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -137,8 +137,8 @@ def rebuild_for_doctype(doctype):
 				"name": frappe.db.escape(doc.name),
 				"content": frappe.db.escape(' ||| '.join(content or '')),
 				"published": published,
-				"title": frappe.db.escape(title or '')[:int(frappe.db.VARCHAR_LEN)],
-				"route": frappe.db.escape(route or '')[:int(frappe.db.VARCHAR_LEN)]
+				"title": frappe.db.escape((title or '')[:int(frappe.db.VARCHAR_LEN)]),
+				"route": frappe.db.escape((route or '')[:int(frappe.db.VARCHAR_LEN)])
 			})
 	if all_contents:
 		insert_values_for_multiple_docs(all_contents)


### PR DESCRIPTION
If you created a doc with a title longer than 140 characters, it's supposed to be truncated to 140.

However, the global search index would break for that doctype due to an error in the query.

The truncate was happening AFTER it was escaped, causing it to lose the closing quote mark which caused a SQL error and broke the index.