### PR TITLE
fix(email): safe_encode to avoid smtp ascii encoding issue

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -6,7 +6,7 @@ import frappe
 import sys
 from six.moves import html_parser as HTMLParser
 import smtplib, quopri, json
-from frappe import msgprint, _, safe_decode
+from frappe import msgprint, _, safe_decode, safe_encode
 from frappe.email.smtp import SMTPServer, get_outgoing_email_account
 from frappe.email.email_body import get_email, get_formatted_html, add_attachment
 from frappe.utils.verified_command import get_signed_params, verify_request
@@ -551,7 +551,7 @@ def prepare_message(email, recipient, recipients_list):
 				print_format_file.update({"parent": message})
 				add_attachment(**print_format_file)
 
-	return message.as_string()
+	return safe_encode(message.as_string())
 
 def clear_outbox():
 	"""Remove low priority older than 31 days in Outbox and expire mails not sent for 7 days.

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -3,9 +3,10 @@
 from __future__ import unicode_literals
 
 import unittest, os, base64
+from frappe import safe_decode
 from frappe.email.receive import Email
 from frappe.email.email_body import (replace_filename_with_cid,
-									 get_email, inline_style_in_html, get_header)
+					get_email, inline_style_in_html, get_header)
 from frappe.email.queue import prepare_message, get_email_queue
 from six import PY3
 
@@ -57,7 +58,7 @@ This is the text version of this email
 			formatted='<h1>' + uni_chr1 + 'abcd' + uni_chr2 + '</h1>',
 			text_content='whatever')
 		result = prepare_message(email=email, recipient='test@test.com', recipients_list=[])
-		self.assertTrue("<h1>=EA=80=80abcd=DE=B4</h1>" in result)
+		self.assertTrue(b"<h1>=EA=80=80abcd=DE=B4</h1>" in result)
 
 	def test_prepare_message_returns_cr_lf(self):
 		email = get_email_queue(
@@ -67,7 +68,8 @@ This is the text version of this email
 			content='<h1>\n this is a test of newlines\n' + '</h1>',
 			formatted='<h1>\n this is a test of newlines\n' + '</h1>',
 			text_content='whatever')
-		result = prepare_message(email=email, recipient='test@test.com', recipients_list=[])
+		result = safe_decode(prepare_message(email=email,
+						recipient='test@test.com', recipients_list=[]))
 		if PY3:
 			self.assertTrue(result.count('\n') == result.count("\r"))
 		else:
@@ -81,9 +83,10 @@ This is the text version of this email
 			subject='Test Subject',
 			content='<h1>Whatever</h1>',
 			text_content='whatever',
-			message_id= "a.really.long.message.id.that.should.not.wrap.until.998.if.it.does.then.exchange.will.break" +
-						".really.long.message.id.that.should.not.wrap.unti")
-		result = prepare_message(email=email, recipient='test@test.com', recipients_list=[])
+			message_id="a.really.long.message.id.that.should.not.wrap.until.998.if.it.does.then.exchange.will.break" +
+			".really.long.message.id.that.should.not.wrap.unti")
+		result = safe_decode(prepare_message(email=email, recipient='test@test.com',
+					recipients_list=[]))
 		self.assertTrue(
 			"a.really.long.message.id.that.should.not.wrap.until.998.if.it.does.then.exchange.will.break" +
 			".really.long.message.id.that.should.not.wrap.unti" in result)


### PR DESCRIPTION
fixes issue where smtplib fails to encode the mail as ascii because it already is encoded.

---

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 801, in reset_password
    user.reset_password(send_email=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 234, in reset_password
    self.password_reset_mail(link)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 253, in password_reset_mail
    "password_reset", {"link": link}, now=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 298, in send_login_mail
    delayed=(not now) if now!=None else self.flags.delay_emails, retry=3)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 476, in sendmail
    inline_images=inline_images, header=header, print_letterhead=print_letterhead)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/queue.py", line 162, in send
    print_letterhead=print_letterhead)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/queue.py", line 185, in add
    send_one(email_queue.name, now=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/queue.py", line 475, in send_one
    raise e
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/queue.py", line 415, in send_one
    smtpserver.sess.sendmail(email.sender, recipient.recipient, message)
  File "/usr/lib64/python3.6/smtplib.py", line 855, in sendmail
    msg = _fix_eols(msg).encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode characters in position 335-339: ordinal not in range(128)
```

