### PR TITLE
fix: load latest custom report instead of latest reference report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -229,8 +229,9 @@ def get_prepared_report_result(report, filters, dn="", user=None):
 				"status": "Completed",
 				"filters": json.dumps(filters),
 				"owner": user,
-				"report_name": report.report_name
-			}
+				"report_name": report.custom_report or report.report_name
+			},
+			order_by = 'creation desc'
 		)
 
 		if doc_list:


### PR DESCRIPTION
Problem:

On creating a custom report named **Custom Stock Balance**, when we Generate New Report it shows latest report. But after refreshing the page, it fetches latest **Stock Balance** report i.e latest reference report.