### PR TITLE
chore: Disable testing for all sites by default

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -460,6 +460,15 @@ def run_tests(context, app=None, module=None, doctype=None, test=(),
 	tests = test
 
 	site = get_site(context)
+
+	allow_tests = frappe.get_conf(site).allow_tests
+
+	if not (allow_tests or os.environ.get('CI')):
+		click.secho('Testing is disabled for the site!', bold=True)
+		click.secho('You can enable tests by entering following command:')
+		click.secho('bench --site {0} set-config allow_tests true'.format(site), fg='green')
+		return
+
 	frappe.init(site=site)
 
 	frappe.flags.skip_before_tests = skip_before_tests


### PR DESCRIPTION
To avoid accidental test execution on any production or non-testing sites

<img width="746" alt="Screenshot 2020-01-03 at 10 05 31 PM" src="https://user-images.githubusercontent.com/13928957/71735890-a1461f00-2e75-11ea-8e81-cd230a221d61.png">

port-of: https://github.com/frappe/frappe/pull/9193