### PR TITLE
fix(email): define _email_account before assignment

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -41,6 +41,8 @@ def get_outgoing_email_account(raise_exception_not_set=True, append_to=None, sen
 		try getting settings from `site_config.json`."""
 
 	sender_email_id = None
+	_email_account = None
+
 	if sender:
 		sender_email_id = parse_addr(sender)[1]
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 97, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext_support/erpnext_support/api/client.py", line 51, in sync
    update_erpnext_support_issue_status_and_communications(erpnext_support_issues, response)
  File "/home/frappe/frappe-bench/apps/erpnext_support/erpnext_support/api/client.py", line 78, in update_erpnext_support_issue_status_and_communications
    notify_user(erpnext_support_issue.name)
  File "/home/frappe/frappe-bench/apps/erpnext_support/erpnext_support/notifications/notifications.py", line 32, in notify_user
    }).insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 253, in insert
    self.run_method("after_insert")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 794, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1078, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1061, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 788, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/doctype/notification_log/notification_log.py", line 17, in after_insert
    send_notification_email(self)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/doctype/notification_log/notification_log.py", line 101, in send_notification_email
    now=frappe.flags.in_test
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 475, in sendmail
    inline_images=inline_images, header=header, print_letterhead=print_letterhead)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/queue.py", line 75, in send
    email_account = get_outgoing_email_account(True, append_to=reference_doctype, sender=sender)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/smtp.py", line 83, in get_outgoing_email_account
    if not email_account and _email_account:
UnboundLocalError: local variable '_email_account' referenced before assignment
```