### PR TITLE
refactor(build): updated variable names, namespaces + style fixes

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -1,16 +1,24 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals, print_function
-import os, frappe, json, shutil, re, warnings, tempfile
-from os.path import exists as path_exists, join as join_path, abspath, isdir
+from __future__ import print_function, unicode_literals
+
+import os
+import re
+import json
+import shutil
+import warnings
+import tempfile
 from distutils.spawn import find_executable
+
 from six import iteritems, text_type
+
+import frappe
 from frappe.utils.minify import JavascriptMinify
 
-"""
-Build the `public` folders and setup languages
-"""
+
+timestamps = {}
+app_paths = None
 
 
 def symlink(target, link_name, overwrite=False):
@@ -23,8 +31,7 @@ def symlink(target, link_name, overwrite=False):
 	'''
 
 	if not overwrite:
-		os.symlink(target, linkname)
-		return
+		return os.symlink(target, link_name)
 
 	# os.replace() may fail if files are on different filesystems
 	link_dir = os.path.dirname(link_name)
@@ -57,15 +64,16 @@ def symlink(target, link_name, overwrite=False):
 		raise
 
 
-app_paths = None
 def setup():
 	global app_paths
 	pymodules = []
 	for app in frappe.get_all_apps(True):
 		try:
 			pymodules.append(frappe.get_module(app))
-		except ImportError: pass
+		except ImportError:
+			pass
 	app_paths = [os.path.dirname(pymodule.__file__) for pymodule in pymodules]
+
 
 def get_node_pacman():
 	pacmans = ['yarn', 'npm']
@@ -74,6 +82,7 @@ def get_node_pacman():
 		if exec_:
 			return exec_
 	raise ValueError('No Node.js Package Manager found.')
+
 
 def bundle(no_compress, app=None, make_copy=False, restore=False, verbose=False):
 	"""concat / minify js files"""
@@ -87,9 +96,10 @@ def bundle(no_compress, app=None, make_copy=False, restore=False, verbose=False)
 	if app:
 		command += ' --app {app}'.format(app=app)
 
-	frappe_app_path = abspath(join_path(app_paths[0], '..'))
+	frappe_app_path = os.path.abspath(os.path.join(app_paths[0], '..'))
 	check_yarn()
 	frappe.commands.popen(command, cwd=frappe_app_path)
+
 
 def watch(no_compress):
 	"""watch and rebuild if necessary"""
@@ -97,67 +107,66 @@ def watch(no_compress):
 
 	pacman = get_node_pacman()
 
-	frappe_app_path = abspath(join_path(app_paths[0], '..'))
+	frappe_app_path = os.path.abspath(os.path.join(app_paths[0], '..'))
 	check_yarn()
 	frappe_app_path = frappe.get_app_path('frappe', '..')
-	frappe.commands.popen('{pacman} run watch'.format(pacman=pacman), cwd = frappe_app_path)
+	frappe.commands.popen('{pacman} run watch'.format(pacman=pacman), cwd=frappe_app_path)
+
 
 def check_yarn():
-	from distutils.spawn import find_executable
 	if not find_executable('yarn'):
-		print('Please install yarn using below command and try again.')
-		print('npm install -g yarn')
-		return
+		print('Please install yarn using below command and try again.\nnpm install -g yarn')
+
 
 def make_asset_dirs(make_copy=False, restore=False):
 	# don't even think of making assets_path absolute - rm -rf ahead.
-	assets_path = join_path(frappe.local.sites_path, "assets")
-	for dir_path in [
-			join_path(assets_path, 'js'),
-			join_path(assets_path, 'css')]:
+	assets_path = os.path.join(frappe.local.sites_path, "assets")
 
-		if not path_exists(dir_path):
+	for dir_path in [os.path.join(assets_path, 'js'), os.path.join(assets_path, 'css')]:
+		if not os.path.exists(dir_path):
 			os.makedirs(dir_path)
 
 	for app_name in frappe.get_all_apps(True):
 		pymodule = frappe.get_module(app_name)
-		app_base_path = abspath(os.path.dirname(pymodule.__file__))
+		app_base_path = os.path.abspath(os.path.dirname(pymodule.__file__))
 
 		symlinks = []
-		app_public_path = join_path(app_base_path, 'public')
+		app_public_path = os.path.join(app_base_path, 'public')
 		# app/public > assets/app
-		symlinks.append([app_public_path, join_path(assets_path, app_name)])
+		symlinks.append([app_public_path, os.path.join(assets_path, app_name)])
 		# app/node_modules > assets/app/node_modules
-		if path_exists(abspath(app_public_path)):
-			symlinks.append([join_path(app_base_path, '..', 'node_modules'), join_path(assets_path, app_name, 'node_modules')])
+		if os.path.exists(os.path.abspath(app_public_path)):
+			symlinks.append([os.path.join(app_base_path, '..', 'node_modules'), os.path.join(
+				assets_path, app_name, 'node_modules')])
 
 		app_doc_path = None
-		if isdir(join_path(app_base_path, 'docs')):
-			app_doc_path = join_path(app_base_path, 'docs')
+		if os.path.isdir(os.path.join(app_base_path, 'docs')):
+			app_doc_path = os.path.join(app_base_path, 'docs')
 
-		elif isdir(join_path(app_base_path, 'www', 'docs')):
-			app_doc_path = join_path(app_base_path, 'www', 'docs')
+		elif os.path.isdir(os.path.join(app_base_path, 'www', 'docs')):
+			app_doc_path = os.path.join(app_base_path, 'www', 'docs')
 
 		if app_doc_path:
-			symlinks.append([app_doc_path, join_path(assets_path, app_name + '_docs')])
+			symlinks.append([app_doc_path, os.path.join(
+				assets_path, app_name + '_docs')])
 
 		for source, target in symlinks:
-			source = abspath(source)
-			if path_exists(source):
+			source = os.path.abspath(source)
+			if os.path.exists(source):
 				if restore:
-					if path_exists(target):
+					if os.path.exists(target):
 						if os.path.islink(target):
 							os.unlink(target)
 						else:
 							shutil.rmtree(target)
 						shutil.copytree(source, target)
 				elif make_copy:
-					if path_exists(target):
-						warnings.warn('Target {target} already exists.'.format(target = target))
+					if os.path.exists(target):
+						warnings.warn('Target {target} already exists.'.format(target=target))
 					else:
 						shutil.copytree(source, target)
 				else:
-					if path_exists(target):
+					if os.path.exists(target):
 						if os.path.islink(target):
 							os.unlink(target)
 						else:
@@ -170,11 +179,13 @@ def make_asset_dirs(make_copy=False, restore=False):
 				# warnings.warn('Source {source} does not exist.'.format(source = source))
 				pass
 
+
 def build(no_compress=False, verbose=False):
-	assets_path = join_path(frappe.local.sites_path, "assets")
+	assets_path = os.path.join(frappe.local.sites_path, "assets")
 
 	for target, sources in iteritems(get_build_maps()):
-		pack(join_path(assets_path, target), sources, no_compress, verbose)
+		pack(os.path.join(assets_path, target), sources, no_compress, verbose)
+
 
 def get_build_maps():
 	"""get all build.jsons with absolute paths"""
@@ -182,8 +193,8 @@ def get_build_maps():
 
 	build_maps = {}
 	for app_path in app_paths:
-		path = join_path(app_path, 'public', 'build.json')
-		if path_exists(path):
+		path = os.path.join(app_path, 'public', 'build.json')
+		if os.path.exists(path):
 			with open(path) as f:
 				try:
 					for target, sources in iteritems(json.loads(f.read())):
@@ -191,9 +202,10 @@ def get_build_maps():
 						source_paths = []
 						for source in sources:
 							if isinstance(source, list):
-								s = frappe.get_pymodule_path(source[0], *source[1].split("/"))
+								s = frappe.get_pymodule_path(
+									source[0], *source[1].split("/"))
 							else:
-								s = join_path(app_path, source)
+								s = os.path.join(app_path, source)
 							source_paths.append(s)
 
 						build_maps[target] = source_paths
@@ -202,7 +214,6 @@ def get_build_maps():
 					print('JSON syntax error {0}'.format(str(e)))
 	return build_maps
 
-timestamps = {}
 
 def pack(target, sources, no_compress, verbose):
 	from six import StringIO
@@ -212,8 +223,9 @@ def pack(target, sources, no_compress, verbose):
 
 	for f in sources:
 		suffix = None
-		if ':' in f: f, suffix = f.split(':')
-		if not path_exists(f) or isdir(f):
+		if ':' in f:
+			f, suffix = f.split(':')
+		if not os.path.exists(f) or os.path.isdir(f):
 			print("did not find " + f)
 			continue
 		timestamps[f] = os.path.getmtime(f)
@@ -223,7 +235,7 @@ def pack(target, sources, no_compress, verbose):
 
 			extn = f.rsplit(".", 1)[1]
 
-			if outtype=="js" and extn=="js" and (not no_compress) and suffix!="concat" and (".min." not in f):
+			if outtype == "js" and extn == "js" and (not no_compress) and suffix != "concat" and (".min." not in f):
 				tmpin, tmpout = StringIO(data.encode('utf-8')), StringIO()
 				jsm.minify(tmpin, tmpout)
 				minified = tmpout.getvalue()
@@ -232,7 +244,7 @@ def pack(target, sources, no_compress, verbose):
 
 				if verbose:
 					print("{0}: {1}k".format(f, int(len(minified) / 1024)))
-			elif outtype=="js" and extn=="html":
+			elif outtype == "js" and extn == "html":
 				# add to frappe.templates
 				outtxt += html_to_js_template(f, data)
 			else:
@@ -248,10 +260,12 @@ def pack(target, sources, no_compress, verbose):
 
 	print("Wrote %s - %sk" % (target, str(int(os.path.getsize(target)/1024))))
 
+
 def html_to_js_template(path, content):
 	'''returns HTML template content as Javascript code, adding it to `frappe.templates`'''
-	return """frappe.templates["{key}"] = '{content}';\n""".format(\
+	return """frappe.templates["{key}"] = '{content}';\n""".format(
 		key=path.rsplit("/", 1)[-1][:-5], content=scrub_html_template(content))
+
 
 def scrub_html_template(content):
 	'''Returns HTML content with removed whitespace and comments'''
@@ -259,32 +273,35 @@ def scrub_html_template(content):
 	content = re.sub("\s+", " ", content)
 
 	# strip comments
-	content =  re.sub("(<!--.*?-->)", "", content)
+	content = re.sub("(<!--.*?-->)", "", content)
 
 	return content.replace("'", "\'")
+
 
 def files_dirty():
 	for target, sources in iteritems(get_build_maps()):
 		for f in sources:
-			if ':' in f: f, suffix = f.split(':')
-			if not path_exists(f) or isdir(f): continue
+			if ':' in f:
+				f, suffix = f.split(':')
+			if not os.path.exists(f) or os.path.isdir(f):
+				continue
 			if os.path.getmtime(f) != timestamps.get(f):
 				print(f + ' dirty')
 				return True
 	else:
 		return False
 
+
 def compile_less():
-	from distutils.spawn import find_executable
 	if not find_executable("lessc"):
 		return
 
 	for path in app_paths:
-		less_path = join_path(path, "public", "less")
-		if path_exists(less_path):
+		less_path = os.path.join(path, "public", "less")
+		if os.path.exists(less_path):
 			for fname in os.listdir(less_path):
 				if fname.endswith(".less") and fname != "variables.less":
-					fpath = join_path(less_path, fname)
+					fpath = os.path.join(less_path, fname)
 					mtime = os.path.getmtime(fpath)
 					if fpath in timestamps and mtime == timestamps[fpath]:
 						continue
@@ -293,5 +310,5 @@ def compile_less():
 
 					print("compiling {0}".format(fpath))
 
-					css_path = join_path(path, "public", "css", fname.rsplit(".", 1)[0] + ".css")
+					css_path = os.path.join(path, "public", "css", fname.rsplit(".", 1)[0] + ".css")
 					os.system("lessc {0} > {1}".format(fpath, css_path))

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -389,19 +389,17 @@ def postgres(context):
 @click.command('jupyter')
 @pass_context
 def jupyter(context):
-	try:
-		from pip import main
-	except ImportError:
-		from pip._internal import main
+	installed_packages = (r.split('==')[0] for r in subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'], encoding='utf8'))
 
-	reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
-	installed_packages = [r.decode().split('==')[0] for r in reqs.split()]
 	if 'jupyter' not in installed_packages:
-		main(['install', 'jupyter'])
+		subprocess.check_output([sys.executable, '-m', 'pip', 'install', 'jupyter'])
+
 	site = get_site(context)
 	frappe.init(site=site)
+
 	jupyter_notebooks_path = os.path.abspath(frappe.get_site_path('jupyter_notebooks'))
 	sites_path = os.path.abspath(frappe.get_site_path('..'))
+
 	try:
 		os.stat(jupyter_notebooks_path)
 	except OSError:
@@ -434,7 +432,7 @@ def console(context):
 	frappe.connect()
 	frappe.local.lang = frappe.db.get_default("lang")
 	import IPython
-	IPython.embed(display_banner = "")
+	IPython.embed(display_banner="")
 
 @click.command('run-tests')
 @click.option('--app', help="For App")
@@ -472,8 +470,8 @@ def run_tests(context, app=None, module=None, doctype=None, test=(),
 		cov.start()
 
 	ret = frappe.test_runner.main(app, module, doctype, context.verbose, tests=tests,
-		force=context.force, profile=profile, junit_xml_output=junit_xml_output,
-		ui_tests = ui_tests, doctype_list_path = doctype_list_path, failfast=failfast)
+								force=context.force, profile=profile, junit_xml_output=junit_xml_output,
+								ui_tests=ui_tests, doctype_list_path=doctype_list_path, failfast=failfast)
 
 	if coverage:
 		cov.stop()

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -12,6 +12,7 @@ from coverage import Coverage
 import cProfile, pstats
 from six import StringIO
 
+
 @click.command('build')
 @click.option('--app', help='Build assets for app')
 @click.option('--make-copy', is_flag=True, default=False, help='Copy the files instead of symlinking')
@@ -26,14 +27,14 @@ def build(app=None, make_copy=False, restore = False, verbose=False):
 	no_compress = frappe.local.conf.developer_mode or False
 	frappe.build.bundle(no_compress, app=app, make_copy=make_copy, restore = restore, verbose=verbose)
 
+
 @click.command('watch')
 def watch():
 	"Watch and concatenate JS and CSS files as and when they change"
-	# if os.environ.get('CI'):
-	# 	return
 	import frappe.build
 	frappe.init('')
 	frappe.build.watch(True)
+
 
 @click.command('clear-cache')
 @pass_context
@@ -51,6 +52,7 @@ def clear_cache(context):
 		finally:
 			frappe.destroy()
 
+
 @click.command('clear-website-cache')
 @pass_context
 def clear_website_cache(context):
@@ -63,6 +65,7 @@ def clear_website_cache(context):
 			frappe.website.render.clear_cache()
 		finally:
 			frappe.destroy()
+
 
 @click.command('destroy-all-sessions')
 @click.option('--reason')
@@ -79,6 +82,7 @@ def destroy_all_sessions(context, reason=None):
 		finally:
 			frappe.destroy()
 
+
 @click.command('show-config')
 @pass_context
 def show_config(context):
@@ -89,12 +93,14 @@ def show_config(context):
 	configuration = frappe.get_site_config(sites_path=sites_path, site_path=site_path)
 	print_config(configuration)
 
+
 def print_config(config):
 	for conf, value in config.items():
 		if isinstance(value, dict):
 			print_config(value)
 		else:
 			print("\t{:<50} {:<15}".format(conf, value))
+
 
 @click.command('reset-perms')
 @pass_context
@@ -111,6 +117,7 @@ def reset_perms(context):
 					reset_perms(d)
 		finally:
 			frappe.destroy()
+
 
 @click.command('execute')
 @click.argument('method')
@@ -191,6 +198,7 @@ def export_doc(context, doctype, docname):
 		finally:
 			frappe.destroy()
 
+
 @click.command('export-json')
 @click.argument('doctype')
 @click.argument('path')
@@ -207,6 +215,7 @@ def export_json(context, doctype, path, name=None):
 		finally:
 			frappe.destroy()
 
+
 @click.command('export-csv')
 @click.argument('doctype')
 @click.argument('path')
@@ -222,6 +231,7 @@ def export_csv(context, doctype, path):
 		finally:
 			frappe.destroy()
 
+
 @click.command('export-fixtures')
 @click.option('--app', default=None, help='Export fixtures of a specific app')
 @pass_context
@@ -235,6 +245,7 @@ def export_fixtures(context, app=None):
 			export_fixtures(app=app)
 		finally:
 			frappe.destroy()
+
 
 @click.command('import-doc')
 @click.argument('path')
@@ -257,12 +268,14 @@ def import_doc(context, path, force=False):
 		finally:
 			frappe.destroy()
 
+
 @click.command('import-csv')
 @click.argument('path')
 @click.option('--only-insert', default=False, is_flag=True, help='Do not overwrite existing records')
 @click.option('--submit-after-import', default=False, is_flag=True, help='Submit document after importing it')
 @click.option('--ignore-encoding-errors', default=False, is_flag=True, help='Ignore encoding errors while coverting to unicode')
 @click.option('--no-email', default=True, is_flag=True, help='Send email if applicable')
+
 
 @pass_context
 def import_csv(context, path, only_insert=False, submit_after_import=False, ignore_encoding_errors=False, no_email=True):
@@ -324,7 +337,7 @@ def data_import(context, file_path, doctype, import_type=None, submit_after_impo
 @click.argument('doctype')
 @click.argument('path')
 @pass_context
-def _bulk_rename(context, doctype, path):
+def bulk_rename(context, doctype, path):
 	"Rename multiple records via CSV file"
 	from frappe.model.rename_doc import bulk_rename
 	from frappe.utils.csvutils import read_csv_content
@@ -341,15 +354,6 @@ def _bulk_rename(context, doctype, path):
 
 	frappe.destroy()
 
-@click.command('mysql')
-def mysql():
-	"""
-		Deprecated
-	"""
-	click.echo("""
-mysql command is deprecated.
-Did you mean "bench mariadb"?
-""")
 
 @click.command('mariadb')
 @pass_context
@@ -374,6 +378,7 @@ def mariadb(context):
 		'--safe-updates',
 		"-A"])
 
+
 @click.command('postgres')
 @pass_context
 def postgres(context):
@@ -385,6 +390,7 @@ def postgres(context):
 	# This is assuming you're within the bench instance.
 	psql = find_executable('psql')
 	subprocess.run([ psql, '-d', frappe.conf.db_name])
+
 
 @click.command('jupyter')
 @pass_context
@@ -423,6 +429,7 @@ frappe.db.connect()
 		jupyter_notebooks_path,
 	])
 
+
 @click.command('console')
 @pass_context
 def console(context):
@@ -432,7 +439,12 @@ def console(context):
 	frappe.connect()
 	frappe.local.lang = frappe.db.get_default("lang")
 	import IPython
-	IPython.embed(display_banner="")
+	all_apps = frappe.get_installed_apps()
+	for app in all_apps:
+		locals()[app] = __import__(app)
+	print("Apps in this namespace:\n{}".format(", ".join(all_apps)))
+	IPython.embed(display_banner="", header="")
+
 
 @click.command('run-tests')
 @click.option('--app', help="For App")
@@ -483,6 +495,7 @@ def run_tests(context, app=None, module=None, doctype=None, test=(),
 	if os.environ.get('CI'):
 		sys.exit(ret)
 
+
 @click.command('run-ui-tests')
 @click.argument('app')
 @click.option('--headless', is_flag=True, help="Run UI Test in headless mode")
@@ -505,6 +518,7 @@ def run_ui_tests(context, app, headless=False):
 	formatted_command = command.format(site_env=site_env, password_env=password_env, run_or_open=run_or_open)
 	frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)
 
+
 @click.command('serve')
 @click.option('--port', default=8000)
 @click.option('--profile', is_flag=True, default=False)
@@ -521,6 +535,7 @@ def serve(context, port=None, profile=False, no_reload=False, no_threading=False
 		site = context.sites[0]
 
 	frappe.app.serve(port=port, profile=profile, no_reload=no_reload, no_threading=no_threading, site=site, sites_path='.')
+
 
 @click.command('request')
 @click.option('--args', help='arguments like `?cmd=test&key=value` or `/api/request/method?..`')
@@ -554,6 +569,7 @@ def request(context, args=None, path=None):
 		finally:
 			frappe.destroy()
 
+
 @click.command('make-app')
 @click.argument('destination')
 @click.argument('app_name')
@@ -561,6 +577,7 @@ def make_app(destination, app_name):
 	"Creates a boilerplate app"
 	from frappe.utils.boilerplate import make_boilerplate
 	make_boilerplate(destination, app_name)
+
 
 @click.command('set-config')
 @click.argument('key')
@@ -585,6 +602,7 @@ def set_config(context, key, value, global_ = False, as_dict=False):
 			update_site_config(key, value, validate=False)
 			frappe.destroy()
 
+
 @click.command('version')
 def get_version():
 	"Show the versions of all the installed apps"
@@ -602,32 +620,6 @@ def get_version():
 		elif hasattr(module, "__version__"):
 			print("{0} {1}".format(m, module.__version__))
 
-
-@click.command('setup-global-help')
-@click.option('--db_type')
-@click.option('--root_password')
-def setup_global_help(db_type=None, root_password=None):
-	'''Deprecated: setup help table in a separate database that will be
-	shared by the whole bench and set `global_help_setup` as 1 in
-	common_site_config.json'''
-	print_in_app_help_deprecation()
-
-@click.command('get-docs-app')
-@click.argument('app')
-def get_docs_app(app):
-	'''Deprecated: Get the docs app for given app'''
-	print_in_app_help_deprecation()
-
-@click.command('get-all-docs-apps')
-def get_all_docs_apps():
-	'''Deprecated: Get docs apps for all apps'''
-	print_in_app_help_deprecation()
-
-@click.command('setup-help')
-@pass_context
-def setup_help(context):
-	'''Deprecated: Setup help table in the current site (called after migrate)'''
-	print_in_app_help_deprecation()
 
 @click.command('rebuild-global-search')
 @click.option('--static-pages', is_flag=True, default=False, help='Rebuild global search for static pages')
@@ -657,6 +649,7 @@ def rebuild_global_search(context, static_pages=False):
 
 		finally:
 			frappe.destroy()
+
 
 @click.command('auto-deploy')
 @click.argument('app')
@@ -702,9 +695,6 @@ def auto_deploy(context, app, migrate=False, restart=False, remote='upstream'):
 	else:
 		print('No Updates')
 
-def print_in_app_help_deprecation():
-	print("In app help has been removed.\nYou can access the documentation on erpnext.com/docs or frappe.io/docs")
-	return
 
 commands = [
 	build,
@@ -723,7 +713,6 @@ commands = [
 	data_import,
 	import_doc,
 	make_app,
-	mysql,
 	mariadb,
 	postgres,
 	request,
@@ -734,9 +723,7 @@ commands = [
 	set_config,
 	show_config,
 	watch,
-	_bulk_rename,
+	bulk_rename,
 	add_to_email_queue,
-	setup_global_help,
-	setup_help,
 	rebuild_global_search
 ]


### PR DESCRIPTION
**feat:**
- add installed apps by default in console namespace `(frappe.commands.utils)`
![Screenshot 2020-01-04 at 10 47 00 PM](https://user-images.githubusercontent.com/36654812/71769623-8f35b080-2f49-11ea-836b-ef84fb6adad8.png)

**fixes:**
- symlink: variable name fix `(frappe.build)`
- jupyter install method `(frappe.commands.utils)`

**local namespace changes:**
- abspath => os.path.abspath `(frappe.build)`
- join_path => os.path.join `(frappe.build)`
- path_exists => os.path.exists `(frappe.build)`
- _bulk_rename => bulk_rename `(frappe.commands.utils)`

**misc:**
- style fixes `(both)`