### PR TITLE
fix(email): define email_server before condition

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -247,13 +247,13 @@ class EmailAccount(Document):
 			exceptions = []
 			seen_status = []
 			uid_reindexed = False
+			email_server = None
 
 			if frappe.local.flags.in_test:
 				incoming_mails = test_mails
 			else:
 				email_sync_rule = self.build_email_sync_rule()
 
-				email_server = None
 				try:
 					email_server = self.get_incoming_server(in_receive=True, email_sync_rule=email_sync_rule)
 				except Exception:

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -305,7 +305,7 @@ class EmailAccount(Document):
 				raise Exception(frappe.as_json(exceptions))
 
 	def handle_bad_emails(self, email_server, uid, raw, reason):
-		if cint(email_server.settings.use_imap):
+		if email_server and cint(email_server.settings.use_imap):
 			import email
 			try:
 				mail = email.message_from_string(raw)


### PR DESCRIPTION
fixes issue where email_server is unhandled in test

```
Traceback (most recent call last):
  File "/home/chnmy/workspace/frappe/benches/master-bench/apps/frappe/frappe/email/doctype/email_account/test_email_account.py", line 44, in test_unread_notification
    self.test_incoming()
  File "/home/chnmy/workspace/frappe/benches/master-bench/apps/frappe/frappe/email/doctype/email_account/test_email_account.py", line 35, in test_incoming
    email_account.receive(test_mails=test_mails)
  File "/home/chnmy/workspace/frappe/benches/master-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 291, in receive
    self.handle_bad_emails(email_server, uid, msg, frappe.get_traceback())
UnboundLocalError: local variable 'email_server' referenced before assignment
```