### PR TITLE
fix: Make background jobs logging quieter if quite flag is passed

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -142,6 +142,8 @@ def start_worker(queue=None, quiet = False):
 	with Connection(redis_connection):
 		queues = get_queue_list(queue)
 		logging_level = "INFO"
+		if quiet:
+			logging_level = "WARNING"
 		Worker(queues, name=get_worker_name(queue)).work(logging_level = logging_level)
 
 def get_worker_name(queue):


### PR DESCRIPTION
I guess it was removed for debugging in [this commit](https://github.com/frappe/frappe/commit/463d1c5ec5312c355b280959b2d0865997df3dcb#diff-efa84b954b242cf207c826c03b4e25c7L143)

