### PR TITLE
fix(email): check if communication hasattr for attachment

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -291,7 +291,7 @@ class EmailAccount(Document):
 
 				else:
 					frappe.db.commit()
-					if communication:
+					if communication and hasattr(communication, "_attachments"):
 						attachments = [d.file_name for d in communication._attachments]
 						communication.notify(attachments=attachments, fetched_from_email_account=True)
 


### PR DESCRIPTION
fixes issue where previous communication has no attribute _attachments before it fails, causing the following error:

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 724, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 295, in receive
    attachments = [d.file_name for d in communication._attachments]
AttributeError: 'Communication' object has no attribute '_attachments'
```

port of #9201 