### PR TITLE
fix: use _user_tags instead of Tag Link

### DIFF
--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -171,7 +171,6 @@ def get_documents_for_tag(tag):
 			"content": res.title
 		})
 
-	print(results)
 	return results
 
 @frappe.whitelist()

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -263,32 +263,8 @@ def delete_bulk(doctype, items):
 @frappe.whitelist()
 @frappe.read_only()
 def get_sidebar_stats(stats, doctype, filters=[]):
-	_user_tags, tag_list = [], []
-	data = frappe._dict(frappe.local.form_dict)
-	filters = json.loads(data["filters"])
 
-	# Show Tags irrespective of any tag filter set
-	for idx, filter in enumerate(filters):
-		if filter[0] == "Tag Link":
-			filters.pop(idx)
-			break
-
-	for tag in frappe.get_all("Tag Link", filters={"document_type": doctype}, fields=["tag"]):
-		if tag.tag in tag_list:
-			continue
-
-		tag_list.append(tag.tag)
-		tag_filters = []
-		tag_filters.extend(filters)
-		tag_filters.extend([['Tag Link', 'tag', '=', tag.tag]])
-
-		fields = ["count(distinct `tab{0}`.`name`) AS total_count".format(doctype)]
-		count = frappe.get_all(doctype, filters=tag_filters, fields=fields)
-
-		if count[0].get("total_count") > 0:
-			_user_tags.append([tag.tag, count[0].get("total_count")])
-
-	return {"stats": {"_user_tags": _user_tags}}
+	return {"stats": get_stats(stats, doctype, filters)}
 
 @frappe.whitelist()
 @frappe.read_only()

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -335,14 +335,13 @@ frappe.views.ListSidebar = class ListSidebar {
 			field: field,
 			stat: stats,
 			sum: sum,
-			label: field === '_user_tags' ? (tags ? __(label) : __("Tag")) : __(label),
+			label: field === '_user_tags' ? (tags ? __(label) : __("Tags")) : __(label),
 		};
 		$(frappe.render_template("list_sidebar_stat", context))
 			.on("click", ".stat-link", function() {
-				var doctype = "Tag Link";
 				var fieldname = $(this).attr('data-field');
 				var label = $(this).attr('data-label');
-				var condition = "=";
+				var condition = "like";
 				var existing = me.list_view.filter_area.filter_list.get_filter(fieldname);
 				if(existing) {
 					existing.remove();
@@ -351,7 +350,7 @@ frappe.views.ListSidebar = class ListSidebar {
 					label = "%,%";
 					condition = "not like";
 				}
-				me.list_view.filter_area.filter_list.add_filter(doctype, fieldname, condition, label)
+				me.list_view.filter_area.filter_list.add_filter(me.list_view.doctype, fieldname, condition, label)
 					.then(function() {
 						me.list_view.refresh();
 					});

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -470,7 +470,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 			tag_editor.wrapper.on('click', '.tagit-label', (e) => {
 				const $this = $(e.currentTarget);
-				this.filter_area.add('Tag Link', 'tag', '=', $this.text());
+				this.filter_area.add(this.doctype, '_user_tags', '=', $this.text());
 			});
 		});
 	}

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -174,11 +174,6 @@ frappe.ui.Filter = class {
 
 		let original_docfield = (this.fieldselect.fields_by_name[doctype] || {})[fieldname];
 
-		if (doctype === "Tag Link" || fieldname === "_user_tags") {
-			original_docfield = {fieldname: "tag", fieldtype: "Data", label: "Tags", parent: "Tag Link"};
-			doctype = "Tag Link";
-		}
-
 		if(!original_docfield) {
 			console.warn(`Field ${fieldname} is not selectable.`);
 			this.remove();

--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -63,11 +63,6 @@ frappe.ui.FilterGroup = class {
 	}
 
 	validate_args(doctype, fieldname) {
-		// Tags attached to the document are maintained seperately in Tag Link
-		// and is not the part of doctype meta therefore tag fieldname validation is ignored.
-		if (doctype === "Tag Link" && fieldname === "tag") {
-			return true;
-		}
 
 		if(doctype && fieldname
 			&& !frappe.meta.has_field(doctype, fieldname)


### PR DESCRIPTION
### Issue
- Tag Link was used to facilitate filtering List View for Tags using `LEFT JOIN`.
- This in-turn caused the query to be slow.
- For repopulating the Tags Dropdown, individual `DISTINCT` query was an overhead.

### Fix:
- Revert the Tag Link usage in List View for filtering using Tags, instead fallback to `_user_tags` column again like before.
