### PR TITLE
fix: Persist scope search in search page

### DIFF
--- a/frappe/templates/includes/search_template.html
+++ b/frappe/templates/includes/search_template.html
@@ -27,6 +27,9 @@
 					</button>
 				</div>
 			</div>
+			{% if frappe.form_dict.scope %}
+				<input type="text" hidden name="scope" value="{{ frappe.form_dict.scope }}">
+			{% endif %}
 		</form>
 	</div>
 </div>


### PR DESCRIPTION
Let's say the search URL is `/search?q=accounts&scope=docs`. This will search for `accounts` keyword in all the pages under `docs` route.

If you change the search text in the search box to `invoice` and press enter, the route becomes `/search?q=invoice` and the `scope` parameter is lost.

This PR attempts to persist the scope parameter.

![image](https://user-images.githubusercontent.com/9355208/71804467-88ae5280-3089-11ea-82ea-44265d49ece3.png)
