### PR TITLE
fix: allow multiple webhooks for identical doctype triggers (v12)

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -1,10 +1,13 @@
 {
+ "actions": [],
+ "autoname": "naming_series:",
  "creation": "2017-09-08 16:16:13.060641",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "sb_doc_events",
+  "naming_series",
   "webhook_doctype",
   "cb_doc_events",
   "webhook_docevent",
@@ -43,6 +46,7 @@
   {
    "fieldname": "webhook_docevent",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Doc Event",
    "options": "after_insert\non_update\non_submit\non_cancel\non_trash\non_update_after_submit\non_change",
    "set_only_once": 1
@@ -117,9 +121,16 @@
    "fieldname": "webhook_json",
    "fieldtype": "Code",
    "label": "JSON Request Body"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Naming Series",
+   "options": "\nHOOK-.####"
   }
  ],
- "modified": "2019-08-26 00:38:14.611267",
+ "links": [],
+ "modified": "2020-01-06 02:51:07.997566",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",
@@ -140,5 +151,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "title_field": "webhook_doctype",
  "track_changes": 1
 }

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -18,9 +18,6 @@ from frappe.utils.jinja import validate_template
 
 
 class Webhook(Document):
-	def autoname(self):
-		self.name = self.webhook_doctype + "-" + self.webhook_docevent
-
 	def validate(self):
 		self.validate_docevent()
 		self.validate_condition()


### PR DESCRIPTION
**Problem:**

Currently, if multiple webhooks are required for the same doctype triggers (different endpoints, conditions, data, etc.), the system blocks their creation.

**Screenshots / GIFs:**

![image](https://user-images.githubusercontent.com/13396535/71814234-c4551680-30a1-11ea-894d-f1c7058e97a9.png)