### PR TITLE
fix: Return empty object if there are no settings for a report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -186,7 +186,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		let report_script_name = this.report_doc.report_type === 'Custom Report'
 			? this.report_doc.reference_report
 			: this.report_name;
-		return frappe.query_reports[report_script_name];
+		return frappe.query_reports[report_script_name] || {};
 	}
 
 	setup_progress_bar() {


### PR DESCRIPTION
Query reports do not have settings.

Fixes the following error while loading custom reports made for query reports.

<img width="964" alt="Screenshot 2020-01-10 at 12 34 44 PM" src="https://user-images.githubusercontent.com/13928957/72133216-e5ba4900-33a6-11ea-890e-6f71ed229bcc.png">


port-of: https://github.com/frappe/frappe/pull/9220