### PR TITLE
fix(email): send notification even if there are no attachments

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -291,8 +291,11 @@ class EmailAccount(Document):
 
 				else:
 					frappe.db.commit()
-					if communication and hasattr(communication, "_attachments"):
-						attachments = [d.file_name for d in communication._attachments]
+					if communication:
+						attachments = []
+						if hasattr(communication, '_attachments'):
+							attachments = [d.file_name for d in communication._attachments]
+
 						communication.notify(attachments=attachments, fetched_from_email_account=True)
 
 			#notify if user is linked to account


### PR DESCRIPTION
Call communication.notify even if there is no _attachments attribute, otherwise the notification will not be sent with the current hotfix (https://github.com/frappe/frappe/commit/24f15401afe4b07b05f2f28ccfbd28b50554b4c0)