### PR TITLE
fix(email): send notification even if there are no attachments

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -293,8 +293,12 @@ class EmailAccount(Document):
 
 				else:
 					frappe.db.commit()
-					if communication and hasattr(communication, "_attachments"):
-						attachments = [d.file_name for d in communication._attachments]
+					if communication:
+						attachments = []
+
+						if hasattr(communication, '_attachments'):
+							attachments = [d.file_name for d in communication._attachments]
+
 						communication.notify(attachments=attachments, fetched_from_email_account=True)
 
 			#notify if user is linked to account


### PR DESCRIPTION
Call communication.notify even if there is no _attachments attribute, otherwise the notification will not be sent with the current hotfix (24f1540)

Duplicate for develop branch of https://github.com/frappe/frappe/pull/9227