### PR TITLE
refactor: simplify is_downloadable code in file.py

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -517,11 +517,7 @@ class File(Document):
 			delete_file(self.thumbnail_url)
 
 	def is_downloadable(self):
-		if self.is_private:
-			if has_permission(self, 'read'):
-				return True
-
-			return False
+		return self.is_private and has_permission(self, 'read')
 
 	def get_extension(self):
 		'''returns split filename and extension'''


### PR DESCRIPTION
These previous four lines

```python
if self.is_private:
  if has_permission(self, 'read'):
    return True
return False
```

... can better be expressed in one line:

```python
return self.is_private and has_permission(self, 'read')
```

Demonstation of correctness:
```python
def old(a, b):
  if a:
    if b:
      return True
    return False

def new(a, b):
  return a and b

for a, b in ((0, 0), (0, 1), (1, 0), (1, 1)):
  assert(new(a, b) == bool(old(a, b)))
```