### PR TITLE
fix: add validation to check for zero values in year, month or date

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -35,10 +35,9 @@ def getdate(string_date=None):
 	elif isinstance(string_date, datetime.date):
 		return string_date
 
-	# dateutil parser does not agree with dates like 0001-01-01
-	if not string_date or string_date=="0001-01-01":
-		return None
-	return parser.parse(string_date).date()
+	# dateutil parser does not agree with dates like 0000-00-00
+	if string_date and not string_date == "0000-00-00":
+		return parser.parse(string_date).date()
 
 def get_datetime(datetime_str=None):
 	if not datetime_str:
@@ -53,8 +52,8 @@ def get_datetime(datetime_str=None):
 	elif isinstance(datetime_str, datetime.date):
 		return datetime.datetime.combine(datetime_str, datetime.time())
 
-	# dateutil parser does not agree with dates like 0001-01-01
-	if not datetime_str or (datetime_str or "").startswith("0001-01-01"):
+	# dateutil parser does not agree with dates like 0000-00-00
+	if not datetime_str or (datetime_str or "").startswith("0000-00-00"):
 		return None
 
 	try:


### PR DESCRIPTION
- Previously we checked for year 0001 which parses fine.
<img width="324" alt="Screenshot 2020-01-13 at 11 41 06 AM" src="https://user-images.githubusercontent.com/6195660/72236316-3b246f00-35ce-11ea-8ffc-3192766ffc44.png">

- Strings with year month or date as 0 give value error, added check for that case.
