### PR TITLE
fix(background_job): use status as get_status is not accessible in html

### DIFF
--- a/frappe/core/page/background_jobs/background_jobs.html
+++ b/frappe/core/page/background_jobs/background_jobs.html
@@ -11,7 +11,7 @@
 		<tbody>
 			{% for j in jobs %}
 			<tr>
-				<td><span class="indicator {{ j.color }}" title="{{ j.get_status() }}">{{ j.queue.split(".").slice(-1)[0] }}</span></td>
+				<td><span class="indicator {{ j.color }}" title="{{ j.status }}">{{ j.queue.split(".").slice(-1)[0] }}</span></td>
 				<td style="overflow: auto;">
 					<div>
 						{{ frappe.utils.encode_tags(j.job_name) }}


### PR DESCRIPTION
**Unable to handle success response**

![image](https://user-images.githubusercontent.com/37302950/72342687-15dd5100-36f3-11ea-9afc-38ef4f380930.png)
