### PR TITLE
fix: Set correct doctype on clicking Customize button

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -256,7 +256,7 @@ frappe.ui.form.Toolbar = Class.extend({
 				}, true);
 			}
 
-			if (frappe.boot.developer_mode===1) {
+			if (frappe.boot.developer_mode===1 && !is_doctype_form) {
 				// edit doctype
 				this.page.add_menu_item(__("Edit DocType"), function() {
 					frappe.set_route('Form', 'DocType', me.frm.doctype);

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -239,14 +239,21 @@ frappe.ui.form.Toolbar = Class.extend({
 			});
 		}
 
-		if(frappe.user_roles.includes("System Manager") && me.frm.meta.issingle === 0) {
+		if (frappe.user_roles.includes("System Manager") && me.frm.meta.issingle === 0) {
+			let doctype = me.frm.doctype;
+			if (me.frm.doctype == 'DocType') {
+				if (me.frm.docname == 'DocType') return;
+				else {
+					doctype = me.frm.docname;
+				}
+			}
 			this.page.add_menu_item(__("Customize"), function() {
 
 				if (me.frm.meta && me.frm.meta.custom) {
-					frappe.set_route('Form', 'DocType', me.frm.doctype);
+					frappe.set_route('Form', 'DocType', doctype);
 				} else {
 					frappe.set_route('Form', 'Customize Form', {
-						doc_type: me.frm.doctype
+						doc_type: doctype
 					});
 				}
 			}, true);

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -240,23 +240,21 @@ frappe.ui.form.Toolbar = Class.extend({
 		}
 
 		if (frappe.user_roles.includes("System Manager") && me.frm.meta.issingle === 0) {
-			let doctype = me.frm.doctype;
-			if (me.frm.doctype == 'DocType') {
-				if (me.frm.docname == 'DocType') return;
-				else {
-					doctype = me.frm.docname;
-				}
-			}
-			this.page.add_menu_item(__("Customize"), function() {
+			let is_doctype_form = me.frm.doctype === 'DocType';
+			let doctype = is_doctype_form ? me.frm.docname : me.frm.doctype;
+			let is_doctype_custom = is_doctype_form ? me.frm.doc.custom : false;
 
-				if (me.frm.meta && me.frm.meta.custom) {
-					frappe.set_route('Form', 'DocType', doctype);
-				} else {
-					frappe.set_route('Form', 'Customize Form', {
-						doc_type: doctype
-					});
-				}
-			}, true);
+			if (doctype != 'DocType' && !is_doctype_custom) {
+				this.page.add_menu_item(__("Customize"), function() {
+					if (me.frm.meta && me.frm.meta.custom) {
+						frappe.set_route('Form', 'DocType', doctype);
+					} else {
+						frappe.set_route('Form', 'Customize Form', {
+							doc_type: doctype
+						});
+					}
+				}, true);
+			}
 
 			if (frappe.boot.developer_mode===1) {
 				// edit doctype


### PR DESCRIPTION
**Before:**
![fix-routing](https://user-images.githubusercontent.com/13928957/72323216-2c24e600-36ce-11ea-8c6e-22a9f5a24c19.gif)

**After:**
![fix-routing2](https://user-images.githubusercontent.com/13928957/72323235-3515b780-36ce-11ea-9ada-7cb30b9101f9.gif)

---
- Menu of Custom DocType form should not show Customize button

port-of: https://github.com/frappe/frappe/pull/9253