### PR TITLE
feat(Report View): show status field derived from docstatus or workflow if not in docfields

### DIFF
--- a/cypress/integration/report_view.js
+++ b/cypress/integration/report_view.js
@@ -19,11 +19,13 @@ context('Report View', () => {
 		cy.server();
 		cy.route('POST', 'api/method/frappe.client.set_value').as('value-update');
 		cy.visit(`/desk#List/${doctype_name}/Report`);
-		let cell = cy.get('.dt-row-0 > .dt-cell--col-3');
+		// check status column added from docstatus
+		cy.get('.dt-row-0 > .dt-cell--col-3').should('contain', 'Submitted');
+		let cell = cy.get('.dt-row-0 > .dt-cell--col-4');
 		// select the cell
 		cell.dblclick();
 		cell.find('input[data-fieldname="enabled"]').check({force: true});
-		cy.get('.dt-row-0 > .dt-cell--col-4').click();
+		cy.get('.dt-row-0 > .dt-cell--col-5').click();
 		cy.wait('@value-update');
 		cy.get('@doc').then(doc => {
 			cy.call('frappe.client.get_value', {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1021,17 +1021,16 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					}
 				};
 			}
-			if (col.field == 'status') {
+			if (col.field === 'status' && !frappe.meta.has_field(this.doctype, 'status')) {
 				// get status from docstatus
 				let status = frappe.get_indicator(d, this.doctype)[0];
 				return {
 					name: d.name,
 					doctype: col.docfield.parent,
 					content: status,
-					editable: this.is_editable(col.docfield, d)
-				}
-			}
-			if (col.field in d) {
+					editable: false
+				};
+			} else if (col.field in d) {
 				const value = d[col.field];
 				return {
 					name: d.name,

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -778,7 +778,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		let doctype_fields = frappe.meta.get_docfields(this.doctype).filter(standard_fields_filter);
 
 		// filter out docstatus field from picker
-		let std_fields = frappe.model.std_fields.filter( df => !in_list('docstatus', df.fieldname));
+		let std_fields = frappe.model.std_fields.filter( df => df.fieldname !== 'docstatus');
 
 		// add status field derived from docstatus, if status is not a standard field
 		if (!frappe.meta.has_field(this.doctype, 'status')) {
@@ -786,7 +786,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				label: __('Status'),
 				fieldname: 'docstatus',
 				fieldtype: 'Data'
-			}].concat(doctype_fields, std_fields);
+			}].concat(doctype_fields);
 		}
 
 		doctype_fields = [{
@@ -794,7 +794,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			fieldname: 'name',
 			fieldtype: 'Data',
 			reqd: 1
-		}].concat(doctype_fields);
+		}].concat(doctype_fields, std_fields);
 
 		out[this.doctype] = doctype_fields;
 
@@ -875,7 +875,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			} else {
 				// if status is not in fields append status column derived from docstatus
 				if (!this.fields.includes(['status', this.doctype]) && !frappe.meta.has_field(this.doctype, 'status')) {
-					column = this.build_column(['status', this.doctype]);
+					column = this.build_column(['docstatus', this.doctype]);
 				}
 			}
 
@@ -910,8 +910,13 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					}
 				}
 				docfield.parent = this.doctype;
-				if (fieldname == "name") {
+				if (fieldname == 'name') {
 					docfield.options = this.doctype;
+				}
+				if (fieldname == 'docstatus' && !frappe.meta.has_field(this.doctype, 'status')) {
+					docfield.label = 'Status';
+					docfield.fieldtype = 'Data';
+					docfield.name = 'status';
 				}
 			}
 		}
@@ -1000,7 +1005,6 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			totals_row[0].content = __('Totals').bold();
 			out.push(totals_row);
 		}
-
 		return out;
 	}
 
@@ -1021,7 +1025,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					}
 				};
 			}
-			if (col.field === 'status' && !frappe.meta.has_field(this.doctype, 'status')) {
+			if (col.field === 'docstatus' && !frappe.meta.has_field(this.doctype, 'status')) {
 				// get status from docstatus
 				let status = frappe.get_indicator(d, this.doctype)[0];
 				return {


### PR DESCRIPTION
Backport of: #9278


**Problem**: 
If status is not a field in doctype, it is shown according to the docstatus or workflow state in list view and in the document. For example: Journal Entry has no standard status field, it is derived from the docstatus and the entry type fields.

![non-standard-status](https://user-images.githubusercontent.com/24353136/72410981-d9136780-378f-11ea-8cd2-dc0a32bded82.png)

Same is not the case in Report View. Status field is not shown in report view

![no_status_field](https://user-images.githubusercontent.com/24353136/72411257-8e461f80-3790-11ea-9496-25406c987e15.png)

Also, its not available in pick columns as it is not a docfield in Journal Entry. Morever, docstatus field is always checked in Pick Columns dialog but never visible in the report.

![docstatus-field-pick](https://user-images.githubusercontent.com/24353136/72411241-84242100-3790-11ea-8b8d-cdaab93af69a.png)

**Fix:**
Enabling the visibility of docstatus field does not make sense, instead status should be shown derived from docstatus or workflow state as it is shown in list view for consistency.

This PR removes Document Status from pick columns and instead shows Status field if the doctype has no status docfield:

![2020-01-15 13 21 29](https://user-images.githubusercontent.com/24353136/72415227-0533e600-379a-11ea-8d40-36bb08f31d23.gif)
