### PR TITLE
fix: Geolocation field

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -1,4 +1,6 @@
 frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlData.extend({
+	horizontal: false,
+
 	make_wrapper() {
 		// Create the elements for map area
 		this._super();

--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -1,4 +1,4 @@
-frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlCode.extend({
+frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlData.extend({
 	make_wrapper() {
 		// Create the elements for map area
 		this._super();


### PR DESCRIPTION
Field inherits from ControlData instead of ControlCode

fixes https://github.com/frappe/erpnext/issues/20221

![half-width-geolocation-data](https://user-images.githubusercontent.com/1040161/72425049-0589ac80-37ad-11ea-9221-2f2683d53af3.png)
