### PR TITLE
fix: Deleting a child table row visually clears other form fields

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -64,16 +64,14 @@ export default class Grid {
 			<div class="small form-clickable-section grid-footer">
 				<div class="row">
 					<div class="col-sm-6 grid-buttons">
-						<button type="reset"
-							class="btn btn-xs btn-danger grid-remove-rows hidden"
+						<button class="btn btn-xs btn-danger grid-remove-rows hidden"
 							style="margin-right: 4px;">
 							${__("Delete")}</button>
-						<button type="reset"
-							class="grid-add-multiple-rows btn btn-xs btn-default hidden"
+						<button class="grid-add-multiple-rows btn btn-xs btn-default hidden"
 							style="margin-right: 4px;">
 							${__("Add Multiple")}</a>
 						<!-- hack to allow firefox include this in tabs -->
-						<button type="reset" class="btn btn-xs btn-default grid-add-row">
+						<button class="btn btn-xs btn-default grid-add-row">
 							${__("Add Row")}</button>
 					</div>
 					<div class="col-sm-6 text-right">


### PR DESCRIPTION
Fixes https://github.com/frappe/frappe/issues/9264