### PR TITLE
fix: default value not set for the date field

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -66,7 +66,7 @@ def set_user_and_static_default_values(doc):
 					doc.set(df.fieldname, user_default_value)
 
 			else:
-				if df.fieldname != doc.meta.title_field:
+				if df.fieldname != doc.meta.title_field or df.fieldtype in ["Date", "Datetime"]:
 					static_default_value = get_static_default_value(df, doctype_user_permissions, allowed_records)
 					if static_default_value is not None:
 						doc.set(df.fieldname, static_default_value)


### PR DESCRIPTION
**Issue**

User has set the title field as posting_date in the stock entry
![image](https://user-images.githubusercontent.com/8780500/72426112-27842e80-37af-11ea-89a3-480fe01d8fbd.png)

But while making the stock entry from the work order user getting the below error
<img width="869" alt="Screenshot 2020-01-15 at 3 50 19 PM" src="https://user-images.githubusercontent.com/8780500/72426163-3f5bb280-37af-11ea-9615-bbf14f99c06c.png">


After debugging came to know that system not set the default value if the field is a title field.

![image](https://user-images.githubusercontent.com/8780500/72426303-7df16d00-37af-11ea-894b-7c7287ce16a9.png)
