### PR TITLE
fix: filter out JS type print formats in Customize form

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -17,6 +17,14 @@ frappe.ui.form.on("Customize Form", {
 			};
 		});
 
+		frm.set_query("default_print_format", function() {
+			return {
+				filters: {
+					'print_format_type': ['!=', 'JS']
+				}
+			}
+		});
+
 		$(frm.wrapper).on("grid-row-render", function(e, grid_row) {
 			if(grid_row.doc && grid_row.doc.fieldtype=="Section Break") {
 				$(grid_row.row).css({"font-weight": "bold"});


### PR DESCRIPTION
JS print formats are filtered out in the print format list anyway (in `get_print_formats`)
