### PR TITLE
fix: change message content for errors without a title

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1546,7 +1546,7 @@ def log_error(message=None, title=None):
 	# this hack tries to be smart about whats a title (single line ;-)) and fixes it
 
 	if message:
-		if '\n' not in message:
+		if '\n' not in message and not title:
 			title = message
 			error = get_traceback()
 		else:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1537,7 +1537,7 @@ def logger(module=None, with_more_info=True):
 	from frappe.utils.logger import get_logger
 	return get_logger(module or 'default', with_more_info=with_more_info)
 
-def log_error(message=None, title=None):
+def log_error(message=None, title=_("Error")):
 	'''Log error to Error Log'''
 
 	# AI ALERT:
@@ -1546,9 +1546,8 @@ def log_error(message=None, title=None):
 	# this hack tries to be smart about whats a title (single line ;-)) and fixes it
 
 	if message:
-		if '\n' not in message and not title:
-			title = message
-			error = get_traceback()
+		if '\n' in title:
+			error, title = title, message
 		else:
 			error = message
 	else:


### PR DESCRIPTION
**Issue:** message gets swapped with title when there is no new line character in the message