### PR TITLE
fix: Geolocation field (v12)

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -1,4 +1,6 @@
-frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlCode.extend({
+frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlData.extend({
+	horizontal: false,
+
 	make_wrapper() {
 		// Create the elements for map area
 		this._super();


### PR DESCRIPTION
Field inherits from ControlData instead of ControlCode
make field full width

fixes https://github.com/frappe/erpnext/issues/20221