### PR TITLE
fix: Style of result image in search

### DIFF
--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -713,6 +713,7 @@ li.user-progress {
 			height: 60px;
 			width: 60px;
 			background-color: #fafbfc;
+			overflow: hidden;
 
 			.flex-text {
 				display: flex;


### PR DESCRIPTION
**Before:** 
<img width="759" alt="Screenshot 2020-01-15 at 5 17 40 PM" src="https://user-images.githubusercontent.com/13928957/72432190-6a98ce80-37bc-11ea-937a-c737c9f884ec.png">

**After:**
<img width="757" alt="Screenshot 2020-01-15 at 5 17 08 PM" src="https://user-images.githubusercontent.com/13928957/72432185-679dde00-37bc-11ea-9e5f-cae8900ba9ec.png">

