### PR TITLE
fix: skip single doctype when rebuilding search index

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -81,6 +81,10 @@ def rebuild_for_doctype(doctype):
 		return filters
 
 	meta = frappe.get_meta(doctype)
+	
+	if cint(meta.issingle) == 1:
+		return
+	
 	if cint(meta.istable) == 1:
 		parent_doctypes = frappe.get_all("DocField", fields="parent", filters={
 			"fieldtype": ["in", frappe.model.table_fields],


### PR DESCRIPTION
When running:

`bench rebuild-global-search`

The script would fail due to attempting to index single doctypes.

fixes #8779 

port-of: https://github.com/frappe/frappe/pull/9187