### PR TITLE
fix: Consider "Small Text" and "Long Text"  as text_field in print macro

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -3,7 +3,7 @@
 		{{ render_table(df, doc) }}
 	{%- elif df.fieldtype=="HTML" and df.options -%}
 		<div>{{ frappe.render_template(df.options, {"doc": doc}) or "" }}</div>
-	{%- elif df.fieldtype in ("Text", "Text Editor", "Code") -%}
+	{%- elif df.fieldtype in ("Text", "Text Editor", "Code", "Small Text", "Long Text") -%}
 		{{ render_text_field(df, doc) }}
 	{%- elif df.fieldtype in ("Image", "Attach Image", "Attach")
 		and (guess_mimetype(doc[df.fieldname])[0] or "").startswith("image/")  -%}


### PR DESCRIPTION
Some users might have following issue in their print formats
![image](https://user-images.githubusercontent.com/13928957/72626350-98267900-3970-11ea-8cc8-6499ad10fd2a.png)
scroll bar in print format. 

Because, "Long Text" was not considered as a text field which is why it was getting rendered differently in the print format.

Got to know about this after the recent [change in ERPNext's Sales Invoice](https://github.com/frappe/erpnext/pull/20141).





port-of: https://github.com/frappe/frappe/pull/9308