### PR TITLE
fix: Set communication sender while creating event

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -73,6 +73,8 @@ class Event(Document):
 		communication.subject = self.subject
 		communication.content = self.description if self.description else self.subject
 		communication.communication_date = self.starts_on
+		communication.sender = self.owner
+		communication.sender_full_name = frappe.utils.get_fullname(self.owner)
 		communication.reference_doctype = self.doctype
 		communication.reference_name = self.name
 		communication.communication_medium = communication_mapping.get(self.event_category) if self.event_category else ""


### PR DESCRIPTION
Previously, even if any user created the event from timeline, it used to show **Guest** as a creator of the Event.
<img width="966" alt="Screenshot 2020-01-20 at 3 01 17 PM" src="https://user-images.githubusercontent.com/13928957/72715012-b91be380-3b95-11ea-8bcb-ac209328b5f1.png">

