### PR TITLE
fix: Small Text should not be rendered as text_field

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -3,7 +3,7 @@
 		{{ render_table(df, doc) }}
 	{%- elif df.fieldtype=="HTML" and df.options -%}
 		<div>{{ frappe.render_template(df.options, {"doc": doc}) or "" }}</div>
-	{%- elif df.fieldtype in ("Text", "Text Editor", "Code", "Small Text", "Long Text") -%}
+	{%- elif df.fieldtype in ("Text", "Text Editor", "Code", "Long Text") -%}
 		{{ render_text_field(df, doc) }}
 	{%- elif df.fieldtype in ("Image", "Attach Image", "Attach")
 		and (guess_mimetype(doc[df.fieldname])[0] or "").startswith("image/")  -%}
@@ -95,7 +95,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {%- macro render_text_field(df, doc) -%}
 {%- if doc.get(df.fieldname) != None -%}
 <div style="padding: 10px 0px" {{ fieldmeta(df) }}>
-	{%- if df.fieldtype in ("Text", "Code") %}<label>{{ _(df.label) }}</label>{%- endif %}
+	{%- if df.fieldtype in ("Text", "Code", "Long Text") %}<label>{{ _(df.label) }}</label>{%- endif %}
 	{%- if df.fieldtype=="Code" %}
 		<pre class="value">{{ doc.get(df.fieldname) }}</pre>
 	{% else -%}


### PR DESCRIPTION
Small Text should not be rendered as text_field to avoid the following issue.

**Before:** 
<img width="754" alt="Screenshot 2020-01-20 at 3 37 18 PM" src="https://user-images.githubusercontent.com/13928957/72718027-25e5ac80-3b9b-11ea-829b-b6f7bede67bf.png">

**After:**
<img width="758" alt="Screenshot 2020-01-20 at 3 36 10 PM" src="https://user-images.githubusercontent.com/13928957/72717969-0a7aa180-3b9b-11ea-8466-40f9e03ed575.png">

- Also, show the label for the Long Text field

This issue was introduced after [this fix](https://github.com/frappe/frappe/pull/9308)

