### PR TITLE
fix(Filters): Options don't change when changing filter condition

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -195,7 +195,7 @@ frappe.ui.Filter = class {
 		// called when condition is changed,
 		// don't change if all is well
 		if(this.field && cur.fieldname == fieldname && df.fieldtype == cur.fieldtype &&
-			df.parent == cur.parent) {
+			df.parent == cur.parent && df.options == cur.options) {
 			return;
 		}
 


### PR DESCRIPTION
Problem:
![condition problem](https://user-images.githubusercontent.com/19775888/72784112-0f4c5d80-3c4e-11ea-8c44-2227fcfabff3.gif)


When changing the condition from **Equals** to **Is** the field is not made again since the fieldtype of both are the same (Select) and all the other conditions are satisfied. That's why the options don't change.

After fix:
![conditions fix](https://user-images.githubusercontent.com/19775888/72784340-9a2d5800-3c4e-11ea-8e0d-1c64a16c542e.gif)
