### PR TITLE
fix: Allow map_docs to accommodate 'args' sent from client call

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -30,10 +30,13 @@ def make_mapped_doc(method, source_name, selected_children=None, args=None):
 	return method(source_name)
 
 @frappe.whitelist()
-def map_docs(method, source_names, target_doc, args:str=None):
-	# args => "{ 'supplier': 100 }"
-	'''Returns the mapped document calling the given mapper method
-	with each of the given source docs on the target doc'''
+def map_docs(method, source_names, target_doc, args: str = None):
+	''' Returns the mapped document calling the given mapper method
+	with each of the given source docs on the target doc
+
+	:param args: Args to pass to the mapper method
+	E.g. args: "{ 'supplier': 'XYZ' }" '''
+
 	method = frappe.get_attr(method)
 	if method not in frappe.whitelisted:
 		raise frappe.PermissionError
@@ -41,7 +44,7 @@ def map_docs(method, source_names, target_doc, args:str=None):
 	for src in json.loads(source_names):
 		_args = (src, target_doc, json.loads(args)) if args else (src, target_doc)
 		target_doc = method(*_args)
-		yield target_doc
+	return target_doc
 
 def get_mapped_doc(from_doctype, from_docname, table_maps, target_doc=None,
 		postprocess=None, ignore_permissions=False, ignore_child_tables=False):


### PR DESCRIPTION
- 'args' can be sent  to the mapper method from the client call (eg. map_current_doc)
- map_docs didn't handle the same

**After fix:**
- Can optionally send args to mapper method.