### PR TITLE
fix: py3 compatibility for error snapshot creation (develop)

### DIFF
--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -128,14 +128,14 @@ def get_snapshot(exception, context=10):
 				value = pydoc.text.repr(getattr(evalue, name))
 
 				# render multilingual string properly
-				if type(value)==str and value.startswith(b"u'"):
+				if type(value) == str and value.startswith("u'"):
 					value = eval(value)
 
 				s['exception'][name] = encode(value)
 
 	# add all local values (of last frame) to the snapshot
 	for name, value in locals.items():
-		if type(value)==str and value.startswith(b"u'"):
+		if type(value) == str and value.startswith("u'"):
 			value = eval(value)
 
 		s['locals'][name] = pydoc.text.repr(value)

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -126,10 +126,18 @@ def get_snapshot(exception, context=10):
 			# prevent py26 DeprecationWarning
 			if (name != 'messages' or sys.version_info < (2.6)) and not name.startswith('__'):
 				value = pydoc.text.repr(getattr(evalue, name))
-				s['exception'][name] = frappe.safe_encode(value)
+
+				# render multilingual string properly
+				if type(value) == str and value.startswith("u'"):
+					value = eval(value)
+
+				s['exception'][name] = encode(value)
 
 	# add all local values (of last frame) to the snapshot
 	for name, value in locals.items():
+		if type(value) == str and value.startswith("u'"):
+			value = eval(value)
+
 		s['locals'][name] = pydoc.text.repr(value)
 
 	return s

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -126,18 +126,10 @@ def get_snapshot(exception, context=10):
 			# prevent py26 DeprecationWarning
 			if (name != 'messages' or sys.version_info < (2.6)) and not name.startswith('__'):
 				value = pydoc.text.repr(getattr(evalue, name))
-
-				# render multilingual string properly
-				if type(value) == str and value.startswith("u'"):
-					value = eval(value)
-
-				s['exception'][name] = encode(value)
+				s['exception'][name] = frappe.safe_encode(value)
 
 	# add all local values (of last frame) to the snapshot
 	for name, value in locals.items():
-		if type(value) == str and value.startswith("u'"):
-			value = eval(value)
-
 		s['locals'][name] = pydoc.text.repr(value)
 
 	return s

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -128,14 +128,14 @@ def get_snapshot(exception, context=10):
 				value = pydoc.text.repr(getattr(evalue, name))
 
 				# render multilingual string properly
-				if type(value) == str and value.startswith("u'"):
+				if isinstance(value, six.text_type):
 					value = eval(value)
 
 				s['exception'][name] = encode(value)
 
 	# add all local values (of last frame) to the snapshot
 	for name, value in locals.items():
-		if type(value) == str and value.startswith("u'"):
+		if isinstance(value, six.text_type):
 			value = eval(value)
 
 		s['locals'][name] = pydoc.text.repr(value)


### PR DESCRIPTION
**Refs:**

- https://discuss.erpnext.com/t/new-errors-in-email-settings/52815/4
- https://discuss.erpnext.com/t/typeerror-can-only-concatenate-list-not-nonetype-to-list-in-chart-of-accounts-importer/52441/5

<hr>

```python
TypeError: startswith first arg must be str or a tuple of str, not bytes
  File "frappe/utils/error.py", line 36, in make_error_snapshot
    snapshot = get_snapshot(exception)
  File "frappe/utils/error.py", line 131, in get_snapshot
    if type(value)==str and value.startswith(b"u'"):
```