### PR TITLE
fix: corrected status option from Success to Complete in scheduled job log

### DIFF
--- a/frappe/core/doctype/scheduled_job_log/scheduled_job_log.json
+++ b/frappe/core/doctype/scheduled_job_log/scheduled_job_log.json
@@ -16,7 +16,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Scheduled\nSuccess\nFailed",
+   "options": "Scheduled\nComplete\nFailed",
    "read_only": 1,
    "reqd": 1
   },
@@ -38,7 +38,7 @@
   }
  ],
  "links": [],
- "modified": "2019-09-25 11:55:10.646458",
+ "modified": "2020-01-22 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Log",


### PR DESCRIPTION
Fixed the options on the screenshot
Before: "Success"
After: "Complete"

![Screen Shot 2020-01-22 at 05 05 43](https://user-images.githubusercontent.com/18157195/72866904-f1760b80-3cd4-11ea-882f-f7bbd5ff4ff6.png)

