### PR TITLE
fix(get_permlevel_access): Lazy load handle different permission types

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -577,7 +577,7 @@ class Document(BaseDocument):
 
 	def get_permlevel_access(self, permission_type='write'):
 		if not hasattr(self, "_has_access_to"):
-			self._has_access_to = frappe._dict()
+			self._has_access_to = {}
 
 		if not self._has_access_to.get(permission_type):
 			self._has_access_to[permission_type] = []

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -577,14 +577,17 @@ class Document(BaseDocument):
 
 	def get_permlevel_access(self, permission_type='write'):
 		if not hasattr(self, "_has_access_to"):
+			self._has_access_to = frappe._dict()
+
+		if not self._has_access_to.get(permission_type):
+			self._has_access_to[permission_type] = []
 			roles = frappe.get_roles()
-			self._has_access_to = []
 			for perm in self.get_permissions():
 				if perm.role in roles and perm.permlevel > 0 and perm.get(permission_type):
-					if perm.permlevel not in self._has_access_to:
-						self._has_access_to.append(perm.permlevel)
+					if perm.permlevel not in self._has_access_to[permission_type]:
+						self._has_access_to[permission_type].append(perm.permlevel)
 
-		return self._has_access_to
+		return self._has_access_to[permission_type]
 
 	def has_permlevel_access_to(self, fieldname, df=None, permission_type='read'):
 		if not df:

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -28,7 +28,6 @@ class TestFormLoad(unittest.TestCase):
 			"blog_intro": "Test Blog Intro",
 			"blogger": "_Test Blogger 1",
 			"content": "Test Blog Content",
-			"doctype": "Blog Post",
 			"title": "_Test Blog Post {}".format(frappe.utils.now()),
 			"published": 0
 		})
@@ -76,7 +75,7 @@ class TestFormLoad(unittest.TestCase):
 
 
 def get_blog(blog_name):
+	frappe.response.docs = []
 	getdoc('Blog Post', blog_name)
 	doc = frappe.response.docs[0]
-	frappe.response.docs = []
 	return doc

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -35,7 +35,9 @@ class TestFormLoad(unittest.TestCase):
 		blog.insert()
 
 		user = frappe.get_doc('User', 'test@example.com')
-		user.remove_roles('Website Manager', 'System Manager')
+
+		user_roles = frappe.get_roles()
+		user.remove_roles(*user_roles)
 		user.add_roles('Blogger')
 
 		make_property_setter('Blog Post', 'published', 'permlevel',  1, 'Int')
@@ -73,6 +75,9 @@ class TestFormLoad(unittest.TestCase):
 
 		frappe.set_user('Administrator')
 
+		# reset user roles
+		user.remove_roles('Blogger', 'Website Manager')
+		user.add_roles(*user_roles)
 
 def get_blog(blog_name):
 	frappe.response.docs = []

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -40,6 +40,7 @@ class TestFormLoad(unittest.TestCase):
 		user.add_roles('Blogger')
 
 		make_property_setter('Blog Post', 'published', 'permlevel',  1, 'Int')
+		reset('Blog Post')
 		add('Blog Post', 'Website Manager', 1)
 		update('Blog Post', 'Website Manager', 1, 'write', 1)
 
@@ -60,7 +61,6 @@ class TestFormLoad(unittest.TestCase):
 
 		frappe.set_user('Administrator')
 		user.add_roles('Website Manager')
-		frappe.cache().hdel("roles", user.name)
 		frappe.set_user(user.name)
 
 		doc = frappe.get_doc('Blog Post', blog.name)

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 
 import frappe, unittest
 from frappe.desk.form.load import getdoctype, getdoc
-from frappe.core.page.permission_manager.permission_manager import update, reset
+from frappe.core.page.permission_manager.permission_manager import update, reset, add
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
+test_dependencies = ['Blog Category', 'Blogger']
 
 class TestFormLoad(unittest.TestCase):
 	def test_load(self):
@@ -20,56 +22,61 @@ class TestFormLoad(unittest.TestCase):
 		self.assertTrue(meta.get("__calendar_js"))
 
 	def test_fieldlevel_permissions_in_load(self):
+		blog = frappe.get_doc({
+			"doctype": "Blog Post",
+			"blog_category": "_Test Blog Category 1",
+			"blog_intro": "Test Blog Intro",
+			"blogger": "_Test Blogger 1",
+			"content": "Test Blog Content",
+			"doctype": "Blog Post",
+			"title": "_Test Blog Post {}".format(frappe.utils.now()),
+			"published": 0
+		})
+
+		blog.insert()
+
 		user = frappe.get_doc('User', 'test@example.com')
-		user.remove_roles('Website Manager')
+		user.remove_roles('Website Manager', 'System Manager')
 		user.add_roles('Blogger')
-		reset('Blog Post')
 
-		frappe.db.set_value('DocField', {
-			'fieldname': 'published',
-			'parent': 'Blog Post'
-		}, 'permlevel', 1)
-
-		update('Blog Post', 'Website Manager', 0, 'permlevel', 1)
+		make_property_setter('Blog Post', 'published', 'permlevel',  1, 'Int')
+		add('Blog Post', 'Website Manager', 1)
+		update('Blog Post', 'Website Manager', 1, 'write', 1)
 
 		frappe.set_user(user.name)
 
-		# print frappe.as_json(get_valid_perms('Blog Post'))
+		blog_doc = get_blog(blog.name)
 
-		frappe.clear_cache(doctype='Blog Post')
+		self.assertEqual(blog_doc.name, blog.name)
+		# since published field has higher permlevel
+		self.assertEqual(blog_doc.published, None)
 
-		blog = frappe.db.get_value('Blog Post', {'title': '_Test Blog Post'})
-
-		getdoc('Blog Post', blog)
-
-		checked = False
-
-		for doc in frappe.response.docs:
-			if doc.name == blog:
-				self.assertEqual(doc.published, None)
-				checked = True
-
-		self.assertTrue(checked, True)
-
-		frappe.db.set_value('DocField', {
-			'fieldname': 'published',
-			'parent': 'Blog Post'
-		}, 'permlevel', 0)
-
-		reset('Blog Post')
-
-		frappe.clear_cache(doctype='Blog Post')
-
-		frappe.response.docs = []
-		getdoc('Blog Post', blog)
-
-		checked = False
-
-		for doc in frappe.response.docs:
-			if doc.name == blog:
-				self.assertEqual(doc.published, 1)
-				checked = True
-
-		self.assertTrue(checked, True)
+		# this will be ignored because user does not
+		# have write access on `published` field (or on permlevel 1 fields)
+		blog_doc.published = 1
+		blog_doc.save()
+		# since published field has higher permlevel
+		self.assertEqual(blog_doc.published, 0)
 
 		frappe.set_user('Administrator')
+		user.add_roles('Website Manager')
+		frappe.cache().hdel("roles", user.name)
+		frappe.set_user(user.name)
+
+		doc = frappe.get_doc('Blog Post', blog.name)
+		doc.published = 1
+		doc.save()
+
+		blog_doc = get_blog(blog.name)
+		# now user should be allowed to read field with higher permlevel
+		# (after adding Website Manager role)
+		self.assertEqual(blog_doc.published, 1)
+
+		frappe.set_user('Administrator')
+
+
+def get_blog(blog_name):
+	getdoc('Blog Post', blog_name)
+	doc = frappe.response.docs[0]
+	frappe.response.docs = []
+	return doc


### PR DESCRIPTION
**Problem:**
`frappe.model.document.get_permlevel_access` is lazy loading the `permission_type` of the first call only!

Therefore if `get_permlevel_access` is called first with `permission_type='read'` then the second time when it's called with `permission_type='write'` it will return the values of **read** rather than **write**

port-of: https://github.com/frappe/frappe/pull/9159