### PR TITLE
fix: auto email report not working for the prepared report

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -126,13 +126,15 @@ class Report(Document):
 		safe_exec(self.report_script, None, loc)
 		return loc['data']
 
-	def get_data(self, filters=None, limit=None, user=None, as_dict=False):
+	def get_data(self, filters=None, limit=None, user=None, as_dict=False, ignore_prepared_report=False):
 		columns = []
 		out = []
 
 		if self.report_type in ('Query Report', 'Script Report', 'Custom Report'):
 			# query and script reports
-			data = frappe.desk.query_report.run(self.name, filters=filters, user=user)
+			data = frappe.desk.query_report.run(self.name,
+				filters=filters, user=user, ignore_prepared_report=ignore_prepared_report)
+
 			for d in data.get('columns'):
 				if isinstance(d, dict):
 					col = frappe._dict(d)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -158,7 +158,7 @@ def get_script(report_name):
 
 @frappe.whitelist()
 @frappe.read_only()
-def run(report_name, filters=None, user=None):
+def run(report_name, filters=None, user=None, ignore_prepared_report=False):
 
 	report = get_report_doc(report_name)
 	if not user:
@@ -169,7 +169,7 @@ def run(report_name, filters=None, user=None):
 
 	result = None
 
-	if report.prepared_report and not report.disable_prepared_report:
+	if report.prepared_report and not report.disable_prepared_report and not ignore_prepared_report:
 		if filters:
 			if isinstance(filters, string_types):
 				filters = json.loads(filters)

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -66,7 +66,7 @@ class AutoEmailReport(Document):
 			self.prepare_dynamic_filters()
 
 		columns, data = report.get_data(limit=self.no_of_rows or 100, user = self.user,
-			filters = self.filters, as_dict=True)
+			filters = self.filters, as_dict=True, ignore_prepared_report=True)
 
 		# add serial numbers
 		columns.insert(0, frappe._dict(fieldname='idx', label='', width='30px'))


### PR DESCRIPTION
**Issue**

Auto email report not working if the report has prepared report property enabled 

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 182, in download
    data = auto_email_report.get_report_content()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 69, in get_report_content
    filters = self.filters, as_dict=True)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 138, in get_data
    for d in data.get('columns'):
TypeError: 'NoneType' object is not iterable
```

Solution:
System will ignore the prepared report property if the report has generated for auto email report