### PR TITLE
fix: Update breadcrumb itemtype to schema.org

### DIFF
--- a/frappe/templates/includes/breadcrumbs.html
+++ b/frappe/templates/includes/breadcrumbs.html
@@ -1,7 +1,7 @@
 {% if not no_breadcrumbs and parents %}
 <div class="container mt-3">
 	<nav aria-label="breadcrumb">
-		<ol class="breadcrumb" itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+		<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 			{%- set parents = parents[-3:] %}
 			{% for parent in parents %}
 				<li class="breadcrumb-item">


### PR DESCRIPTION
data-vocabulary.org is now deprecated in favor of schema.org