### PR TITLE
fix(Merge Docs): make doc merging configurable

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -501,7 +501,7 @@
  "idx": 6,
  "links": [],
  "modified": "2020-01-23 17:58:29.235287",
- "modified_by": "himanshu@erpnext.com",
+ "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",
  "owner": "Administrator",

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -40,6 +40,7 @@
   "allow_copy",
   "allow_rename",
   "allow_import",
+  "allow_merge_with_existing",
   "allow_events_in_timeline",
   "allow_auto_repeat",
   "view_settings",
@@ -488,12 +489,19 @@
    "fieldtype": "Table",
    "label": "Links",
    "options": "DocType Link"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_merge_with_existing",
+   "fieldtype": "Check",
+   "label": "Allow merge with existing"
   }
  ],
  "icon": "fa fa-bolt",
  "idx": 6,
- "modified": "2019-11-25 17:24:03.690192",
- "modified_by": "Administrator",
+ "links": [],
+ "modified": "2020-01-23 17:58:29.235287",
+ "modified_by": "himanshu@erpnext.com",
  "module": "Core",
  "name": "DocType",
  "owner": "Administrator",

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "DL.####",
  "creation": "2013-01-29 17:55:08",
  "doctype": "DocType",
@@ -18,6 +19,7 @@
   "track_changes",
   "track_views",
   "allow_auto_repeat",
+  "allow_merge_with_existing",
   "allow_import",
   "image_view",
   "column_break_5",
@@ -174,14 +176,21 @@
    "fieldname": "allow_import",
    "fieldtype": "Check",
    "label": "Allow Import (via Data Import Tool)"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_merge_with_existing",
+   "fieldtype": "Check",
+   "label": "Allow Merge with Existing"
   }
  ],
  "hide_toolbar": 1,
  "icon": "fa fa-glass",
  "idx": 1,
  "issingle": 1,
- "modified": "2019-10-08 11:16:36.698006",
- "modified_by": "Administrator",
+ "links": [],
+ "modified": "2020-01-23 18:00:02.093331",
+ "modified_by": "himanshu@erpnext.com",
  "module": "Custom",
  "name": "Customize Form",
  "owner": "Administrator",

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -190,7 +190,7 @@
  "issingle": 1,
  "links": [],
  "modified": "2020-01-23 18:00:02.093331",
- "modified_by": "himanshu@erpnext.com",
+ "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",
  "owner": "Administrator",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -31,7 +31,8 @@ doctype_properties = {
 	'track_changes': 'Check',
 	'track_views': 'Check',
 	'allow_auto_repeat': 'Check',
-	'allow_import': 'Check'
+	'allow_import': 'Check',
+	'allow_merge_with_existing': 'Check'
 }
 
 docfield_properties = {

--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -217,6 +217,7 @@ CREATE TABLE `tabDocType` (
   `allow_guest_to_view` int(1) NOT NULL DEFAULT 0,
   `route` varchar(255) DEFAULT NULL,
   `is_published_field` varchar(255) DEFAULT NULL,
+  `allow_merge_with_exsiting` int(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`name`),
   KEY `parent` (`parent`)
 ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED CHARACTER SET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/frappe/database/postgres/framework_postgres.sql
+++ b/frappe/database/postgres/framework_postgres.sql
@@ -222,6 +222,7 @@ CREATE TABLE "tabDocType" (
   "allow_guest_to_view" smallint NOT NULL DEFAULT 0,
   "route" varchar(255) DEFAULT NULL,
   "is_published_field" varchar(255) DEFAULT NULL,
+  "allow_merge_with_exsiting" smallint NOT NULL DEFAULT 0,
   PRIMARY KEY ("name")
 ) ;
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -94,9 +94,6 @@ def rename_doc(doctype, old, new, force=False, merge=False, ignore_permissions=F
 	else:
 		new_doc.add_comment('Edit', _("renamed from {0} to {1}").format(frappe.bold(old), frappe.bold(new)))
 
-	if merge:
-		frappe.delete_doc(doctype, old)
-
 	frappe.clear_cache()
 	frappe.enqueue('frappe.utils.global_search.rebuild_for_doctype', doctype=doctype)
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -148,8 +148,12 @@ frappe.ui.form.Toolbar = Class.extend({
 					fieldtype: "Data",
 					reqd: 1,
 					default: docname
-				}, {
-					label: __("Merge with existing"),
+				}]);
+			}
+
+			if (me.can_rename() && me.frm.meta.allow_merge_with_existing) {
+				fields.push(...[{
+					label: __("Merge with Existing"),
 					fieldname: "merge",
 					fieldtype: "Check",
 					default: 0


### PR DESCRIPTION
- `Merge with Existing` was allowed if a user had permissions to rename, he could merge the doc with the existing.
- Merge with Existing has to be enabled via DocType or via Customize Form
- After merging, the old doc was deleted, which has been reverted

**Breaking Change**
**Doesn't delete the Merged Document anymore**