### PR TITLE
fix(calendar):  UI fix

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -160,7 +160,7 @@ frappe.views.ListSidebar = class ListSidebar {
 				reference_doctype: doctype
 			}
 		}).then(result => {
-			if (!(result && result.length)) return;
+			if (!(result && Array.isArray(result) && result.length)) return;
 			const calendar_views = result;
 			const $link_calendar = this.sidebar.find('.list-link[data-view="Calendar"]');
 

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -160,7 +160,7 @@ frappe.views.ListSidebar = class ListSidebar {
 				reference_doctype: doctype
 			}
 		}).then(result => {
-			if (!result) return;
+			if (!(result && result.length)) return;
 			const calendar_views = result;
 			const $link_calendar = this.sidebar.find('.list-link[data-view="Calendar"]');
 

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -351,6 +351,9 @@ frappe.views.Calendar = Class.extend({
 
 			me.fix_end_date_for_event_render(d);
 			me.prepare_colors(d);
+
+			d.title = frappe.utils.html2text(d.title);
+			
 			return d;
 		});
 	},


### PR DESCRIPTION
**Problem:**

1. Calendar link appears even when there is no entry in **Calendar View** for given **DocType**
2. In ToDo Calendar  when subject field is set to description, html elements appear on event's title

Before:
![before](https://user-images.githubusercontent.com/9103781/73058665-1677a380-3eba-11ea-845e-68eb55938ffc.png) 

After:
![after](https://user-images.githubusercontent.com/9103781/73058653-0cee3b80-3eba-11ea-8592-137bf6081de3.png)


