### PR TITLE
fix: Change of unicode characters in translations and change build version in develop mode

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -4,18 +4,22 @@
 globals attached to frappe module
 + some utility functions that should probably be moved
 """
-from __future__ import unicode_literals, print_function
+from __future__ import print_function, unicode_literals
 
-from six import iteritems, binary_type, text_type, string_types, PY2
-from werkzeug.local import Local, release_local
-import os, sys, importlib, inspect, json
-from past.builtins import cmp
+import importlib
+import inspect
+import json
+import os
+import sys
 
 from faker import Faker
+from past.builtins import cmp
+from six import PY2, binary_type, iteritems, string_types, text_type
+from werkzeug.local import Local, release_local
 
-# public
 from .exceptions import *
-from .utils.jinja import (get_jenv, get_template, render_template, get_email_from_template, get_jloader)
+from .utils.jinja import (get_email_from_template, get_jenv, get_jloader,
+                          get_template, render_template)
 
 # Harmless for Python 3
 # For Python 2 set default encoding to utf-8
@@ -1680,3 +1684,9 @@ def mock(type, size=1, locale='en'):
 
 	from frappe.chat.util import squashify
 	return squashify(results)
+
+def can_use_reloader():
+	return get_site_config().get('use_reloader')
+
+def is_dev_mode():
+	return get_site_config().get('developer_mode')

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -3,28 +3,29 @@
 # MIT License. See license.txt
 from __future__ import unicode_literals
 
-import os
-from six import iteritems
 import logging
+import os
 
-from werkzeug.wrappers import Request
-from werkzeug.local import LocalManager
-from werkzeug.exceptions import HTTPException, NotFound
+from six import iteritems
 from werkzeug.contrib.profiler import ProfilerMiddleware
+from werkzeug.exceptions import HTTPException, NotFound
+from werkzeug.local import LocalManager
+from werkzeug.wrappers import Request
 from werkzeug.wsgi import SharedDataMiddleware
 
 import frappe
-import frappe.handler
-import frappe.auth
 import frappe.api
+import frappe.auth
+import frappe.handler
+import frappe.recorder
 import frappe.utils.response
 import frappe.website.render
-from frappe.utils import get_site_name
-from frappe.middlewares import StaticDataMiddleware
-from frappe.utils.error import make_error_snapshot
-from frappe.core.doctype.comment.comment import update_comments_in_parent_after_request
 from frappe import _
-import frappe.recorder
+from frappe.core.doctype.comment.comment import \
+    update_comments_in_parent_after_request
+from frappe.middlewares import StaticDataMiddleware
+from frappe.utils import get_site_name
+from frappe.utils.error import make_error_snapshot
 
 local_manager = LocalManager([frappe.local])
 
@@ -241,7 +242,7 @@ def serve(port=8000, profile=False, no_reload=False, no_threading=False, site=No
 		log.setLevel(logging.ERROR)
 
 	run_simple('0.0.0.0', int(port), application,
-		use_reloader=False if in_test_env else not no_reload,
+		use_reloader=False if (in_test_env or not frappe.can_use_reloader()) else not no_reload,
 		use_debugger=not in_test_env,
 		use_evalex=not in_test_env,
 		threaded=not no_threading)

--- a/frappe/translations/af.csv
+++ b/frappe/translations/af.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Stelselgebruiker
 DocType: Report,Is Standard,Is Standaard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,volle
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","HTML-kode nie HTML-kode soos &lt;script> of net karakters soos &lt;of>, aangesien dit doelbewus in hierdie veld gebruik kan word"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","HTML-kode nie HTML-kode soos <script> of net karakters soos <of>, aangesien dit doelbewus in hierdie veld gebruik kan word"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} gekritiseer op {1}
 DocType: Website Settings,FavIcon,favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Run
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Voettekste sal sl
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,hangende
 DocType: System Settings,Allow only one session per user,Laat slegs een sessie per gebruiker toe
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Tuisblad / Toetsmap 1 / Toetsmap 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Kies of sleep oor tydgleuwe om &#39;n nuwe gebeurtenis te skep.
 DocType: Contact,Contact Details,Kontakbesonderhede
 DocType: DocField,In Filter,In Filter
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Pad na bedienersertifikaat
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nie genoeg toestemming om skakels te sien nie
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adres Titel is verpligtend.
 DocType: Google Contacts,Push to Google Contacts,Druk op Google Kontakte
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Bygevoeg HTML in die &lt;head> afdeling van die webblad, hoofsaaklik gebruik vir webwerf verifikasie en SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Bygevoeg HTML in die <head> afdeling van die webblad, hoofsaaklik gebruik vir webwerf verifikasie en SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,terugval
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item kan nie by sy eie afstammelinge bygevoeg word nie
 DocType: Session Default Settings,Session Defaults,Sessie verstek
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,waarskuwing
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dit kan op verskeie bladsye gedruk word
 DocType: Data Migration Run,Percent Complete,Persent Voltooi
 DocType: Tag Category,Tag Category,Tag Kategorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ter vergelyking, gebruik> 5, &lt;10 of = 324. Gebruik reekse 5:10 (vir waardes tussen 5 en 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ter vergelyking, gebruik> 5, <10 of = 324. Gebruik reekse 5:10 (vir waardes tussen 5 en 10)."
 DocType: Google Calendar,Pull from Google Calendar,Trek uit Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,help
 DocType: User,Login Before,Login voor
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Laat toe op Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Uitsondering Tipe
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Kies Kolomme
-DocType: Web Page,Add code as &lt;script>,Voeg kode by as &lt;script>
+DocType: Web Page,Add code as <script>,Voeg kode by as <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Maak gebruikertoestemmings skoon
 DocType: Webhook,Headers,kop
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,komende gebeure
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,aandeel-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Waglys moet een van {0} wees
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Standaard sjabloon </h4><p> Gebruik <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> en al die velde van Adres (insluitende persoonlike velde indien enige) sal beskikbaar wees </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Standaard sjabloon </h4><p> Gebruik <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> en al die velde van Adres (insluitende persoonlike velde indien enige) sal beskikbaar wees </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Begin Datum Veld
 DocType: Role,Role Name,Rol Naam
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Skakel na die lessenaar

--- a/frappe/translations/af.csv
+++ b/frappe/translations/af.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Lêer Frien
 DocType: DocField,In Global Search,In Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,streepje-links
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} jaar (s) gelede
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} jaar (s) gelede
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Dit is riskant om hierdie lêer te verwyder: {0}. Kontak asseblief u stelselbestuurder.
 DocType: Currency,Currency Name,Geld Naam
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Geen e-posse
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Geen {0} gevi
 apps/frappe/frappe/config/customization.py,Add custom forms.,Voeg gepasmaakte vorms by.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} in {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,hierdie dokument ingedien
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Opstel&gt; Toestemmings vir gebruikers
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Opstel> Toestemmings vir gebruikers
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Die stelsel bied baie vooraf gedefinieerde rolle. Jy kan nuwe rolle byvoeg om fyner regte te stel.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","As die gebruiker enige rol nagegaan het, word die gebruiker &#39;n &quot;System User&quot;. &quot;Stelselgebruiker&quot; het toegang tot die lessenaar"
 DocType: System Settings,Date and Number Format,Datum en nommerformaat
 apps/frappe/frappe/model/document.py,one of,een van
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Opstel&gt; pas vorm aan
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Opstel> pas vorm aan
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kyk een oomblik
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Wys etikette
 DocType: DocField,HTML Editor,HTML Editor
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Rekening
 DocType: Email Queue,Not Sent,Nie gestuur nie
 DocType: Web Form,Actions,aksies
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Opstel&gt; Gebruiker
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Opstel> Gebruiker
 DocType: Workflow State,align-justify,in lyn-regverdig
 DocType: User,Middle Name (Optional),Middelnaam (opsioneel)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nie toegelaat
@@ -1410,7 +1410,7 @@ DocType: User,System User,Stelselgebruiker
 DocType: Report,Is Standard,Is Standaard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,volle
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","HTML-kode nie HTML-kode soos &lt;script&gt; of net karakters soos &lt;of&gt;, aangesien dit doelbewus in hierdie veld gebruik kan word"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","HTML-kode nie HTML-kode soos &lt;script> of net karakters soos &lt;of>, aangesien dit doelbewus in hierdie veld gebruik kan word"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} gekritiseer op {1}
 DocType: Website Settings,FavIcon,favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Run
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Voettekste sal sl
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,hangende
 DocType: System Settings,Allow only one session per user,Laat slegs een sessie per gebruiker toe
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Tuisblad / Toetsmap 1 / Toetsmap 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Kies of sleep oor tydgleuwe om &#39;n nuwe gebeurtenis te skep.
 DocType: Contact,Contact Details,Kontakbesonderhede
 DocType: DocField,In Filter,In Filter
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Inloggen is nie toegelaat nie
 DocType: Data Migration Run,Current Mapping Action,Huidige kaarte-aksie
 DocType: Dashboard Chart Source,Source Name,Bron Naam
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Geen e-posrekening geassosieer met die gebruiker nie. Voeg &#39;n rekening by onder Gebruiker&gt; E-posboks.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Geen e-posrekening geassosieer met die gebruiker nie. Voeg &#39;n rekening by onder Gebruiker> E-posboks.
 DocType: Email Account,Email Sync Option,E-pos Sync Opsie
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Ry nr
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Reeds in 
 DocType: User Email,Enable Outgoing,Aktiveer Uitgaande
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,Gepasmaakte Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-posrekening nie opgestel nie. Skep &#39;n nuwe e-posrekening vanaf Setup&gt; E-pos&gt; E-posrekening
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posrekening nie opgestel nie. Skep &#39;n nuwe e-posrekening vanaf Setup> E-pos> E-posrekening
 DocType: Comment,Submitted,voorgelê
 DocType: Contact,Pulled from Google Contacts,Van Google Kontakte af getrek
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ongeldige Versoek
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sessie Vervaldatum i
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Hierdie veld sal slegs verskyn as die veldnaam wat hier gedefinieer is, waarde is OF die reëls is waar (voorbeelde): myfield eval: doc.myfield == &#39;My Value&#39; eval: doc.age&gt; 18"
+eval:doc.age>18","Hierdie veld sal slegs verskyn as die veldnaam wat hier gedefinieer is, waarde is OF die reëls is waar (voorbeelde): myfield eval: doc.myfield == &#39;My Value&#39; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Kantoor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,vandag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Sodra u dit gestel het, sal die gebruikers slegs toegangsdokumente (bv. Blog Post) hê waar die skakel bestaan (bv. Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,HOOFLETTERS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Gepasmaakte HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Voer die naam van die gids in
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Geen standaard adres sjabloon gevind nie. Skep &#39;n nuwe een uit Opstel&gt; Drukwerk en handelsmerk&gt; Adresjabloon.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Geen standaard adres sjabloon gevind nie. Skep &#39;n nuwe een uit Opstel> Drukwerk en handelsmerk> Adresjabloon.
 apps/frappe/frappe/auth.py,Unknown User,Onbekende gebruiker
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Kies rol
 DocType: Comment,Deleted,geskrap
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Pad na bedienersertifikaat
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nie genoeg toestemming om skakels te sien nie
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adres Titel is verpligtend.
 DocType: Google Contacts,Push to Google Contacts,Druk op Google Kontakte
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Bygevoeg HTML in die &lt;head&gt; afdeling van die webblad, hoofsaaklik gebruik vir webwerf verifikasie en SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Bygevoeg HTML in die &lt;head> afdeling van die webblad, hoofsaaklik gebruik vir webwerf verifikasie en SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,terugval
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item kan nie by sy eie afstammelinge bygevoeg word nie
 DocType: Session Default Settings,Session Defaults,Sessie verstek
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,waarskuwing
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dit kan op verskeie bladsye gedruk word
 DocType: Data Migration Run,Percent Complete,Persent Voltooi
 DocType: Tag Category,Tag Category,Tag Kategorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ter vergelyking, gebruik&gt; 5, &lt;10 of = 324. Gebruik reekse 5:10 (vir waardes tussen 5 en 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ter vergelyking, gebruik> 5, &lt;10 of = 324. Gebruik reekse 5:10 (vir waardes tussen 5 en 10)."
 DocType: Google Calendar,Pull from Google Calendar,Trek uit Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,help
 DocType: User,Login Before,Login voor
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Aangepaste skrif
 DocType: Address,Address Line 2,Adreslyn 2
 DocType: Address,Reference,verwysing
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Toevertrou aan
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Stel asb. Standaard-e-posrekening op vanaf Opstel&gt; E-pos&gt; E-posrekening
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Stel asb. Standaard-e-posrekening op vanaf Opstel> E-pos> E-posrekening
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Data Migrasie Mapping Detail
 DocType: Data Import,Action,aksie
 DocType: GSuite Settings,Script URL,Skrip URL
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Laat toe op Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Uitsondering Tipe
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Kies Kolomme
-DocType: Web Page,Add code as &lt;script&gt;,Voeg kode by as &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Voeg kode by as &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Maak gebruikertoestemmings skoon
 DocType: Webhook,Headers,kop
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,komende gebeure
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,aandeel-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Waglys moet een van {0} wees
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Standaard sjabloon </h4><p> Gebruik <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> en al die velde van Adres (insluitende persoonlike velde indien enige) sal beskikbaar wees </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Standaard sjabloon </h4><p> Gebruik <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> en al die velde van Adres (insluitende persoonlike velde indien enige) sal beskikbaar wees </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Begin Datum Veld
 DocType: Role,Role Name,Rol Naam
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Skakel na die lessenaar

--- a/frappe/translations/af.csv
+++ b/frappe/translations/af.csv
@@ -1,19 +1,19 @@
 apps/frappe/frappe/utils/change_log.py,New {} releases for the following apps are available,Nuwe () vrystellings vir die volgende programme is beskikbaar
-apps/frappe/frappe/website/doctype/web_form/web_form.py,Please select a Amount Field.,Kies asseblief &#39;n Bedrag veld.
+apps/frappe/frappe/website/doctype/web_form/web_form.py,Please select a Amount Field.,Kies asseblief 'n Bedrag veld.
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Loading import file...,Laai invoerlêer ...
 DocType: Assignment Rule,Last User,Laaste gebruiker
-apps/frappe/frappe/desk/form/assign_to.py,"A new task, {0}, has been assigned to you by {1}. {2}","&#39;N Nuwe taak, {0}, is aan jou toegewys deur {1}. {2}"
+apps/frappe/frappe/desk/form/assign_to.py,"A new task, {0}, has been assigned to you by {1}. {2}","'N Nuwe taak, {0}, is aan jou toegewys deur {1}. {2}"
 apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,Session Defaults Saved,Sessie standaard is gestoor
 apps/frappe/frappe/public/js/frappe/form/controls/attach.js,Reload File,Herlaai lêer
 DocType: Email Queue,Email Queue records.,E-pos waglys rekords.
 DocType: Post,Post,Post
 DocType: Address,Punjab,Punjab
-apps/frappe/frappe/config/settings.py,Rename many items by uploading a .csv file.,Hernoem baie items deur &#39;n .csv-lêer op te laai.
+apps/frappe/frappe/config/settings.py,Rename many items by uploading a .csv file.,Hernoem baie items deur 'n .csv-lêer op te laai.
 DocType: Workflow State,pause,breek
 apps/frappe/frappe/public/js/frappe/web_form/webform_script.js,You are not permitted to access this page.,U mag nie toegang tot hierdie bladsy kry nie.
 DocType: About Us Settings,Website,webwerf
 apps/frappe/frappe/www/third_party_apps.py,You need to be logged in to access this page,Jy moet ingeteken wees om toegang tot hierdie bladsy te kry
-DocType: System Settings,Note: Multiple sessions will be allowed in case of mobile device,Let wel: Meervoudige sessies sal toegelaat word in die geval van &#39;n mobiele toestel
+DocType: System Settings,Note: Multiple sessions will be allowed in case of mobile device,Let wel: Meervoudige sessies sal toegelaat word in die geval van 'n mobiele toestel
 DocType: DocType,Form Settings,Vorminstellings
 apps/frappe/frappe/templates/emails/download_data.html,Download Data,Laai data af
 apps/frappe/frappe/public/js/frappe/form/form.js,Permanently Submit {0}?,Permanent Dien {0} in?
@@ -23,7 +23,7 @@ DocType: Workflow,If Checked workflow status will not override status in list vi
 apps/frappe/frappe/client.py,Invalid file path: {0},Ongeldige lêerpad: {0}
 DocType: Workflow State,eye-open,oog-oop
 DocType: Email Queue,Send After,Stuur na
-apps/frappe/frappe/utils/file_manager.py,Please select a file or url,Kies asseblief &#39;n lêer of url
+apps/frappe/frappe/utils/file_manager.py,Please select a file or url,Kies asseblief 'n lêer of url
 apps/frappe/frappe/public/js/frappe/views/treeview.js,{0} Tree,{0} Boom
 DocType: User,User Emails,Gebruiker e-posse
 DocType: User,Username,Gebruikersnaam
@@ -43,7 +43,7 @@ DocType: Workflow,Document States,Dokument State
 apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! I could not find what you were looking for.,Jammer! Ek kon nie vind waarvoor jy gesoek het nie.
 DocType: Data Migration Run,Logs,Logs
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,There was an error saving filters,Kon nie filters stoor nie
-DocType: Custom DocPerm,This role update User Permissions for a user,Hierdie rol werk gebruikers toestemmings op vir &#39;n gebruiker
+DocType: Custom DocPerm,This role update User Permissions for a user,Hierdie rol werk gebruikers toestemmings op vir 'n gebruiker
 apps/frappe/frappe/public/js/frappe/model/model.js,Rename {0},Hernoem {0}
 DocType: Workflow State,zoom-out,zoom-out
 DocType: Data Import Beta,Import Options,Invoeropsies
@@ -58,12 +58,12 @@ apps/frappe/frappe/model/base_document.py,"{0}, Row {1}","{0}, ry {1}"
 DocType: DocField,Markdown Editor,Markdown Editor
 apps/frappe/frappe/model/document.py,Beginning with,Begin met
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Data Invoer Sjabloon
-apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,&#39;N Fout het voorgekom tydens die instelling van standaard verstellings
+apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,'N Fout het voorgekom tydens die instelling van standaard verstellings
 apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Ouer
-apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Ons het &#39;n versoek ontvang om u {0} data wat verband hou met: {1} af te laai
-DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","As dit geaktiveer is, sal die wagwoord sterkte afgedwing word op grond van die minimum wagwoord telling waarde. &#39;N Waarde van 2 is medium sterk en 4 is baie sterk."
+apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Ons het 'n versoek ontvang om u {0} data wat verband hou met: {1} af te laai
+DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","As dit geaktiveer is, sal die wagwoord sterkte afgedwing word op grond van die minimum wagwoord telling waarde. 'N Waarde van 2 is medium sterk en 4 is baie sterk."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Spanlede&quot; of &quot;Bestuur&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Standaard vir &#39;Check&#39; tipe veld moet &#39;0&#39; of &#39;1&#39; wees.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Standaard vir 'Check' tipe veld moet '0' of '1' wees.
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,gister
 DocType: Contact,Designation,aanwysing
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Outomatiese skakel kan slegs vir een e-posrekening geaktiveer word.
@@ -87,8 +87,8 @@ apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Goog
 DocType: Event,Pulled from Google Calendar,Van Google Kalender af getrek
 DocType: Note,Seen By,Gesien deur
 apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Voeg meerdere by
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,U het &#39;n paar energiepunte gekry
-apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,Nie &#39;n geldige gebruikersfoto nie.
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,U het 'n paar energiepunte gekry
+apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,Nie 'n geldige gebruikersfoto nie.
 DocType: Energy Point Log,Reverted,teruggekeer
 DocType: Success Action,First Success Message,Eerste Suksesboodskap
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Not Like,Nie soos
@@ -98,14 +98,14 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Appreciate,waardeer
 DocType: Workflow State,lock,sluit
 apps/frappe/frappe/config/website.py,Settings for Contact Us Page.,Stellings vir Kontak Ons Page.
 apps/frappe/frappe/core/doctype/user/user.py,Administrator Logged In,Administrateur ingeteken
-DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","Kontakopsies, soos &quot;Verkoopsvraag, Ondersteuningsvraag&quot; ens. Elk op &#39;n nuwe reël of geskei deur kommas."
-apps/frappe/frappe/public/js/frappe/ui/tag_editor.js,Add a tag ...,Voeg &#39;n merker by
+DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","Kontakopsies, soos &quot;Verkoopsvraag, Ondersteuningsvraag&quot; ens. Elk op 'n nuwe reël of geskei deur kommas."
+apps/frappe/frappe/public/js/frappe/ui/tag_editor.js,Add a tag ...,Voeg 'n merker by
 apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,Portret
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,insetsel
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Laat Google Drive toe
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Select {0},Kies {0}
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Voer asseblief basiese URL in
-DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","As dit geaktiveer is, word die dokument gemerk soos gesien, die eerste keer dat &#39;n gebruiker dit oopmaak"
+DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","As dit geaktiveer is, word die dokument gemerk soos gesien, die eerste keer dat 'n gebruiker dit oopmaak"
 DocType: Auto Repeat,Repeat on Day,Herhaal op dag
 DocType: DocField,Color,Kleur
 DocType: Data Migration Run,Log,Meld
@@ -156,7 +156,7 @@ apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified aft
 DocType: Address,Himachal Pradesh,Himachal Pradesh
 DocType: System Settings,"If not set, the currency precision will depend on number format","Indien nie ingestel nie, sal die geldeenheidsprecisie afhang van die nommerformaat"
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Awesomebar,Oop Awesomebar
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Dit lyk asof daar &#39;n probleem met die bediener se streepkonfigurasie is. In geval van versuim, sal die bedrag terugbetaal word na u rekening."
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Dit lyk asof daar 'n probleem met die bediener se streepkonfigurasie is. In geval van versuim, sal die bedrag terugbetaal word na u rekening."
 DocType: Data Import,Import Log,Invoer Log
 DocType: User Permission,Apply To All Document Types,Van toepassing op alle dokumente
 apps/frappe/frappe/config/website.py,Embed image slideshows in website pages.,Voeg beeldskyfies in webbladsye in.
@@ -164,7 +164,7 @@ apps/frappe/frappe/email/doctype/newsletter/newsletter.js,Send,stuur
 DocType: Workflow Action Master,Workflow Action Name,Werkstroom Aksie Naam
 apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can not be merged,DocType kan nie saamgevoeg word nie
 DocType: Web Form Field,Fieldtype,Fieldtype
-apps/frappe/frappe/core/doctype/file/file.py,Not a zip file,Nie &#39;n zip-lêer nie
+apps/frappe/frappe/core/doctype/file/file.py,Not a zip file,Nie 'n zip-lêer nie
 DocType: Global Search DocType,Global Search DocType,Global Search DocType
 DocType: Auto Repeat,"To add dynamic subject, use jinja tags like
 
@@ -199,7 +199,7 @@ apps/frappe/frappe/twofactor.py,"Login session expired, refresh page to retry","
 DocType: Communication,BCC,BCC
 DocType: Unhandled Email,Reason,rede
 DocType: Email Unsubscribe,Email Unsubscribe,E-pos Uitschrijven
-DocType: Website Settings,Select an image of approx width 150px with a transparent background for best results.,Kies &#39;n beeld van ongeveer 150px breedte met &#39;n deursigtige agtergrond vir die beste resultate.
+DocType: Website Settings,Select an image of approx width 150px with a transparent background for best results.,Kies 'n beeld van ongeveer 150px breedte met 'n deursigtige agtergrond vir die beste resultate.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,No activity,Geen aktiwiteit nie
 apps/frappe/frappe/www/third_party_apps.html,Third Party Apps,Derdeparty-programme
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The first user will become the System Manager (you can change this later).,Die eerste gebruiker sal die stelselbestuurder word (jy kan dit later verander).
@@ -216,7 +216,7 @@ apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your b
 apps/frappe/frappe/config/desk.py,Event and other calendars.,Gebeurtenis en ander kalenders.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 ry verpligtend)
 apps/frappe/frappe/templates/includes/comments/comments.html,All fields are necessary to submit the comment.,Alle velde is nodig om die kommentaar in te dien.
-DocType: Custom Script,Adds a client custom script to a DocType,Voeg &#39;n kliënt se eie skrif by tot &#39;n DocType
+DocType: Custom Script,Adds a client custom script to a DocType,Voeg 'n kliënt se eie skrif by tot 'n DocType
 DocType: Print Settings,Printer Name,Drukker naam
 DocType: Webhook,Form URL-Encoded,Vorm URL-gekodeer
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Breedtes kan in px of% gestel word.
@@ -233,7 +233,7 @@ apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed t
 apps/frappe/frappe/model/db_query.py,Please select atleast 1 column from {0} to sort/group,Kies asseblief ten minste 1 kolom van {0} om te sorteer / groepeer
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1}. Restricted field: {2},Nie toegelaat vir {0}: {1}. Beperkte veld: {2}
 DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Kontroleer dit as jy jou betaling met die Sandbox API toets
-apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,U mag nie &#39;n standaard webwerf-tema uitvee nie
+apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,U mag nie 'n standaard webwerf-tema uitvee nie
 DocType: Data Import,Log Details,Log besonderhede
 DocType: Workflow Transition,Example,voorbeeld
 DocType: Webhook Header,Webhook Header,Webhook Header
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Deaktiveer versl
 DocType: Translation,Contributed Translation Doctype Name,Bygedrade vertaling Doctype Naam
 DocType: PayPal Settings,Redirect To,Herlei na
 DocType: Data Migration Mapping,Pull,trek
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript-formaat: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript-formaat: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Grootmaat Update
 DocType: Workflow State,chevron-up,Chevron-up
 DocType: DocType,Allow Guest to View,Laat gas toe om te sien
@@ -264,7 +264,7 @@ DocType: DocShare,Internal record of document shares,Interne rekord van dokument
 DocType: Energy Point Settings,Review Levels,Hersien Vlakke
 DocType: Workflow State,Comment,kommentaar
 DocType: Data Migration Plan,Postprocess Method,Na-proses Metode
-apps/frappe/frappe/public/js/frappe/ui/capture.js,Take Photo,Neem &#39;n foto
+apps/frappe/frappe/public/js/frappe/ui/capture.js,Take Photo,Neem 'n foto
 DocType: Assignment Rule,Round Robin,Ronde Robin
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"You can change Submitted documents by cancelling them and then, amending them.",U kan die ingediende dokumente verander deur hulle te kanselleer en dan te wysig.
 DocType: Data Import,Update records,Dateer rekords op
@@ -273,7 +273,7 @@ DocType: DocField,Display,vertoning
 DocType: Email Group,Total Subscribers,Totale inskrywers
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top {0},Top {0}
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Row Number,Ry nommer
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If a Role does not have access at Level 0, then higher levels are meaningless.","As &#39;n rol nie toegang op vlak 0 het nie, is hoër vlakke betekenisloos."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If a Role does not have access at Level 0, then higher levels are meaningless.","As 'n rol nie toegang op vlak 0 het nie, is hoër vlakke betekenisloos."
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Save As,Stoor as
 DocType: Comment,Seen,gesien
 apps/frappe/frappe/public/js/frappe/form/layout.js,Show more details,Wys meer besonderhede
@@ -281,10 +281,10 @@ DocType: System Settings,Run scheduled jobs only if checked,Begin slegs geskedul
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Will only be shown if section headings are enabled,Sal slegs gewys word as seksieopskrifte aangeskakel is
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Archive,Argief
 apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload,Lêeroplaai
-DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","Voer verstekwaarde velde (sleutels) en waardes in. As u verskeie waardes vir &#39;n veld byvoeg, sal die eerste een gekies word. Hierdie verstek word ook gebruik om toestemming reëls te stel. Om die lys van velde te sien, gaan na &quot;Formuleer aanpas&quot;."
+DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","Voer verstekwaarde velde (sleutels) en waardes in. As u verskeie waardes vir 'n veld byvoeg, sal die eerste een gekies word. Hierdie verstek word ook gebruik om toestemming reëls te stel. Om die lys van velde te sien, gaan na &quot;Formuleer aanpas&quot;."
 DocType: Auto Repeat,Message,Boodskap
 DocType: Communication,Rating,gradering
-DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Druk Breedte van die veld, as die veld &#39;n kolom in &#39;n tabel is"
+DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Druk Breedte van die veld, as die veld 'n kolom in 'n tabel is"
 DocType: Dropbox Settings,Dropbox Access Key,Dropbox toegang sleutel
 apps/frappe/frappe/desk/form/utils.py,Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script,Verkeerde veldnaam <b>{0}</b> in add_fetch-opstelling van persoonlike skrif
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,Kies Google Kontakte waarmee die kontak gesinkroniseer moet word.
@@ -315,7 +315,7 @@ apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permiss
 DocType: Workflow,Transition Rules,Oorgangsreëls
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Showing only first {0} rows in preview,Wys slegs die eerste {0} rye in voorskou
 apps/frappe/frappe/core/doctype/report/report.js,Example:,voorbeeld:
-DocType: Workflow,Defines workflow states and rules for a document.,Definieer werkstroom state en reëls vir &#39;n dokument.
+DocType: Workflow,Defines workflow states and rules for a document.,Definieer werkstroom state en reëls vir 'n dokument.
 DocType: Workflow State,Filter,filter
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Check the Error Log for more information: {0},Gaan na die foutlogboek vir meer inligting: {0}
 apps/frappe/frappe/database/schema.py,Fieldname {0} cannot have special characters like {1},Veldnaam {0} kan nie spesiale karakters soos {1} hê nie
@@ -340,7 +340,7 @@ apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Map Columns,Ka
 DocType: Address,Mizoram,Mizoram
 DocType: Newsletter,Newsletter,nuusbrief
 apps/frappe/frappe/model/db_query.py,Cannot use sub-query in order by,Kan nie subnavraag gebruik in volgorde deur
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options must be a valid DocType for field {1} in row {2},{0}: Opsies moet &#39;n geldige DocType wees vir die veld {1} in ry {2}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options must be a valid DocType for field {1} in row {2},{0}: Opsies moet 'n geldige DocType wees vir die veld {1} in ry {2}
 DocType: Web Form,Button Help,Knoppie Hulp
 DocType: Kanban Board Column,purple,pers
 DocType: About Us Settings,Team Members,Spanlede
@@ -365,11 +365,11 @@ DocType: System Settings,Enable Two Factor Auth,Aktiveer twee faktore
 DocType: Post,Liked By,Gekyk deur
 DocType: DocField,Print Hide If No Value,Druk verberg as geen waarde
 DocType: Kanban Board Column,yellow,geel
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Is Published Field must be a valid fieldname,Die gepubliseerde veld moet &#39;n geldige veldnaam wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Is Published Field must be a valid fieldname,Die gepubliseerde veld moet 'n geldige veldnaam wees
 DocType: Block Module,Block Module,Blok Module
 apps/frappe/frappe/core/doctype/version/version_view.html,New Value,Nuwe waarde
 apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field,"DocType <b>{0}</b> wat vir die veld <b>{1}</b> voorsien word, moet ten minste een skakelveld bevat"
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html,Add a column,Voeg &#39;n kolom by
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html,Add a column,Voeg 'n kolom by
 apps/frappe/frappe/www/contact.html,Your email address,Jou eposadres
 DocType: Desktop Icon,Module,module
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} records out of {1}.,{0} rekords van {1} suksesvol opgedateer.
@@ -382,14 +382,14 @@ DocType: Assignment Rule,Assign Condition,Toewys toestand
 apps/frappe/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py,Download Your Data,Laai u data af
 DocType: Dashboard Chart,Value Based On,Waarde gebaseer op
 DocType: List View Setting,Disable Sidebar Stats,Deaktiveer sybalkstatistieke
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Create a New Format,Skep &#39;n nuwe formaat
-apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Unable to create bucket: {0}. Change it to a more unique name.,Kan nie emmer skep nie: {0}. Verander dit na &#39;n meer unieke naam.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Create a New Format,Skep 'n nuwe formaat
+apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Unable to create bucket: {0}. Change it to a more unique name.,Kan nie emmer skep nie: {0}. Verander dit na 'n meer unieke naam.
 DocType: Webhook,Request URL,Versoek URL
 DocType: Customize Form,Is Table,Is Tabel
 DocType: Email Account,Total number of emails to sync in initial sync process ,Totale aantal e-posse om te sinkroniseer in aanvanklike sinkronisasieproses
 DocType: Website Settings,Set Banner from Image,Stel Banner van Beeld
 DocType: Email Account,SparkPost,SparkPost
-apps/frappe/frappe/templates/emails/new_user.html,A new account has been created for you at {0},&#39;N Nuwe rekening is vir jou geskep by {0}
+apps/frappe/frappe/templates/emails/new_user.html,A new account has been created for you at {0},'N Nuwe rekening is vir jou geskep by {0}
 apps/frappe/frappe/templates/includes/login/login.js,Instructions Emailed,Instruksies E-pos
 apps/frappe/frappe/public/js/frappe/views/communication.js,Enter Email Recipient(s),Voer e-pos ontvanger (s) in
 DocType: Print Format,Verdana,Verdana
@@ -402,7 +402,7 @@ apps/frappe/frappe/utils/bot.py,Can't identify open {0}. Try something else.,Kan
 apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Your information has been submitted,U inligting is ingedien
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be deleted,Gebruiker {0} kan nie uitgevee word nie
 DocType: System Settings,Currency Precision,Geld Precisie
-apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,Nog &#39;n transaksie blokkeer hierdie een. Probeer asseblief oor &#39;n paar sekondes.
+apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,Nog 'n transaksie blokkeer hierdie een. Probeer asseblief oor 'n paar sekondes.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter_list.js,Clear filters,Maak filters skoon
 DocType: Test Runner,App,app
 apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Die aanhangsels kon nie korrek gekoppel word aan die nuwe dokument nie
@@ -427,11 +427,11 @@ DocType: User,Restrict IP,Beperk IP
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,Dashboard
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Kan nie e-posse stuur nie
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Kalender - Kon nie gebeurtenis {0} in Google Kalender opdateer nie, foutkode {1}."
-apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Soek of tik &#39;n opdrag
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Soek of tik 'n opdrag
 DocType: Activity Log,Timeline Name,Tydlyn Naam
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,Slegs een {0} kan as primêr gestel word.
 DocType: Email Account,e.g. smtp.gmail.com,bv. smtp.gmail.com
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add A New Rule,Voeg &#39;n nuwe reël by
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add A New Rule,Voeg 'n nuwe reël by
 DocType: Contact,Sales Master Manager,Verkope Meester Bestuurder
 DocType: User Permission,For Value,Vir Waarde
 DocType: Event,Google Calendar ID,Google Kalender-ID
@@ -446,7 +446,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linkin
 DocType: LDAP Settings,LDAP Middle Name Field,LDAP-middelnaamveld
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Importing {0} of {1},Voer {0} van {1} in
 DocType: GCalendar Account,Allow GCalendar Access,Laat GCalendar-toegang toe
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} is &#39;n verpligte veld
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} is 'n verpligte veld
 apps/frappe/frappe/templates/includes/login/login.js,Login token required,Login token vereis
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Monthly Rank: ,Maandelikse ranglys:
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select multiple list items,Kies verskeie lysitems
@@ -456,14 +456,14 @@ apps/frappe/frappe/public/js/frappe/views/components/ModuleLinkItem.vue,You need
 DocType: Google Maps Settings,Google Maps Settings,Google Maps-instellings
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Laai ...
 DocType: DocField,Password,wagwoord
-apps/frappe/frappe/utils/response.py,Your system is being updated. Please refresh again after a few moments,Jou stelsel word opgedateer. Herlaai asseblief weer na &#39;n paar oomblikke
+apps/frappe/frappe/utils/response.py,Your system is being updated. Please refresh again after a few moments,Jou stelsel word opgedateer. Herlaai asseblief weer na 'n paar oomblikke
 DocType: Blogger,Will be used in url (usually first name).,Sal gebruik word in url (gewoonlik voornaam).
 DocType: Comment,Comment Email,Kommentaar e-pos
 DocType: Auto Email Report,Day of Week,Dag van die week
 DocType: Note,Expire Notification On,Verstryk kennisgewing op
 apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Ctrl+Enter to add comment,Ctrl + Enter om kommentaar by te voeg
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Set as Default Theme,Stel as verstek tema
-apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload in Progress. Please try again in a few moments.,Lêer oplaai in voortsetting. Probeer asseblief weer oor &#39;n paar oomblikke.
+apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload in Progress. Please try again in a few moments.,Lêer oplaai in voortsetting. Probeer asseblief weer oor 'n paar oomblikke.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Edit Heading,Wysig opskrif
 DocType: File,File URL,Lêer URL
 DocType: Version,Table HTML,Tabel HTML
@@ -473,7 +473,7 @@ DocType: Google Calendar,Push to Google Calendar,Druk op Google Kalender
 DocType: Notification Recipient,Email By Document Field,E-pos per dokumentveld
 DocType: Domain Settings,Domain Settings,Domein instellings
 apps/frappe/frappe/email/receive.py,Cannot connect: {0},Kan nie verbind nie: {0}
-apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.,&#39;N Woord op sigself is maklik om te raai.
+apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.,'N Woord op sigself is maklik om te raai.
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Auto assignment failed: {0},Outo-opdrag het misluk: {0}
 apps/frappe/frappe/templates/includes/search_box.html,Search...,Soek...
 apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,Please select Company,Kies asseblief Maatskappy
@@ -494,7 +494,7 @@ DocType: DocField,Hidden,verborge
 DocType: Web Form,Allow Incomplete Forms,Laat onvolledige vorms toe
 apps/frappe/frappe/utils/print_format.py,PDF generation failed,PDF-generasie het misluk
 apps/frappe/frappe/model/base_document.py,{0} must be set first,{0} moet eerste gestel word
-apps/frappe/frappe/utils/password_strength.py,"Use a few words, avoid common phrases.","Gebruik &#39;n paar woorde, vermy algemene frases."
+apps/frappe/frappe/utils/password_strength.py,"Use a few words, avoid common phrases.","Gebruik 'n paar woorde, vermy algemene frases."
 DocType: Workflow State,plane,vliegtuig
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Rounded Corners,Afgeronde hoekies
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","As u nuwe rekords oplaai, word &quot;Naming Series&quot; verplig, indien teenwoordig."
@@ -502,7 +502,7 @@ apps/frappe/frappe/email/doctype/notification/notification.js,Get Alerts for Tod
 DocType: Contact,Google Contacts Id,Google Kontak-ID
 apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can only be renamed by Administrator,DocType kan slegs deur Administrateur hernoem word
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,6 months,6 maande
-apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Please attach an image file to set HTML,Heg &#39;n beeldlêer aan om HTML in te stel
+apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Please attach an image file to set HTML,Heg 'n beeldlêer aan om HTML in te stel
 DocType: Chat Message,Chat Message,Kletsboodskap
 apps/frappe/frappe/utils/oauth.py,Email not verified with {0},E-pos nie geverifieer met {0}
 DocType: Dashboard Chart,Time Series Based On,Tydreeks gebaseer op
@@ -522,7 +522,7 @@ DocType: Dropbox Settings,Note: By default emails for failed backups are sent.,N
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Add Filter,Voeg filter by
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,SMS sent to following numbers: {0},SMS gestuur na volgende nommers: {0}
 apps/frappe/frappe/utils/data.py,{0} and {1},{0} en {1}
-apps/frappe/frappe/public/js/frappe/chat.js,Start a conversation.,Begin &#39;n gesprek.
+apps/frappe/frappe/public/js/frappe/chat.js,Start a conversation.,Begin 'n gesprek.
 DocType: Print Settings,"Always add ""Draft"" Heading for printing draft documents",Voeg altyd &quot;Konsep&quot; -opskrif by vir die druk van konsepdokumente
 apps/frappe/frappe/email/doctype/notification/notification.py,Error in Notification: {},Fout in kennisgewing: {}
 DocType: Data Migration Run,Current Mapping Start,Huidige kaarte begin
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistieke gebaseer op die prestasie van verlede week (van {0} tot {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP-telefoonveld
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","dokument tipe ..., bv. kliënt"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Die kondisie &#39;{0}&#39; is ongeldig
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Die kondisie '{0}' is ongeldig
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Gebruik van subnavraag of funksie is beperk
 apps/frappe/frappe/config/customization.py,Add your own translations,Voeg jou eie vertalings by
@@ -566,7 +566,7 @@ apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Blank Template,
 DocType: About Us Team Member,About Us Team Member,Oor Ons Spanlid
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions.","Toestemmings word ingestel op rolle en dokumenttipes (genoem DocTypes) deur regte soos Lees, Skryf, Skep, Skrap, Inskryf, Kanselleer, Verander, Verslag, Invoer, Uitvoer, Druk, E-pos en Gebruiker Toestemmings in te stel."
 DocType: Assignment Rule Day,Wednesday,Woensdag
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Beeldveld moet &#39;n geldige veldnaam wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Beeldveld moet 'n geldige veldnaam wees
 DocType: Chat Token,Token,teken
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} is restricted,Veldnaam {0} is beperk
 DocType: Property Setter,ID (name) of the entity whose property is to be set,ID (naam) van die entiteit wie se eiendom ingestel moet word
@@ -581,7 +581,7 @@ apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Unzipped {0} files,{
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,empty,leë
 apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js,Show Permissions,Wys toestemmings
 DocType: Data Import,New data will be inserted.,Nuwe data sal ingevoeg word.
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a Link or Dynamic Link,Tydlyn veld moet &#39;n skakel of dinamiese skakel wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a Link or Dynamic Link,Tydlyn veld moet 'n skakel of dinamiese skakel wees
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Date Range,Datumreeks
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Gantt,Gantt
 apps/frappe/frappe/public/js/frappe/views/reports/print_tree.html,Page {0} of {1},Bladsy {0} van {1}
@@ -595,7 +595,7 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log_list.js,View
 apps/frappe/frappe/public/js/frappe/desk.js,Places,plekke
 DocType: Kanban Board Column,darkgrey,donkergrys
 apps/frappe/frappe/model/rename_doc.py,Successful: {0} to {1},Suksesvol: {0} tot {1}
-apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,Kan gebruikersdata nie in demo verander nie. Teken asseblief vir &#39;n nuwe rekening by https://erpnext.com
+apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,Kan gebruikersdata nie in demo verander nie. Teken asseblief vir 'n nuwe rekening by https://erpnext.com
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop,drop
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please duplicate this to make changes,Dui asseblief duplisering om veranderinge aan te bring
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Press Enter to save,Druk Enter om te stoor
@@ -615,7 +615,7 @@ apps/frappe/frappe/desk/reportview.py,No Tags,Geen etikette
 DocType: Email Account,Send Notification to,Stuur kennisgewing aan
 DocType: DocField,Collapsible,opvoubare
 DocType: Translation,Saved,gered
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Options for select. Each option on a new line.,Opsies vir kies. Elke opsie op &#39;n nuwe lyn.
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Options for select. Each option on a new line.,Opsies vir kies. Elke opsie op 'n nuwe lyn.
 apps/frappe/frappe/public/js/frappe/form/form.js,Permanently Cancel {0}?,Permanent Kanselleer {0}?
 DocType: Workflow State,music,musiek
 apps/frappe/frappe/www/qrcode.html,QR Code,QR-kode
@@ -626,9 +626,9 @@ DocType: Print Format,Style Settings,Styl instellings
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Filter By,Filter By
 apps/frappe/frappe/database/database.py,No conditions provided,Geen voorwaardes word voorsien nie
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Y-asse
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,Sorteer veld {0} moet &#39;n geldige veldnaam wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,Sorteer veld {0} moet 'n geldige veldnaam wees
 apps/frappe/frappe/public/js/frappe/list/base_list.js,More,meer
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Create a new record,Skep &#39;n nuwe rekord
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Create a new record,Skep 'n nuwe rekord
 DocType: Contact,Sales Manager,Verkoopsbestuurder
 apps/frappe/frappe/public/js/frappe/model/model.js,Rename,hernoem
 DocType: Print Format,Format Data,Formateer data
@@ -640,7 +640,7 @@ DocType: Customize Form Field,Customize Form Field,Pas vorm veld aan
 DocType: Energy Point Rule,For Document Event,Vir dokumentgebeurtenis
 DocType: Website Settings,Chat Room Name,Kletskamer naam
 DocType: OAuth Client,Grant Type,Toekenningstipe
-apps/frappe/frappe/config/users_and_permissions.py,Check which Documents are readable by a User,Kyk watter dokumente deur &#39;n gebruiker leesbaar is
+apps/frappe/frappe/config/users_and_permissions.py,Check which Documents are readable by a User,Kyk watter dokumente deur 'n gebruiker leesbaar is
 DocType: Deleted Document,Hub Sync ID,Hub-sinkronisasie-ID
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,use % as wildcard,gebruik% as wildkaart
 DocType: Auto Repeat,Quarterly,kwartaallikse
@@ -671,7 +671,7 @@ DocType: Print Format,Default Print Language,Standaard druktaal
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Ancestors Of,Voorouers Van
 apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,Wortel {0} kan nie uitgevee word nie
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Nog geen kommentaar
-apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings","Stel asseblief SMS op voordat u dit instel as &#39;n verifikasie metode, via SMS-instellings"
+apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings","Stel asseblief SMS op voordat u dit instel as 'n verifikasie metode, via SMS-instellings"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,Beide DocType en Naam benodig
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,Kan docstatus nie verander van 1 tot 0
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,U het nie genoeg punte nie
@@ -680,7 +680,7 @@ DocType: Contact,Open,oop
 DocType: Workflow Transition,Defines actions on states and the next step and allowed roles.,Definieer aksies op state en die volgende stap en toegelaat rolle.
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Reviewer,Top beoordelaar
 DocType: Data Migration Mapping,Remote Objectname,Remote Object Name
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","As &#39;n beste praktyk, moenie dieselfde stel toestemmingsreël toewys aan verskillende rolle nie. Plaas eerder verskeie rolle aan dieselfde gebruiker."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","As 'n beste praktyk, moenie dieselfde stel toestemmingsreël toewys aan verskillende rolle nie. Plaas eerder verskeie rolle aan dieselfde gebruiker."
 apps/frappe/frappe/www/confirm_workflow_action.html,Please confirm your action to {0} this document.,Bevestig asseblief u aksie op {0} hierdie dokument.
 DocType: Success Action,Next Actions HTML,Volgende aksies HTML
 apps/frappe/frappe/public/js/frappe/social/social_home.js,Create Post,Skep Pos
@@ -694,9 +694,9 @@ apps/frappe/frappe/public/js/frappe/ui/page.html,Menu,Spyskaart
 DocType: DefaultValue,DefaultValue,Standaard waarde
 DocType: Auto Repeat,Daily,daaglikse
 apps/frappe/frappe/config/users_and_permissions.py,User Roles,Gebruikersrolle
-DocType: Property Setter,Property Setter overrides a standard DocType or Field property,Eiendom Setter oortree &#39;n standaard DocType of Field eiendom
+DocType: Property Setter,Property Setter overrides a standard DocType or Field property,Eiendom Setter oortree 'n standaard DocType of Field eiendom
 apps/frappe/frappe/core/doctype/user/user.py,Cannot Update: Incorrect / Expired Link.,Kan nie opdateer nie: Verkeerde / verouderde skakel.
-apps/frappe/frappe/utils/password_strength.py,Better add a few more letters or another word,Beter voeg nog &#39;n paar letters of &#39;n ander woord by
+apps/frappe/frappe/utils/password_strength.py,Better add a few more letters or another word,Beter voeg nog 'n paar letters of 'n ander woord by
 DocType: Auto Repeat,Repeat on Last Day of the Month,Herhaal op die laaste dag van die maand
 apps/frappe/frappe/twofactor.py,One Time Password (OTP) Registration Code from {},Eenmalige wagwoord (OTP) Registrasiekode van {}
 DocType: DocField,Set Only Once,Stel slegs een keer
@@ -705,8 +705,8 @@ DocType: Address,Nagaland,Nagaland
 DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Gebruikersnaam {0} bestaan reeds
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,"{0}: Kan nie invoer invoer nie, aangesien {1} nie invoerbaar is nie"
-apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Daar is &#39;n fout in u adres sjabloon {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} is &#39;n ongeldige e-posadres in &#39;Ontvangers&#39;
+apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Daar is 'n fout in u adres sjabloon {0}
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} is 'n ongeldige e-posadres in 'Ontvangers'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,host
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Geld Naam
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Geen e-posse
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Skakel verval
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.","Herstel lengte na {0} vir &#39;{1}&#39; in &#39;{2}&#39;; Om die lengte as {3} te stel, sal die afsny van data veroorsaak."
+							Setting the length as {3} will cause truncation of data.","Herstel lengte na {0} vir '{1}' in '{2}'; Om die lengte as {3} te stel, sal die afsny van data veroorsaak."
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Kies Lêerformaat
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Inhoud Hash
@@ -763,22 +763,22 @@ apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standaard DocType kan nie standaard afdrukformaat hê nie, Gebruik pasvorm"
 DocType: Report,Query,navraag
 DocType: Customize Form,Sort Order,Sorteervolgorde
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;In lys vertoning&#39; nie toegelaat vir tipe {0} in ry {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'In lys vertoning' nie toegelaat vir tipe {0} in ry {1}
 DocType: Letter Head,Footer HTML,Footer HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,Kies die etiket waarna jy nuwe veld wil invoeg.
 ,Document Share Report,Dokument Deel Verslag
 DocType: Social Login Key,Base URL,Basis-URL
 DocType: User,Last Login,Laaste Aanmelding
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Jy kan nie &#39;Vertaalbaar&#39; vir veld {0} stel nie
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Jy kan nie 'Vertaalbaar' vir veld {0} stel nie
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,kolom
 DocType: Chat Profile,Chat Profile,Kletsprofiel
-DocType: Custom Field,Adds a custom field to a DocType,Voeg &#39;n pasgemaakte veld by &#39;n DocType
+DocType: Custom Field,Adds a custom field to a DocType,Voeg 'n pasgemaakte veld by 'n DocType
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,Click on the link below to verify your request,Klik op die skakel hieronder om u versoek te verifieer
 DocType: File,Is Home Folder,Is Tuisblad
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar-styl
-apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} is nie &#39;n geldige epos adres nie
+apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} is nie 'n geldige epos adres nie
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Kies ten minste 1 rekord vir druk
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Gebruiker &#39;{0}&#39; het reeds die rol &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Gebruiker '{0}' het reeds die rol '{1}'
 DocType: System Settings,Two Factor Authentication method,Twee faktor verifikasie metode
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Stel eers die naam en stoor die rekord.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Rekords
@@ -819,13 +819,13 @@ DocType: DocShare,Everyone,almal
 DocType: Workflow State,backward,agteruit
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Only one rule allowed with the same Role, Level and {1}","{0}: Slegs een reël word toegelaat met dieselfde Rol, Vlak en {1}"
 DocType: Email Queue,Add Unsubscribe Link,Voeg uittreksel uit
-apps/frappe/frappe/templates/includes/comments/comments.html,No comments yet. Start a new discussion.,Nog geen kommentaar. Begin &#39;n nuwe bespreking.
+apps/frappe/frappe/templates/includes/comments/comments.html,No comments yet. Start a new discussion.,Nog geen kommentaar. Begin 'n nuwe bespreking.
 DocType: Workflow State,share,aandeel
 apps/frappe/frappe/config/settings.py,Set numbering series for transactions.,Stel nommersreeks vir transaksies.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Configure Charts,Stel kaarte op
 DocType: User,Last IP,Laaste IP
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please add a subject to your email,Voeg asseblief &#39;n onderwerp by jou e-pos
-apps/frappe/frappe/share.py,A new document {0} has been shared by with you {1}.,&#39;N Nuwe dokument {0} is gedeel deur jou {1}.
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please add a subject to your email,Voeg asseblief 'n onderwerp by jou e-pos
+apps/frappe/frappe/share.py,A new document {0} has been shared by with you {1}.,'N Nuwe dokument {0} is gedeel deur jou {1}.
 DocType: Data Migration Connector,Data Migration Connector,Data Migrasie Connector
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} reverted {1},{0} teruggestel {1}
 DocType: Email Account,Track Email Status,Track e-pos status
@@ -863,11 +863,11 @@ apps/frappe/frappe/model/base_document.py,Duplicate name {0} {1},Duplikaat naam 
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Retry,weer probeer
 DocType: Contact Phone,Number,aantal
 DocType: Web Form Field,Web Form Field,Web vorm veld
-apps/frappe/frappe/templates/emails/new_message.html,You have a new message from: ,Jy het &#39;n nuwe boodskap van:
+apps/frappe/frappe/templates/emails/new_message.html,You have a new message from: ,Jy het 'n nuwe boodskap van:
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_field.html,Edit HTML,HTML wysig
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Voer asseblief Aanstuur-URL in
 apps/frappe/frappe/core/doctype/language/language.py,"{0} must begin and end with a letter and can only contain letters,
-				hyphen or underscore.","{0} moet met &#39;n letter begin en eindig en kan slegs letters, koppelteken of onderstreepte letters bevat."
+				hyphen or underscore.","{0} moet met 'n letter begin en eindig en kan slegs letters, koppelteken of onderstreepte letters bevat."
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Restore Original Permissions,Herstel oorspronklike toestemmings
 DocType: Address,Shop,Winkel
 DocType: DocField,Button,Button
@@ -875,7 +875,7 @@ apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} is now defa
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,Archived Columns,Argiefkolomme
 DocType: Email Account,Default Outgoing,Verstek Uitgaande
 DocType: Workflow State,play,speel
-apps/frappe/frappe/templates/emails/new_user.html,Click on the link below to complete your registration and set a new password,Klik op die onderstaande skakel om u registrasie te voltooi en stel &#39;n nuwe wagwoord in
+apps/frappe/frappe/templates/emails/new_user.html,Click on the link below to complete your registration and set a new password,Klik op die onderstaande skakel om u registrasie te voltooi en stel 'n nuwe wagwoord in
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not add,Het nie bygevoeg nie
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Email Accounts Assigned,Geen e-pos rekeninge toegeken nie
 DocType: S3 Backup Settings,eu-west-2,EU-wes-2
@@ -885,9 +885,9 @@ DocType: Workflow State,text-width,teks-wydte
 apps/frappe/frappe/public/js/frappe/form/form.js,Maximum Attachment Limit for this record reached.,Maksimum aanhangsel limiet vir hierdie rekord bereik.
 apps/frappe/frappe/public/js/frappe/file_uploader/FileBrowser.vue,Search by filename or extension,Soek volgens lêernaam of uitbreiding
 DocType: Notification,View Properties (via Customize Form),Bekyk eienskappe (via vorm aanpas)
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on a file to select it.,Klik op &#39;n lêer om dit te kies.
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on a file to select it.,Klik op 'n lêer om dit te kies.
 DocType: Note Seen By,Note Seen By,Nota Gesien Deur
-apps/frappe/frappe/utils/password_strength.py,Try to use a longer keyboard pattern with more turns,Probeer &#39;n langer sleutelbordpatroon met meer draaie gebruik
+apps/frappe/frappe/utils/password_strength.py,Try to use a longer keyboard pattern with more turns,Probeer 'n langer sleutelbordpatroon met meer draaie gebruik
 ,LeaderBoard,leader
 DocType: DocType,Default Sort Order,Standaard sorteervolgorde
 DocType: Address,Rajasthan,Rajasthan
@@ -896,7 +896,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Report Builder reports are mana
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Please verify your Email Address,Kontroleer asseblief jou e-posadres
 apps/frappe/frappe/model/document.py,none of,geeneen van
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Add Fields,Voeg velde by
-apps/frappe/frappe/public/js/frappe/views/communication.js,Send Me A Copy,Stuur vir my &#39;n kopie
+apps/frappe/frappe/public/js/frappe/views/communication.js,Send Me A Copy,Stuur vir my 'n kopie
 DocType: Dropbox Settings,App Secret Key,App Geheime Sleutel
 DocType: Webhook,on_submit,on_submit
 apps/frappe/frappe/config/website.py,Web Site,Webwerf
@@ -909,7 +909,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,{0} updated,{
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Report cannot be set for Single types,Verslag kan nie vir enkeltipes gestel word nie
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Share URL,Deel URL
 DocType: System Settings,Allow Consecutive Login Attempts ,Laat opeenvolgende aanmeldpogings toe
-apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,&#39;N Fout het voorgekom tydens die betalingproses. Kontak ons asseblief.
+apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,'N Fout het voorgekom tydens die betalingproses. Kontak ons asseblief.
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} days ago,{0} dae gelede
 DocType: Email Account,Awaiting Password,Wagwoord wag
 DocType: Address,Address Line 1,Adres Lyn 1
@@ -933,12 +933,12 @@ DocType: Address,Dadra and Nagar Haveli,Dadra en Nagar Haveli
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Attach Your Picture,Heg jou prentjie aan
 apps/frappe/frappe/core/doctype/version/version_view.html,Row Values Changed,Rywaardes verander
 DocType: Workflow State,Stop,stop
-DocType: Footer Item,Link to the page you want to open. Leave blank if you want to make it a group parent.,Skakel na die bladsy wat jy wil oopmaak. Los leeg as jy dit &#39;n groepouer wil maak.
+DocType: Footer Item,Link to the page you want to open. Leave blank if you want to make it a group parent.,Skakel na die bladsy wat jy wil oopmaak. Los leeg as jy dit 'n groepouer wil maak.
 DocType: DocType,Is Single,Is enkel
 apps/frappe/frappe/core/doctype/user/user.py,Sign Up is disabled,Aanmelding is gedeaktiveer
 apps/frappe/frappe/email/queue.py,{0} has left the conversation in {1} {2},{0} het die gesprek verlaat in {1} {2}
 DocType: Access Log,Show Document,Wys dokument
-DocType: Blogger,User ID of a Blogger,Gebruikers-ID van &#39;n Blogger
+DocType: Blogger,User ID of a Blogger,Gebruikers-ID van 'n Blogger
 apps/frappe/frappe/core/doctype/user/user.py,There should remain at least one System Manager,Daar moet ten minste een stelselbestuurder bly
 DocType: GCalendar Account,Authorization Code,Magtigingskode
 DocType: PayPal Settings,Mention transaction completion page URL,Noem die transaksie-voltooiingsbladsy-URL
@@ -954,14 +954,14 @@ DocType: LDAP Settings,Organizational Unit for Users,Organisasie-eenheid vir geb
 ,Transaction Log Report,Transaksie Log Verslag
 DocType: Custom DocPerm,Custom DocPerm,Aangepaste DocPerm
 DocType: Newsletter,Send Unsubscribe Link,Stuur Teken Teken uit
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,There are some linked records which needs to be created before we can import your file. Do you want to create the following missing records automatically?,Daar is &#39;n paar gekoppelde rekords wat geskep moet word voordat ons u lêer kan invoer. Wil u die volgende ontbrekende rekords outomaties skep?
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,There are some linked records which needs to be created before we can import your file. Do you want to create the following missing records automatically?,Daar is 'n paar gekoppelde rekords wat geskep moet word voordat ons u lêer kan invoer. Wil u die volgende ontbrekende rekords outomaties skep?
 DocType: Access Log,Method,metode
 DocType: Report,Script Report,Skrifverslag
 DocType: OAuth Authorization Code,Scopes,bestekke
 DocType: About Us Settings,Company Introduction,Maatskappy Inleiding
 DocType: User,Last Password Reset Date,Laaste datum van terugstelling van wagwoord
 DocType: DocField,Length,lengte
-apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Herstel of permanent &#39;n dokument uitvee.
+apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Herstel of permanent 'n dokument uitvee.
 apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Kletsprofiel vir gebruiker {0} bestaan.
 apps/frappe/frappe/public/js/frappe/social/components/PostSidebar.vue,Frequently Visited Links,Skakels wat gereeld besoek word
 DocType: Notification,"To add dynamic subject, use jinja tags like
@@ -1001,12 +1001,12 @@ apps/frappe/frappe/public/js/frappe/views/communication.js,"On {0}, {1} wrote:",
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Cannot delete standard field. You can hide it if you want,Kan nie standaard veld uitvee nie. Jy kan dit wegsteek as jy wil
 DocType: Top Bar Item,For top bar,Vir topbalk
 DocType: Social Login Key,Auth URL Data,Outh-URL-data
-apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,Wag vir u rugsteun. U sal &#39;n e-pos ontvang met die aflaai skakel
+apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,Wag vir u rugsteun. U sal 'n e-pos ontvang met die aflaai skakel
 apps/frappe/frappe/utils/bot.py,Could not identify {0},Kon nie {0} identifiseer nie
 DocType: Address,Address,adres
 apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,Betaling misluk
 DocType: Print Settings,In points. Default is 9.,In punte. Standaard is 9.
-DocType: OAuth Client,Redirect URIs,Herlei URI&#39;s
+DocType: OAuth Client,Redirect URIs,Herlei URI's
 DocType: LDAP Settings,StartTLS,StartTLS
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Submiting {0},Inhandiging {0}
 DocType: Workflow State,heart,hart
@@ -1027,7 +1027,7 @@ DocType: Property Setter,Property Setter,Eiendom Setter
 DocType: Web Form,Allow Print,Laat Print toe
 DocType: Communication,Clicked,gekliek
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Unfollow
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Geen toestemming vir &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Geen toestemming vir '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Geskeduleer om te stuur
 DocType: DocType,Track Seen,Spoor gesien
 DocType: Dropbox Settings,File Backup,Lêer rugsteun
@@ -1045,7 +1045,7 @@ apps/frappe/frappe/public/js/frappe/desk.js,Domains,domeine
 DocType: Blog Category,Blog Category,Blog Kategorie
 apps/frappe/frappe/model/mapper.py,Cannot map because following condition fails: ,Kan nie kaarteer nie omdat die volgende voorwaarde misluk:
 DocType: Role Permission for Page and Report,Roles HTML,Rolle HTML
-apps/frappe/frappe/website/doctype/website_settings/website_settings.js,Select a Brand Image first.,Kies eers &#39;n Brand Image.
+apps/frappe/frappe/website/doctype/website_settings/website_settings.js,Select a Brand Image first.,Kies eers 'n Brand Image.
 DocType: Dashboard Chart Source,Dashboard Chart Source,Bron van die paneelkaart
 DocType: Auto Repeat,Active,aktiewe
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Insert Below,Voeg hieronder in
@@ -1054,12 +1054,12 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Bladsy HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Uitvoer van foutiewe rye
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Groepnaam kan nie leeg wees nie.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Verdere nodes kan slegs geskep word onder &#39;Groep&#39;-tipe nodusse
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Verdere nodes kan slegs geskep word onder 'Groep'-tipe nodusse
 DocType: SMS Parameter,Header,kop
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Onbekende kolom: {0}
 DocType: Notification Recipient,Email By Role,E-pos per rol
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Nothing to update,Niks om op te dateer nie
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Users with role {0}:,Gebruikers met &#39;n rol {0}:
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Users with role {0}:,Gebruikers met 'n rol {0}:
 DocType: Print Format,Custom Format,Gepasmaakte formaat
 DocType: Workflow State,random,ewekansige
 DocType: Newsletter Email Group,Newsletter Email Group,Nuusbrief E-posgroep
@@ -1071,23 +1071,23 @@ DocType: Address,Other Territory,Ander Gebied
 ,Messages,boodskappe
 apps/frappe/frappe/config/website.py,Portal,portaal
 DocType: Email Account,Use Different Email Login ID,Gebruik verskillende e-pos-aanmeldings ID
-apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,Moet &#39;n navraag spesifiseer om te hardloop
-apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Daar is &#39;n probleem met die bediener se braintree-konfigurasie. Moenie bekommerd wees nie, in geval van versuim, sal die bedrag terugbetaal word na u rekening."
+apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,Moet 'n navraag spesifiseer om te hardloop
+apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Daar is 'n probleem met die bediener se braintree-konfigurasie. Moenie bekommerd wees nie, in geval van versuim, sal die bedrag terugbetaal word na u rekening."
 apps/frappe/frappe/www/me.html,Manage Third Party Apps,Bestuur Derdeparty-programme
 DocType: Website Settings,Route Redirects,Roete-aanwysings
 apps/frappe/frappe/config/settings.py,"Language, Date and Time settings","Taal, datum en tyd instellings"
 DocType: User Email,User Email,Gebruiker-e-pos
 DocType: Assignment Rule Day,Saturday,Saterdag
-DocType: User,Represents a User in the system.,Verteenwoordig &#39;n gebruiker in die stelsel.
+DocType: User,Represents a User in the system.,Verteenwoordig 'n gebruiker in die stelsel.
 DocType: List View Setting,Disable Auto Refresh,Deaktiveer outomatiese opdatering
 DocType: Comment,Label,Etiket
 apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed.","Die taak {0}, wat jy aan {1} toegewys het, is gesluit."
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please close this window,Maak asseblief hierdie venster toe
 DocType: Print Format,Print Format Type,Drukformaat Tipe
-DocType: Newsletter,A Lead with this Email Address should exist,&#39;N Lood met hierdie e-posadres moet bestaan
+DocType: Newsletter,A Lead with this Email Address should exist,'N Lood met hierdie e-posadres moet bestaan
 apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Open Source Applications for the Web,Open Source Aansoeke vir die Web
 DocType: Event,Call,Call
-apps/frappe/frappe/website/doctype/website_theme/website_theme.js,"Add the name of a ""Google Web Font"" e.g. ""Open Sans""","Voeg die naam van &#39;n &quot;Google Web Font&quot; by, byvoorbeeld &quot;Open Sans&quot;"
+apps/frappe/frappe/website/doctype/website_theme/website_theme.js,"Add the name of a ""Google Web Font"" e.g. ""Open Sans""","Voeg die naam van 'n &quot;Google Web Font&quot; by, byvoorbeeld &quot;Open Sans&quot;"
 apps/frappe/frappe/public/js/frappe/request.js,Request Timed Out,Versoek uitgeskakel
 apps/frappe/frappe/config/settings.py,Enable / Disable Domains,Aktiveer / deaktiveer domeine
 DocType: Role Permission for Page and Report,Allow Roles,Laat rolle toe
@@ -1095,7 +1095,7 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfull
 DocType: Assignment Rule,"Simple Python Expression, Example: Status in (""Invalid"")","Eenvoudige Python-uitdrukking, voorbeeld: status in (&quot;ongeldig&quot;)"
 DocType: User,Last Active,Laaste Aktief
 DocType: Email Account,SMTP Settings for outgoing emails,SMTP-instellings vir uitgaande e-posse
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,choose an,kies &#39;n
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,choose an,kies 'n
 DocType: Data Export,Filter List,Filter Lys
 DocType: Data Export,Excel,Excel
 DocType: Email Account,Auto Reply Message,Outo-antwoordboodskap
@@ -1109,10 +1109,10 @@ DocType: Address,Kerala,Kerala
 apps/frappe/frappe/public/js/frappe/desk.js,Administration,administrasie
 DocType: User,Simultaneous Sessions,Gelyktydige Sessies
 DocType: Social Login Key,Client Credentials,Kliënt geloofsbriewe
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Open a module or tool,Maak &#39;n module of gereedskap oop
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Open a module or tool,Maak 'n module of gereedskap oop
 DocType: Communication,Delivery Status,Afleweringsstatus
 DocType: Module Def,App Name,Program Naam
-DocType: Workflow,"Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)","Veld wat die werkstroomstaat van die transaksie verteenwoordig (as die veld nie teenwoordig is nie, sal &#39;n nuwe verborge persoonlike veld geskep word)"
+DocType: Workflow,"Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)","Veld wat die werkstroomstaat van die transaksie verteenwoordig (as die veld nie teenwoordig is nie, sal 'n nuwe verborge persoonlike veld geskep word)"
 DocType: Help Article,Knowledge Base Contributor,Kennisbasisbydraer
 DocType: Communication,Sent Read Receipt,Gestuur lees ontvangs
 DocType: Email Queue,Unsubscribe Method,Uitschrijven metode
@@ -1187,7 +1187,7 @@ DocType: GSuite Templates,GSuite Templates,GSuite Templates
 apps/frappe/frappe/utils/goal.py,Goal,doel
 apps/frappe/frappe/email/receive.py,Invalid Mail Server. Please rectify and try again.,Ongeldige posbediener. Regstel asseblief en probeer weer.
 DocType: DocField,"For Links, enter the DocType as range.
-For Select, enter list of Options, each on a new line.","Vir Skakels, tik die DocType as reeks in. Vir Kies, voer &#39;n lys opsies in, elkeen op &#39;n nuwe reël."
+For Select, enter list of Options, each on a new line.","Vir Skakels, tik die DocType as reeks in. Vir Kies, voer 'n lys opsies in, elkeen op 'n nuwe reël."
 DocType: Workflow State,film,film
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Sync Calendar,Sinkroniseer kalender
 apps/frappe/frappe/model/db_query.py,No permission to read {0},Geen toestemming om te lees nie {0}
@@ -1252,14 +1252,14 @@ apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,← Back to upload
 apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Outgoing email account not correct,Uitgaande e-pos rekening is nie korrek nie
 DocType: Transaction Log,Chaining Hash,Chaining Hash
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,Stel asseblief e-pos adres in
-DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","As die gebruiker enige rol nagegaan het, word die gebruiker &#39;n &quot;System User&quot;. &quot;Stelselgebruiker&quot; het toegang tot die lessenaar"
+DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","As die gebruiker enige rol nagegaan het, word die gebruiker 'n &quot;System User&quot;. &quot;Stelselgebruiker&quot; het toegang tot die lessenaar"
 DocType: System Settings,Date and Number Format,Datum en nommerformaat
 apps/frappe/frappe/model/document.py,one of,een van
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Opstel> pas vorm aan
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kyk een oomblik
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Wys etikette
 DocType: DocField,HTML Editor,HTML Editor
-DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","As Streng gebruikertoestemming toegepas word, en gebruikertoestemming vir &#39;n DocType vir &#39;n gebruiker gedefinieer is, sal al die dokumente waar die waarde van die skakel leeg is, nie aan daardie gebruiker vertoon word nie."
+DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","As Streng gebruikertoestemming toegepas word, en gebruikertoestemming vir 'n DocType vir 'n gebruiker gedefinieer is, sal al die dokumente waar die waarde van die skakel leeg is, nie aan daardie gebruiker vertoon word nie."
 DocType: Address,Billing,Rekening
 DocType: Email Queue,Not Sent,Nie gestuur nie
 DocType: Web Form,Actions,aksies
@@ -1318,7 +1318,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,PDF,PDF
 DocType: System Settings,dd/mm/yyyy,dd / mm / jjjj
 DocType: System Settings,Backups,rugsteun
 apps/frappe/frappe/core/doctype/communication/communication.js,Add Contact,Voeg kontak by
-DocType: Notification Recipient,Optional: Always send to these ids. Each Email Address on a new row,Opsioneel: Stuur altyd na hierdie ids. Elke e-pos adres op &#39;n nuwe ry
+DocType: Notification Recipient,Optional: Always send to these ids. Each Email Address on a new row,Opsioneel: Stuur altyd na hierdie ids. Elke e-pos adres op 'n nuwe ry
 apps/frappe/frappe/public/js/frappe/form/layout.js,Hide Details,Versteek Besonderhede
 apps/frappe/frappe/www/qrcode.py,Page has expired!,Bladsy het verval!
 DocType: LDAP Settings,Path to private Key File,Pad na privaat sleutellêer
@@ -1327,7 +1327,7 @@ DocType: Assignment Rule Day,Tuesday,Dinsdag
 DocType: Blog Settings,Blog Settings,Blog instellings
 apps/frappe/frappe/templates/emails/new_user.html,You can also copy-paste this link in your browser,U kan hierdie skakel ook kopieer in u blaaier
 DocType: Workflow State,bullhorn,luidspreker
-apps/frappe/frappe/model/workflow.py,Not a valid Workflow Action,Nie &#39;n geldige Workflow Action
+apps/frappe/frappe/model/workflow.py,Not a valid Workflow Action,Nie 'n geldige Workflow Action
 DocType: Footer Item,Target,teiken
 DocType: System Settings,Number of Backups,Aantal rugsteun
 DocType: Dashboard Chart,Last Year,Laas jaar
@@ -1338,7 +1338,7 @@ DocType: ToDo,Due Date,Vervaldatum
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Quarter Day,Kwartaal
 DocType: Website Settings,Hide Footer Signup,Versteek voetskrifinskrywing
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document,hierdie dokument gekanselleer
-apps/frappe/frappe/core/doctype/report/report.js,Write a Python file in the same folder where this is saved and return column and result.,Skryf &#39;n Python-lêer in dieselfde gids waar dit gered is en stuur kolom en resultaat terug.
+apps/frappe/frappe/core/doctype/report/report.js,Write a Python file in the same folder where this is saved and return column and result.,Skryf 'n Python-lêer in dieselfde gids waar dit gered is en stuur kolom en resultaat terug.
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Add to table,Voeg by tafel
 DocType: Website Theme,Theme URL,Tema-URL
 DocType: Customize Form,Sort Field,Sorteer Veld
@@ -1353,7 +1353,7 @@ DocType: Notification,Slack,slap
 DocType: Custom DocPerm,If user is the owner,As gebruiker die eienaar is
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Follow,volg
 ,Activity,aktiwiteit
-DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Hulp: Om te skakel na &#39;n ander rekord in die stelsel, gebruik &quot;# Vorm / Nota / [Nota Naam]&quot; as die skakel-URL. (moenie &quot;http: //&quot; gebruik nie)"
+DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Hulp: Om te skakel na 'n ander rekord in die stelsel, gebruik &quot;# Vorm / Nota / [Nota Naam]&quot; as die skakel-URL. (moenie &quot;http: //&quot; gebruik nie)"
 DocType: User Permission,Allow,laat
 DocType: Data Import Beta,Update Existing Records,Bestaande rekords opdateer
 apps/frappe/frappe/utils/password_strength.py,Let's avoid repeated words and characters,Kom ons vermy herhaalde woorde en karakters
@@ -1441,9 +1441,9 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Verpligte veld: vaste rol vir
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} gekritiseer {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Veld &#39;{1}&#39; kan nie as Uniek gestel word nie, aangesien dit nie-unieke waardes het"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Veld '{1}' kan nie as Uniek gestel word nie, aangesien dit nie-unieke waardes het"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navigeer lys af
-DocType: Currency,A symbol for this currency. For e.g. $,&#39;N Simbool vir hierdie geldeenheid. Vir bv. $
+DocType: Currency,A symbol for this currency. For e.g. $,'N Simbool vir hierdie geldeenheid. Vir bv. $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Suksesvol opgedateerde vertalings
 apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Frappe Framework,Frappe Framework
 DocType: S3 Backup Settings,Enable Automatic Backup,Aktiveer Outomatiese rugsteun
@@ -1475,7 +1475,7 @@ DocType: Webhook,on_update,on_update
 apps/frappe/frappe/model/rename_doc.py,Ignored: {0} to {1},Ignoreer: {0} tot {1}
 DocType: Address,Gujarat,Gujarat
 apps/frappe/frappe/config/settings.py,Log of error on automated events (scheduler).,Teken van fout op outomatiese gebeure (skeduleerder).
-apps/frappe/frappe/utils/csvutils.py,Not a valid Comma Separated Value (CSV File),Nie &#39;n geldige Comma Separated Value (CSV File)
+apps/frappe/frappe/utils/csvutils.py,Not a valid Comma Separated Value (CSV File),Nie 'n geldige Comma Separated Value (CSV File)
 DocType: Address,Postal,Postal
 DocType: Email Account,Default Incoming,Standaard Inkomend
 DocType: Workflow State,repeat,herhaling
@@ -1546,7 +1546,7 @@ DocType: Report,Query Report,Navraagverslag
 DocType: User,Set New Password,Stel nuwe wagwoord in
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1},Nie toegelaat vir {0}: {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,"%s is not a valid report format. Report format should \
-				one of the following %s",% s is nie &#39;n geldige verslagformaat nie. Verslagformaat moet \ een van die volgende% s wees
+				one of the following %s",% s is nie 'n geldige verslagformaat nie. Verslagformaat moet \ een van die volgende% s wees
 DocType: Chat Message,Chat,chat
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No documents found tagged with {0},Geen dokumente gevind wat met {0} gemerk is
 DocType: LDAP Group Mapping,LDAP Group Mapping,LDAP-groep kartering
@@ -1556,10 +1556,10 @@ apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} from {1} to {2} 
 DocType: Communication,Expired,verstryk
 apps/frappe/frappe/templates/pages/integrations/razorpay_checkout.py,Seems token you are using is invalid!,"Lyk asof jy gebruik, is ongeldig!"
 DocType: DocType,Is Tree,Is Boom
-DocType: Customize Form Field,Number of columns for a field in a Grid (Total Columns in a grid should be less than 11),Aantal kolomme vir &#39;n veld in &#39;n rooster (Totale kolomme in &#39;n rooster moet minder as 11 wees)
+DocType: Customize Form Field,Number of columns for a field in a Grid (Total Columns in a grid should be less than 11),Aantal kolomme vir 'n veld in 'n rooster (Totale kolomme in 'n rooster moet minder as 11 wees)
 DocType: DocType,System,stelsel
 DocType: Web Form,Max Attachment Size (in MB),Maksimum aanhangsel grootte (in MB)
-apps/frappe/frappe/www/login.html,Have an account? Login,Het u &#39;n rekening? Teken aan
+apps/frappe/frappe/www/login.html,Have an account? Login,Het u 'n rekening? Teken aan
 DocType: Workflow State,arrow-down,pyl-down
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Row {0},Ry {0}
 apps/frappe/frappe/model/delete_doc.py,User not allowed to delete {0}: {1},Gebruiker mag nie {0} uitvee nie: {1}
@@ -1581,17 +1581,17 @@ DocType: Dropbox Settings,Dropbox Access Secret,Dropbox Access Secret
 DocType: Tag Link,Document Title,Dokument titel
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,(Mandatory),(Verpligte)
 DocType: Social Login Key,Social Login Provider,Sosiale aanmeldverskaffer
-apps/frappe/frappe/templates/includes/comments/comments.html,Add Another Comment,Voeg nog &#39;n opmerking by
+apps/frappe/frappe/templates/includes/comments/comments.html,Add Another Comment,Voeg nog 'n opmerking by
 apps/frappe/frappe/core/doctype/data_import/importer.py,No data found in the file. Please reattach the new file with data.,Geen data in die lêer gevind nie. Herlaai asseblief die nuwe lêer met data.
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Edit DocType,Wysig DocType
 apps/frappe/frappe/templates/emails/data_deletion_approval.html,Confirm Request,Bevestig versoek
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Vou moet voor &#39;n Afdelingbreek kom
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Vou moet voor 'n Afdelingbreek kom
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Under Development,Onder ontwikkeling
 apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Go to the document,Gaan na die dokument
 apps/frappe/frappe/public/js/frappe/model/meta.js,Last Modified By,Laaste gewysig deur
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Customizations Reset,Aanpassings Herstel
 DocType: Workflow State,hand-down,hand-down
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type ""Select"".",Geen velde gevind wat as Kanban-kolom gebruik kan word nie. Gebruik die Customize Form om &#39;n Custom Field van die tipe &quot;Select&quot; by te voeg.
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type ""Select"".",Geen velde gevind wat as Kanban-kolom gebruik kan word nie. Gebruik die Customize Form om 'n Custom Field van die tipe &quot;Select&quot; by te voeg.
 DocType: Address,GST State,GST Staat
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0}: Kan nie Kanselleer sonder Submit instel nie
 DocType: Website Theme,Theme,tema
@@ -1601,7 +1601,7 @@ DocType: DocType,Is Submittable,Is Submittable
 apps/frappe/frappe/core/doctype/comment/comment.py,New Mention,Nuwe Noem
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,Geen nuwe Google-kontakte is gesinkroniseer nie.
 DocType: File,Uploaded To Google Drive,Op Google Drive opgelaai
-apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a check field can be either 0 or 1,Waarde vir &#39;n tjekveld kan 0 of 1 wees
+apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a check field can be either 0 or 1,Waarde vir 'n tjekveld kan 0 of 1 wees
 apps/frappe/frappe/model/document.py,Could not find {0},Kon nie {0} vind nie
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Filters applied for {0},Filters aansoek gedoen vir {0}
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Column Labels:,Kolom Etikette:
@@ -1615,18 +1615,18 @@ apps/frappe/frappe/core/doctype/data_import/log_details.html,Document can't save
 DocType: Energy Point Rule,Maximum Points,Maksimum punte
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,My Settings,My instellings
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Text Color,Teks Kleur
-apps/frappe/frappe/desk/page/backups/backups.py,Backup job is already queued. You will receive an email with the download link,Rugsteun werk is reeds in die ry. U sal &#39;n e-pos ontvang met die aflaai skakel
+apps/frappe/frappe/desk/page/backups/backups.py,Backup job is already queued. You will receive an email with the download link,Rugsteun werk is reeds in die ry. U sal 'n e-pos ontvang met die aflaai skakel
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,1 Google Calendar Event synced.,1 Google Kalender-geleentheid gesinkroniseer.
 DocType: Desktop Icon,Force Show,Force Show
 apps/frappe/frappe/auth.py,Invalid Request,Ongeldige Versoek
 apps/frappe/frappe/public/js/frappe/form/layout.js,This form does not have any input,Hierdie vorm het geen insette nie
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py,Session Expiry must be in format {0},Verval van die sessie moet in formaat {0} wees
 DocType: Chat Message,Group,groep
-DocType: Footer Item,"Select target = ""_blank"" to open in a new page.",Kies teiken = &quot;_blank&quot; om oop te maak op &#39;n nuwe bladsy.
+DocType: Footer Item,"Select target = ""_blank"" to open in a new page.",Kies teiken = &quot;_blank&quot; om oop te maak op 'n nuwe bladsy.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 year,1 jaar
 apps/frappe/frappe/public/js/frappe/model/model.js,Permanently delete {0}?,Vee permanent {0} uit?
 apps/frappe/frappe/core/doctype/file/file.py,Same file has already been attached to the record,Dieselfde lêer is reeds aan die rekord geheg
-apps/frappe/frappe/model/workflow.py,{0} is not a valid Workflow State. Please update your Workflow and try again.,{0} is nie &#39;n geldige werkstroomstaat nie. Dateer asseblief u Workflow op en probeer weer.
+apps/frappe/frappe/model/workflow.py,{0} is not a valid Workflow State. Please update your Workflow and try again.,{0} is nie 'n geldige werkstroomstaat nie. Dateer asseblief u Workflow op en probeer weer.
 apps/frappe/frappe/templates/emails/energy_points_summary.html,gave {0} points,het {0} punte gegee
 DocType: Workflow State,wrench,wrench
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Set,Nie gestel nie
@@ -1721,27 +1721,27 @@ DocType: Web Form Field,Max Length,Maksimum Lengte
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,For {0} {1},Vir {0} {1}
 DocType: Print Format,Jinja,Jinja
 DocType: Workflow State,map-marker,kaart-merker
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Submit an Issue,Dien &#39;n uitgawe in
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Submit an Issue,Dien 'n uitgawe in
 DocType: Event,Repeat this Event,Herhaal hierdie gebeurtenis
 DocType: Address,Maintenance User,Instandhoudingsgebruiker
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,"LDAP Search String needs to end with a placeholder, eg sAMAccountName={0}","LDAP-soekstring moet eindig met &#39;n plekhouer, bv. SAMAccountName = {0}"
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,"LDAP Search String needs to end with a placeholder, eg sAMAccountName={0}","LDAP-soekstring moet eindig met 'n plekhouer, bv. SAMAccountName = {0}"
 apps/frappe/frappe/utils/password_strength.py,Avoid dates and years that are associated with you.,Vermy datums en jare wat met u geassosieer word.
 DocType: Custom DocPerm,Amend,wysig
 DocType: Data Import,Generated File,Gegenereerde lêer
 DocType: Transaction Log,Previous Hash,Vorige Hash
 DocType: File,Is Attachments Folder,Is aanhangsels gids
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Expand All,Brei alles uit
-apps/frappe/frappe/public/js/frappe/chat.js,Select a chat to start messaging.,Kies &#39;n klets om boodskappe te begin.
+apps/frappe/frappe/public/js/frappe/chat.js,Select a chat to start messaging.,Kies 'n klets om boodskappe te begin.
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,Processing,verwerking
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Please select Entity Type first,Kies asseblief eers Entiteitstipe
 apps/frappe/frappe/templates/includes/login/login.js,Valid Login id required.,Geldige login ID vereis.
-apps/frappe/frappe/model/rename_doc.py,Please select a valid csv file with data,Kies asseblief &#39;n geldige CSV-lêer met data
+apps/frappe/frappe/model/rename_doc.py,Please select a valid csv file with data,Kies asseblief 'n geldige CSV-lêer met data
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} un-shared this document with {1},{0} het hierdie dokument gedeel met {1}
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained {0} point,U het {0} punt behaal
 DocType: LDAP Settings,SSL/TLS Mode,SSL / TLS-modus
 DocType: DocType,"Make ""name"" searchable in Global Search",Maak &quot;naam&quot; soekbaar in Global Search
 apps/frappe/frappe/core/doctype/version/version_view.html,Row # ,Ry #
-apps/frappe/frappe/templates/emails/auto_reply.html,This is an automatically generated reply,Dit is &#39;n outomaties gegenereerde antwoord
+apps/frappe/frappe/templates/emails/auto_reply.html,This is an automatically generated reply,Dit is 'n outomaties gegenereerde antwoord
 DocType: Help Category,Category Description,Kategorie Beskrywing
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Default Theme,Verstek tema
 apps/frappe/frappe/model/document.py,Record does not exist,Rekord bestaan nie
@@ -1766,7 +1766,7 @@ DocType: Dashboard Chart,Average,Gemiddeld
 apps/frappe/frappe/public/js/frappe/form/grid.js,Add Row,Voeg ry by
 DocType: Tag Category,Doctypes,Doctypes
 apps/frappe/frappe/public/js/frappe/form/print.js,Printer,drukker
-apps/frappe/frappe/desk/query_report.py,Query must be a SELECT,Navraag moet &#39;n SELECT wees
+apps/frappe/frappe/desk/query_report.py,Query must be a SELECT,Navraag moet 'n SELECT wees
 DocType: Auto Repeat,Completed,voltooi
 DocType: File,Is Private,Is Privaat
 DocType: Data Export,Select DocType,Kies DocType
@@ -1776,7 +1776,7 @@ DocType: Workflow State,align-center,in lyn-sentrum
 DocType: Address,Lakshadweep Islands,Lakshadweep Eilande
 DocType: DocType,Allow events in timeline,Laat gebeure in die tydlyn toe
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Write,Kan skryf
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit.","Sekere dokumente, soos &#39;n faktuur, moet nie eenmalig verander word nie. Die finale staat vir sulke dokumente word Ingedien. U kan beperk watter rolle kan stuur."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit.","Sekere dokumente, soos 'n faktuur, moet nie eenmalig verander word nie. Die finale staat vir sulke dokumente word Ingedien. U kan beperk watter rolle kan stuur."
 DocType: Newsletter,Test Email Address,Toets e-pos adres
 DocType: Auto Repeat,Reference Document Type,Verwysings dokument tipe
 DocType: ToDo,Sender,sender
@@ -1791,7 +1791,7 @@ apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,hangende
 DocType: System Settings,Allow only one session per user,Laat slegs een sessie per gebruiker toe
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Tuisblad / Toetsmap 1 / Toetsmap 3
 DocType: Website Settings,<head> HTML,<head> HTML
-apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Kies of sleep oor tydgleuwe om &#39;n nuwe gebeurtenis te skep.
+apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Kies of sleep oor tydgleuwe om 'n nuwe gebeurtenis te skep.
 DocType: Contact,Contact Details,Kontakbesonderhede
 DocType: DocField,In Filter,In Filter
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Kanban,Kanban
@@ -1814,7 +1814,7 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.py,Scheduler i
 DocType: Print Settings,Letter,brief
 DocType: DocType,"Naming Options:
 <ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>
-<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Naamopsies: <ol><li> <b>veld: [veldnaam]</b> - volgens veld </li><li> <b>naming_series:</b> - By Naming Series (veld genaamd naming_series moet teenwoordig wees </li><li> <b>Prompt</b> - Spoedige gebruiker vir &#39;n naam </li><li> <b>[reeks]</b> - Reeks volgens voorvoegsel (geskei deur &#39;n punt); byvoorbeeld PRE. ##### </li><li> <b>formaat: VOORBEELD- {MM} meerwoorde {veldnaam1} - {veldnaam2} - {######}</b> - Vervang alle geboorde woorde (veldname, datumwoorde (DD, MM, YY), reeks) met hul waarde. Buite stewels kan enige karakters gebruik word. </li></ol>"
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Naamopsies: <ol><li> <b>veld: [veldnaam]</b> - volgens veld </li><li> <b>naming_series:</b> - By Naming Series (veld genaamd naming_series moet teenwoordig wees </li><li> <b>Prompt</b> - Spoedige gebruiker vir 'n naam </li><li> <b>[reeks]</b> - Reeks volgens voorvoegsel (geskei deur 'n punt); byvoorbeeld PRE. ##### </li><li> <b>formaat: VOORBEELD- {MM} meerwoorde {veldnaam1} - {veldnaam2} - {######}</b> - Vervang alle geboorde woorde (veldname, datumwoorde (DD, MM, YY), reeks) met hul waarde. Buite stewels kan enige karakters gebruik word. </li></ol>"
 apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,Daar was foute tydens die skep van die dokument. Probeer asseblief weer.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,Beeldveld moet van die tipe Heg Beeld wees
 apps/frappe/frappe/permissions.py,You are not allowed to export {} doctype,U mag nie {} leersteks uitvoer nie
@@ -1854,7 +1854,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Open list item,Maak lysite
 DocType: Report,Add Total Row,Voeg totale ry by
 apps/frappe/frappe/public/js/frappe/form/print.js,No Preview available,Geen voorskou beskikbaar
 apps/frappe/frappe/twofactor.py,Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it.,"Gaan asseblief jou geregistreerde e-pos adres na vir instruksies oor hoe om voort te gaan. Moenie hierdie venster toemaak nie, want jy sal daarheen moet terugkeer."
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Byvoorbeeld, as u INV004 kanselleer en wysig, sal dit &#39;n nuwe dokument INV004-1 word. Dit help jou om tred te hou met elke wysiging."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Byvoorbeeld, as u INV004 kanselleer en wysig, sal dit 'n nuwe dokument INV004-1 word. Dit help jou om tred te hou met elke wysiging."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Atleast one field of Parent Document Type is mandatory,Ten minste een veld van Ouer Dokument Type is verpligtend
 apps/frappe/frappe/config/settings.py,Setup Reports to be emailed at regular intervals,Opstelverslae word met gereelde tussenposes per e-pos gestuur
 DocType: Workflow Document State,0 - Draft; 1 - Submitted; 2 - Cancelled,0 - Konsep; 1 - ingedien; 2 - gekanselleer
@@ -1872,7 +1872,7 @@ DocType: Data Export,CSV,CSV
 DocType: Currency,"1 Currency = [?] Fraction
 For e.g. 1 USD = 100 Cent",1 Geld = [?] Fraksie Vir bv. 1 USD = 100 Cent
 DocType: Data Import,Partially Successful,Gedeeltelik Suksesvol
-apps/frappe/frappe/core/doctype/user/user.py,"Too many users signed up recently, so the registration is disabled. Please try back in an hour","Te veel gebruikers het onlangs ingeteken, dus die registrasie is gedeaktiveer. Probeer asseblief oor &#39;n uur terug"
+apps/frappe/frappe/core/doctype/user/user.py,"Too many users signed up recently, so the registration is disabled. Please try back in an hour","Te veel gebruikers het onlangs ingeteken, dus die registrasie is gedeaktiveer. Probeer asseblief oor 'n uur terug"
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add New Permission Rule,Voeg nuwe toestemmingsreël by
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,You can use wildcard %,Jy kan wildcard% gebruik
 DocType: LDAP Settings,LDAP Group Mappings,LDAP-groepkaarte
@@ -1940,7 +1940,7 @@ DocType: Data Import,Do not send Emails,Moenie e-posse stuur nie
 apps/frappe/frappe/utils/password_strength.py,Common names and surnames are easy to guess.,Gewone name en vanne is maklik om te raai.
 DocType: Google Drive,Google Drive,Google Drive
 apps/frappe/frappe/public/js/frappe/model/indicator.js,Draft,Konsep
-apps/frappe/frappe/utils/password_strength.py,This is similar to a commonly used password.,Dit is soortgelyk aan &#39;n algemeen gebruikte wagwoord.
+apps/frappe/frappe/utils/password_strength.py,This is similar to a commonly used password.,Dit is soortgelyk aan 'n algemeen gebruikte wagwoord.
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Female,vroulike
 DocType: Success Action,Success Action,Sukses Aksie
 apps/frappe/frappe/public/js/frappe/model/indicator.js,Not Saved,Nie gestoor nie
@@ -1961,7 +1961,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,AP-suidoos-1
 DocType: DocType,"Must be of type ""Attach Image""",Moet van tipe wees &quot;Heg beeld aan&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Ontkies alles
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Jy kan nie &#39;Slegs lees&#39; vir veld {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Jy kan nie 'Slegs lees' vir veld {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,Nul beteken stuur rekords op enige tyd bygewerk
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,Voltooi instellings
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,Suksesvol opgedateer
@@ -1972,7 +1972,7 @@ DocType: Activity Log,Linked,gekoppel
 apps/frappe/frappe/config/desk.py,Activity log of all users.,Aktiwiteit log van alle gebruikers.
 DocType: Workflow State,shopping-cart,shopping-wa
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Week,week
-DocType: DocType,Open a dialog with mandatory fields to create a new record quickly,Open &#39;n dialoog met verpligte velde om vinnig &#39;n nuwe rekord te maak
+DocType: DocType,Open a dialog with mandatory fields to create a new record quickly,Open 'n dialoog met verpligte velde om vinnig 'n nuwe rekord te maak
 apps/frappe/frappe/templates/includes/login/login.js,Not Allowed: Disabled User,Nie toegelaat: Gestremde gebruiker
 DocType: Social Login Key,Google,Google
 DocType: Email Domain,Example Email Address,Voorbeeld e-pos adres
@@ -1986,7 +1986,7 @@ apps/frappe/frappe/model/naming.py,Invalid naming series (. missing),Ongeldige b
 DocType: Web Form,Show Attachments,Wys aanhangsels
 DocType: Language,Language,Taal
 apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Webleser word nie ondersteun nie
-DocType: Social Login Key,Client URLs,Kliënt-URL&#39;s
+DocType: Social Login Key,Client URLs,Kliënt-URL's
 apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Some information is missing,Sommige inligting ontbreek
 apps/frappe/frappe/public/js/frappe/views/interaction.js,{0} created successfully,{0} suksesvol geskep
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Skipping {0} of {1}, {2}","Slaan {0} van {1}, {2} oor"
@@ -1999,20 +1999,20 @@ apps/frappe/frappe/config/website.py,List of themes for Website.,Lys van temas v
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,"Dear User,","Beste gebruiker,"
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Successfully Updated,Suksesvol opgedateer
 DocType: Activity Log,Logout,Teken uit
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,"Toestemmings op hoër vlakke is veldvlak toestemmings. Alle velde het &#39;n Toestemmingsvlak ingestel teen hulle en die reëls wat by daardie toestemmings gedefinieer is, is van toepassing op die veld. Dit is handig as jy sekere veldlees vir sekere rolle wil versteek of maak."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,"Toestemmings op hoër vlakke is veldvlak toestemmings. Alle velde het 'n Toestemmingsvlak ingestel teen hulle en die reëls wat by daardie toestemmings gedefinieer is, is van toepassing op die veld. Dit is handig as jy sekere veldlees vir sekere rolle wil versteek of maak."
 DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, password=1234 etc.)","Voer statiese url parameters hier in (Bv. Sender = ERPNext, gebruikersnaam = ERPNext, wagwoord = 1234 ens.)."
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","As hierdie instruksies nie nuttig is nie, voeg asseblief jou voorstelle by oor GitHub-probleme."
 DocType: Workflow State,bookmark,Bookmark
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Vouernaam moet nie &#39;/&#39; (slash) insluit nie
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Vouernaam moet nie '/' (slash) insluit nie
 DocType: Note,Note,nota
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Foutverslag
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Uitvoer data in CSV / Excel formaat.
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Setting up Global Search documents.,Opstel van Global Search-dokumente.
 apps/frappe/frappe/www/qrcode.html,Authentication Apps you can use are: ,"Verifikasieprogramme wat jy kan gebruik, is:"
-apps/frappe/frappe/public/js/frappe/form/controls/data.js,{0} already exists. Select another name,{0} bestaan reeds. Kies &#39;n ander naam
+apps/frappe/frappe/public/js/frappe/form/controls/data.js,{0} already exists. Select another name,{0} bestaan reeds. Kies 'n ander naam
 DocType: S3 Backup Settings,None,Geen
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a valid fieldname,Tydlyn veld moet &#39;n geldige veldnaam wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a valid fieldname,Tydlyn veld moet 'n geldige veldnaam wees
 DocType: Contact,Email Ids,E-pos Ids
 DocType: GCalendar Account,Session Token,Session Token
 DocType: Currency,Symbol,simbool
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Inloggen is nie toegelaat nie
 DocType: Data Migration Run,Current Mapping Action,Huidige kaarte-aksie
 DocType: Dashboard Chart Source,Source Name,Bron Naam
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Geen e-posrekening geassosieer met die gebruiker nie. Voeg &#39;n rekening by onder Gebruiker> E-posboks.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Geen e-posrekening geassosieer met die gebruiker nie. Voeg 'n rekening by onder Gebruiker> E-posboks.
 DocType: Email Account,Email Sync Option,E-pos Sync Opsie
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Ry nr
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Reeds in 
 DocType: User Email,Enable Outgoing,Aktiveer Uitgaande
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,Gepasmaakte Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posrekening nie opgestel nie. Skep &#39;n nuwe e-posrekening vanaf Setup> E-pos> E-posrekening
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posrekening nie opgestel nie. Skep 'n nuwe e-posrekening vanaf Setup> E-pos> E-posrekening
 DocType: Comment,Submitted,voorgelê
 DocType: Contact,Pulled from Google Contacts,Van Google Kontakte af getrek
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ongeldige Versoek
@@ -2091,10 +2091,10 @@ apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Print Documents,Druk
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Jump to field,Spring na die veld
 DocType: Contact Us Settings,Forward To Email Address,Stuur na e-pos adres
 DocType: Contact Phone,Is Primary Phone,Is primêre telefoon
-apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,Stuur &#39;n e-pos na {0} om dit hier te skakel.
+apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,Stuur 'n e-pos na {0} om dit hier te skakel.
 DocType: Auto Email Report,Weekdays,weeksdae
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} records will be exported,{0} rekords sal uitgevoer word
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Titelveld moet &#39;n geldige veldnaam wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Titelveld moet 'n geldige veldnaam wees
 DocType: Post Comment,Post Comment,pos kommentaar
 apps/frappe/frappe/config/core.py,Documents,dokumente
 apps/frappe/frappe/config/users_and_permissions.py,Activity Log by ,Aktiwiteit Log deur
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sessie Vervaldatum i
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Hierdie veld sal slegs verskyn as die veldnaam wat hier gedefinieer is, waarde is OF die reëls is waar (voorbeelde): myfield eval: doc.myfield == &#39;My Value&#39; eval: doc.age> 18"
+eval:doc.age>18","Hierdie veld sal slegs verskyn as die veldnaam wat hier gedefinieer is, waarde is OF die reëls is waar (voorbeelde): myfield eval: doc.myfield == 'My Value' eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Kantoor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,vandag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Sodra u dit gestel het, sal die gebruikers slegs toegangsdokumente (bv. Blog Post) hê waar die skakel bestaan (bv. Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,HOOFLETTERS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Gepasmaakte HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Voer die naam van die gids in
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Geen standaard adres sjabloon gevind nie. Skep &#39;n nuwe een uit Opstel> Drukwerk en handelsmerk> Adresjabloon.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Geen standaard adres sjabloon gevind nie. Skep 'n nuwe een uit Opstel> Drukwerk en handelsmerk> Adresjabloon.
 apps/frappe/frappe/auth.py,Unknown User,Onbekende gebruiker
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Kies rol
 DocType: Comment,Deleted,geskrap
@@ -2147,16 +2147,16 @@ DocType: Data Migration Connector,Database Name,Databasis Naam
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Herlaai vorm
 DocType: DocField,Select,Kies
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Besigtig volledige logboek
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Eenvoudige Python-uitdrukking, voorbeeld: status == &#39;Open&#39; en tik == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Eenvoudige Python-uitdrukking, voorbeeld: status == 'Open' en tik == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Lêer nie aangeheg nie
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Konneksie verlore. Sommige funksies kan dalk nie werk nie.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Herhalings soos &quot;aaa&quot; is maklik om te raai
 apps/frappe/frappe/public/js/frappe/chat.js,New Chat,Nuwe klets
-DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","As u dit stel, sal hierdie item in &#39;n aftrekking onder die gekose ouer kom."
+DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","As u dit stel, sal hierdie item in 'n aftrekking onder die gekose ouer kom."
 DocType: Print Format,Show Section Headings,Wys afdelingopskrifte
 DocType: Bulk Update,Limit,limiet
-apps/frappe/frappe/templates/emails/delete_data_confirmation.html,We have received a request for deletion of {0} data associated with: {1},Ons het &#39;n versoek ontvang vir die verwydering van {0} data wat verband hou met: {1}
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Add a new section,Voeg &#39;n nuwe afdeling by
+apps/frappe/frappe/templates/emails/delete_data_confirmation.html,We have received a request for deletion of {0} data associated with: {1},Ons het 'n versoek ontvang vir die verwydering van {0} data wat verband hou met: {1}
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Add a new section,Voeg 'n nuwe afdeling by
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Filtered Records,Gefilterde rekords
 apps/frappe/frappe/www/printview.py,No template found at path: {0},Geen sjabloon gevind op pad nie: {0}
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Email Account,Geen e-pos rekening
@@ -2165,7 +2165,7 @@ DocType: Chat Room,Avatar,op die regte pad
 DocType: Blogger,Posts,poste
 DocType: Social Login Key,Salesforce,Verkoopspan
 DocType: DocType,Has Web View,Het Web View
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"DocType's name should start with a letter and it can only consist of letters, numbers, spaces and underscores","DocType se naam moet begin met &#39;n brief en dit kan slegs bestaan uit letters, syfers, spasies en onderstrepe"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"DocType's name should start with a letter and it can only consist of letters, numbers, spaces and underscores","DocType se naam moet begin met 'n brief en dit kan slegs bestaan uit letters, syfers, spasies en onderstrepe"
 DocType: Dashboard,Dashboard Name,Naam van die paneelbord
 apps/frappe/frappe/www/update-password.html,The password of your account has expired.,Die wagwoord van u rekening is verval.
 DocType: Communication,Spam,Gemorspos
@@ -2179,7 +2179,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,This featur
 apps/frappe/frappe/model/rename_doc.py,Maximum {0} rows allowed,Maksimum {0} rye toegelaat
 DocType: Dashboard Chart Link,Chart,grafiek
 DocType: Email Unsubscribe,Global Unsubscribe,Global Unsubscribe
-apps/frappe/frappe/utils/password_strength.py,This is a very common password.,Dit is &#39;n baie algemene wagwoord.
+apps/frappe/frappe/utils/password_strength.py,This is a very common password.,Dit is 'n baie algemene wagwoord.
 apps/frappe/frappe/email/doctype/email_group/email_group.js,View,Beskou
 DocType: Comment,Assigned,opgedra
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,Klik op <b>Google Drive Access</b> magtig om <b>Google Drive Access</b> te magtig.
@@ -2249,10 +2249,10 @@ apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Will be your login ID,
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.js,Global Search Document Types Reset.,Globale soekdokumenttipes word herstel.
 ,Lead Conversion Time,Lood Gesprek Tyd
 apps/frappe/frappe/desk/page/activity/activity.js,Build Report,Bou verslag
-DocType: Note,Notify users with a popup when they log in,Stel gebruikers in kennis met &#39;n opspring wanneer hulle inteken
+DocType: Note,Notify users with a popup when they log in,Stel gebruikers in kennis met 'n opspring wanneer hulle inteken
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Core Modules {0} cannot be searched in Global Search.,Kernmodules {0} kan nie in Global Search gesoek word nie.
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Open Chat,Maak klets oop
-apps/frappe/frappe/model/rename_doc.py,"{0} {1} does not exist, select a new target to merge","{0} {1} bestaan nie, kies &#39;n nuwe teiken om saam te voeg"
+apps/frappe/frappe/model/rename_doc.py,"{0} {1} does not exist, select a new target to merge","{0} {1} bestaan nie, kies 'n nuwe teiken om saam te voeg"
 DocType: Data Migration Connector,Python Module,Python Module
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Navigate Home,Navigeer tuis
 DocType: GSuite Settings,Google Credentials,Google-geloofsbriewe
@@ -2278,9 +2278,9 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Wys slegs foute
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Stuur E-pos Alert
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Kies asseblief &#39;n ander betaalmetode. Razorpay ondersteun nie transaksies in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Kies asseblief 'n ander betaalmetode. Razorpay ondersteun nie transaksies in valuta '{0}'
 DocType: Data Import,In Progress,In Progress
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Wag vir u rugsteun. Dit kan &#39;n paar minute duur.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Wag vir u rugsteun. Dit kan 'n paar minute duur.
 DocType: Error Snapshot,Pyver,Pyver
 apps/frappe/frappe/core/doctype/user_permission/user_permission.py,User permission already exists,Gebruikers toestemming bestaan reeds
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Mapping column {0} to field {1},Kolom {0} karteer na veld {1}
@@ -2324,7 +2324,7 @@ apps/frappe/frappe/public/js/frappe/form/print.js,With Letter head,Met briefhoof
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} created this {1},{0} het hierdie {1} geskep
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1} in Row {2}. Restricted field: {3},Nie toegelaat vir {0}: {1} in ry {2}. Beperkte veld: {3}
 DocType: S3 Backup Settings,eu-west-1,EU-wes-1
-DocType: Data Import,"If this is checked, rows with valid data will be imported and invalid rows will be dumped into a new file for you to import later.","As dit gekontroleer is, sal rye met geldige data ingevoer word en ongeldige rye sal in &#39;n nuwe lêer gedump word sodat u later kan invoer."
+DocType: Data Import,"If this is checked, rows with valid data will be imported and invalid rows will be dumped into a new file for you to import later.","As dit gekontroleer is, sal rye met geldige data ingevoer word en ongeldige rye sal in 'n nuwe lêer gedump word sodat u later kan invoer."
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Document is only editable by users of role,Dokument is slegs redigeerbaar deur gebruikers van rol
 apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed by {2}.","Die taak {0}, wat jy toegewys het aan {1}, is gesluit deur {2}."
 DocType: Print Format,Show Line Breaks after Sections,Toon lynbreuke na afdelings
@@ -2370,7 +2370,7 @@ DocType: Email Account,ProTip: Add <code>Reference: {{ reference_doctype }} {{ r
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Only users involved in the document are listed,"Slegs gebruikers wat by die dokument betrokke is, word gelys"
 DocType: DocField,Fetch From,Haal Van
 apps/frappe/frappe/modules/utils.py,App not found,Program nie gevind nie
-apps/frappe/frappe/core/doctype/communication/communication.py,Cannot create a {0} against a child document: {1},Kan nie &#39;n {0} teen &#39;n kinderdokument skep nie: {1}
+apps/frappe/frappe/core/doctype/communication/communication.py,Cannot create a {0} against a child document: {1},Kan nie 'n {0} teen 'n kinderdokument skep nie: {1}
 DocType: Social Login Key,Social Login Key,Sosiale aanmeld sleutel
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options {1} must be the same as doctype name {2} for the field {3},{0}: Opsies {1} moet dieselfde wees as die naam {2} vir die veld {3}
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Clear Cache and Reload,Maak die kas skoon en herlaai
@@ -2415,7 +2415,7 @@ DocType: Chat Message,Direct,direkte
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname {1} appears multiple times in rows {2},{0}: Veldnaam {1} verskyn verskeie kere in rye {2}
 DocType: Property Setter,Property Type,Eiendomsoort
 DocType: Workflow State,screenshot,kiekie
-apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,Slegs administrateur kan &#39;n standaardverslag stoor. Hersien en stoor asseblief.
+apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,Slegs administrateur kan 'n standaardverslag stoor. Hersien en stoor asseblief.
 DocType: System Settings,Background Workers,Agtergrondwerkers
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Veldnaam {0} strydig met meta-objek
 DocType: Deleted Document,Data,data
@@ -2441,7 +2441,7 @@ apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Hide Weekends,Ver
 apps/frappe/frappe/config/settings.py,Automatically generates recurring documents.,Genereer outomaties herhalende dokumente.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Is,is
 DocType: Workflow State,info-sign,Info-teken
-apps/frappe/frappe/model/base_document.py,Value for {0} cannot be a list,Waarde vir {0} kan nie &#39;n lys wees nie
+apps/frappe/frappe/model/base_document.py,Value for {0} cannot be a list,Waarde vir {0} kan nie 'n lys wees nie
 DocType: Currency,"How should this currency be formatted? If not set, will use system defaults","Hoe moet hierdie geldeenheid geformateer word? As dit nie ingestel is nie, sal die stelsel standaard gebruik word"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Submit {0} documents?,Dien {0} dokumente in
 apps/frappe/frappe/utils/response.py,You need to be logged in and have System Manager Role to be able to access backups.,Jy moet ingeteken wees en het die stelselbestuurderrol om back-ups te kan kry.
@@ -2462,7 +2462,7 @@ DocType: DocField,Geolocation,ligginggewing
 DocType: Workflow,Emails will be sent with next possible workflow actions,E-pos sal gestuur word met die volgende moontlike workflow-aksies
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Workflow will start after saving.,Werkstroom sal begin nadat jy gestoor is.
 DocType: S3 Backup Settings,ap-northeast-1,AP-noordoos-1
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Iets het verkeerd gegaan tydens die tekengenerasie. Klik op {0} om &#39;n nuwe een te genereer.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Iets het verkeerd gegaan tydens die tekengenerasie. Klik op {0} om 'n nuwe een te genereer.
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Share,Kan deel
 apps/frappe/frappe/email/smtp.py,Invalid recipient address,Ongeldige ontvanger adres
 DocType: Workflow State,step-forward,tree vorentoe
@@ -2479,7 +2479,7 @@ apps/frappe/frappe/email/queue.py,This email was sent to {0} and copied to {1},H
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document {0},het hierdie dokument {0} ingedien
 DocType: Workflow State,th,ste
 DocType: Social Login Key,Provider Name,Verskaffer Naam
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Create a new {0},Skep &#39;n nuwe {0}
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Create a new {0},Skep 'n nuwe {0}
 DocType: Contact,Google Contacts,Google Kontakte
 DocType: GCalendar Account,GCalendar Account,GCalendar-rekening
 DocType: Email Rule,Is Spam,Is Spam
@@ -2505,7 +2505,7 @@ DocType: Event,Google Calendar Event ID,Google Kalender-gebeurtenis-ID
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added",&quot;Ouer&quot; beteken die ouertafel waarin hierdie ry bygevoeg moet word
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,Hersieningspunte:
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,Gedeel met
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,Heg lêers / URL&#39;s aan en voeg in tabel by.
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,Heg lêers / URL's aan en voeg in tabel by.
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Message not setup,Boodskap nie opstelling nie
 DocType: Help Category,Help Articles,Hulpartikels
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Type:,tipe:
@@ -2537,7 +2537,7 @@ DocType: Personal Data Deletion Request,Pending Verification,Hangende verifikasi
 DocType: Website Meta Tag,Website Meta Tag,Meta-webwerf vir webwerf
 DocType: Email Account,"If non standard port (e.g. 587). If on Google Cloud, try port 2525.",As nie standaard poort (bv. 587). As jy in Google Cloud probeer poort 2525.
 apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.","Die skoonmaak van einddatum, aangesien dit nie in die verlede vir gepubliseerde bladsye kan wees nie."
-DocType: User,Send Me A Copy of Outgoing Emails,Stuur vir my &#39;n afskrif van uitgaande e-posse
+DocType: User,Send Me A Copy of Outgoing Emails,Stuur vir my 'n afskrif van uitgaande e-posse
 DocType: System Settings,Scheduler Last Event,Skeduler Laaste Event
 DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Voeg Google Analytics ID by: bv. UA-89XXX57-1. Soek asseblief hulp op Google Analytics vir meer inligting.
 apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,Wagwoord kan nie meer as 100 karakters lank wees nie
@@ -2604,15 +2604,15 @@ apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,S
 DocType: Email Flag Queue,Unread,ongelees
 DocType: Bulk Update,Desk,lessenaar
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping column {0},Slaan kolom oor {0}
-apps/frappe/frappe/utils/data.py,Filter must be a tuple or list (in a list),Filter moet &#39;n tupel of lys wees (in &#39;n lys)
-apps/frappe/frappe/core/doctype/report/report.js,Write a SELECT query. Note result is not paged (all data is sent in one go).,Skryf &#39;n SELECT navraag. Nota resultaat is nie geblaai (alle data word in een keer gestuur).
+apps/frappe/frappe/utils/data.py,Filter must be a tuple or list (in a list),Filter moet 'n tupel of lys wees (in 'n lys)
+apps/frappe/frappe/core/doctype/report/report.js,Write a SELECT query. Note result is not paged (all data is sent in one go).,Skryf 'n SELECT navraag. Nota resultaat is nie geblaai (alle data word in een keer gestuur).
 DocType: Email Account,Attachment Limit (MB),Aanhegsel Limiet (MB)
 DocType: Address,Arunachal Pradesh,Arunachal Pradesh
-DocType: DocType,Child Tables are shown as a Grid in other DocTypes,Kindertabelle word in ander DocTypes as &#39;n rooster getoon
+DocType: DocType,Child Tables are shown as a Grid in other DocTypes,Kindertabelle word in ander DocTypes as 'n rooster getoon
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Setup Auto Email,Opstel Auto E-pos
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Down,Ctrl + Down
 DocType: Chat Profile,Message Preview,Boodskap Voorskou
-apps/frappe/frappe/utils/password_strength.py,This is a top-10 common password.,Dit is &#39;n algemene 10-wagwoord.
+apps/frappe/frappe/utils/password_strength.py,This is a top-10 common password.,Dit is 'n algemene 10-wagwoord.
 DocType: User,User Defaults,Gebruikers standaard
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Core DocTypes cannot be customized.,Kern DocTypes kan nie aangepas word nie.
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Create New,Skep nuwe
@@ -2629,7 +2629,7 @@ apps/frappe/frappe/desk/doctype/note/note_list.js,Notes,notas
 DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),Beperk gebruiker slegs van hierdie IP-adres. Meerdere IP-adresse kan bygevoeg word deur met kommas te skei. Aanvaar ook gedeeltelike IP-adresse soos (111.111.111)
 DocType: Data Import Beta,Import Preview,Voer voorskou in
 DocType: Communication,From,Van
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.,Kies eers &#39;n groepskode.
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.,Kies eers 'n groepskode.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Find {0} in {1},Vind {0} in {1}
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No posts yet,Nog geen plasings nie
 DocType: OAuth Client,Implicit,implisiete
@@ -2656,13 +2656,13 @@ DocType: Data Import,Insert new records,Voeg nuwe rekords in
 apps/frappe/frappe/core/doctype/file/file.py,Unable to read file format for {0},Kan nie lêerformaat vir {0} lees nie.
 apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Slegs administrateurs mag die opnemer gebruik
 DocType: Auto Email Report,Filter Data,Filter data
-apps/frappe/frappe/public/js/frappe/form/controls/select.js,Please attach a file first.,Heg asseblief eers &#39;n lêer aan.
+apps/frappe/frappe/public/js/frappe/form/controls/select.js,Please attach a file first.,Heg asseblief eers 'n lêer aan.
 apps/frappe/frappe/templates/emails/download_data.html,Dear {0},Beste {0}
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 week,1 week
 apps/frappe/frappe/model/naming.py,"There were some errors setting the name, please contact the administrator","Daar was foute om die naam te stel, kontak asseblief die administrateur"
 apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email account not correct,Inkomende e-pos rekening is nie korrek nie
 apps/frappe/frappe/templates/includes/contact.js,"You seem to have written your name instead of your email. \
-				Please enter a valid email address so that we can get back.",Dit lyk asof jy jou naam in plaas van jou e-pos geskryf het. \ Voer asseblief &#39;n geldige epos adres in sodat ons kan terugkom.
+				Please enter a valid email address so that we can get back.",Dit lyk asof jy jou naam in plaas van jou e-pos geskryf het. \ Voer asseblief 'n geldige epos adres in sodat ons kan terugkom.
 DocType: Website Slideshow Item,Website Slideshow Item,Webwerf skyfie-item
 apps/frappe/frappe/model/workflow.py,Self approval is not allowed,Self-goedkeuring word nie toegelaat nie
 DocType: GSuite Templates,Template ID,Sjabloon ID
@@ -2700,11 +2700,11 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,wysiging
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal-betaling gateway instellings
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Top presteerder
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Pasgemaakte velde kan nie by die kern DocTypes gevoeg word nie.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) sal afgeknip word, aangesien maksimum karakters toegelaat word {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) sal afgeknip word, aangesien maksimum karakters toegelaat word {2}"
 DocType: OAuth Client,Response Type,Reaksie Tipe
 DocType: Contact Us Settings,Send enquiries to this email address,Stuur navrae na hierdie e-pos adres
 DocType: Letter Head,Letter Head Name,Letter Hoof Naam
-DocType: DocField,Number of columns for a field in a List View or a Grid (Total Columns should be less than 11),Aantal kolomme vir &#39;n veld in &#39;n lys of &#39;n rooster (totale kolomme moet minder as 11 wees)
+DocType: DocField,Number of columns for a field in a List View or a Grid (Total Columns should be less than 11),Aantal kolomme vir 'n veld in 'n lys of 'n rooster (totale kolomme moet minder as 11 wees)
 apps/frappe/frappe/config/website.py,User editable form on Website.,Gebruiker redigeerbare vorm op die webwerf.
 DocType: Workflow State,file,lêer
 apps/frappe/frappe/www/login.html,Back to Login,Terug na Inloggen
@@ -2715,7 +2715,7 @@ DocType: Email Account,Use ASCII encoding for password,Gebruik ASCII-enkodering 
 DocType: User,Karma,karma
 DocType: Report,Custom Report,Pasgemaakte verslag
 DocType: Dashboard Chart,Bar,bar
-apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Stel &#39;n drukkaart vir hierdie drukformaat in die drukkerinstellings in
+apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Stel 'n drukkaart vir hierdie drukformaat in die drukkerinstellings in
 DocType: DocField,Table,tafel
 DocType: File,File Size,Lêergrootte
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You must login to submit this form,Jy moet inloggen om hierdie vorm in te dien
@@ -2755,9 +2755,9 @@ DocType: Workflow,"Rules for how states are transitions, like next state and whi
 apps/frappe/frappe/desk/form/save.py,{0} {1} already exists,{0} {1} bestaan reeds
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be one of {0},Voeg by om een van {0} te wees
 DocType: Customize Form,Image View,Beeld vertoning
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Dit lyk of iets verkeerd gegaan het tydens die transaksie. Aangesien ons nie die betaling bevestig het nie, sal Paypal u outomaties hierdie bedrag terugbetaal. Indien nie, stuur vir ons &#39;n e-pos en meld die Korrelasie ID: {0}."
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Dit lyk of iets verkeerd gegaan het tydens die transaksie. Aangesien ons nie die betaling bevestig het nie, sal Paypal u outomaties hierdie bedrag terugbetaal. Indien nie, stuur vir ons 'n e-pos en meld die Korrelasie ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Sluit simbole, nommers en hoofletters in die wagwoord in"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Voeg na veld &#39;{0}&#39; in Aangepaste veld &#39;{1}&#39;, met die etiket &#39;{2}&#39;, nie bestaan nie"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Voeg na veld '{0}' in Aangepaste veld '{1}', met die etiket '{2}', nie bestaan nie"
 DocType: List Filter,List Filter,Lys filter
 DocType: Workflow State,signal,sein
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Het Aanhegsels
@@ -2767,7 +2767,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokument herstel
 DocType: Data Export,Data Export,Data Uitvoer
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Kies taal...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Jy kan nie &#39;Opsies&#39; vir veld {0} stel nie
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Jy kan nie 'Opsies' vir veld {0} stel nie
 DocType: Help Article,Author,skrywer
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Hervat stuur
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,heropen
@@ -2781,14 +2781,14 @@ DocType: Web Page,Slideshow,skyfievertoning
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Standaard adres sjabloon kan nie verwyder word nie
 DocType: Contact,Maintenance Manager,Onderhoudbestuurder
 DocType: Workflow State,Search,Soek
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Kies asseblief &#39;n ander betaalmetode. Stripe ondersteun nie transaksies in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Kies asseblief 'n ander betaalmetode. Stripe ondersteun nie transaksies in valuta '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Skuif na asblik
 DocType: Web Form,Web Form Fields,Web vorm velde
 DocType: Data Import,Amended From,Gewysig Van
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Waarskuwing: Kan nie {0} vind in enige tabel wat verband hou met {1}
 DocType: S3 Backup Settings,eu-north-1,EU-noord-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Hierdie dokument is tans in die ry vir uitvoering. Probeer asseblief weer
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Lêer &#39;{0}&#39; nie gevind nie
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Lêer '{0}' nie gevind nie
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Verwyder Afdeling
 DocType: User,Change Password,Verander wagwoord
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X-asveld
@@ -2797,7 +2797,7 @@ apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Hello!,Hello!
 apps/frappe/frappe/config/integrations.py,Braintree payment gateway settings,Braintree betaal gateway instellings
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Rebuild,herbou
 apps/frappe/frappe/www/third_party_apps.html,This will log out {0} from all other devices,Dit sal uit {0} uit alle ander toestelle afmeld
-apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Jy het nie toestemming om &#39;n verslag te kry nie: {0}
+apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Jy het nie toestemming om 'n verslag te kry nie: {0}
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Kalender - Kon nie die gebeurtenis in Google Kalender {0}, foutkode {1} invoeg nie."
 DocType: System Settings,Apply Strict User Permissions,Pas streng gebruiker toestemmings toe
 DocType: S3 Backup Settings,us-west-1,ons-wes-1
@@ -2825,7 +2825,7 @@ apps/frappe/frappe/templates/pages/integrations/payment-success.html,Payment Suc
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No {0} mail,Geen {0} pos
 DocType: OAuth Bearer Token,Revoked,herroep
 DocType: Web Page,Sidebar and Comments,Zijbalk en kommentaar
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Wanneer u &#39;n dokument verander na Kanselleer en dit stoor, sal dit &#39;n nuwe nommer kry wat &#39;n weergawe van die ou nommer is."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Wanneer u 'n dokument verander na Kanselleer en dit stoor, sal dit 'n nuwe nommer kry wat 'n weergawe van die ou nommer is."
 apps/frappe/frappe/email/doctype/notification/notification.py,"Not allowed to attach {0} document,
 				please enable Allow Print For {0} in Print Settings","Nie toegelaat om {0} -dokument aan te heg nie, aktiveer asseblief toelaat dat druk vir {0} in Drukinstellings toegelaat word"
 apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,See the document at {0},Sien die dokument by {0}
@@ -2846,7 +2846,7 @@ apps/frappe/frappe/model/naming.py,Name not set via Prompt,Naam nie ingestel via
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Email Inbox,Email Inbox
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Updating {0} of {1}, {2}","Dateer {0} van {1}, {2} op"
 DocType: Auto Email Report,Filters Display,Filters Wys
-apps/frappe/frappe/public/js/frappe/form/form.js,"""amended_from"" field must be present to do an amendment.",&#39;gewysigde_van&#39; -veld moet aanwesig wees om &#39;n wysiging te doen.
+apps/frappe/frappe/public/js/frappe/form/form.js,"""amended_from"" field must be present to do an amendment.",'gewysigde_van' -veld moet aanwesig wees om 'n wysiging te doen.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,{0} appreciated your work on {1} {2},{0} waardeer u werk op {1} {2}
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Save filters,Stoor filters
 DocType: Address,Plant,plant
@@ -2875,7 +2875,7 @@ apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Misc,misc
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Start new Format,Begin nuwe formaat
 DocType: Workflow State,font,font
 DocType: DocType,Show Preview Popup,Wys voorskou-opspringer
-apps/frappe/frappe/utils/password_strength.py,This is a top-100 common password.,Dit is &#39;n algemene 100 wagwoord.
+apps/frappe/frappe/utils/password_strength.py,This is a top-100 common password.,Dit is 'n algemene 100 wagwoord.
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Please enable pop-ups,Aktiveer pop-ups
 DocType: Contact,Mobile No,Mobiele nommer
 DocType: Communication,Text Content,Teksinhoud
@@ -2962,7 +2962,7 @@ apps/frappe/frappe/templates/emails/energy_points_summary.html,Points Given,Punt
 apps/frappe/frappe/config/website.py,Categorize blog posts.,Kategoriseer blogposte.
 DocType: Workflow State,Time,tyd
 DocType: DocField,Attach,heg
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{{{0}}} is not a valid fieldname pattern. It should be {{field_name}}.,{{{0}}} is nie &#39;n geldige veldnaampatroon nie. Dit moet {{field_name}} wees.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{{{0}}} is not a valid fieldname pattern. It should be {{field_name}}.,{{{0}}} is nie 'n geldige veldnaampatroon nie. Dit moet {{field_name}} wees.
 DocType: Custom Role,Permission Rules,Toestemming Reëls
 DocType: Braintree Settings,Public Key,Publieke sleutel
 DocType: GSuite Settings,GSuite Settings,GSuite instellings
@@ -2975,7 +2975,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Waarde ontbreek vir
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Voeg kind by
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Voer vordering in
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","As aan die voorwaarde voldoen is, sal die gebruiker met die punte beloon word. bv. doc.status == &#39;Gesloten&#39;"
+","As aan die voorwaarde voldoen is, sal die gebruiker met die punte beloon word. bv. doc.status == 'Gesloten'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Indiening van Rekord kan nie uitgevee word nie.
 DocType: GSuite Templates,Template Name,Sjabloon Naam
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nuwe tipe dokument
@@ -2989,7 +2989,7 @@ apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts by {0},Boodskapp
 apps/frappe/frappe/core/doctype/report/report.js,"To format columns, give column labels in the query.","Om kolomme te formateer, gee kolomletters in die navraag."
 DocType: Has Domain,Has Domain,Het Domein
 DocType: User,Allowed In Mentions,Toegelaat om in te noem
-apps/frappe/frappe/www/login.html,Don't have an account? Sign up,Het jy nie &#39;n rekening? Teken aan
+apps/frappe/frappe/www/login.html,Don't have an account? Sign up,Het jy nie 'n rekening? Teken aan
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Cannot remove ID field,Kan nie ID-veld verwyder nie
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Assign Amend if not Submittable,{0}: Kan nie Toewys Wys stel indien nie Submittable
 DocType: Address,Bihar,Bihar
@@ -3007,9 +3007,9 @@ apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,Du
 DocType: Chat Room User,Chat Room User,Kletskamergebruiker
 apps/frappe/frappe/model/workflow.py,Workflow State not set,Werkstroomstaat nie gestel nie
 DocType: Google Calendar,Authorize Google Calendar Access,Magtig toegang tot Google Kalender
-apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,"Die bladsy wat jy soek, word ontbreek. Dit kan wees omdat dit verskuif word of daar is &#39;n tik in die skakel."
+apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,"Die bladsy wat jy soek, word ontbreek. Dit kan wees omdat dit verskuif word of daar is 'n tik in die skakel."
 apps/frappe/frappe/www/404.html,Error Code: {0},Fout Kode: {0}
-DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Beskrywing vir aanbieding bladsy, in gewone teks, slegs &#39;n paar lyne. (maksimum 140 karakters)"
+DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Beskrywing vir aanbieding bladsy, in gewone teks, slegs 'n paar lyne. (maksimum 140 karakters)"
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} are mandatory fields,{0} is verpligte velde
 DocType: Workflow,Allow Self Approval,Laat selfgoedkeuring toe
 DocType: Event,Event Category,Gebeurtenis Kategorie
@@ -3052,7 +3052,7 @@ apps/frappe/frappe/public/js/frappe/ui/capture.js,Retake,terugneem
 apps/frappe/frappe/desk/query_report.py,Report {0} is disabled,Verslag {0} is gedeaktiveer
 DocType: Access Log,Core,Core
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Set Permissions,Stel toestemmings
-DocType: DocField,Set non-standard precision for a Float or Currency field,Stel nie-standaard presisie vir &#39;n Vlot- of Geldveld
+DocType: DocField,Set non-standard precision for a Float or Currency field,Stel nie-standaard presisie vir 'n Vlot- of Geldveld
 DocType: Email Account,Ignore attachments over this size,Ignoreer aanhangsels oor hierdie grootte
 apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move To,Trek na
 DocType: Address,Preferred Billing Address,Gewenste faktuuradres
@@ -3063,7 +3063,7 @@ apps/frappe/frappe/core/doctype/version/version_view.html,Values Changed,Waardes
 DocType: Workflow State,arrow-up,pyl-up
 DocType: Dynamic Link,Link Document Type,Koppel dokumenttipe
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for {0} table,Daar moet ten minste een ry vir die {0} tabel wees
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure Auto Repeat, enable ""Allow Auto Repeat"" from {0}.","Om outomatiese herhaling te konfigureer, skakel &#39;Laat outomatiese herhaling toe&#39; vanaf {0}."
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure Auto Repeat, enable ""Allow Auto Repeat"" from {0}.","Om outomatiese herhaling te konfigureer, skakel 'Laat outomatiese herhaling toe' vanaf {0}."
 DocType: OAuth Bearer Token,Expires In,Verval In
 DocType: DocField,Allow on Submit,Laat toe op Submit
 DocType: DocField,HTML,HTML
@@ -3076,7 +3076,7 @@ apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcomi
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Please enter values for App Access Key and App Secret Key,Voer asseblief waardes in vir die Toegangsleutel vir Toegang en App Geheime Sleutel
 DocType: Web Form,Accept Payment,Aanvaar betaling
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select list item,Kies lysitem
-apps/frappe/frappe/config/core.py,A log of request errors,&#39;N Teken van versoekfoute
+apps/frappe/frappe/config/core.py,A log of request errors,'N Teken van versoekfoute
 DocType: Report,Letter Head,Briefhoof
 DocType: DocType,Quick Entry,Vinnige toegang
 DocType: Web Form,Button Label,Knoppie
@@ -3107,7 +3107,7 @@ DocType: Dashboard Chart,Chart Type,Grafiek Tipe
 DocType: DocType,Auto Name,Outomatiese naam
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Vermy rye soos abc of 6543, aangesien dit maklik is om te raai"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Probeer asseblief weer
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL moet begin met &#39;http: //&#39; of &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL moet begin met 'http: //' of 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Opsie 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,wysig
@@ -3115,12 +3115,12 @@ DocType: Website Settings,Chat Operators,Chat Operateurs
 DocType: S3 Backup Settings,ca-central-1,ca-sentrale-1
 DocType: Contact Us Settings,Pincode,PIN-kode
 apps/frappe/frappe/core/doctype/data_import/importer.py,Please make sure that there are no empty columns in the file.,Maak asseblief seker dat daar nie leë kolomme in die lêer is nie.
-apps/frappe/frappe/config/settings.py,Tracks milestones on the lifecycle of a document if it undergoes multiple stages.,Volg mylpale in die lewensiklus van &#39;n dokument as dit verskeie fases ondergaan.
+apps/frappe/frappe/config/settings.py,Tracks milestones on the lifecycle of a document if it undergoes multiple stages.,Volg mylpale in die lewensiklus van 'n dokument as dit verskeie fases ondergaan.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Renamed files and replaced code in controllers, please check!","Bestuur hernoem en kode in kontroleerders vervang, kyk asb!"
-apps/frappe/frappe/utils/oauth.py,Please ensure that your profile has an email address,Maak asseblief seker dat u profiel &#39;n e-pos adres het
+apps/frappe/frappe/utils/oauth.py,Please ensure that your profile has an email address,Maak asseblief seker dat u profiel 'n e-pos adres het
 apps/frappe/frappe/public/js/frappe/model/create_new.js,You have unsaved changes in this form. Please save before you continue.,U het ongestoorde veranderinge in hierdie vorm. Slaan asseblief voor jy verder gaan.
 DocType: Address,Telangana,Telangana
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for {0} must be an option,Standaard vir {0} moet &#39;n opsie wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for {0} must be an option,Standaard vir {0} moet 'n opsie wees
 DocType: Tag Doc Category,Tag Doc Category,Tag Doc Kategorie
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Report with more than 10 columns looks better in Landscape mode.,Verslag met meer as 10 kolomme lyk beter in Landskapmodus.
 apps/frappe/frappe/database/database.py,Invalid field name: {0},Ongeldige veldnaam: {0}
@@ -3132,7 +3132,7 @@ apps/frappe/frappe/config/integrations.py,Google Services,Google Services
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Up,Ctrl + Up
 apps/frappe/frappe/utils/data.py,1 weeks ago,1 weke gelede
 DocType: Communication,Error,fout
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Please setup a message first,Stel asseblief eers &#39;n boodskap op
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Please setup a message first,Stel asseblief eers 'n boodskap op
 DocType: Auto Repeat,End Date,Einddatum
 DocType: Data Import,Ignore encoding errors,Ignoreer kodering foute
 DocType: Chat Profile,Notifications,Kennisgewings
@@ -3142,7 +3142,7 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enoug
 apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Jy het nie toestemming om toegang tot hierdie lêer te kry nie
 apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Stoor API-geheime:
 apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},Kan nie gekanselleerde dokument skakel nie: {0}
-apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,Kan nie &#39;n standaardverslag wysig nie. Dupliseer asseblief en skep &#39;n nuwe verslag
+apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,Kan nie 'n standaardverslag wysig nie. Dupliseer asseblief en skep 'n nuwe verslag
 apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Maatskappy is verpligtend, aangesien dit jou maatskappy se adres is"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,"For example: If you want to include the document ID, use {0}","Byvoorbeeld: As jy die dokument ID wil insluit, gebruik {0}"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Table Columns for {0},Kies Tabelkolomme vir {0}
@@ -3190,12 +3190,12 @@ DocType: Address,Shipping,Gestuur
 DocType: Workflow State,circle-arrow-down,sirkel-pyl-down
 apps/frappe/frappe/config/desk.py,Private and public Notes.,Privaat en openbare notas.
 DocType: DocField,Datetime,Datum Tyd
-apps/frappe/frappe/templates/includes/login/login.js,Not a valid user,Nie &#39;n geldige gebruiker nie
-apps/frappe/frappe/templates/includes/comments/comments.html,Please enter a valid email address.,Voer asseblief &#39;n geldige e-posadres in.
+apps/frappe/frappe/templates/includes/login/login.js,Not a valid user,Nie 'n geldige gebruiker nie
+apps/frappe/frappe/templates/includes/comments/comments.html,Please enter a valid email address.,Voer asseblief 'n geldige e-posadres in.
 apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Last refreshed,Laaste verfris
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,For Document Type,Vir dokumenttipe
 DocType: Workflow State,arrow-right,pyl-regs
-DocType: Workflow State,Workflow state represents the current state of a document.,Werkstroomstaat verteenwoordig die huidige toestand van &#39;n dokument.
+DocType: Workflow State,Workflow state represents the current state of a document.,Werkstroomstaat verteenwoordig die huidige toestand van 'n dokument.
 DocType: Letter Head,Letter Head Based On,Briefhoof gebaseer op
 apps/frappe/frappe/utils/oauth.py,Token is missing,Token ontbreek
 apps/frappe/frappe/www/update-password.html,Set Password,Stel wagwoord in
@@ -3225,7 +3225,7 @@ apps/frappe/frappe/model/document.py,Incorrect value in row {0}: {1} must be {2}
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Submitted Document cannot be converted back to draft. Transition row {0},"Dokument wat ingedien is, kan nie weer na konsep omgeskakel word nie. Oorgangsreël {0}"
 DocType: Assignment Rule,Assignment Days,Werksdae
 apps/frappe/frappe/desk/reportview.py,Deleting {0},Skrap {0}
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Select an existing format to edit or start a new format.,Kies &#39;n bestaande formaat om &#39;n nuwe formaat te wysig of te begin.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Select an existing format to edit or start a new format.,Kies 'n bestaande formaat om 'n nuwe formaat te wysig of te begin.
 DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,Omseil beperkte IP-adres tjek as twee faktore geaktiveer word
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Created Custom Field {0} in {1},Het aangepaste veld {0} in {1}
 DocType: System Settings,Time Zone,Tydsone
@@ -3254,7 +3254,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Left thi
 DocType: Print Format,Raw Printing,Rou drukwerk
 ,Background Jobs,Agtergrond Werk
 apps/frappe/frappe/public/js/frappe/form/print.js,Printer Settings,Drukkerinstellings
-apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py,Time series based on is required to create a dashboard chart,Tydreekse gebaseer is nodig om &#39;n paneelbordkaart te skep
+apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py,Time series based on is required to create a dashboard chart,Tydreekse gebaseer is nodig om 'n paneelbordkaart te skep
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Energy Points: ,Energiepunte:
 DocType: ToDo,ToDo,ToDo
 DocType: DocField,No Copy,Geen kopie
@@ -3293,7 +3293,7 @@ apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,Ry Statu
 DocType: S3 Backup Settings,sa-east-1,sa-oos-1
 DocType: Workflow Transition,Workflow Transition,Workflow Transition
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,{0} maande gelede
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Aangepaste velde kan slegs by &#39;n standaard DocType gevoeg word.
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Aangepaste velde kan slegs by 'n standaard DocType gevoeg word.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Created By,Gemaak deur
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Dropbox Setup
 DocType: Assignment Rule Day,Assignment Rule Day,Opdragreëldag
@@ -3332,21 +3332,21 @@ DocType: Energy Point Log,Criticism,kritiek
 DocType: Address,Tripura,Tripura
 DocType: About Us Settings,"""Company History""",&quot;Maatskappygeskiedenis&quot;
 apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Hierdie dokument is verander nadat die e-pos gestuur is.
-DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","As dit gemerk is, sal hierdie veld nie oorskryf word nie, gebaseer op haal uit as daar reeds &#39;n waarde bestaan."
+DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","As dit gemerk is, sal hierdie veld nie oorskryf word nie, gebaseer op haal uit as daar reeds 'n waarde bestaan."
 DocType: Access Log,Show Report,Wys verslag
 DocType: Address,Tamil Nadu,Tamil Nadu
 DocType: Email Rule,Email Rule,E-posreël
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with everyone,{0} het hierdie dokument met almal gedeel
 apps/frappe/frappe/desk/page/activity/activity_row.html,Commented on {0}: {1},Opmerkings oor {0}: {1}
-apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Looks like someone sent you to an incomplete URL. Please ask them to look into it.,Dit lyk of iemand jou na &#39;n onvolledige URL gestuur het. Vra hulle asseblief om dit te ondersoek.
+apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Looks like someone sent you to an incomplete URL. Please ask them to look into it.,Dit lyk of iemand jou na 'n onvolledige URL gestuur het. Vra hulle asseblief om dit te ondersoek.
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Your payment has been successfully registered.,Jou betaling is suksesvol geregistreer.
 DocType: Stripe Settings,Secret Key,Geheime Sleutel
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translate {0},Vertaal {0}
 DocType: Notification,Send alert if this field's value changes,Stuur wakker as die waarde van hierdie veld verander
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Tema kleure
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Kies &#39;n DocType om &#39;n nuwe formaat te maak
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Kies 'n DocType om 'n nuwe formaat te maak
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Gebruiker bestaan nie
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Ontvangers&#39; is nie gespesifiseer nie
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Ontvangers' is nie gespesifiseer nie
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,net nou
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,aansoek doen
 DocType: Footer Item,Policy,beleid
@@ -3394,13 +3394,13 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Aangepaste vertal
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,vordering
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,per rol
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Ontbrekende velde
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ongeldige veldnaam &#39;{0}&#39; in outoname
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Soek in &#39;n dokument tipe
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ongeldige veldnaam '{0}' in outoname
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Soek in 'n dokument tipe
 DocType: Custom DocPerm,Role and Level,Rol en Vlak
 DocType: File,Thumbnail URL,Duimnaelskets-URL
 apps/frappe/frappe/desk/moduleview.py,Custom Reports,Aangepaste verslae
 DocType: Website Script,Website Script,Webwerf skrif
-DocType: GSuite Settings,If you aren't using own publish Google Apps Script webapp you can use the default https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec ,"As jy nie &#39;n eie publiseer Google Apps Script-webapparaat gebruik nie, kan jy die standaard https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec gebruik"
+DocType: GSuite Settings,If you aren't using own publish Google Apps Script webapp you can use the default https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec ,"As jy nie 'n eie publiseer Google Apps Script-webapparaat gebruik nie, kan jy die standaard https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec gebruik"
 apps/frappe/frappe/config/settings.py,Customized HTML Templates for printing transactions.,Gepasmaakte HTML Templates vir druk transaksies.
 apps/frappe/frappe/public/js/frappe/form/print.js,Orientation,geaardheid
 DocType: Workflow,Is Active,Is aktief
@@ -3420,7 +3420,7 @@ apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! You are not permitt
 DocType: Workflow State,bell,klok
 DocType: LDAP Settings,LDAP Mobile Field,LDAP mobiele veld
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Share this document with,Deel hierdie dokument met
-apps/frappe/frappe/utils/nestedset.py,{0} {1} cannot be a leaf node as it has children,{0} {1} kan nie &#39;n blaar node wees nie aangesien dit kinders het
+apps/frappe/frappe/utils/nestedset.py,{0} {1} cannot be a leaf node as it has children,{0} {1} kan nie 'n blaar node wees nie aangesien dit kinders het
 DocType: Comment,Info,info
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Add Attachment,Voeg bylae by
 DocType: Data Migration Mapping,Sync,Sync
@@ -3476,18 +3476,18 @@ DocType: Notification,Send days before or after the reference date,Stuur dae voo
 DocType: User,Allow user to login only after this hour (0-24),Laat gebruiker toe om eers na hierdie uur in te teken (0-24)
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,"Assign one by one, in sequence",Ken een vir een in volgorde toe
 DocType: Integration Request,Subscription Notification,Inskrywing kennisgewing
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,or attach a,of heg &#39;n
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,or attach a,of heg 'n
 DocType: Auto Repeat,Start Date,Begindatum
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Value,waarde
 DocType: Dashboard Chart,Filters JSON,Filters JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Klik hier om te verifieer
 DocType: Email Account,Disable SMTP server authentication,Skakel SMTP-bedienerverifikasie uit
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Gekopieër na knipbord.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Voorspelbare vervangings soos &#39;@&#39; in plaas van &#39;a&#39; help nie baie nie.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Voorspelbare vervangings soos '@' in plaas van 'a' help nie baie nie.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Toegewys deur my
 apps/frappe/frappe/utils/data.py,Zero,zero
 DocType: Google Drive,Backup Folder ID,Rugsteunvouer-ID
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Nie in ontwikkelaar af! Stel in site_config.json of maak &#39;Custom&#39; DocType.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Nie in ontwikkelaar af! Stel in site_config.json of maak 'Custom' DocType.
 DocType: Workflow State,globe,wêreld
 DocType: System Settings,dd.mm.yyyy,dd.mm.jjjj
 DocType: Assignment Rule,Priority,prioriteit
@@ -3509,7 +3509,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the 
 DocType: Module Def,Module Name,Module Naam
 DocType: S3 Backup Settings,eu-west-3,EU-wes-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},Laai {0} van {1} op
-DocType: DocType,DocType is a Table / Form in the application.,DocType is &#39;n tabel / vorm in die aansoek.
+DocType: DocType,DocType is a Table / Form in the application.,DocType is 'n tabel / vorm in die aansoek.
 DocType: Social Login Key,Authorize URL,Gee URL aan
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Kalender - Kon nie die gebeurtenis in Google Kalender haal nie, foutkode {0}."
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failed,Die skep van outomatiese herhaling van dokumente kon nie
@@ -3536,7 +3536,7 @@ DocType: Notification,Reference Date,Verwysingsdatum
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP-opstelling met die OTP-app is nie voltooi nie. Kontak die administrateur.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Voer asseblief geldige mobiele nos in
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Sommige van die funksies sal dalk nie in u blaaier werk nie. Dateer asseblief u blaaier op na die nuutste weergawe.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Weet nie, vra &#39;help&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Weet nie, vra 'help'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},het hierdie dokument {0} gekanselleer
 DocType: DocType,Comments and Communications will be associated with this linked document,Kommentaar en kommunikasie sal geassosieer word met hierdie gekoppelde dokument
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
@@ -3561,11 +3561,11 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Save Report,St
 DocType: Webhook,on_cancel,on_cancel
 DocType: Social Login Key,API Endpoint Args,API Endpoint Args
 apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,Administrateur het toegang verkry op {0} op {1} via IP-adres {2}.
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid fieldname,Ouerveld moet &#39;n geldige veldnaam wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid fieldname,Ouerveld moet 'n geldige veldnaam wees
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Misluk tydens die verandering van intekening
 DocType: LDAP Settings,LDAP Group Field,LDAP-groepveld
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Gelykes
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Die opsie &#39;Dynamic Link&#39; tipe veld moet na &#39;n ander skakelveld verwys met opsies as &#39;DocType&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Die opsie 'Dynamic Link' tipe veld moet na 'n ander skakelveld verwys met opsies as 'DocType'
 DocType: About Us Settings,Team Members Heading,Span Lede Opskrif
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Ongeldige CSV-formaat
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Fout met verbinding met die QZ-lade-toepassing ... <br><br> Die QZ Tray-toepassing moet geïnstalleer en loop om die funksie Raw Print te gebruik. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Klik hier om QZ Tray af te laai en te installeer</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Klik hier vir meer inligting oor rou drukwerk</a> ."
@@ -3591,7 +3591,7 @@ DocType: Website Slideshow,Slideshow like display for the website,Skyfievertonin
 apps/frappe/frappe/config/settings.py,Setup Notifications based on various criteria.,Opstel Kennisgewings gebaseer op verskeie kriteria.
 DocType: Comment,Updated,Opgedateer
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Select Module,Kies Module
-apps/frappe/frappe/public/js/frappe/chat.js,Search or Create a New Chat,Soek of skep &#39;n nuwe klets
+apps/frappe/frappe/public/js/frappe/chat.js,Search or Create a New Chat,Soek of skep 'n nuwe klets
 apps/frappe/frappe/sessions.py,Cache Cleared,Cache skoon gemaak
 DocType: Auto Email Report,Dynamic Report Filters,Dinamiese verslagfilters
 DocType: Email Account,UIDVALIDITY,UIDVALIDITY
@@ -3631,7 +3631,7 @@ DocType: Web Page,Insert Code,Voeg kode in
 DocType: Data Migration Run,Current Mapping Type,Huidige Mapping Type
 DocType: ToDo,Low,lae
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,Jy kan dinamiese eienskappe van die dokument by gebruik van Jinja templating.
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,List a document type,Lys &#39;n dokumenttipe
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,List a document type,Lys 'n dokumenttipe
 DocType: Web Page,"Header, Breadcrumbs and Meta Tags","Kop, broodkrummels en metatags"
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"browse,","Snuffel,"
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,3 months,3 maande
@@ -3642,15 +3642,15 @@ apps/frappe/frappe/config/core.py,Errors in Background Events,Foute in agtergron
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,No of Columns,Aantal kolomme
 DocType: Workflow State,Calendar,kalender
 apps/frappe/frappe/client.py,No document found for given filters,Geen dokument vir gegewe filters gevind nie
-apps/frappe/frappe/config/website.py,A user who posts blogs.,&#39;N Gebruiker wat blogs plaas.
-apps/frappe/frappe/model/rename_doc.py,"Another {0} with name {1} exists, select another name","Nog {0} met die naam {1} bestaan, kies &#39;n ander naam"
+apps/frappe/frappe/config/website.py,A user who posts blogs.,'N Gebruiker wat blogs plaas.
+apps/frappe/frappe/model/rename_doc.py,"Another {0} with name {1} exists, select another name","Nog {0} met die naam {1} bestaan, kies 'n ander naam"
 DocType: DocType,Custom?,Custom?
 DocType: Website Settings,Website Theme Image,Webwerf Tema Beeld
 DocType: Workflow State,road,pad
 DocType: User,Timezone,Tydsone
 apps/frappe/frappe/public/js/frappe/model/model.js,Unable to load: {0},Kan nie laai nie: {0}
 apps/frappe/frappe/config/integrations.py,Backup,Ondersteuning
-apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py,Document type is required to create a dashboard chart,Dokumenttipe is nodig om &#39;n paneelbordkaart te skep
+apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py,Document type is required to create a dashboard chart,Dokumenttipe is nodig om 'n paneelbordkaart te skep
 DocType: DocField,Read Only,Lees net
 apps/frappe/frappe/email/doctype/email_group/email_group.js,New Newsletter,Nuwe Nuusbrief
 DocType: Energy Point Log,Energy Point Log,Energiepunt log
@@ -3658,7 +3658,7 @@ DocType: Print Settings,Send Print as PDF,Stuur Druk as PDF
 DocType: Web Form,Amount,bedrag
 DocType: Workflow Transition,Allowed,toegelaat
 DocType: Dashboard Chart,Chart Source,Grafiekbron
-apps/frappe/frappe/core/doctype/doctype/doctype.py,There can be only one Fold in a form,Daar kan net een vou in &#39;n vorm wees
+apps/frappe/frappe/core/doctype/doctype/doctype.py,There can be only one Fold in a form,Daar kan net een vou in 'n vorm wees
 apps/frappe/frappe/core/doctype/file/file.py,Unable to write file format for {0},Kan nie lêerformaat skryf vir {0}
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py,No records present in {0},Geen rekords teenwoordig in {0}
 apps/frappe/frappe/website/doctype/portal_settings/portal_settings.js,Restore to default settings?,Herstel na verstekinstellings?
@@ -3677,7 +3677,7 @@ apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Confirm Your Email,Bev
 apps/frappe/frappe/www/login.html,Or login with,Of log in met
 DocType: Error Snapshot,Locals,locals
 apps/frappe/frappe/desk/page/activity/activity_row.html,Communicated via {0} on {1}: {2},Kommunikeer via {0} op {1}: {2}
-apps/frappe/frappe/core/doctype/comment/comment.py,{0} mentioned you in a comment in {1},{0} het jou genoem in &#39;n opmerking in {1}
+apps/frappe/frappe/core/doctype/comment/comment.py,{0} mentioned you in a comment in {1},{0} het jou genoem in 'n opmerking in {1}
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.html,Select Group By...,Kies groep volgens ...
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,e.g. (55 + 434) / 4 or =Math.sin(Math.PI/2)...,bv. (55 + 434) / 4 of = Math.sin (Math.PI / 2) ...
 apps/frappe/frappe/utils/csvutils.py,{0} is required,{0} is nodig
@@ -3695,7 +3695,7 @@ DocType: Web Page,Web Page,Webblad
 DocType: Workflow Document State,Next Action Email Template,Volgende Aksie E-pos Sjabloon
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","As dit geaktiveer is, word veranderinge aan die dokument nagespoor en in die tydlyn vertoon"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;In Global Search&#39; word nie toegelaat vir tipe {0} in ry {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'In Global Search' word nie toegelaat vir tipe {0} in ry {1}
 DocType: Energy Point Log,Appreciation,waardering
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Kyk lys
 DocType: Workflow,Don't Override Status,Moenie die status oorheers nie
@@ -3708,7 +3708,7 @@ DocType: Prepared Report,Report Start Time,Rapporteer begin tyd
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Data,Uitvoer data
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select Columns,Kies Kolomme
 DocType: Translation,Source Text,Bron teks
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,This is a background report. Please set the appropriate filters and then generate a new one.,Dit is &#39;n agtergrondverslag. Stel die toepaslike filters in en genereer dan &#39;n nuwe.
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,This is a background report. Please set the appropriate filters and then generate a new one.,Dit is 'n agtergrondverslag. Stel die toepaslike filters in en genereer dan 'n nuwe.
 apps/frappe/frappe/www/login.py,Missing parameters for login,Ontbrekende parameters vir aanmelding
 DocType: Workflow State,folder-open,gids oop
 DocType: DocType,"Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended.","Sodra dit ingedien is, kan dokumente wat ingedien word nie verander word nie. Dit kan slegs gekanselleer en gewysig word."
@@ -3722,14 +3722,14 @@ apps/frappe/frappe/public/js/frappe/views/treeview.js,Creating {0},Skep {0}
 DocType: Report,Disable Prepared Report,Deaktiveer voorbereide verslag
 apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,Gebruiker {0} het versoek om data te verwyder
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,Onwettige toegangspunt. Probeer asseblief weer
-apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","Die aansoek is opgedateer na &#39;n nuwe weergawe, verfris asseblief hierdie bladsy"
+apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","Die aansoek is opgedateer na 'n nuwe weergawe, verfris asseblief hierdie bladsy"
 DocType: Notification,Optional: The alert will be sent if this expression is true,Opsioneel: Die waarskuwing sal gestuur word as hierdie uitdrukking waar is
 DocType: Data Migration Plan,Plan Name,Plan Naam
 DocType: Print Settings,Print with letterhead,Druk met briefhoof
-apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,Attach a web link,Heg &#39;n webskakel aan
+apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,Attach a web link,Heg 'n webskakel aan
 DocType: Unhandled Email,Raw Email,Rou e-pos
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select records for assignment,Kies rekords vir opdrag
-apps/frappe/frappe/www/printview.py,{0} is not a raw printing format.,{0} is nie &#39;n rou drukformaat nie.
+apps/frappe/frappe/www/printview.py,{0} is not a raw printing format.,{0} is nie 'n rou drukformaat nie.
 DocType: ToDo,Assigned By,Toegewys deur
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,You can use Customize Form to set levels on fields.,U kan vorm gebruik om vlakke op velde te stel.
 DocType: Dashboard Chart Source,Timeseries,Tyd reeks
@@ -3747,7 +3747,7 @@ apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be renamed,Gebruike
 apps/frappe/frappe/database/schema.py,Fieldname is limited to 64 characters ({0}),Veldnaam is beperk tot 64 karakters ({0})
 apps/frappe/frappe/public/js/frappe/form/grid_row.js,Cannot move row,Kan ry nie skuif nie
 apps/frappe/frappe/config/desk.py,Email Group List,E-posgroeplys
-DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],&#39;N ikoonlêer met .ico uitbreiding. Moet 16 x 16 px wees. Genereer met behulp van &#39;n favicon generator. [Favicon-generator.org]
+DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],'N ikoonlêer met .ico uitbreiding. Moet 16 x 16 px wees. Genereer met behulp van 'n favicon generator. [Favicon-generator.org]
 DocType: Auto Email Report,Format,formaat
 DocType: Email Account,Email Addresses,E-posadresse
 DocType: Web Form,Allow saving if mandatory fields are not filled,Laat spaar toe indien verpligte velde nie gevul word nie
@@ -3783,7 +3783,7 @@ apps/frappe/frappe/integrations/utils.py,Looks like something is wrong with this
 DocType: GCalendar Settings,State,staat
 DocType: Workflow Action,Workflow Action,Workflow Action
 apps/frappe/frappe/utils/bot.py,I found these: ,Ek het dit gevind:
-DocType: Event,Send an email reminder in the morning,Stuur &#39;n e-pos herinnering in die oggend
+DocType: Event,Send an email reminder in the morning,Stuur 'n e-pos herinnering in die oggend
 DocType: Blog Post,Published On,Gepubliseer op
 DocType: Contact,Gender,geslag
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Mandatory Information missing:,Verpligte inligting ontbreek:
@@ -3798,7 +3798,7 @@ DocType: Event,Repeat On,Herhaal On
 DocType: SMS Parameter,SMS Parameter,SMS Parameter
 DocType: Auto Email Report,Half Yearly,Half jaarliks
 DocType: Communication,Marked As Spam,Gemerk as spam
-apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},Daar is &#39;n probleem met die lêer url: {0}
+apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},Daar is 'n probleem met die lêer url: {0}
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Tree,Boom
 apps/frappe/frappe/public/js/frappe/views/treeview.js,You are not allowed to print this report,U mag nie hierdie verslag druk nie
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions,Gebruikers toestemmings
@@ -3815,7 +3815,7 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,More...,Meer ...
 DocType: System Settings,User can login using Email id or Mobile number,Gebruiker kan inskakel met e-pos of mobiele nommer
 DocType: Bulk Update,Update Value,Werkwaarde
 apps/frappe/frappe/core/doctype/communication/communication.js,Mark as {0},Merk as {0}
-apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,Kies asseblief &#39;n nuwe naam om te hernoem
+apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,Kies asseblief 'n nuwe naam om te hernoem
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Invalid column,Ongeldige kolom
 DocType: Data Migration Connector,Data Migration,Data Migrasie
 DocType: User,API Key cannot be  regenerated,API sleutel kan nie regenereer word nie
@@ -3842,7 +3842,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,verstek
 DocType: Translation,Verified,geverifieer
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} bygevoeg
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Soek vir &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Soek vir '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Slaan asseblief eers die verslag op
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} intekenaars bygevoeg
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Nie in nie
@@ -3851,7 +3851,7 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Hub,Hub
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,values separated by commas,waardes geskei deur kommas
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Max width for type Currency is 100px in row {0},Maksimum breedte vir tipe Geld is 100px in ry {0}
 apps/frappe/frappe/config/website.py,Content web page.,Inhoud webblad.
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Add a New Role,Voeg &#39;n nuwe rol by
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Add a New Role,Voeg 'n nuwe rol by
 DocType: Google Contacts,Last Sync On,Laaste sinchroniseer op
 DocType: Deleted Document,Deleted Document,Dokument verwyder
 apps/frappe/frappe/templates/includes/login/login.js,Oops! Something went wrong,Oeps! Iets het verkeerd geloop
@@ -3875,17 +3875,17 @@ DocType: User,"If enabled,  user can login from any IP Address using Two Factor 
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Printer Settings...,Drukkerinstellings ...
 apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Voer asseblief u wagwoord in om voort te gaan
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,my
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} nie &#39;n geldige staat nie
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} nie 'n geldige staat nie
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Van toepassing op alle soorte dokumente
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Energiepuntopdatering
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Kies asseblief &#39;n ander betaalmetode. PayPal ondersteun nie transaksies in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Kies asseblief 'n ander betaalmetode. PayPal ondersteun nie transaksies in valuta '{0}'
 DocType: Chat Message,Room Type,Kamer tipe
 DocType: Data Import Beta,Import Log Preview,Voer logvoorskou in
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Soekveld {0} is nie geldig nie
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,opgelaaide lêer
 DocType: Workflow State,ok-circle,ok-sirkel
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP Gebruikerskepping en Kartering
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Jy kan dinge vind deur te vra om &#39;oranje in kliënte te vind&#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Jy kan dinge vind deur te vra om 'oranje in kliënte te vind'
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Jammer! Gebruiker moet volledige toegang tot hul eie rekord hê.
 ,Usage Info,Gebruik Info
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Wys sleutelbordkortpaaie
@@ -3935,7 +3935,7 @@ DocType: Portal Settings,Custom Menu Items,Aangepaste menu-items
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,"Alle prente wat aan die webwerf skyfie geheg is, moet publiek wees"
 DocType: Workflow State,chevron-right,Chevron-reg
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,"To use Google Drive, enable {0}.",Aktiveer {0} om Google Drive te gebruik.
-apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be in developer mode to edit a Standard Web Form,Jy moet in die ontwikkelaar af wees om &#39;n Standaard Webvorm te wysig
+apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be in developer mode to edit a Standard Web Form,Jy moet in die ontwikkelaar af wees om 'n Standaard Webvorm te wysig
 DocType: Personal Data Deletion Request,Personal Data Deletion Request,Persoonlike gegewensversoek
 DocType: Payment Gateway,Gateway Controller,Gateway Controller
 apps/frappe/frappe/core/doctype/session_default_settings/session_default_settings.py,Default {0},Verstek {0}
@@ -3959,7 +3959,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export Report: 
 DocType: Auto Email Report,Filter Meta,Filter Meta
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please find attached {0}: {1},Vind aangeheg {0}: {1}
 DocType: Web Page,Set Meta Tags,Stel metatags
-DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,Teks wat vir Link na webbladsy vertoon moet word as hierdie vorm &#39;n webblad het. Skakelroete sal outomaties gegenereer word gebaseer op `page_name` en` parent_website_route`
+DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,Teks wat vir Link na webbladsy vertoon moet word as hierdie vorm 'n webblad het. Skakelroete sal outomaties gegenereer word gebaseer op `page_name` en` parent_website_route`
 DocType: S3 Backup Settings,Backup Limit,Rugsteunlimiet
 DocType: Dashboard Chart,Line,lyn
 DocType: Unhandled Email,Message-id,Boodskap-ID
@@ -3983,7 +3983,7 @@ apps/frappe/frappe/permissions.py,Document Type is not submittable,Dokumenttipe 
 DocType: OAuth Client,Skip Authorization,Slaan Magtiging oor
 DocType: Web Form,Amount Field,Bedrag Veld
 DocType: Dropbox Settings,Send Notifications To,Stuur kennisgewings aan
-DocType: Bulk Update,Max 500 records at a time,Maksimum 500 rekords op &#39;n slag
+DocType: Bulk Update,Max 500 records at a time,Maksimum 500 rekords op 'n slag
 DocType: Translation,"If your data is in HTML, please copy paste the exact HTML code with the tags.","As u data in HTML is, kopieer asseblief die presiese HTML-kode met die etikette."
 DocType: Communication,Meeting,Ontmoet
 apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,Kan nie aangehegte lêer oopmaak nie. Het jy dit as CSV uitgevoer?

--- a/frappe/translations/am.csv
+++ b/frappe/translations/am.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,ወላጅ
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},ከሚከተለው ጋር የተዛመደውን {0} ውሂብዎን ለማውረድ ከእርስዎ ጥያቄ ደርሶናል-{1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","የነቃ ከሆነ, የይለፍ ቃል ጥንካሬ ዝቅተኛ የይለፍ ውጤት ዋጋ ላይ ተመስርቶ ተፈጻሚ ይሆናል. 2 አንድ እሴት በመካከለኛ ጠንካራ መሆን እና 4 በጣም ጠንካራ መሆን."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;ቡድን አባላት&quot; ወይም &quot;አስተዳደር&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',መስክ ላይ &#39;ይመልከቱ »አይነት ነባሪ ወይ&#39; 0 &#39;ወይም&#39; 1 &#39;መሆን አለበት
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',መስክ ላይ 'ይመልከቱ »አይነት ነባሪ ወይ' 0 'ወይም' 1 'መሆን አለበት
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,ትናንትና
 DocType: Contact,Designation,ስያሜ
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,ራስ-ሰር መያያዝ ለአንድ ኢሜይል መለያ ብቻ ሊነቃ ይችላል።
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,አሰናክል 
 DocType: Translation,Contributed Translation Doctype Name,የተበረዘ ትርጉም የትርጉም ስም።
 DocType: PayPal Settings,Redirect To,ወደ አቅጣጫ አዙር
 DocType: Data Migration Mapping,Pull,ይጎትቱ
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},ጃቫስክሪፕት ቅርጸት: frappe.query_reports [ &#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},ጃቫስክሪፕት ቅርጸት: frappe.query_reports [ 'REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,የጅምላ ዝማኔ
 DocType: Workflow State,chevron-up,ሸቭሮን-ምትኬ
 DocType: DocType,Allow Guest to View,እንግዳ ይመልከቱ ፍቀድ
@@ -705,7 +705,7 @@ DocType: Slack Webhook URL,Webhook URL,የድርhook ዩአርኤል
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,የተጠቃሚ ስም {0} አስቀድሞ አለ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} importable አይደለም እንደ ከውጪ ማዘጋጀት አይቻልም
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},ከእርስዎ አድራሻ መለጠፊያ ውስጥ አንድ ስህተት አለ {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} በ &#39;ተቀባዮች&#39; ውስጥ ልክ ያልሆነ የኢሜይል አድራሻ ነው.
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} በ 'ተቀባዮች' ውስጥ ልክ ያልሆነ የኢሜይል አድራሻ ነው.
 DocType: Footer Item,"target = ""_blank""",target = &quot;ባዶን&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,አስተናጋጅ
@@ -747,7 +747,7 @@ DocType: Currency,Currency Name,የምንዛሬ ስም
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ምንም ኢሜይሎች
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,አገናኝ ጊዜ አልፎበታል
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",ርዝመቱን ወደ {0} በ <{2}> ውስጥ ለ &#39;{1}&#39; በማድህር ላይ; ርዝመቱን እንደ {3} ማስተካከል የውሂብ መሰንጠቅን ያስከትላል.
+							Setting the length as {3} will cause truncation of data.",ርዝመቱን ወደ {0} በ <{2}> ውስጥ ለ '{1}' በማድህር ላይ; ርዝመቱን እንደ {3} ማስተካከል የውሂብ መሰንጠቅን ያስከትላል.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,የፋይል ቅርጸት ይምረጡ
 DocType: Report,Javascript,ጃቫስክሪፕት
 DocType: File,Content Hash,የይዘት Hash
@@ -762,7 +762,7 @@ apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","መደበኛ DocType አብጅ ቅጽ መጠቀም, ነባሪ ህትመት ቅርጸት ሊኖረው አይችልም"
 DocType: Report,Query,ጥያቄ
 DocType: Customize Form,Sort Order,የድርድር ቅደም ተከተል
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;ዝርዝር ይመልከቱ ውስጥ&#39; ረድፍ ውስጥ አይነት {0} አይፈቀድም {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'ዝርዝር ይመልከቱ ውስጥ' ረድፍ ውስጥ አይነት {0} አይፈቀድም {1}
 DocType: Letter Head,Footer HTML,ግርጌ HTML።
 DocType: Custom Field,Select the label after which you want to insert new field.,አዲስ መስክ ማስገባት ይፈልጋሉ በኋላ ያለውን መለያ ይምረጡ.
 ,Document Share Report,የሰነድ አጋራ ሪፖርት
@@ -1053,7 +1053,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,ገጽ ኤችቲኤምኤል
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,የተሳሳቱ ረድፎችን ይላኩ
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,የቡድን ስም ባዶ ሊሆን አይችልም.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,ተጨማሪ መስቀለኛ ብቻ &#39;ቡድን&#39; አይነት አንጓዎች ስር ሊፈጠር ይችላል
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,ተጨማሪ መስቀለኛ ብቻ 'ቡድን' አይነት አንጓዎች ስር ሊፈጠር ይችላል
 DocType: SMS Parameter,Header,የራስጌ
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},ያልታወቀ አምድ: {0}
 DocType: Notification Recipient,Email By Role,ሚና በ ኢሜይል
@@ -1440,7 +1440,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,አስገዳጅ መስክ: ተቀናብሯል ሚና
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} ነቀፋ {1}
 DocType: Data Migration Mapping,Mapping Name,የካርታ ስም
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: መስክ &#39;{1}&#39; ልዩ ያልሆኑ እሴቶች ስላሉት እንደ ልዩ ሊዋቀር አይችልም።
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: መስክ '{1}' ልዩ ያልሆኑ እሴቶች ስላሉት እንደ ልዩ ሊዋቀር አይችልም።
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,ዝርዝርን ወደታች ያስሱ።
 DocType: Currency,A symbol for this currency. For e.g. $,ለዚህ ምንዛሬ ያመለክታል. ለምሳሌ $ ለ
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,ትርጉሞችን በተሳካ ሁኔታ ዘምኗል
@@ -1959,7 +1959,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-ደቡብ-ምስራቅ -1
 DocType: DocType,"Must be of type ""Attach Image""",&quot;ምስል አያይዝ&quot; አይነት መሆን አለበት
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,ሁሉንም አትምረጥ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},እርስዎ መስክ እንዳልተዋቀረ አይደለም &#39;ብቻ አንብብ&#39; ይችላሉ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},እርስዎ መስክ እንዳልተዋቀረ አይደለም 'ብቻ አንብብ' ይችላሉ {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,ዜሮ በማንኛውም ጊዜ የዘመነ መዛግብት መላክ ማለት ነው
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,ተጠናቋል
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,በተሳካ ሁኔታ ዘምኗል ፡፡
@@ -2002,7 +2002,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,ጉግል ፎክስ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","ጠቃሚ አይደለም, የፊልሙ ጉዳዮች ላይ ጥቆማዎች ላይ ለማከል እባክዎ የት እነዚህን መመሪያዎች ከሆነ."
 DocType: Workflow State,bookmark,ዕልባት
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),የአቃፊ ስም ማካተት የለበትም &#39;/&#39; (ሠረዝ)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),የአቃፊ ስም ማካተት የለበትም '/' (ሠረዝ)
 DocType: Note,Note,ማስታወሻ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,ስህተት ሪፖርት አድርግ
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,ውሂብ በ CSV / Excel ቅርጸት ወደ ውጭ ላክ.
@@ -2106,7 +2106,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ሰዓቶች ለም�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",እዚህ ላይ በተገለጸው fieldname እሴት አለው ወይም ደንብ እውነተኛ (ምሳሌዎች) ናቸው ብቻ ከሆነ ይህ መስክ ይታያል: myfield ኢቫል: doc.myfield == &#39;የእኔ እሴት »ኢቫል: doc.age> 18
+eval:doc.age>18",እዚህ ላይ በተገለጸው fieldname እሴት አለው ወይም ደንብ እውነተኛ (ምሳሌዎች) ናቸው ብቻ ከሆነ ይህ መስክ ይታያል: myfield ኢቫል: doc.myfield == 'የእኔ እሴት »ኢቫል: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ዛሬ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","ይህን ካዋቀሩት በኋላ, ተጠቃሚዎች ብቻ ነው የሚችል መዳረሻ ሰነዶችን ይሆናል (ለምሳሌ. ልጥፍ ብሎግ) አገናኝ (ለምሳሌ. ብሎገር) አለ ቦታ."
@@ -2145,7 +2145,7 @@ DocType: Data Migration Connector,Database Name,የውሂብ ጎታ ስም
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,አድስ ቅጽ
 DocType: DocField,Select,ይምረጡ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,ሙሉ ምዝግብ ማስታወሻን ይመልከቱ።
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",ቀላል የ Python መግለጫ ፣ ምሳሌ-ሁኔታ == &#39;ክፍት&#39; እና type == &#39;ሳንካ&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",ቀላል የ Python መግለጫ ፣ ምሳሌ-ሁኔታ == 'ክፍት' እና type == 'ሳንካ'
 apps/frappe/frappe/utils/csvutils.py,File not attached,ፋይል አልተያያዘም
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,ግንኙነት ጠፍቷል. አንዳንድ ባህሪያት ላይሰሩ ይችላሉ.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; እንደ ይደግማል ለመገመት ቀላል ናቸው
@@ -2785,7 +2785,7 @@ DocType: Data Import,Amended From,ከ እንደተሻሻለው
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},ማስጠንቀቂያ: አልተቻለም ለማግኘት ወደ {0} ጋር የሚዛመድ ማንኛውም ሰንጠረዥ ውስጥ {1}
 DocType: S3 Backup Settings,eu-north-1,ኢዩ-ሰሜን -1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,ይህ ሰነድ በአሁኑ ጊዜ እንዲገደል ወረፋ ነው. እባክዎ ዳግም ይሞክሩ
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ፋይል «{0} &#39;አልተገኘም
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ፋይል «{0} 'አልተገኘም
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,ክፍል አስወግድ
 DocType: User,Change Password,የሚስጥር ቁልፍ ይቀይሩ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X የግራ መስክ
@@ -2972,7 +2972,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,እሴት ጠፍቷ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,የልጅ አክል
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,ሂደት አስመጣ።
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",ሁኔታው ተሟልቶ ከሆነ ተጠቃሚው ነጥቦቹን ይሸልማል። ለምሳሌ doc.status == &#39;ዝግ&#39;
+",ሁኔታው ተሟልቶ ከሆነ ተጠቃሚው ነጥቦቹን ይሸልማል። ለምሳሌ doc.status == 'ዝግ'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: ገብቷል ቅረጽ ሊሰረዝ አይችልም.
 DocType: GSuite Templates,Template Name,የአብነት ስም
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ሰነድ አዲስ አይነት
@@ -3103,7 +3103,7 @@ DocType: Dashboard Chart,Chart Type,የገበታ አይነት
 DocType: DocType,Auto Name,ራስ-ስም
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,እነርሱ ለመገመት ቀላል ናቸው እንደ ኤቢሲ ወይም 6543 ያሉ ተከታታይ ራቅ
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,እባክዎ ዳግም ይሞክሩ
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL በ ‹http: // &#39;ወይም&#39; https: // &#39;መጀመር አለበት
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL በ ‹http: // 'ወይም' https: // 'መጀመር አለበት
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,አማራጭ 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,አርትዕ
@@ -3342,7 +3342,7 @@ DocType: Notification,Send alert if this field's value changes,በዚህ መስ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,ጭብጥ ቀለሞች
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,አዲስ ቅርጸት ለማድረግ አንድ DocType ይምረጡ
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,ተጠቃሚው የለም።
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;ተቀባዮች&#39; አልተገለፀም
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'ተቀባዮች' አልተገለፀም
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,ልክ አሁን
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,ተግብር
 DocType: Footer Item,Policy,ፖሊሲ
@@ -3479,11 +3479,11 @@ DocType: Dashboard Chart,Filters JSON,JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,ለማረጋገጥ እዚህ ላይ ጠቅ ያድርጉ
 DocType: Email Account,Disable SMTP server authentication,የ SMTP አገልጋይ ማረጋገጫ አሰናክል።
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,ወደ ቅንጥብ ሰሌዳ ተቀድቷል።
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ሊገመት እንደ ተለዋጭ ምግብ &#39;@&#39; ይልቅ &#39;አንድ&#39; በጣም ብዙ መርዳት አይደለም.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ሊገመት እንደ ተለዋጭ ምግብ '@' ይልቅ 'አንድ' በጣም ብዙ መርዳት አይደለም.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,እኔ በ የተመደበው
 apps/frappe/frappe/utils/data.py,Zero,ዜሮ
 DocType: Google Drive,Backup Folder ID,ምትኬ አቃፊ መታወቂያ።
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,አይደለም የገንቢ ሁነታ ላይ! site_config.json ውስጥ አዘጋጅ ወይም &#39;ብጁ&#39; DocType ማድረግ.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,አይደለም የገንቢ ሁነታ ላይ! site_config.json ውስጥ አዘጋጅ ወይም 'ብጁ' DocType ማድረግ.
 DocType: Workflow State,globe,ክበብ ምድር
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,ቅድሚያ
@@ -3531,7 +3531,7 @@ DocType: Notification,Reference Date,የማጣቀሻ ቀን
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP መተግበሪያን በመጠቀም የ OTP ማቀናበር አልተጠናቀቀም። እባክዎ አስተዳዳሪውን ያነጋግሩ።
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,የሚሰራ የተንቀሳቃሽ ስልክ ቁጥሮች ያስገቡ
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,ባህሪያት ውስጥ አንዳንዶቹ በአሳሽዎ ላይ ላይሰራ ይችላል. ወደ የቅርብ ጊዜው ስሪት አሳሽዎን ያዘምኑ.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","መጠየቅ, አታውቁምን &#39;እርዳታ&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","መጠየቅ, አታውቁምን 'እርዳታ'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ይህ ሰነድ ተትቷል {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,አስተያየቶች እና የግንኙነት በዚህ የተገናኝ ሰነድ ጋር የተያያዘ ይሆናል
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,አጣራ ...
@@ -3560,7 +3560,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,የደንበኝነት ምዝገባን በማሻሻል ላይ አልተሳካም
 DocType: LDAP Settings,LDAP Group Field,LDAP ቡድን መስክ ፡፡
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,እኩል
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',የሜዳ አማራጮች &#39;ተለዋዋጭ አገናኝ&#39; አይነት &#39;DocType&#39; እንደ አማራጮች ጋር ሌላ አገናኝ መስክ ላይ መጥቀስ አለባቸው
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',የሜዳ አማራጮች 'ተለዋዋጭ አገናኝ' አይነት 'DocType' እንደ አማራጮች ጋር ሌላ አገናኝ መስክ ላይ መጥቀስ አለባቸው
 DocType: About Us Settings,Team Members Heading,ርእስ ቡድን አባላት
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,ልክ ያልሆነ የ CSV ቅርጸት
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","ከ QZ ትሪ ትግበራ ጋር መገናኘት ላይ ስህተት ... <br><br> ጥሬ ማተም ባህሪን ለመጠቀም QZ ትሪ መተግበሪያ ተጭኖ እና አሂድ ያስፈልግዎታል። <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ ትሪ ለመጫን እና ለመጫን እዚህ ጠቅ ያድርጉ</a> ። <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">ስለ ጥሬ ማተሚያ የበለጠ ለማወቅ እዚህ ጠቅ ያድርጉ</a> ።"
@@ -3690,7 +3690,7 @@ DocType: Web Page,Web Page,ድረ ገጽ
 DocType: Workflow Document State,Next Action Email Template,ቀጣይ Action Email Template
 DocType: Blog Category,Blogger,ብሎገር
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline",ከነቃ በሰነዱ ላይ ለውጦች ተደርገው ክትትል ይደረግባቸዋል እንዲሁም በሰዓት ውስጥ ይታያሉ።
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ግሎባል ፍለጋ ውስጥ&#39; አይነት አይፈቀድም {0} ረድፍ ውስጥ {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ግሎባል ፍለጋ ውስጥ' አይነት አይፈቀድም {0} ረድፍ ውስጥ {1}
 DocType: Energy Point Log,Appreciation,አድናቆት ፡፡
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,ይመልከቱ ዝርዝር
 DocType: Workflow,Don't Override Status,ሁኔታ ሻር አትበል
@@ -3880,7 +3880,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,የተሰቀለ ፋይል።
 DocType: Workflow State,ok-circle,ok-ክበብ
 DocType: LDAP Settings,LDAP User Creation and Mapping,የኤል.ዲ.ኤፍ. ተጠቃሚ ፈጠራ እና ካርታ ሥራ
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',አንተ &#39;ደንበኞች ውስጥ ብርቱካናማ ማግኘት&#39; በመጠየቅ ነገሮችን ማግኘት ይችላሉ
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',አንተ 'ደንበኞች ውስጥ ብርቱካናማ ማግኘት' በመጠየቅ ነገሮችን ማግኘት ይችላሉ
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,አዝናለሁ! ተጠቃሚ የራሳቸውን መዝገብ ሙሉ መዳረሻ ሊኖራቸው ይገባል.
 ,Usage Info,አጠቃቀም መረጃ
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,የቁልፍ ሰሌዳ አቋራጮችን አሳይ።

--- a/frappe/translations/am.csv
+++ b/frappe/translations/am.csv
@@ -286,7 +286,7 @@ DocType: Auto Repeat,Message,መልእክት
 DocType: Communication,Rating,ደረጃ አሰጣጥ
 DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","በመስክ ጠረጴዛ ላይ አንድ አምድ ከሆነ, በሜዳ ስፋት አትም"
 DocType: Dropbox Settings,Dropbox Access Key,መሸወጃ መዳረሻ ቁልፍ
-apps/frappe/frappe/desk/form/utils.py,Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script,በብጁ እስክሪፕት ውስጥ የ «_ <b>&lt;</b> የተሳሳተ ቅጥያ» <b>{0}</b>
+apps/frappe/frappe/desk/form/utils.py,Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script,በብጁ እስክሪፕት ውስጥ የ «_ <b><</b> የተሳሳተ ቅጥያ» <b>{0}</b>
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,ለየትኛው እውቂያ መመሳሰል እንዳለበት የ Google እውቂያዎችን ይምረጡ።
 DocType: Web Page,Main Section (HTML),ዋና ክፍል (ኤችቲኤምኤል)
 DocType: Workflow State,headphones,ማዳመጫዎች
@@ -747,7 +747,7 @@ DocType: Currency,Currency Name,የምንዛሬ ስም
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ምንም ኢሜይሎች
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,አገናኝ ጊዜ አልፎበታል
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",ርዝመቱን ወደ {0} በ &lt;{2}> ውስጥ ለ &#39;{1}&#39; በማድህር ላይ; ርዝመቱን እንደ {3} ማስተካከል የውሂብ መሰንጠቅን ያስከትላል.
+							Setting the length as {3} will cause truncation of data.",ርዝመቱን ወደ {0} በ <{2}> ውስጥ ለ &#39;{1}&#39; በማድህር ላይ; ርዝመቱን እንደ {3} ማስተካከል የውሂብ መሰንጠቅን ያስከትላል.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,የፋይል ቅርጸት ይምረጡ
 DocType: Report,Javascript,ጃቫስክሪፕት
 DocType: File,Content Hash,የይዘት Hash
@@ -768,7 +768,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,የሰነድ አጋራ ሪፖርት
 DocType: Social Login Key,Base URL,መነሻ URL
 DocType: User,Last Login,የመጨረሻው መግቢያ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ለትርጉም &lt;&lt; ትራንስክሪፕት >> ማስተካከል አይችሉም {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ለትርጉም << ትራንስክሪፕት >> ማስተካከል አይችሉም {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,አምድ
 DocType: Chat Profile,Chat Profile,የውይይት መገለጫ
 DocType: Custom Field,Adds a custom field to a DocType,አንድ DocType ወደ ብጁ መስክ ያክላል
@@ -1409,7 +1409,7 @@ DocType: User,System User,የስርዓት የተጠቃሚ
 DocType: Report,Is Standard,መደበኛ ነው
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,ሙሉ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",ማድረግ አይችልም &lt;ስክሪፕት> ብቻ ወይም ቁምፊዎች እነሱ ሆን በዚህ መስክ ውስጥ ጥቅም ላይ ሊውል ይችላል ሆኖ እንደ &lt;ወይም> እንደ ኤች ቲ ኤም ኤል እንዲረዱት HTML መለያዎችን
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",ማድረግ አይችልም <ስክሪፕት> ብቻ ወይም ቁምፊዎች እነሱ ሆን በዚህ መስክ ውስጥ ጥቅም ላይ ሊውል ይችላል ሆኖ እንደ <ወይም> እንደ ኤች ቲ ኤም ኤል እንዲረዱት HTML መለያዎችን
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} በ {1} ላይ ተችቷል
 DocType: Website Settings,FavIcon,favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ሩጫ
@@ -1789,7 +1789,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ግርጌ በት�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,በመጠባበቅ ላይ
 DocType: System Settings,Allow only one session per user,ተጠቃሚ ብቻ ነው አንድ ክፍለ ጊዜ ፍቀድ
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,መነሻ / የሙከራ አቃፊ 1 / የሙከራ አቃፊ 3
-DocType: Website Settings,&lt;head> HTML,&lt;ራስ> የኤች ቲ ኤም ኤል
+DocType: Website Settings,<head> HTML,<ራስ> የኤች ቲ ኤም ኤል
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ይምረጡ ወይም አንድ አዲስ ክስተት ለመፍጠር ጊዜ ቦታዎች ላይ ጎትት.
 DocType: Contact,Contact Details,የእውቅያ ዝርዝሮች
 DocType: DocField,In Filter,ማጣሪያ ውስጥ
@@ -2308,7 +2308,7 @@ DocType: LDAP Settings,Path to Server Certificate,የአገልጋይ ሰርቲ�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,አገናኞች ለማየት በቂ ፍቃድ
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,አድራሻ ርዕስ የግዴታ ነው.
 DocType: Google Contacts,Push to Google Contacts,ወደ Google እውቂያዎች ይግፉ።
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","የ &lt;ራስ> ውስጥ ታክሏል ኤችቲኤምኤል ድረ ገጽ ክፍል, በዋነኝነት ድር ማረጋገጫ እና ሲኢኦ ጥቅም ላይ"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","የ <ራስ> ውስጥ ታክሏል ኤችቲኤምኤል ድረ ገጽ ክፍል, በዋነኝነት ድር ማረጋገጫ እና ሲኢኦ ጥቅም ላይ"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,መንገዷ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ንጥል የራሱን ዘር ሊታከሉ አይችሉም
 DocType: Session Default Settings,Session Defaults,የክፍለ ጊዜ ነባሪዎች።
@@ -2427,7 +2427,7 @@ DocType: Workflow State,Warning,ማስጠንቀቂያ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ይህ በበርካታ ገጾች ላይ ሊታተም ይችላል።
 DocType: Data Migration Run,Percent Complete,መቶኛ የተጠናቀቀ
 DocType: Tag Category,Tag Category,መለያ ምድብ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",ለማነፃፀር> 5 ፣ ‹10 ወይም = 324 ይጠቀሙ። ክልሎች ፣ 5 10 (5 እና 10 መካከል ላሉት እሴቶች) ይጠቀሙ ፡፡
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",ለማነፃፀር> 5 ፣ ‹10 ወይም = 324 ይጠቀሙ። ክልሎች ፣ 5 10 (5 እና 10 መካከል ላሉት እሴቶች) ይጠቀሙ ፡፡
 DocType: Google Calendar,Pull from Google Calendar,ከ Google ቀን መቁጠሪያ ጎትት።
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,እርዳታ
 DocType: User,Login Before,መግቢያ በፊት
@@ -3065,7 +3065,7 @@ DocType: DocField,Allow on Submit,አስገባ ላይ ፍቀድ
 DocType: DocField,HTML,ኤችቲኤምኤል
 DocType: Error Snapshot,Exception Type,ለየት አይነት
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,አምዶች ይምረጡ
-DocType: Web Page,Add code as &lt;script>,&lt;ስክሪፕት> እንደ ኮድ ያክሉ
+DocType: Web Page,Add code as <script>,<ስክሪፕት> እንደ ኮድ ያክሉ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,የተጠቃሚ ፈቃዶችን ያፅዱ።
 DocType: Webhook,Headers,ራስጌዎች
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,መጪ ክስተቶች
@@ -3439,16 +3439,16 @@ DocType: Workflow State,share-alt,አጋራ-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ወረፋ ውስጥ አንዱ መሆን አለበት {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> ነባሪ አብነት </h4><p> ይጠቀማል <a href=""http://jinja.pocoo.org/docs/templates/"">ጂንጃ Templating</a> እና ይገኛል (ካለ ብጁ መስኮች ጨምሮ) አድራሻ ሁሉ መስኮች </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> ነባሪ አብነት </h4><p> ይጠቀማል <a href=""http://jinja.pocoo.org/docs/templates/"">ጂንጃ Templating</a> እና ይገኛል (ካለ ብጁ መስኮች ጨምሮ) አድራሻ ሁሉ መስኮች </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,የቀን ቦታ መስክ
 DocType: Role,Role Name,ሚና ስም
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ዴስክ ወደ ቀይር

--- a/frappe/translations/am.csv
+++ b/frappe/translations/am.csv
@@ -741,13 +741,13 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,የፋይ�
 DocType: DocField,In Global Search,* Global Search ውስጥ
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,ገብ-ግራ
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} ዓመት (ቶች) በፊት
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} ዓመት (ቶች) በፊት
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,ይህ ፋይል መሰረዝ አደገኛ ነው: {0}. እባክዎ የስርዓት አስተዳዳሪዎን ያግኙ.
 DocType: Currency,Currency Name,የምንዛሬ ስም
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ምንም ኢሜይሎች
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,አገናኝ ጊዜ አልፎበታል
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",ርዝመቱን ወደ {0} በ &lt;{2}&gt; ውስጥ ለ &#39;{1}&#39; በማድህር ላይ; ርዝመቱን እንደ {3} ማስተካከል የውሂብ መሰንጠቅን ያስከትላል.
+							Setting the length as {3} will cause truncation of data.",ርዝመቱን ወደ {0} በ &lt;{2}> ውስጥ ለ &#39;{1}&#39; በማድህር ላይ; ርዝመቱን እንደ {3} ማስተካከል የውሂብ መሰንጠቅን ያስከትላል.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,የፋይል ቅርጸት ይምረጡ
 DocType: Report,Javascript,ጃቫስክሪፕት
 DocType: File,Content Hash,የይዘት Hash
@@ -768,7 +768,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,የሰነድ አጋራ ሪፖርት
 DocType: Social Login Key,Base URL,መነሻ URL
 DocType: User,Last Login,የመጨረሻው መግቢያ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ለትርጉም &lt;&lt; ትራንስክሪፕት &gt;&gt; ማስተካከል አይችሉም {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ለትርጉም &lt;&lt; ትራንስክሪፕት >> ማስተካከል አይችሉም {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,አምድ
 DocType: Chat Profile,Chat Profile,የውይይት መገለጫ
 DocType: Custom Field,Adds a custom field to a DocType,አንድ DocType ወደ ብጁ መስክ ያክላል
@@ -1035,7 +1035,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,ምንም {0}
 apps/frappe/frappe/config/customization.py,Add custom forms.,ብጁ ቅጾች ያክሉ.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} ውስጥ ከ {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ይህ ሰነድ ገብቷል
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,ማዋቀር&gt; የተጠቃሚ ፈቃዶች
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,ማዋቀር> የተጠቃሚ ፈቃዶች
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,ስርዓቱ ብዙ ቀድሞ የተበየነ ሚና ያቀርባል. እርስዎ በመረጡት ፍቃዶችን ማዘጋጀት አዲስ ሚና ማከል ይችላሉ.
 DocType: Communication,CC,ዝግ መግለጫ
 DocType: Country,Geo,የጂኦ
@@ -1254,7 +1254,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","ተጠቃሚው በተደረገባቸው ማንኛውም ሚና እንዳለው ከሆነ, ተጠቃሚው የ «System ተጠቃሚ» ይሆናል. &quot;የስርዓት ተጠቃሚ» ዴስክቶፕ መዳረሻ እንዳለው"
 DocType: System Settings,Date and Number Format,ቀን እና የቁጥር ቅርጸት
 apps/frappe/frappe/model/document.py,one of,አንዱ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,ማዋቀር&gt; ቅጽ አብጅ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,ማዋቀር> ቅጽ አብጅ
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,አንድ አፍታ በማረጋገጥ ላይ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,አሳይ መለያዎች
 DocType: DocField,HTML Editor,HTML አርታዒ
@@ -1262,7 +1262,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,አከፋፈል
 DocType: Email Queue,Not Sent,የተላከ አይደለም
 DocType: Web Form,Actions,እርምጃዎች
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,ማዋቀር&gt; ተጠቃሚ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,ማዋቀር> ተጠቃሚ
 DocType: Workflow State,align-justify,አሰልፍ-ሰበብ
 DocType: User,Middle Name (Optional),የመካከለኛ ስም (አማራጭ)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,አይፈቀድም
@@ -1409,7 +1409,7 @@ DocType: User,System User,የስርዓት የተጠቃሚ
 DocType: Report,Is Standard,መደበኛ ነው
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,ሙሉ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",ማድረግ አይችልም &lt;ስክሪፕት&gt; ብቻ ወይም ቁምፊዎች እነሱ ሆን በዚህ መስክ ውስጥ ጥቅም ላይ ሊውል ይችላል ሆኖ እንደ &lt;ወይም&gt; እንደ ኤች ቲ ኤም ኤል እንዲረዱት HTML መለያዎችን
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",ማድረግ አይችልም &lt;ስክሪፕት> ብቻ ወይም ቁምፊዎች እነሱ ሆን በዚህ መስክ ውስጥ ጥቅም ላይ ሊውል ይችላል ሆኖ እንደ &lt;ወይም> እንደ ኤች ቲ ኤም ኤል እንዲረዱት HTML መለያዎችን
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} በ {1} ላይ ተችቷል
 DocType: Website Settings,FavIcon,favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ሩጫ
@@ -1789,7 +1789,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ግርጌ በት�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,በመጠባበቅ ላይ
 DocType: System Settings,Allow only one session per user,ተጠቃሚ ብቻ ነው አንድ ክፍለ ጊዜ ፍቀድ
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,መነሻ / የሙከራ አቃፊ 1 / የሙከራ አቃፊ 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;ራስ&gt; የኤች ቲ ኤም ኤል
+DocType: Website Settings,&lt;head> HTML,&lt;ራስ> የኤች ቲ ኤም ኤል
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ይምረጡ ወይም አንድ አዲስ ክስተት ለመፍጠር ጊዜ ቦታዎች ላይ ጎትት.
 DocType: Contact,Contact Details,የእውቅያ ዝርዝሮች
 DocType: DocField,In Filter,ማጣሪያ ውስጥ
@@ -1812,7 +1812,7 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.py,Scheduler i
 DocType: Print Settings,Letter,ደብዳቤ
 DocType: DocType,"Naming Options:
 <ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>
-<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","የአማራጭ አማራጮች: <ol><li> <b>መስክ: [የመስክ ስም]</b> - በመስክ </li><li> <b>የስምሪት ስሞች:</b> - <b>ስሞችን</b> («Naming_series» የሚባል መስክ መሆን አለባቸው) </li><li> <b>አስገቢ</b> - ለተመሳሳይ ስም የሚጠቅስ ተጠቃሚ </li><li> <b>[ተከታታይ]</b> - ተከታታይ በቅድመ-ቃላት (በነጥብ የተለያየ); ለምሳሌ PRE. ##### </li><li> <b>ቅርፀት: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - ሁሉንም የተጠበቁ ቃላትን (የመስክ ስሞች, የቀን ቃላት (DD, MM, YY), ተከታታይ) በፖሊሶቻቸው ይተኩ. ከጎላ ገመድ, ማንኛውም ቁምፊዎች ጥቅም ላይ ሊውሉ ይችላሉ. </li></ol>"
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","የአማራጭ አማራጮች: <ol><li> <b>መስክ: [የመስክ ስም]</b> - በመስክ </li><li> <b>የስምሪት ስሞች:</b> - <b>ስሞችን</b> («Naming_series» የሚባል መስክ መሆን አለባቸው) </li><li> <b>አስገቢ</b> - ለተ���ሳሳይ ስም የሚጠቅስ ተጠቃሚ </li><li> <b>[ተከታታይ]</b> - ተከታታይ በቅድመ-ቃላት (በነጥብ የተለያየ); ለምሳሌ PRE. ##### </li><li> <b>ቅርፀት: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - ሁሉንም የተጠበቁ ቃላትን (የመስክ ስሞች, የቀን ቃላት (DD, MM, YY), ተከታታይ) በፖሊሶቻቸው ይተኩ. ከጎላ ገመድ, ማንኛውም ቁምፊዎች ጥቅም ላይ ሊውሉ ይችላሉ. </li></ol>"
 apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,ሰነዱን በመፍጠር ላይ ሳለ ስህተቶች ነበሩ. እባክዎ ዳግም ይሞክሩ.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,የምስል መስክ አይነት መሆን አለበት ምስል ያያይዙ
 apps/frappe/frappe/permissions.py,You are not allowed to export {} doctype,{} ዶክትሪን እንዲያወጡ አልተፈቀደልዎትም።
@@ -2019,7 +2019,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,በዚህ ጊዜ አይፈቀድም ይግቡና
 DocType: Data Migration Run,Current Mapping Action,የአሁኑ የካርታ ስራ እርምጃ
 DocType: Dashboard Chart Source,Source Name,ምንጭ ስም
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,ከተጠቃሚው ጋር የተገናኘ ምንም የኢሜይል መለያ የለም ፡፡ እባክዎን በተጠቃሚ&gt; በኢሜል ገቢ መልእክት ሳጥን ስር ያክሉ ፡፡
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,ከተጠቃሚው ጋር የተገናኘ ምንም የኢሜይል መለያ የለም ፡፡ እባክዎን በተጠቃሚ> በኢሜል ገቢ መልእክት ሳጥን ስር ያክሉ ፡፡
 DocType: Email Account,Email Sync Option,ኢሜይል አስምር አማራጭ
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,ረድፍ ቁጥር
 DocType: Async Task,Runtime,የሚፈጀውን ጊዜ
@@ -2034,7 +2034,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,አስቀ
 DocType: User Email,Enable Outgoing,የወጪ አንቃ
 DocType: Address,Fax,ፋክስ
 apps/frappe/frappe/config/customization.py,Custom Tags,ብጁ መለያዎች
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,የኢሜይል መለያ ማዋቀር እባክዎ ከማዋቀር&gt; ኢሜል&gt; ከኢሜል አካውንት ውስጥ አዲስ የኢሜይል አካውንት ይፍጠሩ
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,የኢሜይል መለያ ማዋቀር እባክዎ ከማዋቀር> ኢሜል> ከኢሜል አካውንት ውስጥ አዲስ የኢሜይል አካውንት ይፍጠሩ
 DocType: Comment,Submitted,ገብቷል
 DocType: Contact,Pulled from Google Contacts,ከ Google እውቂያዎች የተወሰደ።
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,በትክክለኛ ጥያቄ
@@ -2106,7 +2106,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ሰዓቶች ለም�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",እዚህ ላይ በተገለጸው fieldname እሴት አለው ወይም ደንብ እውነተኛ (ምሳሌዎች) ናቸው ብቻ ከሆነ ይህ መስክ ይታያል: myfield ኢቫል: doc.myfield == &#39;የእኔ እሴት »ኢቫል: doc.age&gt; 18
+eval:doc.age>18",እዚህ ላይ በተገለጸው fieldname እሴት አለው ወይም ደንብ እውነተኛ (ምሳሌዎች) ናቸው ብቻ ከሆነ ይህ መስክ ይታያል: myfield ኢቫል: doc.myfield == &#39;የእኔ እሴት »ኢቫል: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ዛሬ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","ይህን ካዋቀሩት በኋላ, ተጠቃሚዎች ብቻ ነው የሚችል መዳረሻ ሰነዶችን ይሆናል (ለምሳሌ. ልጥፍ ብሎግ) አገናኝ (ለምሳሌ. ብሎገር) አለ ቦታ."
@@ -2120,7 +2120,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,በትልቁ ሆሄያት
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,ብጁ ኤችቲኤምኤል
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,የአቃፊ ስም ያስገቡ
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,ምንም ነባሪ የአድራሻ አብነት አልተገኘም። እባክዎ ከማዋቀር&gt; ማተሚያ እና የምርት ስም አወጣጥ&gt; የአድራሻ አብነት አዲስ ይፍጠሩ።
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,ምንም ነባሪ የአድራሻ አብነት አልተገኘም። እባክዎ ከማዋቀር> ማተሚያ እና የምርት ስም አወጣጥ> የአድራሻ አብነት አዲስ ይፍጠሩ።
 apps/frappe/frappe/auth.py,Unknown User,ያልታወቀ ተጠቃሚ
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,ይምረጡ ሚና
 DocType: Comment,Deleted,ተሰርዟል
@@ -2308,7 +2308,7 @@ DocType: LDAP Settings,Path to Server Certificate,የአገልጋይ ሰርቲ�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,አገናኞች ለማየት በቂ ፍቃድ
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,አድራሻ ርዕስ የግዴታ ነው.
 DocType: Google Contacts,Push to Google Contacts,ወደ Google እውቂያዎች ይግፉ።
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","የ &lt;ራስ&gt; ውስጥ ታክሏል ኤችቲኤምኤል ድረ ገጽ ክፍል, በዋነኝነት ድር ማረጋገጫ እና ሲኢኦ ጥቅም ላይ"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","የ &lt;ራስ> ውስጥ ታክሏል ኤችቲኤምኤል ድረ ገጽ ክፍል, በዋነኝነት ድር ማረጋገጫ እና ሲኢኦ ጥቅም ላይ"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,መንገዷ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ንጥል የራሱን ዘር ሊታከሉ አይችሉም
 DocType: Session Default Settings,Session Defaults,የክፍለ ጊዜ ነባሪዎች።
@@ -2392,7 +2392,7 @@ DocType: Help Article,Knowledge Base Editor,እውቀት ቤዝን አርታዒ
 apps/frappe/frappe/public/js/frappe/views/container.js,Page not found,ገጹ አልተገኘም
 DocType: DocField,Precision,ትክክልነት
 DocType: Website Slideshow,Slideshow Items,የተንሸራታች ትዕይንት ንጥሎች
-apps/frappe/frappe/utils/password_strength.py,Try to avoid repeated words and characters,በተደጋጋሚ ቃላት እና ቁምፊዎች ለማስወገድ ይሞክሩ
+apps/frappe/frappe/utils/password_strength.py,Try to avoid repeated words and characters,በተደጋጋሚ ቃላት እ��� ቁምፊዎች ለማስወገድ ይሞክሩ
 DocType: Workflow Action,Workflow State,የስራ ፍሰት መንግስት
 apps/frappe/frappe/core/doctype/version/version_view.html,Rows Added,ረድፎች ታክሏል
 apps/frappe/frappe/www/list.py,My Account,አካውንቴ
@@ -2427,7 +2427,7 @@ DocType: Workflow State,Warning,ማስጠንቀቂያ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ይህ በበርካታ ገጾች ላይ ሊታተም ይችላል።
 DocType: Data Migration Run,Percent Complete,መቶኛ የተጠናቀቀ
 DocType: Tag Category,Tag Category,መለያ ምድብ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",ለማነፃፀር&gt; 5 ፣ ‹10 ወይም = 324 ይጠቀሙ። ክልሎች ፣ 5 10 (5 እና 10 መካከል ላሉት እሴቶች) ይጠቀሙ ፡፡
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",ለማነፃፀር> 5 ፣ ‹10 ወይም = 324 ይጠቀሙ። ክልሎች ፣ 5 10 (5 እና 10 መካከል ላሉት እሴቶች) ይጠቀሙ ፡፡
 DocType: Google Calendar,Pull from Google Calendar,ከ Google ቀን መቁጠሪያ ጎትት።
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,እርዳታ
 DocType: User,Login Before,መግቢያ በፊት
@@ -2889,7 +2889,7 @@ DocType: Custom Script,Custom Script,ብጁ ስክሪፕት
 DocType: Address,Address Line 2,የአድራሻ መስመር 2
 DocType: Address,Reference,ማጣቀሻ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,የተመደበ
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,እባክዎን ነባሪውን የኢሜል አካውንት ያዋቅሩ ከማዋቀር&gt; ኢሜል&gt; ከኢሜል አካውንት
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,እባክዎን ነባሪውን የኢሜል አካውንት ያዋቅሩ ከማዋቀር> ኢሜል> ከኢሜል አካውንት
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,የውሂብ ጎዳና ማዛመጃ ዝርዝር
 DocType: Data Import,Action,እርምጃ
 DocType: GSuite Settings,Script URL,ስክሪፕት ዩ አር ኤል
@@ -2983,7 +2983,7 @@ apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Al
 apps/frappe/frappe/www/update-password.html,Old Password,የድሮ የይለፍ ቃል
 DocType: S3 Backup Settings,us-east-1,እኛ-ምስራቅ -1
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts by {0},ልጥፎች {0}
-apps/frappe/frappe/core/doctype/report/report.js,"To format columns, give column labels in the query.","ቅርጸት ወደ አምዶች, የሚከተለው መጠይቅ ውስጥ አምድ መለያዎችን ይሰጣሉ."
+apps/frappe/frappe/core/doctype/report/report.js,"To format columns, give column labels in the query.","ቅርጸት ወደ አምዶች, የሚከተለ��� መጠይቅ ውስጥ አምድ መለያዎችን ይሰጣሉ."
 DocType: Has Domain,Has Domain,ጎራ አለው
 DocType: User,Allowed In Mentions,በአዕምሮዎች ውስጥ ተፈቅ .ል ፡፡
 apps/frappe/frappe/www/login.html,Don't have an account? Sign up,መለያ የለህም? ተመዝገቢ
@@ -3065,7 +3065,7 @@ DocType: DocField,Allow on Submit,አስገባ ላይ ፍቀድ
 DocType: DocField,HTML,ኤችቲኤምኤል
 DocType: Error Snapshot,Exception Type,ለየት አይነት
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,አምዶች ይምረጡ
-DocType: Web Page,Add code as &lt;script&gt;,&lt;ስክሪፕት&gt; እንደ ኮድ ያክሉ
+DocType: Web Page,Add code as &lt;script>,&lt;ስክሪፕት> እንደ ኮድ ያክሉ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,የተጠቃሚ ፈቃዶችን ያፅዱ።
 DocType: Webhook,Headers,ራስጌዎች
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,መጪ ክስተቶች
@@ -3439,16 +3439,16 @@ DocType: Workflow State,share-alt,አጋራ-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ወረፋ ውስጥ አንዱ መሆን አለበት {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> ነባሪ አብነት </h4><p> ይጠቀማል <a href=""http://jinja.pocoo.org/docs/templates/"">ጂንጃ Templating</a> እና ይገኛል (ካለ ብጁ መስኮች ጨምሮ) አድራሻ ሁሉ መስኮች </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> ነባሪ አብነት </h4><p> ይጠቀማል <a href=""http://jinja.pocoo.org/docs/templates/"">ጂንጃ Templating</a> እና ይገኛል (ካለ ብጁ መስኮች ጨምሮ) አድራሻ ሁሉ መስኮች </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,የቀን ቦታ መስክ
 DocType: Role,Role Name,ሚና ስም
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ዴስክ ወደ ቀይር

--- a/frappe/translations/ar.csv
+++ b/frappe/translations/ar.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),الإحصائيات بناءً على أداء الأسبوع الماضي (من {0} إلى {1})
 DocType: LDAP Settings,LDAP Phone Field,حقل هاتف LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",نوع الوثيقة ...، على سبيل المثال العملاء
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,الشرط &#39;{0}&#39; غير صالح
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,الشرط '{0}' غير صالح
 DocType: Workflow State,barcode,الباركود
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,استخدام الاستعلام الفرعي أو وظيفة مقيدة
 apps/frappe/frappe/config/customization.py,Add your own translations,أضف الترجمة  الخاصة بك
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,اسم العملة
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,لا رسائل البريد الإلكتروني
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,انتهت صلاحية الرابط
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",إرجاع الطول إلى {0} لـ &#39;{1}&#39; في &#39;{2}&#39;؛ سيتسبب تعيين الطول في {3} في اقتطاع البيانات.
+							Setting the length as {3} will cause truncation of data.",إرجاع الطول إلى {0} لـ '{1}' في '{2}'؛ سيتسبب تعيين الطول في {3} في اقتطاع البيانات.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,حدد تنسيق الملف
 DocType: Report,Javascript,جافا سكريبت
 DocType: File,Content Hash,تجزئة المحتوى
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,وثيقة حصة تقرير
 DocType: Social Login Key,Base URL,الرابط الأساسي
 DocType: User,Last Login,آخر تسجيل دخول
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},لا يمكنك تعيين &#39;ترانزلاتابل&#39; للحقل {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},لا يمكنك تعيين 'ترانزلاتابل' للحقل {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,عمود
 DocType: Chat Profile,Chat Profile,دردشة الملف الشخصي
 DocType: Custom Field,Adds a custom field to a DocType,DocType  اضافة حقل خاص ل
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,حقل إلزامي: ضع صلاحية المحددة ل
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} انتقد {1}
 DocType: Data Migration Mapping,Mapping Name,اسم رسم الخرائط
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: لا يمكن تعيين الحقل &#39;{1}&#39; على أنه فريد لأنه يحتوي على قيم غير فريدة
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: لا يمكن تعيين الحقل '{1}' على أنه فريد لأنه يحتوي على قيم غير فريدة
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,انتقل القائمة لأسفل
 DocType: Currency,A symbol for this currency. For e.g. $,رمز هذه العملة. ر.س مثلاً
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,تم تحديث الترجمات بنجاح
@@ -2004,7 +2004,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,خط جوجل
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",إذا هذه التعليمات حيث لم تكن مفيدة ، يرجى إضافة في اقتراحاتكم بشأن قضايا جيثب .
 DocType: Workflow State,bookmark,المرجعية
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),يجب ألا يتضمن اسم المجلد &#39;/&#39; (شرطة مائلة)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),يجب ألا يتضمن اسم المجلد '/' (شرطة مائلة)
 DocType: Note,Note,ملاحظات
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,أبلغ عن مشكلة
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,تصدير البيانات بتنسيق CSV / Excel.
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,انتهاء الا�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",سيظهر هذا المجال إلا إذا كان FIELDNAME المحدد هنا له قيمة أو قواعد صحيحة (أمثلة): myfield حدة التقييم: doc.myfield == &#39;بلدي القيمة &quot;وحدة التقييم: doc.age> 18
+eval:doc.age>18",سيظهر هذا المجال إلا إذا كان FIELDNAME المحدد هنا له قيمة أو قواعد صحيحة (أمثلة): myfield حدة التقييم: doc.myfield == 'بلدي القيمة &quot;وحدة التقييم: doc.age> 18
 DocType: Social Login Key,Office 365,مكتب 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,اليوم
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",وبمجرد الانتهاء من تعيين هذه ، سوف يكون المستخدمون قادرين فقط الوصول إلى المستندات (على سبيل المثال مدونة بوست) حيث يوجد رابط (مثل مدون ) .
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,اسم قاعدة البيانا
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,نموذج التحديث
 DocType: DocField,Select,حدد
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,عرض السجل الكامل
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",تعبير Python البسيط ، مثال: status == &#39;Open&#39; واكتب == &#39;Bug&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",تعبير Python البسيط ، مثال: status == 'Open' واكتب == 'Bug'
 apps/frappe/frappe/utils/csvutils.py,File not attached,الملف غير مرفق
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,فقد الاتصال، بعض الميزات قد لا تعمل.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",كما يكرر &quot;AAA&quot; من السهل تخمين
@@ -2278,7 +2278,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,عرض الأخطاء فقط
 DocType: Website Settings,Banner HTML,راية HTML
 DocType: Workflow,Send Email Alert,إرسال تنبيه عبر البريد الإلكتروني
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',يرجى تحديد طريقة دفع أخرى. Razorpay لا يعتمد المعاملات بالعملة &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',يرجى تحديد طريقة دفع أخرى. Razorpay لا يعتمد المعاملات بالعملة '{0}'
 DocType: Data Import,In Progress,في تَقَدم
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,في قائمة الانتظار للنسخ الاحتياطي. قد يستغرق بضع دقائق إلى ساعة.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2758,7 +2758,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,عرض الصورة
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.",يبدو وكأنه شيء على ما يرام أثناء العملية. وبما أننا لم تؤكد عملية الدفع، سوف باي بال برد تلقائيا هذا المبلغ. إذا لم يحدث ذلك، يرجى مراسلتنا على البريد الإلكتروني، وأذكر معرف الارتباط: {0}.
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password",تضمين الرموز والأرقام والأحرف الكبيرة في كلمة المرور
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",إدراج بعد الحقل &#39;{0}&#39; المذكورة في حقل مخصص &#39;{1}&#39;، مع التسمية &#39;{2}&#39;، غير موجود
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",إدراج بعد الحقل '{0}' المذكورة في حقل مخصص '{1}'، مع التسمية '{2}'، غير موجود
 DocType: List Filter,List Filter,تصفية القائمة
 DocType: Workflow State,signal,إشارة
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,يحتوي على مرفقات
@@ -2782,7 +2782,7 @@ DocType: Web Page,Slideshow,عرض الشرائح
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,لا يمكن حذف القالب الافتراضي العنوان
 DocType: Contact,Maintenance Manager,مدير الصيانة
 DocType: Workflow State,Search,البحث
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',يرجى تحديد طريقة دفع أخرى. شريط لا يدعم المعاملات بالعملة &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',يرجى تحديد طريقة دفع أخرى. شريط لا يدعم المعاملات بالعملة '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ارسال الى سلة المحذوفات
 DocType: Web Form,Web Form Fields,الحقول نموذج ويب
 DocType: Data Import,Amended From,معدل من
@@ -2976,7 +2976,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,قيمة مفقود�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,إضافة الطفل
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,استيراد التقدم
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",إذا كانت الحالة راضية ، فسيتم مكافأة المستخدم بالنقاط. على سبيل المثال. doc.status == &#39;مغلق&#39;
+",إذا كانت الحالة راضية ، فسيتم مكافأة المستخدم بالنقاط. على سبيل المثال. doc.status == 'مغلق'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: لا يمكن حذف سجل مؤكد.
 DocType: GSuite Templates,Template Name,اسم القالب
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,نوع جديد من الوثيقة
@@ -3396,7 +3396,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,ترجمة مخص
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,تقدم
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,حسب الصلاحية
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,حقول مفقودة
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,FIELDNAME غير صالح &#39;{0}&#39; في autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,FIELDNAME غير صالح '{0}' في autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,بحث في نوع الوثيقة
 DocType: Custom DocPerm,Role and Level,مستوى الصلاحية
 DocType: File,Thumbnail URL,URL المصغرة
@@ -3497,7 +3497,7 @@ DocType: Dashboard Chart,Filters JSON,مرشحات JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,انقر هنا للتأكيد
 DocType: Email Account,Disable SMTP server authentication,تعطيل مصادقة خادم SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,نسخ إلى الحافظة.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,بدائل يمكن التنبؤ بها مثل &#39;@&#39; بدلا من &#39;&#39; لا يساعد كثيرا جدا.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,بدائل يمكن التنبؤ بها مثل '@' بدلا من '' لا يساعد كثيرا جدا.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,يسندها عني
 apps/frappe/frappe/utils/data.py,Zero,صفر
 DocType: Google Drive,Backup Folder ID,معرف مجلد النسخ الاحتياطي
@@ -3856,7 +3856,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,الافتراضي
 DocType: Translation,Verified,التحقق
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} أضيف
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',البحث عن &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',البحث عن '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,يرجى حفظ التقرير الأول
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0}  مشتركين تم اضافتهم
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,ليس في
@@ -3892,7 +3892,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,أنا
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0}   ليست حالة صالحة
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,تنطبق على جميع أنواع الوثائق
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,تحديث نقطة الطاقة
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',يرجى تحديد طريقة دفع أخرى. باي بال لا تدعم المعاملات بالعملة &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',يرجى تحديد طريقة دفع أخرى. باي بال لا تدعم المعاملات بالعملة '{0}'
 DocType: Chat Message,Room Type,نوع الغرفة
 DocType: Data Import Beta,Import Log Preview,استيراد سجل معاينة
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,حقل البحث {0} غير صالح

--- a/frappe/translations/ar.csv
+++ b/frappe/translations/ar.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,نظام المستخدم
 DocType: Report,Is Standard,هو معيار
 DocType: Desktop Icon,_report,_تقرير
 DocType: Dashboard Chart,Full,ممتلئ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",لا علامات HTML شفر HTML مثل &lt;script> أو مجرد شخصيات مثل &lt;أو>، لأنها يمكن أن تستخدم عمدا في هذا المجال
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",لا علامات HTML شفر HTML مثل <script> أو مجرد شخصيات مثل <أو>، لأنها يمكن أن تستخدم عمدا في هذا المجال
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} انتقد يوم {1}
 DocType: Website Settings,FavIcon,علامة المفضلة
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,يركض
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,سيعرض تذي
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,معلق
 DocType: System Settings,Allow only one session per user,السماح لجلسة واحدة فقط لكل مستخدم
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,مجلد الوطن / اختبار 1 / مجلد اختبار 3
-DocType: Website Settings,&lt;head> HTML,<head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,اختر أو اسحب عبر فتحات الوقت لإنشاء حدث جديد.
 DocType: Contact,Contact Details,تفاصيل الاتصال
 DocType: DocField,In Filter,في تصفية
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,المسار إلى شهادة
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ليس هناك إذن كاف لمشاهدة الروابط
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,إسم العنوان إلزامى (لابد من إدخاله)
 DocType: Google Contacts,Push to Google Contacts,اضغط على جهات اتصال Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",وأضاف HTML في القسم &lt;head> من صفحة الويب، تستخدم في المقام الأول للتحقق من الموقع وSEO
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",وأضاف HTML في القسم <head> من صفحة الويب، تستخدم في المقام الأول للتحقق من الموقع وSEO
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,انتكس
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,البند لا يمكن أن تضاف إلى أحفاد الخاصة
 DocType: Session Default Settings,Session Defaults,الجلسة الافتراضية
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,تحذير
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,قد تتم طباعة هذا على صفحات متعددة
 DocType: Data Migration Run,Percent Complete,في المئة كاملة
 DocType: Tag Category,Tag Category,العلامة الفئة
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",للمقارنة ، استخدم> 5 ، &lt;10 أو = 324. للنطاقات ، استخدم 5:10 (للقيم بين 5 و 10).
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",للمقارنة ، استخدم> 5 ، <10 أو = 324. للنطاقات ، استخدم 5:10 (للقيم بين 5 و 10).
 DocType: Google Calendar,Pull from Google Calendar,سحب من تقويم جوجل
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,مساعدة
 DocType: User,Login Before,تسجيل الدخول قبل
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,السماح بالإعتماد
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,نوع الاستثناء
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,اختيار الأعمدة
-DocType: Web Page,Add code as &lt;script>,إضافة التعليمات البرمجية كما &lt;script>
+DocType: Web Page,Add code as <script>,إضافة التعليمات البرمجية كما <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,مسح أذونات المستخدم
 DocType: Webhook,Headers,الترويسات
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,الأحداث القادمة
@@ -3445,15 +3445,15 @@ DocType: Workflow State,share-alt,حصة بديل
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},يجب أن تكون قائمة الانتظار واحدة من {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> افتراضي قالب </ H4> 
  <p> ويستخدم <a href=""http://jinja.pocoo.org/docs/templates/""> جينجا قالبي templating </A> وجميع مجالات عنوان ( بما في ذلك الحقول المخصصة إن وجدت) سوف تكون متاحة </ P> 
  <قبل> <كود> {{address_line1}} العلامة & lt؛ BR & GT؛ 

--- a/frappe/translations/ar.csv
+++ b/frappe/translations/ar.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ملف ال
 DocType: DocField,In Global Search,في البحث العالمية
 DocType: System Settings,Brute Force Security,القوة الغاشمة للأمن
 DocType: Workflow State,indent-left,المسافة البادئة اليسرى
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} سنة مضت
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} سنة مضت
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,أنه أمر محفوف بالمخاطر لحذف هذا الملف: {0}. يرجى الاتصال بمدير النظام الخاص بك.
 DocType: Currency,Currency Name,اسم العملة
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,لا رسائل البريد الإلكتروني
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,لا {0} وج
 apps/frappe/frappe/config/customization.py,Add custom forms.,إضافة نماذج مخصصة.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} في {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,هذه الوثيقة مقدمة / مسجلة
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,الإعداد&gt; أذونات المستخدم
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,الإعداد> أذونات المستخدم
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,ويوفر النظام العديد من أدوار محددة مسبقا. يمكنك إضافة أدوار جديدة لتعيين أذونات الدقيقة.
 DocType: Communication,CC,CC
 DocType: Country,Geo,الجغرافية
@@ -1228,7 +1228,7 @@ DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","على س�
 apps/frappe/frappe/twofactor.py,Incorrect Verification code,رمز التحقق غير صحيح
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,تم تعطيل تكامل جهات اتصال Google.
 DocType: Assignment Rule,Description,وصف
-DocType: Print Settings,Repeat Header and Footer in PDF,كرر رأس وتذييل الصفحة في PDF
+DocType: Print Settings,Repeat Header and Footer in PDF,كرر رأس وتذ��يل الصفحة في PDF
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Failure,بالفشل
 DocType: Address Template,Is Default,افتراضي
 DocType: Data Migration Connector,Connector Type,نوع الموصل
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",إذا كان المستخدم لديه أي دور فحصها، ثم يصبح المستخدم &quot;النظام المستخدم&quot;. &quot;النظام المستخدم&quot; لديه حق الوصول إلى سطح المكتب
 DocType: System Settings,Date and Number Format,صيغة التاريخ و الرقم
 apps/frappe/frappe/model/document.py,one of,واحدة من
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,الإعداد&gt; تخصيص النموذج
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,الإعداد> تخصيص النموذج
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,فحص لحظة واحدة
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,إظهار البطاقات
 DocType: DocField,HTML Editor,محرر HTML
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,الفواتير
 DocType: Email Queue,Not Sent,لا ترسل
 DocType: Web Form,Actions,الإجراءات
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,الإعداد&gt; المستخدم
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,الإعداد> المستخدم
 DocType: Workflow State,align-justify,محاذاة-تبرير
 DocType: User,Middle Name (Optional),الاسم الأوسط (اختياري)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,لا يسمح
@@ -1410,7 +1410,7 @@ DocType: User,System User,نظام المستخدم
 DocType: Report,Is Standard,هو معيار
 DocType: Desktop Icon,_report,_تقرير
 DocType: Dashboard Chart,Full,ممتلئ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",لا علامات HTML شفر HTML مثل &lt;script&gt; أو مجرد شخصيات مثل &lt;أو&gt;، لأنها يمكن أن تستخدم عمدا في هذا المجال
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",لا علامات HTML شفر HTML مثل &lt;script> أو مجرد شخصيات مثل &lt;أو>، لأنها يمكن أن تستخدم عمدا في هذا المجال
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} انتقد يوم {1}
 DocType: Website Settings,FavIcon,علامة المفضلة
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,يركض
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,سيعرض تذي
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,معلق
 DocType: System Settings,Allow only one session per user,السماح لجلسة واحدة فقط لكل مستخدم
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,مجلد الوطن / اختبار 1 / مجلد اختبار 3
-DocType: Website Settings,&lt;head&gt; HTML,<head> HTML
+DocType: Website Settings,&lt;head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,اختر أو اسحب عبر فتحات الوقت لإنشاء حدث جديد.
 DocType: Contact,Contact Details,تفاصيل الاتصال
 DocType: DocField,In Filter,في تصفية
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,الدخول غير مسموح به في هذا الوقت
 DocType: Data Migration Run,Current Mapping Action,إجراء رسم الخرائط الحالي
 DocType: Dashboard Chart Source,Source Name,اسم المصدر
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,لا يوجد حساب بريد إلكتروني مرتبط بالمستخدم. الرجاء إضافة حساب أسفل المستخدم&gt; البريد الوارد للبريد الإلكتروني.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,لا يوجد حساب بريد إلكتروني مرتبط بالمستخدم. الرجاء إضافة حساب أسفل المستخدم> البريد الوارد للبريد الإلكتروني.
 DocType: Email Account,Email Sync Option,مزامنة البريد الإلكتروني الخيار
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,الصف رقم
 DocType: Async Task,Runtime,وقت التشغيل
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,بالف�
 DocType: User Email,Enable Outgoing,تمكين المنتهية ولايته
 DocType: Address,Fax,فاكس
 apps/frappe/frappe/config/customization.py,Custom Tags,كلمات دلائلية حخصصة
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,حساب البريد الإلكتروني لا الإعداد. يرجى إنشاء حساب بريد إلكتروني جديد من الإعداد&gt; البريد الإلكتروني&gt; حساب البريد الإلكتروني
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,حساب البريد الإلكتروني لا الإعداد. يرجى إنشاء حساب بريد إلكتروني جديد من الإعداد> البريد الإلكتروني> حساب البريد الإلكتروني
 DocType: Comment,Submitted,مسجلة
 DocType: Contact,Pulled from Google Contacts,سحبت من اتصالات جوجل
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,طلب غير صالح
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,انتهاء الا�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",سيظهر هذا المجال إلا إذا كان FIELDNAME المحدد هنا له قيمة أو قواعد صحيحة (أمثلة): myfield حدة التقييم: doc.myfield == &#39;بلدي القيمة &quot;وحدة التقييم: doc.age&gt; 18
+eval:doc.age>18",سيظهر هذا المجال إلا إذا كان FIELDNAME المحدد هنا له قيمة أو قواعد صحيحة (أمثلة): myfield حدة التقييم: doc.myfield == &#39;بلدي القيمة &quot;وحدة التقييم: doc.age> 18
 DocType: Social Login Key,Office 365,مكتب 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,اليوم
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",وبمجرد الانتهاء من تعيين هذه ، سوف يكون المستخدمون قادرين فقط الوصول إلى المستندات (على سبيل المثال مدونة بوست) حيث يوجد رابط (مثل مدون ) .
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,الأحرف الكبيرة
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,مخصصةHTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,أدخل اسم المجلد
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,لم يتم العثور على قالب عنوان افتراضي. يرجى إنشاء واحدة جديدة من الإعداد&gt; الطباعة والعلامة التجارية&gt; قالب العنوان.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,لم يتم العثور على قالب عنوان افتراضي. يرجى إنشاء واحدة جديدة من الإعداد> الطباعة والعلامة التجارية> قالب العنوان.
 apps/frappe/frappe/auth.py,Unknown User,مستخدم غير معروف
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,حدد الصلاحية
 DocType: Comment,Deleted,حذف
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,المسار إلى شهادة
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ليس هناك إذن كاف لمشاهدة الروابط
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,إسم العنوان إلزامى (لابد من إدخاله)
 DocType: Google Contacts,Push to Google Contacts,اضغط على جهات اتصال Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",وأضاف HTML في القسم &lt;head&gt; من صفحة الويب، تستخدم في المقام الأول للتحقق من الموقع وSEO
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",وأضاف HTML في القسم &lt;head> من صفحة الويب، تستخدم في المقام الأول للتحقق من الموقع وSEO
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,انتكس
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,البند لا يمكن أن تضاف إلى أحفاد الخاصة
 DocType: Session Default Settings,Session Defaults,الجلسة الافتراضية
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,تحذير
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,قد تتم طباعة هذا على صفحات متعددة
 DocType: Data Migration Run,Percent Complete,في المئة كاملة
 DocType: Tag Category,Tag Category,العلامة الفئة
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",للمقارنة ، استخدم&gt; 5 ، &lt;10 أو = 324. للنطاقات ، استخدم 5:10 (للقيم بين 5 و 10).
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",للمقارنة ، استخدم> 5 ، &lt;10 أو = 324. للنطاقات ، استخدم 5:10 (للقيم بين 5 و 10).
 DocType: Google Calendar,Pull from Google Calendar,سحب من تقويم جوجل
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,مساعدة
 DocType: User,Login Before,تسجيل الدخول قبل
@@ -2456,7 +2456,7 @@ apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Cancelled D
 DocType: Data Migration Run,Start Time,توقيت البدء
 apps/frappe/frappe/model/delete_doc.py,Cannot delete or cancel because {0} {1} is linked with {2} {3} {4},لا يمكن حذف أو إلغاء لأن {0} {1} مرتبط مع {2} {3} {4}
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Read,يمكنه القراءة
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,{0} Chart,{0} الرسم البياني
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,{0} Chart,{0} الرس�� البياني
 DocType: Custom Role,Response,الإستجابة
 DocType: DocField,Geolocation,تحديد الموقع الجغرافي
 DocType: Workflow,Emails will be sent with next possible workflow actions,سيتم إرسال رسائل البريد الإلكتروني مع إجراءات سير العمل التالية المحتملة
@@ -2893,7 +2893,7 @@ DocType: Custom Script,Custom Script,نص مخصص
 DocType: Address,Address Line 2,العنوان سطر 2
 DocType: Address,Reference,مرجع
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,كلف إلى
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,يرجى إعداد حساب البريد الإلكتروني الافتراضي من الإعداد&gt; البريد الإلكتروني&gt; حساب البريد الإلكتروني
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,يرجى إعداد حساب البريد الإلكتروني الافتراضي من الإعداد> البريد الإلكتروني> حساب البريد الإلكتروني
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,بيانات ترحيل بيانات التفاصيل
 DocType: Data Import,Action,حدث
 DocType: GSuite Settings,Script URL,عنوان ورل للنص البرمجي
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,السماح بالإعتماد
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,نوع الاستثناء
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,اختيار الأعمدة
-DocType: Web Page,Add code as &lt;script&gt;,إضافة التعليمات البرمجية كما &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,إضافة التعليمات البرمجية كما &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,مسح أذونات المستخدم
 DocType: Webhook,Headers,الترويسات
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,الأحداث القادمة
@@ -3445,15 +3445,15 @@ DocType: Workflow State,share-alt,حصة بديل
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},يجب أن تكون قائمة الانتظار واحدة من {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> افتراضي قالب </ H4> 
  <p> ويستخدم <a href=""http://jinja.pocoo.org/docs/templates/""> جينجا قالبي templating </A> وجميع مجالات عنوان ( بما في ذلك الحقول المخصصة إن وجدت) سوف تكون متاحة </ P> 
  <قبل> <كود> {{address_line1}} العلامة & lt؛ BR & GT؛ 

--- a/frappe/translations/bg.csv
+++ b/frappe/translations/bg.csv
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Неактиве
 DocType: Translation,Contributed Translation Doctype Name,Име на принос на превода
 DocType: PayPal Settings,Redirect To,пренасочи към
 DocType: Data Migration Mapping,Pull,дърпам
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Формат: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Формат: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Масова актуализация
 DocType: Workflow State,chevron-up,Стрелка-нагоре
 DocType: DocType,Allow Guest to View,Позволете гости да преглеждат
@@ -1027,7 +1027,7 @@ DocType: Property Setter,Property Setter,Property сетер
 DocType: Web Form,Allow Print,Разрешаване на печат
 DocType: Communication,Clicked,Кликнато
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Не следвай
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Няма разрешение за &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Няма разрешение за '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Планирана да изпратите
 DocType: DocType,Track Seen,Track Погледнато
 DocType: Dropbox Settings,File Backup,Архивиране на файлове
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,Име на базата дан�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Обновяване Form
 DocType: DocField,Select,Изберете
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Вижте пълния дневник
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Example: status == &#39;Open&#39; и напишете == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Example: status == 'Open' и напишете == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Файлът не е прикачен
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Изгубената връзка. Възможно е някои функции да не работят.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Повторения като &quot;ААА&quot; са лесни за отгатване
@@ -2975,7 +2975,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Липсва Цен�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Добави Поделемент
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Импортиране на напредъка
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Ако условието е изпълнено, потребителят ще бъде възнаграден с точките. напр. doc.status == &#39;Затворен&#39;"
+","Ако условието е изпълнено, потребителят ще бъде възнаграден с точките. напр. doc.status == 'Затворен'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Осчетоводен Запис не може да бъде изтрит.
 DocType: GSuite Templates,Template Name,Име на шаблона
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,нов тип документ
@@ -3841,7 +3841,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Неустойка
 DocType: Translation,Verified,Потвърден
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} добавен
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Търсене за &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Търсене за '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Моля, запишете справката първо"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,Добавени {0} абонати
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Не в

--- a/frappe/translations/bg.csv
+++ b/frappe/translations/bg.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Архив�
 DocType: DocField,In Global Search,В глобално търсене
 DocType: System Settings,Brute Force Security,Брутална сигурност
 DocType: Workflow State,indent-left,ляво подравняване
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} преди (и) година
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} преди (и) година
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Рисковано е да изтриете този файл: {0}. Моля, обърнете се към вашия System Manager."
 DocType: Currency,Currency Name,Валута Име
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Няма имейли
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Номер {0
 apps/frappe/frappe/config/customization.py,Add custom forms.,Добавяне на персонализирани форми.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} в {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,подадено този документ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Настройка&gt; Разрешения за потребители
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Настройка> Разрешения за потребители
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Системата осигурява много предварително определени роли. Можете да добавяте нови роли за да зададете по-фини разрешения.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Гео
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ако потребителят има някаква проверява роля, след това потребителят се превръща в &quot;Система за потребителя&quot;. &quot;Система за потребителя&quot; има достъп до работния плот"
 DocType: System Settings,Date and Number Format,Форма на дати и числа
 apps/frappe/frappe/model/document.py,one of,един от
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Настройка&gt; Персонализирайте формуляр
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Настройка> Персонализирайте формуляр
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,"Проверка. Един момент, моля."
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Покажи Етикети
 DocType: DocField,HTML Editor,HTML редактор
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Фактуриране
 DocType: Email Queue,Not Sent,Не е изпратено
 DocType: Web Form,Actions,Действия
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Настройка&gt; Потребител
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Настройка> Потребител
 DocType: Workflow State,align-justify,подравняване-justify
 DocType: User,Middle Name (Optional),Презиме (по избор)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Не е разрешен
@@ -1410,7 +1410,7 @@ DocType: User,System User,Системен потребител
 DocType: Report,Is Standard,Е стандартна
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,пълен
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Не HTML Възхвала HTML тагове като &lt;скрипт&gt; или просто символи като &lt;или&gt;, тъй като те биха могли да се използват съзнателно в тази област"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не HTML Възхвала HTML тагове като &lt;скрипт> или просто символи като &lt;или>, тъй като те биха могли да се използват съзнателно в тази област"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} критикуван на {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,тичам
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer ще се 
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,В очакване на
 DocType: System Settings,Allow only one session per user,Оставя само една сесия на потребител
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Начало / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,HTML
+DocType: Website Settings,&lt;head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Изберете или плъзгайте по времеви слотове за създаване на ново събитие.
 DocType: Contact,Contact Details,Данни за контакт
 DocType: DocField,In Filter,Във филтър
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Не е позволено влизането в този момент
 DocType: Data Migration Run,Current Mapping Action,Текущо действие за картографиране
 DocType: Dashboard Chart Source,Source Name,Източник Име
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,"Няма имейл акаунт, свързан с Потребителя. Моля, добавете акаунт в Потребител&gt; Входяща поща."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Няма имейл акаунт, свързан с Потребителя. Моля, добавете акаунт в Потребител> Входяща поща."
 DocType: Email Account,Email Sync Option,Email Sync опция
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Ред №
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Още п
 DocType: User Email,Enable Outgoing,Активиране на изходящо
 DocType: Address,Fax,Факс
 apps/frappe/frappe/config/customization.py,Custom Tags,Персонализирани Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,"Не се настройва имейл акаунт. Моля, създайте нов имейл акаунт от Setup&gt; Email&gt; Email account"
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,"Не се настройва имейл акаунт. Моля, създайте нов имейл акаунт от Setup> Email> Email account"
 DocType: Comment,Submitted,Изпратено
 DocType: Contact,Pulled from Google Contacts,Изтеглено от Google Контакти
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Невалидна заявка
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Сесията из�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",В това поле ще се появи само ако FIELDNAME определено тук има стойност или правилата са верни (примери): myfield Оценка: doc.myfield == &quot;My Value&quot; Оценка: doc.age&gt; 18
+eval:doc.age>18",В това поле ще се появи само ако FIELDNAME определено тук има стойност или правилата са верни (примери): myfield Оценка: doc.myfield == &quot;My Value&quot; Оценка: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Днес
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","След като сте задали този, потребителите ще бъдат в състояние единствено достъп до документи (напр. Блог Post), където съществува връзката (напр. Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ГЛАВНИ БУКВИ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Потребителски HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Въведете име на папка
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,"Не е намерен шаблон за адрес по подразбиране. Моля, създайте нов от Настройка&gt; Печат и брандиране&gt; Шаблон на адреса."
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"Не е намерен шаблон за адрес по подразбиране. Моля, създайте нов от Настройка> Печат и брандиране> Шаблон на адреса."
 apps/frappe/frappe/auth.py,Unknown User,Неизвестен потребител
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Изберете роля
 DocType: Comment,Deleted,Изтрити
@@ -2277,7 +2277,7 @@ DocType: Patch Log,List of patches executed,Списък на изпълнени
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed,{0} е вече отписан
 DocType: Data Import,Show only errors,Показване само на грешки
 DocType: Website Settings,Banner HTML,Реклама HTML
-DocType: Workflow,Send Email Alert,Изпращане на предупреждение по имейл
+DocType: Workflow,Send Email Alert,��зпращане на предупреждение по имейл
 apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',"Моля, изберете друг начин на плащане. Razorpay не поддържа транзакции с валута &quot;{0}&quot;"
 DocType: Data Import,In Progress,Напред
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,На опашка за архивиране. Това може да отнеме няколко минути до един час.
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Път към сертифик
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Няма достатъчно разрешение да виждате връзки
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Заглавие на Адрес е задължително.
 DocType: Google Contacts,Push to Google Contacts,Премини към Google Контакти
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Добавен в HTML &lt;главата&gt; раздел на уеб страницата, използвани главно за проверка сайт и SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Добавен в HTML &lt;главата> раздел на уеб страницата, използвани главно за проверка сайт и SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Рецидивирал
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Позицията не може да бъде добавена към собствените си потомци
 DocType: Session Default Settings,Session Defaults,Сесия по подразбиране
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Предупреждение
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Това може да се отпечата на няколко страници
 DocType: Data Migration Run,Percent Complete,Процента завършени
 DocType: Tag Category,Tag Category,Етикет - Категория
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За сравнение използвайте&gt; 5, &lt;10 или = 324. За диапазони използвайте 5:10 (за стойности между 5 и 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За сравнение използвайте> 5, &lt;10 или = 324. За диапазони използвайте 5:10 (за стойности между 5 и 10)."
 DocType: Google Calendar,Pull from Google Calendar,Издърпайте от Google Календар
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помощ
 DocType: User,Login Before,Вход Преди
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Потребителски Script
 DocType: Address,Address Line 2,Адрес - Ред 2
 DocType: Address,Reference,Препратка
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Възложените
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,"Моля, настройте по подразбиране имейл акаунта от Setup&gt; Email&gt; Email account"
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,"Моля, настройте по подразбиране имейл акаунта от Setup> Email> Email account"
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Данни за картографиране на данни за мигриране
 DocType: Data Import,Action,Действие
 DocType: GSuite Settings,Script URL,URL адрес на скрипта
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Разрешаване на Изпращане
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Тип Изключение
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Избрани Колони
-DocType: Web Page,Add code as &lt;script&gt;,"Добави код, както"
+DocType: Web Page,Add code as &lt;script>,"Добави код, както"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Изчистване на потребителските разрешения
 DocType: Webhook,Headers,Заглавия
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Предстоящи събития
@@ -3442,16 +3442,16 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Опашката трябва да бъде една от {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Default Template </h4><p> Използва <a href=""http://jinja.pocoo.org/docs/templates/"">Джинджа темплейт</a> и във всички сфери на адрес (включително Потребителски полета, ако има такъв) ще бъде на разположение </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Default Template </h4><p> Използва <a href=""http://jinja.pocoo.org/docs/templates/"">Джинджа темплейт</a> и във всички сфери на адрес (включително Потребителски полета, ако има такъв) ще бъде на разположение </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Поле за начална дата
 DocType: Role,Role Name,Роля Име
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Превключване към бюрото

--- a/frappe/translations/bg.csv
+++ b/frappe/translations/bg.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Системен потребител
 DocType: Report,Is Standard,Е стандартна
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,пълен
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не HTML Възхвала HTML тагове като &lt;скрипт> или просто символи като &lt;или>, тъй като те биха могли да се използват съзнателно в тази област"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Не HTML Възхвала HTML тагове като <скрипт> или просто символи като <или>, тъй като те биха могли да се използват съзнателно в тази област"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} критикуван на {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,тичам
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer ще се 
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,В очакване на
 DocType: System Settings,Allow only one session per user,Оставя само една сесия на потребител
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Начало / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,HTML
+DocType: Website Settings,<head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Изберете или плъзгайте по времеви слотове за създаване на ново събитие.
 DocType: Contact,Contact Details,Данни за контакт
 DocType: DocField,In Filter,Във филтър
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Път към сертифик
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Няма достатъчно разрешение да виждате връзки
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Заглавие на Адрес е задължително.
 DocType: Google Contacts,Push to Google Contacts,Премини към Google Контакти
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Добавен в HTML &lt;главата> раздел на уеб страницата, използвани главно за проверка сайт и SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Добавен в HTML <главата> раздел на уеб страницата, използвани главно за проверка сайт и SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Рецидивирал
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Позицията не може да бъде добавена към собствените си потомци
 DocType: Session Default Settings,Session Defaults,Сесия по подразбиране
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Предупреждение
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Това може да се отпечата на няколко страници
 DocType: Data Migration Run,Percent Complete,Процента завършени
 DocType: Tag Category,Tag Category,Етикет - Категория
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За сравнение използвайте> 5, &lt;10 или = 324. За диапазони използвайте 5:10 (за стойности между 5 и 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За сравнение използвайте> 5, <10 или = 324. За диапазони използвайте 5:10 (за стойности между 5 и 10)."
 DocType: Google Calendar,Pull from Google Calendar,Издърпайте от Google Календар
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помощ
 DocType: User,Login Before,Вход Преди
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Разрешаване на Изпращане
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Тип Изключение
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Избрани Колони
-DocType: Web Page,Add code as &lt;script>,"Добави код, както"
+DocType: Web Page,Add code as <script>,"Добави код, както"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Изчистване на потребителските разрешения
 DocType: Webhook,Headers,Заглавия
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Предстоящи събития
@@ -3442,16 +3442,16 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Опашката трябва да бъде една от {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Default Template </h4><p> Използва <a href=""http://jinja.pocoo.org/docs/templates/"">Джинджа темплейт</a> и във всички сфери на адрес (включително Потребителски полета, ако има такъв) ще бъде на разположение </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Default Template </h4><p> Използва <a href=""http://jinja.pocoo.org/docs/templates/"">Джинджа темплейт</a> и във всички сфери на адрес (включително Потребителски полета, ако има такъв) ще бъде на разположение </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Поле за начална дата
 DocType: Role,Role Name,Роля Име
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Превключване към бюрото

--- a/frappe/translations/bn.csv
+++ b/frappe/translations/bn.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,মাতা
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},এর সাথে যুক্ত আপনার {0} ডেটা ডাউনলোড করার জন্য আমরা আপনার কাছ থেকে একটি অনুরোধ পেয়েছি: {1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","সক্রিয় করা হলে, পাসওয়ার্ড ক্ষমতা নূন্যতম পাসওয়ার্ড স্কোরের মান উপর ভিত্তি করে প্রয়োগ করা হবে। 2 এর একটি মান মাঝারি শক্তিশালী হচ্ছে এবং 4 খুব শক্তিশালী হচ্ছে।"
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;টিম সদস্য&quot; বা &quot;ম্যানেজমেন্ট&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',মাঠের &#39;চেক&#39; টাইপ-এর জন্য ডিফল্ট হয় &#39;0&#39; বা &#39;1&#39; হতে হবে
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',মাঠের 'চেক' টাইপ-এর জন্য ডিফল্ট হয় '0' বা '1' হতে হবে
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,গতকাল
 DocType: Contact,Designation,উপাধি
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,স্বয়ংক্রিয় সংযোগ কেবল একটি ইমেল অ্যাকাউন্টের জন্য সক্রিয় করা যেতে পারে।
@@ -251,7 +251,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,নিষ্ক�
 DocType: Translation,Contributed Translation Doctype Name,অবদানযুক্ত অনুবাদ ডক্টাইপের নাম
 DocType: PayPal Settings,Redirect To,পুনর্নির্দেশ
 DocType: Data Migration Mapping,Pull,টান
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},জাভাস্ক্রিপ্ট বিন্যাস: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},জাভাস্ক্রিপ্ট বিন্যাস: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,প্রচুর আপডেট
 DocType: Workflow State,chevron-up,শেভ্রন-আপ
 DocType: DocType,Allow Guest to View,দেখার জন্য অতিথি অনুমতি দিন
@@ -280,7 +280,7 @@ DocType: System Settings,Run scheduled jobs only if checked,চেক যদি 
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Will only be shown if section headings are enabled,শুধুমাত্র যদি অধ্যায় শিরোনামের সক্রিয় করা হয় প্রদর্শন করা হবে
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Archive,সংরক্ষাণাগার
 apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload,ফাইল আপলোড করুন
-DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","ডিফল্ট মান ক্ষেত্র (কী) এবং মান লিখুন. আপনি একটি ক্ষেত্রের জন্য একাধিক মান যোগ করুন, প্রথম এক বাছাই করা হবে. এই সমস্ত ডিফল্ট এছাড়াও &quot;ম্যাচ&quot; অনুমতি নিয়ম সেট করার জন্য ব্যবহৃত হয়. ক্ষেত্র তালিকা দেখুন, &quot;কাস্টমাইজ ফরম &#39;থেকে যান."
+DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","ডিফল্ট মান ক্ষেত্র (কী) এবং মান লিখুন. আপনি একটি ক্ষেত্রের জন্য একাধিক মান যোগ করুন, প্রথম এক বাছাই করা হবে. এই সমস্ত ডিফল্ট এছাড়াও &quot;ম্যাচ&quot; অনুমতি নিয়ম সেট করার জন্য ব্যবহৃত হয়. ক্ষেত্র তালিকা দেখুন, &quot;কাস্টমাইজ ফরম 'থেকে যান."
 DocType: Auto Repeat,Message,বার্তা
 DocType: Communication,Rating,নির্ধারণ
 DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table",ক্ষেত্রের একটি টেবিল একটি কলাম যদি ক্ষেত্রের প্রস্থ মুদ্রণ
@@ -553,7 +553,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),গত সপ্তাহের পারফরম্যান্সের ভিত্তিতে পরিসংখ্যান ({0} থেকে {1} থেকে)
 DocType: LDAP Settings,LDAP Phone Field,এলডিএপি ফোন ক্ষেত্র
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","নথি প্রকার ..., যেমন গ্রাহক"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,কন্ডিশন &#39;{0}&#39; অবৈধ
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,কন্ডিশন '{0}' অবৈধ
 DocType: Workflow State,barcode,বারকোড
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,সাব-কোয়েরি বা ফাংশন ব্যবহার নিষিদ্ধ করা হয়
 apps/frappe/frappe/config/customization.py,Add your own translations,আপনার নিজস্ব অনুবাদ যোগ করুন
@@ -701,7 +701,7 @@ DocType: Slack Webhook URL,Webhook URL,ওয়েবহুক URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,ইউজারনেম {0} আগে থেকেই আছে
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} আমদানিযোগ্য নয় হিসাবে আমদানি সেট করা যায় না
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},আপনার ঠিকানা টেমপ্লেট মধ্যে একটি ত্রুটি আছে {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} &#39;প্রাপকদের&#39; একটি অবৈধ ইমেল ঠিকানা
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} 'প্রাপকদের' একটি অবৈধ ইমেল ঠিকানা
 DocType: Footer Item,"target = ""_blank""",টার্গেট = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,নিমন্ত্রণকর্তা
@@ -762,7 +762,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,ডকুমেন্ট শেয়ার প্রতিবেদন
 DocType: Social Login Key,Base URL,বেস URL
 DocType: User,Last Login,সর্বশেষ লগইন
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},আপনি ক্ষেত্রের জন্য &#39;অনুবাদযোগ্য&#39; সেট করতে পারবেন না {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},আপনি ক্ষেত্রের জন্য 'অনুবাদযোগ্য' সেট করতে পারবেন না {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,স্তম্ভ
 DocType: Chat Profile,Chat Profile,প্রোফাইল প্রোফাইল
 DocType: Custom Field,Adds a custom field to a DocType,একটি DOCTYPE একটি কাস্টম ক্ষেত্র যোগ
@@ -771,7 +771,7 @@ DocType: File,Is Home Folder,হোম ফোল্ডার
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,নববার স্টাইল
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} একটি বৈধ ইমেইল ঠিকানা নয়
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,মুদ্রণের জন্য অন্তত 1 রেকর্ড নির্বাচন করুন
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ব্যবহারকারী &#39;{0}&#39; ইতিমধ্যে ভূমিকা রয়েছে &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ব্যবহারকারী '{0}' ইতিমধ্যে ভূমিকা রয়েছে '{1}'
 DocType: System Settings,Two Factor Authentication method,দুটি ফ্যাক্টর প্রমাণীকরণ পদ্ধতি
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,প্রথমে নাম সেট করুন এবং রেকর্ডটি সংরক্ষণ করুন।
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 রেকর্ড
@@ -1016,7 +1016,7 @@ DocType: Property Setter,Property Setter,প্রপার্টি গোয�
 DocType: Web Form,Allow Print,প্রিন্ট করার অনুমতি দিন
 DocType: Communication,Clicked,ক্লিক
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,অনুসরণ
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},কোন অনুমতি &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},কোন অনুমতি '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,পাঠাতে তফসিলি
 DocType: DocType,Track Seen,ট্র্যাক Seen
 DocType: Dropbox Settings,File Backup,ফাইল ব্যাকআপ
@@ -1043,7 +1043,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,পৃষ্ঠা এইচটিএমএল
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,ত্রুটিযুক্ত সারিগুলি রফতানি করুন
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,গোষ্ঠী নামটি ফাঁকা হতে পারে না।
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,আরও নোড শুধুমাত্র &#39;গ্রুপ&#39; টাইপ নোড অধীনে তৈরি করা যেতে পারে
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,আরও নোড শুধুমাত্র 'গ্রুপ' টাইপ নোড অধীনে তৈরি করা যেতে পারে
 DocType: SMS Parameter,Header,শিরোলেখ
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},অজানা কলাম: {0}
 DocType: Notification Recipient,Email By Role,ইমেল ভূমিকা
@@ -1933,7 +1933,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,AP-দক্ষিণ-পূর্ব-1
 DocType: DocType,"Must be of type ""Attach Image""",টাইপ করতে হবে &quot;চিত্র সংযুক্ত করুন&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,সরিয়ে ফেলুন সব
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ফিল্ডের সেট না না &#39;শুধুমাত্র পাঠযোগ্য&#39; পারেন {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ফিল্ডের সেট না না 'শুধুমাত্র পাঠযোগ্য' পারেন {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,জিরো মানে যে কোনো সময় আপডেট রেকর্ড পাঠাতে
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,সম্পূর্ণ সেটআপ
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,সফলভাবে আপডেট হয়েছে
@@ -1976,7 +1976,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,গুগল ফন্ট
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","সহায়ক নয়, গিটহাব বিষয়ে আপনার পরামর্শ যোগ দয়া যেখানে এই নির্দেশাবলী যদি."
 DocType: Workflow State,bookmark,বুকমার্ক
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ফোল্ডার নাম অন্তর্ভুক্ত করা উচিত নয় &#39;/&#39; (স্ল্যাশ)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ফোল্ডার নাম অন্তর্ভুক্ত করা উচিত নয় '/' (স্ল্যাশ)
 DocType: Note,Note,বিঃদ্রঃ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,ভুলের তথ্য
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / এক্সেল ফর্ম্যাটে ডেটা রপ্তানি করুন
@@ -2078,7 +2078,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ঘন্টা য�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",এই ক্ষেত্রটি প্রদর্শিত হবে শুধুমাত্র যদি FIELDNAME এখানে সংজ্ঞায়িত মূল্য আছে বা নিয়ম সত্য (উদাহরণ) হয়: myfield Eval: doc.myfield == &#39;আমার মূল্য&#39; Eval: doc.age> 18
+eval:doc.age>18",এই ক্ষেত্রটি প্রদর্শিত হবে শুধুমাত্র যদি FIELDNAME এখানে সংজ্ঞায়িত মূল্য আছে বা নিয়ম সত্য (উদাহরণ) হয়: myfield Eval: doc.myfield == 'আমার মূল্য' Eval: doc.age> 18
 DocType: Social Login Key,Office 365,অফিস 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,আজ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","আপনি এই সেট করে থাকেন, শুধুমাত্র সেই ব্যবহারকারীদের ক্ষেত্রে সক্ষম এক্সেস নথি হতে হবে (যেমন. ব্লগ পোস্ট) লিংক (যেমন. ব্লগার) যেখানে বিদ্যমান."
@@ -2117,7 +2117,7 @@ DocType: Data Migration Connector,Database Name,ডেটাবেস নাম
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,সুদ্ধ ফরম
 DocType: DocField,Select,নির্বাচন করা
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,সম্পূর্ণ লগ দেখুন
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","সাধারণ পাইথন এক্সপ্রেশন, উদাহরণ: অবস্থা == &#39;খুলুন&#39; এবং টাইপ করুন == &#39;বাগ&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","সাধারণ পাইথন এক্সপ্রেশন, উদাহরণ: অবস্থা == 'খুলুন' এবং টাইপ করুন == 'বাগ'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,ফাইল সংযুক্ত করা
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,সংযোগ বিচ্ছিন্ন. কিছু বৈশিষ্ট্য কাজ করতে পারে না।
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; মত পুনরাবৃত্তি অনুমান করা সহজ
@@ -2245,7 +2245,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,শুধুমাত্র ত্রুটি দেখান
 DocType: Website Settings,Banner HTML,ব্যানার এইচটিএমএল
 DocType: Workflow,Send Email Alert,ইমেল সতর্কতা পাঠান
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',দয়া করে অন্য একটি অর্থ প্রদানের পদ্ধতি নির্বাচন করুন। Razorpay মুদ্রায় লেনদেন অবলম্বন পাওয়া যায়নি &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',দয়া করে অন্য একটি অর্থ প্রদানের পদ্ধতি নির্বাচন করুন। Razorpay মুদ্রায় লেনদেন অবলম্বন পাওয়া যায়নি '{0}'
 DocType: Data Import,In Progress,চলমান
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,ব্যাকআপ জন্য সারিবদ্ধ. এটি একটি ঘন্টা থেকে কয়েক মিনিট সময় লাগতে পারে.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2657,7 +2657,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,সংশোধনী
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,পেপ্যাল পেমেন্ট গেটওয়ে সেটিংস
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,শীর্ষ অভিনেতা
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,মূল ডক্টটাইপগুলিতে কাস্টম ক্ষেত্রগুলি যুক্ত করা যায় না।
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) ছেঁটে ফেলা পাবেন, যেমন অনুমতি সর্বোচ্চ অক্ষর {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) ছেঁটে ফেলা পাবেন, যেমন অনুমতি সর্বোচ্চ অক্ষর {2}"
 DocType: OAuth Client,Response Type,প্রতিক্রিয়ার প্রকার
 DocType: Contact Us Settings,Send enquiries to this email address,এই ইমেইল ঠিকানায় অনুসন্ধান পাঠান
 DocType: Letter Head,Letter Head Name,চিঠি মাথা নাম
@@ -2713,7 +2713,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,চিত্র দেখুন
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","দেখে মনে হচ্ছে কিছু মত লেনদেনের সময় কিছু ভুল হয়েছে. আমরা পেমেন্ট নিশ্চিত করেননি, পেপ্যাল স্বয়ংক্রিয়ভাবে আপনি এই পরিমাণ ফেরত দেওয়া হবে. ভাষা ব্যবহারযোগ্য না হলে, দয়া করে আমাদের একটি ইমেল পাঠাতে এবং সংশ্লেষন আইডি উল্লেখ: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","পাসওয়ার্ড প্রতীক, সংখ্যা এবং বড় হাতের অক্ষরে অন্তর্ভুক্ত করুন"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ক্ষেত্র &#39;{0}&#39; কাস্টম ফিল্ড উল্লেখিত পর ঢোকান &#39;{1}&#39;, লেবেল সঙ্গে &#39;{2}&#39;, অস্তিত্ব নেই"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ক্ষেত্র '{0}' কাস্টম ফিল্ড উল্লেখিত পর ঢোকান '{1}', লেবেল সঙ্গে '{2}', অস্তিত্ব নেই"
 DocType: List Filter,List Filter,তালিকা ফিল্টার
 DocType: Workflow State,signal,সংকেত
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,সংযুক্তি আছে
@@ -2723,7 +2723,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,ডকুমেন্ট পুনঃস্থাপিত
 DocType: Data Export,Data Export,ডেটা এক্সপোর্ট
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ভাষা নির্বাচন কর...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},আপনি ক্ষেত্রের জন্য &#39;বিকল্প&#39; সেট করতে পারবেন না {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},আপনি ক্ষেত্রের জন্য 'বিকল্প' সেট করতে পারবেন না {0}
 DocType: Help Article,Author,লেখক
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,পুনঃসূচনা পাঠানো
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,পুনরায় খোলা
@@ -2737,14 +2737,14 @@ DocType: Web Page,Slideshow,ছবি
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,ডিফল্ট ঠিকানা টেমপ্লেট মোছা যাবে না
 DocType: Contact,Maintenance Manager,রক্ষণাবেক্ষণ ব্যাবস্থাপক
 DocType: Workflow State,Search,অনুসন্ধান
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',দয়া করে অন্য একটি অর্থ প্রদানের পদ্ধতি নির্বাচন করুন। ডোরা মুদ্রায় লেনদেন অবলম্বন পাওয়া যায়নি &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',দয়া করে অন্য একটি অর্থ প্রদানের পদ্ধতি নির্বাচন করুন। ডোরা মুদ্রায় লেনদেন অবলম্বন পাওয়া যায়নি '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,আবর্জনা সরান
 DocType: Web Form,Web Form Fields,ওয়েব ফরম ক্ষেত্র
 DocType: Data Import,Amended From,সংশোধিত
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},সতর্কতা: অক্ষম এটি {0} এর সাথে সম্পর্কিত কোন টেবিলে {1}
 DocType: S3 Backup Settings,eu-north-1,ইইউ-উত্তর-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,এই দস্তাবেজটি বর্তমানে সঞ্চালনের জন্য সারিবদ্ধ হয়. অনুগ্রহপূর্বক আবার চেষ্টা করুন
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ফাইল &#39;{0}&#39; পাওয়া যায়নি
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ফাইল '{0}' পাওয়া যায়নি
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,বিভাগটি অপসারণ
 DocType: User,Change Password,পাসওয়ার্ড পরিবর্তন করুন
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,এক্স অক্ষ ক্ষেত্র
@@ -2925,7 +2925,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,মূল্য জ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,শিশু করো
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,আমদানি অগ্রগতি
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",শর্তটি সন্তুষ্ট হলে ব্যবহারকারীকে পয়েন্টগুলি দিয়ে পুরস্কৃত করা হবে। যেমন। doc.status == &#39;বন্ধ&#39;
+",শর্তটি সন্তুষ্ট হলে ব্যবহারকারীকে পয়েন্টগুলি দিয়ে পুরস্কৃত করা হবে। যেমন। doc.status == 'বন্ধ'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: জমা রেকর্ড মুছে ফেলা যাবে না.
 DocType: GSuite Templates,Template Name,টেম্পলেট নাম
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ডকুমেন্টের নতুন ধরনের
@@ -3053,7 +3053,7 @@ DocType: Dashboard Chart,Chart Type,চার্ট প্রকার
 DocType: DocType,Auto Name,অটো নাম
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,এবিসি বা 6543 মত সিকোয়েন্স চলুন যেমন তারা অনুমান করা সহজ
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,অনুগ্রহপূর্বক আবার চেষ্টা করুন
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL টি অবশ্যই &#39;http: //&#39; বা &#39;https: //&#39; দিয়ে শুরু করা উচিত
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL টি অবশ্যই 'http: //' বা 'https: //' দিয়ে শুরু করা উচিত
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,অপশন 3
 DocType: Communication,uid,ইউআইডি
 DocType: Workflow State,Edit,সম্পাদন করা
@@ -3289,7 +3289,7 @@ DocType: Notification,Send alert if this field's value changes,এই ক্ষ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,থিম রঙ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,একটি নতুন বিন্যাস করা একটি DOCTYPE নির্বাচন
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,ব্যবহারকারী কোন অস্তিত্ব নেই
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;প্রাপক&#39; নির্দিষ্ট না
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'প্রাপক' নির্দিষ্ট না
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,এক্ষুনি
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,প্রয়োগ করা
 DocType: Footer Item,Policy,নীতি
@@ -3337,7 +3337,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,কাস্ট�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,উন্নতি
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,ভূমিকা দ্বারা
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,নিখোঁজ ক্ষেত্রসমূহ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname অবৈধ FIELDNAME &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname অবৈধ FIELDNAME '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ডকুমেন্ট টাইপ এ অনুসন্ধান
 DocType: Custom DocPerm,Role and Level,ভূমিকা ও শ্রেনী
 DocType: File,Thumbnail URL,থাম্বনেল URL টি
@@ -3423,11 +3423,11 @@ DocType: Dashboard Chart,Filters JSON,ফিল্টারগুলি JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,যাচাই করার জন্য এখানে ক্লিক করুন
 DocType: Email Account,Disable SMTP server authentication,এসএমটিপি সার্ভার প্রমাণীকরণ অক্ষম করুন
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,ক্লিপবোর্ডে অনুলিপি করা হয়েছে।
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,মত আন্দাজের বদল &#39;@&#39; পরিবর্তে &#39;একটি&#39; খুব সাহায্য না.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,মত আন্দাজের বদল '@' পরিবর্তে 'একটি' খুব সাহায্য না.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,আমার দ্বারা নির্ধারিত হয়
 apps/frappe/frappe/utils/data.py,Zero,শূন্য
 DocType: Google Drive,Backup Folder ID,ব্যাকআপ ফোল্ডার আইডি
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,না বিকাশকারী মোডে! Site_config.json সেট অথবা &#39;কাস্টম&#39; DOCTYPE করতে.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,না বিকাশকারী মোডে! Site_config.json সেট অথবা 'কাস্টম' DOCTYPE করতে.
 DocType: Workflow State,globe,পৃথিবী
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,অগ্রাধিকার
@@ -3475,7 +3475,7 @@ DocType: Notification,Reference Date,রেফারেন্স তারিখ
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,ওটিপি অ্যাপ ব্যবহার করে ওটিপি সেটআপ সম্পন্ন হয়নি। প্রশাসকের সাথে যোগাযোগ করুন।
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,বৈধ মোবাইল টি লিখুন দয়া করে
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,বৈশিষ্ট্যগুলির মধ্যে কয়েকটি আপনার ব্রাউজারে কাজ নাও করতে পারে। সাম্প্রতিক সংস্করণে আপনার ব্রাউজার আপডেট করুন।
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","জানেন না জিজ্ঞেস করুন, &#39;সাহায্যের&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","জানেন না জিজ্ঞেস করুন, 'সাহায্যের'"
 DocType: DocType,Comments and Communications will be associated with this linked document,মতামত ও কমিউনিকেশনস এই লিঙ্ক নথির সঙ্গে যুক্ত করা হবে
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,ফিল্টার ...
 DocType: Workflow State,bold,সাহসী
@@ -3503,7 +3503,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,সাবস্ক্রিপশন সংশোধন করার সময় ব্যর্থ হয়েছে
 DocType: LDAP Settings,LDAP Group Field,এলডিএপি গ্রুপ ফিল্ড
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,সমান
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ক্ষেত্রের বিকল্প &#39;ডাইনামিক লিংক&#39; টাইপ &#39;DOCTYPE&#39; হিসাবে অপশন সঙ্গে অন্য লিঙ্ক ক্ষেত্র নির্দেশ করতে হবে
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ক্ষেত্রের বিকল্প 'ডাইনামিক লিংক' টাইপ 'DOCTYPE' হিসাবে অপশন সঙ্গে অন্য লিঙ্ক ক্ষেত্র নির্দেশ করতে হবে
 DocType: About Us Settings,Team Members Heading,শীর্ষক দলের সদস্যদের
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,অবৈধ CSV বিন্যাসে
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","কিউজেড ট্রে অ্যাপ্লিকেশনটিতে সংযোগ করার সময় ত্রুটি ... <br><br> কাঁচা মুদ্রণ বৈশিষ্ট্যটি ব্যবহার করতে আপনার কিউজেড ট্রে অ্যাপ্লিকেশন ইনস্টল এবং চলমান থাকা দরকার। <br><br> <a href=""https://qz.io/download/"" target=""_blank"">কিউজেড ট্রে ডাউনলোড এবং ইনস্টল করতে এখানে ক্লিক করুন</a> । <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">কাঁচা মুদ্রণ সম্পর্কে আরও জানতে এখানে ক্লিক করুন</a> ।"
@@ -3630,7 +3630,7 @@ DocType: Web Page,Web Page,ওয়েব পেজ
 DocType: Workflow Document State,Next Action Email Template,পরবর্তী অ্যাকশন ইমেল টেমপ্লেট
 DocType: Blog Category,Blogger,ব্লগার
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","সক্ষম করা থাকলে, দস্তাবেজের পরিবর্তনগুলি ট্র্যাক করা হয় এবং সময়রেখায় প্রদর্শিত হয়"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;বৈশ্বিক অনুসন্ধান&#39; টাইপ জন্য অনুমতি দেওয়া হয় না {0} সারিতে {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'বৈশ্বিক অনুসন্ধান' টাইপ জন্য অনুমতি দেওয়া হয় না {0} সারিতে {1}
 DocType: Energy Point Log,Appreciation,রসাস্বাদন
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,তালিকা দেখুন
 DocType: Workflow,Don't Override Status,স্থিতি ওভাররাইড না
@@ -3773,7 +3773,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,ডিফল্ট
 DocType: Translation,Verified,যাচাই
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} যোগ করা হয়েছে
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',জন্য অনুসন্ধান করুন &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',জন্য অনুসন্ধান করুন '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,দয়া করে রিপোর্ট প্রথম সংরক্ষণ
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} গ্রাহকদের যোগ করা হয়েছে
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,না
@@ -3808,14 +3808,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,আমা�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} কোনো বৈধ অবস্থা না
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,সমস্ত নথি প্রকারের জন্য প্রয়োগ করুন
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,শক্তি পয়েন্ট আপডেট
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',দয়া করে অন্য একটি অর্থ প্রদানের পদ্ধতি নির্বাচন করুন। পেপ্যাল মুদ্রায় লেনদেন অবলম্বন পাওয়া যায়নি &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',দয়া করে অন্য একটি অর্থ প্রদানের পদ্ধতি নির্বাচন করুন। পেপ্যাল মুদ্রায় লেনদেন অবলম্বন পাওয়া যায়নি '{0}'
 DocType: Chat Message,Room Type,ঘরের বিবরণ
 DocType: Data Import Beta,Import Log Preview,আমদানি পূর্বরূপ দেখুন
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,অনুসন্ধান ফিল্ড {0} বৈধ নয়
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,আপলোড করা ফাইল
 DocType: Workflow State,ok-circle,OK-বৃত্ত
 DocType: LDAP Settings,LDAP User Creation and Mapping,এলডিএপি ব্যবহারকারী তৈরি এবং ম্যাপিং
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',আপনি জিজ্ঞাসা &#39;গ্রাহকদের মধ্যে কমলা এটি&#39; দ্বারা জিনিষ খুঁজে পেতে পারেন
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',আপনি জিজ্ঞাসা 'গ্রাহকদের মধ্যে কমলা এটি' দ্বারা জিনিষ খুঁজে পেতে পারেন
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,দুঃখিত! ব্যবহারকারী তাদের নিজের রেকর্ড করতে সম্পূর্ণ সুযোগ থাকা উচিত.
 ,Usage Info,ইনফো ব্যবহার
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,কীবোর্ড শর্টকাটগুলি দেখান

--- a/frappe/translations/bn.csv
+++ b/frappe/translations/bn.csv
@@ -1394,7 +1394,7 @@ DocType: User,System User,সিস্টেম ব্যবহারকার�
 DocType: Report,Is Standard,মান
 DocType: Desktop Icon,_report,প্রতিবেদন
 DocType: Dashboard Chart,Full,সম্পূর্ণ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","না মত &lt;স্ক্রিপ্ট> বা শুধু অক্ষর মত &lt;বা>, যেমন তারা ইচ্ছাকৃতভাবে এই ক্ষেত্রে ব্যবহার করা যেতে পারে এইচটিএমএল এনকোড এইচটিএমএল ট্যাগ"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","না মত <স্ক্রিপ্ট> বা শুধু অক্ষর মত <বা>, যেমন তারা ইচ্ছাকৃতভাবে এই ক্ষেত্রে ব্যবহার করা যেতে পারে এইচটিএমএল এনকোড এইচটিএমএল ট্যাগ"
 DocType: Website Settings,FavIcon,ফেভিকন
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,চালান
 DocType: Blog Post,Content (HTML),সামগ্রী (এইচটিএমএল)
@@ -1764,7 +1764,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,পাদলে�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,বিচারাধীন
 DocType: System Settings,Allow only one session per user,ব্যবহারকারী প্রতি শুধুমাত্র এক অধিবেশন মঞ্জুর করুন
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,হোম / Test ফোল্ডার 1 / Test ফোল্ডার 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> এইচটিএমএল
+DocType: Website Settings,<head> HTML,<Head> এইচটিএমএল
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,নির্বাচন করুন অথবা একটি নতুন ইভেন্ট তৈরি করতে সময় স্লট জুড়ে টেনে আনুন.
 DocType: Contact,Contact Details,যোগাযোগের ঠিকানা
 DocType: DocField,In Filter,ফিল্টার
@@ -2276,7 +2276,7 @@ DocType: LDAP Settings,Path to Server Certificate,সার্ভার শং�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,লিঙ্ক দেখতে যথেষ্ট অনুমতি
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ঠিকানা শিরোনাম বাধ্যতামূলক.
 DocType: Google Contacts,Push to Google Contacts,গুগল পরিচিতিতে ঠেলাও
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> যোগ এইচটিএমএল ওয়েব পৃষ্ঠার বিভাগে প্রাথমিকভাবে ওয়েবসাইটে যাচাই এবং এসইও জন্য ব্যবহৃত
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",<Head> যোগ এইচটিএমএল ওয়েব পৃষ্ঠার বিভাগে প্রাথমিকভাবে ওয়েবসাইটে যাচাই এবং এসইও জন্য ব্যবহৃত
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,আইটেমটি নিজস্ব সন্তান যোগ করা যাবে না
 DocType: Session Default Settings,Session Defaults,সেশন ডিফল্ট
@@ -2392,7 +2392,7 @@ DocType: Workflow State,Warning,সতর্কতা
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,এটি একাধিক পৃষ্ঠায় মুদ্রিত হতে পারে
 DocType: Data Migration Run,Percent Complete,শতাংশ সম্পূর্ণ
 DocType: Tag Category,Tag Category,ট্যাগ শ্রেণী
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","তুলনার জন্য,> 5, &lt;10 বা = 324 ব্যবহার করুন। ব্যাপ্তিগুলির জন্য, 5:10 ব্যবহার করুন (5 এবং 10 এর মধ্যে মানের জন্য)।"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","তুলনার জন্য,> 5, <10 বা = 324 ব্যবহার করুন। ব্যাপ্তিগুলির জন্য, 5:10 ব্যবহার করুন (5 এবং 10 এর মধ্যে মানের জন্য)।"
 DocType: Google Calendar,Pull from Google Calendar,গুগল ক্যালেন্ডার থেকে টানুন
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,সাহায্য
 DocType: User,Login Before,লগইন আগে
@@ -3016,7 +3016,7 @@ DocType: DocField,Allow on Submit,জমা দিন মঞ্জুরি দ�
 DocType: DocField,HTML,এইচটিএমএল
 DocType: Error Snapshot,Exception Type,ব্যতিক্রম ধরণ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,কলাম চয়ন
-DocType: Web Page,Add code as &lt;script>,&lt;Script> হিসাবে কোড যোগ
+DocType: Web Page,Add code as <script>,<Script> হিসাবে কোড যোগ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ব্যবহারকারী অনুমতি পরিষ্কার করুন
 DocType: Webhook,Headers,শিরোলেখ
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,আসন্ন ঘটনাবলী
@@ -3384,16 +3384,16 @@ DocType: Workflow State,share-alt,শেয়ার-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},সারি কোনো একটি হওয়া আবশ্যক {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> ডিফল্ট টেমপ্লেট </h4><p> ব্যবহার <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja টেমপ্লেট</a> এবং উপলব্ধ করা হবে (যদি থাকে কাস্টম ক্ষেত্র সহ) ঠিকানা সব ক্ষেত্র </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> ডিফল্ট টেমপ্লেট </h4><p> ব্যবহার <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja টেমপ্লেট</a> এবং উপলব্ধ করা হবে (যদি থাকে কাস্টম ক্ষেত্র সহ) ঠিকানা সব ক্ষেত্র </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,তারিখ ক্ষেত্র শুরু করুন
 DocType: Role,Role Name,ভূমিকা নাম
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ডেস্ক স্যুইচ

--- a/frappe/translations/bn.csv
+++ b/frappe/translations/bn.csv
@@ -737,7 +737,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ফাই�
 DocType: DocField,In Global Search,বৈশ্বিক অনুসন্ধান
 DocType: System Settings,Brute Force Security,ব্রাউন ফোর্স নিরাপত্তা
 DocType: Workflow State,indent-left,ইন্ডেন্ট-বাম
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} বছর আগে
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} বছর আগে
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,এটা এই ফাইলটি মোছার জন্য ঝুঁকিপূর্ণ: {0}. আপনার সিস্টেম ম্যানেজার সাথে যোগাযোগ করুন.
 DocType: Currency,Currency Name,মুদ্রার নাম
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,কোন ইমেল
@@ -1025,7 +1025,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,কোন {0}
 apps/frappe/frappe/config/customization.py,Add custom forms.,নিজস্ব ফর্ম যুক্ত করো.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} মধ্যে {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,এই দলিল পেশ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,সেটআপ&gt; ব্যবহারকারীর অনুমতি
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,সেটআপ> ব্যবহারকারীর অনুমতি
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,সিস্টেম অনেক পূর্ব নির্ধারিত ভূমিকা প্রদান করে. আপনি তীক্ষ্ণ স্বরূপ অনুমতি সেট করতে নতুন ভূমিকা যোগ করতে পারেন.
 DocType: Communication,CC,সিসি
 DocType: Country,Geo,জিও
@@ -1242,7 +1242,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","ব্যবহারকারী কোনো ভূমিকা পরীক্ষিত থাকে, তাহলে ব্যবহারকারী একটি &quot;সিস্টেম ব্যবহারকারী&quot; হয়ে. &quot;সিস্টেম ব্যবহারকারী&quot; ডেস্কটপ অ্যাক্সেস রয়েছে"
 DocType: System Settings,Date and Number Format,তারিখ এবং সংখ্যার বিন্যাস
 apps/frappe/frappe/model/document.py,one of,অন্যতম
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,সেটআপ&gt; স্বনির্ধারিত ফর্ম
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,সেটআপ> স্বনির্ধারিত ফর্ম
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,এক মুহূর্ত চেক করা হচ্ছে
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,দেখান ট্যাগ
 DocType: DocField,HTML Editor,এইচটিএমএল সম্পাদক
@@ -1250,7 +1250,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,বিলিং
 DocType: Email Queue,Not Sent,পাঠাই নি
 DocType: Web Form,Actions,পদক্ষেপ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,সেটআপ&gt; ব্যবহারকারী
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,সেটআপ> ব্যবহারকারী
 DocType: Workflow State,align-justify,সারিবদ্ধ-ন্যায্যতা
 DocType: User,Middle Name (Optional),মধ্য নাম (ঐচ্ছিক)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,অননুমোদিত
@@ -1394,7 +1394,7 @@ DocType: User,System User,সিস্টেম ব্যবহারকার�
 DocType: Report,Is Standard,মান
 DocType: Desktop Icon,_report,প্রতিবেদন
 DocType: Dashboard Chart,Full,সম্পূর্ণ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","না মত &lt;স্ক্রিপ্ট&gt; বা শুধু অক্ষর মত &lt;বা&gt;, যেমন তারা ইচ্ছাকৃতভাবে এই ক্ষেত্রে ব্যবহার করা যেতে পারে এইচটিএমএল এনকোড এইচটিএমএল ট্যাগ"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","না মত &lt;স্ক্রিপ্ট> বা শুধু অক্ষর মত &lt;বা>, যেমন তারা ইচ্ছাকৃতভাবে এই ক্ষেত্রে ব্যবহার করা যেতে পারে এইচটিএমএল এনকোড এইচটিএমএল ট্যাগ"
 DocType: Website Settings,FavIcon,ফেভিকন
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,চালান
 DocType: Blog Post,Content (HTML),সামগ্রী (এইচটিএমএল)
@@ -1764,7 +1764,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,পাদলে�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,বিচারাধীন
 DocType: System Settings,Allow only one session per user,ব্যবহারকারী প্রতি শুধুমাত্র এক অধিবেশন মঞ্জুর করুন
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,হোম / Test ফোল্ডার 1 / Test ফোল্ডার 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; এইচটিএমএল
+DocType: Website Settings,&lt;head> HTML,&lt;Head> এইচটিএমএল
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,নির্বাচন করুন অথবা একটি নতুন ইভেন্ট তৈরি করতে সময় স্লট জুড়ে টেনে আনুন.
 DocType: Contact,Contact Details,যোগাযোগের ঠিকানা
 DocType: DocField,In Filter,ফিল্টার
@@ -1993,7 +1993,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,এই সময়ে অনুমোদিত নয় লগইন
 DocType: Data Migration Run,Current Mapping Action,বর্তমান ম্যাপিং অ্যাকশন
 DocType: Dashboard Chart Source,Source Name,উত্স নাম
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,ব্যবহারকারীর সাথে কোনও ইমেল অ্যাকাউন্ট যুক্ত নেই। ব্যবহারকারী&gt; ইমেল ইনবক্সের অধীনে একটি অ্যাকাউন্ট যুক্ত করুন।
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,ব্যবহারকারীর সাথে কোনও ইমেল অ্যাকাউন্ট যুক্ত নেই। ব্যবহারকারী> ইমেল ইনবক্সের অধীনে একটি অ্যাকাউন্ট যুক্ত করুন।
 DocType: Email Account,Email Sync Option,ইমেইল সিঙ্ক অপশন
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,রো নং
 DocType: Async Task,Runtime,রানটাইম
@@ -2003,11 +2003,11 @@ apps/frappe/frappe/public/js/frappe/social/components/Post.vue,Pin Globally,ব�
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Followed by,অনুসরণ করেছে
 DocType: LDAP Settings,LDAP Email Field,দ্বারা LDAP ইমেল ফিল্ড
 apps/frappe/frappe/core/page/dashboard/dashboard.js,{0} List,{0} তালিকা
-apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ইতিমধ্যে ব্যবহারকারীর মধ্যে তালিকার কি
+apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ইতিম���্যে ব্যবহারকারীর মধ্যে তালিকার কি
 DocType: User Email,Enable Outgoing,আউটগোয়িং কলের সক্রিয়
 DocType: Address,Fax,ফ্যাক্স
 apps/frappe/frappe/config/customization.py,Custom Tags,কাস্টম ট্যাগ
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ইমেল অ্যাকাউন্ট সেটআপ করা হয়নি। দয়া করে সেটআপ&gt; ইমেল&gt; ইমেল অ্যাকাউন্ট থেকে একটি নতুন ইমেল অ্যাকাউন্ট তৈরি করুন
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ইমেল অ্যাকাউন্ট সেটআপ করা হয়নি। দয়া করে সেটআপ> ইমেল> ইমেল অ্যাকাউন্ট থেকে একটি নতুন ইমেল অ্যাকাউন্ট তৈরি করুন
 DocType: Comment,Submitted,উপস্থাপিত
 DocType: Contact,Pulled from Google Contacts,গুগল পরিচিতিগুলি থেকে টানা
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,অনুরোধ অগ্রহণযোগ্য
@@ -2078,7 +2078,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ঘন্টা য�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",এই ক্ষেত্রটি প্রদর্শিত হবে শুধুমাত্র যদি FIELDNAME এখানে সংজ্ঞায়িত মূল্য আছে বা নিয়ম সত্য (উদাহরণ) হয়: myfield Eval: doc.myfield == &#39;আমার মূল্য&#39; Eval: doc.age&gt; 18
+eval:doc.age>18",এই ক্ষেত্রটি প্রদর্শিত হবে শুধুমাত্র যদি FIELDNAME এখানে সংজ্ঞায়িত মূল্য আছে বা নিয়ম সত্য (উদাহরণ) হয়: myfield Eval: doc.myfield == &#39;আমার মূল্য&#39; Eval: doc.age> 18
 DocType: Social Login Key,Office 365,অফিস 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,আজ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","আপনি এই সেট করে থাকেন, শুধুমাত্র সেই ব্যবহারকারীদের ক্ষেত্রে সক্ষম এক্সেস নথি হতে হবে (যেমন. ব্লগ পোস্ট) লিংক (যেমন. ব্লগার) যেখানে বিদ্যমান."
@@ -2092,7 +2092,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,বড় হাতের
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,কাস্টম এইচটিএমএল
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ফোল্ডারের নাম লিখুন
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,কোনও ডিফল্ট ঠিকানা টেম্পলেট পাওয়া যায় নি। দয়া করে সেটআপ&gt; মুদ্রণ ও ব্র্যান্ডিং&gt; ঠিকানা টেম্পলেট থেকে একটি নতুন তৈরি করুন।
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,কোনও ডিফল্ট ঠিকানা টেম্পলেট পাওয়া যায় নি। দয়া করে সেটআপ> মুদ্রণ ও ব্র্যান্ডিং> ঠিকানা টেম্পলেট থেকে একটি নতুন তৈরি করুন।
 apps/frappe/frappe/auth.py,Unknown User,অপরিচিত ব্যবহারকারী
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,নির্বাচন ভূমিকা
 DocType: Comment,Deleted,মোছা
@@ -2276,7 +2276,7 @@ DocType: LDAP Settings,Path to Server Certificate,সার্ভার শং�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,লিঙ্ক দেখতে যথেষ্ট অনুমতি
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ঠিকানা শিরোনাম বাধ্যতামূলক.
 DocType: Google Contacts,Push to Google Contacts,গুগল পরিচিতিতে ঠেলাও
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",&lt;Head&gt; যোগ এইচটিএমএল ওয়েব পৃষ্ঠার বিভাগে প্রাথমিকভাবে ওয়েবসাইটে যাচাই এবং এসইও জন্য ব্যবহৃত
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> যোগ এইচটিএমএল ওয়েব পৃষ্ঠার বিভাগে প্রাথমিকভাবে ওয়েবসাইটে যাচাই এবং এসইও জন্য ব্যবহৃত
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,আইটেমটি নিজস্ব সন্তান যোগ করা যাবে না
 DocType: Session Default Settings,Session Defaults,সেশন ডিফল্ট
@@ -2392,7 +2392,7 @@ DocType: Workflow State,Warning,সতর্কতা
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,এটি একাধিক পৃষ্ঠায় মুদ্রিত হতে পারে
 DocType: Data Migration Run,Percent Complete,শতাংশ সম্পূর্ণ
 DocType: Tag Category,Tag Category,ট্যাগ শ্রেণী
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","তুলনার জন্য,&gt; 5, &lt;10 বা = 324 ব্যবহার করুন। ব্যাপ্তিগুলির জন্য, 5:10 ব্যবহার করুন (5 এবং 10 এর মধ্যে মানের জন্য)।"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","তুলনার জন্য,> 5, &lt;10 বা = 324 ব্যবহার করুন। ব্যাপ্তিগুলির জন্য, 5:10 ব্যবহার করুন (5 এবং 10 এর মধ্যে মানের জন্য)।"
 DocType: Google Calendar,Pull from Google Calendar,গুগল ক্যালেন্ডার থেকে টানুন
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,সাহায্য
 DocType: User,Login Before,লগইন আগে
@@ -2496,7 +2496,7 @@ DocType: Webhook,Request Structure,অনুরোধ কাঠামো
 DocType: Personal Data Deletion Request,Pending Verification,অপেক্ষারত যাচাই
 DocType: Website Meta Tag,Website Meta Tag,ওয়েবসাইট মেটা ট্যাগ
 DocType: Email Account,"If non standard port (e.g. 587). If on Google Cloud, try port 2525.",যদি অ স্ট্যান্ডার্ড পোর্ট (যেমন 587)। যদি Google ক্লাউডে থাকে তবে পোর্ট 2525 দেখুন।
-apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.","ক্লিয়ারিং শেষ তারিখ, কারণ এটি প্রকাশিত পৃষ্ঠাগুলির জন্য অতীতের মতো হতে পারে না।"
+apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.","ক্লিয়ারিং শে��� তারিখ, কারণ এটি প্রকাশিত পৃষ্ঠাগুলির জন্য অতীতের মতো হতে পারে না।"
 DocType: User,Send Me A Copy of Outgoing Emails,আমাকে আউটগোইং ইমেইলের একটি কপি পাঠান
 DocType: System Settings,Scheduler Last Event,নির্ধারণকারী সর্বশেষ ইভেন্ট
 DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Google এনালিটিক্স আইডি যোগ করুন যেমন. ইউএ-89XXX57-1. আরো তথ্যের জন্য Google এনালিটিক্স সহায়তার অনুসন্ধান করুন.
@@ -2845,7 +2845,7 @@ DocType: Custom Script,Custom Script,কাস্টম স্ক্রিপ্
 DocType: Address,Address Line 2,ঠিকানা লাইন ২
 DocType: Address,Reference,উল্লেখ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,নিযুক্ত করা
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,সেটআপ&gt; ইমেল&gt; ইমেল অ্যাকাউন্ট থেকে ডিফল্ট ইমেল অ্যাকাউন্ট সেটআপ করুন
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,সেটআপ> ইমেল> ইমেল অ্যাকাউন্ট থেকে ডিফল্ট ইমেল অ্যাকাউন্ট সেটআপ করুন
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ডেটা মাইগ্রেশন ম্যাপিং বিস্তারিত
 DocType: Data Import,Action,কর্ম
 DocType: GSuite Settings,Script URL,স্ক্রিপ্ট URL-
@@ -2993,7 +2993,7 @@ apps/frappe/frappe/templates/includes/contact.js,"Please enter both your email a
 DocType: Assignment Rule,"Simple Python Expression, Example: Status in (""Closed"", ""Cancelled"")","সাধারণ পাইথন এক্সপ্রেশন, উদাহরণ: স্থিতি (&quot;বন্ধ&quot;, &quot;বাতিল&quot;)"
 apps/frappe/frappe/email/smtp.py,Could not connect to outgoing email server,বহির্গামী ইমেইল সার্ভারের সাথে সংযোগ করা যায়নি
 DocType: Blog Post,Rich Text,রিচ টেক্সট
-apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Thank you for your interest in subscribing to our updates,আমাদের আপডেট সাবস্ক্রাইব আপনার আগ্রহের জন্য আপনাকে ধন্যবাদ
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Thank you for your interest in subscribing to our updates,আমাদের আপডেট সাবস্ক্রাইব আপনার আগ্রহের জন্য আ���নাকে ধন্যবাদ
 DocType: Braintree Settings,Payment Gateway Name,পেমেন্ট গেটওয়ে নাম
 DocType: Workflow State,resize-full,পুনরায় আকার-পূর্ণ
 DocType: Workflow State,off,বন্ধ
@@ -3016,7 +3016,7 @@ DocType: DocField,Allow on Submit,জমা দিন মঞ্জুরি দ�
 DocType: DocField,HTML,এইচটিএমএল
 DocType: Error Snapshot,Exception Type,ব্যতিক্রম ধরণ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,কলাম চয়ন
-DocType: Web Page,Add code as &lt;script&gt;,&lt;Script&gt; হিসাবে কোড যোগ
+DocType: Web Page,Add code as &lt;script>,&lt;Script> হিসাবে কোড যোগ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ব্যবহারকারী অনুমতি পরিষ্কার করুন
 DocType: Webhook,Headers,শিরোলেখ
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,আসন্ন ঘটনাবলী
@@ -3384,16 +3384,16 @@ DocType: Workflow State,share-alt,শেয়ার-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},সারি কোনো একটি হওয়া আবশ্যক {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> ডিফল্ট টেমপ্লেট </h4><p> ব্যবহার <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja টেমপ্লেট</a> এবং উপলব্ধ করা হবে (যদি থাকে কাস্টম ক্ষেত্র সহ) ঠিকানা সব ক্ষেত্র </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> ডিফল্ট টেমপ্লেট </h4><p> ব্যবহার <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja টেমপ্লেট</a> এবং উপলব্ধ করা হবে (যদি থাকে কাস্টম ক্ষেত্র সহ) ঠিকানা সব ক্ষেত্র </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,তারিখ ক্ষেত্র শুরু করুন
 DocType: Role,Role Name,ভূমিকা নাম
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ডেস্ক স্যুইচ

--- a/frappe/translations/bs.csv
+++ b/frappe/translations/bs.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Izrada dato
 DocType: DocField,In Global Search,U Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,alineje-lijevo
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} godina prije
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} godina prije
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,To je rizično izbrisati ovu datoteku: {0}. Molimo vas da se obratite System Manager.
 DocType: Currency,Currency Name,Valuta Ime
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No Email
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Nije našao {
 apps/frappe/frappe/config/customization.py,Add custom forms.,Dodaj prilagođenu formu.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} u {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,dostavio ovaj dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Podešavanje&gt; Dozvole korisnika
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Podešavanje> Dozvole korisnika
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sustav nudi brojne unaprijed definirane uloge . Možete dodavati nove uloge postaviti finije dozvole.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ukoliko korisnik ima bilo kakvu ulogu pregledava, onda korisnik postaje &quot;System korisnika&quot;. &quot;System User&quot; ima pristup na desktop"
 DocType: System Settings,Date and Number Format,Datum i oblik brojeva
 apps/frappe/frappe/model/document.py,one of,Jedan od
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Postavke&gt; Prilagodite obrazac
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Postavke> Prilagodite obrazac
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Provjera jednom trenutku
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Prikazi tagove
 DocType: DocField,HTML Editor,HTML Editor
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Naplata
 DocType: Email Queue,Not Sent,Nije poslato
 DocType: Web Form,Actions,Akcije
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Podešavanje&gt; Korisnik
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Podešavanje> Korisnik
 DocType: Workflow State,align-justify,poravnanje-jednako
 DocType: User,Middle Name (Optional),Krsno ime (opcionalno)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ne Dozvoljena
@@ -1410,7 +1410,7 @@ DocType: User,System User,Korisnik sustava
 DocType: Report,Is Standard,Je Standardni
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Pun
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Nemojte HTML kodiranje HTML tagove kao &lt;script&gt; ili samo likovi poput &lt;ili&gt;, kao što se može namjerno koristiti u ovoj oblasti"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nemojte HTML kodiranje HTML tagove kao &lt;script> ili samo likovi poput &lt;ili>, kao što se može namjerno koristiti u ovoj oblasti"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiziran na {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Trči
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer će se isp
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Čekanje
 DocType: System Settings,Allow only one session per user,Dopustite samo jedna sjednica po korisniku
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Početna / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Odaberite ili povucite preko minutaže stvoriti novi događaj.
 DocType: Contact,Contact Details,Kontakt podaci
 DocType: DocField,In Filter,U filtru
@@ -2022,7 +2022,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Prijava nije dopuštena u ovom trenutku
 DocType: Data Migration Run,Current Mapping Action,Aktuelna akcija mapiranja
 DocType: Dashboard Chart Source,Source Name,izvor ime
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Nijedan račun e-pošte nije povezan s korisnikom. Dodajte račun u okviru Korisnik&gt; Inbox.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Nijedan račun e-pošte nije povezan s korisnikom. Dodajte račun u okviru Korisnik> Inbox.
 DocType: Email Account,Email Sync Option,E-mail Sync Opcija
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Red broj
 DocType: Async Task,Runtime,Runtime
@@ -2037,7 +2037,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Već u us
 DocType: User Email,Enable Outgoing,Enable Odlazni
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Custom Tagovi
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Račun e-pošte nije podešen. Izradite novi račun e-pošte iz programa Setup&gt; Email&gt; Account Email
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Račun e-pošte nije podešen. Izradite novi račun e-pošte iz programa Setup> Email> Account Email
 DocType: Comment,Submitted,Potvrđeno
 DocType: Contact,Pulled from Google Contacts,Preuzeto iz Google kontakata
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,U važećem zahtevu
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sjednica Rok u Hours
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Ovo polje će se pojaviti samo ako Naziv Polja ovdje definiran ima vrednost ili pravila su istinite (primjeri): myfield EVAL: doc.myfield == &#39;Moja Vrijednost&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Ovo polje će se pojaviti samo ako Naziv Polja ovdje definiran ima vrednost ili pravila su istinite (primjeri): myfield EVAL: doc.myfield == &#39;Moja Vrijednost&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,danas
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Nakon što ste postavili to, korisnici će biti samo u mogućnosti pristupa dokumentima ( npr. blog post ) gdje jeveza postoji ( npr. Blogger ) ."
@@ -2123,7 +2123,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,VELIKA SLOVA
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Unesite ime foldera
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nije pronađen zadani predložak adrese. Kreirajte novu iz Podešavanje&gt; Štampanje i markiranje&gt; Predložak adresa.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nije pronađen zadani predložak adrese. Kreirajte novu iz Podešavanje> Štampanje i markiranje> Predložak adresa.
 apps/frappe/frappe/auth.py,Unknown User,Nepoznati korisnik
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Odaberite ulogu
 DocType: Comment,Deleted,Deleted
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Put do sertifikata servera
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nije dovoljno dozvolu da vidite linkove
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Naziv adrese je obavezan.
 DocType: Google Contacts,Push to Google Contacts,Pritisnite Google kontakte
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Dodano HTML u &lt;head&gt; odjeljku web stranice, prvenstveno koristi za web stranice verifikaciju i SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML u &lt;head> odjeljku web stranice, prvenstveno koristi za web stranice verifikaciju i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relaps
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Stavka ne može se dodati u svojim potomcima
 DocType: Session Default Settings,Session Defaults,Neispunjene sesije
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Upozorenje
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ovo se može otisnuti na više stranica
 DocType: Data Migration Run,Percent Complete,Percent Complete
 DocType: Tag Category,Tag Category,Tag Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite&gt; 5, &lt;10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite> 5, &lt;10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
 DocType: Google Calendar,Pull from Google Calendar,Povucite iz Google kalendara
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoć
 DocType: User,Login Before,Prijavite Prije
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Prilagođena skripta
 DocType: Address,Address Line 2,Adresa - linija 2
 DocType: Address,Reference,Upućivanje
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Dodijeljeno
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Postavite zadani račun e-pošte iz programa Setup&gt; Email&gt; Account Email
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Postavite zadani račun e-pošte iz programa Setup> Email> Account Email
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Mapiranje mapiranja podataka
 DocType: Data Import,Action,Akcija
 DocType: GSuite Settings,Script URL,skripta URL
@@ -3070,7 +3070,7 @@ DocType: DocField,Allow on Submit,Dopusti pri potvrdi
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Izuzetak Tip
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Odaberi kolone
-DocType: Web Page,Add code as &lt;script&gt;,Dodaj kod kao
+DocType: Web Page,Add code as &lt;script>,Dodaj kod kao
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Izbriši dozvole korisnika
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Najave događaja
@@ -3442,15 +3442,15 @@ DocType: Workflow State,share-alt,Udio-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Red bi trebao biti jedan od {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Standard Template </ h4> 
  <p> <a Koristi href=""http://jinja.pocoo.org/docs/templates/""> Jinja templating </a> i svim oblastima Adresa ( uključujući Custom Fields ako ih ima) će biti dostupan </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/bs.csv
+++ b/frappe/translations/bs.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Korisnik sustava
 DocType: Report,Is Standard,Je Standardni
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Pun
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nemojte HTML kodiranje HTML tagove kao &lt;script> ili samo likovi poput &lt;ili>, kao što se može namjerno koristiti u ovoj oblasti"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Nemojte HTML kodiranje HTML tagove kao <script> ili samo likovi poput <ili>, kao što se može namjerno koristiti u ovoj oblasti"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiziran na {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Trči
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer će se isp
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Čekanje
 DocType: System Settings,Allow only one session per user,Dopustite samo jedna sjednica po korisniku
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Početna / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Odaberite ili povucite preko minutaže stvoriti novi događaj.
 DocType: Contact,Contact Details,Kontakt podaci
 DocType: DocField,In Filter,U filtru
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Put do sertifikata servera
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nije dovoljno dozvolu da vidite linkove
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Naziv adrese je obavezan.
 DocType: Google Contacts,Push to Google Contacts,Pritisnite Google kontakte
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML u &lt;head> odjeljku web stranice, prvenstveno koristi za web stranice verifikaciju i SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Dodano HTML u <head> odjeljku web stranice, prvenstveno koristi za web stranice verifikaciju i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relaps
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Stavka ne može se dodati u svojim potomcima
 DocType: Session Default Settings,Session Defaults,Neispunjene sesije
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Upozorenje
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ovo se može otisnuti na više stranica
 DocType: Data Migration Run,Percent Complete,Percent Complete
 DocType: Tag Category,Tag Category,Tag Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite> 5, &lt;10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite> 5, <10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
 DocType: Google Calendar,Pull from Google Calendar,Povucite iz Google kalendara
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoć
 DocType: User,Login Before,Prijavite Prije
@@ -3070,7 +3070,7 @@ DocType: DocField,Allow on Submit,Dopusti pri potvrdi
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Izuzetak Tip
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Odaberi kolone
-DocType: Web Page,Add code as &lt;script>,Dodaj kod kao
+DocType: Web Page,Add code as <script>,Dodaj kod kao
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Izbriši dozvole korisnika
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Najave događaja
@@ -3442,26 +3442,26 @@ DocType: Workflow State,share-alt,Udio-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Red bi trebao biti jedan od {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Standard Template </ h4> 
  <p> <a Koristi href=""http://jinja.pocoo.org/docs/templates/""> Jinja templating </a> i svim oblastima Adresa ( uključujući Custom Fields ako ih ima) će biti dostupan </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% ako address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} 
- {{}} gradu & lt; br & gt; 
- {% ako država%} {{}} države & lt; br & gt; {% endif -%} {
-% ako pincode%} PIN: {{pincode}} & lt; br & gt; {% endif -%} 
- {{zemlji}} & lt; br & gt; 
- {% ako telefon%} Telefon: {{telefonski}} & lt; br & gt; { % endif -%} 
- {% ako fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% ako email_id%} Email: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% ako address_line2%} {{address_line2}} <br> { % endif -%} 
+ {{}} gradu <br> 
+ {% ako država%} {{}} države <br> {% endif -%} {
+% ako pincode%} PIN: {{pincode}} <br> {% endif -%} 
+ {{zemlji}} <br> 
+ {% ako telefon%} Telefon: {{telefonski}} <br> { % endif -%} 
+ {% ako fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% ako email_id%} Email: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Polje početnog datuma
 DocType: Role,Role Name,Uloga Ime

--- a/frappe/translations/bs.csv
+++ b/frappe/translations/bs.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistika zasnovana na učinku prošle sedmice (od {0} do {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP telefonsko polje
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Vrsta dokumenta ..., npr kupca"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Uvjet &#39;{0}&#39; je nevažeća
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Uvjet '{0}' je nevažeća
 DocType: Workflow State,barcode,barkod
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Upotreba pod-upita ili funkcije je ograničena
 apps/frappe/frappe/config/customization.py,Add your own translations,Dodajte svoj prevodi
@@ -706,7 +706,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Korisničko {0} već postoji
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0} : Ne može se uvesti kao {1} nije za uvoz
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Postoji greška u vašem Adresa Template {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} je nevažeća adresa e-pošte u &#39;Primaocima&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} je nevažeća adresa e-pošte u 'Primaocima'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,domaćin
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Valuta Ime
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No Email
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link Istekao
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Vraćanje dužine na {0} za &#39;{1}&#39; u &#39;{2}&#39;; Podešavanje dužine kao {3} će uzrokovati skraćivanje podataka.
+							Setting the length as {3} will cause truncation of data.",Vraćanje dužine na {0} za '{1}' u '{2}'; Podešavanje dužine kao {3} će uzrokovati skraćivanje podataka.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Izaberite File Format
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Sadržaj Ljestve
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Izvještaj o dijeljenu dokumenata
 DocType: Social Login Key,Base URL,Baza URL
 DocType: User,Last Login,Zadnja prijava
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Ne možete postaviti &#39;Translatable&#39; za polje {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Ne možete postaviti 'Translatable' za polje {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Kolona
 DocType: Chat Profile,Chat Profile,Chat Profil
 DocType: Custom Field,Adds a custom field to a DocType,Dodaje prilagođeno polje u vrstu dokumenta
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Je dom Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Style
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} nije valjana e-mail adresa
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Odaberite atleast 1 zapis za štampanje
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Korisnik &#39;{0}&#39; već ima ulogu &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Korisnik '{0}' već ima ulogu '{1}'
 DocType: System Settings,Two Factor Authentication method,Dva faktorska autentikacijska metoda
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Prvo podesite ime i sačuvajte zapis.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Zapisa
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obavezna polja: set uloga
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritikovan {1}
 DocType: Data Migration Mapping,Mapping Name,Mapiranje Ime
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Polje &#39;{1}&#39; se ne može postaviti kao jedinstveno jer ima jedinstvene vrednosti
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Polje '{1}' se ne može postaviti kao jedinstveno jer ima jedinstvene vrednosti
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Pomaknite se prema dolje
 DocType: Currency,A symbol for this currency. For e.g. $,Simbol za ovu valutu. Kao npr. $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Uspešno ažurirani prevodi
@@ -2005,7 +2005,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Ako ove upute gdje nije korisno , dodajte u svojim prijedlozima o GitHub pitanja ."
 DocType: Workflow State,bookmark,bookmark
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ime foldera treba ne uključuju &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ime foldera treba ne uključuju '/' (slash)
 DocType: Note,Note,Biljeske
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Greška Report
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Izvoz podataka u CSV / Excel formatu.
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sjednica Rok u Hours
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Ovo polje će se pojaviti samo ako Naziv Polja ovdje definiran ima vrednost ili pravila su istinite (primjeri): myfield EVAL: doc.myfield == &#39;Moja Vrijednost&#39; eval: doc.age> 18
+eval:doc.age>18",Ovo polje će se pojaviti samo ako Naziv Polja ovdje definiran ima vrednost ili pravila su istinite (primjeri): myfield EVAL: doc.myfield == 'Moja Vrijednost' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,danas
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Nakon što ste postavili to, korisnici će biti samo u mogućnosti pristupa dokumentima ( npr. blog post ) gdje jeveza postoji ( npr. Blogger ) ."
@@ -2148,7 +2148,7 @@ DocType: Data Migration Connector,Database Name,Ime baze podataka
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Refresh obrazac
 DocType: DocField,Select,Odaberi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Pogledajte cijeli dnevnik
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednostavna Python Expression, Primjer: status == &#39;Open&#39; i upišite == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednostavna Python Expression, Primjer: status == 'Open' i upišite == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,File nije priključen
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Izgubljena konekcija. Neke funkcije možda neće raditi.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Ponavlja kao &quot;AAA&quot; su lako pogoditi
@@ -2279,7 +2279,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Pokaži samo greške
 DocType: Website Settings,Banner HTML,HTML baner
 DocType: Workflow,Send Email Alert,Pošalji Email Alert
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Odaberite drugi način plaćanja. Razorpay ne podržava transakcije u valuti &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Odaberite drugi način plaćanja. Razorpay ne podržava transakcije u valuti '{0}'
 DocType: Data Import,In Progress,U toku
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Čekanju za backup. To može potrajati nekoliko minuta do sat vremena.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2701,7 +2701,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Izmenama
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal postavke payment gateway
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Vrhunski performer
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Prilagođena polja se ne mogu dodati u osnovne DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) će dobiti skraćeni, kao i maksimalno dozvoljenih znakova je {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) će dobiti skraćeni, kao i maksimalno dozvoljenih znakova je {2}"
 DocType: OAuth Client,Response Type,Tip odgovor
 DocType: Contact Us Settings,Send enquiries to this email address,Upite slati na ovu e-mail adresu
 DocType: Letter Head,Letter Head Name,Naziv zaglavlja
@@ -2757,7 +2757,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Prikaz slike
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Izgleda kao da je nešto pošlo po zlu u transakciju. Pošto nismo potvrdili plaćanje, PayPal automatski će vam vratiti taj iznos. Ako se to ne desi, pošaljite nam e-mail, a spomenuti korelacije ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Uključuju simbole, brojeve i slova u lozinku"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Ubacite Nakon polje &#39;{0}&#39; navedenih u Custom Field &#39;{1}&#39;, s etiketom &#39;{2}&#39;, ne postoji"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Ubacite Nakon polje '{0}' navedenih u Custom Field '{1}', s etiketom '{2}', ne postoji"
 DocType: List Filter,List Filter,Filter liste
 DocType: Workflow State,signal,signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ima priloge
@@ -2767,7 +2767,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Obnovljena dokument
 DocType: Data Export,Data Export,Izvoz podataka
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Izaberite jezik ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Ne možete postaviti &#39;Opcije&#39; za polje {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Ne možete postaviti 'Opcije' za polje {0}
 DocType: Help Article,Author,autor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Nastavak Slanje
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Ponovo otvoriti
@@ -2781,14 +2781,14 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Zadani predložak adrese ne može se izbrisati
 DocType: Contact,Maintenance Manager,Održavanje Manager
 DocType: Workflow State,Search,Pretraga
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Odaberite drugi način plaćanja. Pruga ne podržava transakcije u valuti &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Odaberite drugi način plaćanja. Pruga ne podržava transakcije u valuti '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Move u smeće
 DocType: Web Form,Web Form Fields,Web Form Fields
 DocType: Data Import,Amended From,Izmijenjena Od
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Upozorenje: Nije moguće pronaći {0} na bilo sto u vezi sa {1}
 DocType: S3 Backup Settings,eu-north-1,eu-sjever-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Ovaj dokument je trenutno na čekanju za izvršenje. Molimo pokušajte ponovo
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Datoteka &#39;{0}&#39; nije pronađena
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Datoteka '{0}' nije pronađena
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Uklonite točki
 DocType: User,Change Password,Promjena lozinke
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Polje X osi
@@ -2975,7 +2975,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Vrijednost nestao
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Dodaj podređenu stavku
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Uvezi napredak
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Ako je uvjet zadovoljan, korisnik će biti nagrađen bodovima. npr. doc.status == &#39;Zatvoreno&#39;"
+","Ako je uvjet zadovoljan, korisnik će biti nagrađen bodovima. npr. doc.status == 'Zatvoreno'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Sacuvani zapis se ne može se izbrisati.
 DocType: GSuite Templates,Template Name,template Name
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,novi tip dokumenta
@@ -3108,7 +3108,7 @@ DocType: Dashboard Chart,Chart Type,Tip grafikona
 DocType: DocType,Auto Name,Auto Ime
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Izbjegavajte sekvence kao abc ili 6543 jer su lako pogoditi
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Molimo pokušajte ponovo
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL mora početi s &#39;http: //&#39; ili &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL mora početi s 'http: //' ili 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Opcija 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Uredi
@@ -3346,7 +3346,7 @@ DocType: Notification,Send alert if this field's value changes,Pošalji upozoren
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Boje tema
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Odaberite DOCTYPE da napravi novi format
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Korisnik ne postoji
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Primaoci&#39; nisu navedeni
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Primaoci' nisu navedeni
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,upravo sada
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,primijeniti
 DocType: Footer Item,Policy,politika
@@ -3394,7 +3394,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Custom Prijevodi
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,napredak
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,prema ulozi
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Polja koja nedostaju
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Nevažeći Naziv Polja &#39;{0}&#39; u autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Nevažeći Naziv Polja '{0}' u autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Traži u vrsti dokumenta
 DocType: Custom DocPerm,Role and Level,Uloga i Level
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3546,7 +3546,7 @@ DocType: Notification,Reference Date,Referentni datum
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,Podešavanje OTP-a pomoću OTP aplikacije nije završeno. Molimo kontaktirajte administratora.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Unesite valjane mobilne br
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Neke funkcije možda neće raditi na vašem pretraživaču. Molimo vas da ažurirate svoj pretraživač na najnoviju verziju.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ne znam, pitaj &#39;pomoć&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ne znam, pitaj 'pomoć'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},otkazao ovaj dokument {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Komentari i komunikacija će biti povezani s ovom povezani dokument
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
@@ -3705,7 +3705,7 @@ DocType: Web Page,Web Page,Web stranica
 DocType: Workflow Document State,Next Action Email Template,Slijedeća Template Action Action
 DocType: Blog Category,Blogger,Bloger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Ako je omogućeno, promjene dokumenta prate se i prikazuju u vremenskoj traci"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Global Search &quot;nije dozvoljeno tipa {0} u redu {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Global Search &quot;nije dozvoljeno tipa {0} u redu {1}
 DocType: Energy Point Log,Appreciation,Zahvalnost
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Prikaz liste
 DocType: Workflow,Don't Override Status,Ne zamenjuju Status
@@ -3852,7 +3852,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Podrazumjevano
 DocType: Translation,Verified,Provjereno
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} je dodao
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Pretraži stranice za &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Pretraži stranice za '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Molimo da najprije spasiti izvještaj
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} pretplatnika dodano
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Ne nalazi se u
@@ -3888,14 +3888,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Ja
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} nije validan uslov
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Primijeni na sve vrste dokumenata
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Ažuriranje energetske tačke
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Odaberite drugi način plaćanja. PayPal ne podržava transakcije u valuti &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Odaberite drugi način plaćanja. PayPal ne podržava transakcije u valuti '{0}'
 DocType: Chat Message,Room Type,Tip sobe
 DocType: Data Import Beta,Import Log Preview,Uvezi pregled pregleda
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Polje za pretragu {0} nije važeća
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,prenesena datoteka
 DocType: Workflow State,ok-circle,ok-krug
 DocType: LDAP Settings,LDAP User Creation and Mapping,Stvaranje i mapiranje LDAP korisnika
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Možete naći stvari tražeći &#39;Pronađite narančaste kupce&#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Možete naći stvari tražeći 'Pronađite narančaste kupce'
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Žao mi je! Korisnik treba imati potpuni pristup na svoje rekord.
 ,Usage Info,Uporaba Info
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Pokaži prečice na tipkovnici

--- a/frappe/translations/ca.csv
+++ b/frappe/translations/ca.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Usuari de Sistema
 DocType: Report,Is Standard,És Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Complet
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","No etiquetes HTML Codificar HTML, com &lt;script> o simplement caràcters com &lt;o>, ja que podrien ser utilitzats intencionadament en aquest camp"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","No etiquetes HTML Codificar HTML, com <script> o simplement caràcters com <o>, ja que podrien ser utilitzats intencionadament en aquest camp"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticat a {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Correr
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,El peu de pàgina
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pendent
 DocType: System Settings,Allow only one session per user,Permetre només una sessió per usuari
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Carpeta Inici / Test 1 / Carpeta Prova 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> de HTML
+DocType: Website Settings,<head> HTML,<head> de HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Seleccioneu o arrossegament a través de caselles de temps per crear un nou esdeveniment.
 DocType: Contact,Contact Details,Detalls de contacte
 DocType: DocField,In Filter,En Filter
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Certificat de ruta al servidor
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,No hi ha prou permís per veure enllaços
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Títol d'adreça obligatori.
 DocType: Google Contacts,Push to Google Contacts,Empenteu a Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML afegit a la secció &lt;head> de la pàgina web, s&#39;utilitza sobretot per a la verificació del web i SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML afegit a la secció <head> de la pàgina web, s&#39;utilitza sobretot per a la verificació del web i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recaiguda
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,L'article no es pot afegir als seus propis descendents
 DocType: Session Default Settings,Session Defaults,Defectes predeterminats de la sessió
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Advertència
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Es pot imprimir en diverses pàgines
 DocType: Data Migration Run,Percent Complete,Percentatge complet
 DocType: Tag Category,Tag Category,tag Categoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per a la comparació, utilitzeu> 5, &lt;10 o = 324. Per a intervals, utilitzeu 5:10 (per a valors entre 5 i 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per a la comparació, utilitzeu> 5, <10 o = 324. Per a intervals, utilitzeu 5:10 (per a valors entre 5 i 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tira de Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ajuda
 DocType: User,Login Before,Identifica't abans
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Permetre al presentar
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipus d&#39;excepció
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Esculli Columnes
-DocType: Web Page,Add code as &lt;script>,Add code as &lt;script>
+DocType: Web Page,Add code as <script>,Add code as <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Esborra els permisos de l’usuari
 DocType: Webhook,Headers,Encapçalaments
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Pròxims esdeveniments
@@ -3445,26 +3445,26 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Cua ha de ser una de {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Per defecte la plantilla </ h4> 
  <p> <a Usos href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> i tots els camps de la Direcció ( incloent camps personalitzats en el seu cas) estarà disponible </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% if address_line2%} {{address_line2}} & lt; br & gt; { endif% -%} 
- {{ciutat}} & lt; br & gt; 
- {% if%} Estat {{Estat}} & lt; br & gt; {% endif -%} {% if 
- codi PIN%} PIN: {{codi PIN}} & lt; br & gt; {% endif -%} 
- {{país}} & lt; br & gt; 
- {% if telèfon%} Telèfon: {{telèfon}} & lt; br & gt; { % endif -%} 
- {% if fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% if email_ID%} email: {{email_ID}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% if address_line2%} {{address_line2}} <br> { endif% -%} 
+ {{ciutat}} <br> 
+ {% if%} Estat {{Estat}} <br> {% endif -%} {% if 
+ codi PIN%} PIN: {{codi PIN}} <br> {% endif -%} 
+ {{país}} <br> 
+ {% if telèfon%} Telèfon: {{telèfon}} <br> { % endif -%} 
+ {% if fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% if email_ID%} email: {{email_ID}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Camp de data d&#39;inici
 DocType: Role,Role Name,Nom de rol

--- a/frappe/translations/ca.csv
+++ b/frappe/translations/ca.csv
@@ -1,9 +1,9 @@
 apps/frappe/frappe/utils/change_log.py,New {} releases for the following apps are available,Hi ha disponibles noves versions de {} per a les següents aplicacions
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Please select a Amount Field.,Seleccioneu un camp de quantitat.
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Loading import file...,S&#39;està carregant el fitxer d&#39;importació ...
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Loading import file...,S'està carregant el fitxer d'importació ...
 DocType: Assignment Rule,Last User,Últim usuari
-apps/frappe/frappe/desk/form/assign_to.py,"A new task, {0}, has been assigned to you by {1}. {2}","Una nova tasca, {0}, s&#39;ha assignat a vostè per {1}. {2}"
-apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,Session Defaults Saved,S&#39;han desat els defectes de les sessions
+apps/frappe/frappe/desk/form/assign_to.py,"A new task, {0}, has been assigned to you by {1}. {2}","Una nova tasca, {0}, s'ha assignat a vostè per {1}. {2}"
+apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,Session Defaults Saved,S'han desat els defectes de les sessions
 apps/frappe/frappe/public/js/frappe/form/controls/attach.js,Reload File,Torna a carregar fitxer
 DocType: Email Queue,Email Queue records.,Registres de cua de correu electrònic.
 DocType: Post,Post,Post
@@ -12,26 +12,26 @@ apps/frappe/frappe/config/settings.py,Rename many items by uploading a .csv file
 DocType: Workflow State,pause,pausa
 apps/frappe/frappe/public/js/frappe/web_form/webform_script.js,You are not permitted to access this page.,No està autoritzat a accedir a aquesta pàgina.
 DocType: About Us Settings,Website,Lloc web
-apps/frappe/frappe/www/third_party_apps.py,You need to be logged in to access this page,Ha d&#39;estar registrat per accedir a aquesta pàgina
+apps/frappe/frappe/www/third_party_apps.py,You need to be logged in to access this page,Ha d'estar registrat per accedir a aquesta pàgina
 DocType: System Settings,Note: Multiple sessions will be allowed in case of mobile device,Nota: No es permeten diverses sessions en el cas dels dispositius mòbils
 DocType: DocType,Form Settings,Configuració del formulari
 apps/frappe/frappe/templates/emails/download_data.html,Download Data,Descarregueu les dades
 apps/frappe/frappe/public/js/frappe/form/form.js,Permanently Submit {0}?,Presentar permanentment {0}?
 apps/frappe/frappe/desk/page/backups/backups.js,Download Files Backup,Descarrega la còpia de seguretat dels fitxers
 DocType: Address,County,comtat
-DocType: Workflow,If Checked workflow status will not override status in list view,Si l&#39;estat de flux de treball facturat no anul·larà l&#39;estat a la vista de llista
+DocType: Workflow,If Checked workflow status will not override status in list view,Si l'estat de flux de treball facturat no anul·larà l'estat a la vista de llista
 apps/frappe/frappe/client.py,Invalid file path: {0},Ruta no vàlida fitxer: {0}
 DocType: Workflow State,eye-open,eye-open
 DocType: Email Queue,Send After,Enviar Després
 apps/frappe/frappe/utils/file_manager.py,Please select a file or url,Seleccioneu un arxiu o URL
 apps/frappe/frappe/public/js/frappe/views/treeview.js,{0} Tree,{0} Arbre
-DocType: User,User Emails,Els correus electrònics d&#39;usuaris
-DocType: User,Username,Nom d&#39;usuari
+DocType: User,User Emails,Els correus electrònics d'usuaris
+DocType: User,Username,Nom d'usuari
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Import Zip,Importar Zip
 apps/frappe/frappe/model/base_document.py,Value too big,Valors molt alts
 DocType: DocField,DocField,DocField
-DocType: GSuite Settings,Run Script Test,Prova d&#39;execució de seqüència
-apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Seleccioneu Google Calendar amb quin esdeveniment s&#39;ha de sincronitzar.
+DocType: GSuite Settings,Run Script Test,Prova d'execució de seqüència
+apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Seleccioneu Google Calendar amb quin esdeveniment s'ha de sincronitzar.
 DocType: Data Import,Total Rows,Total de files
 DocType: Contact,Department,Departament
 DocType: DocField,Options,Opcions
@@ -42,7 +42,7 @@ DocType: Report,Report Manager,Administrador d'informes
 DocType: Workflow,Document States,Estats Document
 apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! I could not find what you were looking for.,Ho sento! No vaig poder trobar el que estaves buscant.
 DocType: Data Migration Run,Logs,Registres
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,There was an error saving filters,S&#39;ha produït un error en desar els filtres
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,There was an error saving filters,S'ha produït un error en desar els filtres
 DocType: Custom DocPerm,This role update User Permissions for a user,Aquesta actualització de rol canvia permisos d'usuari per a un usuari
 apps/frappe/frappe/public/js/frappe/model/model.js,Rename {0},Canviar el nom {0}
 DocType: Workflow State,zoom-out,menys-zoom
@@ -58,10 +58,10 @@ apps/frappe/frappe/model/base_document.py,"{0}, Row {1}","{0}, {1} Fila"
 DocType: DocField,Markdown Editor,Editor de Markdown
 apps/frappe/frappe/model/document.py,Beginning with,a partir de
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Plantilla d'importació de dades
-apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,S&#39;ha produït un error en configurar els valors predeterminats de sessió
+apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,S'ha produït un error en configurar els valors predeterminats de sessió
 apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Pare
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Hem rebut una sol·licitud per descarregar les vostres {0} dades associades a: {1}
-DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Si està activat, la fortalesa de la contrasenya s&#39;aplicarà en funció del valor mínim contrasenya Score. Un valor de 2 sent mig fort i 4 sent molt fort."
+DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Si està activat, la fortalesa de la contrasenya s'aplicarà en funció del valor mínim contrasenya Score. Un valor de 2 sent mig fort i 4 sent molt fort."
 DocType: About Us Settings,"""Team Members"" or ""Management""","""Membres de l'equip"" o ""Gestió"""
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',"Valor predeterminat pels tipus ""Check"" ha de ser '0' o '1'"
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Ahir
@@ -83,14 +83,14 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Cancel {0} documents?,Vols
 DocType: DocType,Is Published Field,Es publica Camp
 DocType: GCalendar Settings,GCalendar Settings,Configuració de GCalendar
 DocType: Email Group,Email Group,Grup correu electrònic
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Calendar: no s&#39;ha pogut suprimir l&#39;esdeveniment {0} de Google Calendar, codi d&#39;error {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Calendar: no s'ha pogut suprimir l'esdeveniment {0} de Google Calendar, codi d'error {1}."
 DocType: Event,Pulled from Google Calendar,Tirat de Google Calendar
 DocType: Note,Seen By,Vist per
 apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Afegir múltiple
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,Heu guanyat punts energètics
-apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,No és una imatge d&#39;usuari vàlida.
+apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,No és una imatge d'usuari vàlida.
 DocType: Energy Point Log,Reverted,Revertit
-DocType: Success Action,First Success Message,Primer missatge d&#39;èxit
+DocType: Success Action,First Success Message,Primer missatge d'èxit
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Not Like,Not Com
 apps/frappe/frappe/model/document.py,Incorrect value: {0} must be {1} {2},Valor incorrecte: {0} ha de ser {1} {2}
 apps/frappe/frappe/config/customization.py,"Change field properties (hide, readonly, permission etc.)","Canviar les propietats de camp (amagar, de només lectura, el permís etc.)"
@@ -104,7 +104,7 @@ apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,Retrat
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,Insereix
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Permetre l'accés de Google Drive
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Select {0},Seleccioneu {0}
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Introduïu l&#39;URL base
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Introduïu l'URL base
 DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Si està activat, el document es marca com es veu, la primera vegada que un usuari l’obre"
 DocType: Auto Repeat,Repeat on Day,Repeteixi el dia
 DocType: DocField,Color,Color
@@ -133,12 +133,12 @@ DocType: Address,Jammu and Kashmir,Jammu i Caixmir
 DocType: Workflow,Workflow State Field,Campd d'estat de flux de treball (workflow)
 DocType: Language,Guest,Convidat
 DocType: DocType,Title Field,Title Field
-DocType: Error Log,Error Log,Registre d&#39;errors
+DocType: Error Log,Error Log,Registre d'errors
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Invalid URL,URL no vàlid
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Last 7 days,Últims 7 dies
-apps/frappe/frappe/utils/password_strength.py,"Repeats like ""abcabcabc"" are only slightly harder to guess than ""abc""",Repeteix com &quot;abcabcabc&quot; són només una mica més difícil d&#39;endevinar que el &quot;abc&quot;
+apps/frappe/frappe/utils/password_strength.py,"Repeats like ""abcabcabc"" are only slightly harder to guess than ""abc""",Repeteix com &quot;abcabcabc&quot; són només una mica més difícil d'endevinar que el &quot;abc&quot;
 DocType: Notification,Channel,Canal
-apps/frappe/frappe/templates/emails/administrator_logged_in.html,"If you think this is unauthorized, please change the Administrator password.","Si vostè pensa que això no està autoritzat, si us plau, canvieu la contrasenya d&#39;administrador."
+apps/frappe/frappe/templates/emails/administrator_logged_in.html,"If you think this is unauthorized, please change the Administrator password.","Si vostè pensa que això no està autoritzat, si us plau, canvieu la contrasenya d'administrador."
 DocType: Data Import Beta,Data Import Beta,Importació de dades beta
 apps/frappe/frappe/email/doctype/email_account/email_account.py,{0} is mandatory,{0} és obligatori
 DocType: Assignment Rule,Assignment Rules,Normes d’assignació
@@ -152,11 +152,11 @@ DocType: Translation,Translation,traducció
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Mr,Sr
 DocType: OAuth Authorization Code,Client,Client
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Select Column,Selecciona la columna
-apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified after you have loaded it,Aquesta forma s&#39;ha modificat després d&#39;haver carregat
+apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified after you have loaded it,Aquesta forma s'ha modificat després d'haver carregat
 DocType: Address,Himachal Pradesh,Himachal Pradesh
-DocType: System Settings,"If not set, the currency precision will depend on number format",Si no s&#39;estableix la precisió de divises dependrà de format de nombre
+DocType: System Settings,"If not set, the currency precision will depend on number format",Si no s'estableix la precisió de divises dependrà de format de nombre
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Awesomebar,Obriu la barra impressionant
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Sembla que hi ha un problema amb la configuració de la xarxa del servidor. En cas de fracàs, l&#39;import es reemborsarà al vostre compte."
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Sembla que hi ha un problema amb la configuració de la xarxa del servidor. En cas de fracàs, l'import es reemborsarà al vostre compte."
 DocType: Data Import,Import Log,Importa registre
 DocType: User Permission,Apply To All Document Types,Aplica a tots els tipus de document
 apps/frappe/frappe/config/website.py,Embed image slideshows in website pages.,Embed image slideshows in website pages.
@@ -187,7 +187,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,No pending or 
 DocType: Webhook,Doc Event,Esdeveniment doc
 apps/frappe/frappe/public/js/frappe/utils/user.js,You,Vostè
 DocType: Braintree Settings,Braintree Settings,Configuració de Braintree
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Created {0} records successfully.,S&#39;han creat {0} registres correctament.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Created {0} records successfully.,S'han creat {0} registres correctament.
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Save Filter,Desa el filtre
 DocType: Print Format,Helvetica,Helvetica
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Cannot delete {0},No es pot eliminar {0}
@@ -204,15 +204,15 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,No
 apps/frappe/frappe/www/third_party_apps.html,Third Party Apps,Aplicacions de tercers
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The first user will become the System Manager (you can change this later).,El primer usuari es convertirà en l'Administrador del sistema (que pot canviar això més endavant).
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You cannot give review points to yourself,No podeu donar-vos punts de revisió
-apps/frappe/frappe/integrations/doctype/webhook/webhook.py,DocType must be Submittable for the selected Doc Event,El DocType ha de ser presentable per a l&#39;esdeveniment Doc seleccionat
+apps/frappe/frappe/integrations/doctype/webhook/webhook.py,DocType must be Submittable for the selected Doc Event,El DocType ha de ser presentable per a l'esdeveniment Doc seleccionat
 DocType: Workflow State,circle-arrow-up,cercle de fletxa amunt
 DocType: Email Domain,Email Domain,domini de correu electrònic
 DocType: Workflow State,italic,itàlic
 DocType: LDAP Group Mapping,ERPNext Role,Paper ERPNext
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Import without Create,{0}: No es pot establir d'importació sense Crea
 DocType: SMS Settings,Enter url parameter for message,Introdueixi paràmetre url per al missatge
-apps/frappe/frappe/public/js/frappe/utils/common.js,Auto Repeat created for this document,S&#39;ha creat una repetició automàtica per a aquest document
-apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your browser,Mostra l&#39;informe al vostre navegador
+apps/frappe/frappe/public/js/frappe/utils/common.js,Auto Repeat created for this document,S'ha creat una repetició automàtica per a aquest document
+apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your browser,Mostra l'informe al vostre navegador
 apps/frappe/frappe/config/desk.py,Event and other calendars.,Esdeveniments i altres calendaris.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 fila obligatòria)
 apps/frappe/frappe/templates/includes/comments/comments.html,All fields are necessary to submit the comment.,Tots els camps són necessaris per enviar el comentari.
@@ -222,23 +222,23 @@ DocType: Webhook,Form URL-Encoded,Formulari codificat per URL
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Amples es poden establir en píxels o%.
 apps/frappe/frappe/public/js/frappe/form/print.js,Start,Començar
 DocType: Contact,First Name,Nom
-DocType: LDAP Settings,LDAP Username Field,El camp nom d&#39;usuari LDAP
+DocType: LDAP Settings,LDAP Username Field,El camp nom d'usuari LDAP
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,LDAP is not enabled.,LDAP no està habilitat.
 DocType: Portal Settings,Standard Sidebar Menu,Menú Barra Lateral Estàndard
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failure,Error de creació automàtica de repetició de documents
-apps/frappe/frappe/core/doctype/file/file.py,Cannot delete Home and Attachments folders,No es pot eliminar d&#39;Interior i Adjunts carpetes
+apps/frappe/frappe/core/doctype/file/file.py,Cannot delete Home and Attachments folders,No es pot eliminar d'Interior i Adjunts carpetes
 apps/frappe/frappe/config/desk.py,Files,Arxius
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions get applied on Users based on what Roles they are assigned.,Permisos d'aconseguir aplicar en usuaris amb base en el rols que se'ls assigna.
 apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,No et permet enviar missatges de correu electrònic relacionats amb aquest document
-apps/frappe/frappe/model/db_query.py,Please select atleast 1 column from {0} to sort/group,Seleccioneu almenys 1 columna d&#39;{0} per ordenar / grup
+apps/frappe/frappe/model/db_query.py,Please select atleast 1 column from {0} to sort/group,Seleccioneu almenys 1 columna d'{0} per ordenar / grup
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1}. Restricted field: {2},No està permès per a {0}: {1}. Camp restringit: {2}
-DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Comprovar això si està provant el pagament mitjançant l&#39;API de Sandbox
+DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Comprovar això si està provant el pagament mitjançant l'API de Sandbox
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,No se li permet eliminar un tema web estàndar
 DocType: Data Import,Log Details,Detalls del registre
 DocType: Workflow Transition,Example,Exemple
 DocType: Webhook Header,Webhook Header,Encapçalament Webhook
 DocType: Access Log,Report Information,Informació de la informació
-DocType: Print Settings,Print Server,Servidor d&#39;impressió
+DocType: Print Settings,Print Server,Servidor d'impressió
 DocType: Workflow State,gift,regal
 DocType: Communication,Timeline Links,Enllaços de línia de temps
 DocType: Workflow Action,Completed By,Completat amb
@@ -247,7 +247,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.py,Cannot Rem
 apps/frappe/frappe/public/js/frappe/request.js,The resource you are looking for is not available,El recurs que està buscant no està disponible
 DocType: Chat Profile,Chat Background,Xat de fons
 apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Read,Marcar com llegit
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Updating {0},S&#39;està actualitzant {0}
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Updating {0},S'està actualitzant {0}
 apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Desactivar Informe
 DocType: Translation,Contributed Translation Doctype Name,Nom de Doctype de traducció aportada
 DocType: PayPal Settings,Redirect To,per redirigir
@@ -278,26 +278,26 @@ apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Save As,Guardar
 DocType: Comment,Seen,Vist
 apps/frappe/frappe/public/js/frappe/form/layout.js,Show more details,Mostra més detalls
 DocType: System Settings,Run scheduled jobs only if checked,Executar els treballs programats només si s'activa
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Will only be shown if section headings are enabled,només es mostrarà si s&#39;habiliten els títols de secció
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Will only be shown if section headings are enabled,només es mostrarà si s'habiliten els títols de secció
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Archive,Arxiu
-apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload,Càrrega d&#39;arxius
-DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","Introduïu camps de valor per defecte (claus) i valors. Si afegeix diversos valors per a un camp, el primer d&#39;ells serà elegit. Aquests valors predeterminats s&#39;utilitzen també per establir &quot;els partits&quot; regles de permisos. Per veure la llista de camps, aneu a &quot;Personalitzar Form&quot;."
+apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload,Càrrega d'arxius
+DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","Introduïu camps de valor per defecte (claus) i valors. Si afegeix diversos valors per a un camp, el primer d'ells serà elegit. Aquests valors predeterminats s'utilitzen també per establir &quot;els partits&quot; regles de permisos. Per veure la llista de camps, aneu a &quot;Personalitzar Form&quot;."
 DocType: Auto Repeat,Message,Missatge
 DocType: Communication,Rating,classificació
 DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Print Width of the field, if the field is a column in a table"
 DocType: Dropbox Settings,Dropbox Access Key,Dropbox Access Key
 apps/frappe/frappe/desk/form/utils.py,Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script,Nom de camp incorrecte <b>{0}</b> a la configuració add_fetch del script personalitzat
-apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,Seleccioneu Google Contacts amb el qual s&#39;ha de sincronitzar el contacte.
+apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,Seleccioneu Google Contacts amb el qual s'ha de sincronitzar el contacte.
 DocType: Web Page,Main Section (HTML),Secció principal (HTML)
 DocType: Workflow State,headphones,auriculars
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Password is required or select Awaiting Password,Es requereix contrasenya o seleccioneu Tot esperant la contrasenya
 DocType: Email Account,e.g. replies@yourcomany.com. All replies will come to this inbox.,per exemple replies@yourcomany.com. Totes les respostes vindran a aquesta safata d'entrada.
-DocType: Slack Webhook URL,Slack Webhook URL,S&#39;ha reduït l&#39;URL de Webhook
+DocType: Slack Webhook URL,Slack Webhook URL,S'ha reduït l'URL de Webhook
 DocType: Data Migration Run,Current Mapping,Mapeig actual
 apps/frappe/frappe/templates/includes/login/login.js,Valid email and name required,Es requereix un nom i correu electrònic vàlid
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Make all attachments private,Feu que tots els fitxers adjunts siguin privats
 DocType: User,Send Notifications for documents followed by me,Enviar notificacions per a documents seguits per mi
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add User Permissions,Afegeix permisos d&#39;usuaris
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add User Permissions,Afegeix permisos d'usuaris
 DocType: Session Default Settings,Session Default Settings,Configuració predeterminada de la sessió
 DocType: Address,Current,actual
 apps/frappe/frappe/config/core.py,Groups of DocTypes,Grups de doctypes
@@ -319,7 +319,7 @@ DocType: Workflow,Defines workflow states and rules for a document.,Defineix els
 DocType: Workflow State,Filter,Filtre
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Check the Error Log for more information: {0},Consulteu el registre d’errors per obtenir més informació: {0}
 apps/frappe/frappe/database/schema.py,Fieldname {0} cannot have special characters like {1},FIELDNAME {0} no pot tenir caràcters especials com {1}
-apps/frappe/frappe/model/workflow.py,Applying: {0},S&#39;aplica: {0}
+apps/frappe/frappe/model/workflow.py,Applying: {0},S'aplica: {0}
 apps/frappe/frappe/public/js/frappe/request.js,Internal Server Error,error del servidor intern
 apps/frappe/frappe/config/settings.py,Update many values at one time.,Actualitzar molts valors al mateix temps.
 apps/frappe/frappe/model/document.py,Error: Document has been modified after you have opened it,Error: Document ha estat modificat després de que l'hagis obert
@@ -341,7 +341,7 @@ DocType: Address,Mizoram,Mizoram
 DocType: Newsletter,Newsletter,Newsletter
 apps/frappe/frappe/model/db_query.py,Cannot use sub-query in order by,No es pot utilitzar sub-consulta per tal de
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options must be a valid DocType for field {1} in row {2},{0}: les opcions han de ser un document de document vàlid per al camp {1} de la fila {2}
-DocType: Web Form,Button Help,El botó d&#39;ajuda
+DocType: Web Form,Button Help,El botó d'ajuda
 DocType: Kanban Board Column,purple,porpra
 DocType: About Us Settings,Team Members,Membres de l'equip
 DocType: Assignment Rule,System Manager,Administrador del sistema
@@ -361,18 +361,18 @@ DocType: Notification Recipient,Notification Recipient,Destinatari de notificaci
 DocType: Workflow State,Refresh,Refrescar
 DocType: Event,Public,Públic
 apps/frappe/frappe/public/js/frappe/list/base_list.js,Nothing to show,No hi ha res a mostrar
-DocType: System Settings,Enable Two Factor Auth,Activa l&#39;autenticació de dos factors
+DocType: System Settings,Enable Two Factor Auth,Activa l'autenticació de dos factors
 DocType: Post,Liked By,Em va agradar Per
 DocType: DocField,Print Hide If No Value,Imprimir amaga Si No Valor
 DocType: Kanban Board Column,yellow,groc
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Is Published Field must be a valid fieldname,Es publica camp ha de ser un nom de camp vàlid
 DocType: Block Module,Block Module,Mòdul de bloc
 apps/frappe/frappe/core/doctype/version/version_view.html,New Value,nou valor
-apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field,El document <b>{0}</b> proporcionat al camp <b>{1}</b> ha de tenir almenys un camp d&#39;enllaç
+apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field,El document <b>{0}</b> proporcionat al camp <b>{1}</b> ha de tenir almenys un camp d'enllaç
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html,Add a column,Afegir una columna
 apps/frappe/frappe/www/contact.html,Your email address,La seva adreça de correu electrònic
 DocType: Desktop Icon,Module,Mòdul
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} records out of {1}.,S&#39;han actualitzat correctament {0} registres de {1}.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} records out of {1}.,S'han actualitzat correctament {0} registres de {1}.
 DocType: Notification,Send Alert On,Enviar Alerta Sobre
 DocType: Customize Form,"Customize Label, Print Hide, Default etc.","Personalitza etiquetes, amaga impressió, defecte etc."
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Unzipping files...,Com descomprimir fitxers ...
@@ -397,9 +397,9 @@ apps/frappe/frappe/core/doctype/success_action/success_action.js,Select atleast 
 apps/frappe/frappe/public/js/frappe/barcode_scanner/quagga.js,Scan Barcode,Escanejar codi de barres
 DocType: Email Flag Queue,Email Flag Queue,Bandera de correu electrònic de la cua
 DocType: Access Log,Columns / Fields,Columnes / Camps
-apps/frappe/frappe/config/settings.py,Stylesheets for Print Formats,Fulls d&#39;estils per a formats d&#39;impressió
+apps/frappe/frappe/config/settings.py,Stylesheets for Print Formats,Fulls d'estils per a formats d'impressió
 apps/frappe/frappe/utils/bot.py,Can't identify open {0}. Try something else.,No pot identificar obert {0}. Intentar una altra cosa.
-apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Your information has been submitted,La seva informació s&#39;ha enviat
+apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Your information has been submitted,La seva informació s'ha enviat
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be deleted,L'usuari {0} no es pot eliminar
 DocType: System Settings,Currency Precision,precisió de divises
 apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,Una altra transacció està bloquejant aquest. Torneu-ho de nou en uns pocs segons.
@@ -426,7 +426,7 @@ DocType: Energy Point Log,Review,Revisió
 DocType: User,Restrict IP,Restringir IP
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,panell
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,No es poden enviar missatges de correu electrònic en aquest moment
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Calendar: no s&#39;ha pogut actualitzar l&#39;esdeveniment {0} a Google Calendar, codi d&#39;error {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Calendar: no s'ha pogut actualitzar l'esdeveniment {0} a Google Calendar, codi d'error {1}."
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Busca o escriu una ordre
 DocType: Activity Log,Timeline Name,Nom de la línia de temps
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,Només un {0} es pot configurar com a principal.
@@ -445,9 +445,9 @@ apps/frappe/frappe/templates/emails/auto_reply.html,"Your query has been receive
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only if Incoming is enabled.,L’enllaç automàtic només es pot activar si està activada la entrada.
 DocType: LDAP Settings,LDAP Middle Name Field,Camp de nom mig LDAP
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Importing {0} of {1},Important {0} de {1}
-DocType: GCalendar Account,Allow GCalendar Access,Permet l&#39;accés a GCalendar
+DocType: GCalendar Account,Allow GCalendar Access,Permet l'accés a GCalendar
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} és un camp obligatori
-apps/frappe/frappe/templates/includes/login/login.js,Login token required,S&#39;ha requerit el token d&#39;inici de sessió
+apps/frappe/frappe/templates/includes/login/login.js,Login token required,S'ha requerit el token d'inici de sessió
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Monthly Rank: ,Rànquing mensual:
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select multiple list items,Seleccioneu diversos elements de la llista
 DocType: Event,Repeat Till,Repeteix Fins
@@ -456,14 +456,14 @@ apps/frappe/frappe/public/js/frappe/views/components/ModuleLinkItem.vue,You need
 DocType: Google Maps Settings,Google Maps Settings,Configuració de Google Maps
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Carregant ...
 DocType: DocField,Password,Contrasenya
-apps/frappe/frappe/utils/response.py,Your system is being updated. Please refresh again after a few moments,"El seu sistema s&#39;està actualitzant. Si us plau, actualitzi de nou després d&#39;uns moments"
+apps/frappe/frappe/utils/response.py,Your system is being updated. Please refresh again after a few moments,"El seu sistema s'està actualitzant. Si us plau, actualitzi de nou després d'uns moments"
 DocType: Blogger,Will be used in url (usually first name).,Will be used in url (usually first name).
 DocType: Comment,Comment Email,Correu electrònic de comentaris
 DocType: Auto Email Report,Day of Week,Dia de la setmana
 DocType: Note,Expire Notification On,Notificació En expirarà
 apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Ctrl+Enter to add comment,Ctrl + Retorn per afegir comentaris
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Set as Default Theme,Estableix com a tema predeterminat
-apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload in Progress. Please try again in a few moments.,Càrrega d&#39;arxius en progrés. Torneu-ho a provar en uns moments.
+apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload in Progress. Please try again in a few moments.,Càrrega d'arxius en progrés. Torneu-ho a provar en uns moments.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Edit Heading,Edita Capçalera
 DocType: File,File URL,URL del fitxer
 DocType: Version,Table HTML,taula HTML
@@ -473,10 +473,10 @@ DocType: Google Calendar,Push to Google Calendar,Push a Google Calendar
 DocType: Notification Recipient,Email By Document Field,Email per camp del document
 DocType: Domain Settings,Domain Settings,Configuració del domini
 apps/frappe/frappe/email/receive.py,Cannot connect: {0},No es pot connectar: {0}
-apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.,Una paraula de per si és fàcil d&#39;endevinar.
-apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Auto assignment failed: {0},L&#39;assignació automàtica ha fallat: {0}
+apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.,Una paraula de per si és fàcil d'endevinar.
+apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Auto assignment failed: {0},L'assignació automàtica ha fallat: {0}
 apps/frappe/frappe/templates/includes/search_box.html,Search...,Cerca...
-apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,Please select Company,Seleccioneu de l&#39;empresa
+apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,Please select Company,Seleccioneu de l'empresa
 apps/frappe/frappe/utils/nestedset.py,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,La fusió és només possible entre Grup-a-grup o el full de node a node-Leaf
 apps/frappe/frappe/utils/file_manager.py,Added {0},Afegit {0}
 apps/frappe/frappe/templates/includes/search_template.html,No matching records. Search something new,No hi ha registres coincidents. Cercar alguna cosa nova
@@ -487,9 +487,9 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/user_progress_dialog.js,Mark as D
 DocType: Chat Message,Type,Tipus
 DocType: Google Settings,OAuth Client ID,Identificador de client OAuth
 DocType: Auto Repeat,Subject,Subjecte
-apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Back to Desk,Tornar a l&#39;escriptori
+apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Back to Desk,Tornar a l'escriptori
 DocType: Web Form,Amount Based On Field,Quantitat basada en el Camp
-apps/frappe/frappe/core/doctype/docshare/docshare.py,User is mandatory for Share,L&#39;usuari és obligatori per Compartir
+apps/frappe/frappe/core/doctype/docshare/docshare.py,User is mandatory for Share,L'usuari és obligatori per Compartir
 DocType: DocField,Hidden,Ocult
 DocType: Web Form,Allow Incomplete Forms,Permetre formes incompletes
 apps/frappe/frappe/utils/print_format.py,PDF generation failed,La generació de PDF ha fallat
@@ -504,7 +504,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can only be renamed b
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,6 months,6 mesos
 apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Please attach an image file to set HTML,Adjunteu un fitxer d’imatge per configurar HTML
 DocType: Chat Message,Chat Message,Missatge de xat
-apps/frappe/frappe/utils/oauth.py,Email not verified with {0},El correu electrònic no s&#39;ha verificat amb {0}
+apps/frappe/frappe/utils/oauth.py,Email not verified with {0},El correu electrònic no s'ha verificat amb {0}
 DocType: Dashboard Chart,Time Series Based On,Sèrie de temps basada en
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0},canvi de valor de {0}
 DocType: Report,JSON,JSON
@@ -514,31 +514,31 @@ DocType: Communication,Bounced,Rebotats
 DocType: Deleted Document,Deleted Name,nom esborrat
 apps/frappe/frappe/config/users_and_permissions.py,System and Website Users,Usuaris de sistema i lloc web
 DocType: Workflow Document State,Doc Status,Estat del Doc
-DocType: Data Migration Run,Pull Update,Treu l&#39;actualització
+DocType: Data Migration Run,Pull Update,Treu l'actualització
 DocType: Auto Email Report,No of Rows (Max 500),No de files (màx 500)
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.html,Select Field...,Selecciona Camp ...
-DocType: Language,Language Code,Codi d&#39;idioma
-DocType: Dropbox Settings,Note: By default emails for failed backups are sent.,Nota: s&#39;envien per correu electrònic per defecte les còpies de seguretat fallides.
+DocType: Language,Language Code,Codi d'idioma
+DocType: Dropbox Settings,Note: By default emails for failed backups are sent.,Nota: s'envien per correu electrònic per defecte les còpies de seguretat fallides.
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Add Filter,Afegeix un filtre
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,SMS sent to following numbers: {0},SMS enviat als telèfons: {0}
 apps/frappe/frappe/utils/data.py,{0} and {1},{0} i {1}
 apps/frappe/frappe/public/js/frappe/chat.js,Start a conversation.,Comença una conversa.
-DocType: Print Settings,"Always add ""Draft"" Heading for printing draft documents",Sempre afegiu &quot;Projecte de&quot; Rumb a projectes d&#39;impressió de documents
+DocType: Print Settings,"Always add ""Draft"" Heading for printing draft documents",Sempre afegiu &quot;Projecte de&quot; Rumb a projectes d'impressió de documents
 apps/frappe/frappe/email/doctype/notification/notification.py,Error in Notification: {},Error de notificació: {}
 DocType: Data Migration Run,Current Mapping Start,Comença el mapa actual
 apps/frappe/frappe/core/doctype/communication/communication.js,Email has been marked as spam,El correu electrònic ha estat marcat com a correu brossa
 DocType: Comment,Website Manager,Gestor de la Pàgina web
-apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload Disconnected. Please try again.,S&#39;ha desconnectat la càrrega d&#39;arxius. Siusplau torna-ho a provar.
+apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload Disconnected. Please try again.,S'ha desconnectat la càrrega d'arxius. Siusplau torna-ho a provar.
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translations,Traduccions
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,You selected Draft or Cancelled documents,Vostè Projecte seleccionat o documents cancel·lats
-apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Document {0} has been set to state {1} by {2},S&#39;ha definit el document {0} a l&#39;estat {1} per {2}
+apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Document {0} has been set to state {1} by {2},S'ha definit el document {0} a l'estat {1} per {2}
 apps/frappe/frappe/model/document.py,Document Queued,document en cua
 DocType: GSuite Templates,Destination ID,ID de destinació
 DocType: Desktop Icon,List,Llista
-DocType: Activity Log,Link Name,Nom de l&#39;enllaç
+DocType: Activity Log,Link Name,Nom de l'enllaç
 DocType: System Settings,mm/dd/yyyy,mm/dd/aaaa
 apps/frappe/frappe/core/doctype/user/user.py,Invalid Password: ,Contrasenya invàlida:
-DocType: Print Settings,Send document web view link in email,Enviar document internacionalització del link a l&#39;email
+DocType: Print Settings,Send document web view link in email,Enviar document internacionalització del link a l'email
 apps/frappe/frappe/public/js/frappe/ui/slides.js,Previous,Anterior
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Re:,Re:
 DocType: LDAP Settings,Require Trusted Certificate,Requereix un certificat de confiança
@@ -552,21 +552,21 @@ apps/frappe/frappe/utils/file_manager.py,No file attached,No hi ha cap arxiu adj
 DocType: Version,Version,Versió
 DocType: S3 Backup Settings,Endpoint URL,URL del punt final
 DocType: Dashboard,Charts,Gràfics
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions are automatically applied to Standard Reports and searches.,Els permisos s&#39;apliquen automàticament als informes estàndard i a les cerques.
-apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,S&#39;ha produït un error en carregar
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions are automatically applied to Standard Reports and searches.,Els permisos s'apliquen automàticament als informes estàndard i a les cerques.
+apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,S'ha produït un error en carregar
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Estadístiques basades en el rendiment de la setmana passada (de {0} a {1})
 DocType: LDAP Settings,LDAP Phone Field,Camp de telèfon LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Tipus de document ..., per exemple, al client"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,La condició &#39;{0}&#39; no és vàlida
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,La condició '{0}' no és vàlida
 DocType: Workflow State,barcode,Barcode
-apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,L&#39;ús de subconsulta o funció està restringit
+apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,L'ús de subconsulta o funció està restringit
 apps/frappe/frappe/config/customization.py,Add your own translations,Afegir les seves pròpies traduccions
 DocType: Country,Country Name,Nom del país
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Blank Template,Plantilla en blanc
 DocType: About Us Team Member,About Us Team Member,Sobre nosaltres Membre de l'Equip
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions.","Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions."
 DocType: Assignment Rule Day,Wednesday,Dimecres
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Camp d&#39;imatge ha de ser un nom de camp vàlid
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Camp d'imatge ha de ser un nom de camp vàlid
 DocType: Chat Token,Token,simbòlic
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} is restricted,El nom de camp {0} està restringit
 DocType: Property Setter,ID (name) of the entity whose property is to be set,ID (name) of the entity whose property is to be set
@@ -580,7 +580,7 @@ DocType: Workflow State,exclamation-sign,Signe d'exclamació
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Unzipped {0} files,{0} fitxers descomprimits
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,empty,buit
 apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js,Show Permissions,Mostra Permisos
-DocType: Data Import,New data will be inserted.,S&#39;han d&#39;inserir noves dades.
+DocType: Data Import,New data will be inserted.,S'han d'inserir noves dades.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a Link or Dynamic Link,camp de línia de temps ha de ser un vincle o enllaç dinàmic
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Date Range,Rang de dates
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Gantt,Gantt
@@ -595,22 +595,22 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log_list.js,View
 apps/frappe/frappe/public/js/frappe/desk.js,Places,Llocs
 DocType: Kanban Board Column,darkgrey,gris fosc
 apps/frappe/frappe/model/rename_doc.py,Successful: {0} to {1},Exitosa: {0} a {1}
-apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,"No es poden canviar els detalls de l&#39;usuari en demostració. Si us plau, registrar-se per un nou compte a https://erpnext.com"
+apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,"No es poden canviar els detalls de l'usuari en demostració. Si us plau, registrar-se per un nou compte a https://erpnext.com"
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop,Tirar
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please duplicate this to make changes,"Si us plau, duplicar aquesta per fer canvis"
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Press Enter to save,Premeu Retorn per desar
-apps/frappe/frappe/utils/pdf.py,PDF generation failed because of broken image links,Generació de PDF fracassar a causa dels vincles d&#39;imatge trencats
+apps/frappe/frappe/utils/pdf.py,PDF generation failed because of broken image links,Generació de PDF fracassar a causa dels vincles d'imatge trencats
 DocType: Print Settings,Font Size,Mida de la Font
 DocType: System Settings,Disable Standard Email Footer,Desactivar Estàndard Email Peu de pàgina
 DocType: Workflow State,facetime-video,FaceTime i vídeo
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,1 comment,1 comentari
-DocType: Website Slideshow,"Note: For best results,  images must be of the same size and width must be greater than height.","Nota: Per obtenir millors resultats, les imatges han de ser de la mateixa mida i l&#39;amplada ha de ser superior a l&#39;alçada."
+DocType: Website Slideshow,"Note: For best results,  images must be of the same size and width must be greater than height.","Nota: Per obtenir millors resultats, les imatges han de ser de la mateixa mida i l'amplada ha de ser superior a l'alçada."
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,viewed,vist
 DocType: Notification,Days Before,Dies abans
 apps/frappe/frappe/desk/doctype/event/event.py,Daily Events should finish on the Same Day.,Els esdeveniments diaris haurien d’acabar el mateix dia.
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Edit...,Edita ...
 DocType: Workflow State,volume-down,volum cap avall
-apps/frappe/frappe/auth.py,Access not allowed from this IP Address,Accés no permès des d&#39;aquesta adreça IP
+apps/frappe/frappe/auth.py,Access not allowed from this IP Address,Accés no permès des d'aquesta adreça IP
 apps/frappe/frappe/desk/reportview.py,No Tags,No hi ha etiquetes
 DocType: Email Account,Send Notification to,Enviar Notificació a
 DocType: DocField,Collapsible,Plegable
@@ -625,7 +625,7 @@ DocType: Chat Profile,Settings,Ajustos
 DocType: Print Format,Style Settings,Ajustos
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Filter By,Filtra per
 apps/frappe/frappe/database/database.py,No conditions provided,No es proporcionen condicions
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Camps d&#39;eix Y
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Camps d'eix Y
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,Ordenar camp {0} ha de ser un nom de camp vàlid
 apps/frappe/frappe/public/js/frappe/list/base_list.js,More,Més
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Create a new record,Crea un registre nou
@@ -649,7 +649,7 @@ DocType: User,Reset Password Key,Restabliment de contrasenya
 apps/frappe/frappe/model/workflow.py,Illegal Document Status for {0},Estat del document il · legal per {0}
 DocType: Email Account,Enable Auto Reply,Habilita resposta automàtica
 apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Not Seen,No Vist
-apps/frappe/frappe/public/js/frappe/form/print.js,Cannot have multiple printers mapped to a single print format.,No es poden associar diverses impressores amb un format d&#39;impressió únic.
+apps/frappe/frappe/public/js/frappe/form/print.js,Cannot have multiple printers mapped to a single print format.,No es poden associar diverses impressores amb un format d'impressió únic.
 DocType: Workflow State,zoom-in,mes-zoom
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Reference DocType and Reference Name are required,Referència DOCTYPE i Nom Referència es requereixen
 apps/frappe/frappe/utils/jinja.py,Syntax error in template,Error de sintaxi a la plantilla
@@ -660,18 +660,18 @@ apps/frappe/frappe/www/qrcode.html,Scan the QR Code and enter the resulting code
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Enable Gradients,Activa els degradats
 DocType: System Settings,Minimum Password Score,Clau puntuació mínima
 DocType: DocType,Fields,Camps
-DocType: System Settings,Your organization name and address for the email footer.,El seu nom de l&#39;organització i direcció per al peu de pàgina de correu electrònic.
+DocType: System Settings,Your organization name and address for the email footer.,El seu nom de l'organització i direcció per al peu de pàgina de correu electrònic.
 apps/frappe/frappe/core/doctype/data_import/importer.py,Parent Table,Taula Pare
-apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js,S3 Backup complete!,S&#39;ha completat la còpia de seguretat S3.
+apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js,S3 Backup complete!,S'ha completat la còpia de seguretat S3.
 apps/frappe/frappe/config/desktop.py,Developer,Desenvolupador
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Created,Creat
 apps/frappe/frappe/website/doctype/website_settings/website_settings.py,{0} in row {1} cannot have both URL and child items,{0} a la fila {1} no pot tenir les dues coses URL i elements descendents
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for the following tables: {0},Hauria d&#39;haver al menys una fila per a les taules següents: {0}
-DocType: Print Format,Default Print Language,Idioma d&#39;impressió predeterminat
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for the following tables: {0},Hauria d'haver al menys una fila per a les taules següents: {0}
+DocType: Print Format,Default Print Language,Idioma d'impressió predeterminat
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Ancestors Of,Ancestres de
 apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,Root {0} cannot be deleted
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Cap comentari encara
-apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings",Configureu SMS abans de configurar-lo com a mètode d&#39;autenticació mitjançant la configuració de SMS
+apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings",Configureu SMS abans de configurar-lo com a mètode d'autenticació mitjançant la configuració de SMS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,Tant doctype i Nom obligatori
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,No es pot canviar DocStatus de 1 a 0
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,No teniu prou punts
@@ -679,14 +679,14 @@ apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Tak
 DocType: Contact,Open,Obert
 DocType: Workflow Transition,Defines actions on states and the next step and allowed roles.,Defineix les accions dels estats i el següent pas i rols permesos.
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Reviewer,Top revisor
-DocType: Data Migration Mapping,Remote Objectname,Nom de l&#39;objecte remot
+DocType: Data Migration Mapping,Remote Objectname,Nom de l'objecte remot
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","Com a pràctica, no assigni el mateix conjunt de regles permís per a diferents funcions. En el seu lloc, establir diversos rols al mateix usuari."
 apps/frappe/frappe/www/confirm_workflow_action.html,Please confirm your action to {0} this document.,Confirmeu la vostra acció a {0} aquest document.
 DocType: Success Action,Next Actions HTML,Accions següents HTML
 apps/frappe/frappe/public/js/frappe/social/social_home.js,Create Post,Crea una publicació
 apps/frappe/frappe/desk/doctype/event/event.js,Add Participants,Afegeix participants
 DocType: Web Page,Main Section (Markdown),Secció principal (aparició)
-apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Only {0} emailed reports are allowed per user,Només {0} enviar per correu electrònic informes són permesos per l&#39;usuari
+apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Only {0} emailed reports are allowed per user,Només {0} enviar per correu electrònic informes són permesos per l'usuari
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldtype {1} for {2} cannot be unique,{0}: el tipus de camp {1} per a {2} no pot ser únic
 DocType: Address,Address Title,Direcció Títol
 DocType: Website Settings,Footer Items,Peu de pàgina Articles
@@ -697,13 +697,13 @@ apps/frappe/frappe/config/users_and_permissions.py,User Roles,Rols d'usuari
 DocType: Property Setter,Property Setter overrides a standard DocType or Field property,Property Setter overrides a standard DocType or Field property
 apps/frappe/frappe/core/doctype/user/user.py,Cannot Update: Incorrect / Expired Link.,No es pot actualitzar: Enllaç Incorrecte o caducat.
 apps/frappe/frappe/utils/password_strength.py,Better add a few more letters or another word,Millor afegir algunes més lletres o una paraula
-DocType: Auto Repeat,Repeat on Last Day of the Month,Repetiu l&#39;últim dia del mes
-apps/frappe/frappe/twofactor.py,One Time Password (OTP) Registration Code from {},Codi d&#39;inscripció d&#39;un temps de contrasenya (OTP) de {}
+DocType: Auto Repeat,Repeat on Last Day of the Month,Repetiu l'últim dia del mes
+apps/frappe/frappe/twofactor.py,One Time Password (OTP) Registration Code from {},Codi d'inscripció d'un temps de contrasenya (OTP) de {}
 DocType: DocField,Set Only Once,Ajusta només una vegada
 DocType: Email Queue Recipient,Email Queue Recipient,Cua de correu electrònic de destinataris
 DocType: Address,Nagaland,Nagaland
 DocType: Slack Webhook URL,Webhook URL,URL del webhook
-apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Nom d&#39;usuari {0} ja existeix
+apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Nom d'usuari {0} ja existeix
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: no es pot establir d'importació com {1} no és importable
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Hi ha un error en la seva plantilla de direcció {0}
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} és una adreça electrònica no vàlida a &quot;Destinataris&quot;
@@ -714,13 +714,13 @@ DocType: Data Import Beta,Import File,Importa el fitxer
 apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py,Column <b>{0}</b> already exist.,Columna <b>{0}</b> ja existeix.
 DocType: ToDo,High,Alt
 apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,New Event,Nou esdeveniment
-DocType: S3 Backup Settings,Secret Access Key,Clau d&#39;accés secret
+DocType: S3 Backup Settings,Secret Access Key,Clau d'accés secret
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Male,Home
 apps/frappe/frappe/core/doctype/user/user.py,OTP Secret has been reset. Re-registration will be required on next login.,OTP Secret ha estat restablit. La inscripció serà obligatòria en el proper inici de sessió.
 DocType: Communication,From Full Name,De Nom complet
 apps/frappe/frappe/desk/query_report.py,You don't have access to Report: {0},No tens accés a l'informe: {0}
 DocType: User,Send Welcome Email,Enviar Benvingut email
-DocType: Assignment Rule User,Assignment Rule User,Usuari de la norma d&#39;assignació
+DocType: Assignment Rule User,Assignment Rule User,Usuari de la norma d'assignació
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Remove Filter,Treure filtre
 DocType: Web Form Field,Show in filter,Mostra al filtre
 DocType: Address,Daman and Diu,Daman i Diu
@@ -738,29 +738,29 @@ DocType: Workflow State,thumbs-down,thumbs-down
 DocType: User,Send Notifications for Email threads,Enviar notificacions per a fils de correu electrònic
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Prof,profe
 apps/frappe/frappe/core/doctype/page/page.py,Not in Developer Mode,No és de cap manera desenvolupador
-apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,La còpia de seguretat d&#39;un fitxer està preparada
+apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,La còpia de seguretat d'un fitxer està preparada
 DocType: DocField,In Global Search,En Recerca Global
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,guió-esquerra
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> Fa {0} any
-apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"És arriscat eliminar aquesta imatge: {0}. Si us plau, poseu-vos en contacte amb l&#39;administrador del sistema."
+apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"És arriscat eliminar aquesta imatge: {0}. Si us plau, poseu-vos en contacte amb l'administrador del sistema."
 DocType: Currency,Currency Name,Nom moneda
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No hi ha missatges de correu electrònic
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Enllaç caducat
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",S&#39;està revertint la longitud a {0} per a &#39;{1}&#39; a &#39;{2}&#39;; Establir la longitud com a {3} causarà truncament de dades.
+							Setting the length as {3} will cause truncation of data.",S'està revertint la longitud a {0} per a '{1}' a '{2}'; Establir la longitud com a {3} causarà truncament de dades.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Seleccioneu el format de fitxer
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash contingut
-DocType: User,Stores the JSON of last known versions of various installed apps. It is used to show release notes.,Emmagatzema el JSON de les últimes versions conegudes de diferents aplicacions instal·lades. S&#39;utilitza per mostrar notes de la versió.
-DocType: Energy Point Rule,User Field,Camp d&#39;Usuari
+DocType: User,Stores the JSON of last known versions of various installed apps. It is used to show release notes.,Emmagatzema el JSON de les últimes versions conegudes de diferents aplicacions instal·lades. S'utilitza per mostrar notes de la versió.
+DocType: Energy Point Rule,User Field,Camp d'Usuari
 DocType: DocType,MyISAM,MyISAM
 DocType: Data Migration Run,Push Delete,Premeu Suprimeix
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed for {1} {2},{0} ja donat de baixa per {1} {2}
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not remove,No treure
 apps/frappe/frappe/desk/like.py,Liked,Em va agradar
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now,Enviar ara
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Estàndard DOCTYPE no pot tenir format d&#39;impressió per defecte, utilitzeu Personalitzar formulari"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Estàndard DOCTYPE no pot tenir format d'impressió per defecte, utilitzeu Personalitzar formulari"
 DocType: Report,Query,Query
 DocType: Customize Form,Sort Order,Ordre de Classificació
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'A Vista de llista' no permès per al tipus {0} a la fila {1}
@@ -769,26 +769,26 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Document Compartir Reportar
 DocType: Social Login Key,Base URL,URL base
 DocType: User,Last Login,Últim ingrés
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},No podeu definir &#39;Traduït per al camp {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},No podeu definir 'Traduït per al camp {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Columna
 DocType: Chat Profile,Chat Profile,Perfil de xat
 DocType: Custom Field,Adds a custom field to a DocType,Afegeix un camp personalitzat a un DocType
-apps/frappe/frappe/templates/emails/delete_data_confirmation.html,Click on the link below to verify your request,Feu clic a l&#39;enllaç següent per verificar la sol·licitud
+apps/frappe/frappe/templates/emails/delete_data_confirmation.html,Click on the link below to verify your request,Feu clic a l'enllaç següent per verificar la sol·licitud
 DocType: File,Is Home Folder,És Carpeta
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Estil de barra de navegació
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} no és una Adreça de Correu Electrònic vàlida
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Seleccionar com a mínim 1 resultat per a la impressió
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Usuari &#39;{0}&#39; ja té el paper &#39;{1}&#39;
-DocType: System Settings,Two Factor Authentication method,Mètode d&#39;autenticació de dos factors
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Usuari '{0}' ja té el paper '{1}'
+DocType: System Settings,Two Factor Authentication method,Mètode d'autenticació de dos factors
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Primer estableixi el nom i deseu el registre.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Registres
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with {0},Compartit amb {0}
 apps/frappe/frappe/email/queue.py,Unsubscribe,Donar-se de baixa
 DocType: View Log,Reference Name,Referència Nom
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,Change User,Canvia d&#39;usuari
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,Change User,Canvia d'usuari
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Update Translations,Actualitza les traduccions
 DocType: Error Snapshot,Exception,Excepció
-DocType: Email Account,Use IMAP,L&#39;ús de IMAP
+DocType: Email Account,Use IMAP,L'ús de IMAP
 DocType: Activity Log,Activity Log,Registre d'activitat
 DocType: View Log,Viewed By,Vist per
 DocType: Integration Request,Authorized,autoritzat
@@ -803,15 +803,15 @@ DocType: DocField,Index,Índex
 DocType: Email Group,Newsletter Manager,Butlletí Administrador
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 1,Opció 1
 apps/frappe/frappe/public/js/frappe/form/formatters.js,{0} to {1},{0} a {1}
-apps/frappe/frappe/config/settings.py,Log of error during requests.,Entrada d&#39;error durant peticions.
+apps/frappe/frappe/config/settings.py,Log of error during requests.,Entrada d'error durant peticions.
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,{0} has been successfully added to the Email Group.,{0} s'ha afegit al Grup de Correu Electrònic.
 apps/frappe/frappe/public/js/frappe/form/grid.js,Do not edit headers which are preset in the template,No editeu capçaleres que estiguin predefinides a la plantilla
-apps/frappe/frappe/twofactor.py,Login Verification Code from {},Codi de verificació d&#39;inici de sessió de {}
+apps/frappe/frappe/twofactor.py,Login Verification Code from {},Codi de verificació d'inici de sessió de {}
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained {0} points,Heu guanyat {0} punts
 DocType: Address,Uttar Pradesh,Uttar Pradesh
 apps/frappe/frappe/www/confirm_workflow_action.html,Note:,Nota:
 DocType: Address,Pondicherry,Pondicherry
-DocType: Data Import,Import Status,Estat d&#39;importació
+DocType: Data Import,Import Status,Estat d'importació
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Scheduled to send to {0},Programat per enviar a {0}
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Page Shortcuts,Dreceres de pàgina
 DocType: Kanban Board Column,Indicator,Indicador
@@ -825,13 +825,13 @@ apps/frappe/frappe/config/settings.py,Set numbering series for transactions.,Num
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Configure Charts,Configurar gràfics
 DocType: User,Last IP,Darrera IP
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please add a subject to your email,Afegiu un assumpte al vostre correu electrònic
-apps/frappe/frappe/share.py,A new document {0} has been shared by with you {1}.,S&#39;ha compartit un {0} document nou amb tu {1}.
+apps/frappe/frappe/share.py,A new document {0} has been shared by with you {1}.,S'ha compartit un {0} document nou amb tu {1}.
 DocType: Data Migration Connector,Data Migration Connector,Connector de migració de dades
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} reverted {1},{0} va revertir {1}
-DocType: Email Account,Track Email Status,Seguiment de l&#39;estat del correu electrònic
+DocType: Email Account,Track Email Status,Seguiment de l'estat del correu electrònic
 DocType: Note,Notify Users On Every Login,Notificar als usuaris sobre la cada inici de sessió
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Cannot match column {0} with any field,No es pot coincidir la columna {0} amb cap camp
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} records.,S&#39;han actualitzat correctament {0} registres.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} records.,S'han actualitzat correctament {0} registres.
 DocType: PayPal Settings,API Password,API contrasenya
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Enter python module or select connector type,Introduïu el mòdul python o seleccioneu el tipus de connector
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Fieldname not set for Custom Field,FIELDNAME es posa durant Camp personalitzat
@@ -854,10 +854,10 @@ apps/frappe/frappe/core/doctype/communication/communication.js,Are you sure you 
 DocType: Print Settings,Server IP,IP del servidor
 DocType: Email Queue,Attachments,Adjunts
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You don't have the permissions to access this document,Vostè no té els permisos per accedir a aquest document
-DocType: Language,Language Name,Nom d&#39;idioma
+DocType: Language,Language Name,Nom d'idioma
 DocType: Email Group Member,Email Group Member,Correu electrònic del Grup membre
-apps/frappe/frappe/auth.py,Your account has been locked and will resume after {0} seconds,El vostre compte s&#39;ha bloquejat i es reprendrà després de {0} segons
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions are used to limit users to specific records.,Els permisos d&#39;usuari s&#39;utilitzen per limitar els usuaris a registres específics.
+apps/frappe/frappe/auth.py,Your account has been locked and will resume after {0} seconds,El vostre compte s'ha bloquejat i es reprendrà després de {0} segons
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions are used to limit users to specific records.,Els permisos d'usuari s'utilitzen per limitar els usuaris a registres específics.
 DocType: Notification,Value Changed,Valor Changed
 apps/frappe/frappe/model/base_document.py,Duplicate name {0} {1},Nom duplicat {0} {1}
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Retry,Torneu a provar
@@ -865,13 +865,13 @@ DocType: Contact Phone,Number,Número
 DocType: Web Form Field,Web Form Field,Web de camp de formulari
 apps/frappe/frappe/templates/emails/new_message.html,You have a new message from: ,Tens un missatge nou de:
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_field.html,Edit HTML,Edició de HTML
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Introduïu l&#39;URL de redirecció
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Introduïu l'URL de redirecció
 apps/frappe/frappe/core/doctype/language/language.py,"{0} must begin and end with a letter and can only contain letters,
 				hyphen or underscore.","{0} ha de començar i finalitzar amb una lletra i només pot contenir lletres, guionet o guió baix."
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Restore Original Permissions,Restaurar permisos originals
 DocType: Address,Shop,Botiga
 DocType: DocField,Button,Botó
-apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} is now default print format for {1} doctype,{0} és ara el format d&#39;impressió per defecte de {1} tipus de document
+apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} is now default print format for {1} doctype,{0} és ara el format d'impressió per defecte de {1} tipus de document
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,Archived Columns,columnes arxivats
 DocType: Email Account,Default Outgoing,Predeterminar Sortint
 DocType: Workflow State,play,jugar
@@ -907,9 +907,9 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/form_viewers.js,{0} are current
 DocType: ToDo,Assigned By Full Name,Assignat pel nom complet
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,{0} updated,{0} actualitzat
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Report cannot be set for Single types,Informe no es pot ajustar per als tipus individuals
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Share URL,Comparteix l&#39;URL
-DocType: System Settings,Allow Consecutive Login Attempts ,Permet els intents d&#39;inici de sessió consecutius
-apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,S&#39;ha produït un error durant el procés de pagament. Poseu-vos en contacte amb nosaltres.
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Share URL,Comparteix l'URL
+DocType: System Settings,Allow Consecutive Login Attempts ,Permet els intents d'inici de sessió consecutius
+apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,S'ha produït un error durant el procés de pagament. Poseu-vos en contacte amb nosaltres.
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} days ago,Fa {0} dies
 DocType: Email Account,Awaiting Password,Tot esperant la contrasenya
 DocType: Address,Address Line 1,Adreça Línia 1
@@ -926,7 +926,7 @@ DocType: Print Settings,Allow Print for Draft,Permetre impressió per al project
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Set Quantity,Establir Quantitat
 apps/frappe/frappe/public/js/frappe/form/form.js,Submit this document to confirm,Presentar aquest document per confirmar
 DocType: Contact,Unsubscribed,No subscriure
-apps/frappe/frappe/config/users_and_permissions.py,Set custom roles for page and report,funcions personalitzades per a les pàgines i l&#39;informe
+apps/frappe/frappe/config/users_and_permissions.py,Set custom roles for page and report,funcions personalitzades per a les pàgines i l'informe
 DocType: Braintree Settings,Merchant ID,Identificador de comerciant
 apps/frappe/frappe/public/js/frappe/utils/rating_icons.html,Rating: ,classificació:
 DocType: Address,Dadra and Nagar Haveli,Dadra i Nagar Haveli
@@ -940,7 +940,7 @@ apps/frappe/frappe/email/queue.py,{0} has left the conversation in {1} {2},{0} h
 DocType: Access Log,Show Document,Mostra el document
 DocType: Blogger,User ID of a Blogger,ID d'usuari d'un Blogger
 apps/frappe/frappe/core/doctype/user/user.py,There should remain at least one System Manager,Ha de quedar almenys un administrador del sistema
-DocType: GCalendar Account,Authorization Code,Codi d&#39;autorització
+DocType: GCalendar Account,Authorization Code,Codi d'autorització
 DocType: PayPal Settings,Mention transaction completion page URL,Menció transacció URL de la pàgina finalització
 DocType: Help Article,Expert,expert
 DocType: Workflow State,circle-arrow-right,circle-arrow-right
@@ -962,24 +962,24 @@ DocType: About Us Settings,Company Introduction,Introducció de la companyia
 DocType: User,Last Password Reset Date,Data de restabliment de la darrera contrasenya
 DocType: DocField,Length,Longitud
 apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Restaurar o eliminar permanentment un document.
-apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Hi ha un perfil de xat per a l&#39;usuari {0}.
+apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Hi ha un perfil de xat per a l'usuari {0}.
 apps/frappe/frappe/public/js/frappe/social/components/PostSidebar.vue,Frequently Visited Links,Enllaços freqüents
 DocType: Notification,"To add dynamic subject, use jinja tags like
 
 <div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Per afegir subjecte dinàmic, utilitzar etiquetes Jinja com <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
 apps/frappe/frappe/desk/search.py,Invalid Search Field {0},Camp de cerca no vàlid {0}
 DocType: User,Modules HTML,Mòduls HTML
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Permet l&#39;accés a Google Calendar
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Permet l'accés a Google Calendar
 DocType: Assignment Rule,Higher priority rule will be applied first,Primer s’aplicarà una regla de prioritat superior
 DocType: Email Account,"Track if your email has been opened by the recipient.
 <br>
 Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","Feu un seguiment si el destinatari ha obert el vostre correu electrònic. <br> Nota: si envieu a diversos destinataris, fins i tot si un destinatari llegeix el correu electrònic, es considerarà &quot;Obert&quot;"
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Missing Values Required,Camps Obligatoris
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Permetre l&#39;accés als contactes de Google
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Permetre l'accés als contactes de Google
 DocType: Data Migration Connector,Frappe,Frape
 apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Unread,Marcar com no llegit
 DocType: Activity Log,Operation,Operació
-DocType: Customize Form,Change Label (via Custom Translation),Canviar etiqueta (a través de Traducció d&#39;encàrrec)
+DocType: Customize Form,Change Label (via Custom Translation),Canviar etiqueta (a través de Traducció d'encàrrec)
 apps/frappe/frappe/share.py,No permission to {0} {1} {2},Sense permís per {0} {1} {2}
 DocType: Address,Permanent,permanent
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Note: Other permission rules may also apply,Nota: també poden aplicar altres regles de permisos
@@ -988,21 +988,21 @@ apps/frappe/frappe/templates/emails/print_link.html,View this in your browser,Ve
 DocType: DocType,Parent Field (Tree),Camp principal (arbre)
 DocType: DocType,Search Fields,Camps de recerca
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Sync Contacts,Sincronitza contactes
-DocType: System Settings,OTP Issuer Name,Nom de l&#39;emissor de l&#39;OTP
-DocType: OAuth Bearer Token,OAuth Bearer Token,OAuth Portador d&#39;emergència
+DocType: System Settings,OTP Issuer Name,Nom de l'emissor de l'OTP
+DocType: OAuth Bearer Token,OAuth Bearer Token,OAuth Portador d'emergència
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Dr,Dr
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Syncing,Sincronització
-apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Uploaded successfully,S&#39;ha carregat correctament
+apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Uploaded successfully,S'ha carregat correctament
 apps/frappe/frappe/public/js/frappe/dom.js,You are connected to internet.,Esteu connectat a Internet.
-DocType: Social Login Key,Enable Social Login,Habilita l&#39;inici de sessió social
+DocType: Social Login Key,Enable Social Login,Habilita l'inici de sessió social
 DocType: Data Import Beta,Warnings,Advertències
 DocType: Communication,Event,Esdeveniment
 apps/frappe/frappe/public/js/frappe/views/communication.js,"On {0}, {1} wrote:","En {0}, {1} va escriure:"
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Cannot delete standard field. You can hide it if you want,No es pot eliminar de camp estàndard. Podeu ocultar la pena si vols
 DocType: Top Bar Item,For top bar,Per a la barra superior
-DocType: Social Login Key,Auth URL Data,Dades d&#39;URL d&#39;autenticació
-apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,En cua per còpia de seguretat. Rebràs un correu electrònic amb l&#39;enllaç de descàrrega
-apps/frappe/frappe/utils/bot.py,Could not identify {0},No s&#39;ha pogut identificar {0}
+DocType: Social Login Key,Auth URL Data,Dades d'URL d'autenticació
+apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,En cua per còpia de seguretat. Rebràs un correu electrònic amb l'enllaç de descàrrega
+apps/frappe/frappe/utils/bot.py,Could not identify {0},No s'ha pogut identificar {0}
 DocType: Address,Address,Adreça
 apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,Error en el pagament
 DocType: Print Settings,In points. Default is 9.,En punts. El valor per defecte és de 9.
@@ -1011,7 +1011,7 @@ DocType: LDAP Settings,StartTLS,StartTLS
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Submiting {0},Enviant {0}
 DocType: Workflow State,heart,cor
 apps/frappe/frappe/www/update-password.html,Old Password Required.,Edat requereix contrasenya.
-DocType: Role,Desk Access,departament d&#39;accessibilitat
+DocType: Role,Desk Access,departament d'accessibilitat
 DocType: Workflow State,minus,menys
 DocType: S3 Backup Settings,Bucket,Cubeta
 apps/frappe/frappe/public/js/frappe/ui/capture.js,Unable to load camera.,No es pot carregar la càmera.
@@ -1020,7 +1020,7 @@ apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Let's prepare the syst
 apps/frappe/frappe/core/doctype/user/user.py,Already Registered,Ja està registrat
 DocType: System Settings,Float Precision,Precisió Float
 DocType: Notification,Sender Email,Email del remitent
-apps/frappe/frappe/core/doctype/page/page.py,Only Administrator can edit,Només l&#39;administrador pot editar
+apps/frappe/frappe/core/doctype/page/page.py,Only Administrator can edit,Només l'administrador pot editar
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Please select applicable Doctypes,Seleccioneu els tipus de document aplicables
 DocType: DocType,Editable Grid,Editable quadrícula
 DocType: Property Setter,Property Setter,Ajusts de Propietats
@@ -1030,13 +1030,13 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,De
 apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},No té permís per '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Programat per enviar
 DocType: DocType,Track Seen,Vist a la pista
-DocType: Dropbox Settings,File Backup,Còpia de seguretat d&#39;arxius
+DocType: Dropbox Settings,File Backup,Còpia de seguretat d'arxius
 DocType: Kanban Board Column,orange,taronja
 apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} no trobat
 apps/frappe/frappe/config/customization.py,Add custom forms.,Afegir formularis personalitzats.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} {2} en
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,presentat aquest document
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configuració> Permisos d&#39;usuari
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configuració> Permisos d'usuari
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,El sistema ofereix moltes funcions predefinides. Podeu afegir noves funcions per establir permisos més fins.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1072,7 +1072,7 @@ DocType: Address,Other Territory,Un altre territori
 apps/frappe/frappe/config/website.py,Portal,Portal
 DocType: Email Account,Use Different Email Login ID,Utilitzar diferents ID de sessió de correu electrònic
 apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,Must specify a Query to run
-apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Sembla que hi ha un problema amb la configuració de Braintree del servidor. No us preocupeu, en cas de fracàs, l&#39;import es reemborsarà al vostre compte."
+apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Sembla que hi ha un problema amb la configuració de Braintree del servidor. No us preocupeu, en cas de fracàs, l'import es reemborsarà al vostre compte."
 apps/frappe/frappe/www/me.html,Manage Third Party Apps,Gestioneu aplicacions de tercers
 DocType: Website Settings,Route Redirects,Redireccions de ruta
 apps/frappe/frappe/config/settings.py,"Language, Date and Time settings","Ajustaments d'idioma, data i hora"
@@ -1081,17 +1081,17 @@ DocType: Assignment Rule Day,Saturday,Dissabte
 DocType: User,Represents a User in the system.,Representa un usuari en el sistema.
 DocType: List View Setting,Disable Auto Refresh,Desactiva l’actualització automàtica
 DocType: Comment,Label,Etiqueta
-apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed.","La tasca {0}, que va assignar a {1}, s&#39;ha tancat."
+apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed.","La tasca {0}, que va assignar a {1}, s'ha tancat."
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please close this window,"Si us plau, tancament aquesta finestra"
 DocType: Print Format,Print Format Type,Format d'impressió Tipus
-DocType: Newsletter,A Lead with this Email Address should exist,Hi ha d&#39;haver una iniciativa amb aquesta adreça de correu electrònic
+DocType: Newsletter,A Lead with this Email Address should exist,Hi ha d'haver una iniciativa amb aquesta adreça de correu electrònic
 apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Open Source Applications for the Web,Aplicacions de codi obert per a la Web
 DocType: Event,Call,Truca
-apps/frappe/frappe/website/doctype/website_theme/website_theme.js,"Add the name of a ""Google Web Font"" e.g. ""Open Sans""",Afegir el nom d&#39;un &quot;Google Web Font&quot; per exemple &quot;Open Sans&quot;
-apps/frappe/frappe/public/js/frappe/request.js,Request Timed Out,Temps d&#39;espera esgotat
+apps/frappe/frappe/website/doctype/website_theme/website_theme.js,"Add the name of a ""Google Web Font"" e.g. ""Open Sans""",Afegir el nom d'un &quot;Google Web Font&quot; per exemple &quot;Open Sans&quot;
+apps/frappe/frappe/public/js/frappe/request.js,Request Timed Out,Temps d'espera esgotat
 apps/frappe/frappe/config/settings.py,Enable / Disable Domains,Habilita / Deshabilita dominis
 DocType: Role Permission for Page and Report,Allow Roles,permetre Rols
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records out of {1}.,S&#39;han importat correctament {0} registres de {1}.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records out of {1}.,S'han importat correctament {0} registres de {1}.
 DocType: Assignment Rule,"Simple Python Expression, Example: Status in (""Invalid"")","Expressió simple de Python, exemple: estat en (&quot;No vàlid&quot;)"
 DocType: User,Last Active,Últim actiu
 DocType: Email Account,SMTP Settings for outgoing emails,Configuració SMTP per als correus sortints
@@ -1122,7 +1122,7 @@ apps/frappe/frappe/public/js/frappe/views/communication.js,Select Languages,Sele
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Card Details,Detalls de la targeta
 apps/frappe/frappe/__init__.py,No permission for {0},Sense permís per {0}
 DocType: DocType,Advanced,Avançat
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Seems API Key or API Secret is wrong !!!,Sembla clau d&#39;API o API secret està malament !!!
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Seems API Key or API Secret is wrong !!!,Sembla clau d'API o API secret està malament !!!
 apps/frappe/frappe/templates/emails/auto_reply.html,Reference: {0} {1},Referència: {0} {1}
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Mrs,mrs
 DocType: File,Attached To Name,Associat A Nom
@@ -1156,7 +1156,7 @@ apps/frappe/frappe/templates/includes/comments/comments.html,Login to comment,In
 apps/frappe/frappe/core/doctype/data_import/importer.py,Start entering data below this line,Comenceu a introduir dades per sota d'aquesta línia
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed values for {0},valors modificats per {0}
 apps/frappe/frappe/email/doctype/email_account/email_account.py,"Email ID must be unique, Email Account already exists \
-				for {0}","L&#39;identificador de correu electrònic ha de ser únic, el compte de correu electrònic ja existeix \ per {0}"
+				for {0}","L'identificador de correu electrònic ha de ser únic, el compte de correu electrònic ja existeix \ per {0}"
 DocType: Workflow State,retweet,retweet
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Customize...,Personalitza ...
 DocType: Print Format,Align Labels to the Right,Alinea etiquetes cap a la dreta
@@ -1170,24 +1170,24 @@ DocType: Review Level,Review Points,Punts de revisió
 DocType: Workflow Document State,Workflow Action is not created for optional states,L’acció de flux de treball no es crea per a estats opcionals
 DocType: Address,City/Town,Ciutat / Poble
 DocType: Data Migration Connector,Connector Name,Nom del connector
-DocType: Address,Is Your Company Address,La seva adreça és l&#39;empresa
+DocType: Address,Is Your Company Address,La seva adreça és l'empresa
 DocType: Energy Point Log,Social,Social
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google Calendar: no s&#39;ha pogut crear el calendari per a {0}, codi d&#39;error {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google Calendar: no s'ha pogut crear el calendari per a {0}, codi d'error {1}."
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Editing Row,Edició Fila
 DocType: Workflow Action Master,Workflow Action Master,Mestre d'accions de Flux de treball
 DocType: Custom Field,Field Type,Tipus de camp
 apps/frappe/frappe/utils/data.py,only.,només.
 DocType: Route History,Route History,Historial de la ruta
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Give Review Points,Feu punts de revisió
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google Calendar: no s&#39;ha pogut inserir el contacte als contactes de Google {0}, codi d&#39;error {1}."
-apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,El secret d&#39;OTP només es pot restablir per l&#39;administrador.
-apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,Evitar anys que s&#39;associen amb vostè.
-apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Restringeix l&#39;usuari per un document específic
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google Calendar: no s'ha pogut inserir el contacte als contactes de Google {0}, codi d'error {1}."
+apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,El secret d'OTP només es pot restablir per l'administrador.
+apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,Evitar anys que s'associen amb vostè.
+apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Restringeix l'usuari per un document específic
 DocType: GSuite Templates,GSuite Templates,plantilles GSuite
 apps/frappe/frappe/utils/goal.py,Goal,Meta
 apps/frappe/frappe/email/receive.py,Invalid Mail Server. Please rectify and try again.,"No vàlida del servidor de correu. Si us plau, rectifiqui i torni a intentar-ho."
 DocType: DocField,"For Links, enter the DocType as range.
-For Select, enter list of Options, each on a new line.","Per Links, introdueixi la DOCTYPE com rang. En Seleccionar ingressi llista d&#39;opcions, cadascun en una nova línia."
+For Select, enter list of Options, each on a new line.","Per Links, introdueixi la DOCTYPE com rang. En Seleccionar ingressi llista d'opcions, cadascun en una nova línia."
 DocType: Workflow State,film,film
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Sync Calendar,Sincronitza el calendari
 apps/frappe/frappe/model/db_query.py,No permission to read {0},No tens permís per llegir {0}
@@ -1196,11 +1196,11 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Include indent
 apps/frappe/frappe/utils/password_strength.py,Avoid recent years.,Evitar els últims anys.
 apps/frappe/frappe/templates/includes/login/login.js,Verification,Verificació
 apps/frappe/frappe/utils/nestedset.py,Multiple root nodes not allowed.,Nodes arrel múltiple no permesa.
-DocType: Note,"If enabled, users will be notified every time they login. If not enabled, users will only be notified once.","Si està habilitat, els usuaris rebran una notificació cada vegada que s&#39;inicia sessió. Si no està habilitada, els usuaris només han de ser notificats una vegada."
+DocType: Note,"If enabled, users will be notified every time they login. If not enabled, users will only be notified once.","Si està habilitat, els usuaris rebran una notificació cada vegada que s'inicia sessió. Si no està habilitada, els usuaris només han de ser notificats una vegada."
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid {0} condition,La condició {0} no és vàlida
-DocType: OAuth Client,"If checked, users will not see the Confirm Access dialog.","Si se selecciona, els usuaris no podran veure el quadre de diàleg de confirmació d&#39;accés."
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} record deleted,S&#39;ha suprimit el registre {0}
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"tag name..., e.g. #tag","nom de l&#39;etiqueta ..., per exemple, #tag"
+DocType: OAuth Client,"If checked, users will not see the Confirm Access dialog.","Si se selecciona, els usuaris no podran veure el quadre de diàleg de confirmació d'accés."
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} record deleted,S'ha suprimit el registre {0}
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"tag name..., e.g. #tag","nom de l'etiqueta ..., per exemple, #tag"
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Keyboard Shortcuts,Dreceres de teclat
 DocType: Post,Comments,Comentaris
 apps/frappe/frappe/public/js/frappe/dom.js,Confirm,Confirmar
@@ -1215,13 +1215,13 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Login Id is requ
 DocType: Website Slideshow,Website Slideshow,Website Slideshow
 apps/frappe/frappe/core/page/dashboard/dashboard.js,No Data,No hi ha dades
 DocType: Website Settings,"Link that is the website home page. Standard Links (index, login, products, blog, about, contact)","Enllaç que és la pàgina d'inici del lloc web. Enllaços estàndard (índex, inici de sessió, productes, bloc, sobre, contacte)"
-apps/frappe/frappe/email/doctype/email_account/email_account.py,Authentication failed while receiving emails from Email Account {0}. Message from server: {1},Error d&#39;autenticació al rebre correus electrònics de compte de correu electrònic {0}. Missatge del servidor: {1}
+apps/frappe/frappe/email/doctype/email_account/email_account.py,Authentication failed while receiving emails from Email Account {0}. Message from server: {1},Error d'autenticació al rebre correus electrònics de compte de correu electrònic {0}. Missatge del servidor: {1}
 DocType: User,Banner Image,Imatge del banner
 DocType: Custom Field,Custom Field,Camp personalitzat
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which date field must be checked,Si us plau especificar quin camp de data ha de ser verificat
 DocType: Custom DocPerm,Set User Permissions,Establir permisos d'usuari
 DocType: Email Account,Email Account Name,Nom correu electrònic
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Something went wrong while generating dropbox access token. Please check error log for more details.,"Va produir un error en generar el testimoni d&#39;accés Dropbox. Si us plau, comproveu el registre d&#39;errors per a més detalls."
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Something went wrong while generating dropbox access token. Please check error log for more details.,"Va produir un error en generar el testimoni d'accés Dropbox. Si us plau, comproveu el registre d'errors per a més detalls."
 DocType: File,old_parent,old_parent
 apps/frappe/frappe/config/desk.py,"Newsletters to contacts, leads.","Newsletters a contactes, clients potencials."
 DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","per exemple ""Suport "","" Vendes "","" Jerry Yang """
@@ -1233,7 +1233,7 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Failure,Fra
 DocType: Address Template,Is Default,És per defecte
 DocType: Data Migration Connector,Connector Type,Tipus de connector
 apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py,Column Name cannot be empty,Nom de la columna no pot estar buida
-apps/frappe/frappe/email/doctype/email_account/email_account.py,Error while connecting to email account {0},S&#39;ha produït un error en connectar al compte de correu electrònic {0}
+apps/frappe/frappe/email/doctype/email_account/email_account.py,Error while connecting to email account {0},S'ha produït un error en connectar al compte de correu electrònic {0}
 DocType: Workflow State,fast-forward,avanç ràpid
 DocType: Communication,Communication,Comunicació
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,"Check columns to select, drag to set order.","Comproveu columnes per seleccionar, arrossegar per establir l'ordre."
@@ -1244,7 +1244,7 @@ apps/frappe/frappe/core/doctype/version/version_view.html,Table Field,taula camp
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Columns based on,Columnes basat en
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Importing {0} of {1}, {2}","Important {0} de {1}, {2}"
 DocType: Workflow State,move,moviment
-apps/frappe/frappe/model/document.py,Action Failed,Va fallar l&#39;acció
+apps/frappe/frappe/model/document.py,Action Failed,Va fallar l'acció
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,For User,per usuari
 DocType: View Log,View log,Veure el registre
 DocType: Address,Assam,Assam
@@ -1252,14 +1252,14 @@ apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,← Back to upload
 apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Outgoing email account not correct,Sortint compte de correu electrònic no és correcta
 DocType: Transaction Log,Chaining Hash,Encadenant Hash
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,"Si us plau, estableix Adreça de correu electrònic"
-DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Si l&#39;usuari té cap paper marcat, llavors l&#39;usuari es converteix en un &quot;usuari del sistema&quot;. &quot;Usuari del sistema&quot; té accés a l&#39;escriptori"
+DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Si l'usuari té cap paper marcat, llavors l'usuari es converteix en un &quot;usuari del sistema&quot;. &quot;Usuari del sistema&quot; té accés a l'escriptori"
 DocType: System Settings,Date and Number Format,Format de Data i nombres
 apps/frappe/frappe/model/document.py,one of,un
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Configuració> Formulari personalitzat
-apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Comprovació d&#39;un moment
+apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Comprovació d'un moment
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Mostrar Etiquetes
 DocType: DocField,HTML Editor,Editor HTML
-DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Si Aplicar estricte de permisos d&#39;usuari es comprova i permisos d&#39;usuari es defineix per a un tipus de document per a un usuari, llavors tots els documents en què el valor de la relació està en blanc, no es mostraran a l&#39;usuari que"
+DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Si Aplicar estricte de permisos d'usuari es comprova i permisos d'usuari es defineix per a un tipus de document per a un usuari, llavors tots els documents en què el valor de la relació està en blanc, no es mostraran a l'usuari que"
 DocType: Address,Billing,Facturació
 DocType: Email Queue,Not Sent,No Enviat
 DocType: Web Form,Actions,Accions
@@ -1271,7 +1271,7 @@ apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,No Go
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Following fields have missing values:,Següents camps tenen valors que falten:
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,via automatic rule {0} on {1},mitjançant regla automàtica {0} a {1}
 apps/frappe/frappe/core/report/transaction_log_report/transaction_log_report.py,First Transaction,Primera transacció
-apps/frappe/frappe/app.py,You do not have enough permissions to complete the action,No tens prou permisos per completar l&#39;acció
+apps/frappe/frappe/app.py,You do not have enough permissions to complete the action,No tens prou permisos per completar l'acció
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Single DocTypes cannot be customized.,No es poden personalitzar els documents singulars.
 DocType: User,Document Follow,Document Follow
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,No Results,No hi ha resultats
@@ -1285,16 +1285,16 @@ DocType: Email Account,No of emails remaining to be synced,No hi ha missatges de
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the document before assignment,"Si us plau, guardi el document abans de l'assignació"
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Click here to post bugs and suggestions,Feu clic aquí per publicar errors i suggeriments
 DocType: Website Settings,Address and other legal information you may want to put in the footer.,Adreça i informació legal que vols posar al peu de pàgina.
-DocType: Website Sidebar Item,Website Sidebar Item,Lloc web barra lateral d&#39;articles
+DocType: Website Sidebar Item,Website Sidebar Item,Lloc web barra lateral d'articles
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Click on {0} to generate Refresh Token.,Feu clic a {0} per generar un token d’actualització.
-apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py,Reference document has been cancelled,El document de referència s&#39;ha cancel·lat
+apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py,Reference document has been cancelled,El document de referència s'ha cancel·lat
 DocType: PayPal Settings,PayPal Settings,Ajustos de PayPal
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Document Type,Seleccionar tipus de document
 apps/frappe/frappe/utils/nestedset.py,Cannot delete {0} as it has child nodes,No es pot eliminar {0} ja que té nodes secundaris
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} minutes ago,Fa {0} minuts
-apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Assignment Day {0} has been repeated.,El dia de l&#39;assignació {0} s&#39;ha repetit.
+apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Assignment Day {0} has been repeated.,El dia de l'assignació {0} s'ha repetit.
 DocType: Kanban Board Column,lightblue,blau clar
-apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Same Field is entered more than once,El mateix camp s&#39;introdueix més d&#39;una vegada
+apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Same Field is entered more than once,El mateix camp s'introdueix més d'una vegada
 DocType: Print Settings,Enable Raw Printing,Activa la impressió en brut
 DocType: Contact,Contact Numbers,Números de contacte
 DocType: Website Route Redirect,Source,Font
@@ -1309,7 +1309,7 @@ apps/frappe/frappe/public/js/frappe/views/components/Desktop.vue,Show / Hide Car
 DocType: Communication,Feedback Request,Sol·licitud de retroalimentació
 apps/frappe/frappe/config/settings.py,Import Data from CSV / Excel files.,Importar dades des de fitxers CSV / Excel.
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Following fields are missing:,Següents camps falten:
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Cancelling {0},S&#39;està cancel·lant {0}
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Cancelling {0},S'està cancel·lant {0}
 DocType: Web Page,Main Section,Secció Principal
 DocType: Page,Icon,Icona
 apps/frappe/frappe/www/update-password.html,"Hint: Include symbols, numbers and capital letters in the password","Consell: Incloure símbols, números i lletres majúscules en la contrasenya"
@@ -1330,7 +1330,7 @@ DocType: Workflow State,bullhorn,megàfon
 apps/frappe/frappe/model/workflow.py,Not a valid Workflow Action,No és una acció de flux de treball vàlida
 DocType: Footer Item,Target,Objectiu
 DocType: System Settings,Number of Backups,Nombre de còpies de seguretat
-DocType: Dashboard Chart,Last Year,L&#39;any passat
+DocType: Dashboard Chart,Last Year,L'any passat
 DocType: Website Settings,Copyright,Drets d'autor
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Go,anar
 DocType: OAuth Authorization Code,Invalid,Invàlid
@@ -1348,9 +1348,9 @@ apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Afegir més
 DocType: System Settings,Session Expiry Mobile,Sessió de caducitat mòbil
 apps/frappe/frappe/utils/password.py,Incorrect User or Password,Usuari o contrasenya incorrectes
 apps/frappe/frappe/templates/includes/search_box.html,Search results for,Resultats de la cerca
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Introduïu l&#39;URL de token d&#39;accés
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Introduïu l'URL de token d'accés
 DocType: Notification,Slack,Fluix
-DocType: Custom DocPerm,If user is the owner,Si l&#39;usuari és el propietari
+DocType: Custom DocPerm,If user is the owner,Si l'usuari és el propietari
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Follow,Seguiu
 ,Activity,Activitat
 DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Ajuda: Per enllaçar a un altre registre en el sistema, utilitzeu ""#Form/Note/[Note Name]"" com a URL. (no utilitzis ""http://"")"
@@ -1360,37 +1360,37 @@ apps/frappe/frappe/utils/password_strength.py,Let's avoid repeated words and cha
 DocType: Energy Point Rule,Energy Point Rule,Regla del punt d’energia
 DocType: Communication,Delayed,Retard
 apps/frappe/frappe/config/settings.py,List of backups available for download,Llista de les còpies de seguretat disponibles per a baixar
-apps/frappe/frappe/www/login.html,Sign up,Registra&#39;t
+apps/frappe/frappe/www/login.html,Sign up,Registra't
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Row {0}: Not allowed to disable Mandatory for standard fields,Fila {0}: No es permet desactivar el Mandatari per als camps estàndard
 apps/frappe/frappe/config/customization.py,Dashboards,Taulers de comandament
 DocType: Test Runner,Output,sortida
 DocType: Milestone,Track Field,Camp de pista
-DocType: Notification,Set Property After Alert,Després d&#39;establir la propietat Alerta
+DocType: Notification,Set Property After Alert,Després d'establir la propietat Alerta
 apps/frappe/frappe/config/customization.py,Add fields to forms.,Afegir camps als formularis.
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Looks like something is wrong with this site's Paypal configuration.,Sembla que alguna cosa està malament amb la configuració de Paypal d&#39;aquest lloc.
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Looks like something is wrong with this site's Paypal configuration.,Sembla que alguna cosa està malament amb la configuració de Paypal d'aquest lloc.
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Add Review,Afegeix un comentari
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Font Size (px),Mida de la lletra (px)
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Only standard DocTypes are allowed to be customized from Customize Form.,Només es permet personalitzar el document DocTypes estàndard des del formulari de personalització.
 DocType: Email Account,Sendgrid,SendGrid
-DocType: Access Log,File Type,Tipus d&#39;arxiu
+DocType: Access Log,File Type,Tipus d'arxiu
 DocType: S3 Backup Settings,cn-north-1,cn-nord-1
 apps/frappe/frappe/templates/includes/login/login.js,Verification Code,Codi de verificació
 DocType: Workflow State,leaf,full
-DocType: Portal Menu Item,Portal Menu Item,Portal de l&#39;Menú
+DocType: Portal Menu Item,Portal Menu Item,Portal de l'Menú
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Set Filters,Estableix els filtres
 DocType: Contact Us Settings,Email ID,Identificació de l'email
 DocType: Energy Point Rule,Multiplier Field,Camp multiplicador
 DocType: Dashboard Chart,Time Interval,Interval de temps
-DocType: Activity Log,Keep track of all update feeds,Feu un seguiment de tots els feeds d&#39;actualització
+DocType: Activity Log,Keep track of all update feeds,Feu un seguiment de tots els feeds d'actualització
 DocType: OAuth Client,A list of resources which the Client App will have access to after the user allows it.<br> e.g. project,"Una llista dels recursos que el client d'aplicació tindrà accés a la vegada que l'usuari ho permet. <br> per exemple, el projecte"
 DocType: Translation,Translated Text,El text traduït
 DocType: Contact Us Settings,Query Options,Opcions de consulta
-apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,Fetching posts...,S&#39;obtenen publicacions ...
+apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,Fetching posts...,S'obtenen publicacions ...
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Contact Synced with Google Contacts.,Contacte Sincronitzat amb Google Contacts.
 DocType: Access Log,Timestamp,Marca de temps
 DocType: Patch Log,Patch Log,Patch Log
 DocType: Data Migration Mapping,Local Primary Key,Clau primària local
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options required for Link or Table type field {1} in row {2},{0}: opcions necessàries per al camp de tipus d&#39;enllaç o taula {1} a la fila {2}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options required for Link or Table type field {1} in row {2},{0}: opcions necessàries per al camp de tipus d'enllaç o taula {1} a la fila {2}
 apps/frappe/frappe/utils/bot.py,Hello {0},Hola {0}
 apps/frappe/frappe/core/doctype/user/user.py,Welcome to {0},Benvingut a {0}
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Add,Afegir
@@ -1403,7 +1403,7 @@ apps/frappe/frappe/config/users_and_permissions.py,Report of all document shares
 apps/frappe/frappe/www/update-password.html,New Password,Nova Contrasenya
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Filter {0} missing,Filtre {0} que falta
 apps/frappe/frappe/core/doctype/activity_log/activity_log.py,Sorry! You cannot delete auto-generated comments,Ho sento! No es poden eliminar els comentaris generats automàticament
-DocType: Google Settings,Used For Google Maps Integration.,S&#39;utilitza per a la integració de Google Maps.
+DocType: Google Settings,Used For Google Maps Integration.,S'utilitza per a la integració de Google Maps.
 apps/frappe/frappe/core/doctype/communication/communication.js,Reference DocType,Reference DocType
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,No records will be exported,No s’exportaran registres
 DocType: User,System User,Usuari de Sistema
@@ -1420,7 +1420,7 @@ DocType: Workflow State,minus-sign,signe menys
 apps/frappe/frappe/public/js/frappe/request.js,Not Found,Extraviat
 apps/frappe/frappe/www/printview.py,No {0} permission,No {0} permís
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Export Custom Permissions,Exportació permisos personalitzats
-apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,No items found.,No s&#39;ha trobat cap element.
+apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,No items found.,No s'ha trobat cap element.
 DocType: Data Export,Fields Multicheck,Camps Multicheck
 DocType: Activity Log,Login,Iniciar Sessió
 DocType: Web Form,Payments,Pagaments
@@ -1437,12 +1437,12 @@ apps/frappe/frappe/core/doctype/communication/communication.js,Mark as Spam,Marc
 DocType: ToDo,Medium,Medium
 DocType: Comment,Comment By,Comentari de
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Customize Form,Personalitza el Formulari
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Tipus d&#39;entitat
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Tipus d'entitat
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obligatori: paper establert per
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} criticat {1}
 DocType: Data Migration Mapping,Mapping Name,Assignació de nom
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: el camp &quot;{1}&quot; no es pot definir com a únic, ja que té valors no singulars"
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Desplaça&#39;t per la llista cap avall
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Desplaça't per la llista cap avall
 DocType: Currency,A symbol for this currency. For e.g. $,Un símbol per a aquesta moneda. Per exemple: $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Traduccions actualitzades amb èxit
 apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Frappe Framework,Framework Frappe
@@ -1454,16 +1454,16 @@ DocType: User Permission,Applicable For,Aplicable per
 apps/frappe/frappe/core/doctype/version/version_view.html,Success,Èxit
 apps/frappe/frappe/public/js/frappe/desk.js,Session Expired,Sessió expirada
 DocType: Kanban Board Column,Kanban Board Column,Columna Junta Kanban
-apps/frappe/frappe/utils/password_strength.py,Straight rows of keys are easy to guess,files rectes de tecles són fàcils d&#39;endevinar
+apps/frappe/frappe/utils/password_strength.py,Straight rows of keys are easy to guess,files rectes de tecles són fàcils d'endevinar
 DocType: Communication,Phone No.,Número de Telèfon
-DocType: Personal Data Deletion Request,Pending Approval,Pendent d&#39;aprovació
+DocType: Personal Data Deletion Request,Pending Approval,Pendent d'aprovació
 DocType: Workflow State,fire,foc
 apps/frappe/frappe/www/update-password.html,Success! You are good to go 👍,Èxit! És bo anar go
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,; not allowed in condition,; no permès a condició
 DocType: Async Task,Async Task,Async Tasca
 DocType: Workflow State,picture,imatge
 apps/frappe/frappe/www/complete_signup.html,Complete,Completa
-DocType: DocType,Image Field,camp d&#39;imatge
+DocType: DocType,Image Field,camp d'imatge
 DocType: Print Format,Custom HTML Help,Ajuda personalitzada HTML
 DocType: LDAP Settings,Default Role on Creation,Paper per defecte de la creació
 apps/frappe/frappe/website/doctype/contact_us_settings/contact_us_settings.js,See on Website,Veure en el lloc web
@@ -1486,7 +1486,7 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Go to {0} L
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Help on Search,Ajuda i Recerca
 DocType: Milestone,Milestone Tracker,Rastreig de fites
 apps/frappe/frappe/core/doctype/user/user.py,Registered but disabled,Registrat però discapacitats
-apps/frappe/frappe/templates/emails/auto_repeat_fail.html,The Auto Repeat for this document has been disabled.,La repetició automàtica d&#39;aquest document s&#39;ha desactivat.
+apps/frappe/frappe/templates/emails/auto_repeat_fail.html,The Auto Repeat for this document has been disabled.,La repetició automàtica d'aquest document s'ha desactivat.
 DocType: DocType,Hide Copy,Amaga Copiar
 apps/frappe/frappe/public/js/frappe/roles_editor.js,Clear all roles,Desactiveu totes les funcions
 apps/frappe/frappe/model/base_document.py,{0} must be unique,{0} ha de ser únic
@@ -1496,7 +1496,7 @@ DocType: Data Migration Mapping Detail,Local Fieldname,Nom del camp local
 DocType: DocType,Track Changes,Control de canvis
 DocType: Workflow State,Check,comprovar
 DocType: Chat Profile,Offline,desconnectat
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0},S&#39;ha importat correctament {0}
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0},S'ha importat correctament {0}
 DocType: User,API Key,API Key
 DocType: Email Account,Send unsubscribe message in email,Enviar missatge de correu electrònic per donar-se de baixa en
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Edit Title,Edita
@@ -1505,7 +1505,7 @@ apps/frappe/frappe/config/desk.py,Documents assigned to you and by you.,Document
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,You can also copy-paste this ,També podeu copiar-enganxar-ho
 DocType: User,Email Signature,Signatura de correu electrònic
 DocType: Website Settings,Google Analytics ID,ID de Google Analytics
-DocType: Web Form,"For help see <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API and Examples</a>","Per obtenir ajuda, consulteu l&#39; <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">API i els exemples del script de Client</a>"
+DocType: Web Form,"For help see <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API and Examples</a>","Per obtenir ajuda, consulteu l' <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">API i els exemples del script de Client</a>"
 DocType: Custom DocPerm,Delete,Esborrar
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New {0},Nou {0}
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Inbox,Safata d'entrada per defecte
@@ -1538,17 +1538,17 @@ DocType: Email Queue,Expose Recipients,exposar destinataris
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To is mandatory for incoming mails,Annexar A és obligatòria per als correus entrants
 DocType: Contact,Salutation,Salutació
 DocType: Communication,Rejected,Rebutjat
-apps/frappe/frappe/public/js/frappe/ui/tags.js,Remove Tag,Elimina l&#39;etiqueta
+apps/frappe/frappe/public/js/frappe/ui/tags.js,Remove Tag,Elimina l'etiqueta
 DocType: Chat Room User,Admin,Administrador
 DocType: Website Settings,Brand,Marca comercial
-apps/frappe/frappe/config/integrations.py,Google API Settings.,Configuració de l&#39;API de Google
+apps/frappe/frappe/config/integrations.py,Google API Settings.,Configuració de l'API de Google
 DocType: Report,Query Report,Query Report
 DocType: User,Set New Password,Establir una contrasenya
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1},No està permès per a {0}: {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,"%s is not a valid report format. Report format should \
-				one of the following %s",% S no és un format d&#39;informe vàlid. Format de l&#39;informe ha \ un dels següents% s
+				one of the following %s",% S no és un format d'informe vàlid. Format de l'informe ha \ un dels següents% s
 DocType: Chat Message,Chat,Chat
-apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No documents found tagged with {0},No s&#39;ha trobat cap document etiquetat amb {0}
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No documents found tagged with {0},No s'ha trobat cap document etiquetat amb {0}
 DocType: LDAP Group Mapping,LDAP Group Mapping,Mapeig de grups LDAP
 DocType: Dashboard Chart,Chart Options,Opcions del gràfic
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Untitled Column,Columna sense títol
@@ -1573,25 +1573,25 @@ DocType: GSuite Settings,Script Code,codi guió
 apps/frappe/frappe/core/doctype/user/user.js,Create User Email,Crear usuari de correu electrònic
 apps/frappe/frappe/core/doctype/doctype/doctype.py,No Permissions Specified,No hi ha permisos especificats
 apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,{0} not found,{0} no trobat
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} records deleted,S&#39;han suprimit {0} registres
-DocType: Custom Role,Custom Role,El paper d&#39;encàrrec
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} records deleted,S'han suprimit {0} registres
+DocType: Custom Role,Custom Role,El paper d'encàrrec
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 2,Inici / Test Carpeta 2
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter your password,Introduïu la contrasenya
 DocType: Dropbox Settings,Dropbox Access Secret,Dropbox Access Secret
 DocType: Tag Link,Document Title,Títol del document
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,(Mandatory),(Obligatori)
-DocType: Social Login Key,Social Login Provider,Proveïdor d&#39;inici de sessió social
+DocType: Social Login Key,Social Login Provider,Proveïdor d'inici de sessió social
 apps/frappe/frappe/templates/includes/comments/comments.html,Add Another Comment,Afegir un altre comentari
 apps/frappe/frappe/core/doctype/data_import/importer.py,No data found in the file. Please reattach the new file with data.,No hi ha dades trobades al fitxer. Torneu a col·locar el nou fitxer amb dades.
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Edit DocType,Edita Tipus Document
 apps/frappe/frappe/templates/emails/data_deletion_approval.html,Confirm Request,Confirmeu la sol·licitud
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Doblar ha de venir abans d&#39;un salt de secció
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Doblar ha de venir abans d'un salt de secció
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Under Development,En desenvolupament
 apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Go to the document,Aneu al document
 apps/frappe/frappe/public/js/frappe/model/meta.js,Last Modified By,Darrera modificació per
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Customizations Reset,Restabliment de personalitzacions
 DocType: Workflow State,hand-down,hand-down
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type ""Select"".",No s&#39;han trobat camps que es puguin utilitzar com a columna de Kanban. Utilitzeu el formulari personalitzar per afegir un camp personalitzat del tipus &quot;Selecciona&quot;.
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type ""Select"".",No s'han trobat camps que es puguin utilitzar com a columna de Kanban. Utilitzeu el formulari personalitzar per afegir un camp personalitzat del tipus &quot;Selecciona&quot;.
 DocType: Address,GST State,estat GST
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0}: No es pot establir sense Cancel Enviar
 DocType: Website Theme,Theme,Tema
@@ -1599,7 +1599,7 @@ DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,URI de redirec
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Ajuda oberta
 DocType: DocType,Is Submittable,És submittable
 apps/frappe/frappe/core/doctype/comment/comment.py,New Mention,Menció nova
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,No s&#39;ha sincronitzat cap nou contacte de Google.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,No s'ha sincronitzat cap nou contacte de Google.
 DocType: File,Uploaded To Google Drive,Penjat a Google Drive
 apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a check field can be either 0 or 1,El valor per a un camp de verificació pot ser 0 o 1
 apps/frappe/frappe/model/document.py,Could not find {0},No s'ha pogut trobar {0}
@@ -1615,7 +1615,7 @@ apps/frappe/frappe/core/doctype/data_import/log_details.html,Document can't save
 DocType: Energy Point Rule,Maximum Points,Punts màxims
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,My Settings,La meva configuració
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Text Color,Color del text
-apps/frappe/frappe/desk/page/backups/backups.py,Backup job is already queued. You will receive an email with the download link,El treball de còpia de seguretat ja està en cua. Rebràs un correu electrònic amb l&#39;enllaç de descàrrega
+apps/frappe/frappe/desk/page/backups/backups.py,Backup job is already queued. You will receive an email with the download link,El treball de còpia de seguretat ja està en cua. Rebràs un correu electrònic amb l'enllaç de descàrrega
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,1 Google Calendar Event synced.,1 esdeveniment de Google Calendar sincronitzat.
 DocType: Desktop Icon,Force Show,força Mostra
 apps/frappe/frappe/auth.py,Invalid Request,La sol·licitud no és vàlida
@@ -1633,7 +1633,7 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Set,No Configurat
 DocType: Deleted Document,GitHub Sync ID,Identificador de sincronització de GitHub
 DocType: Activity Log,Date,Data
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No more posts,No hi ha més publicacions
-DocType: Access Log,RAW Information Log,Registre d&#39;informació RAW
+DocType: Access Log,RAW Information Log,Registre d'informació RAW
 DocType: Website Settings,Disable Signup,Desactivar Inscripció
 DocType: Email Queue,Email Queue,Cua de correu electrònic
 DocType: Address,Haryana,Haryana
@@ -1648,18 +1648,18 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Me
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,To Do,Per fer
 DocType: Test Runner,Module Path,ruta mòdul
 DocType: Milestone Tracker,Track milestones for any document,Feu el seguiment de les fites per a qualsevol document
-DocType: Social Login Key,Identity Details,Detalls d&#39;identitat
+DocType: Social Login Key,Identity Details,Detalls d'identitat
 apps/frappe/frappe/model/workflow.py,Workflow State transition not allowed from {0} to {1},No es permet la transició per estat de flux de treball des de {0} a {1}
 apps/frappe/frappe/desk/doctype/dashboard/dashboard.js,Show Dashboard,Mostra Tauler
 apps/frappe/frappe/desk/form/assign_to.py,New Message,Nou missatge
 DocType: File,Preview HTML,Vista prèvia HTML
-DocType: Desktop Icon,query-report,consulta d&#39;informe
+DocType: Desktop Icon,query-report,consulta d'informe
 DocType: Data Import Beta,Template Warnings,Advertències de plantilles
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Filters saved,filtres guarden
 DocType: DocField,Percent,Per cent
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Please set filters,"Si us plau, estableix els filtres"
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Linked With,Vinculat Amb
-apps/frappe/frappe/templates/emails/auto_email_report.html,Edit Auto Email Report Settings,Editeu Configuració de l&#39;informe de correu electrònic automàtic
+apps/frappe/frappe/templates/emails/auto_email_report.html,Edit Auto Email Report Settings,Editeu Configuració de l'informe de correu electrònic automàtic
 DocType: Chat Room,Message Count,Recompte de missatges
 DocType: Workflow State,book,llibre
 DocType: Communication,Read by Recipient,Llegir per destinatari
@@ -1671,9 +1671,9 @@ DocType: Auto Email Report,Auto Email Report,Acte Informe correu electrònic
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Delete comment?,Esborrar comentaris?
 DocType: Address Template,This format is used if country specific format is not found,Aquest format s'utilitza si no hi ha el format específic de cada país
 DocType: System Settings,Allow Login using Mobile Number,Permetre que inicia sessió usant Nombre Mòbil
-apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,"Vostè no té permisos suficients per accedir a aquest apartat. Si us plau, poseu-vos en contacte amb l&#39;administrador per obtenir accés."
+apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,"Vostè no té permisos suficients per accedir a aquest apartat. Si us plau, poseu-vos en contacte amb l'administrador per obtenir accés."
 DocType: Custom Field,Custom,A mida
-DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Si s&#39;activa, els usuaris que inicien la sessió des de l&#39;adreça IP restringida, no es demanaran a Autenticació de dos factors"
+DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Si s'activa, els usuaris que inicien la sessió des de l'adreça IP restringida, no es demanaran a Autenticació de dos factors"
 DocType: Auto Repeat,Get Contacts,Obtenir contactes
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts filed under {0},Les entrades sota {0}
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping Untitled Column,Saltant la columna sense títol
@@ -1689,27 +1689,27 @@ DocType: Print Settings,Fonts,Fonts
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Precision should be between 1 and 6,Precisió ha d'estar entre 1 i 6
 apps/frappe/frappe/core/doctype/communication/communication.js,Fw: {0},Fw: {0}
 apps/frappe/frappe/public/js/frappe/utils/utils.js,and,i
-apps/frappe/frappe/templates/emails/auto_email_report.html,This report was generated on {0},Aquest informe s&#39;ha generat a {0}
+apps/frappe/frappe/templates/emails/auto_email_report.html,This report was generated on {0},Aquest informe s'ha generat a {0}
 DocType: Error Snapshot,Frames,Marc
 apps/frappe/frappe/patches/v6_19/comment_feed_communication.py,Assignment,assignació
 DocType: Notification,Slack Channel,Slack Channel
 DocType: About Us Team Member,Image Link,Enllaç a la imatge
-DocType: Auto Email Report,Report Filters,Filtres d&#39;informe
+DocType: Auto Email Report,Report Filters,Filtres d'informe
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,now,ara
 DocType: Workflow State,step-backward,pas enrere
 apps/frappe/frappe/utils/boilerplate.py,{app_title},{app_title}
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please set Dropbox access keys in your site config,Please set Dropbox access keys in your site config
-apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete this record to allow sending to this email address,Eliminar aquest registre per permetre l&#39;enviament a aquesta adreça de correu electrònic
+apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete this record to allow sending to this email address,Eliminar aquest registre per permetre l'enviament a aquesta adreça de correu electrònic
 DocType: Email Account,"If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)","Si no és un port estàndard (per exemple, POP3: 995/110, IMAP: 993/143)"
 apps/frappe/frappe/public/js/frappe/views/components/DeskSection.vue,Customize Shortcuts,Personalitza les dreceres
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,"Només els camps obligatoris són necessaris per als nous registres. Pots eliminar columnes de caràcter no obligatori, si ho desitges."
 apps/frappe/frappe/desk/page/user_profile/user_profile.html,Show More Activity,Mostra més Activitat
 apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,Introduïu el codi que es mostra a l’aplicació OTP.
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Unable to update event,No es pot actualitzar esdeveniment
-apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,El codi de verificació s&#39;ha enviat a la vostra adreça electrònica registrada.
+apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,El codi de verificació s'ha enviat a la vostra adreça electrònica registrada.
 apps/frappe/frappe/core/doctype/user/user.py,Throttled,Tritura
 apps/frappe/frappe/utils/data.py,"Filter must have 4 values (doctype, fieldname, operator, value): {0}","El filtre ha de tenir 4 valors (DOCTYPE, nom de camp, operador, valor): {0}"
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Aplica la regla d&#39;assignació
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Aplica la regla d'assignació
 apps/frappe/frappe/utils/bot.py,show,espectacle
 apps/frappe/frappe/utils/data.py,Invalid field name {0},Nom del camp no vàlid {0}
 apps/frappe/frappe/model/document.py,{0} must be after {1},{0} ha de ser posterior a {1}
@@ -1725,7 +1725,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Sub
 DocType: Event,Repeat this Event,Repetir aquest esdeveniment
 DocType: Address,Maintenance User,Usuari de Manteniment
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,"LDAP Search String needs to end with a placeholder, eg sAMAccountName={0}","La cadena de cerca LDAP ha de finalitzar amb un marcador de posició, per exemple, sAMAccountName = {0}"
-apps/frappe/frappe/utils/password_strength.py,Avoid dates and years that are associated with you.,Evitar dates i anys que s&#39;associen amb vostè.
+apps/frappe/frappe/utils/password_strength.py,Avoid dates and years that are associated with you.,Evitar dates i anys que s'associen amb vostè.
 DocType: Custom DocPerm,Amend,Esmenar
 DocType: Data Import,Generated File,Arxiu generat
 DocType: Transaction Log,Previous Hash,Anterior Hash
@@ -1733,7 +1733,7 @@ DocType: File,Is Attachments Folder,És carpeta Arxius adjunts
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Expand All,expandir tots
 apps/frappe/frappe/public/js/frappe/chat.js,Select a chat to start messaging.,Seleccioneu un xat per començar a enviar missatges.
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,Processing,Processament
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Please select Entity Type first,Seleccioneu primer el tipus d&#39;entitat
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Please select Entity Type first,Seleccioneu primer el tipus d'entitat
 apps/frappe/frappe/templates/includes/login/login.js,Valid Login id required.,Es requereix un nom d'usuari vàlid
 apps/frappe/frappe/model/rename_doc.py,Please select a valid csv file with data,Seleccioneu un arxiu csv vàlids amb dades
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} un-shared this document with {1},{0} no-compartit aquest document {1}
@@ -1745,7 +1745,7 @@ apps/frappe/frappe/templates/emails/auto_reply.html,This is an automatically gen
 DocType: Help Category,Category Description,Descripció de la Categoria
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Default Theme,Tema per defecte
 apps/frappe/frappe/model/document.py,Record does not exist,El registre no existeix
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,The process for deletion of {0} data associated with {1} has been initiated.,El procés per a la supressió de {0} dades associades a {1} s&#39;ha iniciat.
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,The process for deletion of {0} data associated with {1} has been initiated.,El procés per a la supressió de {0} dades associades a {1} s'ha iniciat.
 apps/frappe/frappe/core/doctype/version/version_view.html,Original Value,valor original
 DocType: Help Category,Help Category,ajuda Categoria
 apps/frappe/frappe/utils/oauth.py,User {0} is disabled,L'usuari {0} està deshabilitat
@@ -1781,7 +1781,7 @@ DocType: Newsletter,Test Email Address,Adreça de correu electrònic de prova
 DocType: Auto Repeat,Reference Document Type,Referència Tipus de document
 DocType: ToDo,Sender,Remitent
 DocType: Google Drive,Backup Folder Name,Nom de la carpeta de seguretat
-apps/frappe/frappe/email/doctype/notification/notification.py,Error while evaluating Notification {0}. Please fix your template.,S&#39;ha produït un error en avaluar la notificació {0}. Corregiu la vostra plantilla.
+apps/frappe/frappe/email/doctype/notification/notification.py,Error while evaluating Notification {0}. Please fix your template.,S'ha produït un error en avaluar la notificació {0}. Corregiu la vostra plantilla.
 DocType: GSuite Settings,Google Apps Script,Google Apps Script
 apps/frappe/frappe/templates/includes/comments/comments.html,Leave a Comment,Deixa un comentari
 apps/frappe/frappe/website/doctype/help_article/templates/help_article.html,More articles on {0},Més articles sobre {0}
@@ -1800,7 +1800,7 @@ DocType: Workflow Document State,Is Optional State,És un Estat opcional
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,The {0} is already on auto repeat {1},El {0} ja està en repetició automàtica {1}
 DocType: Letter Head,Header HTML,Capçalera HTML
 apps/frappe/frappe/core/doctype/communication/communication.js,Relink,Tornar a vincular
-apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,No s&#39;ha enviat SMS. Contacteu amb l&#39;administrador.
+apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,No s'ha enviat SMS. Contacteu amb l'administrador.
 DocType: Web Page,"Page to show on the website
 ",Pàgina per mostrar a la pàgina web
 apps/frappe/frappe/config/settings.py,Create and manage newsletter,Crea i gestiona el butlletí
@@ -1808,18 +1808,18 @@ DocType: Note,Seen By Table,Vist per la taula
 apps/frappe/frappe/www/third_party_apps.html,Logged in,Connectat
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Sending and Inbox,Per defecte Enviament i Safata d'entrada
 DocType: System Settings,OTP App,Aplicació OTP
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record out of {1}.,S&#39;ha actualitzat correctament {0} registre fora de {1}.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record out of {1}.,S'ha actualitzat correctament {0} registre fora de {1}.
 DocType: Google Drive,Send Email for Successful Backup,Envieu un correu electrònic per fer una còpia de seguretat amb èxit
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.py,Scheduler is inactive. Cannot import data.,El planificador està inactiu. No es poden importar dades.
 DocType: Print Settings,Letter,Carta
 DocType: DocType,"Naming Options:
 <ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>
-<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Opcions de nomenclatura: <ol><li> <b>field: [fieldname]</b> - Per Field </li><li> <b>naming_series:</b> - Per nomenar sèries (el camp anomenat nom_series ha d&#39;estar present </li><li> <b>Pregunta</b> : usuari indicador d&#39;un nom </li><li> <b>[sèrie]</b> - Sèrie per prefix (separat per un punt); per exemple PRE. ##### </li><li> <b>format: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - Substituïu totes les paraules preparades (noms de camp, paraules de data (DD, MM, AA), sèrie) amb el seu valor. A l&#39;exterior, es poden utilitzar tots els caràcters. </li></ol>"
-apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,S&#39;ha produït un error en crear el document. Siusplau torna-ho a provar.
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,Camp d&#39;imatge ha de ser de tipus Adjuntar imatge
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Opcions de nomenclatura: <ol><li> <b>field: [fieldname]</b> - Per Field </li><li> <b>naming_series:</b> - Per nomenar sèries (el camp anomenat nom_series ha d'estar present </li><li> <b>Pregunta</b> : usuari indicador d'un nom </li><li> <b>[sèrie]</b> - Sèrie per prefix (separat per un punt); per exemple PRE. ##### </li><li> <b>format: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - Substituïu totes les paraules preparades (noms de camp, paraules de data (DD, MM, AA), sèrie) amb el seu valor. A l'exterior, es poden utilitzar tots els caràcters. </li></ol>"
+apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,S'ha produït un error en crear el document. Siusplau torna-ho a provar.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,Camp d'imatge ha de ser de tipus Adjuntar imatge
 apps/frappe/frappe/permissions.py,You are not allowed to export {} doctype,No teniu permès exportar {} tipus de document
 DocType: DocField,Columns,columnes
-apps/frappe/frappe/desk/form/assign_to.py,Shared with user {0} with read access,S&#39;ha compartit amb l&#39;usuari {0} amb accés de lectura
+apps/frappe/frappe/desk/form/assign_to.py,Shared with user {0} with read access,S'ha compartit amb l'usuari {0} amb accés de lectura
 DocType: GCalendar Account,Next Sync Token,Següent token de sincronització
 DocType: Energy Point Settings,Energy Point Settings,Configuració del punt d’energia
 DocType: Async Task,Succeeded,Succeït
@@ -1831,13 +1831,13 @@ apps/frappe/frappe/core/doctype/version/version_view.html,Rows Removed,files tre
 apps/frappe/frappe/permissions.py,{0} {1} not found,{0} {1} no trobat
 apps/frappe/frappe/www/login.py,Mobile Number,Número de mòbil
 DocType: Comment,Attachment Removed,fixació retirats
-apps/frappe/frappe/utils/password_strength.py,Recent years are easy to guess.,En els últims anys són fàcils d&#39;endevinar.
+apps/frappe/frappe/utils/password_strength.py,Recent years are easy to guess.,En els últims anys són fàcils d'endevinar.
 DocType: Calendar View,Subject Field,Camp Assumpte
-apps/frappe/frappe/public/js/frappe/views/interaction.js,The document has been assigned to {0},El document s&#39;ha assignat a {0}
-DocType: System Settings,Show Full Error and Allow Reporting of Issues to the Developer,Mostrar un error complet i permeti la comunicació de les emissions a l&#39;Desenvolupador
+apps/frappe/frappe/public/js/frappe/views/interaction.js,The document has been assigned to {0},El document s'ha assignat a {0}
+DocType: System Settings,Show Full Error and Allow Reporting of Issues to the Developer,Mostrar un error complet i permeti la comunicació de les emissions a l'Desenvolupador
 apps/frappe/frappe/www/third_party_apps.html,Active Sessions,Sessions actives
 DocType: DocType,ASC,ASC
-apps/frappe/frappe/public/js/frappe/form/print.js,New Print Format Name,Nou nom de format d&#39;impressió
+apps/frappe/frappe/public/js/frappe/form/print.js,New Print Format Name,Nou nom de format d'impressió
 apps/frappe/frappe/templates/emails/data_deletion_approval.html,Click on the link below to approve the request,Feu clic a l’enllaç següent per aprovar la sol·licitud
 DocType: Workflow State,align-left,alinear-esquerra
 DocType: User,Defaults,Predeterminats
@@ -1850,7 +1850,7 @@ DocType: Address,Chandigarh,Chandigarh
 DocType: DocShare,DocShare,DocShare
 DocType: Assignment Rule Day,Friday,Divendres
 apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Edit in full page,Edita a pàgina completa
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Open list item,Obre la llista de l&#39;element
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Open list item,Obre la llista de l'element
 DocType: Report,Add Total Row,Afegir total de Fila
 apps/frappe/frappe/public/js/frappe/form/print.js,No Preview available,No hi ha vista prèvia disponible
 apps/frappe/frappe/twofactor.py,Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it.,Consulteu la vostra adreça de correu electrònic registrada per obtenir instruccions sobre com procedir. No tanqueu aquesta finestra ja que haurà de tornar-hi.
@@ -1865,7 +1865,7 @@ apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Customize,Personalitza
 apps/frappe/frappe/core/doctype/user/user.js,View Permitted Documents,Mostra els documents permesos
 apps/frappe/frappe/utils/print_format.py,You need to install pycups to use this feature!,Heu d’instal·lar picots per utilitzar aquesta funció.
-apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Your connection request to Google Calendar was successfully accepted,S&#39;ha acceptat la vostra sol·licitud de connexió a Google Calendar
+apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Your connection request to Google Calendar was successfully accepted,S'ha acceptat la vostra sol·licitud de connexió a Google Calendar
 DocType: Tag Link,Tag Link,Enllaç d’etiqueta
 apps/frappe/frappe/core/report/transaction_log_report/transaction_log_report.py,Chain Integrity,Integritat de cadena
 DocType: Data Export,CSV,CSV
@@ -1880,46 +1880,46 @@ DocType: LDAP Settings,LDAP Group Mappings,Mapeig de grups LDAP
 DocType: Chat Message Attachment,Chat Message Attachment,Missatge de xat adjunt
 DocType: LDAP Settings,Path to CA Certs File,Camí al fitxer de certificats de CA
 DocType: Address,Manipur,Manipur
-DocType: Web Form Field,Allow Read On All Link Options,Permet llegir totes les opcions d&#39;enllaç
+DocType: Web Form Field,Allow Read On All Link Options,Permet llegir totes les opcions d'enllaç
 DocType: DocType,Database Engine,motor de base
-DocType: Customize Form,"Fields separated by comma (,) will be included in the ""Search By"" list of Search dialog box","Els camps separats per coma (,) s&#39;inclouran en el &quot;Cercar per&quot; llista de quadre de diàleg Cerca"
+DocType: Customize Form,"Fields separated by comma (,) will be included in the ""Search By"" list of Search dialog box","Els camps separats per coma (,) s'inclouran en el &quot;Cercar per&quot; llista de quadre de diàleg Cerca"
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Please Duplicate this Website Theme to customize.,Si us plau Duplicar aquest tema Pàgina web per personalitzar.
 DocType: Address,Meghalaya,Meghalaya
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Nom d&#39;usuari o contrasenya incorrectes
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Nom d'usuari o contrasenya incorrectes
 DocType: DocField,Text Editor,Editor de text
 apps/frappe/frappe/config/website.py,Settings for About Us Page.,Configuració de pàgina sobre nosaltres.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit Custom HTML,Edició de HTML personalitzat
-DocType: Error Snapshot,Error Snapshot,Instantània d&#39;error
+DocType: Error Snapshot,Error Snapshot,Instantània d'error
 DocType: S3 Backup Settings,ap-northeast-3,ap-nord-est-3
 DocType: Data Migration Mapping,Remote Primary Key,Clau primària remota
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,In,En
 DocType: Notification,Value Change,Canvi de valor
 DocType: Google Contacts,Authorize Google Contacts Access,Autoritzeu Google Contact Access
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Es mostren només els camps numèrics de l&#39;informe
-DocType: Data Import Beta,Import Type,Tipus d&#39;importació
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Es mostren només els camps numèrics de l'informe
+DocType: Data Import Beta,Import Type,Tipus d'importació
 DocType: Access Log,HTML Page,Pàgina HTML
 DocType: Address,Subsidiary,Filial
-apps/frappe/frappe/public/js/frappe/form/print.js,Attempting Connection to QZ Tray...,S&#39;està intentant la connexió a la safata QZ ...
+apps/frappe/frappe/public/js/frappe/form/print.js,Attempting Connection to QZ Tray...,S'està intentant la connexió a la safata QZ ...
 DocType: System Settings,In Hours,En Hores
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive: no s&#39;ha pogut trobar la carpeta a Google Drive - Codi d&#39;error {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive: no s'ha pogut trobar la carpeta a Google Drive - Codi d'error {0}
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,With Letterhead,De carta
 apps/frappe/frappe/email/smtp.py,Invalid Outgoing Mail Server or Port,Invàlid servidor de correu sortint o Port
 DocType: Custom DocPerm,Write,Escriure
 apps/frappe/frappe/core/doctype/report/report.py,Only Administrator allowed to create Query / Script Reports,Només l'Administrador té permís per crear QUERY/SCRIPT Reports
 apps/frappe/frappe/public/js/frappe/form/save.js,Updating,Actualització
 DocType: Data Import Beta,Preview,Preestrena
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated","El camp &quot;valor&quot; és obligatori. Si us plau, especifiqui el valor d&#39;actualitzar"
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated","El camp &quot;valor&quot; és obligatori. Si us plau, especifiqui el valor d'actualitzar"
 DocType: Customize Form,Use this fieldname to generate title,Utilitzeu aquest nom de camp per generar títol
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Email From,Importació de correu electrònic De
 apps/frappe/frappe/contacts/doctype/contact/contact.js,Invite as User,Convida com usuari
 DocType: Data Migration Run,Started,Va començar
-apps/frappe/frappe/permissions.py,User {0} does not have access to this document,L&#39;usuari {0} no té accés a aquest document
+apps/frappe/frappe/permissions.py,User {0} does not have access to this document,L'usuari {0} no té accés a aquest document
 DocType: Data Migration Run,End Time,Hora de finalització
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Select Attachments,Seleccionar adjunts
 apps/frappe/frappe/model/naming.py, for {0},per {0}
 apps/frappe/frappe/public/js/frappe/form/print.js,You are not allowed to print this document,No està permès imprimir aquest document
 apps/frappe/frappe/data_migration/doctype/data_migration_run/data_migration_run.js,Currently updating {0},Actualitzant actualment {0}
-apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Please set filters value in Report Filter table.,"Si us plau, estableix el valor en la taula de filtres Filtre d&#39;informe."
+apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Please set filters value in Report Filter table.,"Si us plau, estableix el valor en la taula de filtres Filtre d'informe."
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export All {0} rows?,Exporta totes les files {0}?
 DocType: Page,Standard,Estàndard
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Attach File,Adjuntar Arxiu
@@ -1938,19 +1938,19 @@ apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Insert Above,Inseriu s
 apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Add script for Child Table,Afegiu un script per a la taula infantil
 apps/frappe/frappe/desk/form/utils.py,Comment can only be edited by the owner,El propietari només pot editar el comentari
 DocType: Data Import,Do not send Emails,No enviïs correus electrònics
-apps/frappe/frappe/utils/password_strength.py,Common names and surnames are easy to guess.,noms i cognoms comuns són fàcils d&#39;endevinar.
+apps/frappe/frappe/utils/password_strength.py,Common names and surnames are easy to guess.,noms i cognoms comuns són fàcils d'endevinar.
 DocType: Google Drive,Google Drive,Google Drive
 apps/frappe/frappe/public/js/frappe/model/indicator.js,Draft,Esborrany
-apps/frappe/frappe/utils/password_strength.py,This is similar to a commonly used password.,Això és similar a una clau d&#39;ús comú.
+apps/frappe/frappe/utils/password_strength.py,This is similar to a commonly used password.,Això és similar a una clau d'ús comú.
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Female,Dona
-DocType: Success Action,Success Action,Acció d&#39;èxit
+DocType: Success Action,Success Action,Acció d'èxit
 apps/frappe/frappe/public/js/frappe/model/indicator.js,Not Saved,No Saved
 apps/frappe/frappe/www/third_party_apps.html,Revoke,Revocar
-apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You are now following this document. You will receive daily updates via email. You can change this in User Settings.,Ara seguiu aquest document. Rebrà actualitzacions diàries per correu electrònic. Podeu canviar-ho a Configuració de l&#39;usuari.
+apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You are now following this document. You will receive daily updates via email. You can change this in User Settings.,Ara seguiu aquest document. Rebrà actualitzacions diàries per correu electrònic. Podeu canviar-ho a Configuració de l'usuari.
 DocType: Contact,Replied,Respost
 DocType: Newsletter,Test,Prova
 DocType: Custom Field,Default Value,Valor per defecte
-DocType: Email Account,Enable Automatic Linking in Documents,Habilita l&#39;enllaç automàtic en documents
+DocType: Email Account,Enable Automatic Linking in Documents,Habilita l'enllaç automàtic en documents
 DocType: System Settings,Allow Guests to Upload Files,Permet als convidats carregar fitxers
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify,Verificar
 DocType: Workflow Document State,Update Field,Actualitzar camps
@@ -1962,15 +1962,15 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-sud-est-1
 DocType: DocType,"Must be of type ""Attach Image""",Ha de ser del tipus &quot;Adjunta imatge&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Cancel totes les seleccions
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},No es pot desarmar &#39;només lectura&#39; per al camp {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},No es pot desarmar 'només lectura' per al camp {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,Zero significa enviar els registres actualitzats en qualsevol moment
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,Instal·lació completa
-apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,S&#39;ha actualitzat correctament
+apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,S'ha actualitzat correctament
 DocType: Workflow State,asterisk,asterisc
 DocType: Data Import,Successful,Èxit
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Please do not change the template headings.,"Si us plau, no canvïis les capçaleres de la plantilla."
 DocType: Activity Log,Linked,Vinculat
-apps/frappe/frappe/config/desk.py,Activity log of all users.,Registre d&#39;activitat de tots els usuaris.
+apps/frappe/frappe/config/desk.py,Activity log of all users.,Registre d'activitat de tots els usuaris.
 DocType: Workflow State,shopping-cart,Cistella de la compra
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Week,setmana
 DocType: DocType,Open a dialog with mandatory fields to create a new record quickly,Obriu un diàleg amb camps obligatoris per crear un registre nou ràpidament
@@ -1978,7 +1978,7 @@ apps/frappe/frappe/templates/includes/login/login.js,Not Allowed: Disabled User,
 DocType: Social Login Key,Google,Google
 DocType: Email Domain,Example Email Address,Exemple Adreça de correu electrònic
 apps/frappe/frappe/public/js/frappe/ui/sort_selector.js,Most Used,Més Utilitzades
-,user-profile,perfil d&#39;usuari
+,user-profile,perfil d'usuari
 apps/frappe/frappe/www/login.html,Forgot Password,Has oblidat la contrasenya
 DocType: Dropbox Settings,Backup Frequency,Freqüència de còpia de seguretat
 DocType: Workflow State,Inverse,Invers
@@ -1989,7 +1989,7 @@ DocType: Language,Language,Idioma
 apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Navegador no compatible
 DocType: Social Login Key,Client URLs,URL del client
 apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Some information is missing,falta informació
-apps/frappe/frappe/public/js/frappe/views/interaction.js,{0} created successfully,S&#39;ha creat {0} amb èxit
+apps/frappe/frappe/public/js/frappe/views/interaction.js,{0} created successfully,S'ha creat {0} amb èxit
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Skipping {0} of {1}, {2}","Saltant {0} de {1}, {2}"
 DocType: Custom DocPerm,Cancel,Cancel·la
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Bulk Delete,Suprimeix a granel
@@ -1998,19 +1998,19 @@ DocType: Dashboard Chart,Dashboard Chart,Taula de tauler
 DocType: Dashboard Chart,Last Quarter,Últim trimestre
 apps/frappe/frappe/config/website.py,List of themes for Website.,Llista de temes per a la pàgina web.
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,"Dear User,","Estimat usuari,"
-apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Successfully Updated,S&#39;ha actualitzat correctament
+apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Successfully Updated,S'ha actualitzat correctament
 DocType: Activity Log,Logout,Tancar sessió
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,Permisos en els nivells més alts són els permisos de nivell de camp. Tots els camps tenen un conjunt Nivell de permís en contra i les regles definides en el qual els permisos s'apliquen al camp. Això és útil en el cas que vulgui amagar o fer cert camp de només lectura per a certes funcions.
 DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, password=1234 etc.)","Introduïu els paràmetres d'URL estàtiques aquí (Ex. Remitent = ERPNext, nom d'usuari = ERPNext, password = 1234 etc.)"
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Si aquestes instruccions no són útils, si us plau agreguin en els seus suggeriments sobre qüestions de GitHub."
 DocType: Workflow State,bookmark,marcador
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),nom del grup no ha d&#39;incloure &#39;/&#39; (barra)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),nom del grup no ha d'incloure '/' (barra)
 DocType: Note,Note,Nota
-apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Informa d&#39;un problema
+apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Informa d'un problema
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Exporta les dades en format CSV / Excel.
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Setting up Global Search documents.,Configuració de documents de la cerca global.
-apps/frappe/frappe/www/qrcode.html,Authentication Apps you can use are: ,Les aplicacions d&#39;autenticació que podeu utilitzar són:
+apps/frappe/frappe/www/qrcode.html,Authentication Apps you can use are: ,Les aplicacions d'autenticació que podeu utilitzar són:
 apps/frappe/frappe/public/js/frappe/form/controls/data.js,{0} already exists. Select another name,{0} ja existeix. Seleccioni un altre nom
 DocType: S3 Backup Settings,None,Cap
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a valid fieldname,camp de línia de temps ha de ser un nom de camp vàlid
@@ -2025,7 +2025,7 @@ DocType: Dashboard Chart Source,Source Name,font Nom
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,No hi ha cap compte de correu electrònic associat a l’Usuari. Afegeix un compte a Usuari> Bústia de correu electrònic.
 DocType: Email Account,Email Sync Option,Sincronitzar correu Opció
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Fila núm
-DocType: Async Task,Runtime,Temps d&#39;execució
+DocType: Async Task,Runtime,Temps d'execució
 DocType: Post,Is Pinned,Està fixat
 DocType: Contact Us Settings,Introduction,Introducció
 apps/frappe/frappe/public/js/frappe/social/components/Post.vue,Pin Globally,Pin globalment
@@ -2043,15 +2043,15 @@ DocType: Contact,Pulled from Google Contacts,Tirat de Google Contactes
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Petició invàlida
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Compiled Successfully,Recopilada amb èxit
 DocType: System Settings,Email Footer Address,Email peu de pàgina
-apps/frappe/frappe/public/js/frappe/form/grid.js,Table updated,taula s&#39;actualitza
+apps/frappe/frappe/public/js/frappe/form/grid.js,Table updated,taula s'actualitza
 DocType: Activity Log,Timeline DocType,DOCTYPE línia de temps
-DocType: Success Action,Action Timeout (Seconds),Temps d&#39;espera d&#39;acció (segons)
+DocType: Success Action,Action Timeout (Seconds),Temps d'espera d'acció (segons)
 DocType: DocField,Text,Text
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Sending,Enviament per defecte
 DocType: Workflow State,volume-off,volum-off
 apps/frappe/frappe/public/js/frappe/form/templates/timeline_item.html,Liked by {0},Ha agradat a {0}
 DocType: LDAP Settings,LDAP Security,Seguretat LDAP
-DocType: Footer Item,Footer Item,Peu de pàgina de l&#39;article
+DocType: Footer Item,Footer Item,Peu de pàgina de l'article
 ,Download Backups,Descàrrega Backups
 DocType: Energy Point Log,Points,Punts
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1,Inici / Carpeta Prova 1
@@ -2065,7 +2065,7 @@ DocType: Property Setter,DocType or Field,DocType or Field
 apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You unfollowed this document,Heu deixat sense omplir aquest document
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Primary Color,Color primari
 DocType: Communication,Soft-Bounced,-Soft Rebotats
-DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Si està habilitat, tots els usuaris poden iniciar la sessió des de qualsevol adreça IP mitjançant l&#39;Autenticació de dos factors. Això també es pot establir per als usuaris específics de la pàgina d&#39;usuari"
+DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Si està habilitat, tots els usuaris poden iniciar la sessió des de qualsevol adreça IP mitjançant l'Autenticació de dos factors. Això també es pot establir per als usuaris específics de la pàgina d'usuari"
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Seems Publishable Key or Secret Key is wrong !!!,Sembla Clau publicable o clau secreta està malament !!!
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Quick Help for Setting Permissions,Ajuda Ràpida per Establir permisos
 DocType: Tag Doc Category,Doctype to Assign Tags,Doctype per assignar etiquetes
@@ -2094,7 +2094,7 @@ DocType: Contact Us Settings,Forward To Email Address,Reenviar al Correu Electr�
 DocType: Contact Phone,Is Primary Phone,És telèfon principal
 apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,Envia un correu electrònic a {0} per enllaçar-lo aquí.
 DocType: Auto Email Report,Weekdays,Dies laborables
-apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} records will be exported,{0} registres s&#39;exportaran
+apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} records will be exported,{0} registres s'exportaran
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,El Camp Títol ha de ser un nom de camp vàlid
 DocType: Post Comment,Post Comment,Escriu un comentari
 apps/frappe/frappe/config/core.py,Documents,Documents
@@ -2109,21 +2109,21 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Caducitat de la ses
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",apareixerà aquest camp només si el nom del camp definit aquí té valor o les regles són veritables (exemples): eval myfield: doc.myfield == &#39;La meva Valor&#39; eval: doc.age> 18
+eval:doc.age>18",apareixerà aquest camp només si el nom del camp definit aquí té valor o les regles són veritables (exemples): eval myfield: doc.myfield == 'La meva Valor' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,avui
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Un cop establert, els usuaris només tindran accés als documents (per exemple. Blog) on hi hagil'enllaç (per exemple. Blogger)."
-DocType: Data Import Beta,Submit After Import,Envieu després d&#39;importar
+DocType: Data Import Beta,Submit After Import,Envieu després d'importar
 DocType: Error Log,Log of Scheduler Errors,Registre d'errors de planificació
 DocType: User,Bio,Bio
 DocType: OAuth Client,App Client Secret,App secret de client
 apps/frappe/frappe/public/js/frappe/form/save.js,Submitting,Presentar
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of the document to which the data will get added to.,El pare és el nom del document al qual s&#39;afegiran les dades.
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive: no s&#39;ha pogut crear una carpeta a Google Drive - Codi d&#39;error {0}
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of the document to which the data will get added to.,El pare és el nom del document al qual s'afegiran les dades.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive: no s'ha pogut crear una carpeta a Google Drive - Codi d'error {0}
 DocType: DocType,UPPER CASE,MAJÚSCULES
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML personalitzat
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Introduïu carpeta de nom
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,No s&#39;ha trobat cap plantilla d&#39;adreces per defecte. Creeu-ne un de nou a Configuració> Impressió i marca> Plantilla d&#39;adreces.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,No s'ha trobat cap plantilla d'adreces per defecte. Creeu-ne un de nou a Configuració> Impressió i marca> Plantilla d'adreces.
 apps/frappe/frappe/auth.py,Unknown User,Usuari desconegut
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Seleccioneu Rol
 DocType: Comment,Deleted,Suprimit
@@ -2140,7 +2140,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Create Chart,C
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,john@doe.com,john@doe.com
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Don't Import,No importeu
 DocType: Web Page,Center,Centre
-DocType: Notification,Value To Be Set,Valor d&#39;ajust
+DocType: Notification,Value To Be Set,Valor d'ajust
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Edit {0},Edita {0}
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,First Level,Primer Nivell
 DocType: Workflow Document State,Represents the states allowed in one document and role assigned to change the state.,Representa els estats permesos en un sol document i el rol assignat a canviar l'estat.
@@ -2148,10 +2148,10 @@ DocType: Data Migration Connector,Database Name,Nom de la base de dades
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Formulari d'actualització
 DocType: DocField,Select,Seleccionar
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Veure registre complet
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expressió Python simple, exemple: status == &#39;Obrir&#39; i escriviu == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expressió Python simple, exemple: status == 'Obrir' i escriviu == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,L'arxiu no s'adjunta
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Connexió perduda. Pot ser que algunes funcions no funcionin.
-apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Repeteix com &quot;AAA&quot; són fàcils d&#39;endevinar
+apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Repeteix com &quot;AAA&quot; són fàcils d'endevinar
 apps/frappe/frappe/public/js/frappe/chat.js,New Chat,Nou xat
 DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","Establint aquest, aquest article vindrà en un desplegable sota el pare seleccionat."
 DocType: Print Format,Show Section Headings,Mostra títols de les seccions
@@ -2170,7 +2170,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"DocType's name should start 
 DocType: Dashboard,Dashboard Name,Nom del tauler
 apps/frappe/frappe/www/update-password.html,The password of your account has expired.,La contrasenya del vostre compte ha caducat.
 DocType: Communication,Spam,Correu brossa
-DocType: Integration Request,Integration Request,Sol·licitud d&#39;integració
+DocType: Integration Request,Integration Request,Sol·licitud d'integració
 apps/frappe/frappe/public/js/frappe/views/communication.js,Dear,Estimat
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Add Group,Afegir grup
 DocType: Address,Maharashtra,Maharashtra
@@ -2183,25 +2183,25 @@ DocType: Email Unsubscribe,Global Unsubscribe,Global Donar-se de baixa
 apps/frappe/frappe/utils/password_strength.py,This is a very common password.,Aquesta és una contrasenya molt comú.
 apps/frappe/frappe/email/doctype/email_group/email_group.js,View,Veure
 DocType: Comment,Assigned,Assignat
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,Feu clic a <b>Autoritza l&#39;accés</b> a Google Drive per autoritzar l&#39; <b>accés</b> a Google Drive.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,Feu clic a <b>Autoritza l'accés</b> a Google Drive per autoritzar l' <b>accés</b> a Google Drive.
 DocType: Print Format,Js,js
 apps/frappe/frappe/public/js/frappe/views/communication.js,Select Print Format,Seleccionar el format d'impressió
-apps/frappe/frappe/utils/password_strength.py,Short keyboard patterns are easy to guess,patrons de teclat curts són fàcils d&#39;endevinar
+apps/frappe/frappe/utils/password_strength.py,Short keyboard patterns are easy to guess,patrons de teclat curts són fàcils d'endevinar
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Generate New Report,Genera un nou informe
 DocType: Portal Settings,Portal Menu,menú portal
-apps/frappe/frappe/database/schema.py,Length of {0} should be between 1 and 1000,Longitud de {0} ha d&#39;estar entre 1 i 1000
+apps/frappe/frappe/database/schema.py,Length of {0} should be between 1 and 1000,Longitud de {0} ha d'estar entre 1 i 1000
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,Search for anything,Cerca de res
-DocType: Data Migration Connector,Hostname,Nom de l&#39;amfitrió
-DocType: Data Migration Mapping,Condition Detail,Detall d&#39;estat
+DocType: Data Migration Connector,Hostname,Nom de l'amfitrió
+DocType: Data Migration Mapping,Condition Detail,Detall d'estat
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"For currency {0}, the minimum transaction amount should be {1}","Per a la moneda {0}, l’import mínim de la transacció ha de ser {1}"
 DocType: DocField,Print Hide,Imprimir Amaga
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,To User,A l&#39;Usuari
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,To User,A l'Usuari
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter Value,Introduir valor
 DocType: Workflow State,tint,tint
 DocType: DocField,In Preview,A la vista prèvia
 DocType: Webhook,JSON Request Body,Requestrgan de sol·licitud de JSON
 DocType: Web Page,Style,Estil
-DocType: Prepared Report,Report End Time,Hora de finalització d&#39;informes
+DocType: Prepared Report,Report End Time,Hora de finalització d'informes
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,e.g.:,per exemple:
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,{0} comments,{0} comentaris
 apps/frappe/frappe/public/js/frappe/desk.js,Version Updated,Versió actualitzada
@@ -2210,7 +2210,7 @@ DocType: Workflow State,forward,endavant
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} edited this {1},{0} ha editat aquest {1}
 DocType: Custom DocPerm,Submit,Presentar
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,New Folder,Carpeta nova
-DocType: Email Account,Uses the Email Address mentioned in this Account as the Sender for all emails sent using this Account. ,Utilitza l&#39;adreça de correu electrònic esmentada en aquest compte com a remitent per a tots els correus electrònics enviats utilitzant aquest compte.
+DocType: Email Account,Uses the Email Address mentioned in this Account as the Sender for all emails sent using this Account. ,Utilitza l'adreça de correu electrònic esmentada en aquest compte com a remitent per a tots els correus electrònics enviats utilitzant aquest compte.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Toggle Charts,Canvia les cartes
 DocType: Website Settings,Sub-domain provided by erpnext.com,Sub-domini proporcionat per erpnext.com
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Setting up your system,Configuració del vostre sistema
@@ -2238,15 +2238,15 @@ apps/frappe/frappe/desk/query_report.py,Total,Total
 DocType: Event,Participants,Participants
 DocType: Integration Request,Reference DocName,Referència DocName
 DocType: Web Form,Success Message,Missatge d'èxit
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Export Customizations,Les personalitzacions d&#39;exportació
-apps/frappe/frappe/website/doctype/web_page/web_page.py,End Date cannot be before Start Date!,La data de finalització no pot ser abans de la data d&#39;inici.
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Export Customizations,Les personalitzacions d'exportació
+apps/frappe/frappe/website/doctype/web_page/web_page.py,End Date cannot be before Start Date!,La data de finalització no pot ser abans de la data d'inici.
 DocType: DocType,User Cannot Search,L'usuari no pot Cercar
 DocType: Communication Link,Communication Link,Enllaç de comunicació
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Invalid Output Format,Format de sortida no vàlid
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Cannot {0} {1},No es pot {0} {1}
-DocType: Custom DocPerm,Apply this rule if the User is the Owner,"Aplicar aquesta regla, si l&#39;usuari és el propietari"
+DocType: Custom DocPerm,Apply this rule if the User is the Owner,"Aplicar aquesta regla, si l'usuari és el propietari"
 DocType: Global Search Settings,Global Search Settings,Configuració global de la cerca
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Will be your login ID,Serà la seva ID d&#39;inici de sessió
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Will be your login ID,Serà la seva ID d'inici de sessió
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.js,Global Search Document Types Reset.,Restabliment dels tipus de document de cerca global.
 ,Lead Conversion Time,Temps de conversió del plom
 apps/frappe/frappe/desk/page/activity/activity.js,Build Report,Redactar Informe
@@ -2257,14 +2257,14 @@ apps/frappe/frappe/model/rename_doc.py,"{0} {1} does not exist, select a new tar
 DocType: Data Migration Connector,Python Module,Mòdul Python
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Navigate Home,Navega cap a casa
 DocType: GSuite Settings,Google Credentials,Les credencials de Google
-apps/frappe/frappe/www/qrcode.html,QR Code for Login Verification,Codi QR per a la verificació d&#39;inici de sessió
+apps/frappe/frappe/www/qrcode.html,QR Code for Login Verification,Codi QR per a la verificació d'inici de sessió
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Add to To Do,Afegir a la llista de coses per fer
 DocType: Footer Item,Company,Empresa
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Average of {0},Mitjana de {0}
 DocType: User,Logout from all devices while changing Password,Tanqueu tots els dispositius mentre canvieu la contrasenya
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify Password,Verificar Contrasenya
 apps/frappe/frappe/public/js/frappe/form/sidebar/attachments.js,There were errors,Hi van haver errors
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Introduïu l&#39;ID del client i el secret del client a la configuració de Google.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Introduïu l'ID del client i el secret del client a la configuració de Google.
 apps/frappe/frappe/core/doctype/communication/communication.js,Close,Close
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 0 to 2,No es pot canviar DocStatus de 0 a 2
 DocType: File,Attached To Field,Adjunt al camp
@@ -2279,17 +2279,17 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Mostra només errors
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Envia una alerta de correu electrònic
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Si us plau seleccioneu un altre mètode de pagament. Razorpay no admet transaccions en moneda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Si us plau seleccioneu un altre mètode de pagament. Razorpay no admet transaccions en moneda '{0}'
 DocType: Data Import,In Progress,En progrés
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,En cua per còpia de seguretat. Es pot prendre un parell de minuts a una hora.
 DocType: Error Snapshot,Pyver,Pyver
-apps/frappe/frappe/core/doctype/user_permission/user_permission.py,User permission already exists,El permís d&#39;usuari ja existeix
+apps/frappe/frappe/core/doctype/user_permission/user_permission.py,User permission already exists,El permís d'usuari ja existeix
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Mapping column {0} to field {1},Assignació de la columna {0} al camp {1}
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,View {0},Visualitza {0}
 DocType: User,Hourly,Hora per hora
-apps/frappe/frappe/config/integrations.py,Register OAuth Client App,Register OAuth client d&#39;aplicació
+apps/frappe/frappe/config/integrations.py,Register OAuth Client App,Register OAuth client d'aplicació
 DocType: DocField,Fetch If Empty,Obtenir si està buit
-DocType: Data Migration Connector,Authentication Credentials,Credencials d&#39;autenticació
+DocType: Data Migration Connector,Authentication Credentials,Credencials d'autenticació
 DocType: Role,Two Factor Authentication,Autenticació de dos factors
 apps/frappe/frappe/templates/pages/integrations/braintree_checkout.html,Pay,Pagar
 DocType: Energy Point Settings,Point Allocation Periodicity,Periodicitat d’assignació de punts
@@ -2298,8 +2298,8 @@ apps/frappe/frappe/model/base_document.py,"{0} {1} cannot be ""{2}"". It should 
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,gained by {0} via automatic rule {1},guanyada per {0} mitjançant la regla automàtica {1}
 apps/frappe/frappe/utils/data.py,{0} or {1},{0} o {1}
 DocType: Workflow State,trash,escombraries
-DocType: System Settings,Older backups will be automatically deleted,còpies de seguretat anteriors s&#39;eliminaran de forma automàtica
-apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Invalid Access Key ID or Secret Access Key.,Identificador de clau d&#39;accés no vàlid o clau d&#39;accés secret.
+DocType: System Settings,Older backups will be automatically deleted,còpies de seguretat anteriors s'eliminaran de forma automàtica
+apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Invalid Access Key ID or Secret Access Key.,Identificador de clau d'accés no vàlid o clau d'accés secret.
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You lost some energy points,Heu perdut alguns punts d’energia
 DocType: Post,Is Globally Pinned,Està fixat globalment
 apps/frappe/frappe/desk/page/user_profile/user_profile.html,Recent Activity,Activitat recent
@@ -2307,19 +2307,19 @@ DocType: Workflow Transition,Conditions,Condicions
 DocType: Event,Leave blank to repeat always,Deixar en blanc per repetir sempre
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Confirmed,Confirmat
 DocType: Event,Ends on,Finalitza en
-DocType: Payment Gateway,Gateway,Porta d&#39;enllaç
+DocType: Payment Gateway,Gateway,Porta d'enllaç
 DocType: LDAP Settings,Path to Server Certificate,Certificat de ruta al servidor
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,No hi ha prou permís per veure enllaços
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Títol d'adreça obligatori.
 DocType: Google Contacts,Push to Google Contacts,Empenteu a Google Contacts
-DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML afegit a la secció <head> de la pàgina web, s&#39;utilitza sobretot per a la verificació del web i SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML afegit a la secció <head> de la pàgina web, s'utilitza sobretot per a la verificació del web i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recaiguda
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,L'article no es pot afegir als seus propis descendents
 DocType: Session Default Settings,Session Defaults,Defectes predeterminats de la sessió
-DocType: System Settings,Expiry time of QR Code Image Page,Temps de caducitat de la pàgina d&#39;imatge del codi QR
+DocType: System Settings,Expiry time of QR Code Image Page,Temps de caducitat de la pàgina d'imatge del codi QR
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,Mostra totals
 DocType: Error Snapshot,Relapses,Les recaigudes
-apps/frappe/frappe/public/js/frappe/social/pages/UserList.vue,No user found,No s&#39;ha trobat cap usuari
+apps/frappe/frappe/public/js/frappe/social/pages/UserList.vue,No user found,No s'ha trobat cap usuari
 DocType: Address,Preferred Shipping Address,Adreça d'enviament preferida
 apps/frappe/frappe/public/js/frappe/form/print.js,With Letter head,Amb capçalera
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} created this {1},{0} creat aquest {1}
@@ -2334,14 +2334,14 @@ DocType: Blogger,Short Name,Nom curt
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Linked with {0},Enllaçat amb {0}
 apps/frappe/frappe/email/doctype/email_account/email_account.js,"You are selecting Sync Option as ALL, It will resync all \
 				read as well as unread message from server. This may also cause the duplication\
-				of Communication (emails).","Que està seleccionant l&#39;opció de sincronització com tot, es torna a sincronitzar tots els \ llegir, així com els missatges no llegits des del servidor. Això també pot causar la duplicació \ de comunicació (e-mails)."
+				of Communication (emails).","Que està seleccionant l'opció de sincronització com tot, es torna a sincronitzar tots els \ llegir, així com els missatges no llegits des del servidor. Això també pot causar la duplicació \ de comunicació (e-mails)."
 DocType: Workflow State,magnet,imant
 apps/frappe/frappe/geo/doctype/currency/currency.js,This Currency is disabled. Enable to use in transactions,Aquesta moneda és deshabilitada Habilitala per a utilitzar-la en les transaccions
 DocType: Desktop Icon,Blocked,obstruït
 DocType: Contact Us Settings,"Default: ""Contact Us""","""Contacte"" predeterminat"
 DocType: Contact,Purchase Manager,Gerent de Compres
-DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Quan estigui habilitat, permetrà als convidats pujar fitxers a l&#39;aplicació. Podeu habilitar-la si voleu recopilar fitxers de l&#39;usuari sense haver-hi de iniciar sessió, per exemple, al formulari web d&#39;aplicacions laborals."
-apps/frappe/frappe/public/js/frappe/ui/tags.js,toggle Tag,commuta l&#39;etiqueta
+DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Quan estigui habilitat, permetrà als convidats pujar fitxers a l'aplicació. Podeu habilitar-la si voleu recopilar fitxers de l'usuari sense haver-hi de iniciar sessió, per exemple, al formulari web d'aplicacions laborals."
+apps/frappe/frappe/public/js/frappe/ui/tags.js,toggle Tag,commuta l'etiqueta
 DocType: Custom Script,Sample,Mostra
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,"For performance, only the first 100 rows were processed.","Per obtenir el rendiment, només es van processar les 100 primeres files."
 DocType: Braintree Settings,Private Key,Clau privada
@@ -2351,12 +2351,12 @@ DocType: User,Website User,Lloc web de l'usuari
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,Algunes columnes es podrien tallar en imprimir a PDF. Proveu de mantenir el nombre de columnes de menys de 10.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not equals,No Equival
 DocType: Data Import Beta,Don't Send Emails,No envieu correus electrònics
-DocType: Integration Request,Integration Request Service,Sol·licitud de Servei d&#39;Integració
+DocType: Integration Request,Integration Request Service,Sol·licitud de Servei d'Integració
 DocType: Access Log,Access Log,Accés al registre
 DocType: Website Script,Script to attach to all web pages.,Script to attach to all web pages.
 DocType: Web Form,Allow Multiple,Permetre múltiple
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Assign,Assignar
-DocType: Translation,PR sent,S&#39;ha enviat un PR
+DocType: Translation,PR sent,S'ha enviat un PR
 DocType: Auto Email Report,Only Send Records Updated in Last X Hours,Enviar només els registres actualitzats en últimes hores X
 DocType: Communication,Feedback,Resposta
 apps/frappe/frappe/public/js/frappe/form/controls/base_control.js,Open Translation,Obre la traducció
@@ -2371,11 +2371,11 @@ DocType: Email Account,ProTip: Add <code>Reference: {{ reference_doctype }} {{ r
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Only users involved in the document are listed,Només es mostren els usuaris implicats en el document
 DocType: DocField,Fetch From,Obtenir des de
 apps/frappe/frappe/modules/utils.py,App not found,App not found
-apps/frappe/frappe/core/doctype/communication/communication.py,Cannot create a {0} against a child document: {1},No es pot crear un {0} en contra d&#39;un document secundari: {1}
-DocType: Social Login Key,Social Login Key,Clau d&#39;accés social
+apps/frappe/frappe/core/doctype/communication/communication.py,Cannot create a {0} against a child document: {1},No es pot crear un {0} en contra d'un document secundari: {1}
+DocType: Social Login Key,Social Login Key,Clau d'accés social
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options {1} must be the same as doctype name {2} for the field {3},{0}: les opcions {1} han de ser les mateixes que el nom de text {2} per al camp {3}
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Clear Cache and Reload,Neteja la memòria cau i torna a carregar
-DocType: Portal Settings,Custom Sidebar Menu,Menú d&#39;encàrrec de la barra lateral
+DocType: Portal Settings,Custom Sidebar Menu,Menú d'encàrrec de la barra lateral
 DocType: Workflow State,pencil,llapis
 apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,Missatges de xat i altres notificacions.
 apps/frappe/frappe/public/js/frappe/social/Home.vue,Social Home,Llar social
@@ -2405,7 +2405,7 @@ apps/frappe/frappe/templates/emails/password_reset.html,Please click on the foll
 DocType: Notification,Days After,Dies Després
 apps/frappe/frappe/public/js/frappe/form/print.js,QZ Tray Connection Active!,Connexió de safata QZ activa
 DocType: Contact Us Settings,Settings for Contact Us Page,Ajustos per Contacti'ns Pàgina
-DocType: Print Settings,Enable Print Server,Activa el servidor d&#39;impressió
+DocType: Print Settings,Enable Print Server,Activa el servidor d'impressió
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} weeks ago,Fa {0} setmanes
 DocType: Email Account,Footer,Peu de pàgina
 apps/frappe/frappe/config/integrations.py,Authentication,autenticació
@@ -2423,7 +2423,7 @@ DocType: Deleted Document,Data,Dades
 apps/frappe/frappe/public/js/frappe/model/model.js,Document Status,Estat del document
 apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,Approval Required,Aprovació obligatòria
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,The following records needs to be created before we can import your file.,Cal crear els registres següents per poder importar el vostre fitxer.
-DocType: OAuth Authorization Code,OAuth Authorization Code,Codi d&#39;autorització OAuth
+DocType: OAuth Authorization Code,OAuth Authorization Code,Codi d'autorització OAuth
 apps/frappe/frappe/core/doctype/data_import/importer.py,Not allowed to Import,No es permet importar
 DocType: Deleted Document,Deleted DocType,dOCTYPE eliminat
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permission Levels,Nivells de permisos
@@ -2436,8 +2436,8 @@ DocType: Google Calendar,Pull from Google Calendar,Tira de Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ajuda
 DocType: User,Login Before,Identifica't abans
 DocType: Web Page,Insert Style,Inserir Estil
-DocType: Prepared Report,Error Message,Missatge d&#39;error
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,New Report name,Nou nom d&#39;Informe
+DocType: Prepared Report,Error Message,Missatge d'error
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,New Report name,Nou nom d'Informe
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Hide Weekends,Amaga caps de setmana
 apps/frappe/frappe/config/settings.py,Automatically generates recurring documents.,Genera automàticament documents recurrents.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Is,És
@@ -2446,7 +2446,7 @@ apps/frappe/frappe/model/base_document.py,Value for {0} cannot be a list,Valor {
 DocType: Currency,"How should this currency be formatted? If not set, will use system defaults","Com s'ha de formatar aquesta moneda? Si no s'estableix, s'utilitzarà valors predeterminats del sistema"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Submit {0} documents?,Enviar documents {0}?
 apps/frappe/frappe/utils/response.py,You need to be logged in and have System Manager Role to be able to access backups.,Has d'estar connectat i tenir l'Administrador del sistema de funcions per poder accedir a les còpies de seguretat.
-apps/frappe/frappe/public/js/frappe/form/print.js,Printer Mapping,Cartografia d&#39;impressora
+apps/frappe/frappe/public/js/frappe/form/print.js,Printer Mapping,Cartografia d'impressora
 apps/frappe/frappe/public/js/frappe/form/form.js,Please save before attaching.,"Si us plau, guardi abans de connectar."
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Added {0} ({1}),Afegit {0} ({1})
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Fieldtype cannot be changed from {0} to {1} in row {2},FieldType no es pot canviar de {0} a {1} a la fila {2}
@@ -2460,21 +2460,21 @@ apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Read,Es 
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,{0} Chart,{0} Gràfic
 DocType: Custom Role,Response,Resposta
 DocType: DocField,Geolocation,Geolocalització
-DocType: Workflow,Emails will be sent with next possible workflow actions,Els correus electrònics s&#39;enviaran amb les següents accions de flux de treball possibles
+DocType: Workflow,Emails will be sent with next possible workflow actions,Els correus electrònics s'enviaran amb les següents accions de flux de treball possibles
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Workflow will start after saving.,El worflow s'iniciarà després de desar.
 DocType: S3 Backup Settings,ap-northeast-1,ap-nord-est-1
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Alguna cosa va fallar durant la generació del testimoni. Feu clic a {0} per generar-ne un de nou.
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Share,Pot compartir
 apps/frappe/frappe/email/smtp.py,Invalid recipient address,Direcció del destinatari no vàlid
 DocType: Workflow State,step-forward,pas cap endavant
-DocType: System Settings,Allow Login After Fail,Permet l&#39;inici de sessió després d&#39;un error
+DocType: System Settings,Allow Login After Fail,Permet l'inici de sessió després d'un error
 DocType: Role Permission for Page and Report,Set Role For,Per establir Rol
 DocType: GCalendar Account,The name that will appear in Google Calendar,El nom que apareixerà a Google Calendar
-apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Direct room with {0} already exists.,L&#39;habitació directa amb {0} ja existeix.
+apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Direct room with {0} already exists.,L'habitació directa amb {0} ja existeix.
 apps/frappe/frappe/core/doctype/user/user.js,Refreshing...,Actualitzant ...
 DocType: Event,Starts on,Comença en
 DocType: System Settings,System Settings,Configuració del sistema
-DocType: GCalendar Settings,Google API Credentials,Credencials de l&#39;API de Google
+DocType: GCalendar Settings,Google API Credentials,Credencials de l'API de Google
 apps/frappe/frappe/public/js/frappe/desk.js,Session Start Failed,Inici de Sessió Error
 apps/frappe/frappe/email/queue.py,This email was sent to {0} and copied to {1},Aquest correu electrònic va ser enviat a {0} i copiat a {1}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document {0},ha enviat aquest document {0}
@@ -2489,12 +2489,12 @@ apps/frappe/frappe/desk/doctype/todo/todo_list.js,Open {0},Obrir {0}
 DocType: Data Import Beta,Import Warnings,Advertències d’importació
 DocType: OAuth Client,Default Redirect URI,Defecte URI de redireccionament
 DocType: Auto Repeat,Recipients,Destinataris
-DocType: System Settings,Choose authentication method to be used by all users,Trieu el mètode d&#39;autenticació que tots els usuaris utilitzaran
+DocType: System Settings,Choose authentication method to be used by all users,Trieu el mètode d'autenticació que tots els usuaris utilitzaran
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Doctype required,Es requereix Doctype
 DocType: Workflow State,ok-sign,ok-sign
 apps/frappe/frappe/config/settings.py,Deleted Documents,documents eliminats
 apps/frappe/frappe/public/js/frappe/form/grid.js,The CSV format is case sensitive,El format CSV distingeix entre majúscules i minúscules
-apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,Icona d&#39;escriptori ja existeix
+apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,Icona d'escriptori ja existeix
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Duplicate,Duplicar
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} cannot be hidden and mandatory without default,{0}: el camp {1} de la fila {2} no es pot amagar i obligatòriament per defecte
 DocType: Newsletter,Create and Send Newsletters,Crear i enviar butlletins de notícies
@@ -2502,7 +2502,7 @@ apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your 
 DocType: Address,Andaman and Nicobar Islands,Illes Andaman i Nicobar
 DocType: Google Contacts,Pull from Google Contacts,Treu de Google Contacts
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,Si us plau especificar quin valor del camp ha de ser verificat
-DocType: Event,Google Calendar Event ID,Identificador d&#39;esdeveniments de Google Calendar
+DocType: Event,Google Calendar Event ID,Identificador d'esdeveniments de Google Calendar
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added","""Pare"" es refereix a la taula principal en la qual cal afegir aquesta fila"
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,Punts de revisió:
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,Compartit Amb
@@ -2514,16 +2514,16 @@ apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Your payment
 DocType: Comment,Unshared,incompartible
 DocType: Address,Karnataka,Karnataka
 apps/frappe/frappe/desk/moduleview.py,Module Not Found,Mòdul no trobat
-apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,{0}: {1} is set to state {2},{0}: {1} està establert per a l&#39;estat {2}
+apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,{0}: {1} is set to state {2},{0}: {1} està establert per a l'estat {2}
 DocType: User,Location,Ubicació
 apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move to Row Number,Desplaceu-vos al número de fila
 ,Permitted Documents For User,Documents permesos Per Usuari
 apps/frappe/frappe/core/doctype/docshare/docshare.py,"You need to have ""Share"" permission","Vostè necessita tenir el permís ""Compartir"""
 DocType: Comment,Assignment Completed,assignació Completat
 apps/frappe/frappe/public/js/frappe/form/grid.js,Bulk Edit {0},Edita granel {0}
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Download Report,Baixa l&#39;informe
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Download Report,Baixa l'informe
 apps/frappe/frappe/workflow/doctype/workflow/workflow_list.js,Not active,No actiu
-apps/frappe/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py,Only Administrator is allowed to create Dashboard Chart Sources,Només l&#39;administrador està autoritzat a crear fonts gràfiques de tauler de control
+apps/frappe/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py,Only Administrator is allowed to create Dashboard Chart Sources,Només l'administrador està autoritzat a crear fonts gràfiques de tauler de control
 DocType: About Us Settings,Settings for the About Us Page,Configuració de la pàgina Qui som
 apps/frappe/frappe/config/integrations.py,Stripe payment gateway settings,configuració de la passarel·la de pagament de la ratlla
 apps/frappe/frappe/public/js/frappe/form/print.js,Print Sent to the printer!,Impressió enviada a la impressora
@@ -2538,7 +2538,7 @@ DocType: Personal Data Deletion Request,Pending Verification,Pendent de verifica
 DocType: Website Meta Tag,Website Meta Tag,Etiqueta Meta del lloc web
 DocType: Email Account,"If non standard port (e.g. 587). If on Google Cloud, try port 2525.","Si el port no és estàndard (per exemple, 587). Si a Google Cloud, proveu el port 2525."
 apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.","Esborra la data de finalització, ja que no pot ser anterior per a pàgines publicades."
-DocType: User,Send Me A Copy of Outgoing Emails,Envia&#39;m una còpia de correus electrònics sortints
+DocType: User,Send Me A Copy of Outgoing Emails,Envia'm una còpia de correus electrònics sortints
 DocType: System Settings,Scheduler Last Event,Programador Últim esdeveniment
 DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,"Afegir Google Analytics ID: per exemple. UA-89XXX57-1. Si us plau, busca ajuda sobre Google Analytics per obtenir més informació."
 apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,La contrasenya no pot contenir més de 100 caràcters
@@ -2548,7 +2548,7 @@ DocType: Notification Recipient,"Expression, Optional","Expressió, opcional"
 DocType: GSuite Settings,Copy and paste this code into and empty Code.gs in your project at script.google.com,Còpia i pega el codi a Code.gs i buit en el seu projecte a script.google.com
 apps/frappe/frappe/email/queue.py,This email was sent to {0},Aquest correu electrònic va ser enviat a {0}
 DocType: System Settings,Hide footer in auto email reports,Amaga el peu de pàgina als informes de correu electrònic automàtic
-DocType: DocField,Remember Last Selected Value,Recordeu que l&#39;últim valor seleccionat
+DocType: DocField,Remember Last Selected Value,Recordeu que l'últim valor seleccionat
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,This document cannot be reverted,Aquest document no es pot revertir
 DocType: Email Account,Check this to pull emails from your mailbox,Selecciona perenviar correus electrònics de la seva bústia de correu
 apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,click here,clica aquí
@@ -2558,22 +2558,22 @@ DocType: User,Allow Modules,Permetre mòduls
 DocType: Unhandled Email,Unhandled Email,no controlada per correu electrònic
 DocType: Assignment Rule Day,Monday,Dilluns
 apps/frappe/frappe/utils/password_strength.py,Make use of longer keyboard patterns,Fer ús de patrons de teclat més llargs
-apps/frappe/frappe/templates/includes/integrations/stripe_checkout.js,Processing...,S&#39;està processant ...
+apps/frappe/frappe/templates/includes/integrations/stripe_checkout.js,Processing...,S'està processant ...
 DocType: Data Import,Don't create new records,No creeu nous registres
 apps/frappe/frappe/utils/nestedset.py,Nested set error. Please contact the Administrator.,Nested set error. Please contact the Administrator.
 DocType: Workflow State,envelope,embolcall
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 2,Opció 2
-apps/frappe/frappe/utils/print_format.py,Printing failed,No s&#39;ha pogut imprimir
+apps/frappe/frappe/utils/print_format.py,Printing failed,No s'ha pogut imprimir
 apps/frappe/frappe/www/update-password.html,New Password Required.,Nova contrasenya requerida.
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with {1},{0} compartit aquest document {1}
 DocType: Website Settings,Brand Image,Imatge de marca
 DocType: Print Settings,A4,A4
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Google Calendar has been configured.,S&#39;ha configurat Google Calendar.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Google Calendar has been configured.,S'ha configurat Google Calendar.
 apps/frappe/frappe/config/website.py,"Setup of top navigation bar, footer and logo.","Configuració de barra de navegació superior, peu de pàgina i el logo."
 DocType: Web Form Field,Max Value,valor màxim
 apps/frappe/frappe/core/doctype/doctype/doctype.py,For {0} at level {1} in {2} in row {3},Per {0} a nivell {1} a {2} en fila {3}
 DocType: Auto Repeat,Preview Message,Missatge de vista prèvia
-DocType: User Social Login,User Social Login,Accés social de l&#39;usuari
+DocType: User Social Login,User Social Login,Accés social de l'usuari
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} criticized your work on {1} with {2} point,{0} va criticar el vostre treball a {1} amb {2} punt
 DocType: Contact,All,Tots
 DocType: Email Queue,Recipient,Receptor
@@ -2585,10 +2585,10 @@ DocType: Address,Sikkim,Sikkim
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Set Chart,Estableix el gràfic
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Are you sure?,Estàs segur?
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Set,Setembre
-apps/frappe/frappe/desk/search.py,This query style is discontinued,Aquest estil de consulta s&#39;interromp
-DocType: Notification,Trigger Method,Mètode d&#39;activació
-apps/frappe/frappe/utils/data.py,Operator must be one of {0},L&#39;operador ha de ser un {0}
-DocType: Dropbox Settings,Dropbox Access Token,Dropbox accés d&#39;emergència
+apps/frappe/frappe/desk/search.py,This query style is discontinued,Aquest estil de consulta s'interromp
+DocType: Notification,Trigger Method,Mètode d'activació
+apps/frappe/frappe/utils/data.py,Operator must be one of {0},L'operador ha de ser un {0}
+DocType: Dropbox Settings,Dropbox Access Token,Dropbox accés d'emergència
 DocType: Workflow State,align-right,alinear a la dreta
 DocType: Auto Email Report,Email To,Destinatari
 apps/frappe/frappe/core/doctype/file/file.py,Folder {0} is not empty,Carpeta {0} no està buit
@@ -2600,8 +2600,8 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Field {0} is not selec
 DocType: Webhook,Webhook,Webhook
 DocType: System Settings,Session Expiry,Caducitat Sessió
 DocType: Workflow State,ban-circle,ban-cercle
-apps/frappe/frappe/desk/query_report.py,Report updated successfully,L&#39;informe s&#39;ha actualitzat correctament
-apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Slack Webhook Error,S&#39;ha produït un fracàs en l&#39;error de Webhook
+apps/frappe/frappe/desk/query_report.py,Report updated successfully,L'informe s'ha actualitzat correctament
+apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Slack Webhook Error,S'ha produït un fracàs en l'error de Webhook
 DocType: Email Flag Queue,Unread,no llegit
 DocType: Bulk Update,Desk,Escriptori
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping column {0},Saltar a la columna {0}
@@ -2613,7 +2613,7 @@ DocType: DocType,Child Tables are shown as a Grid in other DocTypes,Les taules i
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Setup Auto Email,Configuració automàtica de correu electrònic
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Down,Ctrl + A baix
 DocType: Chat Profile,Message Preview,Visualització prèvia de missatges
-apps/frappe/frappe/utils/password_strength.py,This is a top-10 common password.,Es tracta d&#39;una contrasenya comuna entre els 10 primers.
+apps/frappe/frappe/utils/password_strength.py,This is a top-10 common password.,Es tracta d'una contrasenya comuna entre els 10 primers.
 DocType: User,User Defaults,La configuració d'usuari
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Core DocTypes cannot be customized.,No es poden personalitzar els tipus de document bàsics.
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Create New,Crear nou
@@ -2639,7 +2639,7 @@ DocType: Letter Head,Default Letter Head,Capçalera per defecte
 DocType: OAuth Client,"URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.
 <br>e.g. http://hostname//api/method/frappe.www.login.login_via_facebook","URI per a la recepció de codi d'autorització una vegada que l'usuari permet l'accés, així com les respostes de fallada. Normalment, un extrem REST exposat pel client de l'aplicació. <br> per exemple, http: //hostname//api/method/frappe.www.login.login_via_facebook"
 apps/frappe/frappe/model/base_document.py,Not allowed to change {0} after submission,No es pot canviar {0} després de ser presentat
-DocType: Data Migration Mapping,Migration ID Field,Camp d&#39;identificació de la migració
+DocType: Data Migration Mapping,Migration ID Field,Camp d'identificació de la migració
 DocType: Dashboard Chart,Last Synced On,Darrer sincronitzat
 DocType: Comment,Comment Type,Tipus Comentari
 DocType: OAuth Client,OAuth Client,client OAuth
@@ -2654,8 +2654,8 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Loading,Ca
 apps/frappe/frappe/config/integrations.py,"Enter keys to enable login via Facebook, Google, GitHub.","Introduïu les claus per permetre inici de sessió a través de Facebook, Google, GitHub."
 DocType: Event,Sent/Received Email,Correu enviat / rebut
 DocType: Data Import,Insert new records,Insereix nous registres
-apps/frappe/frappe/core/doctype/file/file.py,Unable to read file format for {0},No es pot llegir el format d&#39;arxiu per a {0}
-apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Només l&#39;administrador està autoritzat a utilitzar la gravadora
+apps/frappe/frappe/core/doctype/file/file.py,Unable to read file format for {0},No es pot llegir el format d'arxiu per a {0}
+apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Només l'administrador està autoritzat a utilitzar la gravadora
 DocType: Auto Email Report,Filter Data,Filtrar dades
 apps/frappe/frappe/public/js/frappe/form/controls/select.js,Please attach a file first.,Si us plau adjuntar un arxiu primer.
 apps/frappe/frappe/templates/emails/download_data.html,Dear {0},Estimat {0}
@@ -2665,14 +2665,14 @@ apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email acc
 apps/frappe/frappe/templates/includes/contact.js,"You seem to have written your name instead of your email. \
 				Please enter a valid email address so that we can get back.","Sembla que han escrit el seu nom en lloc del seu correu electrònic. \ Si us plau, introdueixi una adreça vàlida de correu electrònic perquè puguem tornar."
 DocType: Website Slideshow Item,Website Slideshow Item,Website Slideshow Item
-apps/frappe/frappe/model/workflow.py,Self approval is not allowed,L&#39;autoregulació no està permesa
+apps/frappe/frappe/model/workflow.py,Self approval is not allowed,L'autoregulació no està permesa
 DocType: GSuite Templates,Template ID,ID de plantilla
 apps/frappe/frappe/integrations/doctype/oauth_client/oauth_client.py,Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed,No es permet la combinació del tipus de subvenció ( <code>{0}</code> ) i el tipus de resposta ( <code>{1}</code> )
 apps/frappe/frappe/desk/form/assign_to.py,New Message from {0},Nou missatge de {0}
 DocType: Portal Settings,Default Role at Time of Signup,El paper per defecte en el moment de la Inscripció
 DocType: DocType,Title Case,Títol del Cas
-apps/frappe/frappe/templates/emails/download_data.html,Click on the link below to download your data,Feu clic a l&#39;enllaç següent per descarregar les vostres dades
-apps/frappe/frappe/core/doctype/user/user.py,Enabled email inbox for user {0},S&#39;ha habilitat la safata d&#39;entrada de correu electrònic per a l&#39;usuari {0}
+apps/frappe/frappe/templates/emails/download_data.html,Click on the link below to download your data,Feu clic a l'enllaç següent per descarregar les vostres dades
+apps/frappe/frappe/core/doctype/user/user.py,Enabled email inbox for user {0},S'ha habilitat la safata d'entrada de correu electrònic per a l'usuari {0}
 DocType: Data Migration Run,Data Migration Run,Execució de la migració de dades
 DocType: Blog Post,Email Sent,Correu electrònic enviat
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Older,Més vells
@@ -2680,7 +2680,7 @@ DocType: DocField,Ignore XSS Filter,Ignorar filtre XSS
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,removed,eliminat
 apps/frappe/frappe/config/integrations.py,Dropbox backup settings,la configuració de còpia de seguretat de Dropbox
 DocType: Webhook,Webhook Trigger,Disparador del webhook
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,{0} Google Calendar Events synced.,{0} Esdeveniments de Google Calendar s&#39;han sincronitzat.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,{0} Google Calendar Events synced.,{0} Esdeveniments de Google Calendar s'han sincronitzat.
 DocType: Dashboard Chart,Time Series,Sèries temporals
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be disabled,L'usuari {0} no es pot desactivar
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Google Settings,Configuració de Google
@@ -2695,13 +2695,13 @@ apps/frappe/frappe/desk/page/user_profile/user_profile.js,No More Activity,No hi
 DocType: Auto Repeat,Template,Plantilla
 DocType: Address,Delhi,Delhi
 apps/frappe/frappe/desk/doctype/calendar_view/calendar_view.js,Show Calendar,Mostra calendari
-apps/frappe/frappe/config/integrations.py,LDAP Settings,Configuració d&#39;LDAP
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Name,Nom de l&#39;entitat
+apps/frappe/frappe/config/integrations.py,LDAP Settings,Configuració d'LDAP
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Name,Nom de l'entitat
 apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Rectificativo
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,configuració de la passarel·la de pagament de PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Espectacle superior
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Els camps personalitzats no es poden afegir als documents DocTycle principals.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) resultaran truncades, com caràcters màxim permès és {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) resultaran truncades, com caràcters màxim permès és {2}"
 DocType: OAuth Client,Response Type,Tipus de resposta
 DocType: Contact Us Settings,Send enquiries to this email address,Envieu les seves consultes a la següent adreça de correu electrònic
 DocType: Letter Head,Letter Head Name,Nom Carta Head
@@ -2710,13 +2710,13 @@ apps/frappe/frappe/config/website.py,User editable form on Website.,Formulari d'
 DocType: Workflow State,file,Expedient
 apps/frappe/frappe/www/login.html,Back to Login,Tornar a inici
 DocType: Data Migration Mapping,Local DocType,DocType local
-apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} {1} added,S&#39;ha afegit {0} {1}
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} {1} added,S'ha afegit {0} {1}
 apps/frappe/frappe/model/rename_doc.py,You need write permission to rename,Cal el permís d'escriptura per canviar el nom
 DocType: Email Account,Use ASCII encoding for password,Utilitzeu la codificació ASCII per a la contrasenya
 DocType: User,Karma,Karma
 DocType: Report,Custom Report,Informe personalitzat
 DocType: Dashboard Chart,Bar,Bar
-apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Definiu un mapa d&#39;impressora per a aquest format d&#39;impressió a la configuració de la impressora
+apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Definiu un mapa d'impressora per a aquest format d'impressió a la configuració de la impressora
 DocType: DocField,Table,Taula
 DocType: File,File Size,Mida del fitxer
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You must login to submit this form,Has d'iniciar sessió per presentar aquest formulari
@@ -2735,9 +2735,9 @@ apps/frappe/frappe/public/js/frappe/web_form/web_form_list.js,No more items to d
 apps/frappe/frappe/public/js/frappe/form/form.js,Go to previous record,Vés al registre anterior
 DocType: Email Account,no failed attempts,intents fallits sense
 DocType: GSuite Settings,refresh_token,refresh_token
-DocType: Dropbox Settings,App Access Key,Aplicació Clau d&#39;Accés
+DocType: Dropbox Settings,App Access Key,Aplicació Clau d'Accés
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat failed for {0},Ha fallat la repetició automàtica per a {0}
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Activa l&#39;API de Google a la configuració de Google.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Activa l'API de Google a la configuració de Google.
 DocType: Session Default,Session Default,Per defecte de la sessió
 DocType: Chat Room,Last Message,Últim missatge
 DocType: OAuth Bearer Token,Access Token,Token d'accés
@@ -2750,7 +2750,7 @@ DocType: DocField,In Standard Filter,En Filtre predeterminat
 DocType: Web Form,Allow Edit,Permetre Editar
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Paste,Enganxa
 DocType: Webhook,Doc Events,Esdeveniments doc
-DocType: Auto Email Report,Based on Permissions For User,Sobre la base de permisos per a l&#39;usuari
+DocType: Auto Email Report,Based on Permissions For User,Sobre la base de permisos per a l'usuari
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Cannot change state of Cancelled Document. Transition row {0},No es pot canviar l'estat de Document Cancel·lat. Transition row {0}
 DocType: Workflow,"Rules for how states are transitions, like next state and which role is allowed to change state etc.","Normes de com els estats són transicions, com pròxim estat i a quin rol se li permet canviar l'estat, etc."
 apps/frappe/frappe/desk/form/save.py,{0} {1} already exists,{0} {1} ja existeix
@@ -2758,7 +2758,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Veure imatges
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Sembla que alguna cosa ha anat malament durant la transacció. Ja que no hem confirmat el pagament, PayPal li reemborsarà automàticament aquesta quantitat. Si no és així, si us plau, envieu-nos un correu electrònic i esmentar la identificació de correlació: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Incloure símbols, números i lletres majúscules en la contrasenya"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Després d&#39;inserir camp &#39;{0}&#39; esmentat en el camp personalitzat &#39;{1}&#39;, amb l&#39;etiqueta &#39;{2}&#39;, no hi"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Després d'inserir camp '{0}' esmentat en el camp personalitzat '{1}', amb l'etiqueta '{2}', no hi"
 DocType: List Filter,List Filter,Filtre de llista
 DocType: Workflow State,signal,senyal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Té fitxers adjunts
@@ -2767,10 +2767,10 @@ DocType: S3 Backup Settings,us-east-2,nosaltres-est-2
 apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atleast 10 characters,El comentari hauria de tenir com a mínim 10 caràcters
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,document restaurat
 DocType: Data Export,Data Export,Exportació de dades
-apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Selecciona l&#39;idioma ...
+apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Selecciona l'idioma ...
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},No podeu configurar &quot;Opcions&quot; per al camp {0}
 DocType: Help Article,Author,autor
-apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,reprendre l&#39;enviament
+apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,reprendre l'enviament
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Reobrir
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Show Warnings,Mostra els avisos
 apps/frappe/frappe/core/doctype/communication/communication.js,Re: {0},Re: {0}
@@ -2782,25 +2782,25 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,La Plantilla de la direcció predeterminada no es pot eliminar
 DocType: Contact,Maintenance Manager,Gerent de Manteniment
 DocType: Workflow State,Search,cerca
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Si us plau seleccioneu un altre mètode de pagament. Raya no admet transaccions en moneda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Si us plau seleccioneu un altre mètode de pagament. Raya no admet transaccions en moneda '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Mou a la paperera
 DocType: Web Form,Web Form Fields,Web Form Fields
 DocType: Data Import,Amended From,Modificada Des de
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Avís: No es pot trobar {0} en qualsevol taula relacionada amb {1}
 DocType: S3 Backup Settings,eu-north-1,eu-nord-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Aquest document es posa en cua per a la seva execució actualment. Siusplau torna-ho a provar
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Arxiu &#39;{0}&#39; no trobat
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Arxiu '{0}' no trobat
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Traieu la Secció
 DocType: User,Change Password,Canvia la contrasenya
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Camp d&#39;eix X
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Camp d'eix X
 apps/frappe/frappe/public/js/frappe/form/controls/data.js,Invalid Email: {0},Emails: {0}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Hello!,Hola!
 apps/frappe/frappe/config/integrations.py,Braintree payment gateway settings,Configuració de la passarel·la de pagament de Braintree
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Rebuild,Reconstruir
 apps/frappe/frappe/www/third_party_apps.html,This will log out {0} from all other devices,Això tancarà la sessió {0} des de tots els altres dispositius
 apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},No té permís per obtenir un informe sobre: {0}
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Calendar: no s&#39;ha pogut inserir l&#39;esdeveniment al Google Calendar {0}, codi d&#39;error {1}."
-DocType: System Settings,Apply Strict User Permissions,Aplicar permisos d&#39;usuari estrictes
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Calendar: no s'ha pogut inserir l'esdeveniment al Google Calendar {0}, codi d'error {1}."
+DocType: System Settings,Apply Strict User Permissions,Aplicar permisos d'usuari estrictes
 DocType: S3 Backup Settings,us-west-1,us-oest-1
 DocType: DocField,Allow Bulk Edit,Permetre Edició massiva
 DocType: Blog Post,Blog Post,Post Blog
@@ -2819,22 +2819,22 @@ apps/frappe/frappe/core/doctype/data_import/data_import.py,Can't save the form a
 DocType: Workflow,States,Units
 DocType: Notification,Attach Print,Adjuntar Imprimir
 DocType: Assignment Rule,Assignment Rule,Regla d’assignació
-apps/frappe/frappe/core/doctype/user/user.py,Suggested Username: {0},Suggerida Nom d&#39;usuari: {0}
+apps/frappe/frappe/core/doctype/user/user.py,Suggested Username: {0},Suggerida Nom d'usuari: {0}
 DocType: Assignment Rule Day,Day,dia
 apps/frappe/frappe/public/js/frappe/desk.js,Modules,mòduls
-apps/frappe/frappe/templates/pages/integrations/payment-success.html,Payment Success,L&#39;èxit de pagament
+apps/frappe/frappe/templates/pages/integrations/payment-success.html,Payment Success,L'èxit de pagament
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No {0} mail,No {0} electrònic
 DocType: OAuth Bearer Token,Revoked,revocat
 DocType: Web Page,Sidebar and Comments,Barra lateral i Comentaris
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Quan es modifiqui un document després de cancelar-lo i guardar-lo, tindrà un nou número que és una versió de l'antic nombre."
 apps/frappe/frappe/email/doctype/notification/notification.py,"Not allowed to attach {0} document,
-				please enable Allow Print For {0} in Print Settings","No es permet admetre {0} document, habiliteu Permetre impressió per a {0} a la configuració d&#39;impressió"
+				please enable Allow Print For {0} in Print Settings","No es permet admetre {0} document, habiliteu Permetre impressió per a {0} a la configuració d'impressió"
 apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,See the document at {0},Vegeu el document a {0}
 DocType: Stripe Settings,Publishable Key,clau publicable
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Start Import,Inicia la importació
-apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Type,Tipus d&#39;exportació
+apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Type,Tipus d'exportació
 DocType: Workflow State,circle-arrow-left,circle-arrow-left
-DocType: System Settings,Force User to Reset Password,Força l&#39;usuari a restablir la contrasenya
+DocType: System Settings,Force User to Reset Password,Força l'usuari a restablir la contrasenya
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"To get the updated report, click on {0}.","Per obtenir l’informe actualitzat, feu clic a {0}."
 apps/frappe/frappe/sessions.py,Redis cache server not running. Please contact Administrator / Tech support,"Servidor de memòria cau Redis parat. Si us plau, poseu-vos en contacte amb l'Administrador / Suport tècnic"
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_header.html,Searching,recerca
@@ -2844,10 +2844,10 @@ DocType: LDAP Settings,LDAP First Name Field,LDAP camp de nom
 DocType: Contact,Middle Name,Segon nom
 DocType: Custom Field,Field Description,Descripció del camp
 apps/frappe/frappe/model/naming.py,Name not set via Prompt,Nom no establert a través de Prompt
-apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Email Inbox,Safata d&#39;entrada de correu electrònic
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Email Inbox,Safata d'entrada de correu electrònic
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Updating {0} of {1}, {2}","Actualitzant {0} de {1}, {2}"
 DocType: Auto Email Report,Filters Display,filtres de visualització
-apps/frappe/frappe/public/js/frappe/form/form.js,"""amended_from"" field must be present to do an amendment.",El camp &quot;modificat_de&quot; ha d&#39;estar present per realitzar una modificació.
+apps/frappe/frappe/public/js/frappe/form/form.js,"""amended_from"" field must be present to do an amendment.",El camp &quot;modificat_de&quot; ha d'estar present per realitzar una modificació.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,{0} appreciated your work on {1} {2},{0} ha agraït el teu treball a {1} {2}
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Save filters,Desa els filtres
 DocType: Address,Plant,Planta
@@ -2860,7 +2860,7 @@ DocType: Workflow State,glass,vidre
 DocType: DocType,Timeline Field,Línia de temps camp
 DocType: Country,Time Zones,Zones horàries
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list up,Navega cap a la llista
-apps/frappe/frappe/core/page/permission_manager/permission_manager.py,There must be atleast one permission rule.,Hi ha d&#39;haver almenys una regla de permís.
+apps/frappe/frappe/core/page/permission_manager/permission_manager.py,There must be atleast one permission rule.,Hi ha d'haver almenys una regla de permís.
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Get Items,Obtenir elements
 DocType: Contact,Image,Imatge
 DocType: Workflow State,remove-sign,eliminar l'efecte de signe
@@ -2870,8 +2870,8 @@ DocType: Domain Settings,Domains HTML,Dominis HTML
 apps/frappe/frappe/templates/includes/search_template.html,Type something in the search box to search,Escriu alguna cosa en el quadre de cerca per buscar
 apps/frappe/frappe/config/settings.py,Define workflows for forms.,Definir els fluxos de treball per a les formes.
 DocType: Address,Other,Un altre
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,Introduïu l&#39;URL d&#39;autorització
-DocType: S3 Backup Settings,Access Key ID,Identificador de clau d&#39;accés
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,Introduïu l'URL d'autorització
+DocType: S3 Backup Settings,Access Key ID,Identificador de clau d'accés
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Misc,Altra informació
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Start new Format,Començar una nova Format
 DocType: Workflow State,font,font
@@ -2900,7 +2900,7 @@ DocType: GSuite Settings,Script URL,URL del guió
 apps/frappe/frappe/www/update-password.html,Please enter the password,"Si us plau, introdueixi la contrasenya"
 apps/frappe/frappe/www/printview.py,Not allowed to print cancelled documents,No es permet imprimir documents cancel·lats
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,No se li permet crear columnes
-DocType: Data Import,If you don't want to create any new records while updating the older records.,Si no voleu crear cap registre nou mentre s&#39;actualitzen els registres més antics.
+DocType: Data Import,If you don't want to create any new records while updating the older records.,Si no voleu crear cap registre nou mentre s'actualitzen els registres més antics.
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Info:,Info:
 DocType: Custom Field,Permission Level,Nivell de permís
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Cannot set Submit, Cancel, Amend without Write","{0}: No es pot establir a Presentat, Anul·lat, Modificat sense escriptura"
@@ -2912,7 +2912,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Saving,Estalvi
 DocType: Print Settings,Print Style Preview,Vista prèvia de l'estil d'impressió
 apps/frappe/frappe/core/doctype/file/test_file.py,Test_Folder,Test_Folder
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You are not allowed to update this Web Form Document,Vostè no està autoritzat a actualitzar aquest formulari web
-apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Establiu l&#39;URL base a la clau d&#39;accés social de Frappe
+apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Establiu l'URL base a la clau d'accés social de Frappe
 DocType: About Us Settings,About Us Settings,Ajustaments del Sobre nosaltres
 DocType: Website Settings,Website Theme,Lloc web temàtic
 DocType: User,Api Access,Api Access
@@ -2952,12 +2952,12 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 DocType: Web Form,Allow Delete,Permetre Esborrar
 DocType: Notification,Message Examples,Exemples de missatges
 DocType: Web Form,Login Required,Inici de sessió obligatori
-DocType: Email Account,Email Login ID,Correu electrònic d&#39;usuari ID
+DocType: Email Account,Email Login ID,Correu electrònic d'usuari ID
 apps/frappe/frappe/templates/pages/integrations/payment-cancel.html,Payment Cancelled,pagament cancel·lat
 ,Addresses And Contacts,Adreces i contactes
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Please select document type first.,Seleccioneu primer el tipus de document.
-apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Clear Error Logs,Registres d&#39;errors clars
-apps/frappe/frappe/core/doctype/user/user.js,Reset OTP Secret,Restablir el secret d&#39;OTP
+apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Clear Error Logs,Registres d'errors clars
+apps/frappe/frappe/core/doctype/user/user.js,Reset OTP Secret,Restablir el secret d'OTP
 DocType: Email Account,Notify if unreplied for (in mins),Notificar si UNREPLIED per (en minuts)
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Points Given,Punts donats
 apps/frappe/frappe/config/website.py,Categorize blog posts.,Classificar les entrades del blog.
@@ -2968,15 +2968,15 @@ DocType: Custom Role,Permission Rules,Regles de permisos
 DocType: Braintree Settings,Public Key,Clau pública
 DocType: GSuite Settings,GSuite Settings,ajustaments GSuite
 DocType: Address,Links,Enllaços
-DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Utilitza el nom de l&#39;adreça de correu electrònic esmentat en aquest compte com a nom del remitent per a tots els correus electrònics enviats amb aquest compte.
+DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Utilitza el nom de l'adreça de correu electrònic esmentat en aquest compte com a nom del remitent per a tots els correus electrònics enviats amb aquest compte.
 DocType: Energy Point Rule,Field To Check,Camp per comprovar
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Contactes de Google: no s&#39;ha pogut actualitzar el contacte dels contactes de Google {0}, codi d&#39;error {1}."
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Contactes de Google: no s'ha pogut actualitzar el contacte dels contactes de Google {0}, codi d'error {1}."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,Seleccioneu el tipus de document.
 apps/frappe/frappe/model/base_document.py,Value missing for,Falta a
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Afegir Nen
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Avanç d’importació
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Si la condició es compleix, l&#39;usuari serà recompensat amb els punts. per exemple. doc.status == &#39;Tancat&#39;"
+","Si la condició es compleix, l'usuari serà recompensat amb els punts. per exemple. doc.status == 'Tancat'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: No es pot eliminar un Registre Enviat.
 DocType: GSuite Templates,Template Name,Nom de la plantilla
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nou tipus de document
@@ -2990,7 +2990,7 @@ apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts by {0},Missatges
 apps/frappe/frappe/core/doctype/report/report.js,"To format columns, give column labels in the query.","Per formatar columnes, donar títols de les columnes a la consulta."
 DocType: Has Domain,Has Domain,té domini
 DocType: User,Allowed In Mentions,Esmentats en mencions
-apps/frappe/frappe/www/login.html,Don't have an account? Sign up,No tens un compte? Registra&#39;t
+apps/frappe/frappe/www/login.html,Don't have an account? Sign up,No tens un compte? Registra't
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Cannot remove ID field,No es pot eliminar el camp ID
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Assign Amend if not Submittable,{0}: No es pot establir Assignar esmenar si no submittable
 DocType: Address,Bihar,Bihar
@@ -3008,12 +3008,12 @@ apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,No
 DocType: Chat Room User,Chat Room User,Usuari de la sala de xat
 apps/frappe/frappe/model/workflow.py,Workflow State not set,Estat del flux de treball no configurat
 DocType: Google Calendar,Authorize Google Calendar Access,Autoritzeu Google Calendar Access
-apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,La pàgina que està buscant no es troba. Això podria ser degut a que es mou o hi ha un error tipogràfic a l&#39;enllaç.
-apps/frappe/frappe/www/404.html,Error Code: {0},Codi d&#39;error: {0}
+apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,La pàgina que està buscant no es troba. Això podria ser degut a que es mou o hi ha un error tipogràfic a l'enllaç.
+apps/frappe/frappe/www/404.html,Error Code: {0},Codi d'error: {0}
 DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Descripció de pàgina de llistat, en text, només un parell de línies. (Màxim 140 caràcters)"
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} are mandatory fields,{0} són camps obligatoris
-DocType: Workflow,Allow Self Approval,Permet l&#39;autoaprovenció
-DocType: Event,Event Category,Categoria d&#39;esdeveniments
+DocType: Workflow,Allow Self Approval,Permet l'autoaprovenció
+DocType: Event,Event Category,Categoria d'esdeveniments
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,John Doe,John Doe
 DocType: DocType,Name Case,Nom del cas
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with everyone,Compartit amb tothom
@@ -3025,16 +3025,16 @@ DocType: Workflow Document State,Only Allow Edit For,Només Permetre Edita Per
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Backing up to Google Drive.,Còpia de seguretat de Google Drive
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: {0},Obligatori: {0}
 apps/frappe/frappe/templates/includes/comments/comments.html,Your Name,El teu nom
-apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Connection Success,Connexió d&#39;èxit
+apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Connection Success,Connexió d'èxit
 DocType: DocType,InnoDB,InnoDB
-DocType: DocType,Default Sort Field,Camp d&#39;ordenació predeterminada
+DocType: DocType,Default Sort Field,Camp d'ordenació predeterminada
 DocType: File,Is Folder,És Carpeta
 DocType: Document Follow,DocType,Doctype
 DocType: Website Theme,Theme JSON,Tema JSON
 DocType: User,Mute Sounds,Sons Silenci
 DocType: Top Bar Item,Top Bar Item,Element de barra superior
 apps/frappe/frappe/utils/csvutils.py,"Unknown file encoding. Tried utf-8, windows-1250, windows-1252.","Codificació d'arxiu desconegut. Intentat utf-8, Finestres 1250, windows-1252."
-apps/frappe/frappe/printing/doctype/print_style/print_style.py,Standard Print Style cannot be changed. Please duplicate to edit.,No es pot canviar l&#39;estil d&#39;impressió estàndard. Dupliqueu per editar.
+apps/frappe/frappe/printing/doctype/print_style/print_style.py,Standard Print Style cannot be changed. Please duplicate to edit.,No es pot canviar l'estil d'impressió estàndard. Dupliqueu per editar.
 DocType: Website Settings,Robots.txt,robots.txt
 DocType: LDAP Settings,LDAP Last Name Field,Camp de cognom LDAP
 DocType: S3 Backup Settings,eu-central-1,eu-central-1
@@ -3056,35 +3056,35 @@ DocType: Access Log,Core,Nucli
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Set Permissions,establir permisos
 DocType: DocField,Set non-standard precision for a Float or Currency field,Ajusta una precisió no estàndard per a un camp Float o moneda
 DocType: Email Account,Ignore attachments over this size,No feu cas dels accessoris més d'aquesta mida
-apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move To,Moure&#39;s cap a
+apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move To,Moure's cap a
 DocType: Address,Preferred Billing Address,Preferit Direcció de facturació
 apps/frappe/frappe/database/database.py,Too many writes in one request. Please send smaller requests,Massa escriu en una petició. Si us plau enviar sol·licituds més petites
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive has been configured.,S&#39;ha configurat Google Drive.
-apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Document Type {0} has been repeated.,El tipus de document {0} s&#39;ha repetit.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive has been configured.,S'ha configurat Google Drive.
+apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Document Type {0} has been repeated.,El tipus de document {0} s'ha repetit.
 apps/frappe/frappe/core/doctype/version/version_view.html,Values Changed,Els valors modificats
 DocType: Workflow State,arrow-up,arrow-up
 DocType: Dynamic Link,Link Document Type,Enllaç Tipus de document
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for {0} table,Hauria d&#39;haver-hi com a mínim una fila per a la taula {0}
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for {0} table,Hauria d'haver-hi com a mínim una fila per a la taula {0}
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure Auto Repeat, enable ""Allow Auto Repeat"" from {0}.","Per configurar la repetició automàtica, activeu &quot;Permet la repetició automàtica&quot; des de {0}."
 DocType: OAuth Bearer Token,Expires In,en expira
 DocType: DocField,Allow on Submit,Permetre al presentar
 DocType: DocField,HTML,HTML
-DocType: Error Snapshot,Exception Type,Tipus d&#39;excepció
+DocType: Error Snapshot,Exception Type,Tipus d'excepció
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Esculli Columnes
 DocType: Web Page,Add code as <script>,Add code as <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Esborra els permisos de l’usuari
 DocType: Webhook,Headers,Encapçalaments
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Pròxims esdeveniments
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Please enter values for App Access Key and App Secret Key,"Si us plau, introdueixi els valors amb accés a aplicacions clau i l&#39;App clau secreta"
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Please enter values for App Access Key and App Secret Key,"Si us plau, introdueixi els valors amb accés a aplicacions clau i l'App clau secreta"
 DocType: Web Form,Accept Payment,accepti el pagament
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Select list item,Selecciona l&#39;element de la llista
-apps/frappe/frappe/config/core.py,A log of request errors,Un registre d&#39;errors de petició
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Select list item,Selecciona l'element de la llista
+apps/frappe/frappe/config/core.py,A log of request errors,Un registre d'errors de petició
 DocType: Report,Letter Head,Capçalera de la carta
 DocType: DocType,Quick Entry,Entrada ràpida
 DocType: Web Form,Button Label,Etiqueta de botó
 apps/frappe/frappe/public/js/frappe/list/list_view.js,{0} items selected,{0} elements seleccionats
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Suspend Sending,Enviament de suspendre
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,User Permissions created sucessfully,Permisos d&#39;usuari creats amb èxit
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,User Permissions created sucessfully,Permisos d'usuari creats amb èxit
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Fetching default Global Search documents.,Obtenció de documents de cerca global per defecte.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Drag elements from the sidebar to add. Drag them back to trash.,Arrossegueu els elements de la barra lateral per afegir. Arrossegament de nou a les escombraries.
 DocType: Workflow State,resize-small,canviar la mida petita
@@ -3093,7 +3093,7 @@ apps/frappe/frappe/core/doctype/communication/communication.js,Relink Communicat
 DocType: Translation,Contributed,Hi va contribuir
 apps/frappe/frappe/config/customization.py,Form Customization,Personalització del formulari
 apps/frappe/frappe/www/third_party_apps.html,No Active Sessions,No hi ha sessions actives
-DocType: Web Form,Route to Success Link,Enllaç de ruta cap a l&#39;èxit
+DocType: Web Form,Route to Success Link,Enllaç de ruta cap a l'èxit
 DocType: Top Bar Item,Right,Dreta
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,No Upcoming Events,No hi ha esdeveniments pròxims
 DocType: User,User Type,Tipus d'usuari
@@ -3107,9 +3107,9 @@ DocType: Email Account,Yandex.Mail,Yandex.Mail
 DocType: Dashboard Chart,Chart Name,Nom del gràfic
 DocType: Dashboard Chart,Chart Type,Tipus de diagrama
 DocType: DocType,Auto Name,Nom Automàtic
-apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Evitar seqüències com abc o 6543, ja que són fàcils d&#39;endevinar"
+apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Evitar seqüències com abc o 6543, ja que són fàcils d'endevinar"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Siusplau torna-ho a provar
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',L&#39;URL ha de començar amb &quot;http: //&quot; o &quot;https: //&quot;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',L'URL ha de començar amb &quot;http: //&quot; o &quot;https: //&quot;
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Opció 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,Edita
@@ -3142,28 +3142,28 @@ DocType: DocField,Column Break,Salt de columna
 DocType: Assignment Rule Day,Thursday,Dijous
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough review points,No teniu prou punts de revisió
 apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Vostè no té permís per accedir a aquesta imatge
-apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Desa l&#39;API secret:
+apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Desa l'API secret:
 apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},No es pot vincular document anul·lat: {0}
 apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,"No es pot editar un informe estàndard. Si us plau, duplicar i crear un nou informe"
-apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Company és obligatòria, ja que és la direcció de l&#39;empresa"
+apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Company és obligatòria, ja que és la direcció de l'empresa"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,"For example: If you want to include the document ID, use {0}","Per exemple: Si voleu incloure la identificació de document, utilitzeu {0}"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Table Columns for {0},Seleccionar columnes de taula per {0}
 DocType: Custom Field,Options Help,Opcions d'Ajuda
 DocType: Footer Item,Group Label,Label Group
 DocType: Kanban Board,Kanban Board,Junta Kanban
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts has been configured.,S&#39;ha configurat Google Contactes.
-apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,1 record will be exported,S&#39;exportarà 1 registre
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts has been configured.,S'ha configurat Google Contactes.
+apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,1 record will be exported,S'exportarà 1 registre
 DocType: DocField,Report Hide,Amaga Informe
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Tree view not available for {0},vista d&#39;arbre no està disponible per a {0}
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Tree view not available for {0},vista d'arbre no està disponible per a {0}
 DocType: DocType,Restrict To Domain,Restringir al domini
 DocType: Domain,Domain,Domini
 DocType: Custom Field,Label Help,Label Help
 DocType: Workflow State,star-empty,star-empty
-apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,Les dates són sovint fàcils d&#39;endevinar.
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Contactes de Google: no s&#39;ha pogut sincronitzar els contactes dels contactes de Google {0}, codi d&#39;error {1}."
+apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,Les dates són sovint fàcils d'endevinar.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Contactes de Google: no s'ha pogut sincronitzar els contactes dels contactes de Google {0}, codi d'error {1}."
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Next actions,Properes accions
 apps/frappe/frappe/email/doctype/notification/notification.py,"Cannot edit Standard Notification. To edit, please disable this and duplicate it","No es pot editar la notificació estàndard. Per editar-lo, inhabiliteu-lo i torneu-lo a duplicar"
-apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,No s’ha enviat el correu electrònic del codi de verificació. Contacteu amb l&#39;administrador.
+apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,No s’ha enviat el correu electrònic del codi de verificació. Contacteu amb l'administrador.
 DocType: Workflow State,ok,ok
 DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Aquests valors s'actualitzaran automàticament en les transaccions i també podrà ser útil restringir els permisos per a aquest usuari en transaccions que contenen aquests valors.
 apps/frappe/frappe/twofactor.py,Verfication Code,Codi de verificació
@@ -3182,8 +3182,8 @@ DocType: Data Import,If you are updating/overwriting already created records.,Si
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Is Global,És global
 DocType: Email Account,Use SSL,Utilitza SSL
 DocType: Workflow State,play-circle,joc de cercle
-apps/frappe/frappe/public/js/frappe/views/interaction.js,The document could not be correctly assigned,El document no s&#39;ha pogut assignar correctament
-apps/frappe/frappe/public/js/frappe/form/layout.js,"Invalid ""depends_on"" expression",L&#39;expressió &quot;depends_on&quot; no és vàlida
+apps/frappe/frappe/public/js/frappe/views/interaction.js,The document could not be correctly assigned,El document no s'ha pogut assignar correctament
+apps/frappe/frappe/public/js/frappe/form/layout.js,"Invalid ""depends_on"" expression",L'expressió &quot;depends_on&quot; no és vàlida
 DocType: Communication,Keeps track of all communications,Fa un seguiment de totes les comunicacions
 apps/frappe/frappe/public/js/frappe/chat.js,Group Name,Nom del grup
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Print Format to Edit,Seleccioneu Format d'impressió a Edita
@@ -3201,7 +3201,7 @@ DocType: Workflow State,Workflow state represents the current state of a documen
 DocType: Letter Head,Letter Head Based On,Cap de lletra basat
 apps/frappe/frappe/utils/oauth.py,Token is missing,Token falta
 apps/frappe/frappe/www/update-password.html,Set Password,Establir contrasenya
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records.,S&#39;han importat correctament {0} registres.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records.,S'han importat correctament {0} registres.
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Note: Changing the Page Name will break previous URL to this page.,Nota: El canvi del nom de la pàgina es trencarà URL anterior a aquesta pàgina.
 apps/frappe/frappe/utils/file_manager.py,Removed {0},Eliminat {0}
 DocType: SMS Settings,SMS Settings,Ajustaments de SMS
@@ -3220,7 +3220,7 @@ DocType: Comment,Bot,bot
 DocType: Help Article,Help Article,ajuda article
 DocType: Page,Page Name,Nom de pàgina
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Also adding the dependent currency field {0},"A més, afegiu el camp de moneda dependent {0}"
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not locate locate - {0},Google Drive: no s&#39;ha pogut localitzar la ubicació - {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not locate locate - {0},Google Drive: no s'ha pogut localitzar la ubicació - {0}
 DocType: S3 Backup Settings,ap-south-1,ap-sud-1
 apps/frappe/frappe/core/doctype/file/file.js,Unzip,obrir la cremallera
 apps/frappe/frappe/model/document.py,Incorrect value in row {0}: {1} must be {2} {3},Valor incorrecte a la fila {0}: {1} ha de ser {2} {3}
@@ -3228,7 +3228,7 @@ apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Submitted Document cann
 DocType: Assignment Rule,Assignment Days,Jornades d’assignació
 apps/frappe/frappe/desk/reportview.py,Deleting {0},Eliminació {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Select an existing format to edit or start a new format.,Seleccioneu un format existent per editar o iniciar un nou format.
-DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,Direcció d&#39;adreça IP restringida per bypass Si habilita dos Autenticació de factor
+DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,Direcció d'adreça IP restringida per bypass Si habilita dos Autenticació de factor
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Created Custom Field {0} in {1},Creat camp personalitzat {0} a {1}
 DocType: System Settings,Time Zone,Fus horari
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Special Characters are not allowed,Els caràcters especials no estan permesos
@@ -3239,11 +3239,11 @@ DocType: User,Redirect URL,URL de redireccionament
 DocType: SMS Settings,Enter url parameter for receiver nos,Introdueix els paràmetres URL per als receptors
 DocType: Chat Profile,Online,en línia
 DocType: Email Account,Always use Account's Name as Sender's Name,Utilitzeu sempre el nom del compte com a nom del remitent
-apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,Només l&#39;administrador pot eliminar la cua de correu electrònic
+apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,Només l'administrador pot eliminar la cua de correu electrònic
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Setting this Address Template as default as there is no other default,En establir aquesta plantilla de direcció per defecte ja que no hi ha altre defecte
 DocType: Workflow State,Home,casa
 DocType: OAuth Provider Settings,Auto,acte
-DocType: System Settings,User can login using Email id or User Name,L&#39;usuari pot iniciar la sessió utilitzant l&#39;identificador de correu electrònic o el nom d&#39;usuari
+DocType: System Settings,User can login using Email id or User Name,L'usuari pot iniciar la sessió utilitzant l'identificador de correu electrònic o el nom d'usuari
 DocType: Workflow State,question-sign,question-sign
 apps/frappe/frappe/model/base_document.py,{0} is disabled,{0} està desactivat
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",El camp &quot;ruta&quot; és obligatori per a les visualitzacions web
@@ -3262,7 +3262,7 @@ DocType: ToDo,ToDo,ToT
 DocType: DocField,No Copy,No Copy
 DocType: Workflow State,qrcode,qrcode
 DocType: Chat Token,IP Address,Adreça IP
-DocType: Data Import,Submit after importing,Enviar després d&#39;importar
+DocType: Data Import,Submit after importing,Enviar després d'importar
 apps/frappe/frappe/www/login.html,Login with LDAP,Entrada amb LDAP
 DocType: Web Form,Breadcrumbs,Breadcrumbs
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Rank: ,Rànquing:
@@ -3272,9 +3272,9 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Drop files he
 DocType: OAuth Authorization Code,Expiration time,temps de termini
 DocType: Web Page,Website Sidebar,Barra Lateral pàgina web
 DocType: Web Form,Show Sidebar,Mostra la barra lateral
-apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be logged in to access this {0}.,Has d&#39;estar registrat per accedir a aquest {0}.
+apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be logged in to access this {0}.,Has d'estar registrat per accedir a aquest {0}.
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Complete By,Completat per
-apps/frappe/frappe/utils/password_strength.py,All-uppercase is almost as easy to guess as all-lowercase.,Tot en majúscules és gairebé tan fàcil d&#39;endevinar com en minúscules.
+apps/frappe/frappe/utils/password_strength.py,All-uppercase is almost as easy to guess as all-lowercase.,Tot en majúscules és gairebé tan fàcil d'endevinar com en minúscules.
 DocType: Website Settings,Top Bar Items,Elements de la barra superior
 DocType: Notification,Print Settings,Paràmetres d'impressió
 DocType: Page,Yes,Sí
@@ -3283,13 +3283,13 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,About {0} s
 DocType: Calendar View,End Date Field,Camp de data de finalització
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Global Shortcuts,Dreceres generals
 DocType: Desktop Icon,Page,Pàgina
-apps/frappe/frappe/utils/bot.py,Could not find {0} in {1},No s&#39;ha pogut trobar {0} a {1}
-apps/frappe/frappe/utils/password_strength.py,Names and surnames by themselves are easy to guess.,Els noms i cognoms que per si mateixos són fàcils d&#39;endevinar.
+apps/frappe/frappe/utils/bot.py,Could not find {0} in {1},No s'ha pogut trobar {0} a {1}
+apps/frappe/frappe/utils/password_strength.py,Names and surnames by themselves are easy to guess.,Els noms i cognoms que per si mateixos són fàcils d'endevinar.
 apps/frappe/frappe/config/website.py,Knowledge Base,Base de coneixements
 DocType: Workflow State,briefcase,briefcase
 apps/frappe/frappe/model/document.py,Value cannot be changed for {0},El valor no pot ser canviat per {0}
 DocType: Workflow State,"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange","Estil representa el color del botó: Èxit - Verd, Perill - vermell, Inverse - Negre, Primària - Blau Fosc, Informació - blau clar, Advertència - Orange"
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Aquesta sol·licitud encara no ha estat aprovada per l&#39;usuari.
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Aquesta sol·licitud encara no ha estat aprovada per l'usuari.
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Please Install the ldap3 library via pip to use ldap functionality.,Instal·leu la biblioteca ldap3 mitjançant pip per utilitzar la funcionalitat ldap.
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,Estat de fila
 DocType: S3 Backup Settings,sa-east-1,sa-est-1
@@ -3298,7 +3298,7 @@ apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,Fa {0} m
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Els camps personalitzats només es poden afegir a un document de document estàndard.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Created By,Creat per
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Configuració de Dropbox
-DocType: Assignment Rule Day,Assignment Rule Day,Dia de la norma d&#39;assignació
+DocType: Assignment Rule Day,Assignment Rule Day,Dia de la norma d'assignació
 DocType: Workflow State,resize-horizontal,resize-horizontal
 apps/frappe/frappe/templates/emails/download_data.html,Download Link,Enllaç de descàrrega
 DocType: Chat Message,Content,Contingut
@@ -3311,7 +3311,7 @@ apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} appreciated 
 DocType: Milestone,Document,Document
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Series {0} already used in {1},La sèrie {0} ja s'utilitza a {1}
 apps/frappe/frappe/core/doctype/data_import/importer.py,Unsupported File Format,Format de fitxer no admès
-apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray...,S&#39;està intentant llançar QZ Safata ...
+apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray...,S'està intentant llançar QZ Safata ...
 DocType: Assignment Rule,Example: {{ subject }},Exemple: {{subjecte}}
 DocType: DocField,Code,Codi
 DocType: Workflow,"All possible Workflow States and roles of the workflow. Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Tots els possibles estats de flux de treball i les funcions de flux de treball. Opcions DocStatus: 0 és &quot;salvat&quot;, 1 es &quot;Enviat&quot; i 2 és &quot;Cancel·lat&quot;"
@@ -3322,33 +3322,33 @@ DocType: Auto Repeat,Print Format,Format d'impressió
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Toggle Grid View,Canvia la vista en quadrícula
 apps/frappe/frappe/public/js/frappe/form/form.js,Go to next record,Vés al registre següent
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Invalid payment gateway credentials,credencials de passarel·la de pagaments no vàlids
-DocType: Data Import,This is the template file generated with only the rows having some error. You should use this file for correction and import.,Aquest és el fitxer de plantilla generat amb només les files que tenen algun error. Heu d&#39;utilitzar aquest fitxer per a la correcció i la importació.
+DocType: Data Import,This is the template file generated with only the rows having some error. You should use this file for correction and import.,Aquest és el fitxer de plantilla generat amb només les files que tenen algun error. Heu d'utilitzar aquest fitxer per a la correcció i la importació.
 apps/frappe/frappe/config/users_and_permissions.py,Set Permissions on Document Types and Roles,Establir permisos en Tipus de documents i funcions
 DocType: Data Migration Run,Remote ID,ID remot
 apps/frappe/frappe/model/meta.py,No Label,sense etiqueta
 DocType: System Settings,Use socketio to upload file,Utilitzeu socketio per carregar el fitxer
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Refreshing,Refrescant
 apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.js,Modified By,per modificada
-apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specified,Adreça de correu electrònic d&#39;assistència no especificada
+apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specified,Adreça de correu electrònic d'assistència no especificada
 DocType: Energy Point Log,Criticism,Crítica
 DocType: Address,Tripura,Tripura
 DocType: About Us Settings,"""Company History""","""Història de l'empresa"""
-apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Aquest document s&#39;ha modificat després d&#39;enviar el correu electrònic.
+apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Aquest document s'ha modificat després d'enviar el correu electrònic.
 DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","Si es marca, aquest camp no es sobreescriurà basant-se en Obtenir un valor si ja existeix un valor."
-DocType: Access Log,Show Report,Mostra l&#39;informe
+DocType: Access Log,Show Report,Mostra l'informe
 DocType: Address,Tamil Nadu,tamil Nadu
 DocType: Email Rule,Email Rule,Regla de correu electrònic
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with everyone,{0} compartit aquest document amb tothom
 apps/frappe/frappe/desk/page/activity/activity_row.html,Commented on {0}: {1},Comentat {0}: {1}
 apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Looks like someone sent you to an incomplete URL. Please ask them to look into it.,"Sembla que algú li va enviar a un URL incompleta. Si us plau, demanar-los que mirar-hi."
-apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Your payment has been successfully registered.,El vostre pagament s&#39;ha registrat correctament.
+apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Your payment has been successfully registered.,El vostre pagament s'ha registrat correctament.
 DocType: Stripe Settings,Secret Key,clau secreta
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translate {0},Tradueix {0}
 DocType: Notification,Send alert if this field's value changes,Enviar alerta si canvia el valor d'aquest camp
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Colors del tema
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Seleccioneu un tipus de document per fer un nou format
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,L&#39;usuari no existeix
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,No s&#39;especifiquen els &quot;destinataris&quot;
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,L'usuari no existeix
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,No s'especifiquen els &quot;destinataris&quot;
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,ara mateix
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,aplicar
 DocType: Footer Item,Policy,política
@@ -3362,11 +3362,11 @@ DocType: Data Migration Plan,Data Migration Plan,Pla de migració de dades
 apps/frappe/frappe/core/doctype/communication/communication.js,Reply,Respondre
 apps/frappe/frappe/config/core.py,Pages in Desk (place holders),Articles a la turística (marcadors de posició)
 DocType: DocField,Collapsible Depends On,Plegable Depèn de
-DocType: Print Style,Print Style Name,Nom de l&#39;estil d&#39;impressió
+DocType: Print Style,Print Style Name,Nom de l'estil d'impressió
 DocType: Print Settings,Allow page break inside tables,Permetre salt de pàgina dins de les taules
 DocType: Email Account,SMTP Server,Servidor SMTP
 DocType: Print Format,Print Format Help,Format d'impressió Ajuda
-apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,{0} room must have atmost one user.,L&#39;habitació {0} ha de tenir un màxim d&#39;un usuari.
+apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,{0} room must have atmost one user.,L'habitació {0} ha de tenir un màxim d'un usuari.
 DocType: DocType,Beta,beta
 DocType: Dashboard Chart,Count,Comptar
 apps/frappe/frappe/templates/includes/comments/comments.py,New Comment on {0}: {1},Nou comentari sobre {0}: {1}
@@ -3375,19 +3375,19 @@ apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are updating, pl
 DocType: DocField,Translatable,Traduïble
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Syncing {0} of {1},Sincronització {0} de {1}
 DocType: Letter Head,Letter Head in HTML,Cap Carta a HTML
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,User Profile,Perfil d&#39;usuari
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,User Profile,Perfil d'usuari
 DocType: Web Form,Web Form,Formulari Web
-apps/frappe/frappe/public/js/frappe/form/controls/date.js,Date {0} must be in format: {1},La data {0} ha d&#39;estar en format: {1}
+apps/frappe/frappe/public/js/frappe/form/controls/date.js,Date {0} must be in format: {1},La data {0} ha d'estar en format: {1}
 DocType: About Us Settings,Org History Heading,Org History Heading
 DocType: Print Settings,Allow Print for Cancelled,Permetre impressió per Cancel·lat
-DocType: Communication,Integrations can use this field to set email delivery status,Integracions poden utilitzar aquest camp per a establir l&#39;estat de lliurament de correu electrònic
+DocType: Communication,Integrations can use this field to set email delivery status,Integracions poden utilitzar aquest camp per a establir l'estat de lliurament de correu electrònic
 DocType: Web Form,Web Page Link Text,Text del link a la Pàgina Web
 DocType: Page,System Page,sistema de Pàgina
 apps/frappe/frappe/config/settings.py,"Set default format, page size, print style etc.","Establir format predeterminat, mida de pàgina, l'estil d'impressió, etc."
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,ESC,ESC
 apps/frappe/frappe/modules/utils.py,Customizations for <b>{0}</b> exported to:<br>{1},Personalitzacions per <b>{0}</b> exportats a: <br> {1}
 DocType: Website Settings,Include Search in Top Bar,Incloure Cerca a Top Bar
-DocType: GSuite Settings,Allow GSuite access,Permetre l&#39;accés GSuite
+DocType: GSuite Settings,Allow GSuite access,Permetre l'accés GSuite
 DocType: DocType,DESC,DESC
 DocType: DocType,Naming,Naming
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select All,Selecciona tot
@@ -3396,17 +3396,17 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Traduccions perso
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,progrés
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,per rol
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Els camps que falten
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,nom de camp no vàlid &#39;{0}&#39; a AutoName
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,nom de camp no vàlid '{0}' a AutoName
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Cercar en un tipus de document
 DocType: Custom DocPerm,Role and Level,Rols i Nivell
 DocType: File,Thumbnail URL,URL en miniatura
 apps/frappe/frappe/desk/moduleview.py,Custom Reports,Informes personalitzats
 DocType: Website Script,Website Script,Website Script
 DocType: GSuite Settings,If you aren't using own publish Google Apps Script webapp you can use the default https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec ,Si no utilitzeu publicar pròpia Google Apps Script aplicació web es pot utilitzar el valor predeterminat https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec
-apps/frappe/frappe/config/settings.py,Customized HTML Templates for printing transactions.,Plantilles HTML personalitzades per a transaccions d&#39;impressió.
+apps/frappe/frappe/config/settings.py,Customized HTML Templates for printing transactions.,Plantilles HTML personalitzades per a transaccions d'impressió.
 apps/frappe/frappe/public/js/frappe/form/print.js,Orientation,Orientació
 DocType: Workflow,Is Active,Està actiu
-apps/frappe/frappe/desk/query_report.py,{0} saved successfully,{0} s&#39;ha desat correctament
+apps/frappe/frappe/desk/query_report.py,{0} saved successfully,{0} s'ha desat correctament
 apps/frappe/frappe/desk/form/utils.py,No further records,No hi ha registres addicionals
 DocType: DocField,Long Text,Text llarg
 DocType: Workflow State,Primary,Primari
@@ -3416,7 +3416,7 @@ DocType: Web Form,Go to this URL after completing the form (only for Guest users
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,(Ctrl + G),(Ctrl + G)
 DocType: Contact,More Information,Més informació
 DocType: Data Migration Mapping,Field Maps,Mapes de camp
-DocType: Desktop Icon,Desktop Icon,Icona d&#39;escriptori
+DocType: Desktop Icon,Desktop Icon,Icona d'escriptori
 apps/frappe/frappe/templates/pages/integrations/payment-success.html,Your payment was successfully accepted,El seu pagament va ser acceptat amb èxit
 apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! You are not permitted to view this page.,Ho sento! No està autoritzat a veure aquesta pàgina.
 DocType: Workflow State,bell,campana
@@ -3426,7 +3426,7 @@ apps/frappe/frappe/utils/nestedset.py,{0} {1} cannot be a leaf node as it has ch
 DocType: Comment,Info,Info
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Add Attachment,arxiu adjunt
 DocType: Data Migration Mapping,Sync,Sincronitzar
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client Secret before social login is enabled,Introduïu Client Secret abans d&#39;activar l&#39;inici de sessió social
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client Secret before social login is enabled,Introduïu Client Secret abans d'activar l'inici de sessió social
 DocType: Communication,Email,Correu electrònic
 apps/frappe/frappe/templates/includes/contact.js,Thank you for your message,Gràcies pel seu missatge
 apps/frappe/frappe/public/js/frappe/views/communication.js,Send Read Receipt,Enviar confirmació de lectura
@@ -3435,7 +3435,7 @@ DocType: Data Migration Mapping,Data Migration Mapping,Cartografia de la migraci
 DocType: Auto Email Report,Period,Període
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,About {0} minute remaining,Resta aproximadament {0} minuts
 apps/frappe/frappe/www/login.py,Invalid Login Token,Invalid Login Token
-apps/frappe/frappe/public/js/frappe/chat.js,Discard,Descarta&#39;t
+apps/frappe/frappe/public/js/frappe/chat.js,Discard,Descarta't
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 hour ago,Fa 1 dia
 DocType: Website Settings,Home Page,Home Page
 DocType: Error Snapshot,Parent Error Snapshot,Snapshot Error Pares
@@ -3466,13 +3466,13 @@ DocType: Address Template,"<h4>Default Template</h4>
  {% if fax%} Fax: {{fax}} <br> {% endif -%} 
  {% if email_ID%} email: {{email_ID}} <br> {% endif -%} 
  </ code> </ pre>"
-DocType: Calendar View,Start Date Field,Camp de data d&#39;inici
+DocType: Calendar View,Start Date Field,Camp de data d'inici
 DocType: Role,Role Name,Nom de rol
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Passar a escriptori
 apps/frappe/frappe/config/core.py,Script or Query reports,Script o consulta informes
 DocType: Contact Phone,Is Primary Mobile,És mòbil principal
 DocType: Workflow Document State,Workflow Document State,Flux de treball de documents Estat
-apps/frappe/frappe/public/js/frappe/request.js,File too big,L&#39;arxiu és massa gran
+apps/frappe/frappe/public/js/frappe/request.js,File too big,L'arxiu és massa gran
 apps/frappe/frappe/core/doctype/user/user.py,Email Account added multiple times,Compte de correu electrònic afegeix diverses vegades
 DocType: Energy Point Settings,Last Point Allocation Date,Data d’assignació del darrer punt
 DocType: Payment Gateway,Payment Gateway,Passarel·la de Pagament
@@ -3481,7 +3481,7 @@ DocType: Milestone Tracker,Field to Track,Camp per rastrejar
 apps/frappe/frappe/utils/change_log.py,New updates are available,Hi ha noves actualitzacions disponibles
 DocType: Portal Settings,Hide Standard Menu,Amaga menú estàndard
 apps/frappe/frappe/config/settings.py,Add / Manage Email Domains.,Afegeix / Administrar dominis de correu electrònic.
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This link has already been activated for verification.,Aquest enllaç ja s&#39;ha activat per verificar-lo.
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This link has already been activated for verification.,Aquest enllaç ja s'ha activat per verificar-lo.
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Cannot cancel before submitting. See Transition {0},No es pot cancel·lar abans de presentar Veure Transició {0}
 apps/frappe/frappe/www/printview.py,Print Format {0} is disabled,Format d'impressió {0} està deshabilitat
 ,Address and Contacts,Direcció i contactes
@@ -3494,7 +3494,7 @@ DocType: Auto Repeat,Start Date,Data De Inici
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Value,Valor
 DocType: Dashboard Chart,Filters JSON,Filtres JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Fes clic aquí per verificar
-DocType: Email Account,Disable SMTP server authentication,Desactivar l&#39;autenticació del servidor SMTP
+DocType: Email Account,Disable SMTP server authentication,Desactivar l'autenticació del servidor SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Copiat al porta-retalls.
 apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,substitucions predictibles com &quot;@&quot; en lloc de &quot;a&quot; no ajuden molt.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Assignat By Em
@@ -3510,21 +3510,21 @@ DocType: Auto Repeat,Weekly,Setmanal
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Dark Color,Color fosc
 DocType: SMS Settings,Eg. smsgateway.com/api/send_sms.cgi,Ex. smsgateway.com/api/send_sms.cgi
 DocType: Communication,In Reply To,En resposta a
-DocType: DocType,Allow Import (via Data Import Tool),Permetre la importació (a través de l&#39;eina d&#39;importació de dades)
+DocType: DocType,Allow Import (via Data Import Tool),Permetre la importació (a través de l'eina d'importació de dades)
 apps/frappe/frappe/public/js/frappe/web_form/web_form_list.js,Sr,sr
 DocType: DocField,Float,Float
 DocType: Print Settings,Page Settings,Configuració de la pàgina
-apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Saving...,S&#39;està desant ...
+apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Saving...,S'està desant ...
 apps/frappe/frappe/www/update-password.html,Invalid Password,contrasenya invàlida
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record out of {1}.,S&#39;ha importat correctament {0} registre fora de {1}.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record out of {1}.,S'ha importat correctament {0} registre fora de {1}.
 DocType: Contact,Purchase Master Manager,Administraodr principal de compres
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the lock icon to toggle public/private,Feu clic a la icona de bloqueig per alternar públic / privat
 DocType: Module Def,Module Name,Nom del mòdul
 DocType: S3 Backup Settings,eu-west-3,eu-oest-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},Carregant {0} de {1}
 DocType: DocType,DocType is a Table / Form in the application.,Doctype és una taula / formulari en l'aplicació.
-DocType: Social Login Key,Authorize URL,Autoritza l&#39;URL
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Calendar: no s&#39;ha pogut obtenir l&#39;esdeveniment de Google Calendar, codi d&#39;error {0}."
+DocType: Social Login Key,Authorize URL,Autoritza l'URL
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Calendar: no s'ha pogut obtenir l'esdeveniment de Google Calendar, codi d'error {0}."
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failed,Fallada la repetició automàtica de documents
 DocType: Email Account,GMail,GMail
 DocType: Letter Head,Letter Head Image,Imatge de cap de lletra
@@ -3546,9 +3546,9 @@ apps/frappe/frappe/config/integrations.py,Google Drive Backup.,Còpia de seguret
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} assigned {1}: {2},{0} assignat a {1}: {2}
 apps/frappe/frappe/www/contact.py,New Message from Website Contact Page,Nou missatge de Lloc web Pàgina
 DocType: Notification,Reference Date,Data de Referència
-apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,La configuració OTP mitjançant l’aplicació OTP no s’ha completat. Contacteu amb l&#39;administrador.
+apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,La configuració OTP mitjançant l’aplicació OTP no s’ha completat. Contacteu amb l'administrador.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Entra números de mòbil vàlids
-apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,"Algunes de les característiques podrien no funcionar en el seu navegador. Si us plau, actualitzi el seu navegador a l&#39;última versió."
+apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,"Algunes de les característiques podrien no funcionar en el seu navegador. Si us plau, actualitzi el seu navegador a l'última versió."
 apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","No sap, pregunti &quot;ajuda&quot;"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ha cancel·lat aquest document {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Comentaris i Comunicacions estaran associats amb aquest document vinculat
@@ -3569,23 +3569,23 @@ apps/frappe/frappe/config/settings.py,Add / Manage Email Accounts.,Afegir / Admi
 DocType: Comment,Published,Publicat
 apps/frappe/frappe/templates/emails/auto_reply.html,Thank you for your email,Gràcies per el teu email
 DocType: DocField,Small Text,Text petit
-DocType: Workflow,Allow approval for creator of the document,Permet l&#39;aprovació del creador del document
+DocType: Workflow,Allow approval for creator of the document,Permet l'aprovació del creador del document
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Save Report,Desa l’informe
 DocType: Webhook,on_cancel,on_cancelar
 DocType: Social Login Key,API Endpoint Args,API Endpoint Args
-apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,Administrador accedeix {0} el {1} a través de l&#39;adreça IP {2}.
+apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,Administrador accedeix {0} el {1} a través de l'adreça IP {2}.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid fieldname,El camp pare ha de ser un nom de camp vàlid
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,No s&#39;ha pogut modificar la subscripció
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,No s'ha pogut modificar la subscripció
 DocType: LDAP Settings,LDAP Group Field,Camp del grup LDAP
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Equival
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType'
 DocType: About Us Settings,Team Members Heading,Team Members Heading
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Format CSV no vàlid
-apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","S&#39;ha produït un error en connectar-se a l&#39;aplicació de safata QZ ... <br><br> Heu de tenir instal·lada i en funcionament l’aplicació QZ Tray per utilitzar la funció d’impressió en brut. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Feu clic aquí per descarregar i instal·lar QZ Safata</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Feu clic aquí per obtenir més informació sobre la impressió en brut</a> ."
+apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","S'ha produït un error en connectar-se a l'aplicació de safata QZ ... <br><br> Heu de tenir instal·lada i en funcionament l’aplicació QZ Tray per utilitzar la funció d’impressió en brut. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Feu clic aquí per descarregar i instal·lar QZ Safata</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Feu clic aquí per obtenir més informació sobre la impressió en brut</a> ."
 apps/frappe/frappe/desk/page/backups/backups.js,Set Number of Backups,Establir el nombre de còpies de seguretat
 DocType: DocField,Do not allow user to change after set the first time,No permetre que l'usuari pugui canviar després d'establir la primera vegada
 apps/frappe/frappe/utils/data.py,1 year ago,fa 1 any
-apps/frappe/frappe/config/users_and_permissions.py,"View Log of all print, download and export events","Visualitza el registre de tots els esdeveniments d&#39;impressió, descàrrega i exportació"
+apps/frappe/frappe/config/users_and_permissions.py,"View Log of all print, download and export events","Visualitza el registre de tots els esdeveniments d'impressió, descàrrega i exportació"
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 month,1 mes
 DocType: Contact,Contact,Contacte
 DocType: User,Third Party Authentication,Third Party Authentication
@@ -3598,8 +3598,8 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Export Report:
 DocType: Data Migration Run,Push Update,Push Update
 DocType: Email Account,Port,Port
 DocType: Print Format,Arial,Arial
-apps/frappe/frappe/auth.py,Incomplete login details,Dades d&#39;inici de sessió incompletes
-apps/frappe/frappe/config/core.py,Models (building blocks) of the Application,Models (blocs de construcció) de l&#39;Aplicació
+apps/frappe/frappe/auth.py,Incomplete login details,Dades d'inici de sessió incompletes
+apps/frappe/frappe/config/core.py,Models (building blocks) of the Application,Models (blocs de construcció) de l'Aplicació
 DocType: Website Slideshow,Slideshow like display for the website,Presentació com a pantalla per al lloc web
 apps/frappe/frappe/config/settings.py,Setup Notifications based on various criteria.,Configurar notificacions basades en diversos criteris.
 DocType: Comment,Updated,Actualitzat
@@ -3618,32 +3618,32 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.js,This docu
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive Backup Successful.,Execució de còpia de seguretat de Google Drive
 DocType: Workflow,DocType on which this Workflow is applicable.,DOCTYPE en què el present del flux de treball és aplicable.
 DocType: User,Enabled,Activat
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,No s&#39;ha pogut completar la configuració
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,No s'ha pogut completar la configuració
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,New {0}: {1},Nou {0}: {1}
 DocType: Tag Category,Category Name,Nom de categoria
 apps/frappe/frappe/model/db_query.py,Parent is required to get child table data,Els pares han d’obtenir dades de la taula infantil
-apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Subscribers,Els subscriptors d&#39;importació
+apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Subscribers,Els subscriptors d'importació
 DocType: Print Settings,PDF Settings,Configuració de PDF
 DocType: Kanban Board Column,Column Name,Nom de la columna
 DocType: Language,Based On,Basat en
 DocType: Email Account,"For more information, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">click here</a>.","Per a més informació, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">feu clic aquí</a> ."
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Number of columns does not match with data,El nombre de columnes no coincideix amb les dades
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Make Default,Estableix com a predeterminat
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Execution Time: {0} sec,Temps d&#39;execució: {0} seg
-apps/frappe/frappe/model/utils/__init__.py,Invalid include path,El camí d&#39;accés no és vàlid
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Execution Time: {0} sec,Temps d'execució: {0} seg
+apps/frappe/frappe/model/utils/__init__.py,Invalid include path,El camí d'accés no és vàlid
 DocType: Communication,Email Account,Compte de correu electrònic
 DocType: Workflow State,Download,Descarregar
 DocType: Blog Post,Blog Intro,Bloc Intro
 DocType: Async Task,Result,Resultat
 DocType: Webhook,on_update_after_submit,on_update_after_submit
-DocType: System Settings,Allow Login using User Name,Permet l&#39;inici de sessió mitjançant el nom d&#39;usuari
+DocType: System Settings,Allow Login using User Name,Permet l'inici de sessió mitjançant el nom d'usuari
 apps/frappe/frappe/core/doctype/report/report.js,Enable Report,Habilita Reportar
 DocType: DocField,Display Depends On,display depèn
 DocType: Social Login Key,API Endpoint,Endpoint API
 DocType: Web Page,Insert Code,Insereix Codi
-DocType: Data Migration Run,Current Mapping Type,Tipus d&#39;assignació actual
+DocType: Data Migration Run,Current Mapping Type,Tipus d'assignació actual
 DocType: ToDo,Low,Sota
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,Pot afegir propietats dinàmiques del document mitjançant l&#39;ús de plantilles Jinja.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,Pot afegir propietats dinàmiques del document mitjançant l'ús de plantilles Jinja.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,List a document type,Llista un tipus de document
 DocType: Web Page,"Header, Breadcrumbs and Meta Tags","Capçalera, panellets i etiquetes meta"
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"browse,","navegar,"
@@ -3672,7 +3672,7 @@ DocType: Web Form,Amount,Quantitat
 DocType: Workflow Transition,Allowed,Mascotes
 DocType: Dashboard Chart,Chart Source,Font del gràfic
 apps/frappe/frappe/core/doctype/doctype/doctype.py,There can be only one Fold in a form,Només hi pot haver un plec en el formulari
-apps/frappe/frappe/core/doctype/file/file.py,Unable to write file format for {0},No es pot escriure el format d&#39;arxiu per a {0}
+apps/frappe/frappe/core/doctype/file/file.py,Unable to write file format for {0},No es pot escriure el format d'arxiu per a {0}
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py,No records present in {0},No hi ha registres presents a {0}
 apps/frappe/frappe/website/doctype/portal_settings/portal_settings.js,Restore to default settings?,Restaurar a la configuració per defecte?
 apps/frappe/frappe/website/doctype/website_settings/website_settings.py,Invalid Home Page,Home Page no vàlida
@@ -3689,12 +3689,12 @@ apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please select D
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Confirm Your Email,Confirma teu email
 apps/frappe/frappe/www/login.html,Or login with,O ingressar amb
 DocType: Error Snapshot,Locals,Els locals
-apps/frappe/frappe/desk/page/activity/activity_row.html,Communicated via {0} on {1}: {2},Comunicada a través d&#39;{0} el {1}: {2}
-apps/frappe/frappe/core/doctype/comment/comment.py,{0} mentioned you in a comment in {1},{0} t&#39;ha mencionat en un comentari en {1}
+apps/frappe/frappe/desk/page/activity/activity_row.html,Communicated via {0} on {1}: {2},Comunicada a través d'{0} el {1}: {2}
+apps/frappe/frappe/core/doctype/comment/comment.py,{0} mentioned you in a comment in {1},{0} t'ha mencionat en un comentari en {1}
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.html,Select Group By...,Selecciona un grup per ...
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,e.g. (55 + 434) / 4 or =Math.sin(Math.PI/2)...,per exemple (55 + 434) / 4 o = Math.sin (Math.PI / 2) ...
 apps/frappe/frappe/utils/csvutils.py,{0} is required,{0} és necessari
-DocType: Integration Request,Integration Type,Tipus d&#39;Integració
+DocType: Integration Request,Integration Type,Tipus d'Integració
 DocType: Newsletter,Send Attachements,Enviar Attachements
 apps/frappe/frappe/config/integrations.py,Google Contacts Integration.,Integració de contactes de Google.
 DocType: Transaction Log,Transaction Log,Registre de transaccions
@@ -3705,24 +3705,24 @@ DocType: DocField,Perm Level,Perm Level
 apps/frappe/frappe/www/confirm_workflow_action.html,View document,Visualitza el document
 apps/frappe/frappe/desk/doctype/event/event.py,Events In Today's Calendar,Esdeveniments A l'Agenda d'avui
 DocType: Web Page,Web Page,Pàgina Web
-DocType: Workflow Document State,Next Action Email Template,Plantilla de correu electrònic d&#39;acció següent
+DocType: Workflow Document State,Next Action Email Template,Plantilla de correu electrònic d'acció següent
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Si està activat, es fa un seguiment dels canvis al document i es mostren a la línia de temps"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;A la recerca global&#39; no permès per al tipus {0} a la fila {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'A la recerca global' no permès per al tipus {0} a la fila {1}
 DocType: Energy Point Log,Appreciation,Apreciació
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,veure Llista
-DocType: Workflow,Don't Override Status,No correcció d&#39;estat
+DocType: Workflow,Don't Override Status,No correcció d'estat
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Search term,El terme de cerca
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The First User: You,La Primera Usuari:
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Newsletter should have atleast one recipient,El butlletí hauria de tenir com a mínim un destinatari
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Upload {0} files,Carregueu {0} fitxers
 DocType: Deleted Document,GCalendar Sync ID,Identificador de sincronització GCalendar
-DocType: Prepared Report,Report Start Time,Hora d&#39;inici de l&#39;informe
+DocType: Prepared Report,Report Start Time,Hora d'inici de l'informe
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Data,Exportar dades
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select Columns,Seleccionar columnes
 DocType: Translation,Source Text,font del text
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,This is a background report. Please set the appropriate filters and then generate a new one.,Aquest és un informe de fons. Configureu els filtres adequats i en genereu un de nou.
-apps/frappe/frappe/www/login.py,Missing parameters for login,Paràmetres que falten per a l&#39;inici de sessió
+apps/frappe/frappe/www/login.py,Missing parameters for login,Paràmetres que falten per a l'inici de sessió
 DocType: Workflow State,folder-open,-Carpeta oberta
 DocType: DocType,"Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended.","Un cop enviats, els documents enviables no es poden canviar. Només es poden cancel·lar i modificar."
 DocType: OAuth Authorization Code,Validity,Validesa
@@ -3731,18 +3731,18 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Reports,Informes
 DocType: Page,No,No
 DocType: Property Setter,Set Value,Valor seleccionat
 DocType: Webhook,Webhook Data,Dades de Webhook
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Creating {0},S&#39;està creant {0}
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Creating {0},S'està creant {0}
 DocType: Report,Disable Prepared Report,Desactiva l’informe preparat
-apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,L&#39;usuari {0} ha sol·licitat la supressió de dades
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,Il · legal testimoni d&#39;accés. Siusplau torna-ho a provar
-apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","L&#39;aplicació s&#39;ha actualitzat a una nova versió, si us plau, tornar a carregar aquesta pàgina"
+apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,L'usuari {0} ha sol·licitat la supressió de dades
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,Il · legal testimoni d'accés. Siusplau torna-ho a provar
+apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","L'aplicació s'ha actualitzat a una nova versió, si us plau, tornar a carregar aquesta pàgina"
 DocType: Notification,Optional: The alert will be sent if this expression is true,Opcional: L'alerta s'enviat si aquesta expressió és veritable
 DocType: Data Migration Plan,Plan Name,Nom del pla
 DocType: Print Settings,Print with letterhead,Imprimir de carta
 apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,Attach a web link,Adjunteu un enllaç web
 DocType: Unhandled Email,Raw Email,E-mail prima
-apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select records for assignment,Seleccioneu els registres per a l&#39;assignació
-apps/frappe/frappe/www/printview.py,{0} is not a raw printing format.,{0} no és un format d&#39;impressió en brut.
+apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select records for assignment,Seleccioneu els registres per a l'assignació
+apps/frappe/frappe/www/printview.py,{0} is not a raw printing format.,{0} no és un format d'impressió en brut.
 DocType: ToDo,Assigned By,assignat per
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,You can use Customize Form to set levels on fields.,Podeu utilitzar Personalitzar Formulari per establir els nivells dels camps.
 DocType: Dashboard Chart Source,Timeseries,Sèries temporals
@@ -3760,10 +3760,10 @@ apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be renamed,L'usuari
 apps/frappe/frappe/database/schema.py,Fieldname is limited to 64 characters ({0}),Nom de camp està limitat a 64 caràcters ({0})
 apps/frappe/frappe/public/js/frappe/form/grid_row.js,Cannot move row,No es pot moure la fila
 apps/frappe/frappe/config/desk.py,Email Group List,Llista de grups de correu electrònic
-DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],Un arxiu d&#39;icona amb ico extensió. En cas de ser de 16 x 16 píxels. Generat usant un generador de favicon. [favicon-generator.org]
+DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],Un arxiu d'icona amb ico extensió. En cas de ser de 16 x 16 píxels. Generat usant un generador de favicon. [favicon-generator.org]
 DocType: Auto Email Report,Format,format
 DocType: Email Account,Email Addresses,Adreces de correu electrònic
-DocType: Web Form,Allow saving if mandatory fields are not filled,Permetre l&#39;estalvi si els camps obligatoris no s&#39;omplen
+DocType: Web Form,Allow saving if mandatory fields are not filled,Permetre l'estalvi si els camps obligatoris no s'omplen
 DocType: S3 Backup Settings,us-west-2,nosaltres-oest-2
 apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Select Child Table,Seleccioneu Taula infantil
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Trigger Primary Action,Trigger Action primari
@@ -3771,9 +3771,9 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Change,Canv
 DocType: Email Domain,domain name,nom de domini
 DocType: Contact Email,Contact Email,Correu electrònic de contacte
 DocType: Kanban Board Column,Order,ordre
-apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No results found for {0} in Global Search,No s&#39;han trobat resultats per a {0} a la cerca global
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No results found for {0} in Global Search,No s'han trobat resultats per a {0} a la cerca global
 DocType: Report,Ref DocType,Ref DocType
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client ID before social login is enabled,Introduïu l&#39;identificador de client abans que l&#39;inici de sessió social estigui habilitat
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client ID before social login is enabled,Introduïu l'identificador de client abans que l'inici de sessió social estigui habilitat
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Amend without Cancel,{0}: No es pot establir a Corregir sense Cancel·lar abans
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Full Page,Pàgina plena
 DocType: DocType,Is Child Table,És Taula fill
@@ -3792,7 +3792,7 @@ apps/frappe/frappe/email/doctype/notification/notification.js,No alerts for toda
 DocType: Print Settings,Send Email Print Attachments as PDF (Recommended),Enviar els arxius adjunts deels correus electrònics com a PDF (Recomanat)
 DocType: Web Page,Left,Esquerra
 DocType: Event,All Day,Tot el dia
-apps/frappe/frappe/integrations/utils.py,Looks like something is wrong with this site's payment gateway configuration. No payment has been made.,Sembla que alguna cosa està malament amb la configuració de la passarel·la de pagament d&#39;aquest lloc. No s&#39;ha realitzat el pagament.
+apps/frappe/frappe/integrations/utils.py,Looks like something is wrong with this site's payment gateway configuration. No payment has been made.,Sembla que alguna cosa està malament amb la configuració de la passarel·la de pagament d'aquest lloc. No s'ha realitzat el pagament.
 DocType: GCalendar Settings,State,Estat
 DocType: Workflow Action,Workflow Action,Acció de flux de treball
 apps/frappe/frappe/utils/bot.py,I found these: ,He trobat els següents:
@@ -3804,14 +3804,14 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} rever
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Check Request URL,Sol·licitar URL de sol·licitud
 apps/frappe/frappe/client.py,Only 200 inserts allowed in one request,Només 200 insercions permesos en una petició
 DocType: Footer Item,URL,URL
-apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,Torneu a la pantalla de verificació i introduïu el codi que mostra l&#39;aplicació d&#39;autenticació
+apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,Torneu a la pantalla de verificació i introduïu el codi que mostra l'aplicació d'autenticació
 DocType: ToDo,Reference Type,Tipus de referència
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Please enable developer mode to create new connection,Activa el mode desenvolupador per crear una nova connexió
 DocType: Event,Repeat On,Repeat On
 DocType: SMS Parameter,SMS Parameter,Paràmetre SMS
 DocType: Auto Email Report,Half Yearly,Semestrals
 DocType: Communication,Marked As Spam,Marcat com a correu brossa
-apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},Hi ha una mica de problema amb la url de l&#39;arxiu: {0}
+apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},Hi ha una mica de problema amb la url de l'arxiu: {0}
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Tree,arbre
 apps/frappe/frappe/public/js/frappe/views/treeview.js,You are not allowed to print this report,No està autoritzat a imprimir aquest informe
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions,Permisos d'usuari
@@ -3825,18 +3825,18 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,text in document t
 apps/frappe/frappe/core/doctype/test_runner/test_runner.js,Run Tests,executar proves
 apps/frappe/frappe/handler.py,Logged Out,tancat la sessió
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,More...,Més ...
-DocType: System Settings,User can login using Email id or Mobile number,L&#39;usuari pot iniciar la sessió utilitzant correu electrònic d&#39;identificació o número de mòbil
+DocType: System Settings,User can login using Email id or Mobile number,L'usuari pot iniciar la sessió utilitzant correu electrònic d'identificació o número de mòbil
 DocType: Bulk Update,Update Value,Actualització Valor
 apps/frappe/frappe/core/doctype/communication/communication.js,Mark as {0},Marcar com {0}
 apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,"Si us plau, seleccioni un nou nom per canviar el nom"
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Invalid column,Columna no vàlida
 DocType: Data Migration Connector,Data Migration,Migració de dades
-DocType: User,API Key cannot be  regenerated,No es pot regenerar la clau de l&#39;API
+DocType: User,API Key cannot be  regenerated,No es pot regenerar la clau de l'API
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Something went wrong,Alguna cosa ha anat malament
 DocType: System Settings,Number Format,Format de nombre
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record.,Registre {0} amb èxit.
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Summary,Resum
-DocType: Event,Event Participants,Participants de l&#39;esdeveniment
+DocType: Event,Event Participants,Participants de l'esdeveniment
 DocType: Auto Repeat,Frequency,Freqüència
 DocType: Custom Field,Insert After,Inserir després
 DocType: Event,Sync with Google Calendar,Sincronització amb Google Calendar
@@ -3848,15 +3848,15 @@ apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,Assign 
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Section Heading,Capçalera de secció
 DocType: Website Settings,Title Prefix,Títol Prefix
 DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,Notificacions i electrònics massius seran enviats des d'aquest servidor sortint.
-DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,Es poden utilitzar qualsevol llenguatge d&#39;impressora basat en cadenes. Escriure ordres en brut requereix el coneixement del llenguatge propi de la impressora proporcionat pel fabricant de la impressora. Consulteu el manual per a desenvolupadors proporcionat pel fabricant de la impressora sobre com escriure les seves ordres natives. Aquestes ordres es presenten al servidor mitjançant l&#39;idioma de plantilla de Jinja.
+DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,Es poden utilitzar qualsevol llenguatge d'impressora basat en cadenes. Escriure ordres en brut requereix el coneixement del llenguatge propi de la impressora proporcionat pel fabricant de la impressora. Consulteu el manual per a desenvolupadors proporcionat pel fabricant de la impressora sobre com escriure les seves ordres natives. Aquestes ordres es presenten al servidor mitjançant l'idioma de plantilla de Jinja.
 DocType: Workflow State,cog,cog
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Sync on Migrate,Sincronització en Migrar
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently Viewing,Visualitzant
 DocType: DocField,Default,Defecte
 DocType: Translation,Verified,Verificat
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} afegits
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cerca &#39;{0}&#39;
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Si us plau, guardi l&#39;informe primer"
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cerca '{0}'
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Si us plau, guardi l'informe primer"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonats afegir
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,No En
 DocType: Workflow State,star,estrella
@@ -3883,7 +3883,7 @@ apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,This Kanban Boar
 apps/frappe/frappe/desk/moduleview.py,Standard Reports,Informes estàndard
 DocType: Dashboard Chart Link,Dashboard Chart Link,Enllaç del quadre de tauler
 DocType: User,Email Settings,Configuració del correu electrònic
-apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop Here,Deixa&#39;t aquí
+apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop Here,Deixa't aquí
 DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Si està activat, l’usuari es pot iniciar la sessió des de qualsevol adreça IP mitjançant Autofacturació de dos factors, també es pot configurar per a tots els usuaris a la configuració del sistema"
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Printer Settings...,Configuració de la impressora ...
 apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Introduïu la contrasenya per continuar
@@ -3891,24 +3891,24 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Jo
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} no és un Estat vàlida
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Sol·liciteu tots els tipus de documents
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Actualització del punt d’energia
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Si us plau seleccioneu un altre mètode de pagament. PayPal no admet transaccions en moneda &#39;{0}&#39;
-DocType: Chat Message,Room Type,Tipus d&#39;habitació
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Si us plau seleccioneu un altre mètode de pagament. PayPal no admet transaccions en moneda '{0}'
+DocType: Chat Message,Room Type,Tipus d'habitació
 DocType: Data Import Beta,Import Log Preview,Importa la vista prèvia del registre
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,camp de cerca {0} no és vàlid
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,fitxer penjat
 DocType: Workflow State,ok-circle,ok-circle
 DocType: LDAP Settings,LDAP User Creation and Mapping,Creació i mapeig d’usuaris LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Es poden trobar coses preguntant &quot;trobar taronja en els clients &#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Es poden trobar coses preguntant &quot;trobar taronja en els clients '
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Ho sento! L'usuari ha de tenir accés complet al seu propi rècord.
-,Usage Info,Informació d&#39;ús
+,Usage Info,Informació d'ús
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Mostra les dreceres de teclat
 apps/frappe/frappe/utils/oauth.py,Invalid Token,token invàlid
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not upload backup - Error {0},Google Drive: no s&#39;ha pogut carregar una còpia de seguretat: error {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not upload backup - Error {0},Google Drive: no s'ha pogut carregar una còpia de seguretat: error {0}
 DocType: Email Account,Email Server,Servidor de correu electrònic
 DocType: Assignment Rule,Document Type,Tipus de document
 DocType: Address,Tax Category,Categoria Tributària
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Label is mandatory,Etiqueta obligatòria
-DocType: PayPal Settings,API Username,Nom d&#39;usuari API
+DocType: PayPal Settings,API Username,Nom d'usuari API
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Half Day,Medi Dia
 DocType: Communication,Communication Type,Tipus de comunicació
 DocType: DocField,Unique,Únic
@@ -3929,7 +3929,7 @@ DocType: GCalendar Settings,Enable,Permetre
 DocType: Google Maps Settings,Home Address,Adreça de casa
 apps/frappe/frappe/core/doctype/data_export/exporter.py,You can only upload upto 5000 records in one go. (may be less in some cases),Només es pot carregar fins a 5.000 registres d'una sola vegada. (Pot ser inferior en alguns casos)
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Applicable Document Types,Tipus de document aplicable
-apps/frappe/frappe/config/settings.py,Set up rules for user assignments.,Configura les regles per a les assignacions d&#39;usuaris.
+apps/frappe/frappe/config/settings.py,Set up rules for user assignments.,Configura les regles per a les assignacions d'usuaris.
 apps/frappe/frappe/model/document.py,Insufficient Permission for {0},De permís suficient per a {0}
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Report was not saved (there were errors),L'Informe no s'ha guardat (hi ha errors)
 apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,No es pot canviar el contingut de la capçalera
@@ -3943,7 +3943,7 @@ DocType: Communication,To and CC,Per i CC
 DocType: SMS Settings,Static Parameters,Paràmetres estàtics
 DocType: Chat Message,Room,habitació
 apps/frappe/frappe/public/js/frappe/change_log.html,updated to {0},actualitzat a {0}
-apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,Les tasques de fons no s’estan executant. Contacteu amb l&#39;administrador
+apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,Les tasques de fons no s’estan executant. Contacteu amb l'administrador
 DocType: Portal Settings,Custom Menu Items,Elements de menú personalitzat
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,Totes les imatges adjunts a Slideshow del lloc web han de ser públics
 DocType: Workflow State,chevron-right,Chevron-dreta
@@ -3960,15 +3960,15 @@ DocType: DocType,Allow Auto Repeat,Permet la repetició automàtica
 apps/frappe/frappe/public/js/frappe/form/controls/multiselect_list.js,No values to show,No hi ha valors a mostrar
 DocType: Desktop Icon,_doctype,_doctype
 DocType: Communication,Email Template,Plantilla de correu electrònic
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record.,S&#39;ha actualitzat correctament el registre de {0}.
-apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},L&#39;usuari {0} no té accés doctype mitjançant permís de rol per al document {1}
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record.,S'ha actualitzat correctament el registre de {0}.
+apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},L'usuari {0} no té accés doctype mitjançant permís de rol per al document {1}
 apps/frappe/frappe/templates/includes/login/login.js,Both login and password required,Es requereix usuari i contrassenya
 apps/frappe/frappe/model/document.py,Please refresh to get the latest document.,"Si us plau, actualitza per obtenir l'últim document."
 DocType: User,Security Settings,Configuració de seguretat
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Add Column,Afegir columna
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Select Filters,Seleccioneu Filtres
 ,Desktop,Escriptori
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export Report: {0},Informe d&#39;exportació: {0}
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export Report: {0},Informe d'exportació: {0}
 DocType: Auto Email Report,Filter Meta,filtre Meta
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please find attached {0}: {1},Trobeu el fitxer adjunt {0}: {1}
 DocType: Web Page,Set Meta Tags,Estableix les etiquetes meta
@@ -3980,10 +3980,10 @@ DocType: Patch Log,Patch,Pedàs
 DocType: Activity Log,Failed,Fracassat
 DocType: Web Form,Allow Comments,Permetre comentaris
 DocType: Dashboard Chart,Last Week,La setmana passada
-DocType: System Settings,Bypass Two Factor Auth for users who login from restricted IP Address,Anul·lar dos autors de factors per als usuaris que inicien la sessió des de l&#39;adreça IP restringida
+DocType: System Settings,Bypass Two Factor Auth for users who login from restricted IP Address,Anul·lar dos autors de factors per als usuaris que inicien la sessió des de l'adreça IP restringida
 DocType: Event,Google Calendar,Google Calendar
-apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,{0} per deixar de rebre correus electrònics d&#39;aquest tipus
-apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Obriu l&#39;aplicació d&#39;autenticació al vostre telèfon mòbil.
+apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,{0} per deixar de rebre correus electrònics d'aquest tipus
+apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Obriu l'aplicació d'autenticació al vostre telèfon mòbil.
 apps/frappe/frappe/model/rename_doc.py,merged {0} into {1},fusionat {0} a {1}
 DocType: System Settings,mm-dd-yyyy,mm-dd-aaaa
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.js,New Connection,Nova connexió
@@ -3999,9 +3999,9 @@ DocType: Dropbox Settings,Send Notifications To,Enviar notificacions a
 DocType: Bulk Update,Max 500 records at a time,Màxim 500 registres alhora
 DocType: Translation,"If your data is in HTML, please copy paste the exact HTML code with the tags.","Si les dades estan en format HTML, si us plau copiar i enganxar el codi HTML exacta amb les etiquetes."
 DocType: Communication,Meeting,Reunió
-apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,No es pot obrir l&#39;arxiu adjunt. Ha exportat com CSV?
+apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,No es pot obrir l'arxiu adjunt. Ha exportat com CSV?
 DocType: DocField,Ignore User Permissions,Ignora els permisos d'usuari
-apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Saved Successfully,S&#39;ha desat correctament
+apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Saved Successfully,S'ha desat correctament
 apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,"Si us plau, consulti al seu administrador per verificar la seva inscripció"
 DocType: Domain Settings,Active Domains,Els dominis actius
 apps/frappe/frappe/public/js/integrations/razorpay.js,Show Log,Mostra registre

--- a/frappe/translations/ca.csv
+++ b/frappe/translations/ca.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,La còpia d
 DocType: DocField,In Global Search,En Recerca Global
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,guió-esquerra
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; Fa {0} any
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> Fa {0} any
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"És arriscat eliminar aquesta imatge: {0}. Si us plau, poseu-vos en contacte amb l&#39;administrador del sistema."
 DocType: Currency,Currency Name,Nom moneda
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No hi ha missatges de correu electrònic
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} no trobat
 apps/frappe/frappe/config/customization.py,Add custom forms.,Afegir formularis personalitzats.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} {2} en
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,presentat aquest document
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Configuració&gt; Permisos d&#39;usuari
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configuració> Permisos d&#39;usuari
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,El sistema ofereix moltes funcions predefinides. Podeu afegir noves funcions per establir permisos més fins.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Si l&#39;usuari té cap paper marcat, llavors l&#39;usuari es converteix en un &quot;usuari del sistema&quot;. &quot;Usuari del sistema&quot; té accés a l&#39;escriptori"
 DocType: System Settings,Date and Number Format,Format de Data i nombres
 apps/frappe/frappe/model/document.py,one of,un
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Configuració&gt; Formulari personalitzat
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Configuració> Formulari personalitzat
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Comprovació d&#39;un moment
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Mostrar Etiquetes
 DocType: DocField,HTML Editor,Editor HTML
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Facturació
 DocType: Email Queue,Not Sent,No Enviat
 DocType: Web Form,Actions,Accions
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Configuració&gt; Usuari
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Configuració> Usuari
 DocType: Workflow State,align-justify,align-justify
 DocType: User,Middle Name (Optional),Cognom 1
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,No permès
@@ -1410,7 +1410,7 @@ DocType: User,System User,Usuari de Sistema
 DocType: Report,Is Standard,És Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Complet
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","No etiquetes HTML Codificar HTML, com &lt;script&gt; o simplement caràcters com &lt;o&gt;, ja que podrien ser utilitzats intencionadament en aquest camp"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","No etiquetes HTML Codificar HTML, com &lt;script> o simplement caràcters com &lt;o>, ja que podrien ser utilitzats intencionadament en aquest camp"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticat a {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Correr
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,El peu de pàgina
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pendent
 DocType: System Settings,Allow only one session per user,Permetre només una sessió per usuari
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Carpeta Inici / Test 1 / Carpeta Prova 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; de HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> de HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Seleccioneu o arrossegament a través de caselles de temps per crear un nou esdeveniment.
 DocType: Contact,Contact Details,Detalls de contacte
 DocType: DocField,In Filter,En Filter
@@ -2022,7 +2022,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Login no permès en aquest moment
 DocType: Data Migration Run,Current Mapping Action,Acció de cartografia actual
 DocType: Dashboard Chart Source,Source Name,font Nom
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,No hi ha cap compte de correu electrònic associat a l’Usuari. Afegeix un compte a Usuari&gt; Bústia de correu electrònic.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,No hi ha cap compte de correu electrònic associat a l’Usuari. Afegeix un compte a Usuari> Bústia de correu electrònic.
 DocType: Email Account,Email Sync Option,Sincronitzar correu Opció
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Fila núm
 DocType: Async Task,Runtime,Temps d&#39;execució
@@ -2037,7 +2037,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Ja està 
 DocType: User Email,Enable Outgoing,Habilita sortint
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Les etiquetes personalitzades
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Compte de correu electrònic no configurat. Creeu un nou compte de correu electrònic des de Configuració&gt; Correu electrònic&gt; Compte de correu electrònic
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Compte de correu electrònic no configurat. Creeu un nou compte de correu electrònic des de Configuració> Correu electrònic> Compte de correu electrònic
 DocType: Comment,Submitted,Enviat
 DocType: Contact,Pulled from Google Contacts,Tirat de Google Contactes
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Petició invàlida
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Caducitat de la ses
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",apareixerà aquest camp només si el nom del camp definit aquí té valor o les regles són veritables (exemples): eval myfield: doc.myfield == &#39;La meva Valor&#39; eval: doc.age&gt; 18
+eval:doc.age>18",apareixerà aquest camp només si el nom del camp definit aquí té valor o les regles són veritables (exemples): eval myfield: doc.myfield == &#39;La meva Valor&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,avui
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Un cop establert, els usuaris només tindran accés als documents (per exemple. Blog) on hi hagil'enllaç (per exemple. Blogger)."
@@ -2123,7 +2123,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,MAJÚSCULES
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML personalitzat
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Introduïu carpeta de nom
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,No s&#39;ha trobat cap plantilla d&#39;adreces per defecte. Creeu-ne un de nou a Configuració&gt; Impressió i marca&gt; Plantilla d&#39;adreces.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,No s&#39;ha trobat cap plantilla d&#39;adreces per defecte. Creeu-ne un de nou a Configuració> Impressió i marca> Plantilla d&#39;adreces.
 apps/frappe/frappe/auth.py,Unknown User,Usuari desconegut
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Seleccioneu Rol
 DocType: Comment,Deleted,Suprimit
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Certificat de ruta al servidor
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,No hi ha prou permís per veure enllaços
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Títol d'adreça obligatori.
 DocType: Google Contacts,Push to Google Contacts,Empenteu a Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML afegit a la secció &lt;head&gt; de la pàgina web, s&#39;utilitza sobretot per a la verificació del web i SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML afegit a la secció &lt;head> de la pàgina web, s&#39;utilitza sobretot per a la verificació del web i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recaiguda
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,L'article no es pot afegir als seus propis descendents
 DocType: Session Default Settings,Session Defaults,Defectes predeterminats de la sessió
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Advertència
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Es pot imprimir en diverses pàgines
 DocType: Data Migration Run,Percent Complete,Percentatge complet
 DocType: Tag Category,Tag Category,tag Categoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per a la comparació, utilitzeu&gt; 5, &lt;10 o = 324. Per a intervals, utilitzeu 5:10 (per a valors entre 5 i 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per a la comparació, utilitzeu> 5, &lt;10 o = 324. Per a intervals, utilitzeu 5:10 (per a valors entre 5 i 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tira de Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ajuda
 DocType: User,Login Before,Identifica't abans
@@ -2893,7 +2893,7 @@ DocType: Custom Script,Custom Script,Custom Script
 DocType: Address,Address Line 2,Adreça Línia 2
 DocType: Address,Reference,referència
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Assignat a
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Configureu el compte de correu electrònic per defecte des de Configuració&gt; Correu electrònic&gt; Compte de correu electrònic
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Configureu el compte de correu electrònic per defecte des de Configuració> Correu electrònic> Compte de correu electrònic
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detall de cartografia de la migració de dades
 DocType: Data Import,Action,Acció
 DocType: GSuite Settings,Script URL,URL del guió
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Permetre al presentar
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipus d&#39;excepció
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Esculli Columnes
-DocType: Web Page,Add code as &lt;script&gt;,Add code as &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Add code as &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Esborra els permisos de l’usuari
 DocType: Webhook,Headers,Encapçalaments
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Pròxims esdeveniments
@@ -3445,15 +3445,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Cua ha de ser una de {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Per defecte la plantilla </ h4> 
  <p> <a Usos href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> i tots els camps de la Direcció ( incloent camps personalitzats en el seu cas) estarà disponible </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/cs.csv
+++ b/frappe/translations/cs.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistiky založené na minulém týdnu (od {0} do {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP telefonní pole
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","typ dokumentu ..., např zákazník"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Stavem &#39;{0}&#39; je neplatná
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Stavem '{0}' je neplatná
 DocType: Workflow State,barcode,Barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Použití pod-dotazu nebo funkce je omezeno
 apps/frappe/frappe/config/customization.py,Add your own translations,Přidejte svůj vlastní překlady
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Jméno měny
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,žádné e-maily
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link vypršel
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Vrácení délky na {0} pro &#39;{1}&#39; v &#39;{2}&#39;; Nastavení délky jako {3} způsobí zkrácení dat.
+							Setting the length as {3} will cause truncation of data.",Vrácení délky na {0} pro '{1}' v '{2}'; Nastavení délky jako {3} způsobí zkrácení dat.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Vyberte formát souboru
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Otisk obsahu (hash)
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokument Share Report
 DocType: Social Login Key,Base URL,Základní URL
 DocType: User,Last Login,Poslední přihlášení
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Pro políčko {0} nelze nastavit hodnotu &#39;Translatable&#39;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Pro políčko {0} nelze nastavit hodnotu 'Translatable'
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Sloupec
 DocType: Chat Profile,Chat Profile,Profil rozhovoru
 DocType: Custom Field,Adds a custom field to a DocType,Přidá přizpůsobené pole do DocType
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Je Domovská složka
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Styl navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} není platná e-mailová adresa
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Zvolte aspoň 1 záznamů pro tisk
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Uživatel &#39;{0}&#39; již má za úkol &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Uživatel '{0}' již má za úkol '{1}'
 DocType: System Settings,Two Factor Authentication method,Metoda ověřování dvěma faktory
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Nejprve nastavte název a uložte záznam.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 záznamů
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Povinné pole: nastaven role
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritizoval {1}
 DocType: Data Migration Mapping,Mapping Name,Mapování názvu
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Pole &#39;{1}&#39; nelze nastavit jako jedinečné, protože má nejedinečné hodnoty"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Pole '{1}' nelze nastavit jako jedinečné, protože má nejedinečné hodnoty"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Přejděte seznam dolů
 DocType: Currency,A symbol for this currency. For e.g. $,"Symbol této měny,  např. $"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Úspěšně aktualizované překlady
@@ -2005,7 +2005,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Písmo Google
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Pakliže tyto instrukce nebyly nápomocné, prosím přidejte Vaše doporučení na GitHub Issues."
 DocType: Workflow State,bookmark,záložka
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Název složky by neměl obsahovat &#39;/&#39; (lomítko)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Název složky by neměl obsahovat '/' (lomítko)
 DocType: Note,Note,Poznámka
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Error Report
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Exportovat data ve formátu CSV / Excel.
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Vypršení platnosti
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Toto pole se objeví pouze v případě, že fieldname zde definovány má hodnotu OR pravidla jsou pravými (příklady): myfield eval: doc.myfield == &quot;Můj Value &#39;eval: doc.age> 18"
+eval:doc.age>18","Toto pole se objeví pouze v případě, že fieldname zde definovány má hodnotu OR pravidla jsou pravými (příklady): myfield eval: doc.myfield == &quot;Můj Value 'eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Dnes
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Pakliže toto nastavíte, uživatelé budou moci přistoupit pouze na dokumenty (např.: příspěvky blogu), kam existují odkazy (např.: blogger)."
@@ -2148,7 +2148,7 @@ DocType: Data Migration Connector,Database Name,Název databáze
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Obnovit formulář
 DocType: DocField,Select,Vybrat
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Zobrazit celý protokol
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednoduchý výraz Python, příklad: status == &#39;Open&#39; a napište == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednoduchý výraz Python, příklad: status == 'Open' a napište == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Soubor není příložen
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Spojení ztraceno. Některé funkce nemusí fungovat.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Opakuje typu &quot;AAA&quot;, lze snadno uhodnout"
@@ -2701,7 +2701,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Kterým se mění
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal nastavení platební brána
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Nejlépe účinkující
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Vlastní pole nelze přidat k základním typům DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) dostane zkrácen, protože max povolené znaky je {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) dostane zkrácen, protože max povolené znaky je {2}"
 DocType: OAuth Client,Response Type,Typ Response
 DocType: Contact Us Settings,Send enquiries to this email address,Odeslat dotazy na tuto emailovou adresu
 DocType: Letter Head,Letter Head Name,Název hlavičkového listu
@@ -2758,7 +2758,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Image View
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Vypadá to, že se něco během transakce špatně. Protože jsme nepotvrdily platbu Paypal bude vám automaticky tuto částku. Pokud se tak nestane, zašlete nám e-mail a uveďte ID korelace: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Do hesla vložte symboly, čísla a velká písmena"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Vložte Po pole &#39;{0}&#39; uvedenou ve vlastním poli &#39;{1}&#39;, se štítkem &#39;{2}&#39; neexistuje"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Vložte Po pole '{0}' uvedenou ve vlastním poli '{1}', se štítkem '{2}' neexistuje"
 DocType: List Filter,List Filter,Seznam filtrů
 DocType: Workflow State,signal,signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Má Přílohy
@@ -2782,14 +2782,14 @@ DocType: Web Page,Slideshow,Promítání obrázků
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Výchozí šablony adresy nemůže být smazán
 DocType: Contact,Maintenance Manager,Správce údržby
 DocType: Workflow State,Search,Hledat
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vyberte prosím jinou platební metodu. Stripe nepodporuje transakce v měně {0} &#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vyberte prosím jinou platební metodu. Stripe nepodporuje transakce v měně {0} '
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Přesunout do koše
 DocType: Web Form,Web Form Fields,Pole webových formulářů
 DocType: Data Import,Amended From,Platném znění
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Varování: Nelze najít {0} v tabulce vztahující se k {1}
 DocType: S3 Backup Settings,eu-north-1,eu-sever-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Tento dokument je v současné době zařazen do fronty pro provedení. Prosím zkuste to znovu
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Soubor &#39;{0}&#39; nebyl nalezen
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Soubor '{0}' nebyl nalezen
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Odstranit oddíl
 DocType: User,Change Password,Změnit heslo
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Pole osy X
@@ -2976,7 +2976,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Chybí hodnota pro
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Přidat dítě
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Importovat pokrok
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Pokud je podmínka splněna, uživatel bude odměněn body. např. doc.status == &#39;Uzavřeno&#39;"
+","Pokud je podmínka splněna, uživatel bude odměněn body. např. doc.status == 'Uzavřeno'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Odeslaný záznam nemůže být smazán.
 DocType: GSuite Templates,Template Name,Název šablony
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Nový typ dokumentu
@@ -3396,7 +3396,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Vlastní Překlad
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Pokrok
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,podle role
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,chybějící Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neplatný fieldname &#39;{0}&#39; v autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neplatný fieldname '{0}' v autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Hledat v typu dokumentu
 DocType: Custom DocPerm,Role and Level,Role a úroveň
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3496,7 +3496,7 @@ DocType: Dashboard Chart,Filters JSON,Filtry JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Klikněte zde pro ověření
 DocType: Email Account,Disable SMTP server authentication,Zakázat ověřování serveru SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Zkopírováno do schránky.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Předvídatelné substituce jako &#39;@&#39; místo &#39;a&#39; nepomohou moc.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Předvídatelné substituce jako '@' místo 'a' nepomohou moc.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Přidělené Me
 apps/frappe/frappe/utils/data.py,Zero,Nula
 DocType: Google Drive,Backup Folder ID,ID záložní složky
@@ -3549,7 +3549,7 @@ DocType: Notification,Reference Date,Referenční datum
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,Nastavení OTP pomocí aplikace OTP nebylo dokončeno. Obraťte se prosím na správce.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Zadejte platné mobilní nos
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Některé funkce nemusí ve vašem prohlížeči fungovat. Aktualizujte svůj prohlížeč na nejnovější verzi.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nevím, zeptejte se &#39;help&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nevím, zeptejte se 'help'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},zrušen tento dokument {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Komentáře a komunikace bude spojena s tímto propojeného dokumentu
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filtr ...
@@ -3708,7 +3708,7 @@ DocType: Web Page,Web Page,Www stránky
 DocType: Workflow Document State,Next Action Email Template,Další šablona e-mailů akce
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Pokud je tato možnost povolena, jsou změny dokumentu sledovány a zobrazeny na časové ose"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;V globálním vyhledávání&#39; není povolen typ {0} v řádku {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'V globálním vyhledávání' není povolen typ {0} v řádku {1}
 DocType: Energy Point Log,Appreciation,Uznání
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Zobrazit seznam
 DocType: Workflow,Don't Override Status,Nepotlačí Stav
@@ -3855,7 +3855,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Výchozí
 DocType: Translation,Verified,Ověřeno
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0}: přidáno
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Hledat &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Hledat '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Prosím, uložte sestavu jako první"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} odběratelé přidáni
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Ne V
@@ -3898,7 +3898,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,nahraný soubor
 DocType: Workflow State,ok-circle,ok-circle
 DocType: LDAP Settings,LDAP User Creation and Mapping,Vytvoření a mapování uživatelů LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Můžete najít věci tím, že žádá &quot;najít oranžovou zákazníků &#39;"
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Můžete najít věci tím, že žádá &quot;najít oranžovou zákazníků '"
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Je nám líto! Uživatel by měl mít kompletní přístup k vlastnímu záznamu.
 ,Usage Info,využití Info
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Zobrazit klávesové zkratky

--- a/frappe/translations/cs.csv
+++ b/frappe/translations/cs.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Systémový uživatel
 DocType: Report,Is Standard,Je standardní
 DocType: Desktop Icon,_report,_zpráva
 DocType: Dashboard Chart,Full,Plný
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nenechte HTML Kódování HTML tagy jako &lt;script> nebo jen znaky jako &lt;nebo>, protože by mohly být záměrně použity v tomto oboru"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Nenechte HTML Kódování HTML tagy jako <script> nebo jen znaky jako <nebo>, protože by mohly být záměrně použity v tomto oboru"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritizoval {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Běh
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Zápatí se zobra
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Až do
 DocType: System Settings,Allow only one session per user,Umožňují pouze jednu relaci na jednoho uživatele
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Nová událost: Zvolte nebo táhněte skrz Časová pole.
 DocType: Contact,Contact Details,Kontaktní údaje
 DocType: DocField,In Filter,Ve filtru
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Cesta k certifikátu serveru
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nedostatečné povolení k zobrazení odkazů
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresa Název je povinný.
 DocType: Google Contacts,Push to Google Contacts,Push to Kontakty Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Přidáno HTML do sekce &lt;head> webové stránky, používané zejména pro ověřování webových stránek a SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Přidáno HTML do sekce <head> webové stránky, používané zejména pro ověřování webových stránek a SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relabující
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Položka nemůže být přidána jako svůj vlastní podřízený potomek
 DocType: Session Default Settings,Session Defaults,Výchozí nastavení relace
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Upozornění
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,To se může vytisknout na více stránkách
 DocType: Data Migration Run,Percent Complete,Procento dokončeno
 DocType: Tag Category,Tag Category,tag Kategorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pro srovnání použijte> 5, &lt;10 nebo = 324. Pro rozsahy použijte 5:10 (pro hodnoty mezi 5 a 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pro srovnání použijte> 5, <10 nebo = 324. Pro rozsahy použijte 5:10 (pro hodnoty mezi 5 a 10)."
 DocType: Google Calendar,Pull from Google Calendar,Vytáhněte z Kalendáře Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Nápověda
 DocType: User,Login Before,Přihlášení před
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Povolit při Odeslání
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Typ výjimky
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vybrat sloupce
-DocType: Web Page,Add code as &lt;script>,Přidat kód jako &lt;script>
+DocType: Web Page,Add code as <script>,Přidat kód jako <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Vymazat uživatelská oprávnění
 DocType: Webhook,Headers,Záhlaví
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Připravované akce
@@ -3445,26 +3445,26 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Fronta by měla být jedna z {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Používá href=""http://jinja.pocoo.org/docs/templates/""> Jinja šablon </a> a všechna pole Adresa ( včetně Custom Fields-li nějaké) budou k dispozici </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {%, pokud address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} {
- {}} city & lt; br & gt; 
- {%, pokud stav%} {{}} state & lt; br & gt; {% endif -%} {
-% v případě, PSC%} PIN: {{PSC}} & lt; br & gt; {% endif -%} 
- {{country}} & lt; br & gt; 
- {%, pokud telefon%} Telefon: {{tel}} & lt; br & gt; { % endif -%} 
- {% v případě, fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {%, pokud email_id%} E-mail: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {%, pokud address_line2%} {{address_line2}} <br> { % endif -%} {
+ {}} city <br> 
+ {%, pokud stav%} {{}} state <br> {% endif -%} {
+% v případě, PSC%} PIN: {{PSC}} <br> {% endif -%} 
+ {{country}} <br> 
+ {%, pokud telefon%} Telefon: {{tel}} <br> { % endif -%} 
+ {% v případě, fax%} Fax: {{fax}} <br> {% endif -%} 
+ {%, pokud email_id%} E-mail: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Pole Datum zahájení
 DocType: Role,Role Name,Název role

--- a/frappe/translations/cs.csv
+++ b/frappe/translations/cs.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Zálohován
 DocType: DocField,In Global Search,V Globální hledání
 DocType: System Settings,Brute Force Security,Bojová bezpečnost
 DocType: Workflow State,indent-left,indent-left
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} rok (roky)
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} rok (roky)
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Je to riskantní smazat tento soubor: {0}. Prosím, obraťte se na správce systému."
 DocType: Currency,Currency Name,Jméno měny
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,žádné e-maily
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0}: nenaleze
 apps/frappe/frappe/config/customization.py,Add custom forms.,Přidat vlastní formuláře.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} na {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,předložen tento dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Nastavení&gt; Uživatelská oprávnění
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Nastavení> Uživatelská oprávnění
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Systém poskytuje mnoho předdefinovaných rolí. Můžete přidat vlastní nové role pro detailnější nastavení oprávnění.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","V případě, že uživatel nemá žádnou roli zkontrolovat, uživatel se stává &quot;System User&quot;. &quot;System User&quot; má přístup k ploše"
 DocType: System Settings,Date and Number Format,Formát čísel a data
 apps/frappe/frappe/model/document.py,one of,jeden z
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Nastavení&gt; Přizpůsobit formulář
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Nastavení> Přizpůsobit formulář
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kontrola jeden okamžik
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Zobrazit štítky
 DocType: DocField,HTML Editor,Editor HTML
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Fakturace
 DocType: Email Queue,Not Sent,Neodesláno
 DocType: Web Form,Actions,Akce
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Nastavení&gt; Uživatel
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Nastavení> Uživatel
 DocType: Workflow State,align-justify,zarovnat-vyplnit
 DocType: User,Middle Name (Optional),Druhé jméno (volitelné)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Není povoleno
@@ -1410,7 +1410,7 @@ DocType: User,System User,Systémový uživatel
 DocType: Report,Is Standard,Je standardní
 DocType: Desktop Icon,_report,_zpráva
 DocType: Dashboard Chart,Full,Plný
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Nenechte HTML Kódování HTML tagy jako &lt;script&gt; nebo jen znaky jako &lt;nebo&gt;, protože by mohly být záměrně použity v tomto oboru"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nenechte HTML Kódování HTML tagy jako &lt;script> nebo jen znaky jako &lt;nebo>, protože by mohly být záměrně použity v tomto oboru"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritizoval {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Běh
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Zápatí se zobra
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Až do
 DocType: System Settings,Allow only one session per user,Umožňují pouze jednu relaci na jednoho uživatele
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Nová událost: Zvolte nebo táhněte skrz Časová pole.
 DocType: Contact,Contact Details,Kontaktní údaje
 DocType: DocField,In Filter,Ve filtru
@@ -2022,7 +2022,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Přihlášení není povoleno v tuto dobu
 DocType: Data Migration Run,Current Mapping Action,Současná mapovací akce
 DocType: Dashboard Chart Source,Source Name,Název zdroje
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,K Uživateli není spojen žádný e-mailový účet. Přidejte účet do složky Uživatel&gt; E-mailová schránka.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,K Uživateli není spojen žádný e-mailový účet. Přidejte účet do složky Uživatel> E-mailová schránka.
 DocType: Email Account,Email Sync Option,E-mail Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Řádek č
 DocType: Async Task,Runtime,Runtime
@@ -2037,7 +2037,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Je již v
 DocType: User Email,Enable Outgoing,Povolit odchozí
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Vlastní Tagy
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-mailový účet není nastaven. Vytvořte nový e-mailový účet z nabídky Nastavení&gt; E-mail&gt; E-mailový účet
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-mailový účet není nastaven. Vytvořte nový e-mailový účet z nabídky Nastavení> E-mail> E-mailový účet
 DocType: Comment,Submitted,Vloženo
 DocType: Contact,Pulled from Google Contacts,Vyvoláno z kontaktů Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Neplatná žádost
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Vypršení platnosti
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Toto pole se objeví pouze v případě, že fieldname zde definovány má hodnotu OR pravidla jsou pravými (příklady): myfield eval: doc.myfield == &quot;Můj Value &#39;eval: doc.age&gt; 18"
+eval:doc.age>18","Toto pole se objeví pouze v případě, že fieldname zde definovány má hodnotu OR pravidla jsou pravými (příklady): myfield eval: doc.myfield == &quot;Můj Value &#39;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Dnes
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Pakliže toto nastavíte, uživatelé budou moci přistoupit pouze na dokumenty (např.: příspěvky blogu), kam existují odkazy (např.: blogger)."
@@ -2123,7 +2123,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,VELKÁ PÍSMENA
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Vlastní HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Zadejte název složky
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nebyla nalezena žádná výchozí adresa. Vytvořte nový z nabídky Nastavení&gt; Tisk a branding&gt; Šablona adresy.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nebyla nalezena žádná výchozí adresa. Vytvořte nový z nabídky Nastavení> Tisk a branding> Šablona adresy.
 apps/frappe/frappe/auth.py,Unknown User,Neznámý uživatel
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Vyberte roli
 DocType: Comment,Deleted,Vypouští se
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Cesta k certifikátu serveru
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nedostatečné povolení k zobrazení odkazů
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresa Název je povinný.
 DocType: Google Contacts,Push to Google Contacts,Push to Kontakty Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Přidáno HTML do sekce &lt;head&gt; webové stránky, používané zejména pro ověřování webových stránek a SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Přidáno HTML do sekce &lt;head> webové stránky, používané zejména pro ověřování webových stránek a SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relabující
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Položka nemůže být přidána jako svůj vlastní podřízený potomek
 DocType: Session Default Settings,Session Defaults,Výchozí nastavení relace
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Upozornění
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,To se může vytisknout na více stránkách
 DocType: Data Migration Run,Percent Complete,Procento dokončeno
 DocType: Tag Category,Tag Category,tag Kategorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pro srovnání použijte&gt; 5, &lt;10 nebo = 324. Pro rozsahy použijte 5:10 (pro hodnoty mezi 5 a 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pro srovnání použijte> 5, &lt;10 nebo = 324. Pro rozsahy použijte 5:10 (pro hodnoty mezi 5 a 10)."
 DocType: Google Calendar,Pull from Google Calendar,Vytáhněte z Kalendáře Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Nápověda
 DocType: User,Login Before,Přihlášení před
@@ -2893,7 +2893,7 @@ DocType: Custom Script,Custom Script,Přizpůsobený skript
 DocType: Address,Address Line 2,Adresní řádek 2
 DocType: Address,Reference,reference
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Přiřazeno (komu)
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Nastavte výchozí e-mailový účet z nabídky Nastavení&gt; E-mail&gt; E-mailový účet
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Nastavte výchozí e-mailový účet z nabídky Nastavení> E-mail> E-mailový účet
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detail mapování migrace dat
 DocType: Data Import,Action,Akce
 DocType: GSuite Settings,Script URL,Adresa URL skriptu
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Povolit při Odeslání
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Typ výjimky
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vybrat sloupce
-DocType: Web Page,Add code as &lt;script&gt;,Přidat kód jako &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Přidat kód jako &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Vymazat uživatelská oprávnění
 DocType: Webhook,Headers,Záhlaví
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Připravované akce
@@ -3445,15 +3445,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Fronta by měla být jedna z {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Používá href=""http://jinja.pocoo.org/docs/templates/""> Jinja šablon </a> a všechna pole Adresa ( včetně Custom Fields-li nějaké) budou k dispozici </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/cz.csv
+++ b/frappe/translations/cz.csv
@@ -1144,7 +1144,7 @@ apps/frappe/frappe/database.py +217,Too many writes in one request. Please send 
 DocType: Workflow State,arrow-up,šipka-nahoru
 DocType: DocField,Allow on Submit,Povolit při Odeslání
 apps/frappe/frappe/core/page/desktop/desktop.js +48,All Applications,Všechny aplikace
-DocType: Web Page,Add code as &lt;script&gt;,Přidat kód jako &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Přidat kód jako &lt;script>
 apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +7,Select Type,Vyberte typ
 apps/frappe/frappe/core/doctype/file_data/file_data.py +42,No permission to write / remove.,Bez oprávnění k zápisu / odebrání.
 DocType: Workflow,"All possible Workflow States and roles of the workflow. <br>Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Všechny možné stavy toků (workflow) a role toků. <br>Možnosti stavů dokumentů (Docstatus): 0 je ""Uloženo"", 1 je ""Vloženo"" a 2 je ""Zrušeno"""
@@ -1159,7 +1159,7 @@ apps/frappe/frappe/desk/form/save.py +30,Did not save,Nebylo uloženo
 DocType: Property Setter,Property,Vlastnost
 DocType: Website Slideshow,"Note: For best results, images must be of the same size and width must be greater than height.","Poznámka: Pro nejlepší výsledky, obrázky musí být stejné velikosti a šířka musí být větší než výška."
 DocType: DocType,Auto Name,Automatický název
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +169,Permissions can be managed via Setup &gt; Role Permissions Manager,Oprávnění mohou být spravována přes Nastavení &gt; Správce rolí a oprávnění
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +169,Permissions can be managed via Setup > Role Permissions Manager,Oprávnění mohou být spravována přes Nastavení > Správce rolí a oprávnění
 apps/frappe/frappe/core/page/data_import_tool/importer.py +67,Please make sure that there are no empty columns in the file.,"Prosím ujistěte se, zda v souboru nejsou prázdné sloupce."
 sites/assets/js/desk.min.js +600,You have unsaved changes in this form. Please save before you continue.,"V tomto formuláři máte neuložené změny. Prosím, uložte změny než budete pokračovat."
 apps/frappe/frappe/core/doctype/doctype/doctype.py +269,Default for {0} must be an option,Výchozí pro {0} musí být možnost
@@ -1377,7 +1377,7 @@ apps/frappe/frappe/templates/generators/web_form.html +18,Please login to create
 apps/frappe/frappe/desk/reportview.py +69,{0} is saved,{0} uloženo
 apps/frappe/frappe/core/doctype/user/user.py +234,User {0} cannot be renamed,Uživatel: {0} nemůže být přejmenován
 apps/frappe/frappe/website/doctype/website_settings/website_settings.js +17,Exported,Exportováno
-DocType: DocPerm,"JSON list of DocTypes used to apply User Permissions. If empty, all linked DocTypes will be used to apply User Permissions.","JSON sezam DocTypes použitých pro aplikování uživatelských oprávnění. Pakliže je prázdný, všechny provázané DocTypes budou použity pro aplikování uživatelských oprávnění."
+DocType: DocPerm,"JSON list of DocTypes used to apply User Permissions. If empty, all linked DocTypes will be used to apply User Permissions.","JSON sezam DocTypes použitých pro aplikování uživatelských oprávnění. Pakliže je prázdný, v��echny provázané DocTypes budou použity pro aplikování uživatelských oprávnění."
 DocType: Report,Ref DocType,Referenční DocType
 apps/frappe/frappe/core/doctype/doctype/doctype.py +390,{0}: Cannot set Amend without Cancel,{0}: Nelze Změnit bez Zrušení
 sites/assets/js/form.min.js +256,Full Page,Full Page

--- a/frappe/translations/cz.csv
+++ b/frappe/translations/cz.csv
@@ -1144,7 +1144,7 @@ apps/frappe/frappe/database.py +217,Too many writes in one request. Please send 
 DocType: Workflow State,arrow-up,šipka-nahoru
 DocType: DocField,Allow on Submit,Povolit při Odeslání
 apps/frappe/frappe/core/page/desktop/desktop.js +48,All Applications,Všechny aplikace
-DocType: Web Page,Add code as &lt;script>,Přidat kód jako &lt;script>
+DocType: Web Page,Add code as <script>,Přidat kód jako <script>
 apps/frappe/frappe/core/page/data_import_tool/data_import_main.html +7,Select Type,Vyberte typ
 apps/frappe/frappe/core/doctype/file_data/file_data.py +42,No permission to write / remove.,Bez oprávnění k zápisu / odebrání.
 DocType: Workflow,"All possible Workflow States and roles of the workflow. <br>Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Všechny možné stavy toků (workflow) a role toků. <br>Možnosti stavů dokumentů (Docstatus): 0 je ""Uloženo"", 1 je ""Vloženo"" a 2 je ""Zrušeno"""

--- a/frappe/translations/da.csv
+++ b/frappe/translations/da.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Parent
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Vi har modtaget en anmodning fra dig om at downloade dine {0} data tilknyttet: {1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Hvis aktiveret, vil kodeordets styrke blive håndhævet baseret på værdien Minimum Password Score. En værdi på 2 er medium stærk og 4 er meget stærk."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Team medlemmer&quot; eller &quot;Management&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Standard for &quot;Kontrollér&quot; type felt skal enten være &#39;0&#39; eller &#39;1&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Standard for &quot;Kontrollér&quot; type felt skal enten være '0' eller '1'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,I går
 DocType: Contact,Designation,Betegnelse
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Automatisk linking kan kun aktiveres for en e-mail-konto.
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Deaktiver rappor
 DocType: Translation,Contributed Translation Doctype Name,Bidragt oversættelse Doctype Navn
 DocType: PayPal Settings,Redirect To,Omdirigér til
 DocType: Data Migration Mapping,Pull,Trække
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [&#39;rapportnavn&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports ['rapportnavn'] = {}
 DocType: Bulk Update,Bulk Update,Bulk opdatering
 DocType: Workflow State,chevron-up,chevron-up
 DocType: DocType,Allow Guest to View,Tillad Gæst til visning
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistikker baseret på sidste uges resultater (fra {0} til {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP-telefonfelt
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","dokumenttype ..., fx kunde"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Tilstanden &#39;{0}&#39; er ugyldig
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Tilstanden '{0}' er ugyldig
 DocType: Workflow State,barcode,stregkode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Brug af underforespørgsel eller funktion er begrænset
 apps/frappe/frappe/config/customization.py,Add your own translations,Tilføj dine egne oversættelser
@@ -706,7 +706,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Brugernavn {0} findes allerede
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Kan ikke sætte import som {1} er ikke kan indporteres
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Der er en fejl i din adresseskabelon {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} er en ugyldig e-mail-adresse i &#39;Modtagere&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} er en ugyldig e-mail-adresse i 'Modtagere'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,Vært
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Valuta Navn
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Ingen e-mails
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link udløbet
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Gendannelse af længden til {0} for &#39;{1}&#39; i &#39;{2}&#39;; Indstilling af længden som {3} vil medføre afkortning af data.
+							Setting the length as {3} will cause truncation of data.",Gendannelse af længden til {0} for '{1}' i '{2}'; Indstilling af længden som {3} vil medføre afkortning af data.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Vælg Filformat
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Indhold Hash
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokument Del Report
 DocType: Social Login Key,Base URL,Basiswebadresse
 DocType: User,Last Login,Sidste log ind
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Du kan ikke angive &#39;Oversættelig&#39; for felt {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Du kan ikke angive 'Oversættelig' for felt {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Kolonne
 DocType: Chat Profile,Chat Profile,Chat profil
 DocType: Custom Field,Adds a custom field to a DocType,Tilføjer et brugerdefineret felt til et DocType
@@ -1006,7 +1006,7 @@ apps/frappe/frappe/utils/bot.py,Could not identify {0},Kunne ikke identificere {
 DocType: Address,Address,Adresse
 apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,Betaling mislykkedes
 DocType: Print Settings,In points. Default is 9.,I point. Standard er 9.
-DocType: OAuth Client,Redirect URIs,Omdiriger URI&#39;er
+DocType: OAuth Client,Redirect URIs,Omdiriger URI'er
 DocType: LDAP Settings,StartTLS,STARTTLS
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Submiting {0},Indsender {0}
 DocType: Workflow State,heart,hjerte
@@ -1054,7 +1054,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Side HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Eksport Fejllagte rækker
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Gruppens navn kan ikke være tomt.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Yderligere noder kan kun oprettes under &#39;koncernens typen noder
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Yderligere noder kan kun oprettes under 'koncernens typen noder
 DocType: SMS Parameter,Header,Overskrift
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Ukendt kolonne: {0}
 DocType: Notification Recipient,Email By Role,E-mail Ved Rolle
@@ -1318,7 +1318,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,PDF,PDF
 DocType: System Settings,dd/mm/yyyy,dd/mm/åååå
 DocType: System Settings,Backups,Sikkerhedskopier
 apps/frappe/frappe/core/doctype/communication/communication.js,Add Contact,Tilføj Kontakt
-DocType: Notification Recipient,Optional: Always send to these ids. Each Email Address on a new row,Valgfrit: Send altid til disse id&#39;er. Hver e-mail-adresse på en ny række
+DocType: Notification Recipient,Optional: Always send to these ids. Each Email Address on a new row,Valgfrit: Send altid til disse id'er. Hver e-mail-adresse på en ny række
 apps/frappe/frappe/public/js/frappe/form/layout.js,Hide Details,Skjul detaljer
 apps/frappe/frappe/www/qrcode.py,Page has expired!,Siden er udløbet!
 DocType: LDAP Settings,Path to private Key File,Sti til privat nøglefil
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obligatorisk felt: sæt rolle for
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritiseret {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Felt &#39;{1}&#39; kan ikke indstilles som unikt, da det har ikke-unikke værdier"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Felt '{1}' kan ikke indstilles som unikt, da det har ikke-unikke værdier"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Naviger listen ned
 DocType: Currency,A symbol for this currency. For e.g. $,Et symbol for denne valuta. For eksempel $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Succesfuldt opdaterede oversættelser
@@ -1525,7 +1525,7 @@ DocType: Communication,Received,Modtaget
 DocType: Notification,"Trigger on valid methods like ""before_insert"", ""after_update"", etc (will depend on the DocType selected)","Trigger om gyldige metoder som &quot;before_insert&quot;, &quot;after_update&quot; osv (afhænger af den valgte DocType)"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0} {1},ændret værdi på {0} {1}
 apps/frappe/frappe/core/doctype/user/user.py,Adding System Manager to this User as there must be atleast one System Manager,Tilføjelse System Manager til denne Bruger da der skal være mindst én System Manager
-DocType: Chat Message,URLs,URL&#39;er
+DocType: Chat Message,URLs,URL'er
 DocType: Data Migration Run,Total Pages,Samlede sider
 apps/frappe/frappe/core/doctype/user_permission/user_permission.py,{0} has already assigned default value for {1}.,{0} har allerede tildelt standardværdien for {1}.
 DocType: DocField,Attach Image,Vedhæft billede
@@ -2004,7 +2004,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google-skrifttype
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Hvis disse anvisninger, hvis ikke nyttigt, bedes du tilføje i dine forslag på GitHub Issues."
 DocType: Workflow State,bookmark,bogmærke
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Mappenavnet skal ikke indeholde &#39;/&#39; (skråstreg)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Mappenavnet skal ikke indeholde '/' (skråstreg)
 DocType: Note,Note,Bemærk
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Fejlrapport
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Eksporter data i CSV / Excel-format.
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,Databasens navn
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Opdater Form
 DocType: DocField,Select,Vælg
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Se fuld log
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, eksempel: status == &#39;Open&#39; og type == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, eksempel: status == 'Open' og type == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Fil ikke vedhæftet
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Forbindelse afbrudt. Nogle funktioner fungerer muligvis ikke.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Gentagelser som ""aaa"" er nemme at gætte"
@@ -2278,7 +2278,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Vis kun fejl
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Send Email Alert
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Vælg en anden betalingsmetode. Razorpay understøtter ikke transaktioner i sedler &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Vælg en anden betalingsmetode. Razorpay understøtter ikke transaktioner i sedler '{0}'
 DocType: Data Import,In Progress,I gang
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,I kø til sikkerhedskopi. Det kan tage et par minutter til en time.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2700,7 +2700,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Ændring
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal betaling gateway indstillinger
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Top Performer
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Brugerdefinerede felter kan ikke føjes til kerne DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) vil få afkortet, da max tilladte tegn er {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) vil få afkortet, da max tilladte tegn er {2}"
 DocType: OAuth Client,Response Type,reaktion Type
 DocType: Contact Us Settings,Send enquiries to this email address,Send forespørgsler til denne e-mailadresse
 DocType: Letter Head,Letter Head Name,Brevhovednavn
@@ -2757,7 +2757,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Billede View
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Ligner noget gik galt under transaktionen. Da vi ikke har bekræftet betalingen, vil Paypal automatisk refundere dig beløbet. Hvis den ikke gør det, så send os en e-mail og nævne Correlation ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Inkluder symboler, tal og store bogstaver i adgangskoden"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Indsæt Efter feltet &#39;{0}&#39; er nævnt i brugerdefinerede Field &#39;{1}&#39;, med etiketten &#39;{2}&#39;, eksisterer ikke"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Indsæt Efter feltet '{0}' er nævnt i brugerdefinerede Field '{1}', med etiketten '{2}', eksisterer ikke"
 DocType: List Filter,List Filter,List Filter
 DocType: Workflow State,signal,signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Har vedhæftede filer
@@ -2767,7 +2767,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokument gendannet
 DocType: Data Export,Data Export,Data Eksport
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Vælg sprog...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Du kan ikke angive &#39;Valg&#39; for felt {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Du kan ikke angive 'Valg' for felt {0}
 DocType: Help Article,Author,Forfatter
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Genoptag afsendelse
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Genåben
@@ -2781,7 +2781,7 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Standard-adresseskabelon kan ikke slettes
 DocType: Contact,Maintenance Manager,Vedligeholdelseschef
 DocType: Workflow State,Search,Søg
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vælg venligst en anden betalingsmetode. Stripe understøtter ikke transaktioner i valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vælg venligst en anden betalingsmetode. Stripe understøtter ikke transaktioner i valuta '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Flytte til skrald
 DocType: Web Form,Web Form Fields,Felter Web Form
 DocType: Data Import,Amended From,Ændret Fra
@@ -2975,7 +2975,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Værdi mangler for
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Tilføj ny
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Import af fremskridt
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Hvis betingelsen er opfyldt, vil brugeren blive belønnet med point. f.eks. doc.status == &#39;Lukket&#39;"
+","Hvis betingelsen er opfyldt, vil brugeren blive belønnet med point. f.eks. doc.status == 'Lukket'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Den godkendte post kan ikke slettes.
 DocType: GSuite Templates,Template Name,Skabelonnavn
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ny dokumenttype
@@ -3107,7 +3107,7 @@ DocType: Dashboard Chart,Chart Type,Diagramtype
 DocType: DocType,Auto Name,Auto Navn
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Undgå sekvenser som abc eller 6543, da de er nemme at gætte"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Prøv igen
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL skal starte med &#39;http: //&#39; eller &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL skal starte med 'http: //' eller 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Mulighed 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Redigér
@@ -3346,7 +3346,7 @@ DocType: Notification,Send alert if this field's value changes,"Send besked, hvi
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Temafarver
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Vælg en DocType at lave et nyt format
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,bruger eksisterer ikke
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Modtagere&#39; er ikke angivet
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Modtagere' er ikke angivet
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,lige nu
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Ansøg
 DocType: Footer Item,Policy,Politik
@@ -3394,7 +3394,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Brugerdefinerede 
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Fremskridt
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,efter rolle
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,manglende felter
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ugyldigt feltnavn &#39;{0}&#39; i autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ugyldigt feltnavn '{0}' i autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Søg i en dokumenttype
 DocType: Custom DocPerm,Role and Level,Rolle og niveau
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3483,7 +3483,7 @@ DocType: Dashboard Chart,Filters JSON,Filtre JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Klik her for at verificere
 DocType: Email Account,Disable SMTP server authentication,Deaktiver SMTP-servergodkendelse
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Kopieret til udklipsholder.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Forudsigelige udskiftninger som &#39;@&#39; i stedet for &#39;a&#39; ikke hjælper meget.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Forudsigelige udskiftninger som '@' i stedet for 'a' ikke hjælper meget.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Tildelt af mig
 apps/frappe/frappe/utils/data.py,Zero,Nul
 DocType: Google Drive,Backup Folder ID,Sikkerhedskopimappe-id
@@ -3536,7 +3536,7 @@ DocType: Notification,Reference Date,Henvisning Dato
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP-opsætning ved hjælp af OTP-appen blev ikke afsluttet. Kontakt administrator.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Indtast venligst gyldige mobiltelefonnumre
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Nogle af funktionerne fungerer muligvis ikke i din browser. Opdater din browser til den nyeste version.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ved ikke, spørg &#39;hjælp&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ved ikke, spørg 'hjælp'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},annulleret dette dokument {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Kommentarer og kommunikation vil være forbundet med dette forbundet dokument
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
@@ -3565,7 +3565,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Fejlede under ændring af abonnement
 DocType: LDAP Settings,LDAP Group Field,LDAP-gruppefelt
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Lig
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Valg &#39;Dynamic Link&#39; type feltet skal pege på en anden Link Field med muligheder som &#39;DocType&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Valg 'Dynamic Link' type feltet skal pege på en anden Link Field med muligheder som 'DocType'
 DocType: About Us Settings,Team Members Heading,Team Members Udgifts
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Ugyldigt CSV-format
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Fejl ved forbindelse til QZ Tray Application ... <br><br> Du skal have QZ Tray-applikation installeret og kørt for at bruge Raw Print-funktionen. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Klik her for at downloade og installere QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Klik her for at lære mere om Raw Printing</a> ."
@@ -3695,7 +3695,7 @@ DocType: Web Page,Web Page,Hjemmeside
 DocType: Workflow Document State,Next Action Email Template,Næste handling e-mail skabelon
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Hvis det er aktiveret, spores ændringer til dokumentet og vises på tidslinjen"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;I Global søgning&#39; er ikke tilladt for type {0} i række {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'I Global søgning' er ikke tilladt for type {0} i række {1}
 DocType: Energy Point Log,Appreciation,Påskønnelse
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Se liste
 DocType: Workflow,Don't Override Status,Må ikke Tilsidesæt status
@@ -3842,7 +3842,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Standard
 DocType: Translation,Verified,Verified
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} tilføjet
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Søg efter &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Søg efter '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Venligst gemme rapporten først
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonnenter tilføjet
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Ikke I
@@ -3878,7 +3878,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Mig
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} ikke en gyldig stat
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Anvend alle dokumenttyper
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Energipunktopdatering
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Vælg en anden betalingsmetode. PayPal understøtter ikke transaktioner i sedler &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Vælg en anden betalingsmetode. PayPal understøtter ikke transaktioner i sedler '{0}'
 DocType: Chat Message,Room Type,Værelses type
 DocType: Data Import Beta,Import Log Preview,Eksempel på importlog
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Søgefelt {0} er ikke gyldig

--- a/frappe/translations/da.csv
+++ b/frappe/translations/da.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Fil backup 
 DocType: DocField,In Global Search,I Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,led-venstre
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} år (e) siden
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} år (e) siden
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Det er risikabelt at slette denne fil: {0}. Kontakt din systemadministrator.
 DocType: Currency,Currency Name,Valuta Navn
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Ingen e-mails
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Ingen {0} fun
 apps/frappe/frappe/config/customization.py,Add custom forms.,Tilføj brugerdefinerede formularer.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} i {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,godkendte dette dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Opsætning&gt; Brugertilladelser
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Opsætning> Brugertilladelser
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Systemet giver mange foruddefinerede roller. Du kan tilføje nye roller at indstille finere tilladelser.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Hvis brugeren har blot én rolle markeret, så bliver brugeren en ""Systembruger"". Systembrugere har adgang til skrivebordet"
 DocType: System Settings,Date and Number Format,Dato og nummerformat
 apps/frappe/frappe/model/document.py,one of,en af
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Opsætning&gt; Tilpas form
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Opsætning> Tilpas form
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kontrol ene øjeblik
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Vis Tags
 DocType: DocField,HTML Editor,HTML Editor
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Fakturering
 DocType: Email Queue,Not Sent,Ikke Sent
 DocType: Web Form,Actions,Handlinger
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Opsætning&gt; Bruger
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Opsætning> Bruger
 DocType: Workflow State,align-justify,tilpasse-retfærdiggøre
 DocType: User,Middle Name (Optional),Mellemnavn (valgfrit)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ikke Tilladt
@@ -1410,7 +1410,7 @@ DocType: User,System User,Systembruger
 DocType: Report,Is Standard,Er standard
 DocType: Desktop Icon,_report,_rapport
 DocType: Dashboard Chart,Full,Fuld
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Må ikke HTML Encode HTML tags som &lt;script&gt; eller bare tegn som &lt;eller&gt;, som de kunne være bevidst anvendes i dette område"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Må ikke HTML Encode HTML tags som &lt;script> eller bare tegn som &lt;eller>, som de kunne være bevidst anvendes i dette område"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiseret den {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Løb
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Sidefod vises kun
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Afventer
 DocType: System Settings,Allow only one session per user,Tillad kun én session per bruger
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Forside / Test Mappe 1 / Test Mappe 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Vælg eller træk på tværs af tidsintervaller for at oprette en ny begivenhed.
 DocType: Contact,Contact Details,Kontaktoplysninger
 DocType: DocField,In Filter,I Filter
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Log ind er ikke tilladt på dette tidspunkt
 DocType: Data Migration Run,Current Mapping Action,Aktuel kortlægning
 DocType: Dashboard Chart Source,Source Name,Kilde Navn
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Ingen e-mail-konto tilknyttet brugeren. Tilføj en konto under Bruger&gt; E-mail-indbakke.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Ingen e-mail-konto tilknyttet brugeren. Tilføj en konto under Bruger> E-mail-indbakke.
 DocType: Email Account,Email Sync Option,E-mail-synkronisering Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Række nr
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Allerede 
 DocType: User Email,Enable Outgoing,Aktiver udgående
 DocType: Address,Fax,Telefax
 apps/frappe/frappe/config/customization.py,Custom Tags,Brugerdefinerede Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-mail-konto er ikke opsat. Opret en ny e-mail-konto fra Opsætning&gt; E-mail&gt; E-mail-konto
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-mail-konto er ikke opsat. Opret en ny e-mail-konto fra Opsætning> E-mail> E-mail-konto
 DocType: Comment,Submitted,Godkendt
 DocType: Contact,Pulled from Google Contacts,Trukket fra Google-kontakter
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ugyldig forespørgsel
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Session Udløb i Hou
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Dette felt vises kun, hvis feltnavn defineres her har værdi ELLER reglerne er sande (eksempler): myfield eval: doc.myfield == &quot;Min Værdi&quot; eval: doc.age&gt; 18"
+eval:doc.age>18","Dette felt vises kun, hvis feltnavn defineres her har værdi ELLER reglerne er sande (eksempler): myfield eval: doc.myfield == &quot;Min Værdi&quot; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Kontor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,I dag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Når du har indstillet dette, vil brugerne kun kunne få adgang til dokumenter (f.eks. Blog Post) hvor linket eksisterer (f.eks. Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,STORE BOGSTAVER
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Tilpasset HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Indtast mappenavn
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Ingen standardadresseskabelon fundet. Opret en ny fra Opsætning&gt; Udskrivning og branding&gt; Adresseskabelon.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Ingen standardadresseskabelon fundet. Opret en ny fra Opsætning> Udskrivning og branding> Adresseskabelon.
 apps/frappe/frappe/auth.py,Unknown User,Ukendt bruger
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Vælg Rolle
 DocType: Comment,Deleted,Slettet
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Sti til servercertifikat
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ikke nok tilladelse til at se links
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresse Titel er obligatorisk.
 DocType: Google Contacts,Push to Google Contacts,Tryk på til Google-kontakter
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Tilføjet HTML i -sektionen af hjemmesiden, der primært anvendes til hjemmesidens verificering og SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Tilføjet HTML i -sektionen af hjemmesiden, der primært anvendes til hjemmesidens verificering og SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiverende
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Punkt kan ikke føjes til sine egne efterkommere
 DocType: Session Default Settings,Session Defaults,Standard for session
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Advarsel
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dette kan udskrives på flere sider
 DocType: Data Migration Run,Percent Complete,Procent fuldført
 DocType: Tag Category,Tag Category,tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning skal du bruge&gt; 5, &lt;10 eller = 324. For intervaller skal du bruge 5:10 (til værdier mellem 5 og 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning skal du bruge> 5, &lt;10 eller = 324. For intervaller skal du bruge 5:10 (til værdier mellem 5 og 10)."
 DocType: Google Calendar,Pull from Google Calendar,Træk fra Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjælp
 DocType: User,Login Before,Log ind før
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Tilpasset Script
 DocType: Address,Address Line 2,Adresse 2
 DocType: Address,Reference,Henvisning
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Tildelt til
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Indstil standard e-mail-konto fra Opsætning&gt; E-mail&gt; E-mail-konto
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Indstil standard e-mail-konto fra Opsætning> E-mail> E-mail-konto
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Data Migration Mapping Detail
 DocType: Data Import,Action,Handling
 DocType: GSuite Settings,Script URL,Script URL
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Tillad på Godkend
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Undtagelsestype
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vælg kolonner
-DocType: Web Page,Add code as &lt;script&gt;,Føje kode som &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Føje kode som &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Ryd brugertilladelser
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kommende begivenheder
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,aktie-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kø skal være en af {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Standardskabelon </h4><p> Bruger <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templatering</a> og alle områderne adresse (herunder brugerdefinerede felter hvis nogen) vil være til rådighed </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Standardskabelon </h4><p> Bruger <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templatering</a> og alle områderne adresse (herunder brugerdefinerede felter hvis nogen) vil være til rådighed </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Startdatafelt
 DocType: Role,Role Name,Rollenavn
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Skift til skrivebordet

--- a/frappe/translations/da.csv
+++ b/frappe/translations/da.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Systembruger
 DocType: Report,Is Standard,Er standard
 DocType: Desktop Icon,_report,_rapport
 DocType: Dashboard Chart,Full,Fuld
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Må ikke HTML Encode HTML tags som &lt;script> eller bare tegn som &lt;eller>, som de kunne være bevidst anvendes i dette område"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Må ikke HTML Encode HTML tags som <script> eller bare tegn som <eller>, som de kunne være bevidst anvendes i dette område"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiseret den {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Løb
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Sidefod vises kun
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Afventer
 DocType: System Settings,Allow only one session per user,Tillad kun én session per bruger
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Forside / Test Mappe 1 / Test Mappe 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Vælg eller træk på tværs af tidsintervaller for at oprette en ny begivenhed.
 DocType: Contact,Contact Details,Kontaktoplysninger
 DocType: DocField,In Filter,I Filter
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Sti til servercertifikat
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ikke nok tilladelse til at se links
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresse Titel er obligatorisk.
 DocType: Google Contacts,Push to Google Contacts,Tryk på til Google-kontakter
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Tilføjet HTML i -sektionen af hjemmesiden, der primært anvendes til hjemmesidens verificering og SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Tilføjet HTML i -sektionen af hjemmesiden, der primært anvendes til hjemmesidens verificering og SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiverende
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Punkt kan ikke føjes til sine egne efterkommere
 DocType: Session Default Settings,Session Defaults,Standard for session
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Advarsel
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dette kan udskrives på flere sider
 DocType: Data Migration Run,Percent Complete,Procent fuldført
 DocType: Tag Category,Tag Category,tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning skal du bruge> 5, &lt;10 eller = 324. For intervaller skal du bruge 5:10 (til værdier mellem 5 og 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning skal du bruge> 5, <10 eller = 324. For intervaller skal du bruge 5:10 (til værdier mellem 5 og 10)."
 DocType: Google Calendar,Pull from Google Calendar,Træk fra Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjælp
 DocType: User,Login Before,Log ind før
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Tillad på Godkend
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Undtagelsestype
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vælg kolonner
-DocType: Web Page,Add code as &lt;script>,Føje kode som &lt;script>
+DocType: Web Page,Add code as <script>,Føje kode som <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Ryd brugertilladelser
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kommende begivenheder
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,aktie-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kø skal være en af {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Standardskabelon </h4><p> Bruger <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templatering</a> og alle områderne adresse (herunder brugerdefinerede felter hvis nogen) vil være til rådighed </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Standardskabelon </h4><p> Bruger <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templatering</a> og alle områderne adresse (herunder brugerdefinerede felter hvis nogen) vil være til rådighed </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Startdatafelt
 DocType: Role,Role Name,Rollenavn
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Skift til skrivebordet

--- a/frappe/translations/de.csv
+++ b/frappe/translations/de.csv
@@ -558,7 +558,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistiken basieren auf der Leistung der letzten Woche (von {0} bis {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP-Telefonfeld
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Dokumententyp ..., z. B. Kunde"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Der Zustand &#39;{0}&#39; ist ungültig
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Der Zustand '{0}' ist ungültig
 DocType: Workflow State,barcode,Barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Die Verwendung von Teilabfragen oder Funktionen ist eingeschränkt.
 apps/frappe/frappe/config/customization.py,Add your own translations,Eigene Übersetzungen hinzufügen
@@ -770,7 +770,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokumentenfreigabebericht
 DocType: Social Login Key,Base URL,Basis-URL
 DocType: User,Last Login,Letzte Anmeldung
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Sie können &#39;Übersetzbar&#39; für Feld {0} nicht festlegen
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Sie können 'Übersetzbar' für Feld {0} nicht festlegen
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Spalte
 DocType: Chat Profile,Chat Profile,Chatprofil
 DocType: Custom Field,Adds a custom field to a DocType,Fügt einem DocType ein benutzerdefiniertes Feld hinzu
@@ -779,7 +779,7 @@ DocType: File,Is Home Folder,Ist Ordner für Startseite
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Style
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ist keine gültige E-Mail-Adresse
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Wählen Sie mindestens einen Datensatz für den Druck
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Benutzer &#39;{0}&#39; hat bereits die Rolle &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Benutzer '{0}' hat bereits die Rolle '{1}'
 DocType: System Settings,Two Factor Authentication method,Zwei Faktor-Authentifizierungsmethode
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Legen Sie zuerst den Namen fest und speichern Sie den Datensatz.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Datensätze
@@ -1442,7 +1442,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Pflichtfeld: set Rolle für
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritisiert {1}
 DocType: Data Migration Mapping,Mapping Name,Name der Zuordnung
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Feld &#39;{1}&#39; kann nicht als eindeutig festgelegt werden, da es nicht eindeutige Werte enthält"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Feld '{1}' kann nicht als eindeutig festgelegt werden, da es nicht eindeutige Werte enthält"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Liste nach unten navigieren
 DocType: Currency,A symbol for this currency. For e.g. $,"Ein Symbol für diese Währung, z. B. €"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Erfolgreich aktualisierte Übersetzungen
@@ -2111,7 +2111,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sitzungsende in Stu
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Dieses Feld wird nur angezeigt, wenn der Feldname hier definierten Wert hat oder die Regeln erfüllt sind (Beispiele): myfield eval: doc.myfield == &#39;My Value&#39; eval: doc.age> 18"
+eval:doc.age>18","Dieses Feld wird nur angezeigt, wenn der Feldname hier definierten Wert hat oder die Regeln erfüllt sind (Beispiele): myfield eval: doc.myfield == 'My Value' eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Büro 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Heute
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Sobald dies eingestellt wurde, haben die Benutzer nur Zugriff auf Dokumente (z. B. Blog-Eintrag), bei denen eine Verknüpfung existiert (z. B. Blogger)."
@@ -2150,7 +2150,7 @@ DocType: Data Migration Connector,Database Name,Name der Datenbank
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Formular aktualisieren
 DocType: DocField,Select,Auswählen
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Vollständiges Protokoll anzeigen
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Einfacher Python-Ausdruck, Beispiel: status == &#39;Open&#39; und type == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Einfacher Python-Ausdruck, Beispiel: status == 'Open' und type == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Datei nicht angehängt
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Verbindung unterbrochen. Einige Funktionen funktionieren möglicherweise nicht.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Wiederholt wie &quot;aaa&quot; sind leicht zu erraten
@@ -2760,7 +2760,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Bildansicht
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Es scheint, als wäre während der Transaktion etwas falsch gelaufen. Da wir die Zahlung nicht bestätigt haben, wird Paypal  automatisch diesen Betrag an Sie zurück erstatten. Ist dies nicht der Fall, senden Sie uns bitte eine E-Mail und geben Sie die Abstimmungs ID: {0} an."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Geben Sie Symbole, Zahlen und Großbuchstaben in das Passwort ein"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Dahinter einfügen Feld &#39;{0}&#39; in benutzerdefinierten Feld erwähnt &#39;{1}&#39;, mit dem Label &#39;{2}&#39; existiert nicht"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Dahinter einfügen Feld '{0}' in benutzerdefinierten Feld erwähnt '{1}', mit dem Label '{2}' existiert nicht"
 DocType: List Filter,List Filter,Listenfilter
 DocType: Workflow State,signal,Signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Hat Anhänge
@@ -2770,7 +2770,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokument wiederhergestellt
 DocType: Data Export,Data Export,Datenexport
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Sprache auswählen...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Sie können &#39;Optionen&#39; nicht für das Feld {0} setzen
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Sie können 'Optionen' nicht für das Feld {0} setzen
 DocType: Help Article,Author,Autor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Senden fortsetzen
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Wieder öffnen
@@ -2784,7 +2784,7 @@ DocType: Web Page,Slideshow,Diaschau
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Standard-Adressvorlage kann nicht gelöscht werden
 DocType: Contact,Maintenance Manager,Leiter der Wartung
 DocType: Workflow State,Search,Suchen
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Bitte wählen Sie eine andere Zahlungsmethode. Stripe unterstützt keine Transaktionen in der Währung &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Bitte wählen Sie eine andere Zahlungsmethode. Stripe unterstützt keine Transaktionen in der Währung '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,In den Papierkorb verschieben
 DocType: Web Form,Web Form Fields,Web-Formularfelder
 DocType: Data Import,Amended From,Abgeändert von
@@ -2978,7 +2978,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Fehlender Wert für
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Unterpunkt hinzufügen
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Importfortschritt
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Wenn die Bedingung erfüllt ist, wird der Benutzer mit den Punkten belohnt. z.B. doc.status == &#39;Geschlossen&#39;"
+","Wenn die Bedingung erfüllt ist, wird der Benutzer mit den Punkten belohnt. z.B. doc.status == 'Geschlossen'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Übertragener Datensatz kann nicht gelöscht werden.
 DocType: GSuite Templates,Template Name,Vorlagenname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,neuer Dokumententyp
@@ -3397,7 +3397,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Benutzerdefiniert
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Fortschritt
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,durch Rolle
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Nicht ausgefüllte Felder
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ungültige Feldname &#39;{0}&#39; in auton
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ungültige Feldname '{0}' in auton
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Suche in einem Dokumenttyp
 DocType: Custom DocPerm,Role and Level,Rolle und Ebene
 DocType: File,Thumbnail URL,Thumbnail-URL
@@ -3497,7 +3497,7 @@ DocType: Dashboard Chart,Filters JSON,Filtert JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Hier klicken um die Richtigkeit zu bestätigen
 DocType: Email Account,Disable SMTP server authentication,Deaktivieren Sie die SMTP-Serverauthentifizierung
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,In die Zwischenablage kopiert.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Vorhersehbare Substitutionen wie &#39;@&#39; anstelle von &#39;a&#39; helfen nicht sehr viel.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Vorhersehbare Substitutionen wie '@' anstelle von 'a' helfen nicht sehr viel.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Von mir zugewiesen
 apps/frappe/frappe/utils/data.py,Zero,Null
 DocType: Google Drive,Backup Folder ID,Sicherungsordner-ID
@@ -3709,7 +3709,7 @@ DocType: Web Page,Web Page,Webseite
 DocType: Workflow Document State,Next Action Email Template,Nächste Aktion E-Mail-Vorlage
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Wenn diese Option aktiviert ist, werden Änderungen am Dokument nachverfolgt und in der Zeitleiste angezeigt"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;In Globaler Suche&#39; nicht zulässig für Typ {0} in Zeile {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'In Globaler Suche' nicht zulässig für Typ {0} in Zeile {1}
 DocType: Energy Point Log,Appreciation,Anerkennung
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Liste anzeigen
 DocType: Workflow,Don't Override Status,Status nicht überschreiben
@@ -3856,7 +3856,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Standard
 DocType: Translation,Verified,Verifiziert
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} hinzugefügt
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Suche nach &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Suche nach '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Bitte speichern Sie den Bericht zuerst
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} Empfänger hinzugefügt
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Nicht in

--- a/frappe/translations/de.csv
+++ b/frappe/translations/de.csv
@@ -743,7 +743,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Dateisicher
 DocType: DocField,In Global Search,In globaler Suche
 DocType: System Settings,Brute Force Security,Brute-Force-Sicherheit
 DocType: Workflow State,indent-left,Einzug links
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,Vor&gt; {0} Jahr (en)
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,Vor> {0} Jahr (en)
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Es ist riskant, diese Datei zu löschen: {0}. Bitte kontaktieren Sie Ihren System-Manager."
 DocType: Currency,Currency Name,Währungsbezeichnung
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Keine E-Mails
@@ -1037,7 +1037,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Kein(e) {0} g
 apps/frappe/frappe/config/customization.py,Add custom forms.,Benutzerdefinierte Formulare hinzufügen
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} in {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,Dieses Dokument eingereicht
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Setup&gt; Benutzerberechtigungen
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Setup> Benutzerberechtigungen
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,"Das System bietet viele vordefinierte Rollen. Es können neue Rollen hinzugefügt werden, um feinere Berechtigungen festzulegen."
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1256,7 +1256,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Wenn der Benutzer eine Rolle geprüft hat, wird er ein ""System User"". ""System User"" haben Zugriff auf den Desktop."
 DocType: System Settings,Date and Number Format,Datums- und Zahlenformat
 apps/frappe/frappe/model/document.py,one of,eine(r/s) von
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Setup&gt; Formular anpassen
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Setup> Formular anpassen
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,"Einen Moment bitte, Überprüfung läuft."
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Schlagwörter anzeigen
 DocType: DocField,HTML Editor,HTML-Editor
@@ -1264,7 +1264,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Abrechnung
 DocType: Email Queue,Not Sent,Nicht versendet
 DocType: Web Form,Actions,Aktionen
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Setup&gt; Benutzer
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Setup> Benutzer
 DocType: Workflow State,align-justify,Blocksatz
 DocType: User,Middle Name (Optional),Weiterer Vorname (optional)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nicht zulässig
@@ -1411,7 +1411,7 @@ DocType: User,System User,Systembenutzer
 DocType: Report,Is Standard,Ist Standard
 DocType: Desktop Icon,_report,_Bericht
 DocType: Dashboard Chart,Full,Voll
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Nicht HTML Encode HTML-Tags wie &lt;script&gt; oder einfach nur Zeichen wie &lt;oder&gt;, da sie absichtlich auf diesem Gebiet verwendet werden könnten,"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nicht HTML Encode HTML-Tags wie &lt;script> oder einfach nur Zeichen wie &lt;oder>, da sie absichtlich auf diesem Gebiet verwendet werden könnten,"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} am {1} kritisiert
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Lauf
@@ -1791,7 +1791,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Die Fußzeile wir
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Ausstehend
 DocType: System Settings,Allow only one session per user,Nur eine Sitzung pro Benutzer zulassen
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Startseite/Test-Ordner 1/Test-Ordner 3
-DocType: Website Settings,&lt;head&gt; HTML,HTML
+DocType: Website Settings,&lt;head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Um ein neues Ereignis zu erstellen, Zeitfenster markieren oder über ein Zeitfenster ziehen"
 DocType: Contact,Contact Details,Kontakt-Details
 DocType: DocField,In Filter,Im Filter
@@ -2024,7 +2024,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Anmelden zur Zeit nicht erlaubt
 DocType: Data Migration Run,Current Mapping Action,Aktuelle Abbildungsaktion
 DocType: Dashboard Chart Source,Source Name,Quellenname
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Dem Benutzer ist kein E-Mail-Konto zugeordnet. Bitte fügen Sie unter Benutzer&gt; E-Mail-Posteingang ein Konto hinzu.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Dem Benutzer ist kein E-Mail-Konto zugeordnet. Bitte fügen Sie unter Benutzer> E-Mail-Posteingang ein Konto hinzu.
 DocType: Email Account,Email Sync Option,E-Mail-Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Reihe Nr
 DocType: Async Task,Runtime,Laufzeit
@@ -2039,7 +2039,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Bereits i
 DocType: User Email,Enable Outgoing,Ausgehend aktivieren
 DocType: Address,Fax,Telefax
 apps/frappe/frappe/config/customization.py,Custom Tags,Benutzerdefinierte Schlagwörter
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-Mail-Konto nicht eingerichtet. Bitte erstellen Sie ein neues E-Mail-Konto über Setup&gt; E-Mail&gt; E-Mail-Konto
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-Mail-Konto nicht eingerichtet. Bitte erstellen Sie ein neues E-Mail-Konto über Setup> E-Mail> E-Mail-Konto
 DocType: Comment,Submitted,Gebucht
 DocType: Contact,Pulled from Google Contacts,Aus Google-Kontakten gezogen
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ungültige Anfrage
@@ -2111,7 +2111,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sitzungsende in Stu
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Dieses Feld wird nur angezeigt, wenn der Feldname hier definierten Wert hat oder die Regeln erfüllt sind (Beispiele): myfield eval: doc.myfield == &#39;My Value&#39; eval: doc.age&gt; 18"
+eval:doc.age>18","Dieses Feld wird nur angezeigt, wenn der Feldname hier definierten Wert hat oder die Regeln erfüllt sind (Beispiele): myfield eval: doc.myfield == &#39;My Value&#39; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Büro 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Heute
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Sobald dies eingestellt wurde, haben die Benutzer nur Zugriff auf Dokumente (z. B. Blog-Eintrag), bei denen eine Verknüpfung existiert (z. B. Blogger)."
@@ -2125,7 +2125,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,GROSSBUCHSTABEN
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Benutzerdefiniertes HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Ordnernamen eingeben
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Keine Standardadressvorlage gefunden. Erstellen Sie unter Setup&gt; Drucken und Markieren&gt; Adressvorlage eine neue.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Keine Standardadressvorlage gefunden. Erstellen Sie unter Setup> Drucken und Markieren> Adressvorlage eine neue.
 apps/frappe/frappe/auth.py,Unknown User,Unbekannter Benutzer
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Rolle auswählen
 DocType: Comment,Deleted,Gelöscht
@@ -2314,7 +2314,7 @@ DocType: LDAP Settings,Path to Server Certificate,Pfad zum Server-Zertifikat
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,"Nicht genügend Erlaubnis, Links zu sehen"
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adressbezeichnung muss zwingend angegeben werden.
 DocType: Google Contacts,Push to Google Contacts,Zu Google-Kontakten verschieben
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML im ""head""-Abschnitt der Web-Seite hinzugefügt. Wird vor allem für Webseiten-Verifikation und SEO verwendet"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML im ""head""-Abschnitt der Web-Seite hinzugefügt. Wird vor allem für Webseiten-Verifikation und SEO verwendet"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Rückfällig
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Artikel kann nicht zu seinen eigenen Abkömmlingen hinzugefügt werden
 DocType: Session Default Settings,Session Defaults,Sitzungsstandards
@@ -2433,7 +2433,7 @@ DocType: Workflow State,Warning,Warnung
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dies kann auf mehreren Seiten ausgedruckt werden
 DocType: Data Migration Run,Percent Complete,Prozent abgeschlossen
 DocType: Tag Category,Tag Category,Tag Kategorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Verwenden Sie zum Vergleich&gt; 5, &lt;10 oder = 324. Verwenden Sie für Bereiche 5:10 (für Werte zwischen 5 und 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Verwenden Sie zum Vergleich> 5, &lt;10 oder = 324. Verwenden Sie für Bereiche 5:10 (für Werte zwischen 5 und 10)."
 DocType: Google Calendar,Pull from Google Calendar,Aus Google Kalender ziehen
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hilfe
 DocType: User,Login Before,Anmelden vor
@@ -2895,7 +2895,7 @@ DocType: Custom Script,Custom Script,Benutzerdefiniertes Skript
 DocType: Address,Address Line 2,Adresse Zeile 2
 DocType: Address,Reference,Referenz
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Zugewiesen zu
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Bitte richten Sie das Standard-E-Mail-Konto über Setup&gt; E-Mail&gt; E-Mail-Konto ein
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Bitte richten Sie das Standard-E-Mail-Konto über Setup> E-Mail> E-Mail-Konto ein
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Datenmigrations-Mapping-Detail
 DocType: Data Import,Action,Aktion
 DocType: GSuite Settings,Script URL,Skript-URL
@@ -3072,7 +3072,7 @@ DocType: DocField,Allow on Submit,Beim Übertragen zulassen
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Ausnahmetyp
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Spalten auswählen
-DocType: Web Page,Add code as &lt;script&gt;,"Code als ""script""  hinzufügen"
+DocType: Web Page,Add code as &lt;script>,"Code als ""script""  hinzufügen"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Benutzerrechte löschen
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kommende Veranstaltungen
@@ -3446,15 +3446,15 @@ DocType: Workflow State,share-alt,teilen-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Warteschlange sollte eine von {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> Verwendet <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> und alle Felder der Adresse ( einschließlich Custom Fields falls vorhanden) zur Verfügung </ p> 
  <pre> <code> {{ADDRESS_LINE1}} & lt; br & gt; 

--- a/frappe/translations/de.csv
+++ b/frappe/translations/de.csv
@@ -1411,7 +1411,7 @@ DocType: User,System User,Systembenutzer
 DocType: Report,Is Standard,Ist Standard
 DocType: Desktop Icon,_report,_Bericht
 DocType: Dashboard Chart,Full,Voll
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nicht HTML Encode HTML-Tags wie &lt;script> oder einfach nur Zeichen wie &lt;oder>, da sie absichtlich auf diesem Gebiet verwendet werden könnten,"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Nicht HTML Encode HTML-Tags wie <script> oder einfach nur Zeichen wie <oder>, da sie absichtlich auf diesem Gebiet verwendet werden könnten,"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} am {1} kritisiert
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Lauf
@@ -1791,7 +1791,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Die Fußzeile wir
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Ausstehend
 DocType: System Settings,Allow only one session per user,Nur eine Sitzung pro Benutzer zulassen
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Startseite/Test-Ordner 1/Test-Ordner 3
-DocType: Website Settings,&lt;head> HTML,HTML
+DocType: Website Settings,<head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Um ein neues Ereignis zu erstellen, Zeitfenster markieren oder über ein Zeitfenster ziehen"
 DocType: Contact,Contact Details,Kontakt-Details
 DocType: DocField,In Filter,Im Filter
@@ -2314,7 +2314,7 @@ DocType: LDAP Settings,Path to Server Certificate,Pfad zum Server-Zertifikat
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,"Nicht genügend Erlaubnis, Links zu sehen"
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adressbezeichnung muss zwingend angegeben werden.
 DocType: Google Contacts,Push to Google Contacts,Zu Google-Kontakten verschieben
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML im ""head""-Abschnitt der Web-Seite hinzugefügt. Wird vor allem für Webseiten-Verifikation und SEO verwendet"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML im ""head""-Abschnitt der Web-Seite hinzugefügt. Wird vor allem für Webseiten-Verifikation und SEO verwendet"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Rückfällig
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Artikel kann nicht zu seinen eigenen Abkömmlingen hinzugefügt werden
 DocType: Session Default Settings,Session Defaults,Sitzungsstandards
@@ -2433,7 +2433,7 @@ DocType: Workflow State,Warning,Warnung
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dies kann auf mehreren Seiten ausgedruckt werden
 DocType: Data Migration Run,Percent Complete,Prozent abgeschlossen
 DocType: Tag Category,Tag Category,Tag Kategorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Verwenden Sie zum Vergleich> 5, &lt;10 oder = 324. Verwenden Sie für Bereiche 5:10 (für Werte zwischen 5 und 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Verwenden Sie zum Vergleich> 5, <10 oder = 324. Verwenden Sie für Bereiche 5:10 (für Werte zwischen 5 und 10)."
 DocType: Google Calendar,Pull from Google Calendar,Aus Google Kalender ziehen
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hilfe
 DocType: User,Login Before,Anmelden vor
@@ -3072,7 +3072,7 @@ DocType: DocField,Allow on Submit,Beim Übertragen zulassen
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Ausnahmetyp
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Spalten auswählen
-DocType: Web Page,Add code as &lt;script>,"Code als ""script""  hinzufügen"
+DocType: Web Page,Add code as <script>,"Code als ""script""  hinzufügen"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Benutzerrechte löschen
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kommende Veranstaltungen
@@ -3446,26 +3446,26 @@ DocType: Workflow State,share-alt,teilen-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Warteschlange sollte eine von {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> Verwendet <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> und alle Felder der Adresse ( einschließlich Custom Fields falls vorhanden) zur Verfügung </ p> 
- <pre> <code> {{ADDRESS_LINE1}} & lt; br & gt; 
- {% if ADDRESS_LINE2%} {{ADDRESS_LINE2}} & lt; br & gt; { % endif -%} 
- {{city}} & lt; br & gt; 
- {% if Zustand%} {{Zustand}} & lt; br & gt; {% endif -%} {% 
- wenn PIN-Code%} PIN: {{Pincode}} & lt; br & gt; {% endif -%} 
- {{country}} & lt; br & gt; 
- {% if Telefon%} Telefon: {{Telefon}} & lt; br & gt; { % endif -%} 
- {% if Fax%} Fax: {{Fax}} & lt; br & gt; {% endif -%} 
- {% if email_id%} E-Mail: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{ADDRESS_LINE1}} <br> 
+ {% if ADDRESS_LINE2%} {{ADDRESS_LINE2}} <br> { % endif -%} 
+ {{city}} <br> 
+ {% if Zustand%} {{Zustand}} <br> {% endif -%} {% 
+ wenn PIN-Code%} PIN: {{Pincode}} <br> {% endif -%} 
+ {{country}} <br> 
+ {% if Telefon%} Telefon: {{Telefon}} <br> { % endif -%} 
+ {% if Fax%} Fax: {{Fax}} <br> {% endif -%} 
+ {% if email_id%} E-Mail: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Startdatum Feld
 DocType: Role,Role Name,Rollenname

--- a/frappe/translations/el.csv
+++ b/frappe/translations/el.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Χρήστης συστήματος
 DocType: Report,Is Standard,Είναι πρότυπο
 DocType: Desktop Icon,_report,_ΑΝΑΦΟΡΑ
 DocType: Dashboard Chart,Full,Γεμάτος
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Μην ετικέτες HTML Encode HTML όπως &lt;script> ή απλά χαρακτήρες όπως &lt;ή>, καθώς θα μπορούσαν να χρησιμοποιούνται σκόπιμα σε αυτό το πεδίο"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Μην ετικέτες HTML Encode HTML όπως <script> ή απλά χαρακτήρες όπως <ή>, καθώς θα μπορούσαν να χρησιμοποιούνται σκόπιμα σε αυτό το πεδίο"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} επικρίθηκε στις {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Τρέξιμο
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Το υποσέλ
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Εκκρεμής
 DocType: System Settings,Allow only one session per user,Επιτρέπουν μόνο μια συνεδρία ανά χρήστη
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Αρχική Σελίδα / Δοκιμή Φάκελος 1 / Έλεγχος φακέλου 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Επιλέξτε ή σύρετε χρονοθυρίδες για να δημιουργήσετε ένα νέο συμβάν.
 DocType: Contact,Contact Details,Στοιχεία επικοινωνίας επαφής
 DocType: DocField,In Filter,Στο φίλτρο
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Πιστοποιητικό δ�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Δεν υπάρχει αρκετή άδεια για να δείτε συνδέσμους
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Ο τίτλος της διεύθυνσης είναι υποχρεωτικός.
 DocType: Google Contacts,Push to Google Contacts,Πατήστε στις Επαφές Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Προστέθηκε HTML στην ενότητα &lt;head> της ιστοσελίδας, που χρησιμοποιούνται κυρίως για την επαλήθευση της ιστοσελίδας και SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Προστέθηκε HTML στην ενότητα <head> της ιστοσελίδας, που χρησιμοποιούνται κυρίως για την επαλήθευση της ιστοσελίδας και SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Υποτροπή
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Το είδος δεν μπορεί να προστεθεί στους δικούς του απογόνους
 DocType: Session Default Settings,Session Defaults,Προεπιλογές περιόδου σύνδεσης
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Προειδοποίηση
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Αυτό μπορεί να εκτυπωθεί σε πολλές σελίδες
 DocType: Data Migration Run,Percent Complete,Το ποσοστό ολοκληρώνεται
 DocType: Tag Category,Tag Category,Tag Κατηγορία
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Για σύγκριση, χρησιμοποιήστε> 5, &lt;10 ή = 324. Για σειρές, χρησιμοποιήστε 5:10 (για τιμές μεταξύ 5 και 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Για σύγκριση, χρησιμοποιήστε> 5, <10 ή = 324. Για σειρές, χρησιμοποιήστε 5:10 (για τιμές μεταξύ 5 και 10)."
 DocType: Google Calendar,Pull from Google Calendar,Τραβήξτε από το Ημερολόγιο Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Βοήθεια
 DocType: User,Login Before,Είσοδος πριν από
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Επιτρέπεται κατά την υπο�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Εξαίρεση Τύπος
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Διαλέξτε Στήλες
-DocType: Web Page,Add code as &lt;script>,Προσθήκη κώδικα ως <script>
+DocType: Web Page,Add code as <script>,Προσθήκη κώδικα ως <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Εκκαθάριση δικαιωμάτων χρήστη
 DocType: Webhook,Headers,Κεφαλίδες
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Ανερχόμενες εκδηλώσεις
@@ -3445,15 +3445,15 @@ DocType: Workflow State,share-alt,Share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Η ουρά πρέπει να είναι μία από τις {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> προεπιλεγμένο πρότυπο </ h4> 
  <p> <a χρήσεις href=""http://jinja.Pocoo.Org/docs/templates/""> τζίντζα templating </a> και όλα τα πεδία της διεύθυνσης ( συμπεριλαμβανομένων των προσαρμοσμένων πεδίων αν υπάρχουν) θα είναι διαθέσιμη </ p> 
  <pre> <κωδικός> {{address_line1}} & lt? br & gt? 

--- a/frappe/translations/el.csv
+++ b/frappe/translations/el.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Το αρχ
 DocType: DocField,In Global Search,Στην Σφαιρική Αναζήτηση
 DocType: System Settings,Brute Force Security,Ασφάλεια βίαιης βίας
 DocType: Workflow State,indent-left,Εσοχή-αριστερά
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} χρόνια πριν
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} χρόνια πριν
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Είναι επικίνδυνο να διαγράψετε αυτό το αρχείο: {0}. Επικοινωνήστε με το διαχειριστή του συστήματός σας.
 DocType: Currency,Currency Name,Όνομα νομίσματος
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Δεν Emails
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Δεν βρέ
 apps/frappe/frappe/config/customization.py,Add custom forms.,Προσθέστε προσαρμοσμένες φόρμες.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} στο {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,υπέβαλε αυτό το έγγραφο
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Ρύθμιση&gt; Δικαιώματα χρήστη
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Ρύθμιση> Δικαιώματα χρήστη
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Το σύστημα παρέχει πολλούς προκαθορισμένες ρόλους. Μπορείτε να προσθέσετε νέους ρόλους για να ορίσετε ειδικότερα δικαιώματα .
 DocType: Communication,CC,CC
 DocType: Country,Geo,Γεωγραφία
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Εάν ο χρήστης δεν έχει κανένα ρόλο ελεγχθεί, τότε ο χρήστης γίνεται ένα &quot;Χρήστης Συστήματος». &quot;Ο χρήστης του συστήματος&quot; έχει πρόσβαση στην επιφάνεια εργασίας"
 DocType: System Settings,Date and Number Format,Ημερομηνία και μορφή αριθμών
 apps/frappe/frappe/model/document.py,one of,Ένας από
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Ρυθμίσεις&gt; Προσαρμογή φόρμας
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Ρυθμίσεις> Προσαρμογή φόρμας
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Έλεγχος μια στιγμή
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Δείτε τις ετικέτες
 DocType: DocField,HTML Editor,HTML Editor
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Χρέωση
 DocType: Email Queue,Not Sent,Δεν απεστάλη
 DocType: Web Form,Actions,Ενέργειες
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Ρύθμιση&gt; Χρήστης
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Ρύθμιση> Χρήστης
 DocType: Workflow State,align-justify,Ευθυγράμμιση σε όλη τη γραμμή
 DocType: User,Middle Name (Optional),Πατρώνυμο (προαιρετικό)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Δεν επιτρέπεται
@@ -1410,7 +1410,7 @@ DocType: User,System User,Χρήστης συστήματος
 DocType: Report,Is Standard,Είναι πρότυπο
 DocType: Desktop Icon,_report,_ΑΝΑΦΟΡΑ
 DocType: Dashboard Chart,Full,Γεμάτος
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Μην ετικέτες HTML Encode HTML όπως &lt;script&gt; ή απλά χαρακτήρες όπως &lt;ή&gt;, καθώς θα μπορούσαν να χρησιμοποιούνται σκόπιμα σε αυτό το πεδίο"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Μην ετικέτες HTML Encode HTML όπως &lt;script> ή απλά χαρακτήρες όπως &lt;ή>, καθώς θα μπορούσαν να χρησιμοποιούνται σκόπιμα σε αυτό το πεδίο"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} επικρίθηκε στις {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Τρέξιμο
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Το υποσέλ
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Εκκρεμής
 DocType: System Settings,Allow only one session per user,Επιτρέπουν μόνο μια συνεδρία ανά χρήστη
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Αρχική Σελίδα / Δοκιμή Φάκελος 1 / Έλεγχος φακέλου 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Επιλέξτε ή σύρετε χρονοθυρίδες για να δημιουργήσετε ένα νέο συμβάν.
 DocType: Contact,Contact Details,Στοιχεία επικοινωνίας επαφής
 DocType: DocField,In Filter,Στο φίλτρο
@@ -2022,7 +2022,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Η είσοδος δεν επιτρέπεται αυτή τη στιγμή
 DocType: Data Migration Run,Current Mapping Action,Τρέχουσα δράση χαρτογράφησης
 DocType: Dashboard Chart Source,Source Name,Όνομα πηγή
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Δεν υπάρχει λογαριασμός ηλεκτρονικού ταχυδρομείου που σχετίζεται με τον Χρήστη. Προσθέστε ένα λογαριασμό κάτω από το User&gt; Email Inbox.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Δεν υπάρχει λογαριασμός ηλεκτρονικού ταχυδρομείου που σχετίζεται με τον Χρήστη. Προσθέστε ένα λογαριασμό κάτω από το User> Email Inbox.
 DocType: Email Account,Email Sync Option,Email επιλογή Sync
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Αριθμός σειράς
 DocType: Async Task,Runtime,Διάρκεια
@@ -2037,7 +2037,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Ήδη σ
 DocType: User Email,Enable Outgoing,Ενεργοποίηση εξερχομένων
 DocType: Address,Fax,Φαξ
 apps/frappe/frappe/config/customization.py,Custom Tags,προσαρμοσμένες ετικέτες
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Ο λογαριασμός ηλεκτρονικού ταχυδρομείου δεν έχει ρυθμιστεί. Δημιουργήστε ένα νέο λογαριασμό ηλεκτρονικού ταχυδρομείου από το Setup&gt; Email&gt; Email Account
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Ο λογαριασμός ηλεκτρονικού ταχυδρομείου δεν έχει ρυθμιστεί. Δημιουργήστε ένα νέο λογαριασμό ηλεκτρονικού ταχυδρομείου από το Setup> Email> Email Account
 DocType: Comment,Submitted,Υποβλήθηκε
 DocType: Contact,Pulled from Google Contacts,Προέρχεται από τις Επαφές Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ακυρη Αίτηση
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Λήξη συνεδ
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Αυτό το πεδίο θα εμφανιστεί μόνο αν η ΌνομαΠεδίου ορίζεται εδώ έχει αξία ή οι κανόνες είναι αλήθεια (παραδείγματα): myfield eval: doc.myfield == «Αξία μου» eval: doc.age&gt; 18
+eval:doc.age>18",Αυτό το πεδίο θα εμφανιστεί μόνο αν η ΌνομαΠεδίου ορίζεται εδώ έχει αξία ή οι κανόνες είναι αλήθεια (παραδείγματα): myfield eval: doc.myfield == «Αξία μου» eval: doc.age> 18
 DocType: Social Login Key,Office 365,Γραφείο 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Σήμερα
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Αφού οριστεί, οι χρήστες θα έχουν πρόσβαση μονο σε έγγραφα ( π.Χ. Blog post), όπου υπάρχει σύνδεσμος ( π.Χ. Blogger ) ."
@@ -2123,7 +2123,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ΚΕΦΑΛΑΊΑ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Προσαρμοσμένος κώδικας HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Πληκτρολογήστε το όνομα του φακέλου
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Δεν βρέθηκε προεπιλεγμένο πρότυπο διεύθυνσης. Δημιουργήστε ένα νέο από το Setup&gt; Printing and Branding&gt; Template Address.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Δεν βρέθηκε προεπιλεγμένο πρότυπο διεύθυνσης. Δημιουργήστε ένα νέο από το Setup> Printing and Branding> Template Address.
 apps/frappe/frappe/auth.py,Unknown User,Αγνωστος χρήστης
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Επιλέξτε ρόλο
 DocType: Comment,Deleted,Διεγραμμένο
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Πιστοποιητικό δ�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Δεν υπάρχει αρκετή άδεια για να δείτε συνδέσμους
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Ο τίτλος της διεύθυνσης είναι υποχρεωτικός.
 DocType: Google Contacts,Push to Google Contacts,Πατήστε στις Επαφές Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Προστέθηκε HTML στην ενότητα &lt;head&gt; της ιστοσελίδας, που χρησιμοποιούνται κυρίως για την επαλήθευση της ιστοσελίδας και SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Προστέθηκε HTML στην ενότητα &lt;head> της ιστοσελίδας, που χρησιμοποιούνται κυρίως για την επαλήθευση της ιστοσελίδας και SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Υποτροπή
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Το είδος δεν μπορεί να προστεθεί στους δικούς του απογόνους
 DocType: Session Default Settings,Session Defaults,Προεπιλογές περιόδου σύνδεσης
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Προειδοποίηση
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Αυτό μπορεί να εκτυπωθεί σε πολλές σελίδες
 DocType: Data Migration Run,Percent Complete,Το ποσοστό ολοκληρώνεται
 DocType: Tag Category,Tag Category,Tag Κατηγορία
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Για σύγκριση, χρησιμοποιήστε&gt; 5, &lt;10 ή = 324. Για σειρές, χρησιμοποιήστε 5:10 (για τιμές μεταξύ 5 και 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Για σύγκριση, χρησιμοποιήστε> 5, &lt;10 ή = 324. Για σειρές, χρησιμοποιήστε 5:10 (για τιμές μεταξύ 5 και 10)."
 DocType: Google Calendar,Pull from Google Calendar,Τραβήξτε από το Ημερολόγιο Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Βοήθεια
 DocType: User,Login Before,Είσοδος πριν από
@@ -2893,7 +2893,7 @@ DocType: Custom Script,Custom Script,Προσαρμοσμένο script
 DocType: Address,Address Line 2,Γραμμή διεύθυνσης 2
 DocType: Address,Reference,Αναφορά
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Ανατέθηκε σε
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Ρυθμίστε τον προεπιλεγμένο λογαριασμό ηλεκτρονικού ταχυδρομείου από το Setup&gt; Email&gt; Email Account
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Ρυθμίστε τον προεπιλεγμένο λογαριασμό ηλεκτρονικού ταχυδρομείου από το Setup> Email> Email Account
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Λεπτομέρειες χαρτογράφησης μετανάστευσης δεδομένων
 DocType: Data Import,Action,Ενέργεια
 DocType: GSuite Settings,Script URL,URL δέσμης ενεργειών
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Επιτρέπεται κατά την υπο�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Εξαίρεση Τύπος
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Διαλέξτε Στήλες
-DocType: Web Page,Add code as &lt;script&gt;,Προσθήκη κώδικα ως <script>
+DocType: Web Page,Add code as &lt;script>,Προσθήκη κώδικα ως <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Εκκαθάριση δικαιωμάτων χρήστη
 DocType: Webhook,Headers,Κεφαλίδες
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Ανερχόμενες εκδηλώσεις
@@ -3445,15 +3445,15 @@ DocType: Workflow State,share-alt,Share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Η ουρά πρέπει να είναι μία από τις {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> προεπιλεγμένο πρότυπο </ h4> 
  <p> <a χρήσεις href=""http://jinja.Pocoo.Org/docs/templates/""> τζίντζα templating </a> και όλα τα πεδία της διεύθυνσης ( συμπεριλαμβανομένων των προσαρμοσμένων πεδίων αν υπάρχουν) θα είναι διαθέσιμη </ p> 
  <pre> <κωδικός> {{address_line1}} & lt? br & gt? 

--- a/frappe/translations/el.csv
+++ b/frappe/translations/el.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Στατιστικά με βάση την απόδοση της περασμένης εβδομάδας (από {0} έως {1})
 DocType: LDAP Settings,LDAP Phone Field,Πεδίο τηλεφώνου LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Τύπος εγγράφου ..., π.χ. πελατών"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Η Κατάσταση &#39;{0}&#39; δεν είναι έγκυρη
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Η Κατάσταση '{0}' δεν είναι έγκυρη
 DocType: Workflow State,barcode,Barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Η χρήση υπο-ερωτήματος ή συνάρτησης είναι περιορισμένη
 apps/frappe/frappe/config/customization.py,Add your own translations,Προσθέστε τις δικές σας μεταφράσεις
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Όνομα νομίσματος
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Δεν Emails
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Η σύνδεση έληξε
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Επαναφορά μήκους στο {0} για &#39;{1}&#39; στο &#39;{2}&#39;; Ο ορισμός του μήκους ως {3} θα προκαλέσει περικοπή δεδομένων.
+							Setting the length as {3} will cause truncation of data.",Επαναφορά μήκους στο {0} για '{1}' στο '{2}'; Ο ορισμός του μήκους ως {3} θα προκαλέσει περικοπή δεδομένων.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Επιλέξτε Μορφή αρχείου
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash περιεχομένου
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Είναι Προσωπικόςφάκελος
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Στυλ Navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} δεν είναι μια έγκυρη διεύθυνση ηλεκτρονικού ταχυδρομείου
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Επιλέξτε atleast 1 εγγραφή για εκτύπωση
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Ο χρήστης &#39;{0}&#39; έχει ήδη το ρόλο &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Ο χρήστης '{0}' έχει ήδη το ρόλο '{1}'
 DocType: System Settings,Two Factor Authentication method,Μέθοδος ελέγχου ταυτότητας δύο παραγόντων
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Αρχικά ορίστε το όνομα και αποθηκεύστε την εγγραφή.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 εγγραφές
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Υποχρεωτικό πεδίο: που ο ρόλος για
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} επικρίνεται {1}
 DocType: Data Migration Mapping,Mapping Name,Όνομα χαρτογράφησης
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Το πεδίο &#39;{1}&#39; δεν μπορεί να οριστεί ως Μοναδικό καθώς έχει μη μοναδικές τιμές
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Το πεδίο '{1}' δεν μπορεί να οριστεί ως Μοναδικό καθώς έχει μη μοναδικές τιμές
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Πλοηγηθείτε στη λίστα κάτω
 DocType: Currency,A symbol for this currency. For e.g. $,Ένα σύμβολο για το νόμισμα αυτό. Για παράδειγμα $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Οι μεταφράσεις έχουν ενημερωθεί με επιτυχία
@@ -2005,7 +2005,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Γραμματοσειρά Google
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Εάν αυτές οι οδηγίες δεν ήταν χρήσιμες, Παρακαλώ να προσθέσετε τις δικές σας προτάσεις σχετικά με τα θέματα github."
 DocType: Workflow State,bookmark,Σελιδοδείκτης
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Το όνομα του φακέλου δεν πρέπει να περιλαμβάνει &#39;/&#39; (κάθετο)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Το όνομα του φακέλου δεν πρέπει να περιλαμβάνει '/' (κάθετο)
 DocType: Note,Note,Σημείωση
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Αναφορά σφάλματος
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Εξαγωγή δεδομένων σε μορφή CSV / Excel.
@@ -2148,7 +2148,7 @@ DocType: Data Migration Connector,Database Name,Όνομα βάσης δεδομ
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Ανανέωση φόρμας
 DocType: DocField,Select,Επιλογή
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Προβολή πλήρους αρχείου καταγραφής
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Απλή έκφραση Python, Παράδειγμα: status == &#39;Άνοιγμα&#39; και πληκτρολογήστε == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Απλή έκφραση Python, Παράδειγμα: status == 'Άνοιγμα' και πληκτρολογήστε == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Δεν έχει γίνει επισύναψη του αρχείου
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Η σύνδεση χάθηκε. Ορισμένες λειτουργίες ενδέχεται να μην λειτουργούν.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Επαναλήψεις όπως &quot;ααα&quot; είναι εύκολο να μαντέψει
@@ -2701,7 +2701,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Για την τροπ
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,Ρυθμίσεις πύλη πληρωμών PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Top Performer
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Τα προσαρμοσμένα πεδία δεν μπορούν να προστεθούν στα βασικά DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) θα πάρει περικοπεί, όπως max χαρακτήρων που επιτρέπονται είναι {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) θα πάρει περικοπεί, όπως max χαρακτήρων που επιτρέπονται είναι {2}"
 DocType: OAuth Client,Response Type,Τύπος απάντηση
 DocType: Contact Us Settings,Send enquiries to this email address,Στείλτε ερωτήματα σε αυτή τη διεύθυνση ηλεκτρονικού ταχυδρομείου
 DocType: Letter Head,Letter Head Name,Όνομα κεφαλίδας επιστολόχαρτου
@@ -2758,7 +2758,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Προβολή εικόνας
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Μοιάζει με κάτι πήγε στραβά κατά τη διάρκεια της συναλλαγής. Από τη στιγμή που δεν έχουν επιβεβαιώσει την πληρωμή, Paypal, θα σας επιστρέψουμε αυτόματα αυτό το ποσό. Αν δεν το κάνει, παρακαλούμε να μας στείλετε ένα email και αναφέρουν το αναγνωριστικό Συσχέτιση: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Συμπεριλάβετε σύμβολα, αριθμούς και κεφαλαία γράμματα στον κωδικό πρόσβασης"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Εισάγετε Μετά πεδίο &#39;{0}&#39; αναφέρεται στην Προσαρμοσμένο πεδίο &#39;{1}&#39;, με την ετικέτα &#39;{2}&#39;, δεν υπάρχει"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Εισάγετε Μετά πεδίο '{0}' αναφέρεται στην Προσαρμοσμένο πεδίο '{1}', με την ετικέτα '{2}', δεν υπάρχει"
 DocType: List Filter,List Filter,Λίστα φίλτρου
 DocType: Workflow State,signal,Σήμα
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Έχει συνημμένα
@@ -2782,14 +2782,14 @@ DocType: Web Page,Slideshow,Παρουσίαση
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Το προεπιλεγμένο πρότυπο διεύθυνσης δεν μπορεί να διαγραφεί
 DocType: Contact,Maintenance Manager,Υπεύθυνος συντήρησης
 DocType: Workflow State,Search,Αναζήτηση
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Επιλέξτε έναν άλλο τρόπο πληρωμής. Το Stripe δεν υποστηρίζει τις συναλλαγές στο νόμισμα &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Επιλέξτε έναν άλλο τρόπο πληρωμής. Το Stripe δεν υποστηρίζει τις συναλλαγές στο νόμισμα '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Μετακίνηση στον κάδο απορριμμάτων
 DocType: Web Form,Web Form Fields,Πεδία φόρμας ιστοσελίδας
 DocType: Data Import,Amended From,Τροποποίηση από
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Προειδοποίηση: Ανίκανος να βρει {0} σε κάθε τραπέζι που σχετίζονται με {1}
 DocType: S3 Backup Settings,eu-north-1,eu-βορρά-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Αυτό το έγγραφο αυτή τη στιγμή στην ουρά για εκτέλεση. ΠΑΡΑΚΑΛΩ προσπαθησε ξανα
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Αρχείο &#39;{0}&#39; δεν βρέθηκε
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Αρχείο '{0}' δεν βρέθηκε
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Κατάργηση τμήματος
 DocType: User,Change Password,Άλλαξε κωδικό
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Πεδίο άξονα Χ
@@ -2976,7 +2976,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Η τιμή λείπ
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Προσθήκη παιδιού
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Πρόοδος εισαγωγής
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Αν η κατάσταση είναι ικανοποιημένη, ο χρήστης θα ανταμειφθεί με τα σημεία. π.χ. doc.status == &#39;Κλειστό&#39;"
+","Αν η κατάσταση είναι ικανοποιημένη, ο χρήστης θα ανταμειφθεί με τα σημεία. π.χ. doc.status == 'Κλειστό'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Οι υποβεβλημένες εγγραφές δεν μπορούν να διαγραφούν.
 DocType: GSuite Templates,Template Name,Όνομα προτύπου
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,νέος τύπος του εγγράφου
@@ -3396,7 +3396,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Προσαρμο�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Πρόοδος
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,ανά Ρόλο
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,λείπει πεδία
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Μη έγκυρο πεδίο με όνομα &#39;{0}&#39; σε autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Μη έγκυρο πεδίο με όνομα '{0}' σε autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Αναζήτηση σε ένα είδος εγγράφου
 DocType: Custom DocPerm,Role and Level,Ρόλος και επίπεδο
 DocType: File,Thumbnail URL,Μικρογραφία URL
@@ -3496,7 +3496,7 @@ DocType: Dashboard Chart,Filters JSON,Φίλτρα JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Κάντε κλικ εδώ για να επιβεβαιώσετε
 DocType: Email Account,Disable SMTP server authentication,Απενεργοποιήστε τον έλεγχο ταυτότητας διακομιστή SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Αντιγράφηκε στο πρόχειρο.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,"Προβλέψιμη αντικαταστάσεις, όπως &#39;@&#39; αντί του «α» δεν βοηθούν πολύ."
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,"Προβλέψιμη αντικαταστάσεις, όπως '@' αντί του «α» δεν βοηθούν πολύ."
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Ανάθεση από Μένα
 apps/frappe/frappe/utils/data.py,Zero,Μηδέν
 DocType: Google Drive,Backup Folder ID,Αναγνωριστικό φακέλου αντιγράφων ασφαλείας
@@ -3855,7 +3855,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Προεπιλεγμένο
 DocType: Translation,Verified,Επαληθεύτηκε
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} Προστέθηκε
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Αναζήτηση για &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Αναζήτηση για '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Παρακαλούμε να αποθηκεύσετε την πρώτη έκθεση
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} συνδρομητές προστέθηκαν
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Δεν Στο

--- a/frappe/translations/es-CL.csv
+++ b/frappe/translations/es-CL.csv
@@ -1,15 +1,15 @@
 apps/frappe/frappe/contacts/doctype/address/address.py +59,"Company is mandatory, as it is your company address","Compañía es obligatoria, igual que la dirección de la empresa"
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 
@@ -29,7 +29,7 @@ apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py +24,Column Name can
 ,Feedback Ratings,Ratings de Feedback
 apps/frappe/frappe/email/queue.py +259,Cannot send this email. You have crossed the sending limit of {0} emails for this month.,No se puede enviar este correo electrónico. Usted ha cruzado el límite de envío de {0} mensajes de correo electrónico para este mes.
 apps/frappe/frappe/model/db_query.py +616,Cannot use sub-query in order by,No se puede utilizar una sub-consulta en order by
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup &gt; Role Permissions Manager,Los permisos se pueden gestionar a través de Configuración &gt; Administrador de permisos
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup > Role Permissions Manager,Los permisos se pueden gestionar a través de Configuración > Administrador de permisos
 DocType: LDAP Settings,LDAP First Name Field,Campo de Primer Nombre LDAP
 DocType: Feedback Request,Feedback Rating,Rating de Feedback
 DocType: Dynamic Link,Link Title,Título del Enlace

--- a/frappe/translations/es-CL.csv
+++ b/frappe/translations/es-CL.csv
@@ -1,15 +1,15 @@
 apps/frappe/frappe/contacts/doctype/address/address.py +59,"Company is mandatory, as it is your company address","Compañía es obligatoria, igual que la dirección de la empresa"
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/es-MX.csv
+++ b/frappe/translations/es-MX.csv
@@ -1,21 +1,21 @@
 DocType: Currency,Smallest circulating fraction unit (coin). For e.g. 1 cent for USD and it should be entered as 0.01,"Fracción más pequeña de circulación (moneda). Por ejemplo, 1 centavo por USD y debe ser ingresado como 0.01"
 DocType: Data Migration Plan,Postprocess Method,Método de Postproceso
 DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Si está activado Aplicar Permiso de Usuario Estricto y se ha definido el Permiso de Usuario para un DocType para un Usuario, todos los documentos en los que el valor del enlace esté en blanco no se mostrarán a ese Usuario"
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py +19,Please select Minimum Password Score,Por favor selecciona la Puntuación Mínima de la Contraseña
 DocType: Currency,Smallest Currency Fraction Value,Valor de la fracción de moneda más pequeña
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup > Role Permissions Manager,Los permisos se pueden gestionar a través de Configuración > Administrador de permisos
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/es-MX.csv
+++ b/frappe/translations/es-MX.csv
@@ -1,21 +1,21 @@
 DocType: Currency,Smallest circulating fraction unit (coin). For e.g. 1 cent for USD and it should be entered as 0.01,"Fracción más pequeña de circulación (moneda). Por ejemplo, 1 centavo por USD y debe ser ingresado como 0.01"
 DocType: Data Migration Plan,Postprocess Method,Método de Postproceso
 DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Si está activado Aplicar Permiso de Usuario Estricto y se ha definido el Permiso de Usuario para un DocType para un Usuario, todos los documentos en los que el valor del enlace esté en blanco no se mostrarán a ese Usuario"
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py +19,Please select Minimum Password Score,Por favor selecciona la Puntuación Mínima de la Contraseña
 DocType: Currency,Smallest Currency Fraction Value,Valor de la fracción de moneda más pequeña
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup &gt; Role Permissions Manager,Los permisos se pueden gestionar a través de Configuración &gt; Administrador de permisos
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup > Role Permissions Manager,Los permisos se pueden gestionar a través de Configuración > Administrador de permisos
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/es-PE.csv
+++ b/frappe/translations/es-PE.csv
@@ -165,7 +165,7 @@ DocType: Email Account,Use TLS,Utilice TLS
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py +33,Default Address Template cannot be deleted,Plantilla de la Direcciones Predeterminadas no puede eliminarse
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +34,Select Document Types to set which User Permissions are used to limit access.,Seleccione los Tipos de Documento para establecer los Permisos de Usuario para limitar el acceso.
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py +30,You are not allowed to delete a standard Website Theme,No se le permite eliminar un tema Sitio web estándar
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup &gt; Role Permissions Manager,Los permisos se pueden gestionar a través de Configuración > Administrador de Funciones
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup > Role Permissions Manager,Los permisos se pueden gestionar a través de Configuración > Administrador de Funciones
 apps/frappe/frappe/core/doctype/doctype/doctype.py +796,{0}: Permission at level 0 must be set before higher levels are set,{0} : Permiso en el nivel 0 se debe establecer antes de fijar niveles más altos
 DocType: System Settings,dd-mm-yyyy,dd- mm- aaaa
 apps/frappe/frappe/config/desk.py +54,"Newsletters to contacts, leads.","Boletines para contactos, clientes potenciales ."

--- a/frappe/translations/es.csv
+++ b/frappe/translations/es.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Estadísticas basadas en el rendimiento de la semana pasada (de {0} a {1})
 DocType: LDAP Settings,LDAP Phone Field,Campo de teléfono LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Tipo de documento, por ejemplo; Cliente"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,La condición &#39;{0}&#39; no es válida
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,La condición '{0}' no es válida
 DocType: Workflow State,barcode,Código de barras
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,El uso de la sub-query o función está restringido.
 apps/frappe/frappe/config/customization.py,Add your own translations,Añada sus propias traducciones
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Nombre de la divisa
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No hay mensajes de correo electrónico
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Enlace Expirado
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Revertir la longitud a {0} para &#39;{1}&#39; en &#39;{2}&#39;; Establecer la longitud como {3} causará el truncamiento de los datos.
+							Setting the length as {3} will cause truncation of data.",Revertir la longitud a {0} para '{1}' en '{2}'; Establecer la longitud como {3} causará el truncamiento de los datos.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Seleccionar Formato de Archivo
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Contenido Hash
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Reporte de documentos compartidos
 DocType: Social Login Key,Base URL,URL Base
 DocType: User,Last Login,Último ingreso
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},No puede establecer &#39;Translatable&#39; para el campo {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},No puede establecer 'Translatable' para el campo {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Columna
 DocType: Chat Profile,Chat Profile,Perfil de Chat
 DocType: Custom Field,Adds a custom field to a DocType,Añade un campo personalizado para el 'DocType'
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Es Carpeta
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Estilo de barra de navegación
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} no es una dirección de correo electrónico válida
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Seleccionar al menos 1 registro para la impresión
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Usuario &#39;{0}&#39; ya tiene el papel &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Usuario '{0}' ya tiene el papel '{1}'
 DocType: System Settings,Two Factor Authentication method,Método de autenticación de dos factores
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Primero configure el nombre y guarde el registro.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 registros
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Campo obligatorio: establecer rol para
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} criticado {1}
 DocType: Data Migration Mapping,Mapping Name,Nombre de Mapeo
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: El campo &#39;{1}&#39; no se puede establecer como Único ya que tiene valores no únicos
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: El campo '{1}' no se puede establecer como Único ya que tiene valores no únicos
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navegar por la lista hacia abajo
 DocType: Currency,A symbol for this currency. For e.g. $,"Un símbolo para esta moneda. Por ejemplo, $"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Traducciones actualizadas con éxito
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Vencimiento de sesi
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",aparecerá este campo sólo si el nombre del campo definido aquí tiene valor o las reglas son verdaderos (ejemplos): eval myfield: doc.myfield == &#39;Mi Valor&#39; eval: doc.age> 18
+eval:doc.age>18",aparecerá este campo sólo si el nombre del campo definido aquí tiene valor o las reglas son verdaderos (ejemplos): eval myfield: doc.myfield == 'Mi Valor' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hoy
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Una vez que haya establecido esto, los usuarios sólo podrán acceder a ciertos documentos, (por ejemplo: Entrada de blog si esta relacionado con  Blogger)."
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,Nombre de la base de datos
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Actualizar formulario
 DocType: DocField,Select,Seleccionar
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Ver registro completo
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expresión simple de Python, ejemplo: estado == &#39;Abrir&#39; y tipo == &#39;Error&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expresión simple de Python, ejemplo: estado == 'Abrir' y tipo == 'Error'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Archivo no adjuntado
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Conexión perdida. Algunas características pueden no funcionar.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Repeticiones como ""aaa"" son fáciles de adivinar"
@@ -2278,7 +2278,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Mostrar solo errores
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Enviar Alerta de Correo Electrónico
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Por favor seleccione otro método de pago. Razorpay no admite transacciones en moneda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Por favor seleccione otro método de pago. Razorpay no admite transacciones en moneda '{0}'
 DocType: Data Import,In Progress,En Progreso
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,En cola para copia de seguridad. Se puede tomar un par de minutos a una hora.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2700,7 +2700,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Corrigiento
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,Configuración de la pasarela de pago de PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,El mejor intérprete
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Los campos personalizados no se pueden agregar a los DocTypes principales.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) resultarán truncadas, como caracteres máximo permitido es {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) resultarán truncadas, como caracteres máximo permitido es {2}"
 DocType: OAuth Client,Response Type,Tipo de respuesta
 DocType: Contact Us Settings,Send enquiries to this email address,Enviar solicitudes a esta dirección de correo electrónico
 DocType: Letter Head,Letter Head Name,Nombre de membrete
@@ -2781,14 +2781,14 @@ DocType: Web Page,Slideshow,Presentación
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,La plantilla de direcciones por defecto no puede ser eliminada
 DocType: Contact,Maintenance Manager,Gerente de Mantenimiento
 DocType: Workflow State,Search,Buscar
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Seleccione otro método de pago. Stripe no admite transacciones en moneda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Seleccione otro método de pago. Stripe no admite transacciones en moneda '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Mover a la papelera
 DocType: Web Form,Web Form Fields,Campos de Formulario Web
 DocType: Data Import,Amended From,Modificado Desde
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Advertencia: No se puede encontrar {0} en cualquier tabla relacionada con {1}
 DocType: S3 Backup Settings,eu-north-1,eu-north-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,"Este documento se pone en cola para su ejecución actualmente. Por favor, inténtelo de nuevo"
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Archivo &#39;{0}&#39; no encontrado
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Archivo '{0}' no encontrado
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Remover la sección
 DocType: User,Change Password,Cambiar contraseña
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Campo Eje X
@@ -2975,7 +2975,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Falta un valor para
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Agregar hijo
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Progreso de importación
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Si se cumple la condición, el usuario será recompensado con los puntos. p.ej. doc.status == &#39;Cerrado&#39;"
+","Si se cumple la condición, el usuario será recompensado con los puntos. p.ej. doc.status == 'Cerrado'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: El registro enviado no puede ser eliminado.
 DocType: GSuite Templates,Template Name,Nombre de Plantilla
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nuevo tipo de documento
@@ -3107,7 +3107,7 @@ DocType: Dashboard Chart,Chart Type,Tipo de Gráfico
 DocType: DocType,Auto Name,Nombre Automático
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Evitar secuencias como abc o 6543, ya que son fáciles de adivinar"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,"Por favor, inténtelo de nuevo"
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',La URL debe comenzar con &#39;http: //&#39; o &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',La URL debe comenzar con 'http: //' o 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Opción 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,Editar
@@ -3346,7 +3346,7 @@ DocType: Notification,Send alert if this field's value changes,Enviar alerta si 
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Colores temáticos
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Seleccione un 'DocType' para crear un nuevo formato
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,el usuario no existe
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Destinatarios&#39; no especificado
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Destinatarios' no especificado
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,justo ahora
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Aplicar
 DocType: Footer Item,Policy,Política
@@ -3706,7 +3706,7 @@ DocType: Web Page,Web Page,Página Web
 DocType: Workflow Document State,Next Action Email Template,Plantilla de Correo Electrónico de próxima acción
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Si está habilitado, los cambios en el documento se rastrean y se muestran en la línea de tiempo"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;En búsqueda global&#39; no se permite el tipo {0} en la fila {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'En búsqueda global' no se permite el tipo {0} en la fila {1}
 DocType: Energy Point Log,Appreciation,Apreciación
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Ver Lista
 DocType: Workflow,Don't Override Status,No sobreescriba el estado
@@ -3853,7 +3853,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Predeterminado
 DocType: Translation,Verified,Verificado
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} añadido
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Buscar por &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Buscar por '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Por favor, guarde el informe primero"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} suscriptores añadidos
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,No en
@@ -3889,14 +3889,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Yo
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} no es un estado válido
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Aplicar a todos los tipos de documentos
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Actualización de puntos de energía
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Por favor seleccione otro método de pago. PayPal no admite transacciones en moneda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Por favor seleccione otro método de pago. PayPal no admite transacciones en moneda '{0}'
 DocType: Chat Message,Room Type,Tipo de Habitación
 DocType: Data Import Beta,Import Log Preview,Vista previa de registro de importación
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,campo de búsqueda {0} no es válido
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,archivo subido
 DocType: Workflow State,ok-circle,ok- círculo
 DocType: LDAP Settings,LDAP User Creation and Mapping,Creación y mapeo de usuarios LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Se pueden encontrar cosas preguntando &quot;encontrar naranja en los clientes &#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Se pueden encontrar cosas preguntando &quot;encontrar naranja en los clientes '
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,"Lamentablemente, el usuario debe tener acceso completo a sus propios registros."
 ,Usage Info,Información de Uso
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Mostrar atajos de teclado

--- a/frappe/translations/es.csv
+++ b/frappe/translations/es.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,La copia de
 DocType: DocField,In Global Search,En Búsqueda Global
 DocType: System Settings,Brute Force Security,Fuerza Bruta de Seguridad
 DocType: Workflow State,indent-left,Guión - izquierda
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; Hace {0} año (s)
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> Hace {0} año (s)
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Es arriesgado eliminar este archivo: {0}. Por favor, póngase en contacto con el administrador del sistema."
 DocType: Currency,Currency Name,Nombre de la divisa
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No hay mensajes de correo electrónico
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,No hay {0}
 apps/frappe/frappe/config/customization.py,Add custom forms.,Agregar formularios personalizados.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} en {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,presentado este documento
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Configuración&gt; Permisos de usuario
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configuración> Permisos de usuario
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,El sistema ofrece una gran cantidad de roles predefinidos. Usted puede agregar nuevos roles para afinar los permisos.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Si el usuario tiene algún rol asignado, entonces el usuario se convierte en un ""Usuario del Sistema"". Los ""Usuarios del sistema"" tienen acceso al escritorio"
 DocType: System Settings,Date and Number Format,Formato de Fecha y Número
 apps/frappe/frappe/model/document.py,one of,uno de
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Configurar&gt; Personalizar formulario
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Configurar> Personalizar formulario
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Comprobando un momento
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Mostrar etiquetas
 DocType: DocField,HTML Editor,Editor de HTML
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Facturación
 DocType: Email Queue,Not Sent,No enviado
 DocType: Web Form,Actions,Acciones
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Configuración&gt; Usuario
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Configuración> Usuario
 DocType: Workflow State,align-justify,alinear-justificar
 DocType: User,Middle Name (Optional),Segundo nombre (opcional)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,No permitido
@@ -1410,7 +1410,7 @@ DocType: User,System User,Usuario del sistema
 DocType: Report,Is Standard,Es estándar
 DocType: Desktop Icon,_report,_informe
 DocType: Dashboard Chart,Full,Completo
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","No etiquetas HTML Codificar HTML, como &lt;script&gt; o simplemente caracteres como &lt;u&gt;, ya que podrían ser utilizados intencionadamente en este campo"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","No etiquetas HTML Codificar HTML, como &lt;script> o simplemente caracteres como &lt;u>, ya que podrían ser utilizados intencionadamente en este campo"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticado por {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Correr
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,El pie de página
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pendiente
 DocType: System Settings,Allow only one session per user,Permitir sólo una sesión por usuario
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Carpeta Inicio / Test 1 / Carpeta Prueba 3
-DocType: Website Settings,&lt;head&gt; HTML,HTML
+DocType: Website Settings,&lt;head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Seleccione o arrastre a través de los intervalos de tiempo para crear un nuevo evento.
 DocType: Contact,Contact Details,Detalles de contacto
 DocType: DocField,In Filter,En filtro
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,No se permite iniciar sesión en este momento
 DocType: Data Migration Run,Current Mapping Action,Acción actual de mapeo
 DocType: Dashboard Chart Source,Source Name,Nombre de la Fuente
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,No cuenta de correo electrónico asociada con el usuario. Agregue una cuenta en Usuario&gt; Bandeja de entrada de correo electrónico.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,No cuenta de correo electrónico asociada con el usuario. Agregue una cuenta en Usuario> Bandeja de entrada de correo electrónico.
 DocType: Email Account,Email Sync Option,Opción de Sincronizar Correo Electrónico
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Fila Nro
 DocType: Async Task,Runtime,Tiempo de ejecución.
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Ya esta e
 DocType: User Email,Enable Outgoing,Habilitar correos salientes
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Etiquetas Personalizadas
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Cuenta de correo electrónico no configurada. Cree una nueva cuenta de correo electrónico desde Configuración&gt; Correo electrónico&gt; Cuenta de correo electrónico
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Cuenta de correo electrónico no configurada. Cree una nueva cuenta de correo electrónico desde Configuración> Correo electrónico> Cuenta de correo electrónico
 DocType: Comment,Submitted,Validado
 DocType: Contact,Pulled from Google Contacts,Extraído de los contactos de Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Solicitud no válida
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Vencimiento de sesi
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",aparecerá este campo sólo si el nombre del campo definido aquí tiene valor o las reglas son verdaderos (ejemplos): eval myfield: doc.myfield == &#39;Mi Valor&#39; eval: doc.age&gt; 18
+eval:doc.age>18",aparecerá este campo sólo si el nombre del campo definido aquí tiene valor o las reglas son verdaderos (ejemplos): eval myfield: doc.myfield == &#39;Mi Valor&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hoy
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Una vez que haya establecido esto, los usuarios sólo podrán acceder a ciertos documentos, (por ejemplo: Entrada de blog si esta relacionado con  Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,MAYÚSCULAS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML Personalizado
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Introduzca nombre de carpeta
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,No se encontró una plantilla de dirección predeterminada. Cree uno nuevo desde Configuración&gt; Impresión y marca&gt; Plantilla de dirección.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,No se encontró una plantilla de dirección predeterminada. Cree uno nuevo desde Configuración> Impresión y marca> Plantilla de dirección.
 apps/frappe/frappe/auth.py,Unknown User,Usuario Desconocido
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Seleccione rol
 DocType: Comment,Deleted,Eliminado
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Ruta al certificado del servid
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,No hay suficiente permiso para ver los enlaces.
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,La dirección principal es obligatoria
 DocType: Google Contacts,Push to Google Contacts,Empuje a Contactos de Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML añadido en la sección &lt;head&gt; de la página web, utiliza sobre todo para la verificación de la web y SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML añadido en la sección &lt;head> de la página web, utiliza sobre todo para la verificación de la web y SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Reincidido
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,El producto no se puede añadir a sus propios heredados
 DocType: Session Default Settings,Session Defaults,Valores predeterminados de sesión
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Advertencia
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Esto puede imprimirse en varias páginas.
 DocType: Data Migration Run,Percent Complete,Porcentaje Completo
 DocType: Tag Category,Tag Category,Categoría de Etiqueta
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparación, use&gt; 5, &lt;10 o = 324. Para rangos, use 5:10 (para valores entre 5 y 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparación, use> 5, &lt;10 o = 324. Para rangos, use 5:10 (para valores entre 5 y 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tire de Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ayuda
 DocType: User,Login Before,Iniciar antes
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Secuencia personalizada
 DocType: Address,Address Line 2,Dirección línea 2
 DocType: Address,Reference,Referencia
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Asignado a
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Configure la cuenta de correo electrónico predeterminada desde Configuración&gt; Correo electrónico&gt; Cuenta de correo electrónico
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Configure la cuenta de correo electrónico predeterminada desde Configuración> Correo electrónico> Cuenta de correo electrónico
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detalle de asignación de migración de datos
 DocType: Data Import,Action,Acción
 DocType: GSuite Settings,Script URL,Url del Script
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Permitir en 'validar'
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipo de excepción
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Seleccionar columnas
-DocType: Web Page,Add code as &lt;script&gt;,Agregar código como &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Agregar código como &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Borrar permisos de usuario
 DocType: Webhook,Headers,Encabezados
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Próximos eventos
@@ -3443,15 +3443,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Cola debe ser una de {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Por defecto la plantilla </ h4> 
  <p> <a Usos href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/es.csv
+++ b/frappe/translations/es.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Usuario del sistema
 DocType: Report,Is Standard,Es estándar
 DocType: Desktop Icon,_report,_informe
 DocType: Dashboard Chart,Full,Completo
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","No etiquetas HTML Codificar HTML, como &lt;script> o simplemente caracteres como &lt;u>, ya que podrían ser utilizados intencionadamente en este campo"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","No etiquetas HTML Codificar HTML, como <script> o simplemente caracteres como <u>, ya que podrían ser utilizados intencionadamente en este campo"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticado por {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Correr
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,El pie de página
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pendiente
 DocType: System Settings,Allow only one session per user,Permitir sólo una sesión por usuario
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Carpeta Inicio / Test 1 / Carpeta Prueba 3
-DocType: Website Settings,&lt;head> HTML,HTML
+DocType: Website Settings,<head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Seleccione o arrastre a través de los intervalos de tiempo para crear un nuevo evento.
 DocType: Contact,Contact Details,Detalles de contacto
 DocType: DocField,In Filter,En filtro
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Ruta al certificado del servid
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,No hay suficiente permiso para ver los enlaces.
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,La dirección principal es obligatoria
 DocType: Google Contacts,Push to Google Contacts,Empuje a Contactos de Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML añadido en la sección &lt;head> de la página web, utiliza sobre todo para la verificación de la web y SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML añadido en la sección <head> de la página web, utiliza sobre todo para la verificación de la web y SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Reincidido
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,El producto no se puede añadir a sus propios heredados
 DocType: Session Default Settings,Session Defaults,Valores predeterminados de sesión
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Advertencia
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Esto puede imprimirse en varias páginas.
 DocType: Data Migration Run,Percent Complete,Porcentaje Completo
 DocType: Tag Category,Tag Category,Categoría de Etiqueta
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparación, use> 5, &lt;10 o = 324. Para rangos, use 5:10 (para valores entre 5 y 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparación, use> 5, <10 o = 324. Para rangos, use 5:10 (para valores entre 5 y 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tire de Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ayuda
 DocType: User,Login Before,Iniciar antes
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Permitir en 'validar'
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipo de excepción
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Seleccionar columnas
-DocType: Web Page,Add code as &lt;script>,Agregar código como &lt;script>
+DocType: Web Page,Add code as <script>,Agregar código como <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Borrar permisos de usuario
 DocType: Webhook,Headers,Encabezados
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Próximos eventos
@@ -3443,26 +3443,26 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Cola debe ser una de {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Por defecto la plantilla </ h4> 
  <p> <a Usos href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% if address_line2%} {{address_line2}} & lt; br & gt; { endif% -%} 
- {{ciudad}} & lt; br & gt; 
- {% if%} Estado {{Estado}} & lt; br & gt; {% endif -%} {% if 
- código PIN%} PIN: {{código PIN}} & lt; br & gt; {% endif -%} 
- {{país}} & lt; br & gt; 
- {% if teléfono%} Teléfono: {{teléfono}} & lt; br & gt; { % endif -%} 
- {% if fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% if email_ID%} Email: {{email_ID}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% if address_line2%} {{address_line2}} <br> { endif% -%} 
+ {{ciudad}} <br> 
+ {% if%} Estado {{Estado}} <br> {% endif -%} {% if 
+ código PIN%} PIN: {{código PIN}} <br> {% endif -%} 
+ {{país}} <br> 
+ {% if teléfono%} Teléfono: {{teléfono}} <br> { % endif -%} 
+ {% if fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% if email_ID%} Email: {{email_ID}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Campo de Fecha de Inicio
 DocType: Role,Role Name,Nombre del rol

--- a/frappe/translations/es_cl.csv
+++ b/frappe/translations/es_cl.csv
@@ -1,15 +1,15 @@
 apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Compañía es obligatoria, igual que la dirección de la empresa"
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/es_cl.csv
+++ b/frappe/translations/es_cl.csv
@@ -1,15 +1,15 @@
 apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Compañía es obligatoria, igual que la dirección de la empresa"
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/es_mx.csv
+++ b/frappe/translations/es_mx.csv
@@ -4,15 +4,15 @@ apps/frappe/frappe/core/doctype/system_settings/system_settings.py,Please select
 DocType: Currency,Smallest Currency Fraction Value,Valor de la fracción de moneda más pequeña
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 
@@ -26,4 +26,4 @@ DocType: Address Template,"<h4>Default Template</h4>
  {% if email_ID%} Email: {{email_ID}} &amp; lt; br &amp; gt ; {% endif -%} 
  <!-- code--> <!-- pre--></code></pre></h4>"
 DocType: Data Migration Plan,Postprocess Method,Método de Postproceso
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML

--- a/frappe/translations/es_mx.csv
+++ b/frappe/translations/es_mx.csv
@@ -4,15 +4,15 @@ apps/frappe/frappe/core/doctype/system_settings/system_settings.py,Please select
 DocType: Currency,Smallest Currency Fraction Value,Valor de la fracción de moneda más pequeña
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> Por defecto la plantilla <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> y todos los campos de la Dirección ( incluyendo campos personalizados en su caso) estará disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 
@@ -26,4 +26,4 @@ DocType: Address Template,"<h4>Default Template</h4>
  {% if email_ID%} Email: {{email_ID}} &amp; lt; br &amp; gt ; {% endif -%} 
  <!-- code--> <!-- pre--></code></pre></h4>"
 DocType: Data Migration Plan,Postprocess Method,Método de Postproceso
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML

--- a/frappe/translations/et.csv
+++ b/frappe/translations/et.csv
@@ -83,8 +83,8 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Cancel {0} documents?,Tüh
 DocType: DocType,Is Published Field,Kas Avaldatud Field
 DocType: GCalendar Settings,GCalendar Settings,GCalendari seaded
 DocType: Email Group,Email Group,E Group
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google&#39;i kalender - sündmust {0} ei saanud Google&#39;i kalendrist kustutada, veakood {1}."
-DocType: Event,Pulled from Google Calendar,Tõmmatud Google&#39;i kalendrist
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google'i kalender - sündmust {0} ei saanud Google'i kalendrist kustutada, veakood {1}."
+DocType: Event,Pulled from Google Calendar,Tõmmatud Google'i kalendrist
 DocType: Note,Seen By,näinud
 apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Lisa mitu
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,Saite mõned energiapunktid
@@ -102,7 +102,7 @@ DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query
 apps/frappe/frappe/public/js/frappe/ui/tag_editor.js,Add a tag ...,Lisage silt ...
 apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,Portree
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,Sisesta
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Luba Google Drive&#39;i juurdepääs
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Luba Google Drive'i juurdepääs
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Select {0},Vali {0}
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Palun sisestage Base URL
 DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Kui see on lubatud, märgistatakse dokument nähtavana, kui kasutaja selle esimest korda avab"
@@ -216,7 +216,7 @@ apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your b
 apps/frappe/frappe/config/desk.py,Event and other calendars.,Sündmus ja teiste kalendreid.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 rida kohustuslik)
 apps/frappe/frappe/templates/includes/comments/comments.html,All fields are necessary to submit the comment.,Kõik väljad on vajalik esitada kommentaari.
-DocType: Custom Script,Adds a client custom script to a DocType,Lisab kliendi kohandatud skripti DocType&#39;i
+DocType: Custom Script,Adds a client custom script to a DocType,Lisab kliendi kohandatud skripti DocType'i
 DocType: Print Settings,Printer Name,Printeri nimi
 DocType: Webhook,Form URL-Encoded,Vormi URL-i kodeering
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Laiused saab määrata px või%.
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Keela teated
 DocType: Translation,Contributed Translation Doctype Name,Kaasatud tõlkedoktüübi nimi
 DocType: PayPal Settings,Redirect To,Suuna
 DocType: Data Migration Mapping,Pull,Tõmba
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Formaat: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Formaat: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,hulgivärskendamine
 DocType: Workflow State,chevron-up,Chevron-up
 DocType: DocType,Allow Guest to View,Luba külastajana Vaata
@@ -287,7 +287,7 @@ DocType: Communication,Rating,Hinnang
 DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Trüki laius alal, kui väli on veerg tabelis"
 DocType: Dropbox Settings,Dropbox Access Key,Dropbox Access Key
 apps/frappe/frappe/desk/form/utils.py,Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script,Kohandatud skripti konfigureerimine add_fetchis vale väljanime <b>{0}</b>
-apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,"Valige Google&#39;i kontaktid, kellega kontakt tuleks sünkroonida."
+apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,"Valige Google'i kontaktid, kellega kontakt tuleks sünkroonida."
 DocType: Web Page,Main Section (HTML),Peaosa (HTML)
 DocType: Workflow State,headphones,kõrvaklapid
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Password is required or select Awaiting Password,Parooli on vaja või valige Ootan salasõna
@@ -414,7 +414,7 @@ DocType: Assignment Rule,Assign To Users,Määra kasutajatele
 apps/frappe/frappe/public/js/frappe/utils/utils.js,or,või
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,module name...,Mooduli nimetus ...
 apps/frappe/frappe/templates/pages/integrations/payment-success.html,Continue,Jätkama
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,Google&#39;i integratsioon on keelatud.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,Google'i integratsioon on keelatud.
 DocType: Custom Field,Fieldname,Fieldname
 DocType: Workflow State,certificate,tunnistus
 apps/frappe/frappe/templates/includes/login/login.js,Verifying...,Kontrollimine ...
@@ -426,7 +426,7 @@ DocType: Energy Point Log,Review,Ülevaade
 DocType: User,Restrict IP,Keelatud IP
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,armatuurlaud
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Ei saa saata meile sel ajal
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google&#39;i kalender - sündmust {0} ei saanud Google&#39;i kalendris värskendada, veakood {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google'i kalender - sündmust {0} ei saanud Google'i kalendris värskendada, veakood {1}."
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Otsi või anna käsk
 DocType: Activity Log,Timeline Name,Timeline Nimi
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,Ainult ühte {0} saab seada primaarseks.
@@ -434,7 +434,7 @@ DocType: Email Account,e.g. smtp.gmail.com,nt smtp.gmail.com
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add A New Rule,Lisa uus reegel
 DocType: Contact,Sales Master Manager,Müük Master Manager
 DocType: User Permission,For Value,Väärtuse jaoks
-DocType: Event,Google Calendar ID,Google&#39;i kalendri ID
+DocType: Event,Google Calendar ID,Google'i kalendri ID
 apps/frappe/frappe/www/complete_signup.html,One Last Step,One Last Step
 apps/frappe/frappe/config/settings.py,Import Data,Andmete importimine
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer,Nimi Dokumendi liik (DocType) soovite selles valdkonnas siduda. nt Klienditeenindus
@@ -445,7 +445,7 @@ apps/frappe/frappe/templates/emails/auto_reply.html,"Your query has been receive
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only if Incoming is enabled.,"Automaatset linkimist saab aktiveerida ainult siis, kui sissetulev on lubatud."
 DocType: LDAP Settings,LDAP Middle Name Field,LDAP keskmise nime väli
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Importing {0} of {1},{0} {1} importimine
-DocType: GCalendar Account,Allow GCalendar Access,Luba GCalendar&#39;i juurdepääs
+DocType: GCalendar Account,Allow GCalendar Access,Luba GCalendar'i juurdepääs
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} on kohustuslik väli
 apps/frappe/frappe/templates/includes/login/login.js,Login token required,Sisselogimisnumber on nõutav
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Monthly Rank: ,Kuu asetus:
@@ -469,7 +469,7 @@ DocType: File,File URL,Faili URL
 DocType: Version,Table HTML,Tabel HTML
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Add Subscribers,Lisa Abonentide
 apps/frappe/frappe/desk/doctype/event/event.py,Upcoming Events for Today,Tulevased sündmused Täna
-DocType: Google Calendar,Push to Google Calendar,Pöörake Google&#39;i kalendrisse
+DocType: Google Calendar,Push to Google Calendar,Pöörake Google'i kalendrisse
 DocType: Notification Recipient,Email By Document Field,Email dokumendi Field
 DocType: Domain Settings,Domain Settings,domeeni seaded
 apps/frappe/frappe/email/receive.py,Cannot connect: {0},Ei saa ühendust: {0}
@@ -499,7 +499,7 @@ DocType: Workflow State,plane,lennuk
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Rounded Corners,Ümardatud nurgad
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","Kui teil on üleslaadimise uusi rekordeid, &quot;nimetamine Series&quot; muutub kohustuslikuks, kui see on olemas."
 apps/frappe/frappe/email/doctype/notification/notification.js,Get Alerts for Today,Saada Märguanded Täna
-DocType: Contact,Google Contacts Id,Google&#39;i kontaktide ID
+DocType: Contact,Google Contacts Id,Google'i kontaktide ID
 apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can only be renamed by Administrator,DocType saab nimeks Administrator
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,6 months,6 kuud
 apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Please attach an image file to set HTML,HTML-i seadistamiseks lisage pildifail
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Valuuta nimi
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,nr kirjad
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link aegunud
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.","Pikkuse ennistamine väärtusele {0} väärtuse &#39;{1}&#39; jaoks &#39;{2}&#39;; Kui määrate pikkuseks {3}, kärbitakse andmeid."
+							Setting the length as {3} will cause truncation of data.","Pikkuse ennistamine väärtusele {0} väärtuse '{1}' jaoks '{2}'; Kui määrate pikkuseks {3}, kärbitakse andmeid."
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Vali failivorming
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Sisu Hash
@@ -763,7 +763,7 @@ apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form",Standard DocType ei saa vaikimisi trükiformaadis kasutada Kohanda vormi
 DocType: Report,Query,Query
 DocType: Customize Form,Sort Order,Järjekord
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&quot;In List View &#39;ei ole lubatud tüüp {0} järjest {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&quot;In List View 'ei ole lubatud tüüp {0} järjest {1}
 DocType: Letter Head,Footer HTML,Jaluse HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,"Valige silt, mille järel soovite lisada uue valdkonna."
 ,Document Share Report,Dokumendi Jaga aruanne
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Kas Home Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbaari stiil
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ei ole kehtiv e-posti aadress
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Valima vähemalt 1 kirje printimiseks
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Kasutaja {0} &#39;on juba roll &quot;{1}&quot;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Kasutaja {0} 'on juba roll &quot;{1}&quot;
 DocType: System Settings,Two Factor Authentication method,Kaks teguri autentimise meetodit
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Esmalt määrake nimi ja salvestage see kirje.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 plaati
@@ -969,13 +969,13 @@ DocType: Notification,"To add dynamic subject, use jinja tags like
 <div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Lisada dünaamiline teema, kasutada Jinja sildid nagu <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
 apps/frappe/frappe/desk/search.py,Invalid Search Field {0},Kehtetu otsinguväli {0}
 DocType: User,Modules HTML,Moodulid HTML
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Luba Google&#39;i kalendri juurdepääs
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Luba Google'i kalendri juurdepääs
 DocType: Assignment Rule,Higher priority rule will be applied first,Kõigepealt rakendatakse kõrgema prioriteediga reeglit
 DocType: Email Account,"Track if your email has been opened by the recipient.
 <br>
 Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","Jälgige, kas saaja on teie e-posti avanud. <br> Märkus. Kui sa saadad mitmele adressaadile, isegi kui üks adressaat loeb e-kirja, loetakse see &quot;avatuks&quot;"
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Missing Values Required,Kadunud väärtusi Vajalikud
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Luba Google&#39;i kontaktidele juurdepääs
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Luba Google'i kontaktidele juurdepääs
 DocType: Data Migration Connector,Frappe,frappe
 apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Unread,Märgi mitteloetuks
 DocType: Activity Log,Operation,Operation
@@ -1027,7 +1027,7 @@ DocType: Property Setter,Property Setter,Kinnisvara setter
 DocType: Web Form,Allow Print,Laske Prindi
 DocType: Communication,Clicked,Klõpsanud
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Jälgi
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nr luba &quot;{0} &#39;{1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nr luba &quot;{0} '{1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Plaanitud saata
 DocType: DocType,Track Seen,Rada näinud
 DocType: Dropbox Settings,File Backup,Faili varundamine
@@ -1072,7 +1072,7 @@ DocType: Address,Other Territory,Muu territoorium
 apps/frappe/frappe/config/website.py,Portal,Portal
 DocType: Email Account,Use Different Email Login ID,Kasutada erinevaid Saatke Sisene ID
 apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,Peab määrata Query joosta
-apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Tundub, et serveri Braintree&#39;i konfiguratsiooniga on probleem. Ärge muretsege, ebaõnnestumise korral tagastatakse summa teie kontole."
+apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Tundub, et serveri Braintree'i konfiguratsiooniga on probleem. Ärge muretsege, ebaõnnestumise korral tagastatakse summa teie kontole."
 apps/frappe/frappe/www/me.html,Manage Third Party Apps,Kolmanda osapoole rakenduste haldamine
 DocType: Website Settings,Route Redirects,Marsruudi ümbersuunamised
 apps/frappe/frappe/config/settings.py,"Language, Date and Time settings","Keel, kuupäeva ja kellaaja seaded"
@@ -1139,7 +1139,7 @@ DocType: DocType,User Cannot Create,Kasutaja ei saa luua
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Successfully Done,Edukalt tehtud
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox access is approved!,Dropbox juurdepääs on heaks!
 DocType: Customize Form,Enter Form Type,Sisesta vorm Type
-DocType: Google Drive,Authorize Google Drive Access,Google Drive&#39;i juurdepääsu volitamine
+DocType: Google Drive,Authorize Google Drive Access,Google Drive'i juurdepääsu volitamine
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Missing parameter Kanban Board Name,Puudub parameeter Kanbani juhatuse nimi
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_stat.html,No records tagged.,No arvestust märgistatud.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Field,Eemalda Field
@@ -1172,14 +1172,14 @@ DocType: Address,City/Town,City / Town
 DocType: Data Migration Connector,Connector Name,Ühendusnimi
 DocType: Address,Is Your Company Address,Kas teie firma Aadress
 DocType: Energy Point Log,Social,Sotsiaalne
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google&#39;i kalender - saidi {0} jaoks ei saanud kalendrit luua, veakood {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google'i kalender - saidi {0} jaoks ei saanud kalendrit luua, veakood {1}."
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Editing Row,Toimetajad Row
 DocType: Workflow Action Master,Workflow Action Master,Töövoo Action Master
 DocType: Custom Field,Field Type,Field Type
 apps/frappe/frappe/utils/data.py,only.,ainult.
 DocType: Route History,Route History,Marsruudi ajalugu
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Give Review Points,Andke ülevaatuspunkte
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google&#39;i kalender - kontakti ei saanud Google&#39;i kontaktidesse {0} sisestada, veakood {1}."
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google'i kalender - kontakti ei saanud Google'i kontaktidesse {0} sisestada, veakood {1}."
 apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,OTP-salasõna võib administraator taastada.
 apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,"Vältida aastat, mis on seotud teid."
 apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Kasutaja piiramine konkreetse dokumendi jaoks
@@ -1226,7 +1226,7 @@ DocType: File,old_parent,old_parent
 apps/frappe/frappe/config/desk.py,"Newsletters to contacts, leads.","Uudiskirju kontaktid, viib."
 DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","nt &quot;Support&quot;, &quot;Müük&quot;, &quot;Jerry Yang&quot;"
 apps/frappe/frappe/twofactor.py,Incorrect Verification code,Vale kinnituskood
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,Google&#39;i kontaktide integreerimine on keelatud.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,Google'i kontaktide integreerimine on keelatud.
 DocType: Assignment Rule,Description,Kirjeldus
 DocType: Print Settings,Repeat Header and Footer in PDF,Korda Päis ja jalus PDF
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Failure,Rike
@@ -1267,7 +1267,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Set
 DocType: Workflow State,align-justify,"viia, õigustada"
 DocType: User,Middle Name (Optional),Lähis nimi (valikuline)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ei ole lubatud
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,No Google Calendar Event to sync.,Sünkroonimiseks pole ühtegi Google&#39;i kalendri sündmust.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,No Google Calendar Event to sync.,Sünkroonimiseks pole ühtegi Google'i kalendri sündmust.
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Following fields have missing values:,Pärast väljad on kadunud väärtusi:
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,via automatic rule {0} on {1},automaatse reegli {0} kaudu {1}
 apps/frappe/frappe/core/report/transaction_log_report/transaction_log_report.py,First Transaction,Esimene tehing
@@ -1386,7 +1386,7 @@ DocType: OAuth Client,A list of resources which the Client App will have access 
 DocType: Translation,Translated Text,tõlgitud tekst
 DocType: Contact Us Settings,Query Options,Päringu valikud
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,Fetching posts...,Postituste toomine ...
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Contact Synced with Google Contacts.,Kontakt on sünkroonitud Google&#39;i kontaktidega.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Contact Synced with Google Contacts.,Kontakt on sünkroonitud Google'i kontaktidega.
 DocType: Access Log,Timestamp,Timestamp
 DocType: Patch Log,Patch Log,Patch Logi
 DocType: Data Migration Mapping,Local Primary Key,Kohalik peamine võti
@@ -1425,7 +1425,7 @@ DocType: Data Export,Fields Multicheck,Väli Multicheck
 DocType: Activity Log,Login,Logi sisse
 DocType: Web Form,Payments,Maksed
 apps/frappe/frappe/www/qrcode.html,Hi {0},Tere {0}
-apps/frappe/frappe/config/integrations.py,Google Drive Integration.,Google Drive&#39;i integreerimine.
+apps/frappe/frappe/config/integrations.py,Google Drive Integration.,Google Drive'i integreerimine.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,{0} reverted your points on {1} {2},{0} tõi teie punktid tagasi {1} {2}
 DocType: System Settings,Enable Scheduled Jobs,Luba Planeeritud Jobs
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Notes:,Märkused:
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Kohustuslik väli: määrata roll
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritiseerisid {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: välja &#39;{1}&#39; ei saa seada unikaalseks, kuna sellel on mitte unikaalsed väärtused"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: välja '{1}' ei saa seada unikaalseks, kuna sellel on mitte unikaalsed väärtused"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Liikuge loendis allapoole
 DocType: Currency,A symbol for this currency. For e.g. $,Sümbol selle valuuta. Sest näiteks $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Tõlked on uuendatud
@@ -1599,8 +1599,8 @@ DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,Ümber suunama
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Avage spikker
 DocType: DocType,Is Submittable,Kas esitatav
 apps/frappe/frappe/core/doctype/comment/comment.py,New Mention,Uus märkus
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,Uusi Google&#39;i kontakte ei sünkroonitud.
-DocType: File,Uploaded To Google Drive,Google Drive&#39;i üles laaditud
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,Uusi Google'i kontakte ei sünkroonitud.
+DocType: File,Uploaded To Google Drive,Google Drive'i üles laaditud
 apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a check field can be either 0 or 1,Väärtus tšeki valdkonnas võib olla kas 0 või 1
 apps/frappe/frappe/model/document.py,Could not find {0},Ei leia {0}
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Filters applied for {0},Filtrid on taotletud {0}
@@ -1616,7 +1616,7 @@ DocType: Energy Point Rule,Maximum Points,Maksimaalne punktide arv
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,My Settings,Minu seaded
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Text Color,Teksti värv
 apps/frappe/frappe/desk/page/backups/backups.py,Backup job is already queued. You will receive an email with the download link,Backup töö on juba järjekorras. Saate alla laadida linki
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,1 Google Calendar Event synced.,1 Google&#39;i kalendri sündmus on sünkroonitud.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,1 Google Calendar Event synced.,1 Google'i kalendri sündmus on sünkroonitud.
 DocType: Desktop Icon,Force Show,Force Näita
 apps/frappe/frappe/auth.py,Invalid Request,Vale taotlus
 apps/frappe/frappe/public/js/frappe/form/layout.js,This form does not have any input,See vorm ei ole mingit sisendit
@@ -1865,7 +1865,7 @@ apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Customize,Kohanda
 apps/frappe/frappe/core/doctype/user/user.js,View Permitted Documents,Vaadake lubatavaid dokumente
 apps/frappe/frappe/utils/print_format.py,You need to install pycups to use this feature!,Selle funktsiooni kasutamiseks peate installima pycupid!
-apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Your connection request to Google Calendar was successfully accepted,Teie ühenduse taotlus Google&#39;i kalendrisse on edukalt vastu võetud
+apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Your connection request to Google Calendar was successfully accepted,Teie ühenduse taotlus Google'i kalendrisse on edukalt vastu võetud
 DocType: Tag Link,Tag Link,Sildilink
 apps/frappe/frappe/core/report/transaction_log_report/transaction_log_report.py,Chain Integrity,Keti terviklikkus
 DocType: Data Export,CSV,CSV
@@ -1893,14 +1893,14 @@ DocType: S3 Backup Settings,ap-northeast-3,ap-kirde-3
 DocType: Data Migration Mapping,Remote Primary Key,Remote Primary Key
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,In,Sisse
 DocType: Notification,Value Change,Väärtus Muutus
-DocType: Google Contacts,Authorize Google Contacts Access,Google&#39;i kontaktide juurdepääsu volitamine
+DocType: Google Contacts,Authorize Google Contacts Access,Google'i kontaktide juurdepääsu volitamine
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Kuvatakse aruandest ainult Numbrilised väljad
 DocType: Data Import Beta,Import Type,Impordi tüüp
 DocType: Access Log,HTML Page,HTML-leht
 DocType: Address,Subsidiary,Tütarettevõte
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting Connection to QZ Tray...,QZ-salvega ühenduse loomise proovimine ...
 DocType: System Settings,In Hours,Tundides
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Google Drive&#39;ist ei leitud kausta - veakood {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Google Drive'ist ei leitud kausta - veakood {0}
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,With Letterhead,Mis Letterhead
 apps/frappe/frappe/email/smtp.py,Invalid Outgoing Mail Server or Port,Vale Outgoing Mail Server või Port
 DocType: Custom DocPerm,Write,Kirjutage
@@ -2001,7 +2001,7 @@ apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permiss
 DocType: Activity Log,Logout,Logi välja
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,"Õigused kõrgematel tasanditel on Field Tase õigused. Kõik väljad on õigustetasemele komplekt neile ja reeglid määratletud, et load kehtivad valdkonnas. See on kasulik, kui soovid peita või teha teatud valdkonnas lugemiseks vaid teatud rollid."
 DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, password=1234 etc.)","Sisesta staatiline url parameetrid (n. Saatjale = ERPNext, kasutajanimi = ERPNext parooliga 1234 jne)"
-apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google&#39;i font
+apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google'i font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Kui neid juhiseid, kus ei ole kasulik, lisage oma ettepanekuid github küsimused."
 DocType: Workflow State,bookmark,järjehoidja
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Kausta nimi ei tohi sisaldada &quot;/&quot; (kaldkriipsuga)
@@ -2038,7 +2038,7 @@ DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,kohandatud sildid
 apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posti konto pole seadistatud. Palun looge uus e-posti konto jaotises Seadistamine> E-post> E-posti konto
 DocType: Comment,Submitted,Esitatud
-DocType: Contact,Pulled from Google Contacts,Tõmmatud Google&#39;i kontaktidest
+DocType: Contact,Pulled from Google Contacts,Tõmmatud Google'i kontaktidest
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Kehtivas taotluses
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Compiled Successfully,Koostatud edukalt
 DocType: System Settings,Email Footer Address,Email jalus Aadress
@@ -2118,7 +2118,7 @@ DocType: User,Bio,Bio
 DocType: OAuth Client,App Client Secret,App kliendi saladus
 apps/frappe/frappe/public/js/frappe/form/save.js,Submitting,Esitades
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of the document to which the data will get added to.,"Vanem on dokumendi nimi, millele andmed lisatakse."
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Google Drive&#39;is ei saanud kausta luua - veakood {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Google Drive'is ei saanud kausta luua - veakood {0}
 DocType: DocType,UPPER CASE,SUURTÄHTEDE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Sisesta kataloogi nimi
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,Andmebaasi nimi
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Värskenda vorm
 DocType: DocField,Select,Valima
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Vaata kogu logi
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Lihtne Pythoni avaldus, näide: olek == &#39;Ava&#39; ja tippige == &#39;Viga&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Lihtne Pythoni avaldus, näide: olek == 'Ava' ja tippige == 'Viga'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Faili ei kinnitatud
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Ühendus kaotsi läinud Mõned funktsioonid ei pruugi töötada.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Kordab nagu &quot;aaa&quot; on lihtne ära arvata
@@ -2182,7 +2182,7 @@ DocType: Email Unsubscribe,Global Unsubscribe,Global tellimine
 apps/frappe/frappe/utils/password_strength.py,This is a very common password.,See on väga levinud parool.
 apps/frappe/frappe/email/doctype/email_group/email_group.js,View,Vaade
 DocType: Comment,Assigned,Sihtotstarbelised
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,<b>Google Drive&#39;i juurdepääsu autoriseerimiseks</b> klõpsake valikul <b>Volita</b> Google Drive&#39;i juurdepääsu.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,<b>Google Drive'i juurdepääsu autoriseerimiseks</b> klõpsake valikul <b>Volita</b> Google Drive'i juurdepääsu.
 DocType: Print Format,Js,Js
 apps/frappe/frappe/public/js/frappe/views/communication.js,Select Print Format,Valige Print Format
 apps/frappe/frappe/utils/password_strength.py,Short keyboard patterns are easy to guess,Lühike klaviatuuri mustrid on lihtne ära arvata
@@ -2220,7 +2220,7 @@ apps/frappe/frappe/core/doctype/system_settings/system_settings.py,Please select
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Added,Lisatud
 DocType: Personal Data Download Request,Personal Data Download Request,Isikuandmete allalaadimise taotlus
 DocType: DocField,Table MultiSelect,Tabel MultiSelect
-apps/frappe/frappe/config/integrations.py,Google Calendar Integration.,Google&#39;i kalendri integratsioon.
+apps/frappe/frappe/config/integrations.py,Google Calendar Integration.,Google'i kalendri integratsioon.
 DocType: Auto Repeat,Half-yearly,Poolaasta-
 apps/frappe/frappe/templates/emails/upcoming_events.html,Daily Event Digest is sent for Calendar Events where reminders are set.,Daily Event Digest saadetakse Üritused kus meeldetuletused seada.
 DocType: Braintree Settings,Header Image,Päise pilt
@@ -2263,7 +2263,7 @@ apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Average of {0},Keskm
 DocType: User,Logout from all devices while changing Password,Väljuge kõikidest seadmetest parooli vahetamisel
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify Password,Kinnita parool
 apps/frappe/frappe/public/js/frappe/form/sidebar/attachments.js,There were errors,Vigu
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Sisestage Google&#39;i seadetes kliendi ID ja kliendi saladus.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Sisestage Google'i seadetes kliendi ID ja kliendi saladus.
 apps/frappe/frappe/core/doctype/communication/communication.js,Close,Lähedane
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 0 to 2,Ei saa muuta docstatus 0-2
 DocType: File,Attached To Field,Väli lisatud
@@ -2310,7 +2310,7 @@ DocType: Payment Gateway,Gateway,Gateway
 DocType: LDAP Settings,Path to Server Certificate,Tee serveri sertifikaadini
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Pole piisavalt luba näha lingid
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Aadress Pealkiri on kohustuslik.
-DocType: Google Contacts,Push to Google Contacts,Pöörake Google&#39;i kontaktidesse
+DocType: Google Contacts,Push to Google Contacts,Pöörake Google'i kontaktidesse
 DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Lisatud HTML <head> osas veebilehe, mida kasutatakse peamiselt veebilehel kontrollimist ja SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Retsidiveerunud
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Punkt ei saa lisada oma järeltulijad
@@ -2372,7 +2372,7 @@ DocType: DocField,Fetch From,Tõmba välja
 apps/frappe/frappe/modules/utils.py,App not found,App ei leitud
 apps/frappe/frappe/core/doctype/communication/communication.py,Cannot create a {0} against a child document: {1},Ei saa luua {0} lapse vastu dokument: {1}
 DocType: Social Login Key,Social Login Key,Sotsiaalse sisselogimise võti
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options {1} must be the same as doctype name {2} for the field {3},{0}: valikud {1} peavad olema väljal {3} samad kui doctype&#39;i nimi {2}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options {1} must be the same as doctype name {2} for the field {3},{0}: valikud {1} peavad olema väljal {3} samad kui doctype'i nimi {2}
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Clear Cache and Reload,Tühjendage vahemälu ja laadige uuesti
 DocType: Portal Settings,Custom Sidebar Menu,Custom Külgriba menüü
 DocType: Workflow State,pencil,pliiats
@@ -2431,7 +2431,7 @@ apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multip
 DocType: Data Migration Run,Percent Complete,Protsent täidetud
 DocType: Tag Category,Tag Category,tag Kategooria
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Võrdluseks kasutage> 5, <10 või = 324. Vahemike jaoks kasutage 5:10 (väärtuste vahemikus 5–10)."
-DocType: Google Calendar,Pull from Google Calendar,Tõmmake Google&#39;i kalendrist
+DocType: Google Calendar,Pull from Google Calendar,Tõmmake Google'i kalendrist
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aitama
 DocType: User,Login Before,Logi Enne
 DocType: Web Page,Insert Style,Sisesta Style
@@ -2468,7 +2468,7 @@ apps/frappe/frappe/email/smtp.py,Invalid recipient address,Vale saaja aadress
 DocType: Workflow State,step-forward,samm edasi
 DocType: System Settings,Allow Login After Fail,Luba sisselogimine pärast nurjumist
 DocType: Role Permission for Page and Report,Set Role For,Määra roll
-DocType: GCalendar Account,The name that will appear in Google Calendar,"Nimi, mis kuvatakse Google&#39;i kalendris"
+DocType: GCalendar Account,The name that will appear in Google Calendar,"Nimi, mis kuvatakse Google'i kalendris"
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Direct room with {0} already exists.,Otsene tuba {0} juba on olemas.
 apps/frappe/frappe/core/doctype/user/user.js,Refreshing...,Värskendav ...
 DocType: Event,Starts on,Algab
@@ -2480,7 +2480,7 @@ apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this docum
 DocType: Workflow State,th,th
 DocType: Social Login Key,Provider Name,Pakkuja nimi
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Create a new {0},Loo uus {0}
-DocType: Contact,Google Contacts,Google&#39;i kontaktid
+DocType: Contact,Google Contacts,Google'i kontaktid
 DocType: GCalendar Account,GCalendar Account,GCalendari konto
 DocType: Email Rule,Is Spam,Kas Spam
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Report {0},Aruanne {0}
@@ -2499,9 +2499,9 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} can
 DocType: Newsletter,Create and Send Newsletters,Loo ja saatke uudiskirju
 apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,Aitäh kommentaari eest. See avaldatakse pärast heakskiitmist
 DocType: Address,Andaman and Nicobar Islands,Andamani ja Nicobari saared
-DocType: Google Contacts,Pull from Google Contacts,Tõmmake Google&#39;i kontaktide hulgast
+DocType: Google Contacts,Pull from Google Contacts,Tõmmake Google'i kontaktide hulgast
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,"Palun täpsustage, mis on väärtuse väljal tuleb kontrollida"
-DocType: Event,Google Calendar Event ID,Google&#39;i kalendri sündmuse ID
+DocType: Event,Google Calendar Event ID,Google'i kalendri sündmuse ID
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added","&quot;Vanem&quot; tähendab vanemale tabeli, kus see rida tuleb lisada"
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,Ülevaatamispunktid:
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,Jagada
@@ -2567,7 +2567,7 @@ apps/frappe/frappe/www/update-password.html,New Password Required.,New Password 
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with {1},{0} jagas seda dokumenti {1}ga
 DocType: Website Settings,Brand Image,kaubamärgi maine
 DocType: Print Settings,A4,A4
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Google Calendar has been configured.,Google&#39;i kalender on konfigureeritud.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Google Calendar has been configured.,Google'i kalender on konfigureeritud.
 apps/frappe/frappe/config/website.py,"Setup of top navigation bar, footer and logo.","Setup top navigation bar, jalus ja logo."
 DocType: Web Form Field,Max Value,max Value
 apps/frappe/frappe/core/doctype/doctype/doctype.py,For {0} at level {1} in {2} in row {3},Sest {0} tasemel {1} on {2} järjest {3}
@@ -2591,7 +2591,7 @@ DocType: Dropbox Settings,Dropbox Access Token,Dropbox pääsuluba
 DocType: Workflow State,align-right,viia paremale
 DocType: Auto Email Report,Email To,Saada
 apps/frappe/frappe/core/doctype/file/file.py,Folder {0} is not empty,Folder {0} ei ole tühi
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,{0} Google Contacts synced.,{0} Google&#39;i kontaktid on sünkroonitud.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,{0} Google Contacts synced.,{0} Google'i kontaktid on sünkroonitud.
 DocType: Page,Roles,Rollid
 apps/frappe/frappe/model/base_document.py,Error: Value missing for {0}: {1},Viga: Väärtus kadunud {0}: {1}
 DocType: Blog Post,Content (Markdown),Sisu (märgistus)
@@ -2679,10 +2679,10 @@ DocType: DocField,Ignore XSS Filter,Ignoreeri XSS Filter
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,removed,eemaldatud
 apps/frappe/frappe/config/integrations.py,Dropbox backup settings,Dropbox backup seaded
 DocType: Webhook,Webhook Trigger,Webhooki päästik
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,{0} Google Calendar Events synced.,{0} Google&#39;i kalendri sündmused on sünkroonitud.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,{0} Google Calendar Events synced.,{0} Google'i kalendri sündmused on sünkroonitud.
 DocType: Dashboard Chart,Time Series,Ajasari
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be disabled,Kasutaja {0} ei saa välja lülitada
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Google Settings,Google&#39;i seaded
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Google Settings,Google'i seaded
 apps/frappe/frappe/templates/emails/administrator_logged_in.html,"Dear System Manager,","Lugupeetud System Manager,"
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} self assigned this task: {1},{0} ise omistas selle ülesande: {1}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Your Country,Sinu riik
@@ -2699,8 +2699,8 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Millega muudetakse
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal makse gateway seaded
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Tippnäitleja
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Kohandatud välju ei saa põhilistesse DocTypes&#39;i lisada.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) saavad kärbitud, kui max lubatud tähemärkide {2}"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Kohandatud välju ei saa põhilistesse DocTypes'i lisada.
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) saavad kärbitud, kui max lubatud tähemärkide {2}"
 DocType: OAuth Client,Response Type,Vastus Type
 DocType: Contact Us Settings,Send enquiries to this email address,Saada päringuid sellele aadressile
 DocType: Letter Head,Letter Head Name,Kiri Head nimi
@@ -2736,7 +2736,7 @@ DocType: Email Account,no failed attempts,no ebaõnnestunud katseid
 DocType: GSuite Settings,refresh_token,refresh_token
 DocType: Dropbox Settings,App Access Key,App Access Key
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat failed for {0},Automaatne kordus nurjus {0}
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Luba Google&#39;i seadetes Google API.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Luba Google'i seadetes Google API.
 DocType: Session Default,Session Default,Seansi vaikimisi
 DocType: Chat Room,Last Message,Viimane sõnum
 DocType: OAuth Bearer Token,Access Token,Access Token
@@ -2767,7 +2767,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,dokumendi taastatud
 DocType: Data Export,Data Export,Andmete eksportimine
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Vali keel...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Väljale {0} ei saa määrata &#39;Valikud&#39;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Väljale {0} ei saa määrata 'Valikud'
 DocType: Help Article,Author,autor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Jätka saatmine
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Taastada
@@ -2788,7 +2788,7 @@ DocType: Data Import,Amended From,Muudetud From
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Hoiatus: Ei leia {0} tahes tabelis seotud {1}
 DocType: S3 Backup Settings,eu-north-1,eu-põhja-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,See dokument on praegu sabas täitmiseks. Palun proovi uuesti
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Faili &#39;{0}&#39; ei leitud
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Faili '{0}' ei leitud
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Eemalda jaos
 DocType: User,Change Password,Muuda salasõna
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X-teljevälja
@@ -2798,7 +2798,7 @@ apps/frappe/frappe/config/integrations.py,Braintree payment gateway settings,Bra
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Rebuild,Ümberehitada
 apps/frappe/frappe/www/third_party_apps.html,This will log out {0} from all other devices,See logib kõikidest teistest seadmetest välja {0}
 apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Sa ei pea luba saada aruande: {0}
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google&#39;i kalender - sündmust ei õnnestunud Google&#39;i kalendrisse {0} sisestada, veakood {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google'i kalender - sündmust ei õnnestunud Google'i kalendrisse {0} sisestada, veakood {1}."
 DocType: System Settings,Apply Strict User Permissions,Ranged kasutajalubasid
 DocType: S3 Backup Settings,us-west-1,us-lääs-1
 DocType: DocField,Allow Bulk Edit,Luba Bulk Edit
@@ -2838,7 +2838,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"To get the up
 apps/frappe/frappe/sessions.py,Redis cache server not running. Please contact Administrator / Tech support,Redis cache server ei tööta. Palun pöörduge administraatori / Tehniline tugi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_header.html,Searching,otsimine
 DocType: Currency,Fraction,Murdosa
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Event Synced with Google Calendar.,Sündmus on sünkroonitud Google&#39;i kalendriga.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Event Synced with Google Calendar.,Sündmus on sünkroonitud Google'i kalendriga.
 DocType: LDAP Settings,LDAP First Name Field,LDAP Eesnimi Field
 DocType: Contact,Middle Name,Keskmine nimi
 DocType: Custom Field,Field Description,Field kirjeldus
@@ -2853,7 +2853,7 @@ DocType: Address,Plant,Taim
 apps/frappe/frappe/core/doctype/communication/communication.js,Reply All,Vasta kõigile
 DocType: DocType,Setup,Setup
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,All Records,Kõik plaadid
-DocType: Google Contacts,Email Address whose Google Contacts are to be synced.,"E-posti aadress, mille Google&#39;i kontakte tuleb sünkroonida."
+DocType: Google Contacts,Email Address whose Google Contacts are to be synced.,"E-posti aadress, mille Google'i kontakte tuleb sünkroonida."
 DocType: Email Account,Initial Sync Count,Esmane Sync Krahv
 DocType: Workflow State,glass,klaas
 DocType: DocType,Timeline Field,Timeline Field
@@ -2930,7 +2930,7 @@ apps/frappe/frappe/core/doctype/data_import/importer_new.py,Invalid Template,Val
 apps/frappe/frappe/model/db_query.py,Illegal SQL Query,Ebaseaduslik SQL päring
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Mandatory:,Kohustuslik:
 DocType: Chat Message,Mentions,Mainib
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,"To use Google Contacts, enable {0}.",Google&#39;i kontaktide kasutamiseks lubage {0}.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,"To use Google Contacts, enable {0}.",Google'i kontaktide kasutamiseks lubage {0}.
 apps/frappe/frappe/public/js/frappe/utils/utils.js,{0} Modules,{0} moodulid
 DocType: Chat Room,Chat Room,Jututuba
 DocType: Chat Profile,Conversation Tones,Vestlushelinad
@@ -2969,13 +2969,13 @@ DocType: GSuite Settings,GSuite Settings,GSuite Seaded
 DocType: Address,Links,Lingid
 DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Kasutab sellel kontol mainitud e-posti aadressinime saatja nimena kõigil selle konto kaudu saadetud meilidel.
 DocType: Energy Point Rule,Field To Check,Kontrollitav väli
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Google&#39;i kontaktid - Google&#39;i kontaktide {0} kontakti ei saanud värskendada, veakood {1}."
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Google'i kontaktid - Google'i kontaktide {0} kontakti ei saanud värskendada, veakood {1}."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,Palun valige dokumendi tüüp.
 apps/frappe/frappe/model/base_document.py,Value missing for,Väärtus puuduvad
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Lisa Child
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Impordi käik
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Kui tingimus on täidetud, premeeritakse kasutajat punktidega. nt. doc.status == &#39;Suletud&#39;"
+","Kui tingimus on täidetud, premeeritakse kasutajat punktidega. nt. doc.status == 'Suletud'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Esitatud Record ei saa kustutada.
 DocType: GSuite Templates,Template Name,malli nimi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Uue dokumendi tüüp
@@ -3006,7 +3006,7 @@ DocType: Activity Log,Full Name,Täisnimi
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,Duplicate filtri nimi
 DocType: Chat Room User,Chat Room User,Jututuba Kasutaja
 apps/frappe/frappe/model/workflow.py,Workflow State not set,Töövoo olek pole määratud
-DocType: Google Calendar,Authorize Google Calendar Access,Google&#39;i kalendri juurdepääsu volitamine
+DocType: Google Calendar,Authorize Google Calendar Access,Google'i kalendri juurdepääsu volitamine
 apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,"Lehe otsite on puudu. See võiks olla, sest see liigub või on kirjaviga link."
 apps/frappe/frappe/www/404.html,Error Code: {0},Veakood: {0}
 DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Kirjeldus nimekirjade lehele, lihttekstina, ainult paar rida. (max 140 tähemärki)"
@@ -3021,7 +3021,7 @@ DocType: Web Form,Success URL,Edu URL
 DocType: Email Account,Append To,Lisab
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Number of DB backups cannot be less than 1,DB-i varukoopiate arv ei tohi olla väiksem kui 1
 DocType: Workflow Document State,Only Allow Edit For,Ainult Laske Muuda
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Backing up to Google Drive.,Varundamine Google Drive&#39;i.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Backing up to Google Drive.,Varundamine Google Drive'i.
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: {0},Kohustuslik väli: {0}
 apps/frappe/frappe/templates/includes/comments/comments.html,Your Name,Sinu nimi
 apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Connection Success,Ühenduse edu
@@ -3128,7 +3128,7 @@ DocType: Milestone,Milestone,Verstapost
 DocType: User,User Image,Kasutaja Image
 apps/frappe/frappe/core/doctype/doctype/doctype.js,Go to {0},Minge lehele {0}
 apps/frappe/frappe/email/queue.py,Emails are muted,Kirjad on summutatud
-apps/frappe/frappe/config/integrations.py,Google Services,Google&#39;i teenused
+apps/frappe/frappe/config/integrations.py,Google Services,Google'i teenused
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Up,Ctrl + Up
 apps/frappe/frappe/utils/data.py,1 weeks ago,1 nädal tagasi
 DocType: Communication,Error,Eksimus
@@ -3149,7 +3149,7 @@ apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Se
 DocType: Custom Field,Options Help,Valikud Abi
 DocType: Footer Item,Group Label,Märgistus
 DocType: Kanban Board,Kanban Board,Kanban Board
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts has been configured.,Google&#39;i kontaktid on konfigureeritud.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts has been configured.,Google'i kontaktid on konfigureeritud.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,1 record will be exported,1 kirje eksporditakse
 DocType: DocField,Report Hide,Aruanne Peida
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Tree view not available for {0},Puunäkymä ole saadaval {0}
@@ -3158,7 +3158,7 @@ DocType: Domain,Domain,Domeeni
 DocType: Custom Field,Label Help,Label Abi
 DocType: Workflow State,star-empty,star-tühi
 apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,Kuupäevad on sageli lihtne ära arvata.
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Google&#39;i kontaktid - Google&#39;i kontaktide {0} kontakte ei saanud sünkroonida, veakood {1}."
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Google'i kontaktid - Google'i kontaktide {0} kontakte ei saanud sünkroonida, veakood {1}."
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Next actions,Järgmine tegevusi
 apps/frappe/frappe/email/doctype/notification/notification.py,"Cannot edit Standard Notification. To edit, please disable this and duplicate it",Standardteatise ei saa muuta. Muutmiseks keelake see välja ja kopeerige see
 apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,Kontrollikoodi e-posti aadressi ei saadetud. Palun pöörduge administraatori poole.
@@ -3293,7 +3293,7 @@ apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,Rida ole
 DocType: S3 Backup Settings,sa-east-1,sa-ida-1
 DocType: Workflow Transition,Workflow Transition,Töövoo Transition
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,{0} kuud tagasi
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Kohandatud välju saab lisada ainult standardsesse DocType&#39;i.
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Kohandatud välju saab lisada ainult standardsesse DocType'i.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Created By,Loodud
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Dropbox Setup
 DocType: Assignment Rule Day,Assignment Rule Day,Ülesannete reeglite päev
@@ -3511,7 +3511,7 @@ DocType: S3 Backup Settings,eu-west-3,eu-lääs-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},Üleslaadimine: {0} {1} -st
 DocType: DocType,DocType is a Table / Form in the application.,DocType on tabel / hagiavalduses.
 DocType: Social Login Key,Authorize URL,URL-i autoriseerimine
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google&#39;i kalender - sündmust ei õnnestunud Google&#39;i kalendrist tuua, veakood {0}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google'i kalender - sündmust ei õnnestunud Google'i kalendrist tuua, veakood {0}."
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failed,Automaatne dokumendi loomine ebaõnnestus
 DocType: Email Account,GMail,GMail
 DocType: Letter Head,Letter Head Image,Kirja pea pilt
@@ -3529,7 +3529,7 @@ DocType: Chat Message,Visitor,Külastaja
 DocType: User,Allow user to login only before this hour (0-24),Luba kasutajal sisse logida ainult enne seda tund (0-24)
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"Drag and drop files, ",Failide lohistamine
 DocType: Social Login Key,Access Token URL,Juurdepääs Tokeni URL-ile
-apps/frappe/frappe/config/integrations.py,Google Drive Backup.,Google Drive&#39;i varundamine.
+apps/frappe/frappe/config/integrations.py,Google Drive Backup.,Google Drive'i varundamine.
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} assigned {1}: {2},{0} määratud {1}: {2}
 apps/frappe/frappe/www/contact.py,New Message from Website Contact Page,Uus Sõnum Veebileht Kontakt Page
 DocType: Notification,Reference Date,Viide kuupäev
@@ -3597,12 +3597,12 @@ DocType: Auto Email Report,Dynamic Report Filters,Dünaamilised aruandefiltrid
 DocType: Email Account,UIDVALIDITY,UIDVALIDITY
 apps/frappe/frappe/public/js/frappe/views/communication.js,New Email,New Post
 DocType: Custom DocPerm,Export,Eksport
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,"To use Google Calendar, enable {0}.",Google&#39;i kalendri kasutamiseks lubage {0}.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,"To use Google Calendar, enable {0}.",Google'i kalendri kasutamiseks lubage {0}.
 apps/frappe/frappe/public/js/frappe/form/print.js,QZ Tray Failed: ,QZ-salve nurjus:
 DocType: Dropbox Settings,Dropbox Settings,Dropbox seaded
 DocType: About Us Settings,More content for the bottom of the page.,Rohkem sisu eest lehekülje allosas.
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.js,This document has been reverted,See dokument on tagasi võetud
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive Backup Successful.,Google Drive&#39;i varundamine õnnestus.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive Backup Successful.,Google Drive'i varundamine õnnestus.
 DocType: Workflow,DocType on which this Workflow is applicable.,DocType millele see töövoog on kohaldatav.
 DocType: User,Enabled,Lubatud
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,Seadistamise lõpetamine ebaõnnestus
@@ -3667,7 +3667,7 @@ apps/frappe/frappe/templates/includes/login/login.js,Invalid Login. Try again.,V
 DocType: Auto Email Report,Send only if there is any data,"Saada ainult siis, kui on olemas kõik andmed"
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Totals Row,Totals Row
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Permission at level 0 must be set before higher levels are set,{0}: Luba tasemel 0 tuleb kehtestada enne kõrgem tase määratakse
-DocType: Contact,Sync with Google Contacts,Sünkrooni Google&#39;i kontaktidega
+DocType: Contact,Sync with Google Contacts,Sünkrooni Google'i kontaktidega
 DocType: Tag Link,Document Tag,Dokumendi silt
 apps/frappe/frappe/desk/doctype/todo/todo.py,Assignment closed by {0},Ülesanne suletud {0}
 DocType: Integration Request,Remote,kauge
@@ -3683,7 +3683,7 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,e.g. (55 + 434) / 
 apps/frappe/frappe/utils/csvutils.py,{0} is required,{0} on nõutav
 DocType: Integration Request,Integration Type,integratsiooni Type
 DocType: Newsletter,Send Attachements,Saada Kinnitused
-apps/frappe/frappe/config/integrations.py,Google Contacts Integration.,Google&#39;i kontaktide integreerimine.
+apps/frappe/frappe/config/integrations.py,Google Contacts Integration.,Google'i kontaktide integreerimine.
 DocType: Transaction Log,Transaction Log,Tehingute logi
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last month's performance (from {0} to {1}),Statistika põhineb eelmise kuu tootlusel (alates {0} kuni {1})
 DocType: Contact Us Settings,City,City
@@ -3807,7 +3807,7 @@ DocType: Prepared Report,Prepared Report,Ettevalmistatud aruanne
 apps/frappe/frappe/config/website.py,Add meta tags to your web pages,Lisage oma veebilehtedele metasilte
 DocType: Workflow State,User,Kasutaja
 DocType: Website Settings,"Show title in browser window as ""Prefix - title""",Show tiitli brauseri akna &quot;Eesliide - pealkiri&quot;
-DocType: Payment Gateway,Gateway Settings,Gateway&#39;i seaded
+DocType: Payment Gateway,Gateway Settings,Gateway'i seaded
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,text in document type,teksti dokumendi tüüp
 apps/frappe/frappe/core/doctype/test_runner/test_runner.js,Run Tests,porrvitestid
 apps/frappe/frappe/handler.py,Logged Out,Välja logitud
@@ -3826,7 +3826,7 @@ apps/frappe/frappe/public/js/frappe/views/interaction.js,Summary,Kokkuvõte
 DocType: Event,Event Participants,Sündmuse osalised
 DocType: Auto Repeat,Frequency,sagedus
 DocType: Custom Field,Insert After,Sisesta Pärast
-DocType: Event,Sync with Google Calendar,Sünkrooni Google&#39;i kalendriga
+DocType: Event,Sync with Google Calendar,Sünkrooni Google'i kalendriga
 DocType: Access Log,Report Name,Aruande nimetus
 DocType: Desktop Icon,Reverse Icon Color,Tagurpidi Märk Värv
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Save,Salvesta
@@ -3934,7 +3934,7 @@ apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Ple
 DocType: Portal Settings,Custom Menu Items,Kohandatud menüü üksused
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,Kõik veebisaidi slaidiseanssidest lisatud pildid peaksid olema avalikud
 DocType: Workflow State,chevron-right,Chevron paremas
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,"To use Google Drive, enable {0}.",Google Drive&#39;i kasutamiseks lubage {0}.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,"To use Google Drive, enable {0}.",Google Drive'i kasutamiseks lubage {0}.
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be in developer mode to edit a Standard Web Form,Sa pead olema arendaja režiimi muutmine Standard Web Form
 DocType: Personal Data Deletion Request,Personal Data Deletion Request,Isikuandmete kustutamise taotlus
 DocType: Payment Gateway,Gateway Controller,Gateway Controller
@@ -3968,7 +3968,7 @@ DocType: Activity Log,Failed,Ebaõnnestunud
 DocType: Web Form,Allow Comments,Laske Kommentaarid
 DocType: Dashboard Chart,Last Week,Eelmine nädal
 DocType: System Settings,Bypass Two Factor Auth for users who login from restricted IP Address,"Kasutaja, kes siseneb piiratud IP-aadressist, mööda kaks tegurit Auth"
-DocType: Event,Google Calendar,Google&#39;i kalender
+DocType: Event,Google Calendar,Google'i kalender
 apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,"{0}, et lõpetada selliste e-kirjade saamine"
 apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Avage oma mobiiltelefoni autentimisrakendus.
 apps/frappe/frappe/model/rename_doc.py,merged {0} into {1},ühendati {0} arvesse {1}

--- a/frappe/translations/et.csv
+++ b/frappe/translations/et.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Failide var
 DocType: DocField,In Global Search,Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,indent-vasakule
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} aasta tagasi
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} aasta tagasi
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,See on riskantne kustutada seda faili: {0}. Palun võtke System Manager.
 DocType: Currency,Currency Name,Valuuta nimi
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,nr kirjad
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,No {0} leitud
 apps/frappe/frappe/config/customization.py,Add custom forms.,Lisa custom vorme.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} {2}-st
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,esitatud käesoleva dokumendi
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Seadistamine&gt; Kasutaja õigused
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Seadistamine> Kasutaja õigused
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Süsteem pakub palju ettemääratud rollid. Saate lisada uusi rolle seada peenem õigused.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Kui kasutajal on roll kontrollida, siis kasutaja saab &quot;System User&quot;. &quot;Süsteem Kasutaja&quot; on juurdepääs töölauale"
 DocType: System Settings,Date and Number Format,Kuupäev ja Arvuvorming
 apps/frappe/frappe/model/document.py,one of,üks
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Seadistamine&gt; Vormi kohandamine
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Seadistamine> Vormi kohandamine
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kontroll üks hetk
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Näita Sildid
 DocType: DocField,HTML Editor,HTML-redaktor
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Arved
 DocType: Email Queue,Not Sent,Ei Saadetud
 DocType: Web Form,Actions,Actions
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Seadistamine&gt; Kasutaja
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Seadistamine> Kasutaja
 DocType: Workflow State,align-justify,"viia, õigustada"
 DocType: User,Middle Name (Optional),Lähis nimi (valikuline)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ei ole lubatud
@@ -1410,7 +1410,7 @@ DocType: User,System User,Süsteemi kasutaja
 DocType: Report,Is Standard,Kas Standard
 DocType: Desktop Icon,_report,_aruanne
 DocType: Dashboard Chart,Full,Täis
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ära HTML kodeerimine HTML nagu &lt;script&gt; või lihtsalt sümboleid, näiteks &lt;või&gt;, kuna neid võib tahtlikult kasutada selles valdkonnas"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ära HTML kodeerimine HTML nagu &lt;script> või lihtsalt sümboleid, näiteks &lt;või>, kuna neid võib tahtlikult kasutada selles valdkonnas"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiseeriti saidil {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Jookse
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Jalus kuvatakse �
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pooleliolev
 DocType: System Settings,Allow only one session per user,Luba ainult ühe seansi kasutaja kohta
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Vali ja lohista üle ajaühikud luua uus sündmus.
 DocType: Contact,Contact Details,Kontaktandmed
 DocType: DocField,In Filter,In Filter
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Sisene ole lubatud sel ajal
 DocType: Data Migration Run,Current Mapping Action,Praegune kaardistamistegevus
 DocType: Dashboard Chart Source,Source Name,Allikas Nimi
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Kasutajaga pole seotud ühtegi e-posti kontot. Lisage konto jaotises Kasutaja&gt; E-posti postkast.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Kasutajaga pole seotud ühtegi e-posti kontot. Lisage konto jaotises Kasutaja> E-posti postkast.
 DocType: Email Account,Email Sync Option,Saatke Sync variant
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rida nr
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Juba kasu
 DocType: User Email,Enable Outgoing,Luba Väljuv
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,kohandatud sildid
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-posti konto pole seadistatud. Palun looge uus e-posti konto jaotises Seadistamine&gt; E-post&gt; E-posti konto
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posti konto pole seadistatud. Palun looge uus e-posti konto jaotises Seadistamine> E-post> E-posti konto
 DocType: Comment,Submitted,Esitatud
 DocType: Contact,Pulled from Google Contacts,Tõmmatud Google&#39;i kontaktidest
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Kehtivas taotluses
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Session lõppemine T
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","See väli ilmub ainult siis, kui fieldname määratletud siin on väärtuse või reeglid on tõsi (näited): myfield eval: doc.myfield == &quot;Minu Value&quot; eval: doc.age&gt; 18"
+eval:doc.age>18","See väli ilmub ainult siis, kui fieldname määratletud siin on väärtuse või reeglid on tõsi (näited): myfield eval: doc.myfield == &quot;Minu Value&quot; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,täna
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Kui oled selle kasutajad saavad ainult juurdepääs dokumentidele (nt. Blog Post), kus on olemas seos (nt. Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,SUURTÄHTEDE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Sisesta kataloogi nimi
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Vaikimisi aadressimalli ei leitud. Palun looge uus kaust Seadistamine&gt; Printimine ja bränding&gt; Aadressimall.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Vaikimisi aadressimalli ei leitud. Palun looge uus kaust Seadistamine> Printimine ja bränding> Aadressimall.
 apps/frappe/frappe/auth.py,Unknown User,Tundmatu kasutaja
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Vali Role
 DocType: Comment,Deleted,Kustutatud
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Tee serveri sertifikaadini
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Pole piisavalt luba näha lingid
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Aadress Pealkiri on kohustuslik.
 DocType: Google Contacts,Push to Google Contacts,Pöörake Google&#39;i kontaktidesse
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Lisatud HTML &lt;head&gt; osas veebilehe, mida kasutatakse peamiselt veebilehel kontrollimist ja SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Lisatud HTML &lt;head> osas veebilehe, mida kasutatakse peamiselt veebilehel kontrollimist ja SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Retsidiveerunud
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Punkt ei saa lisada oma järeltulijad
 DocType: Session Default Settings,Session Defaults,Seansi vaikeväärtused
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Hoiatus
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Selle võib printida mitmele lehele
 DocType: Data Migration Run,Percent Complete,Protsent täidetud
 DocType: Tag Category,Tag Category,tag Kategooria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Võrdluseks kasutage&gt; 5, &lt;10 või = 324. Vahemike jaoks kasutage 5:10 (väärtuste vahemikus 5–10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Võrdluseks kasutage> 5, &lt;10 või = 324. Vahemike jaoks kasutage 5:10 (väärtuste vahemikus 5–10)."
 DocType: Google Calendar,Pull from Google Calendar,Tõmmake Google&#39;i kalendrist
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aitama
 DocType: User,Login Before,Logi Enne
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Custom Script
 DocType: Address,Address Line 2,Aadress Line 2
 DocType: Address,Reference,Viide
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Määratud
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Seadistage vaikimisi kasutatav e-posti konto seadistustes&gt; E-post&gt; E-posti konto
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Seadistage vaikimisi kasutatav e-posti konto seadistustes> E-post> E-posti konto
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Andmete rände kaardistamise üksikasjad
 DocType: Data Import,Action,Action
 DocType: GSuite Settings,Script URL,Script URL
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Laske Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Erand Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vali veerud
-DocType: Web Page,Add code as &lt;script&gt;,Lisa koodi &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Lisa koodi &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Tühjenda kasutaja õigused
 DocType: Webhook,Headers,Päised
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Sündmused
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,aktsiate alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Järjekord peaks olema üks {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Vaikemalliga </h4><p> Kasutab <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja vormivad</a> kõik väljad Aadress (sh Custom Fields kui üldse) on saadaval </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Vaikemalliga </h4><p> Kasutab <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja vormivad</a> kõik väljad Aadress (sh Custom Fields kui üldse) on saadaval </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Alguskuupäev
 DocType: Role,Role Name,Role nimi
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch to Desk

--- a/frappe/translations/et.csv
+++ b/frappe/translations/et.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Süsteemi kasutaja
 DocType: Report,Is Standard,Kas Standard
 DocType: Desktop Icon,_report,_aruanne
 DocType: Dashboard Chart,Full,Täis
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ära HTML kodeerimine HTML nagu &lt;script> või lihtsalt sümboleid, näiteks &lt;või>, kuna neid võib tahtlikult kasutada selles valdkonnas"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ära HTML kodeerimine HTML nagu <script> või lihtsalt sümboleid, näiteks <või>, kuna neid võib tahtlikult kasutada selles valdkonnas"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiseeriti saidil {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Jookse
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Jalus kuvatakse �
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pooleliolev
 DocType: System Settings,Allow only one session per user,Luba ainult ühe seansi kasutaja kohta
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Vali ja lohista üle ajaühikud luua uus sündmus.
 DocType: Contact,Contact Details,Kontaktandmed
 DocType: DocField,In Filter,In Filter
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Tee serveri sertifikaadini
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Pole piisavalt luba näha lingid
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Aadress Pealkiri on kohustuslik.
 DocType: Google Contacts,Push to Google Contacts,Pöörake Google&#39;i kontaktidesse
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Lisatud HTML &lt;head> osas veebilehe, mida kasutatakse peamiselt veebilehel kontrollimist ja SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Lisatud HTML <head> osas veebilehe, mida kasutatakse peamiselt veebilehel kontrollimist ja SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Retsidiveerunud
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Punkt ei saa lisada oma järeltulijad
 DocType: Session Default Settings,Session Defaults,Seansi vaikeväärtused
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Hoiatus
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Selle võib printida mitmele lehele
 DocType: Data Migration Run,Percent Complete,Protsent täidetud
 DocType: Tag Category,Tag Category,tag Kategooria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Võrdluseks kasutage> 5, &lt;10 või = 324. Vahemike jaoks kasutage 5:10 (väärtuste vahemikus 5–10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Võrdluseks kasutage> 5, <10 või = 324. Vahemike jaoks kasutage 5:10 (väärtuste vahemikus 5–10)."
 DocType: Google Calendar,Pull from Google Calendar,Tõmmake Google&#39;i kalendrist
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aitama
 DocType: User,Login Before,Logi Enne
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Laske Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Erand Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vali veerud
-DocType: Web Page,Add code as &lt;script>,Lisa koodi &lt;script>
+DocType: Web Page,Add code as <script>,Lisa koodi <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Tühjenda kasutaja õigused
 DocType: Webhook,Headers,Päised
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Sündmused
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,aktsiate alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Järjekord peaks olema üks {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Vaikemalliga </h4><p> Kasutab <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja vormivad</a> kõik väljad Aadress (sh Custom Fields kui üldse) on saadaval </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Vaikemalliga </h4><p> Kasutab <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja vormivad</a> kõik väljad Aadress (sh Custom Fields kui üldse) on saadaval </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Alguskuupäev
 DocType: Role,Role Name,Role nimi
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch to Desk

--- a/frappe/translations/fa.csv
+++ b/frappe/translations/fa.csv
@@ -724,7 +724,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,نسخه پ
 DocType: DocField,In Global Search,در جهانی جستجو
 DocType: System Settings,Brute Force Security,امنیت نیروی بیرحمانه
 DocType: Workflow State,indent-left,تورفتگی سمت چپ
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} سال پیش
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} سال پیش
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,این خطرناک است این فایل را حذف کنید: {0}. لطفا با مدیر سیستم تماس بگیرید.
 DocType: Currency,Currency Name,نام ارز
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,هیچ ایمیل
@@ -1015,7 +1015,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,بدون {0} 
 apps/frappe/frappe/config/customization.py,Add custom forms.,اضافه کردن فرم های سفارشی.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} در {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ارسال این سند
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,تنظیم&gt; مجوزهای کاربر
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,تنظیم> مجوزهای کاربر
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,سیستم بسیاری از نقش های از پیش تعریف شده را فراهم می کند. شما می توانید نقش های جدید اضافه برای تنظیم دسترسی ظریف.
 DocType: Communication,CC,CC
 DocType: Country,Geo,ژئو
@@ -1227,7 +1227,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",اگر کاربر هر نقش بررسی است، پس از آن کاربر یک &quot;سیستم کاربر&quot; می شود. &quot;سیستم کاربر&quot; دسترسی به دسکتاپ است
 DocType: System Settings,Date and Number Format,تاریخ و شماره فرمت
 apps/frappe/frappe/model/document.py,one of,یکی از
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,تنظیم&gt; سفارشی کردن فرم
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,تنظیم> سفارشی کردن فرم
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,چک کردن یک لحظه
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,نمایش برچسب ها
 DocType: DocField,HTML Editor,ویرایشگر HTML
@@ -1235,7 +1235,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,صدور صورت حساب
 DocType: Email Queue,Not Sent,ارسال نشد
 DocType: Web Form,Actions,عملیات
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,تنظیم&gt; کاربر
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,تنظیم> کاربر
 DocType: Workflow State,align-justify,چین-توجیه
 DocType: User,Middle Name (Optional),نام میانه (اختیاری)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,غیر مجاز
@@ -1377,7 +1377,7 @@ DocType: User,System User,سیستم کاربر
 DocType: Report,Is Standard,آیا استاندارد
 DocType: Desktop Icon,_report,_گزارش
 DocType: Dashboard Chart,Full,پر شده
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",آیا دستورات HTML رمز HTML مانند &lt;script&gt; به و یا فقط شخصیت های مانند &lt;یا&gt;، به عنوان آنها می تواند به عمد در این زمینه استفاده می شود
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",آیا دستورات HTML رمز HTML مانند &lt;script> به و یا فقط شخصیت های مانند &lt;یا>، به عنوان آنها می تواند به عمد در این زمینه استفاده می شود
 DocType: Website Settings,FavIcon,موارد دلخواه
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,اجرا کن
 DocType: Blog Post,Content (HTML),محتوا (HTML)
@@ -1736,7 +1736,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,پاورقی در
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,در انتظار
 DocType: System Settings,Allow only one session per user,اجازه می دهد تنها یک جلسه در هر کاربر
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,پوشه اصلی / آزمایش / 1 تست پوشه 3
-DocType: Website Settings,&lt;head&gt; HTML,HTML
+DocType: Website Settings,&lt;head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,انتخاب و یا کشیدن در سراسر شکاف زمان برای ایجاد یک رویداد جدید.
 DocType: Contact,Contact Details,اطلاعات تماس
 DocType: DocField,In Filter,در فیلتر
@@ -1875,7 +1875,7 @@ DocType: Address,Madhya Pradesh,مادها پرادش
 DocType: Deleted Document,New Name,نام جدید
 DocType: System Settings,Is First Startup,اولین راه اندازی است
 DocType: Communication,Email Status,وضعیت ایمیل
-apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the document before removing assignment,لطفا قبل از حذف انتساب سند را ذخیره کنید
+apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the document before removing assignment,لطفا قبل از حذف انتساب سن�� را ذخیره کنید
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Insert Above,درج بالاتر
 apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Add script for Child Table,اسکریپت را برای جدول کودک اضافه کنید
 apps/frappe/frappe/desk/form/utils.py,Comment can only be edited by the owner,نظر می تواند توسط مالک ویرایش شود
@@ -1963,7 +1963,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,ورود در این زمان مجاز نیست
 DocType: Data Migration Run,Current Mapping Action,اقدامات نقشه برداری فعلی
 DocType: Dashboard Chart Source,Source Name,نام منبع
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,هیچ حساب ایمیل مرتبط با کاربر نیست. لطفاً یک حساب کاربری در زیر کاربر&gt; صندوق ورودی ایمیل اضافه کنید.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,هیچ حساب ایمیل مرتبط با کاربر نیست. لطفاً یک حساب کاربری در زیر کاربر> صندوق ورودی ایمیل اضافه کنید.
 DocType: Email Account,Email Sync Option,ایمیل همگام سازی گزینه
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,ردیف شماره
 DocType: Async Task,Runtime,در زمان اجرا
@@ -1978,7 +1978,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,در حا
 DocType: User Email,Enable Outgoing,فعال خروجی
 DocType: Address,Fax,فکس
 apps/frappe/frappe/config/customization.py,Custom Tags,سفارشی برچسب ها
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,حساب ایمیل تنظیم نشده است. لطفاً یک حساب ایمیل جدید از طریق تنظیم&gt; ایمیل&gt; حساب ایمیل ایجاد کنید
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,حساب ایمیل تنظیم نشده است. لطفاً یک حساب ایمیل جدید از طریق تنظیم> ایمیل> حساب ایمیل ایجاد کنید
 DocType: Comment,Submitted,ارسال شده
 DocType: Contact,Pulled from Google Contacts,از مخاطبین Google کشیده شد
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,در درخواست معتبر
@@ -2048,7 +2048,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,جلسه انقضا�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",در این زمینه به نظر می رسد تنها در صورتی که FIELDNAME تعریف شده در اینجا دارای ارزش و یا قوانین واقعی (مثال): myfield محاسبه-: doc.myfield == &#39;ارزش من &quot;تابع eval: doc.age&gt; 18
+eval:doc.age>18",در این زمینه به نظر می رسد تنها در صورتی که FIELDNAME تعریف شده در اینجا دارای ارزش و یا قوانین واقعی (مثال): myfield محاسبه-: doc.myfield == &#39;ارزش من &quot;تابع eval: doc.age> 18
 DocType: Social Login Key,Office 365,دفتر 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,امروز
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",هنگامی که شما تعیین کرده اند این، کاربران تنها اسناد دسترسی قادر باشد (. به عنوان مثال وبلاگ پست) که در آن پیوند وجود دارد (به عنوان مثال بلاگر).
@@ -2061,7 +2061,7 @@ apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of th
 DocType: DocType,UPPER CASE,حروف
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,سفارشی HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,نام پوشه را وارد کنید
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,هیچ الگوی پیش فرض آدرس یافت نشد. لطفاً یک مورد جدید از Setup&gt; چاپ و برندسازی&gt; الگوی آدرس ایجاد کنید.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,هیچ الگوی پیش فرض آدرس یافت نشد. لطفاً یک مورد جدید از Setup> چاپ و برندسازی> الگوی آدرس ایجاد کنید.
 apps/frappe/frappe/auth.py,Unknown User,کاربر ناشناس
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,انتخاب نقش
 DocType: Comment,Deleted,حذف
@@ -2244,7 +2244,7 @@ DocType: LDAP Settings,Path to Server Certificate,مسیر به گواهی سر�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,نه اجازه اندازه کافی برای دیدن لینک
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,عنوان نشانی الزامی است.
 DocType: Google Contacts,Push to Google Contacts,به مخاطبین Google فشار دهید
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",اضافه شده در HTML قسمت &lt;head&gt; بخش از صفحه وب، در درجه اول برای تأیید وب سایت و بهینه سازی سایت استفاده
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",اضافه شده در HTML قسمت &lt;head> بخش از صفحه وب، در درجه اول برای تأیید وب سایت و بهینه سازی سایت استفاده
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,دچار عود
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,مورد می تواند به بازماندگان خود را اضافه نمی شوند
 DocType: Session Default Settings,Session Defaults,جلسه پیش فرض
@@ -2360,7 +2360,7 @@ DocType: Workflow State,Warning,هشدار
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,این ممکن است در چندین صفحه چاپ شود
 DocType: Data Migration Run,Percent Complete,درصد کامل
 DocType: Tag Category,Tag Category,برچسب رده
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",برای مقایسه ، از 5 ، &lt;10 یا 324 استفاده کنید. برای محدوده ها ، از 5:10 (برای مقادیر بین 5 تا 10) استفاده کنید.
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",برای مقایسه ، از 5 ، &lt;10 یا 324 استفاده کنید. برای محدوده ها ، از 5:10 (برای مقادیر بین 5 تا 10) استفاده کنید.
 DocType: Google Calendar,Pull from Google Calendar,از تقویم Google بکشید
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,کمک
 DocType: User,Login Before,ورود به قبل از
@@ -2807,7 +2807,7 @@ DocType: Custom Script,Custom Script,سفارشی اسکریپت
 DocType: Address,Address Line 2,خط 2 آدرس
 DocType: Address,Reference,ارجاع
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,اختصاص یافته به
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,لطفاً حساب پیش فرض پست الکترونیکی را از تنظیم&gt; ایمیل&gt; حساب ایمیل تنظیم کنید
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,لطفاً حساب پیش فرض پست الکترونیکی را از تنظیم> ایمیل> حساب ایمیل تنظیم کنید
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,جزئیات نقشه برداری مهاجرت
 DocType: Data Import,Action,اقدام
 DocType: GSuite Settings,Script URL,URL اسکریپت
@@ -2979,7 +2979,7 @@ DocType: DocField,Allow on Submit,اجازه می دهد در ارسال
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,نوع استثنا
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,انتخاب ستون
-DocType: Web Page,Add code as &lt;script&gt;,اضافه کردن کد به عنوان &lt;script&gt; و
+DocType: Web Page,Add code as &lt;script>,اضافه کردن کد به عنوان &lt;script> و
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,مجوزهای کاربر را پاک کنید
 DocType: Webhook,Headers,سربرگ ها
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,رویدادهای نزدیک
@@ -3100,7 +3100,7 @@ apps/frappe/frappe/templates/includes/login/login.js,Not a valid user,یک کا�
 apps/frappe/frappe/templates/includes/comments/comments.html,Please enter a valid email address.,لطفا یک آدرس ایمیل معتبر وارد کنید.
 apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Last refreshed,آخرین تجدید
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,For Document Type,برای نوع سند
-DocType: Workflow State,arrow-right,فلش سمت راست
+DocType: Workflow State,arrow-right,فلش س��ت راست
 DocType: Workflow State,Workflow state represents the current state of a document.,وضعیت گردش کار نشان دهنده وضعیت جاری یک سند است.
 DocType: Letter Head,Letter Head Based On,نامه سر مبتنی بر
 apps/frappe/frappe/utils/oauth.py,Token is missing,رمز گم شده است
@@ -3338,16 +3338,16 @@ DocType: Workflow State,share-alt,سهم-ALT
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},صف باید یکی از شود {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4 style="";text-align:right;direction:rtl""> به طور پیش فرض الگو </h4><p style="";text-align:right;direction:rtl""> با استفاده از <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja قالب</a> و تمامی زمینه های آدرس (از جمله زمینه های سفارشی در صورت وجود) در دسترس خواهد بود </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4 style="";text-align:right;direction:rtl""> به طور پیش فرض الگو </h4><p style="";text-align:right;direction:rtl""> با استفاده از <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja قالب</a> و تمامی زمینه های آدرس (از جمله زمینه های سفارشی در صورت وجود) در دسترس خواهد بود </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,فیلد تاریخ شروع
 DocType: Role,Role Name,نام نقش
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,تغییر به میز
@@ -3724,7 +3724,7 @@ DocType: DocField,Default,پیش فرض
 DocType: Translation,Verified,تأیید شده
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} اضافه شد
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',جستجو برای &#39;{0}
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,لطفا گزارش نجات اول
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,��طفا گزارش نجات اول
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} مشترک افزوده شد
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,نه در
 DocType: Workflow State,star,ستاره

--- a/frappe/translations/fa.csv
+++ b/frappe/translations/fa.csv
@@ -62,7 +62,7 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred whil
 apps/frappe/frappe/public/js/frappe/model/model.js,Parent,والدین
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.",اگر فعال باشد، قدرت رمز عبور خواهد شد بر اساس حداقل ارزش کلمه عبور اجرا می شود. مقدار 2 که متوسط قوی و 4 بسیار قوی.
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;اعضای تیم&quot; یا &quot;مدیریت&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',به طور پیش فرض برای چک &#39;نوع درست یا باید به صورت&#39; 0 &#39;یا&#39; 1 &#39;است
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',به طور پیش فرض برای چک 'نوع درست یا باید به صورت' 0 'یا' 1 'است
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,دیروز
 DocType: Contact,Designation,تعیین
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,پیوند خودکار می تواند فقط برای یک حساب ایمیل فعال شود.
@@ -248,7 +248,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,غیر فعال 
 DocType: Translation,Contributed Translation Doctype Name,نام مستند ترجمه
 DocType: PayPal Settings,Redirect To,تغییر مسیر به
 DocType: Data Migration Mapping,Pull,کشیدن
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},جاوا اسکریپت فرمت: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},جاوا اسکریپت فرمت: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,به روز رسانی فله
 DocType: Workflow State,chevron-up,شورون تا
 DocType: DocType,Allow Guest to View,اجازه مهمان نمایش
@@ -541,7 +541,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,آپلود نشد
 DocType: LDAP Settings,LDAP Phone Field,زمینه تلفن LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",نوع سند ...، به عنوان مثال مشتری
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,وضعیت &#39;{0}&#39; نامعتبر است
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,وضعیت '{0}' نامعتبر است
 DocType: Workflow State,barcode,بارکد
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,استفاده از زیر پرس و جو یا تابع محدود شده است
 apps/frappe/frappe/config/customization.py,Add your own translations,اضافه کردن ترجمه خود را
@@ -730,7 +730,7 @@ DocType: Currency,Currency Name,نام ارز
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,هیچ ایمیل
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,پیوند به پایان رسیده است
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",بازگرداندن طول به {0} برای {1} &#39;در&#39; {2} &#39;؛ تنظیم طول به عنوان {3} باعث کاهش اطلاعات می شود.
+							Setting the length as {3} will cause truncation of data.",بازگرداندن طول به {0} برای {1} 'در' {2} '؛ تنظیم طول به عنوان {3} باعث کاهش اطلاعات می شود.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,انتخاب فرمت فایل
 DocType: Report,Javascript,جاوا اسکریپت
 DocType: File,Content Hash,هش محتوا
@@ -751,7 +751,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,سند اشتراک گزارش
 DocType: Social Login Key,Base URL,URL پایه
 DocType: User,Last Login,تاریخ و زمان آخرین ورود
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},شما نمی توانید &#39;Translatable&#39; را برای فیلد {0} تنظیم کنید
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},شما نمی توانید 'Translatable' را برای فیلد {0} تنظیم کنید
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,ستون
 DocType: Chat Profile,Chat Profile,نمای چت
 DocType: Custom Field,Adds a custom field to a DocType,می افزاید: درست سفارشی را به یک DOCTYPE
@@ -760,7 +760,7 @@ DocType: File,Is Home Folder,صفحه اصلی پوشه است
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,سبک نوار
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} یک آدرس ایمیل معتبر نیست
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,حداقل 1 رکورد برای چاپ انتخاب کنید
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',کاربر &#39;{0}&#39; در حال حاضر نقش دارد: &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',کاربر '{0}' در حال حاضر نقش دارد: '{1}'
 DocType: System Settings,Two Factor Authentication method,دو روش اعتبار فاکتور
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,اول نام را تنظیم کرده و رکورد را ذخیره کنید.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 رکورد
@@ -1006,7 +1006,7 @@ DocType: Property Setter,Property Setter,املاک گذارنده
 DocType: Web Form,Allow Print,اجازه چاپ
 DocType: Communication,Clicked,کلیک
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,لغو ادامه
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},بدون اجازه &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},بدون اجازه '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,برنامه ریزی به ارسال
 DocType: DocType,Track Seen,آهنگ دیده
 DocType: Dropbox Settings,File Backup,پشتیبان فایل
@@ -1033,7 +1033,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,صفحه HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,صادرات ردیف خطا
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,نام گروه نمیتواند خالی باشد
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,گره علاوه بر این می تواند تنها تحت نوع گره &#39;گروه&#39; ایجاد
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,گره علاوه بر این می تواند تنها تحت نوع گره 'گروه' ایجاد
 DocType: SMS Parameter,Header,سربرگ
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},ستون ناشناخته: {0}
 DocType: Notification Recipient,Email By Role,ایمیل توسط نقش
@@ -1946,7 +1946,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,قلم گوگل
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",اگر این دستورالعمل که در آن مفید نیست، لطفا پیشنهادات خود را اضافه کنید در مسائل گیتهاب.
 DocType: Workflow State,bookmark,چوب الف
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),نام پوشه باید شامل از &#39;/&#39; (اسلش)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),نام پوشه باید شامل از '/' (اسلش)
 DocType: Note,Note,یادداشت
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,گزارش خطا
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,صادرات داده ها در قالب CSV / اکسل.
@@ -2048,7 +2048,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,جلسه انقضا�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",در این زمینه به نظر می رسد تنها در صورتی که FIELDNAME تعریف شده در اینجا دارای ارزش و یا قوانین واقعی (مثال): myfield محاسبه-: doc.myfield == &#39;ارزش من &quot;تابع eval: doc.age> 18
+eval:doc.age>18",در این زمینه به نظر می رسد تنها در صورتی که FIELDNAME تعریف شده در اینجا دارای ارزش و یا قوانین واقعی (مثال): myfield محاسبه-: doc.myfield == 'ارزش من &quot;تابع eval: doc.age> 18
 DocType: Social Login Key,Office 365,دفتر 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,امروز
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",هنگامی که شما تعیین کرده اند این، کاربران تنها اسناد دسترسی قادر باشد (. به عنوان مثال وبلاگ پست) که در آن پیوند وجود دارد (به عنوان مثال بلاگر).
@@ -2086,7 +2086,7 @@ DocType: Data Migration Connector,Database Name,نام پایگاه داده
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,فرم تازه کردن
 DocType: DocField,Select,انتخاب
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,مشاهده کامل گزارش
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",بیان ساده پایتون ، مثال: status == &#39;Open&#39; و نوع == &#39;اشکال&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",بیان ساده پایتون ، مثال: status == 'Open' و نوع == 'اشکال'
 apps/frappe/frappe/utils/csvutils.py,File not attached,فایل های پیوست نمی
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,ارتباط از دست رفته برخی از ویژگی های ممکن است کار نکند.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",تکرار مانند &quot;AAA&quot; به راحتی حدس زده
@@ -2213,7 +2213,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,فقط خطاها را نمایش دهید
 DocType: Website Settings,Banner HTML,بنر HTML
 DocType: Workflow,Send Email Alert,ارسال هشدار ایمیل
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',لطفا روش پرداخت دیگری را انتخاب کنید. Razorpay از انجام تراکنش در ارز را پشتیبانی نمی کند &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',لطفا روش پرداخت دیگری را انتخاب کنید. Razorpay از انجام تراکنش در ارز را پشتیبانی نمی کند '{0}'
 DocType: Data Import,In Progress,در حال پیش رفت
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,در صف برای تهیه پشتیبان. ممکن است چند دقیقه تا یک ساعت طول می کشد.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2622,7 +2622,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,اصلاح
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,پی پال تنظیمات دروازه پرداخت
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,عمل کننده عالی
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,زمینه های سفارشی را نمی توان به DocTypes اصلی اضافه کرد.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: &#39;{1}&#39; ({3}) کوتاه خواهد شد، به عنوان شخصیت های حداکثر مجاز {2}
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: '{1}' ({3}) کوتاه خواهد شد، به عنوان شخصیت های حداکثر مجاز {2}
 DocType: OAuth Client,Response Type,نوع پاسخ
 DocType: Contact Us Settings,Send enquiries to this email address,ارسال سوالات به این آدرس ایمیل
 DocType: Letter Head,Letter Head Name,نام سر نامه
@@ -2676,7 +2676,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,تصویر مشخصات
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.",نظر می رسد چیزی در معامله را اشتباه رفت. از آنجا که ما پرداخت را اعلام نکرده اند، پی پال به طور خودکار شما این مقدار بازپرداخت. اگر آن را ندارد، لطفا به ما ایمیل بفرستید و ذکر ID همبستگی: {0}.
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password",شامل نمادها، اعداد و حروف بزرگ در رمز عبور
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",قرار دادن بعد از میدان &#39;{0}&#39; ذکر شده در سفارشی درست &#39;{1}&#39;، با برچسب &#39;{2}، وجود ندارد
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",قرار دادن بعد از میدان '{0}' ذکر شده در سفارشی درست '{1}'، با برچسب '{2}، وجود ندارد
 DocType: List Filter,List Filter,لیست فیلتر
 DocType: Workflow State,signal,سیگنال
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,دارای فایل پیوست
@@ -2686,7 +2686,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,سند ترمیم
 DocType: Data Export,Data Export,صادرات داده
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,زبان را انتخاب کنید...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},شما نمی توانید گزینه &#39;Options&#39; را برای فیلد {0} تنظیم کنید
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},شما نمی توانید گزینه 'Options' را برای فیلد {0} تنظیم کنید
 DocType: Help Article,Author,نویسنده
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,رزومه ارسال
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,بازگشایی
@@ -2700,7 +2700,7 @@ DocType: Web Page,Slideshow,نمایش به صورت اسلاید
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,به طور پیش فرض آدرس الگو نمی تواند حذف شود
 DocType: Contact,Maintenance Manager,مدیر نگهداری و تعمیرات
 DocType: Workflow State,Search,جستجو
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',لطفا روش پرداخت دیگری را انتخاب کنید. خط خطی انجام تراکنش در ارز را پشتیبانی نمی کند &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',لطفا روش پرداخت دیگری را انتخاب کنید. خط خطی انجام تراکنش در ارز را پشتیبانی نمی کند '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,انتقال به سطل زباله
 DocType: Web Form,Web Form Fields,فرم وب
 DocType: Data Import,Amended From,اصلاح از
@@ -2887,7 +2887,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,ارزش از دست
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,اضافه کردن کودک
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,پیشرفت واردات
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",اگر شرط راضی باشد کاربر با امتیاز پاداش می گیرد. به عنوان مثال. doc.status == &#39;بسته&#39;
+",اگر شرط راضی باشد کاربر با امتیاز پاداش می گیرد. به عنوان مثال. doc.status == 'بسته'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: رکورد ثبت شده نمی تواند حذف شود.
 DocType: GSuite Templates,Template Name,نام الگو
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,نوع جدیدی از سند
@@ -3291,7 +3291,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,ترجمه های
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,پیش رفتن
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,توسط نقش
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,زمینه های از دست رفته
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,FIELDNAME نامعتبر &#39;{0} در autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,FIELDNAME نامعتبر '{0} در autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,جستجو در یک نوع سند
 DocType: Custom DocPerm,Role and Level,نقش و سطح
 DocType: File,Thumbnail URL,URL تصویر بند انگشتی
@@ -3377,7 +3377,7 @@ DocType: Dashboard Chart,Filters JSON,فیلترهای JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,به منظور بررسی اینجا را کلیک کنید
 DocType: Email Account,Disable SMTP server authentication,تأیید هویت سرور SMTP را غیرفعال کنید
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,در کلیپ بورد کپی شد.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,تعویض قابل پیش بینی مانند &#39;@&#39; به جای &#39;A&#39; خیلی زیاد کمک نمی کند.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,تعویض قابل پیش بینی مانند '@' به جای 'A' خیلی زیاد کمک نمی کند.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,اختصاص داده شده توسط من
 apps/frappe/frappe/utils/data.py,Zero,صفر
 DocType: Google Drive,Backup Folder ID,شناسه پوشه پشتیبان
@@ -3427,7 +3427,7 @@ DocType: Notification,Reference Date,مرجع تاریخ
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,نصب OTP با استفاده از برنامه OTP تکمیل نشد. لطفا با سرپرست تماس بگیرید.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,لطفا NOS تلفن همراه معتبر وارد کنید
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,برخی از ویژگی های ممکن را در مرورگر خود کار نمی کند. لطفا مرورگر خود را به آخرین نسخه به روز رسانی.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",هنوز مطمئن شوید که، از &#39;کمک&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",هنوز مطمئن شوید که، از 'کمک'
 DocType: DocType,Comments and Communications will be associated with this linked document,نظرات و ارتباطات خواهد شد با این سند مرتبط مرتبط
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,فیلتر ...
 DocType: Workflow State,bold,جسور
@@ -3723,7 +3723,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,پیش فرض
 DocType: Translation,Verified,تأیید شده
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} اضافه شد
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',جستجو برای &#39;{0}
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',جستجو برای '{0}
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,��طفا گزارش نجات اول
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} مشترک افزوده شد
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,نه در
@@ -3758,14 +3758,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,من
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} نه دولت معتبر
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,به کلیه انواع اسناد اعمال شود
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,به روز رسانی نقطه انرژی
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',لطفا روش پرداخت دیگری را انتخاب کنید. پی پال انجام تراکنش در ارز را پشتیبانی نمی کند &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',لطفا روش پرداخت دیگری را انتخاب کنید. پی پال انجام تراکنش در ارز را پشتیبانی نمی کند '{0}'
 DocType: Chat Message,Room Type,نوع اتاق
 DocType: Data Import Beta,Import Log Preview,پیش نمایش ورود به سیستم واردات
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,قسمت جستجو {0} معتبر نیست
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,پرونده بارگذاری شده
 DocType: Workflow State,ok-circle,OK-دایره
 DocType: LDAP Settings,LDAP User Creation and Mapping,ایجاد و نقشه برداری کاربر LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',شما می توانید همه چیز را با پرسیدن &#39;پیدا کردن پرتقال در مشتریان پیدا
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',شما می توانید همه چیز را با پرسیدن 'پیدا کردن پرتقال در مشتریان پیدا
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,با عرض پوزش! کاربر باید دسترسی کامل به رکورد خود را دارند.
 ,Usage Info,اطلاعات استفاده
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,میانبرهای صفحه کلید را نمایش دهید

--- a/frappe/translations/fa.csv
+++ b/frappe/translations/fa.csv
@@ -1377,7 +1377,7 @@ DocType: User,System User,سیستم کاربر
 DocType: Report,Is Standard,آیا استاندارد
 DocType: Desktop Icon,_report,_گزارش
 DocType: Dashboard Chart,Full,پر شده
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",آیا دستورات HTML رمز HTML مانند &lt;script> به و یا فقط شخصیت های مانند &lt;یا>، به عنوان آنها می تواند به عمد در این زمینه استفاده می شود
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",آیا دستورات HTML رمز HTML مانند <script> به و یا فقط شخصیت های مانند <یا>، به عنوان آنها می تواند به عمد در این زمینه استفاده می شود
 DocType: Website Settings,FavIcon,موارد دلخواه
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,اجرا کن
 DocType: Blog Post,Content (HTML),محتوا (HTML)
@@ -1736,7 +1736,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,پاورقی در
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,در انتظار
 DocType: System Settings,Allow only one session per user,اجازه می دهد تنها یک جلسه در هر کاربر
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,پوشه اصلی / آزمایش / 1 تست پوشه 3
-DocType: Website Settings,&lt;head> HTML,HTML
+DocType: Website Settings,<head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,انتخاب و یا کشیدن در سراسر شکاف زمان برای ایجاد یک رویداد جدید.
 DocType: Contact,Contact Details,اطلاعات تماس
 DocType: DocField,In Filter,در فیلتر
@@ -2244,7 +2244,7 @@ DocType: LDAP Settings,Path to Server Certificate,مسیر به گواهی سر�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,نه اجازه اندازه کافی برای دیدن لینک
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,عنوان نشانی الزامی است.
 DocType: Google Contacts,Push to Google Contacts,به مخاطبین Google فشار دهید
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",اضافه شده در HTML قسمت &lt;head> بخش از صفحه وب، در درجه اول برای تأیید وب سایت و بهینه سازی سایت استفاده
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",اضافه شده در HTML قسمت <head> بخش از صفحه وب، در درجه اول برای تأیید وب سایت و بهینه سازی سایت استفاده
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,دچار عود
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,مورد می تواند به بازماندگان خود را اضافه نمی شوند
 DocType: Session Default Settings,Session Defaults,جلسه پیش فرض
@@ -2360,7 +2360,7 @@ DocType: Workflow State,Warning,هشدار
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,این ممکن است در چندین صفحه چاپ شود
 DocType: Data Migration Run,Percent Complete,درصد کامل
 DocType: Tag Category,Tag Category,برچسب رده
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",برای مقایسه ، از 5 ، &lt;10 یا 324 استفاده کنید. برای محدوده ها ، از 5:10 (برای مقادیر بین 5 تا 10) استفاده کنید.
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",برای مقایسه ، از 5 ، <10 یا 324 استفاده کنید. برای محدوده ها ، از 5:10 (برای مقادیر بین 5 تا 10) استفاده کنید.
 DocType: Google Calendar,Pull from Google Calendar,از تقویم Google بکشید
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,کمک
 DocType: User,Login Before,ورود به قبل از
@@ -2979,7 +2979,7 @@ DocType: DocField,Allow on Submit,اجازه می دهد در ارسال
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,نوع استثنا
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,انتخاب ستون
-DocType: Web Page,Add code as &lt;script>,اضافه کردن کد به عنوان &lt;script> و
+DocType: Web Page,Add code as <script>,اضافه کردن کد به عنوان <script> و
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,مجوزهای کاربر را پاک کنید
 DocType: Webhook,Headers,سربرگ ها
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,رویدادهای نزدیک
@@ -3338,16 +3338,16 @@ DocType: Workflow State,share-alt,سهم-ALT
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},صف باید یکی از شود {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4 style="";text-align:right;direction:rtl""> به طور پیش فرض الگو </h4><p style="";text-align:right;direction:rtl""> با استفاده از <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja قالب</a> و تمامی زمینه های آدرس (از جمله زمینه های سفارشی در صورت وجود) در دسترس خواهد بود </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4 style="";text-align:right;direction:rtl""> به طور پیش فرض الگو </h4><p style="";text-align:right;direction:rtl""> با استفاده از <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja قالب</a> و تمامی زمینه های آدرس (از جمله زمینه های سفارشی در صورت وجود) در دسترس خواهد بود </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,فیلد تاریخ شروع
 DocType: Role,Role Name,نام نقش
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,تغییر به میز

--- a/frappe/translations/fi.csv
+++ b/frappe/translations/fi.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,järjestelmäkäyttäjä
 DocType: Report,Is Standard,on perus
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Koko
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Älä HTML Pakkaa HTML tageja kuten &lt;script> tai vain merkkejä kuten &lt;tai>, koska ne voidaan tarkoituksellisesti käyttää tällä alalla"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Älä HTML Pakkaa HTML tageja kuten <script> tai vain merkkejä kuten <tai>, koska ne voidaan tarkoituksellisesti käyttää tällä alalla"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} arvosteltiin {1}
 DocType: Website Settings,FavIcon,Faviconi
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Juosta
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Alatunniste näky
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Odottaa
 DocType: System Settings,Allow only one session per user,Vain yksi istunto per käyttäjä
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Etusivu / Testi kansio 1 / Test-kansion 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
+DocType: Website Settings,<head> HTML,<Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Valitse tai vieritä oikea aikaväli tehdäksesi uuden tapahtuman
 DocType: Contact,Contact Details,"yhteystiedot, lisätiedot"
 DocType: DocField,In Filter,suodatuksessa
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Polku palvelinvarmenteeseen
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ei tarpeeksi lupaa nähdä linkit
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,osoiteotsikko on pakollinen.
 DocType: Google Contacts,Push to Google Contacts,Siirry Google-yhteystietoihin
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Lisätty HTML &lt;head> -osioon sivun, käytetään pääasiassa verkkosivuilla todentaminen ja SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Lisätty HTML <head> -osioon sivun, käytetään pääasiassa verkkosivuilla todentaminen ja SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Uusiutunut
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,tuotetta ei voi lisätä omaksi alatuotteekseen
 DocType: Session Default Settings,Session Defaults,Istunnon oletukset
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Varoitus
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Tämä voidaan tulostaa useille sivuille
 DocType: Data Migration Run,Percent Complete,Prosenttiosuus on täydellinen
 DocType: Tag Category,Tag Category,Tagi -kategoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Vertailun vuoksi käytä> 5, &lt;10 tai = 324. Käytä alueita 5:10 (arvoille 5-10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Vertailun vuoksi käytä> 5, <10 tai = 324. Käytä alueita 5:10 (arvoille 5-10)."
 DocType: Google Calendar,Pull from Google Calendar,Vedä Google-kalenterista
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ohje
 DocType: User,Login Before,Kirjaudu Ennen
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Salli vahvistuksessa
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Poikkeus Tyyppi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Valitse sarakkeet
-DocType: Web Page,Add code as &lt;script>,Lisää koodi
+DocType: Web Page,Add code as <script>,Lisää koodi
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Tyhjennä käyttöoikeudet
 DocType: Webhook,Headers,otsikot
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Tulevat tapahtumat
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,Jaa-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Jonon pitäisi olla yksi {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Default Template </h4><p> Käyttää <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templaattimateriaalit</a> ja kaikilla aloilla Address (mukaan lukien omat kentät mahdollinen) on saatavilla </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Default Template </h4><p> Käyttää <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templaattimateriaalit</a> ja kaikilla aloilla Address (mukaan lukien omat kentät mahdollinen) on saatavilla </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Aloituspäiväkentä
 DocType: Role,Role Name,Rooli Name
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Vaihda työpöydälle

--- a/frappe/translations/fi.csv
+++ b/frappe/translations/fi.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Tilastot perustuvat viime viikon suorituskykyyn (välillä {0} - {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP-puhelinkenttä
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","dokumentin tyyppi.., esim. asiakas"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Ehto &#39;{0}&#39; ei kelpaa
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Ehto '{0}' ei kelpaa
 DocType: Workflow State,barcode,Viivakoodi
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Alihakemiston tai toiminnon käyttöä rajoitetaan
 apps/frappe/frappe/config/customization.py,Add your own translations,Lisää oma käännökset
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokumentin jako raportti
 DocType: Social Login Key,Base URL,Base URL
 DocType: User,Last Login,Viimeksi kirjautunut
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Et voi asettaa &#39;Translatable&#39; kentälle {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Et voi asettaa 'Translatable' kentälle {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,sarake
 DocType: Chat Profile,Chat Profile,Chat-profiili
 DocType: Custom Field,Adds a custom field to a DocType,Lisää oman kentän tietuetyyppiin
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Pakollinen kenttä: set rooli
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} arvosteli {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Kenttää &#39;{1}&#39; ei voida asettaa yksilölliseksi, koska sillä on ei-ainutlaatuiset arvot"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Kenttää '{1}' ei voida asettaa yksilölliseksi, koska sillä on ei-ainutlaatuiset arvot"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Selaa luetteloa alaspäin
 DocType: Currency,A symbol for this currency. For e.g. $,"valuutan symboli, esim €"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Päivitetty käännökset
@@ -2004,7 +2004,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google-fontti
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",elleivät nämä ohjeet auta lisää ehdotus GitHub:lle aiheesa
 DocType: Workflow State,bookmark,kirjanmerkki
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Kansion nimi ei pitäisi sisällyttää &#39;/&#39; (kauttaviiva)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Kansion nimi ei pitäisi sisällyttää '/' (kauttaviiva)
 DocType: Note,Note,Muistiinpano
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Virheraportti
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Vie tiedot CSV / Excel-muodossa.
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Istunto vanhenee (t
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Tämä kenttä näkyy vain, jos fieldname määritelty tässä on arvo TAI säännöt ovat totta (esimerkkejä): myfield eval: doc.myfield == &#39;My Arvo &quot;eval: doc.age> 18"
+eval:doc.age>18","Tämä kenttä näkyy vain, jos fieldname määritelty tässä on arvo TAI säännöt ovat totta (esimerkkejä): myfield eval: doc.myfield == 'My Arvo &quot;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Tänään
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Kun olet asettanut tämän, käyttäjät voivat vain tutustua asiakirjoihin (esim. Blogiviesti) jos linkki on olemassa (esim. Blogger)."
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,Tietokannan nimi
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Päivitä muoto
 DocType: DocField,Select,Valitse
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Näytä koko loki
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Yksinkertainen Python-lauseke, esimerkki: status == &#39;Avaa&#39; ja kirjoita == &#39;Vika&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Yksinkertainen Python-lauseke, esimerkki: status == 'Avaa' ja kirjoita == 'Vika'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Tiedostoa ei ole liitetty
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Yhteys kadotettu. Jotkin ominaisuudet eivät välttämättä toimi.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Toistot kuten &quot;aaa&quot; on helppo arvata
@@ -2757,7 +2757,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,kuvanäkymä
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Näyttää jotain meni pieleen tapahtuman aikana. Koska emme ole vahvistaneet maksu, Paypal automaattisesti palautamme tämän määrän. Jos näin ei ole, lähetä meille sähköpostia ja mainita korrelaatio ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Sisältyä merkkejä, numeroita ja isoja kirjaimia salasanaa"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Aseta jälkeen kenttä &#39;{0}&#39; mainitaan Oma kenttä &quot;{1}&quot;, jossa merkintä &quot;{2}&quot;, ei ole olemassa"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Aseta jälkeen kenttä '{0}' mainitaan Oma kenttä &quot;{1}&quot;, jossa merkintä &quot;{2}&quot;, ei ole olemassa"
 DocType: List Filter,List Filter,Listan suodatin
 DocType: Workflow State,signal,Signaali
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Onko liitteitä
@@ -2767,7 +2767,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokumentti Palautettu
 DocType: Data Export,Data Export,Tietojen vienti
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Valitse kieli...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Et voi asettaa &#39;Options&#39; kentälle {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Et voi asettaa 'Options' kentälle {0}
 DocType: Help Article,Author,kirjailija
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,jatka lähettäminen
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Avaa uudestaan
@@ -2781,14 +2781,14 @@ DocType: Web Page,Slideshow,Diaesitys
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,"oletus osoite, mallipohjaa ei voi poistaa"
 DocType: Contact,Maintenance Manager,Huollon ylläpitäjä
 DocType: Workflow State,Search,Haku
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Valitse toinen maksutapa. Raita ei tue käteisrahaan &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Valitse toinen maksutapa. Raita ei tue käteisrahaan '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Siirtää roskakoriin
 DocType: Web Form,Web Form Fields,Verkkosivun Lomakkeen kentät
 DocType: Data Import,Amended From,Korjattu mistä
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Varoitus: ei löydy {0} millään taulukossa liittyvät {1}
 DocType: S3 Backup Settings,eu-north-1,EU-pohjois-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Tämä asiakirja on parhaillaan jonossa suoritettavaksi. Yritä uudelleen
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Tiedosto {0} &#39;ei löytynyt
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Tiedosto {0} 'ei löytynyt
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,poista jakso
 DocType: User,Change Password,Vaihda salasana
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X-akselikenttä
@@ -2975,7 +2975,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Arvo puuttuu
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,lisää alasidos
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Tuo eteneminen
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Jos ehto täyttyy, käyttäjä palkitaan pisteillä. esimerkiksi. doc.status == &#39;Suljettu&#39;"
+","Jos ehto täyttyy, käyttäjä palkitaan pisteillä. esimerkiksi. doc.status == 'Suljettu'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Vahvistettua tietuetta ei voi poistaa.
 DocType: GSuite Templates,Template Name,Mallin nimi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,uudentyyppinen asiakirja
@@ -3107,7 +3107,7 @@ DocType: Dashboard Chart,Chart Type,Kaaviotyyppi
 DocType: DocType,Auto Name,Auto Name
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Vältä sekvenssit kuten abc tai 6543, koska ne on helppo arvata"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Yritä uudelleen
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL-osoitteen on alkava &#39;http: //&#39; tai &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL-osoitteen on alkava 'http: //' tai 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Vaihtoehto 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,muokkaa
@@ -3346,7 +3346,7 @@ DocType: Notification,Send alert if this field's value changes,"Lähetä hälyty
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Teemavärit
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Valitse tietuetyyppi tehdäksesi uuden formaatin
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Käyttäjää ei ole olemassa
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Vastaanottajat&#39; ei ole määritelty
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Vastaanottajat' ei ole määritelty
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,juuri nyt
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Käytä
 DocType: Footer Item,Policy,Käytäntö
@@ -3394,7 +3394,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Mukautetut kielik
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Edistyminen
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,Rooli
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Puuttuvia kenttiä
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Virheellinen fieldname &#39;{0}&#39; in autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Virheellinen fieldname '{0}' in autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Haku asiakirjatyypit
 DocType: Custom DocPerm,Role and Level,Rooli ja Level
 DocType: File,Thumbnail URL,Pikkukuvan URL
@@ -3695,7 +3695,7 @@ DocType: Web Page,Web Page,Verkkosivu
 DocType: Workflow Document State,Next Action Email Template,Seuraava toiminto sähköpostimalli
 DocType: Blog Category,Blogger,Bloggaaja
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Jos tämä on käytössä, asiakirjan muutoksia seurataan ja ne näytetään aikajanalla"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Global haku&#39; kielletty tyyppi {0} rivillä {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Global haku' kielletty tyyppi {0} rivillä {1}
 DocType: Energy Point Log,Appreciation,arvostus
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Katso List
 DocType: Workflow,Don't Override Status,Älä poikkeuta tilaa

--- a/frappe/translations/fi.csv
+++ b/frappe/translations/fi.csv
@@ -673,7 +673,7 @@ apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,kantaa {0} ei v
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Ei vielä kommentteja
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings",Aseta tekstiviesti ennen sen asettamista todentamismenetelmänä SMS-asetusten kautta
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,sekä tietuetyyppi että nimi vaaditaan
-apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,Dokumentin tilaa ei voi muuttaa 1 -&gt; 0
+apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,Dokumentin tilaa ei voi muuttaa 1 -> 0
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,Sinulla ei ole tarpeeksi pisteitä
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Take Backup Now,Ota varmuuskopio nyt
 DocType: Contact,Open,Avoin
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Tiedoston v
 DocType: DocField,In Global Search,Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,luetelmakohta vasemmassa
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} vuosi sitten
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} vuosi sitten
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Se on riskialtista poistaa tiedoston: {0}. Ota yhteyttä System Manager.
 DocType: Currency,Currency Name,valuutan nimi
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ei Sähköpostit
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Tietueita ei 
 apps/frappe/frappe/config/customization.py,Add custom forms.,lisää omia lomakkeita/muotoja
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} in {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,Vahvisti tämän dokumentin
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Asennus&gt; Käyttäjän oikeudet
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Asennus> Käyttäjän oikeudet
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,"Järjestelmässä on monia ennalta määriteltyjä rooleja, voit lisätä uusia rooleja määritelläksesi tarkempia käyttöoikeuksia"
 DocType: Communication,CC,CC
 DocType: Country,Geo,sijainti
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Jos käyttäjällä on mitään roolia valittuna, käyttäjä tulee &quot;System User&quot;. &quot;Järjestelmän Käyttäjä&quot; on työpöydällä"
 DocType: System Settings,Date and Number Format,Päivämäärän ja numeron muoto
 apps/frappe/frappe/model/document.py,one of,Yksi
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Asennus&gt; Mukauta lomaketta
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Asennus> Mukauta lomaketta
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Tarkistetaan yksi hetki
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Näytä tagit
 DocType: DocField,HTML Editor,HTML-editori
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Laskutus
 DocType: Email Queue,Not Sent,Ei lähetetty
 DocType: Web Form,Actions,Toiminnot
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Asennus&gt; Käyttäjä
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Asennus> Käyttäjä
 DocType: Workflow State,align-justify,oikea tasaus
 DocType: User,Middle Name (Optional),Toinen nimi (valinnainen)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ei Sallittu
@@ -1410,7 +1410,7 @@ DocType: User,System User,järjestelmäkäyttäjä
 DocType: Report,Is Standard,on perus
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Koko
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Älä HTML Pakkaa HTML tageja kuten &lt;script&gt; tai vain merkkejä kuten &lt;tai&gt;, koska ne voidaan tarkoituksellisesti käyttää tällä alalla"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Älä HTML Pakkaa HTML tageja kuten &lt;script> tai vain merkkejä kuten &lt;tai>, koska ne voidaan tarkoituksellisesti käyttää tällä alalla"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} arvosteltiin {1}
 DocType: Website Settings,FavIcon,Faviconi
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Juosta
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Alatunniste näky
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Odottaa
 DocType: System Settings,Allow only one session per user,Vain yksi istunto per käyttäjä
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Etusivu / Testi kansio 1 / Test-kansion 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Valitse tai vieritä oikea aikaväli tehdäksesi uuden tapahtuman
 DocType: Contact,Contact Details,"yhteystiedot, lisätiedot"
 DocType: DocField,In Filter,suodatuksessa
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Kirjaudu kielletty tällä hetkellä
 DocType: Data Migration Run,Current Mapping Action,Nykyinen kartoitus
 DocType: Dashboard Chart Source,Source Name,Source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Ei käyttäjän tiliä. Lisää tili käyttäjälle&gt; Sähköpostin saapuneet -kohtaan.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Ei käyttäjän tiliä. Lisää tili käyttäjälle> Sähköpostin saapuneet -kohtaan.
 DocType: Email Account,Email Sync Option,Sähköposti synkronointivaihtoehto
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rivi nro
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Jo käytt
 DocType: User Email,Enable Outgoing,aktivoi lähtevä
 DocType: Address,Fax,Faksi
 apps/frappe/frappe/config/customization.py,Custom Tags,Mukautetut tunnisteet
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Sähköpostitiliä ei ole määritetty. Luo uusi sähköpostitili kohdasta Asetukset&gt; Sähköposti&gt; Sähköpostitili
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Sähköpostitiliä ei ole määritetty. Luo uusi sähköpostitili kohdasta Asetukset> Sähköposti> Sähköpostitili
 DocType: Comment,Submitted,Vahvistettu
 DocType: Contact,Pulled from Google Contacts,Poistettu Google-yhteystiedoista
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Virheellinen pyyntö
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Istunto vanhenee (t
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Tämä kenttä näkyy vain, jos fieldname määritelty tässä on arvo TAI säännöt ovat totta (esimerkkejä): myfield eval: doc.myfield == &#39;My Arvo &quot;eval: doc.age&gt; 18"
+eval:doc.age>18","Tämä kenttä näkyy vain, jos fieldname määritelty tässä on arvo TAI säännöt ovat totta (esimerkkejä): myfield eval: doc.myfield == &#39;My Arvo &quot;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Tänään
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Kun olet asettanut tämän, käyttäjät voivat vain tutustua asiakirjoihin (esim. Blogiviesti) jos linkki on olemassa (esim. Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ISOT KIRJAIMET
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Mukautettu HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Anna kansion nimi
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Oletusosoitemallia ei löytynyt. Luo uusi kansiosta Asetukset&gt; Tulostaminen ja tuotemerkit&gt; Osoitemalli.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Oletusosoitemallia ei löytynyt. Luo uusi kansiosta Asetukset> Tulostaminen ja tuotemerkit> Osoitemalli.
 apps/frappe/frappe/auth.py,Unknown User,Tuntematon käyttäjä
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Valitse rooli
 DocType: Comment,Deleted,poistettu
@@ -2265,7 +2265,7 @@ apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify Password,Vahvista sala
 apps/frappe/frappe/public/js/frappe/form/sidebar/attachments.js,There were errors,Virheitä havaittu
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Kirjoita asiakastunnus ja asiakassalaisuus Google-asetuksiin.
 apps/frappe/frappe/core/doctype/communication/communication.js,Close,Sulje
-apps/frappe/frappe/model/document.py,Cannot change docstatus from 0 to 2,Dokumentin tilaa ei voi muuttaa 0 -&gt; 2
+apps/frappe/frappe/model/document.py,Cannot change docstatus from 0 to 2,Dokumentin tilaa ei voi muuttaa 0 -> 2
 DocType: File,Attached To Field,Liittyy kentälle
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Update,Muuta
 DocType: Transaction Log,Transaction Hash,Transaction Hash
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Polku palvelinvarmenteeseen
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ei tarpeeksi lupaa nähdä linkit
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,osoiteotsikko on pakollinen.
 DocType: Google Contacts,Push to Google Contacts,Siirry Google-yhteystietoihin
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Lisätty HTML &lt;head&gt; -osioon sivun, käytetään pääasiassa verkkosivuilla todentaminen ja SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Lisätty HTML &lt;head> -osioon sivun, käytetään pääasiassa verkkosivuilla todentaminen ja SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Uusiutunut
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,tuotetta ei voi lisätä omaksi alatuotteekseen
 DocType: Session Default Settings,Session Defaults,Istunnon oletukset
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Varoitus
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Tämä voidaan tulostaa useille sivuille
 DocType: Data Migration Run,Percent Complete,Prosenttiosuus on täydellinen
 DocType: Tag Category,Tag Category,Tagi -kategoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Vertailun vuoksi käytä&gt; 5, &lt;10 tai = 324. Käytä alueita 5:10 (arvoille 5-10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Vertailun vuoksi käytä> 5, &lt;10 tai = 324. Käytä alueita 5:10 (arvoille 5-10)."
 DocType: Google Calendar,Pull from Google Calendar,Vedä Google-kalenterista
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ohje
 DocType: User,Login Before,Kirjaudu Ennen
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Mukautettu skripti
 DocType: Address,Address Line 2,osoiterivi 2
 DocType: Address,Reference,Viite
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,nimetty
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Asenna oletus sähköpostitili kohdasta Asennus&gt; Sähköposti&gt; Sähköpostitili
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Asenna oletus sähköpostitili kohdasta Asennus> Sähköposti> Sähköpostitili
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Data Migration Mapping Detail
 DocType: Data Import,Action,Toiminto
 DocType: GSuite Settings,Script URL,script-URL
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Salli vahvistuksessa
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Poikkeus Tyyppi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Valitse sarakkeet
-DocType: Web Page,Add code as &lt;script&gt;,Lisää koodi
+DocType: Web Page,Add code as &lt;script>,Lisää koodi
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Tyhjennä käyttöoikeudet
 DocType: Webhook,Headers,otsikot
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Tulevat tapahtumat
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,Jaa-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Jonon pitäisi olla yksi {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Default Template </h4><p> Käyttää <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templaattimateriaalit</a> ja kaikilla aloilla Address (mukaan lukien omat kentät mahdollinen) on saatavilla </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Default Template </h4><p> Käyttää <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templaattimateriaalit</a> ja kaikilla aloilla Address (mukaan lukien omat kentät mahdollinen) on saatavilla </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Aloituspäiväkentä
 DocType: Role,Role Name,Rooli Name
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Vaihda työpöydälle

--- a/frappe/translations/fr-CA.csv
+++ b/frappe/translations/fr-CA.csv
@@ -1,14 +1,14 @@
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> Modèle par défaut <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> et tous les champs d'adresse ( y compris les champs personnalisés le cas échéant) sera disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/fr-CA.csv
+++ b/frappe/translations/fr-CA.csv
@@ -1,14 +1,14 @@
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4> Modèle par défaut <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> et tous les champs d'adresse ( y compris les champs personnalisés le cas échéant) sera disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -1,6 +1,6 @@
 apps/frappe/frappe/utils/change_log.py,New {} releases for the following apps are available,De nouvelles {} versions pour les applications suivantes sont disponibles
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Please select a Amount Field.,Veuillez sélectionner un Champ Montant.
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Loading import file...,Chargement du fichier d&#39;importation ...
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Loading import file...,Chargement du fichier d'importation ...
 DocType: Assignment Rule,Last User,Dernier utilisateur
 apps/frappe/frappe/desk/form/assign_to.py,"A new task, {0}, has been assigned to you by {1}. {2}","Une nouvelle tâche, {0}, vous a été attribuée par {1}. {2}"
 apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,Session Defaults Saved,Session par défaut enregistrée
@@ -31,7 +31,7 @@ apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Import Zip,Importer 
 apps/frappe/frappe/model/base_document.py,Value too big,Valeur trop grande
 DocType: DocField,DocField,DocField
 DocType: GSuite Settings,Run Script Test,Exécuter un Script de Test
-apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Sélectionnez Google Agenda pour lequel l&#39;événement doit être synchronisé.
+apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Sélectionnez Google Agenda pour lequel l'événement doit être synchronisé.
 DocType: Data Import,Total Rows,Total des lignes
 DocType: Contact,Department,Département
 DocType: DocField,Options,Options
@@ -42,11 +42,11 @@ DocType: Report,Report Manager,Gestionnaire de Rapports
 DocType: Workflow,Document States,États du Document
 apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! I could not find what you were looking for.,Désolé ! Je n'ai pas trouvé ce que vous recherchiez.
 DocType: Data Migration Run,Logs,Journaux
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,There was an error saving filters,Une erreur s&#39;est produite lors de l&#39;enregistrement des filtres
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,There was an error saving filters,Une erreur s'est produite lors de l'enregistrement des filtres
 DocType: Custom DocPerm,This role update User Permissions for a user,Ce rôle met à jour les Autorisations Utilisateur pour un utilisateur
 apps/frappe/frappe/public/js/frappe/model/model.js,Rename {0},Renommer {0}
 DocType: Workflow State,zoom-out,Réduire
-DocType: Data Import Beta,Import Options,Options d&#39;importation
+DocType: Data Import Beta,Import Options,Options d'importation
 apps/frappe/frappe/public/js/frappe/form/form.js,Cannot open {0} when its instance is open,Impossible d'ouvrir {0} quand son instance est ouverte
 apps/frappe/frappe/model/document.py,Table {0} cannot be empty,La Table {0} ne peut pas être vide
 DocType: SMS Parameter,Parameter,Paramètre
@@ -58,7 +58,7 @@ apps/frappe/frappe/model/base_document.py,"{0}, Row {1}","{0}, Ligne {1}"
 DocType: DocField,Markdown Editor,Markdown Editor
 apps/frappe/frappe/model/document.py,Beginning with,Commençant par
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Modèle d'import de données
-apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,Une erreur s&#39;est produite lors de la définition des paramètres de session par défaut.
+apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,Une erreur s'est produite lors de la définition des paramètres de session par défaut.
 apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Parent
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Nous avons reçu une demande de votre part pour télécharger vos données {0} associées à: {1}.
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Si activé, la force du mot de passe sera appliquée en fonction de la Valeur Minimale du Score du Mot de Passe. Une valeur de 2 étant moyennement forte et 4 très forte."
@@ -83,11 +83,11 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Cancel {0} documents?,Annu
 DocType: DocType,Is Published Field,Est un Champ Publié
 DocType: GCalendar Settings,GCalendar Settings,Paramètres GCalendar
 DocType: Email Group,Email Group,Groupe Email
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Agenda - Impossible de supprimer l&#39;événement {0} de Google Agenda, code d&#39;erreur {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Agenda - Impossible de supprimer l'événement {0} de Google Agenda, code d'erreur {1}."
 DocType: Event,Pulled from Google Calendar,Tiré de Google Agenda
 DocType: Note,Seen By,Vu Par
 apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Ajout Multiple
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,Vous avez gagné des points d&#39;énergie
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,Vous avez gagné des points d'énergie
 apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,Image utilisateur non valide.
 DocType: Energy Point Log,Reverted,Inversé
 DocType: Success Action,First Success Message,Premier message de succès
@@ -104,8 +104,8 @@ apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,Portrait
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,Insérer
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Autoriser l'accès à Google Drive
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Select {0},Sélectionner {0}
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Veuillez entrer l&#39;URL de base
-DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Si activé, le document est marqué comme vu, la première fois qu&#39;un utilisateur l&#39;ouvre"
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Veuillez entrer l'URL de base
+DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Si activé, le document est marqué comme vu, la première fois qu'un utilisateur l'ouvre"
 DocType: Auto Repeat,Repeat on Day,Répéter Chaque
 DocType: DocField,Color,Couleur
 DocType: Data Migration Run,Log,Journal
@@ -139,9 +139,9 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,La
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""abcabcabc"" are only slightly harder to guess than ""abc""","Les répétitions comme ""ABCABCABC"" sont seulement un peu plus difficiles à deviner que ""abc"""
 DocType: Notification,Channel,Canal
 apps/frappe/frappe/templates/emails/administrator_logged_in.html,"If you think this is unauthorized, please change the Administrator password.","Si vous pensez que cela n'est pas autorisé, veuillez changer le mot de passe Administrateur."
-DocType: Data Import Beta,Data Import Beta,Bêta d&#39;importation de données
+DocType: Data Import Beta,Data Import Beta,Bêta d'importation de données
 apps/frappe/frappe/email/doctype/email_account/email_account.py,{0} is mandatory,{0} est obligatoire
-DocType: Assignment Rule,Assignment Rules,Règles d&#39;attribution
+DocType: Assignment Rule,Assignment Rules,Règles d'attribution
 DocType: Workflow State,eject,éjecter
 apps/frappe/frappe/public/js/frappe/form/form.js,Field {0} not found.,Champ {0} introuvable.
 DocType: Chat Room,Owner,Responsable
@@ -154,7 +154,7 @@ DocType: OAuth Authorization Code,Client,Client
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Select Column,Sélectionner la colonne
 apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified after you have loaded it,Ce formulaire a été modifié après que vous l'ayez chargé
 DocType: Address,Himachal Pradesh,Himachal Pradesh
-DocType: System Settings,"If not set, the currency precision will depend on number format","Si elle n&#39;est pas définie, la précision de la devise dépend du format de nombre"
+DocType: System Settings,"If not set, the currency precision will depend on number format","Si elle n'est pas définie, la précision de la devise dépend du format de nombre"
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Awesomebar,Ouvrez Awesomebar
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Il semble qu'il y a un problème avec la configuration de Stripe sur le serveur. En cas d'erreur, le montant est remboursé sur votre compte."
 DocType: Data Import,Import Log,Journal d'import
@@ -192,7 +192,7 @@ apps/frappe/frappe/public/js/frappe/list/list_filter.js,Save Filter,Enregistrer 
 DocType: Print Format,Helvetica,Helvetica
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Cannot delete {0},Impossible de supprimer {0}
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,Verification Link,Lien de vérification
-apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Ancestors Of,Pas d&#39;ancêtres de
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Ancestors Of,Pas d'ancêtres de
 DocType: Address,Jharkhand,Jharkhand
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Newsletter has already been sent,La Newsletter a déjà été envoyée
 apps/frappe/frappe/twofactor.py,"Login session expired, refresh page to retry","La session de connexion a expiré, veuillez actualiser la page pour réessayer"
@@ -217,13 +217,13 @@ apps/frappe/frappe/config/desk.py,Event and other calendars.,Événement et autr
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 ligne obligatoire)
 apps/frappe/frappe/templates/includes/comments/comments.html,All fields are necessary to submit the comment.,Tous les champs sont nécessaires pour soumettre le commentaire
 DocType: Custom Script,Adds a client custom script to a DocType,Ajoute un script client personnalisé à un DocType
-DocType: Print Settings,Printer Name,Nom de l&#39;imprimante
+DocType: Print Settings,Printer Name,Nom de l'imprimante
 DocType: Webhook,Form URL-Encoded,Formulaire encodé en URL
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Les largeurs peuvent être réglées en px ou %.
 apps/frappe/frappe/public/js/frappe/form/print.js,Start,Démarrer
 DocType: Contact,First Name,Prénom
 DocType: LDAP Settings,LDAP Username Field,Champ Nom d'utilisateur LDAP
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,LDAP is not enabled.,LDAP n&#39;est pas activé.
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,LDAP is not enabled.,LDAP n'est pas activé.
 DocType: Portal Settings,Standard Sidebar Menu,Menu Standard de la Barre Latérale
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failure,Echec de la création automatique de document
 apps/frappe/frappe/core/doctype/file/file.py,Cannot delete Home and Attachments folders,Impossible de supprimer les dossiers d’accueil et les pièces jointes
@@ -232,13 +232,13 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,Vous n'êtes pas autorisé à envoyer un email en relation avec ce document
 apps/frappe/frappe/model/db_query.py,Please select atleast 1 column from {0} to sort/group,Veuillez sélectionner au moins 1 colonne de {0} pour trier / grouper
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1}. Restricted field: {2},Non autorisé pour {0}: {1}. Champ restreint: {2}
-DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Cochez cette case si vous testez votre paiement en utilisant l&#39;API Sandbox
+DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Cochez cette case si vous testez votre paiement en utilisant l'API Sandbox
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,Vous n'êtes pas autorisé à supprimer un Thème standard du Site Web
 DocType: Data Import,Log Details,Détails du journal
 DocType: Workflow Transition,Example,Exemple
 DocType: Webhook Header,Webhook Header,En-Tête Webhook
-DocType: Access Log,Report Information,Rapport d&#39;information
-DocType: Print Settings,Print Server,Serveur d&#39;imprimante
+DocType: Access Log,Report Information,Rapport d'information
+DocType: Print Settings,Print Server,Serveur d'imprimante
 DocType: Workflow State,gift,cadeau
 DocType: Communication,Timeline Links,Liens chronologiques
 DocType: Workflow Action,Completed By,Effectué par
@@ -314,11 +314,11 @@ apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add / Up
 apps/frappe/frappe/www/printview.py,Not allowed to print draft documents,Non autorisé à imprimer des brouillons de documents
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Reset to defaults,Rétablir par défaut
 DocType: Workflow,Transition Rules,Règles de Transition
-apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Showing only first {0} rows in preview,Afficher uniquement les {0} premières lignes de l&#39;aperçu
+apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Showing only first {0} rows in preview,Afficher uniquement les {0} premières lignes de l'aperçu
 apps/frappe/frappe/core/doctype/report/report.js,Example:,Exemple :
 DocType: Workflow,Defines workflow states and rules for a document.,Défini les états du flux de travail et les règles pour un document.
 DocType: Workflow State,Filter,Filtre
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Check the Error Log for more information: {0},Consultez le journal des erreurs pour plus d&#39;informations: {0}
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Check the Error Log for more information: {0},Consultez le journal des erreurs pour plus d'informations: {0}
 apps/frappe/frappe/database/schema.py,Fieldname {0} cannot have special characters like {1},Nom du Champ {0} ne peut pas avoir des caractères spéciaux comme {1}
 apps/frappe/frappe/model/workflow.py,Applying: {0},Application: {0}
 apps/frappe/frappe/public/js/frappe/request.js,Internal Server Error,Erreur Interne du Serveur
@@ -406,7 +406,7 @@ DocType: System Settings,Currency Precision,Précision de la Devise
 apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,Une autre transaction bloque celle-ci. Essayez de nouveau dans quelques secondes.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter_list.js,Clear filters,Effacer les filtres
 DocType: Test Runner,App,App
-apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Les pièces jointes n&#39;ont pas pu être correctement liées au nouveau document
+apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Les pièces jointes n'ont pas pu être correctement liées au nouveau document
 DocType: Chat Message Attachment,Attachment,Pièce jointe
 DocType: Auto Repeat,Yearly,Annuel
 DocType: Communication,Message ID,ID de Message
@@ -415,7 +415,7 @@ DocType: Assignment Rule,Assign To Users,Attribuer aux utilisateurs
 apps/frappe/frappe/public/js/frappe/utils/utils.js,or,ou
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,module name...,Nom du module ...
 apps/frappe/frappe/templates/pages/integrations/payment-success.html,Continue,Continuer
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,L&#39;intégration de Google est désactivée.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,L'intégration de Google est désactivée.
 DocType: Custom Field,Fieldname,Nom du Champ
 DocType: Workflow State,certificate,certificat
 apps/frappe/frappe/templates/includes/login/login.js,Verifying...,Vérification…
@@ -427,7 +427,7 @@ DocType: Energy Point Log,Review,La revue
 DocType: User,Restrict IP,Restreindre l'IP
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,Tableau de Bord
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Impossible d'envoyer des emails en ce moment
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Agenda - Impossible de mettre à jour l&#39;événement {0} dans Google Agenda, code d&#39;erreur {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Agenda - Impossible de mettre à jour l'événement {0} dans Google Agenda, code d'erreur {1}."
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Rechercher ou taper une commande
 DocType: Activity Log,Timeline Name,Nom de la Chronologie
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,Un seul {0} peut être défini comme primaire.
@@ -443,17 +443,17 @@ DocType: Role Profile,Roles Assigned,Rôles Assignés
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search Help,Aide de Recherche
 DocType: Top Bar Item,Parent Label,Étiquette Parente
 apps/frappe/frappe/templates/emails/auto_reply.html,"Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail.","Votre requête a été reçue. Nous vous répondrons au plus vite. Si vous avez des informations supplémentaires, veuillez répondre à cet email."
-apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only if Incoming is enabled.,La liaison automatique ne peut être activée que si l&#39;option Entrant est activée.
+apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only if Incoming is enabled.,La liaison automatique ne peut être activée que si l'option Entrant est activée.
 DocType: LDAP Settings,LDAP Middle Name Field,Champ de prénom LDAP
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Importing {0} of {1},Importer {0} de {1}
-DocType: GCalendar Account,Allow GCalendar Access,Autoriser l&#39;accès à GCalendar
+DocType: GCalendar Account,Allow GCalendar Access,Autoriser l'accès à GCalendar
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} est un champ obligatoire
 apps/frappe/frappe/templates/includes/login/login.js,Login token required,Identifiants de Connexion Requis
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Monthly Rank: ,Classement mensuel:
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select multiple list items,Sélectionner plusieurs éléments de liste
 DocType: Event,Repeat Till,Répéter Jusqu'au
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New,Nouveau(elle)
-apps/frappe/frappe/public/js/frappe/views/components/ModuleLinkItem.vue,You need to create these first: ,Vous devez d&#39;abord créer ces éléments:
+apps/frappe/frappe/public/js/frappe/views/components/ModuleLinkItem.vue,You need to create these first: ,Vous devez d'abord créer ces éléments:
 DocType: Google Maps Settings,Google Maps Settings,Paramètres Google Maps
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Chargement en Cours ...
 DocType: DocField,Password,Mot de Passe
@@ -475,7 +475,7 @@ DocType: Notification Recipient,Email By Document Field,Email Par Champ de Docum
 DocType: Domain Settings,Domain Settings,Paramètres de Domaine
 apps/frappe/frappe/email/receive.py,Cannot connect: {0},Impossible de se connecter : {0}
 apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.,Un mot unique est facile à deviner.
-apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Auto assignment failed: {0},L&#39;affectation automatique a échoué: {0}
+apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Auto assignment failed: {0},L'affectation automatique a échoué: {0}
 apps/frappe/frappe/templates/includes/search_box.html,Search...,Rechercher...
 apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,Please select Company,Veuillez sélectionner une Société
 apps/frappe/frappe/utils/nestedset.py,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,La combinaison n'est possible que de Groupe à Groupe ou Nœud-Feuille à Nœud-Feuille
@@ -490,7 +490,7 @@ DocType: Google Settings,OAuth Client ID,ID client OAuth
 DocType: Auto Repeat,Subject,Sujet
 apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Back to Desk,Retour au bureau
 DocType: Web Form,Amount Based On Field,Montant Basé sur le Champ
-apps/frappe/frappe/core/doctype/docshare/docshare.py,User is mandatory for Share,L&#39;utilisateur est obligatoire pour Partager
+apps/frappe/frappe/core/doctype/docshare/docshare.py,User is mandatory for Share,L'utilisateur est obligatoire pour Partager
 DocType: DocField,Hidden,Masqué
 DocType: Web Form,Allow Incomplete Forms,Autoriser les Formulaires Incomplets
 apps/frappe/frappe/utils/print_format.py,PDF generation failed,La génération de PDF a échoué
@@ -560,7 +560,7 @@ DocType: LDAP Settings,LDAP Phone Field,Champ de téléphone LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","type de document ..., ex. client"
 apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,La Condition '{0}' est invalide
 DocType: Workflow State,barcode,Code Barre
-apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,L&#39;utilisation de la sous-requête ou de la fonction est restreinte
+apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,L'utilisation de la sous-requête ou de la fonction est restreinte
 apps/frappe/frappe/config/customization.py,Add your own translations,Ajoutez vos propres traductions
 DocType: Country,Country Name,Nom Pays
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Blank Template,Modèle vierge
@@ -570,7 +570,7 @@ DocType: Assignment Rule Day,Wednesday,Mercredi
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Champ de l'image doit être un champ valide
 DocType: Chat Token,Token,Jeton
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} is restricted,Le nom de champ {0} est restreint
-DocType: Property Setter,ID (name) of the entity whose property is to be set,ID (nom) de l&#39;entité dont la propriété doit être définie
+DocType: Property Setter,ID (name) of the entity whose property is to be set,ID (nom) de l'entité dont la propriété doit être définie
 DocType: Website Settings,Website Theme Image Link,Lien de l'Image du Thème du Site Web
 DocType: Web Form,Sidebar Items,Articles de la Barre Latérale
 DocType: Web Form,Show as Grid,Montrer comme grille
@@ -638,7 +638,7 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Like,Comme
 DocType: Assignment Rule,Automation,Automatisation
 DocType: Google Drive,Last Backup On,Dernière sauvegarde activée
 DocType: Customize Form Field,Customize Form Field,Personnaliser un Champ de Formulaire
-DocType: Energy Point Rule,For Document Event,Pour documenter l&#39;événement
+DocType: Energy Point Rule,For Document Event,Pour documenter l'événement
 DocType: Website Settings,Chat Room Name,Nom de la Salle de Chat
 DocType: OAuth Client,Grant Type,Type de Subvention
 apps/frappe/frappe/config/users_and_permissions.py,Check which Documents are readable by a User,Vérifier quels Documents sont lisibles par un Utilisateur
@@ -650,7 +650,7 @@ DocType: User,Reset Password Key,Réinitialiser le Mot de Passe
 apps/frappe/frappe/model/workflow.py,Illegal Document Status for {0},Statut de document non autorisé pour {0}
 DocType: Email Account,Enable Auto Reply,Activer la Réponse Automatique
 apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Not Seen,Non Vu
-apps/frappe/frappe/public/js/frappe/form/print.js,Cannot have multiple printers mapped to a single print format.,Impossible d&#39;imprimer plusieurs imprimantes sur un seul format d&#39;impression.
+apps/frappe/frappe/public/js/frappe/form/print.js,Cannot have multiple printers mapped to a single print format.,Impossible d'imprimer plusieurs imprimantes sur un seul format d'impression.
 DocType: Workflow State,zoom-in,Agrandir
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Reference DocType and Reference Name are required,DocType de la Référence et le Nom de la Référence sont nécessaires
 apps/frappe/frappe/utils/jinja.py,Syntax error in template,Erreur de syntaxe dans le modèle
@@ -668,19 +668,19 @@ apps/frappe/frappe/config/desktop.py,Developer,Développeur
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Created,Créé Par
 apps/frappe/frappe/website/doctype/website_settings/website_settings.py,{0} in row {1} cannot have both URL and child items,{0} à la ligne {1} ne peut pas avoir à la fois une URL et des sous-articles
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for the following tables: {0},Il devrait y avoir au moins une ligne pour les tables suivantes: {0}
-DocType: Print Format,Default Print Language,Langue d&#39;impression par défaut
+DocType: Print Format,Default Print Language,Langue d'impression par défaut
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Ancestors Of,Ancêtres de
 apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,Racine {0} ne peut pas être supprimée
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Pas encore de commentaires
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings",Veuillez configurer les SMS avant de les choisir comme méthode d'authentification
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,Les champs DocType et Nom sont nécessaires
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,Impossible de changer le statut du document de 1 à 0
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,Vous n&#39;avez pas assez de points
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,Vous n'avez pas assez de points
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Take Backup Now,Faites une Sauvegarde Maintenant
 DocType: Contact,Open,Ouvert
 DocType: Workflow Transition,Defines actions on states and the next step and allowed roles.,Définit les actions sur les états et l’étape suivantes ainsi que les rôles autorisés.
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Reviewer,Meilleur critique
-DocType: Data Migration Mapping,Remote Objectname,Nom de l&#39;objet distant
+DocType: Data Migration Mapping,Remote Objectname,Nom de l'objet distant
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.",La meilleure pratique est de ne pas attribuer le même ensemble de règle d'autorisation pour différents Rôles. Définissez plutôt plusieurs Rôles à un même utilisateur.
 apps/frappe/frappe/www/confirm_workflow_action.html,Please confirm your action to {0} this document.,Veuillez confirmer votre action sur {0} ce document.
 DocType: Success Action,Next Actions HTML,HTML pour les actions suivantes
@@ -715,7 +715,7 @@ DocType: Data Import Beta,Import File,Importer le fichier
 apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py,Column <b>{0}</b> already exist.,Colonne <b>{0}</b> existe déjà.
 DocType: ToDo,High,Haut
 apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,New Event,Nouvel évènement
-DocType: S3 Backup Settings,Secret Access Key,Clé d&#39;accès secrète
+DocType: S3 Backup Settings,Secret Access Key,Clé d'accès secrète
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Male,Masculin
 apps/frappe/frappe/core/doctype/user/user.py,OTP Secret has been reset. Re-registration will be required on next login.,OTP Secret a été réinitialisé. Une nouvelle inscription sera requise lors de la prochaine connexion.
 DocType: Communication,From Full Name,Nom de l’Expéditeur
@@ -749,12 +749,12 @@ DocType: Currency,Currency Name,Nom de la Devise
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Aucun Email
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Le lien a expiré
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Rétablir la longueur à {0} pour &#39;{1}&#39; dans &#39;{2}&#39;; Définir la longueur sous la forme {3} provoquera une troncature des données.
+							Setting the length as {3} will cause truncation of data.",Rétablir la longueur à {0} pour '{1}' dans '{2}'; Définir la longueur sous la forme {3} provoquera une troncature des données.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Sélectionnez le format du fichier
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash du Contenu
 DocType: User,Stores the JSON of last known versions of various installed apps. It is used to show release notes.,Conserve le JSON des dernières versions connues de diverses applications installées. Il est utilisé pour montrer les notes de version.
-DocType: Energy Point Rule,User Field,Champ de l&#39;utilisateur
+DocType: Energy Point Rule,User Field,Champ de l'utilisateur
 DocType: DocType,MyISAM,MyISAM
 DocType: Data Migration Run,Push Delete,Transmission et Suppression
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed for {1} {2},{0} déjà désabonné pour {1} {2}
@@ -778,7 +778,7 @@ apps/frappe/frappe/templates/emails/delete_data_confirmation.html,Click on the l
 DocType: File,Is Home Folder,Est le Dossier d'Accueil
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Style de barre de navigation
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} n’est pas une Adresse Email valide
-apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Sélectionner au moins 1 enregistrement pour l&#39;impression
+apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Sélectionner au moins 1 enregistrement pour l'impression
 apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Utilisateur '{0}' a déjà le rôle '{1}'
 DocType: System Settings,Two Factor Authentication method,Méthode d'Authentification à Double Facteur
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Commencez par définir le nom et enregistrez l’enregistrement.
@@ -786,7 +786,7 @@ apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 enr
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with {0},Partagé avec {0}
 apps/frappe/frappe/email/queue.py,Unsubscribe,Se Désinscrire
 DocType: View Log,Reference Name,Nom de la Référence
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,Change User,Changer d&#39;utilisateur
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,Change User,Changer d'utilisateur
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Update Translations,Mettre à jour les traductions
 DocType: Error Snapshot,Exception,Exception
 DocType: Email Account,Use IMAP,Utiliser IMAP
@@ -825,7 +825,7 @@ DocType: Workflow State,share,part
 apps/frappe/frappe/config/settings.py,Set numbering series for transactions.,Définir des séries numérotées pour les transactions.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Configure Charts,Configurer les graphiques
 DocType: User,Last IP,Dernière Adresse IP
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please add a subject to your email,S&#39;il vous plaît ajouter un sujet à votre email
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please add a subject to your email,S'il vous plaît ajouter un sujet à votre email
 apps/frappe/frappe/share.py,A new document {0} has been shared by with you {1}.,Un nouveau document {0} a été partagé avec vous {1}.
 DocType: Data Migration Connector,Data Migration Connector,Connecteur de Migration de Données
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} reverted {1},{0} annulé {1}
@@ -838,7 +838,7 @@ apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migratio
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Fieldname not set for Custom Field,Nom du Champ n'a pas été défini pour un Champ Personnalisé
 apps/frappe/frappe/public/js/frappe/model/model.js,Last Updated By,Dernière Mise à Jour Par
 apps/frappe/frappe/email/doctype/email_group/email_group.js,View Subscribers,Voir Abonnés
-apps/frappe/frappe/public/js/frappe/form/print.js,"PDF printing via ""Raw Print"" is not yet supported. Please remove the printer mapping in Printer Settings and try again.",L&#39;impression PDF via &quot;Raw Print&quot; n&#39;est pas encore prise en charge. Supprimez le mappage d&#39;imprimante dans les paramètres de l&#39;imprimante et réessayez.
+apps/frappe/frappe/public/js/frappe/form/print.js,"PDF printing via ""Raw Print"" is not yet supported. Please remove the printer mapping in Printer Settings and try again.",L'impression PDF via &quot;Raw Print&quot; n'est pas encore prise en charge. Supprimez le mappage d'imprimante dans les paramètres de l'imprimante et réessayez.
 DocType: Webhook,after_insert,after_insert
 apps/frappe/frappe/core/doctype/file/file.py,Cannot delete file as it belongs to {0} {1} for which you do not have permissions,Impossible de supprimer le fichier parce qu'il appartient à {0} {1} pour lequel vous n'avez pas d'autorisations
 DocType: Website Theme,Custom JS,JS personnalisé
@@ -850,7 +850,7 @@ DocType: Review Level,Level Name,Nom du niveau
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,Cannot update {0},Impossible de mettre à jour {0}
 DocType: Data Migration Mapping,Mapping,Mapping
 DocType: Web Page,0 is highest,0 est le plus élevé
-apps/frappe/frappe/public/js/frappe/microtemplate.js,Please enable pop-ups in your browser,S&#39;il vous plaît activer les pop-ups dans votre navigateur
+apps/frappe/frappe/public/js/frappe/microtemplate.js,Please enable pop-ups in your browser,S'il vous plaît activer les pop-ups dans votre navigateur
 apps/frappe/frappe/core/doctype/communication/communication.js,Are you sure you want to relink this communication to {0}?,Êtes-vous sûr de vouloir relier cette communication à {0} ?
 DocType: Print Settings,Server IP,IP serveur
 DocType: Email Queue,Attachments,Pièces jointes
@@ -866,7 +866,7 @@ DocType: Contact Phone,Number,Nombre
 DocType: Web Form Field,Web Form Field,Champ de Formulaire Web
 apps/frappe/frappe/templates/emails/new_message.html,You have a new message from: ,Vous avez un nouveau message de:
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_field.html,Edit HTML,Modifier le code HTML
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Veuillez entrer l&#39;URL de redirection
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Veuillez entrer l'URL de redirection
 apps/frappe/frappe/core/doctype/language/language.py,"{0} must begin and end with a letter and can only contain letters,
 				hyphen or underscore.","{0} doit commencer et se terminer par une lettre et ne peut contenir que des lettres, des tirets ou des traits de soulignement."
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Restore Original Permissions,Restaurer les Autorisations Originales
@@ -946,12 +946,12 @@ DocType: PayPal Settings,Mention transaction completion page URL,Mentionnez la p
 DocType: Help Article,Expert,Expert
 DocType: Workflow State,circle-arrow-right,flèche-cercle-droite
 DocType: Role Profile,Role Profile,Profil de rôle
-apps/frappe/frappe/permissions.py,Document Type is not importable,Le type de document n&#39;est pas importable
+apps/frappe/frappe/permissions.py,Document Type is not importable,Le type de document n'est pas importable
 DocType: LDAP Settings,LDAP Server Url,Url du Serveur LDAP
 apps/frappe/frappe/public/js/frappe/form/form.js,Cannot open instance when its {0} is open,Impossible d'ouvrir une instance quand son {0} est ouverte
 apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Header HTML set from attachment {0},En-tête HTML défini à partir de la pièce jointe {0}
 apps/frappe/frappe/config/desktop.py,Customization,Personnalisation
-DocType: LDAP Settings,Organizational Unit for Users,Unité d&#39;organisation pour les utilisateurs
+DocType: LDAP Settings,Organizational Unit for Users,Unité d'organisation pour les utilisateurs
 ,Transaction Log Report,Rapport du journal des transactions
 DocType: Custom DocPerm,Custom DocPerm,Permission de Document Personnalisé
 DocType: Newsletter,Send Unsubscribe Link,Envoyer le Lien de Désabonnement
@@ -963,20 +963,20 @@ DocType: About Us Settings,Company Introduction,Présentation de la Société
 DocType: User,Last Password Reset Date,Date de réinitialisation du dernier mot de passe
 DocType: DocField,Length,Longueur
 apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Restaurer ou supprimer définitivement un document.
-apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Le profil de chat pour l&#39;utilisateur {0} existe.
+apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Le profil de chat pour l'utilisateur {0} existe.
 apps/frappe/frappe/public/js/frappe/social/components/PostSidebar.vue,Frequently Visited Links,Liens fréquemment visités
 DocType: Notification,"To add dynamic subject, use jinja tags like
 
-<div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Pour ajouter l&#39;objet dynamique, utiliser des balises comme Jinja <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
+<div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Pour ajouter l'objet dynamique, utiliser des balises comme Jinja <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
 apps/frappe/frappe/desk/search.py,Invalid Search Field {0},Champ de recherche invalide {0}
 DocType: User,Modules HTML,Modules HTML
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Autoriser l&#39;accès à Google Agenda
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Autoriser l'accès à Google Agenda
 DocType: Assignment Rule,Higher priority rule will be applied first,La règle de priorité supérieure sera appliquée en premier
 DocType: Email Account,"Track if your email has been opened by the recipient.
 <br>
 Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","Suivre si votre email a été ouvert par le destinataire. <br> Remarque: Si vous envoyez à plusieurs destinataires, même si 1 destinataire lit le courrier électronique, il sera considéré comme &quot;ouvert&quot;"
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Missing Values Required,Valeurs Manquantes Requises
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Autoriser l&#39;accès aux contacts Google
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Autoriser l'accès aux contacts Google
 DocType: Data Migration Connector,Frappe,Frappe
 apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Unread,Marquer comme non Lu
 DocType: Activity Log,Operation,Opération
@@ -1001,9 +1001,9 @@ DocType: Communication,Event,Événement
 apps/frappe/frappe/public/js/frappe/views/communication.js,"On {0}, {1} wrote:","Sur {0}, {1} a écrit :"
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Cannot delete standard field. You can hide it if you want,Suppression de champ standard impossible. Vous pouvez le cacher si vous voulez
 DocType: Top Bar Item,For top bar,Pour la barre supérieure
-DocType: Social Login Key,Auth URL Data,Données d&#39;URL d&#39;authentification
-apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,En file d&#39;attente pour la sauvegarde. Vous recevrez un courriel avec le lien de téléchargement
-apps/frappe/frappe/utils/bot.py,Could not identify {0},Impossible d&#39;identifier {0}
+DocType: Social Login Key,Auth URL Data,Données d'URL d'authentification
+apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,En file d'attente pour la sauvegarde. Vous recevrez un courriel avec le lien de téléchargement
+apps/frappe/frappe/utils/bot.py,Could not identify {0},Impossible d'identifier {0}
 DocType: Address,Address,Adresse
 apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,Le Paiement a Échoué
 DocType: Print Settings,In points. Default is 9.,En points. 9 par défaut.
@@ -1020,7 +1020,7 @@ apps/frappe/frappe/core/doctype/user/user.py,Welcome email sent,Email de bienven
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Let's prepare the system for first use.,Préparons le système pour la première utilisation.
 apps/frappe/frappe/core/doctype/user/user.py,Already Registered,Déjà Inscrit
 DocType: System Settings,Float Precision,Nombre de Décimales
-DocType: Notification,Sender Email,Email d&#39;expéditeur
+DocType: Notification,Sender Email,Email d'expéditeur
 apps/frappe/frappe/core/doctype/page/page.py,Only Administrator can edit,Seul l'Administrateur peut modifier
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Please select applicable Doctypes,Veuillez sélectionner les types de docteurs applicables
 DocType: DocType,Editable Grid,Grille Éditable
@@ -1080,7 +1080,7 @@ apps/frappe/frappe/config/settings.py,"Language, Date and Time settings","Param�
 DocType: User Email,User Email,Email de l'Utilisateur
 DocType: Assignment Rule Day,Saturday,Samedi
 DocType: User,Represents a User in the system.,Représente un Utilisateur dans le système.
-DocType: List View Setting,Disable Auto Refresh,Désactiver l&#39;actualisation automatique
+DocType: List View Setting,Disable Auto Refresh,Désactiver l'actualisation automatique
 DocType: Comment,Label,Étiquette
 apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed.","La tâche {0}, que vous avez attribuée à {1}, a été fermée."
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please close this window,Veuillez fermer cette fenêtre
@@ -1140,11 +1140,11 @@ DocType: DocType,User Cannot Create,L'utilisateur ne peut pas Créer
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Successfully Done,Fait avec succès
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox access is approved!,Accès Dropbox approuvé!
 DocType: Customize Form,Enter Form Type,Entrez le Type de Formulaire
-DocType: Google Drive,Authorize Google Drive Access,Autoriser l&#39;accès à Google Drive
+DocType: Google Drive,Authorize Google Drive Access,Autoriser l'accès à Google Drive
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Missing parameter Kanban Board Name,Paramètre manquant Nom du tableau Kanban
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_stat.html,No records tagged.,Aucun enregistrement étiqueté.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Field,Supprimer le Champ
-apps/frappe/frappe/public/js/frappe/request.js,You are not connected to Internet. Retry after sometime.,Vous n&#39;êtes pas connecté à Internet. Réessayez après un certain temps.
+apps/frappe/frappe/public/js/frappe/request.js,You are not connected to Internet. Retry after sometime.,Vous n'êtes pas connecté à Internet. Réessayez après un certain temps.
 apps/frappe/frappe/public/js/frappe/form/form.js,"Allowing DocType, DocType. Be careful!","Autorisation de DocType, DocType. Soyez prudent !"
 apps/frappe/frappe/config/core.py,"Customized Formats for Printing, Email","Formats Personnalisés pour l'Impression, l'Email"
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Sum of {0},Somme de {0}
@@ -1157,30 +1157,30 @@ apps/frappe/frappe/templates/includes/comments/comments.html,Login to comment,Co
 apps/frappe/frappe/core/doctype/data_import/importer.py,Start entering data below this line,Commencez à entrer les données ci-dessous
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed values for {0},valeurs modifiées pour {0}
 apps/frappe/frappe/email/doctype/email_account/email_account.py,"Email ID must be unique, Email Account already exists \
-				for {0}","L&#39;identifiant de messagerie doit être unique, le compte de messagerie existe déjà \ pour {0}"
+				for {0}","L'identifiant de messagerie doit être unique, le compte de messagerie existe déjà \ pour {0}"
 DocType: Workflow State,retweet,retweet
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Customize...,Personnaliser...
 DocType: Print Format,Align Labels to the Right,Alignez les Étiquettes à Droite
 DocType: Assignment Rule,Disabled,Desactivé
 DocType: File,Uploaded To Dropbox,Téléchargé sur Dropbox
 DocType: Workflow State,eye-close,oeil-fermé
-apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For more information, {0}.","Pour plus d&#39;informations, {0}."
+apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For more information, {0}.","Pour plus d'informations, {0}."
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,Repeats {0},Répète {0}
 DocType: OAuth Provider Settings,OAuth Provider Settings,Paramètres du Fournisseur OAuth
-DocType: Review Level,Review Points,Points d&#39;examen
-DocType: Workflow Document State,Workflow Action is not created for optional states,L&#39;action de flux de travail n&#39;est pas créée pour les états facultatifs
+DocType: Review Level,Review Points,Points d'examen
+DocType: Workflow Document State,Workflow Action is not created for optional states,L'action de flux de travail n'est pas créée pour les états facultatifs
 DocType: Address,City/Town,Ville
 DocType: Data Migration Connector,Connector Name,Nom du Connecteur
 DocType: Address,Is Your Company Address,Est l'Adresse de votre Entreprise
 DocType: Energy Point Log,Social,Social
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google Agenda - Impossible de créer un agenda pour {0}, code d&#39;erreur {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google Agenda - Impossible de créer un agenda pour {0}, code d'erreur {1}."
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Editing Row,Modifier Ligne
 DocType: Workflow Action Master,Workflow Action Master,Actions de Base du Flux de Travail
 DocType: Custom Field,Field Type,Type de Champ
 apps/frappe/frappe/utils/data.py,only.,seulement.
 DocType: Route History,Route History,Histoire de la route
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Give Review Points,Donner des points de révision
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google Agenda - Impossible d&#39;insérer un contact dans Google Contacts {0}, code d&#39;erreur {1}."
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google Agenda - Impossible d'insérer un contact dans Google Contacts {0}, code d'erreur {1}."
 apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,Le Secret OTP ne peut être réinitialisé que par l'Administrateur.
 apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,Évitez les années qui vous sont associées.
 apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Restreindre l'utilisateur à un document spécifique
@@ -1194,7 +1194,7 @@ DocType: Workflow State,film,film
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Sync Calendar,Calendrier de synchronisation
 apps/frappe/frappe/model/db_query.py,No permission to read {0},Pas d'autorisation pour lire {0}
 apps/frappe/frappe/config/desktop.py,Tools,Outils
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Include indentation,Inclure l&#39;indentation
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Include indentation,Inclure l'indentation
 apps/frappe/frappe/utils/password_strength.py,Avoid recent years.,Éviter les années récentes.
 apps/frappe/frappe/templates/includes/login/login.js,Verification,Vérification
 apps/frappe/frappe/utils/nestedset.py,Multiple root nodes not allowed.,Plusieurs nœuds racines non autorisés.
@@ -1228,7 +1228,7 @@ DocType: File,old_parent,grand_parent
 apps/frappe/frappe/config/desk.py,"Newsletters to contacts, leads.","Newsletters aux contacts, prospects."
 DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","e.g. ""Support"",""Vente"",""Jerry Yang"""
 apps/frappe/frappe/twofactor.py,Incorrect Verification code,Code de Vérification incorrect
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,L&#39;intégration de Google Contacts est désactivée.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,L'intégration de Google Contacts est désactivée.
 DocType: Assignment Rule,Description,Description
 DocType: Print Settings,Repeat Header and Footer in PDF,Répéter En-Tête et Pied de Page en PDF
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Failure,Échec
@@ -1288,7 +1288,7 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the do
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Click here to post bugs and suggestions,Cliquez ici pour publier des bugs et des suggestions
 DocType: Website Settings,Address and other legal information you may want to put in the footer.,Adresse et autres informations juridiques que vous voudriez mettre dans le pied de page.
 DocType: Website Sidebar Item,Website Sidebar Item,Objet de la Barre Latérale du Site Web
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Click on {0} to generate Refresh Token.,Cliquez sur {0} pour générer le jeton d&#39;actualisation.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Click on {0} to generate Refresh Token.,Cliquez sur {0} pour générer le jeton d'actualisation.
 apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py,Reference document has been cancelled,Le document de référence a été annulé
 DocType: PayPal Settings,PayPal Settings,Paramètres PayPal
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Document Type,Sélectionner le Type de Document
@@ -1297,7 +1297,7 @@ apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} minutes ago,Il y a 
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Assignment Day {0} has been repeated.,Le jour d’affectation {0} a été répété.
 DocType: Kanban Board Column,lightblue,bleu clair
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Same Field is entered more than once,Champ identique entré plus d'une fois
-DocType: Print Settings,Enable Raw Printing,Activer l&#39;impression brute
+DocType: Print Settings,Enable Raw Printing,Activer l'impression brute
 DocType: Contact,Contact Numbers,Numéro de contact
 DocType: Website Route Redirect,Source,Source
 apps/frappe/frappe/templates/includes/list/filters.html,clear,effacer
@@ -1332,7 +1332,7 @@ DocType: Workflow State,bullhorn,Mégaphone (bullhorn)
 apps/frappe/frappe/model/workflow.py,Not a valid Workflow Action,Action de flux de travail non valide
 DocType: Footer Item,Target,Cible
 DocType: System Settings,Number of Backups,Nombre de Sauvegardes
-DocType: Dashboard Chart,Last Year,L&#39;année dernière
+DocType: Dashboard Chart,Last Year,L'année dernière
 DocType: Website Settings,Copyright,Droit d'Auteur
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Go,Aller
 DocType: OAuth Authorization Code,Invalid,Invalide
@@ -1350,7 +1350,7 @@ apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Ajouter Plus
 DocType: System Settings,Session Expiry Mobile,Expiration de Session Mobile
 apps/frappe/frappe/utils/password.py,Incorrect User or Password,Utilisateur ou mot de passe incorrect
 apps/frappe/frappe/templates/includes/search_box.html,Search results for,Résultats de recherche pour
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Veuillez entrer l&#39;URL du jeton d&#39;accès
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Veuillez entrer l'URL du jeton d'accès
 DocType: Notification,Slack,Slack
 DocType: Custom DocPerm,If user is the owner,Si l'utilisateur est le responsable
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Follow,Suivre
@@ -1359,7 +1359,7 @@ DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[
 DocType: User Permission,Allow,Autoriser
 DocType: Data Import Beta,Update Existing Records,Mettre à jour les enregistrements existants
 apps/frappe/frappe/utils/password_strength.py,Let's avoid repeated words and characters,Évitons les mots et les caractères répétés
-DocType: Energy Point Rule,Energy Point Rule,Règle de point d&#39;énergie
+DocType: Energy Point Rule,Energy Point Rule,Règle de point d'énergie
 DocType: Communication,Delayed,Différé
 apps/frappe/frappe/config/settings.py,List of backups available for download,Liste des sauvegardes disponibles au téléchargement
 apps/frappe/frappe/www/login.html,Sign up,S'inscrire
@@ -1405,7 +1405,7 @@ apps/frappe/frappe/config/users_and_permissions.py,Report of all document shares
 apps/frappe/frappe/www/update-password.html,New Password,Nouveau Mot de Passe
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Filter {0} missing,Filtre {0} manquant
 apps/frappe/frappe/core/doctype/activity_log/activity_log.py,Sorry! You cannot delete auto-generated comments,Désolé ! Vous ne pouvez pas supprimer les commentaires générés automatiquement
-DocType: Google Settings,Used For Google Maps Integration.,Utilisé pour l&#39;intégration de Google Maps.
+DocType: Google Settings,Used For Google Maps Integration.,Utilisé pour l'intégration de Google Maps.
 apps/frappe/frappe/core/doctype/communication/communication.js,Reference DocType,DocType de la Référence
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,No records will be exported,Aucun enregistrement ne sera exporté
 DocType: User,System User,Utilisateur Système
@@ -1417,7 +1417,7 @@ apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized o
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Exécuter
 DocType: Blog Post,Content (HTML),Contenu (HTML)
-DocType: Personal Data Download Request,User Name,Nom d&#39;utilisateur
+DocType: Personal Data Download Request,User Name,Nom d'utilisateur
 DocType: Workflow State,minus-sign,signe moins
 apps/frappe/frappe/public/js/frappe/request.js,Not Found,Non Trouvé
 apps/frappe/frappe/www/printview.py,No {0} permission,Pas d’autorisation {0}
@@ -1439,18 +1439,18 @@ apps/frappe/frappe/core/doctype/communication/communication.js,Mark as Spam,Marq
 DocType: ToDo,Medium,Moyen
 DocType: Comment,Comment By,Commentaire de
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Customize Form,Personnaliser le formulaire
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Type d&#39;entité
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Type d'entité
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Champ obligatoire : rôle défini pour
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} critiqué {1}
 DocType: Data Migration Mapping,Mapping Name,Nom du Mapping
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Le champ &#39;{1}&#39; ne peut pas être défini comme Unique car il contient des valeurs non uniques.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Le champ '{1}' ne peut pas être défini comme Unique car il contient des valeurs non uniques.
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Naviguer dans la liste
 DocType: Currency,A symbol for this currency. For e.g. $,Un symbole pour cette monnaie. Par exemple $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Traductions mises à jour avec succès
 apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Frappe Framework,Modèle Frappe
 DocType: S3 Backup Settings,Enable Automatic Backup,Activer la sauvegarde automatique
-apps/frappe/frappe/config/settings.py,Email Templates for common queries.,Modèles d&#39;e-mail pour les requêtes courantes
-apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Permission Error,Erreur d&#39;autorisation
+apps/frappe/frappe/config/settings.py,Email Templates for common queries.,Modèles d'e-mail pour les requêtes courantes
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Permission Error,Erreur d'autorisation
 apps/frappe/frappe/model/naming.py,Name of {0} cannot be {1},Nom de {0} ne peut pas être {1}
 DocType: User Permission,Applicable For,Applicable Pour
 apps/frappe/frappe/core/doctype/version/version_view.html,Success,Réussite
@@ -1482,7 +1482,7 @@ DocType: Address,Postal,Postal
 DocType: Email Account,Default Incoming,Entrant par Défaut
 DocType: Workflow State,repeat,répéter
 DocType: Website Settings,Banner,Bannière
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,Value must be one of {0},La valeur doit être l&#39;une des {0}
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,Value must be one of {0},La valeur doit être l'une des {0}
 DocType: Role,"If disabled, this role will be removed from all users.","Si désactivé, ce rôle sera retiré de tous les utilisateurs."
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Go to {0} List,Aller à la liste {0}
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Help on Search,Aide lors de la Recherche
@@ -1500,14 +1500,14 @@ DocType: Workflow State,Check,Vérifier
 DocType: Chat Profile,Offline,Hors Ligne
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0},Importé avec succès {0}
 DocType: User,API Key,Clé API
-DocType: Email Account,Send unsubscribe message in email,Envoyer un message de désabonnement dans l&#39;email
+DocType: Email Account,Send unsubscribe message in email,Envoyer un message de désabonnement dans l'email
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Edit Title,Modifier le Titre
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Fieldname which will be the DocType for this link field.,Nom du champ qui sera le DocType pour ce champ lié
 apps/frappe/frappe/config/desk.py,Documents assigned to you and by you.,Documents attribués à vous et par vous.
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,You can also copy-paste this ,Vous pouvez également copier-coller cette
 DocType: User,Email Signature,Signature Email
 DocType: Website Settings,Google Analytics ID,ID Google Analytics
-DocType: Web Form,"For help see <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API and Examples</a>","Pour obtenir de l&#39;aide, voir <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">API de script client et exemples</a>"
+DocType: Web Form,"For help see <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API and Examples</a>","Pour obtenir de l'aide, voir <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">API de script client et exemples</a>"
 DocType: Custom DocPerm,Delete,Supprimer
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New {0},Nouveau(elle) {0}
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Inbox,Boîte de Réception par Défaut
@@ -1598,7 +1598,7 @@ DocType: Address,GST State,État GST
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0} : Impossible de choisir Annuler sans Soumettre
 DocType: Website Theme,Theme,Thème
 DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,URI de Redirection Lié au Code Auth
-apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Ouvrir l&#39;aide
+apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Ouvrir l'aide
 DocType: DocType,Is Submittable,Est Soumissible
 apps/frappe/frappe/core/doctype/comment/comment.py,New Mention,Nouvelle Mention
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,Aucun nouveau contact Google synchronisé.
@@ -1635,11 +1635,11 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Set,Non Défini
 DocType: Deleted Document,GitHub Sync ID,GitHub Sync ID
 DocType: Activity Log,Date,Date
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No more posts,Pas plus de messages
-DocType: Access Log,RAW Information Log,Journal d&#39;informations RAW
+DocType: Access Log,RAW Information Log,Journal d'informations RAW
 DocType: Website Settings,Disable Signup,Désactiver Inscription
 DocType: Email Queue,Email Queue,File d'Attente Email
 DocType: Address,Haryana,Haryana
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} appreciation points for {1} {2},{0} points d&#39;appréciation pour {1} {2}
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} appreciation points for {1} {2},{0} points d'appréciation pour {1} {2}
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Roles can be set for users from their User page.,Les rôles peuvent être définis pour les utilisateurs à partir de leur page Utilisateur .
 apps/frappe/frappe/templates/includes/comments/comments.html,Add Comment,Ajouter un Commentaire
 DocType: DocField,Mandatory,Obligatoire
@@ -1649,9 +1649,9 @@ apps/frappe/frappe/utils/backups.py,Download link for your backup will be emaile
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Meaning of Submit, Cancel, Amend","Signification de Soumettre, Annuler, Modifier"
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,To Do,Tâche à Faire
 DocType: Test Runner,Module Path,Chemin du Module
-DocType: Milestone Tracker,Track milestones for any document,Suivre les jalons pour n&#39;importe quel document
-DocType: Social Login Key,Identity Details,Détails de l&#39;identité
-apps/frappe/frappe/model/workflow.py,Workflow State transition not allowed from {0} to {1},La transition d&#39;état du flux de travail n&#39;est pas autorisée de {0} à {1}.
+DocType: Milestone Tracker,Track milestones for any document,Suivre les jalons pour n'importe quel document
+DocType: Social Login Key,Identity Details,Détails de l'identité
+apps/frappe/frappe/model/workflow.py,Workflow State transition not allowed from {0} to {1},La transition d'état du flux de travail n'est pas autorisée de {0} à {1}.
 apps/frappe/frappe/desk/doctype/dashboard/dashboard.js,Show Dashboard,Afficher le tableau de bord
 apps/frappe/frappe/desk/form/assign_to.py,New Message,Nouveau Message
 DocType: File,Preview HTML,Aperçu HTML
@@ -1675,7 +1675,7 @@ DocType: Address Template,This format is used if country specific format is not 
 DocType: System Settings,Allow Login using Mobile Number,Autoriser la Connexion en utilisant un Numéro de Téléphone Portable
 apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,Vous ne disposez pas de suffisamment d'autorisations pour accéder à cette ressource. Veuillez contacter votre responsable pour obtenir l'accès.
 DocType: Custom Field,Custom,Personnaliser
-DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Si cette option est activée, les utilisateurs qui se connectent à partir d&#39;une adresse IP restreinte ne seront pas invités à utiliser l&#39;authentification à deux facteurs."
+DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Si cette option est activée, les utilisateurs qui se connectent à partir d'une adresse IP restreinte ne seront pas invités à utiliser l'authentification à deux facteurs."
 DocType: Auto Repeat,Get Contacts,Obtenir les contacts
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts filed under {0},Messages déposés en vertu de {0}
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping Untitled Column,Saut de colonne sans titre
@@ -1705,13 +1705,13 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete t
 DocType: Email Account,"If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)","Si port non standard (par exemple, POP3: 995/110, IMAP: 993/143)"
 apps/frappe/frappe/public/js/frappe/views/components/DeskSection.vue,Customize Shortcuts,Personnaliser les raccourcis
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,Seuls les champs obligatoires sont nécessaires pour les nouveaux enregistrements. Vous pouvez supprimer des colonnes non obligatoires si vous le souhaitez.
-apps/frappe/frappe/desk/page/user_profile/user_profile.html,Show More Activity,Afficher plus d&#39;activité
-apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,Entrez le code affiché dans l&#39;application OTP.
+apps/frappe/frappe/desk/page/user_profile/user_profile.html,Show More Activity,Afficher plus d'activité
+apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,Entrez le code affiché dans l'application OTP.
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Unable to update event,Impossible de mettre à jour l'événement
 apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,Le code de vérification a été envoyé à votre adresse e-mail enregistrée.
 apps/frappe/frappe/core/doctype/user/user.py,Throttled,Étranglé
 apps/frappe/frappe/utils/data.py,"Filter must have 4 values (doctype, fieldname, operator, value): {0}","Le Filtre doit avoir 4 valeurs (doctype, nom du champ, opérateur, valeur) : {0}"
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Appliquer la règle d&#39;assignation
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Appliquer la règle d'assignation
 apps/frappe/frappe/utils/bot.py,show,montrer
 apps/frappe/frappe/utils/data.py,Invalid field name {0},Nom de champ {0} invalide
 apps/frappe/frappe/model/document.py,{0} must be after {1},{0} doit être après {1}
@@ -1760,7 +1760,7 @@ apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Fetch 
 DocType: Chat Room,Name,Nom
 DocType: Contact Us Settings,Skype,Skype
 DocType: Chat Profile,Notification Tones,Tonalités de notification
-DocType: Assignment Rule,Load Balancing,L&#39;équilibrage de charge
+DocType: Assignment Rule,Load Balancing,L'équilibrage de charge
 DocType: OAuth Authorization Code,Valid,Valide
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Open Link,Ouvrir Lien
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Your Language,Votre Langue
@@ -1783,12 +1783,12 @@ DocType: Newsletter,Test Email Address,Adresse Email de Test
 DocType: Auto Repeat,Reference Document Type,Type du document de référence
 DocType: ToDo,Sender,Expéditeur
 DocType: Google Drive,Backup Folder Name,Nom du dossier de sauvegarde
-apps/frappe/frappe/email/doctype/notification/notification.py,Error while evaluating Notification {0}. Please fix your template.,Erreur lors de l&#39;évaluation de la notification {0}. Veuillez corriger votre modèle.
+apps/frappe/frappe/email/doctype/notification/notification.py,Error while evaluating Notification {0}. Please fix your template.,Erreur lors de l'évaluation de la notification {0}. Veuillez corriger votre modèle.
 DocType: GSuite Settings,Google Apps Script,Google Apps Script
 apps/frappe/frappe/templates/includes/comments/comments.html,Leave a Comment,Laissez un Commentaire
-apps/frappe/frappe/website/doctype/help_article/templates/help_article.html,More articles on {0},Plus d&#39;articles sur {0}
+apps/frappe/frappe/website/doctype/help_article/templates/help_article.html,More articles on {0},Plus d'articles sur {0}
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,No contacts linked to document,Aucun contact lié au document
-DocType: Letter Head,Footer will display correctly only in PDF,Le pied de page ne s&#39;affichera correctement qu&#39;en PDF
+DocType: Letter Head,Footer will display correctly only in PDF,Le pied de page ne s'affichera correctement qu'en PDF
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,En Attente
 DocType: System Settings,Allow only one session per user,Autoriser une seule session par utilisateur
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Accueil / Dossier Test 1 / Dossier Test 3
@@ -1802,7 +1802,7 @@ DocType: Workflow Document State,Is Optional State,Est facultatif
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,The {0} is already on auto repeat {1},Le {0} est déjà en répétition automatique {1}
 DocType: Letter Head,Header HTML,En-tête HTML
 apps/frappe/frappe/core/doctype/communication/communication.js,Relink,Reconnecter
-apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,SMS n&#39;a pas été envoyé. S&#39;il vous plaît contacter l&#39;administrateur.
+apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,SMS n'a pas été envoyé. S'il vous plaît contacter l'administrateur.
 DocType: Web Page,"Page to show on the website
 ",Page à afficher sur le site Web
 apps/frappe/frappe/config/settings.py,Create and manage newsletter,Créer et gérer une newsletter
@@ -1812,18 +1812,18 @@ apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Sen
 DocType: System Settings,OTP App,Application OTP
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record out of {1}.,Enregistrement {0} mis à jour avec succès sur {1}.
 DocType: Google Drive,Send Email for Successful Backup,Envoyer un courrier électronique pour une sauvegarde réussie
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.py,Scheduler is inactive. Cannot import data.,Le planificateur est inactif. Impossible d&#39;importer des données.
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.py,Scheduler is inactive. Cannot import data.,Le planificateur est inactif. Impossible d'importer des données.
 DocType: Print Settings,Letter,Lettre
 DocType: DocType,"Naming Options:
 <ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>
-<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Options de nommage: <ol><li> <b>field: [fieldname]</b> - Par champ </li><li> <b>naming_series:</b> - En nommant les séries (le champ appelé naming_series doit être présent </li><li> <b>Invite</b> - Demander à l&#39;utilisateur un nom </li><li> <b>[série]</b> - Série par préfixe (séparé par un point); par exemple PRE. ##### </li><li> <b>format: EXEMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - Remplace tous les mots accolés (noms de champs, mots de date (JJ, MM, AA), séries) par leur valeur. Des accolades extérieures, des caractères peuvent être utilisés. </li></ol>"
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Options de nommage: <ol><li> <b>field: [fieldname]</b> - Par champ </li><li> <b>naming_series:</b> - En nommant les séries (le champ appelé naming_series doit être présent </li><li> <b>Invite</b> - Demander à l'utilisateur un nom </li><li> <b>[série]</b> - Série par préfixe (séparé par un point); par exemple PRE. ##### </li><li> <b>format: EXEMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - Remplace tous les mots accolés (noms de champs, mots de date (JJ, MM, AA), séries) par leur valeur. Des accolades extérieures, des caractères peuvent être utilisés. </li></ol>"
 apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,Il y avait des erreurs lors de la création du document. Veuillez réessayer.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,Champ de l'image doit être du type Image Jointe
-apps/frappe/frappe/permissions.py,You are not allowed to export {} doctype,Vous n&#39;êtes pas autorisé à exporter {} doctype
+apps/frappe/frappe/permissions.py,You are not allowed to export {} doctype,Vous n'êtes pas autorisé à exporter {} doctype
 DocType: DocField,Columns,Colonnes
-apps/frappe/frappe/desk/form/assign_to.py,Shared with user {0} with read access,Partagé avec l&#39;utilisateur {0} avec accès en lecture
+apps/frappe/frappe/desk/form/assign_to.py,Shared with user {0} with read access,Partagé avec l'utilisateur {0} avec accès en lecture
 DocType: GCalendar Account,Next Sync Token,Jeton de synchronisation suivant
-DocType: Energy Point Settings,Energy Point Settings,Paramètres de points d&#39;énergie
+DocType: Energy Point Settings,Energy Point Settings,Paramètres de points d'énergie
 DocType: Async Task,Succeeded,Réussi
 apps/frappe/frappe/public/js/frappe/form/save.js,Mandatory fields required in {0},Champs Obligatoires Requis : {0}
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Reset Permissions for {0}?,Réinitialiser des Autorisations pour {0} ?
@@ -1839,7 +1839,7 @@ apps/frappe/frappe/public/js/frappe/views/interaction.js,The document has been a
 DocType: System Settings,Show Full Error and Allow Reporting of Issues to the Developer,Montrer l'Erreur Complète et Autoriser l'envoi de Rapports d'Erreurs aux Développeurs
 apps/frappe/frappe/www/third_party_apps.html,Active Sessions,Sessions Actives
 DocType: DocType,ASC,ASC
-apps/frappe/frappe/public/js/frappe/form/print.js,New Print Format Name,Nouveau nom du format d&#39;impression
+apps/frappe/frappe/public/js/frappe/form/print.js,New Print Format Name,Nouveau nom du format d'impression
 apps/frappe/frappe/templates/emails/data_deletion_approval.html,Click on the link below to approve the request,Cliquez sur le lien ci-dessous pour approuver la demande.
 DocType: Workflow State,align-left,aligné-gauche
 DocType: User,Defaults,Valeurs Par Défaut
@@ -1880,14 +1880,14 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add New Pe
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,You can use wildcard %,Vous pouvez utiliser % comme joker
 DocType: LDAP Settings,LDAP Group Mappings,Mappages de groupe LDAP
 DocType: Chat Message Attachment,Chat Message Attachment,Chat Message Attachment
-DocType: LDAP Settings,Path to CA Certs File,Chemin d&#39;accès au fichier de certificats de certification
+DocType: LDAP Settings,Path to CA Certs File,Chemin d'accès au fichier de certificats de certification
 DocType: Address,Manipur,Manipur
 DocType: Web Form Field,Allow Read On All Link Options,Autoriser la lecture de toutes les options de lien
 DocType: DocType,Database Engine,Moteur de Base de Données
 DocType: Customize Form,"Fields separated by comma (,) will be included in the ""Search By"" list of Search dialog box","Les champs séparés par une virgule (,) seront inclus dans la liste ""Recherche par"" de la boîte de dialogue de Recherche"
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Please Duplicate this Website Theme to customize.,Veuillez Dupliquer le thème de ce site Web pour le personnaliser.
 DocType: Address,Meghalaya,Meghalaya
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Nom d&#39;utilisateur ou mot de passe invalide
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Nom d'utilisateur ou mot de passe invalide
 DocType: DocField,Text Editor,Éditeur de Texte
 apps/frappe/frappe/config/website.py,Settings for About Us Page.,Paramètres de la Page A Propos.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit Custom HTML,Modifier HTML Personnalisé
@@ -1896,14 +1896,14 @@ DocType: S3 Backup Settings,ap-northeast-3,ap-nord-est-3
 DocType: Data Migration Mapping,Remote Primary Key,Clé primaire distante
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,In,Dans
 DocType: Notification,Value Change,Modification de Valeur
-DocType: Google Contacts,Authorize Google Contacts Access,Autoriser l&#39;accès à Google Contacts
+DocType: Google Contacts,Authorize Google Contacts Access,Autoriser l'accès à Google Contacts
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Afficher uniquement les champs numériques du rapport
-DocType: Data Import Beta,Import Type,Type d&#39;importation
+DocType: Data Import Beta,Import Type,Type d'importation
 DocType: Access Log,HTML Page,Page HTML
 DocType: Address,Subsidiary,Filiale
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting Connection to QZ Tray...,Tentative de connexion au bac QZ ...
 DocType: System Settings,In Hours,En Heures
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Dossier introuvable dans Google Drive - Code d&#39;erreur {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Dossier introuvable dans Google Drive - Code d'erreur {0}
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,With Letterhead,Avec en-tête de Lettre
 apps/frappe/frappe/email/smtp.py,Invalid Outgoing Mail Server or Port,Serveur d'Envoi de Mail ou Port Invalide
 DocType: Custom DocPerm,Write,Écrire
@@ -1915,7 +1915,7 @@ DocType: Customize Form,Use this fieldname to generate title,Utilisez ce nom de 
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Email From,Importer Email Depuis
 apps/frappe/frappe/contacts/doctype/contact/contact.js,Invite as User,Inviter en tant qu'Utilisateur
 DocType: Data Migration Run,Started,Commencé
-apps/frappe/frappe/permissions.py,User {0} does not have access to this document,L&#39;utilisateur {0} n&#39;a pas accès à ce document.
+apps/frappe/frappe/permissions.py,User {0} does not have access to this document,L'utilisateur {0} n'a pas accès à ce document.
 DocType: Data Migration Run,End Time,Heure de Fin
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Select Attachments,Sélectionner Pièces Jointes
 apps/frappe/frappe/model/naming.py, for {0},pour {0}
@@ -1948,7 +1948,7 @@ apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Female,Féminin
 DocType: Success Action,Success Action,Action de succès
 apps/frappe/frappe/public/js/frappe/model/indicator.js,Not Saved,Non Sauvegardé
 apps/frappe/frappe/www/third_party_apps.html,Revoke,Révoquer
-apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You are now following this document. You will receive daily updates via email. You can change this in User Settings.,Vous suivez maintenant ce document. Vous recevrez des mises à jour quotidiennes par courrier électronique. Vous pouvez modifier cela dans les paramètres de l&#39;utilisateur.
+apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You are now following this document. You will receive daily updates via email. You can change this in User Settings.,Vous suivez maintenant ce document. Vous recevrez des mises à jour quotidiennes par courrier électronique. Vous pouvez modifier cela dans les paramètres de l'utilisateur.
 DocType: Contact,Replied,Répondu
 DocType: Newsletter,Test,Test
 DocType: Custom Field,Default Value,Valeur par Défaut
@@ -1960,7 +1960,7 @@ DocType: Chat Profile,Enable Chat,Activer le chat
 DocType: LDAP Settings,Base Distinguished Name (DN),"""Distinguished Name"" (DN) de base"
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Leave this conversation,Se désinscrire
 apps/frappe/frappe/model/base_document.py,Options not set for link field {0},Options non définis pour le champ lié {0}
-apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker,File d&#39;attente / travailleur
+apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker,File d'attente / travailleur
 DocType: S3 Backup Settings,ap-southeast-1,ap-sud-est-1
 DocType: DocType,"Must be of type ""Attach Image""","Doit être de type ""Joindre l'Image"""
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Tout Déselectionner
@@ -1972,7 +1972,7 @@ DocType: Workflow State,asterisk,Astérisque
 DocType: Data Import,Successful,Réussi
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Please do not change the template headings.,Veuillez ne pas modifier les sections du modèle.
 DocType: Activity Log,Linked,Lié
-apps/frappe/frappe/config/desk.py,Activity log of all users.,Journal d&#39;activité de tous les utilisateurs.
+apps/frappe/frappe/config/desk.py,Activity log of all users.,Journal d'activité de tous les utilisateurs.
 DocType: Workflow State,shopping-cart,panier
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Week,Semaine
 DocType: DocType,Open a dialog with mandatory fields to create a new record quickly,Ouvrir une boîte de dialogue avec des champs obligatoires pour créer rapidement un nouvel enregistrement
@@ -1980,7 +1980,7 @@ apps/frappe/frappe/templates/includes/login/login.js,Not Allowed: Disabled User,
 DocType: Social Login Key,Google,Google
 DocType: Email Domain,Example Email Address,Example d'Adresse Email
 apps/frappe/frappe/public/js/frappe/ui/sort_selector.js,Most Used,Plus Utilisé
-,user-profile,profil de l&#39;utilisateur
+,user-profile,profil de l'utilisateur
 apps/frappe/frappe/www/login.html,Forgot Password,Mot de Passe Oublié
 DocType: Dropbox Settings,Backup Frequency,Fréquence de Sauvegarde
 DocType: Workflow State,Inverse,Inverse
@@ -2024,7 +2024,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Connexion non autorisée pour le moment
 DocType: Data Migration Run,Current Mapping Action,Action de cartographie actuelle
 DocType: Dashboard Chart Source,Source Name,Nom de la Source
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Aucun compte de messagerie associé à l&#39;utilisateur. Veuillez ajouter un compte sous Utilisateur> Boîte de réception par courrier électronique.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Aucun compte de messagerie associé à l'utilisateur. Veuillez ajouter un compte sous Utilisateur> Boîte de réception par courrier électronique.
 DocType: Email Account,Email Sync Option,Option de Synchronisation d'Email
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rangée No
 DocType: Async Task,Runtime,Temps d’Exécution
@@ -2047,7 +2047,7 @@ apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Compiled Succe
 DocType: System Settings,Email Footer Address,Pied de Page Email
 apps/frappe/frappe/public/js/frappe/form/grid.js,Table updated,Table Mise à Jour
 DocType: Activity Log,Timeline DocType,DocType Chronologie
-DocType: Success Action,Action Timeout (Seconds),Délai d&#39;attente de l&#39;action (secondes)
+DocType: Success Action,Action Timeout (Seconds),Délai d'attente de l'action (secondes)
 DocType: DocField,Text,Texte
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Sending,Envoi par Défaut
 DocType: Workflow State,volume-off,couper-son
@@ -2067,7 +2067,7 @@ DocType: Property Setter,DocType or Field,DocType ou Champ
 apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You unfollowed this document,Vous avez non suivi ce document
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Primary Color,Couleur primaire
 DocType: Communication,Soft-Bounced,Soft-Bounced
-DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Si cette option est activée, tous les utilisateurs peuvent se connecter à partir de n&#39;importe quelle adresse IP à l&#39;aide de l&#39;authentification à deux facteurs. Cela peut également être défini uniquement pour des utilisateurs spécifiques dans la page Utilisateur"
+DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Si cette option est activée, tous les utilisateurs peuvent se connecter à partir de n'importe quelle adresse IP à l'aide de l'authentification à deux facteurs. Cela peut également être défini uniquement pour des utilisateurs spécifiques dans la page Utilisateur"
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Seems Publishable Key or Secret Key is wrong !!!,La Clé Publiable ou la Clé Secrète est erronée !!!
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Quick Help for Setting Permissions,Aide Rapide pour Définir les Autorisations
 DocType: Tag Doc Category,Doctype to Assign Tags,Doctype auquel affecter les balises
@@ -2100,7 +2100,7 @@ apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} records wil
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Champ Titre doit être un nom de champ valide
 DocType: Post Comment,Post Comment,Poster un commentaire
 apps/frappe/frappe/config/core.py,Documents,Documents
-apps/frappe/frappe/config/users_and_permissions.py,Activity Log by ,Journal d&#39;activité par
+apps/frappe/frappe/config/users_and_permissions.py,Activity Log by ,Journal d'activité par
 DocType: Social Login Key,Custom Base URL,URL de base personnalisée
 DocType: Email Flag Queue,Is Completed,Est Complété
 apps/frappe/frappe/website/doctype/web_form/web_form.js,Get Fields,Obtenir des champs
@@ -2121,11 +2121,11 @@ DocType: User,Bio,Biographie
 DocType: OAuth Client,App Client Secret,Secret Client de l'App
 apps/frappe/frappe/public/js/frappe/form/save.js,Submitting,Soumission
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of the document to which the data will get added to.,Parent est le nom du document auquel les données seront ajoutées.
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Impossible de créer un dossier dans Google Drive - Code d&#39;erreur {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Impossible de créer un dossier dans Google Drive - Code d'erreur {0}
 DocType: DocType,UPPER CASE,MAJUSCULE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML Personnalisé
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Entrez le nom du dossier
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Aucun modèle d&#39;adresse par défaut trouvé. Veuillez en créer un nouveau depuis Configuration> Impression et création de marque> Modèle d&#39;adresse.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Aucun modèle d'adresse par défaut trouvé. Veuillez en créer un nouveau depuis Configuration> Impression et création de marque> Modèle d'adresse.
 apps/frappe/frappe/auth.py,Unknown User,Utilisateur Inconnu
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Sélectionner le Rôle
 DocType: Comment,Deleted,Supprimé
@@ -2150,7 +2150,7 @@ DocType: Data Migration Connector,Database Name,Nom de la Base de Données
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Actualiser le Formulaire
 DocType: DocField,Select,Sélectionner
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Voir le journal complet
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expression Python simple, Exemple: status == &#39;Open&#39; et tapez == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expression Python simple, Exemple: status == 'Open' et tapez == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Fichier joint manquant
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Connexion perdue. Certaines fonctionnalités peuvent ne pas fonctionner.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Les répétitions comme ""aaa"" sont faciles à deviner"
@@ -2185,7 +2185,7 @@ DocType: Email Unsubscribe,Global Unsubscribe,Se Désabonner Globalement
 apps/frappe/frappe/utils/password_strength.py,This is a very common password.,C’est un mot de passe très commun.
 apps/frappe/frappe/email/doctype/email_group/email_group.js,View,Vue
 DocType: Comment,Assigned,Attribué
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,Cliquez sur <b>Autoriser l&#39;accès</b> à Google Drive pour autoriser l&#39; <b>accès</b> à Google Drive.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,Cliquez sur <b>Autoriser l'accès</b> à Google Drive pour autoriser l' <b>accès</b> à Google Drive.
 DocType: Print Format,Js,Js
 apps/frappe/frappe/public/js/frappe/views/communication.js,Select Print Format,Sélectionner le Format d'Impression
 apps/frappe/frappe/utils/password_strength.py,Short keyboard patterns are easy to guess,Modèles de clavier courts sont faciles à deviner
@@ -2197,7 +2197,7 @@ DocType: Data Migration Connector,Hostname,Hostname
 DocType: Data Migration Mapping,Condition Detail,Détail de la Condition
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"For currency {0}, the minimum transaction amount should be {1}","Pour la devise {0}, le montant minimum de la transaction doit être {1}"
 DocType: DocField,Print Hide,Cacher à l'Impression
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,To User,À l&#39;utilisateur
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,To User,À l'utilisateur
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter Value,Entrez une Valeur
 DocType: Workflow State,tint,teinte
 DocType: DocField,In Preview,En aperçu
@@ -2226,14 +2226,14 @@ DocType: DocField,Table MultiSelect,Tableau MultiSelect
 apps/frappe/frappe/config/integrations.py,Google Calendar Integration.,Intégration de Google Agenda.
 DocType: Auto Repeat,Half-yearly,Semestriel
 apps/frappe/frappe/templates/emails/upcoming_events.html,Daily Event Digest is sent for Calendar Events where reminders are set.,Un Récapitulatif Quotidien est envoyé pour les Événements du Calendrier ayant des rappels.
-DocType: Braintree Settings,Header Image,Image d&#39;en-tête
+DocType: Braintree Settings,Header Image,Image d'en-tête
 apps/frappe/frappe/website/doctype/website_settings/website_settings.js,View Website,Voir Le Site Web
 DocType: Web Form,Message to be displayed on successful completion (only for Guest users),Message à afficher après une exécution réussie (uniquement pour les utilisateurs invités)
 DocType: Workflow State,remove,retirer
 DocType: Email Domain,If non standard port (e.g. 587),Si port non standard (e.g. 587)
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} criticism points for {1} {2},{0} points de critique pour {1} {2}
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} criticism point for {1} {2},{0} point de critique pour {1} {2}
-apps/frappe/frappe/templates/includes/comments/comments.py,Comments cannot have links or email addresses,Les commentaires ne peuvent pas avoir de liens ou d&#39;adresses électroniques
+apps/frappe/frappe/templates/includes/comments/comments.py,Comments cannot have links or email addresses,Les commentaires ne peuvent pas avoir de liens ou d'adresses électroniques
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Reload,Recharger
 apps/frappe/frappe/config/customization.py,Add your own Tag Categories,Ajoutez vos propres catégories de balises
 apps/frappe/frappe/desk/query_report.py,Total,Total
@@ -2266,7 +2266,7 @@ apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Average of {0},Moyen
 DocType: User,Logout from all devices while changing Password,Déconnecter de tous les appareils lors de la modification du mot de passe
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify Password,Vérifier Le Mot De Passe
 apps/frappe/frappe/public/js/frappe/form/sidebar/attachments.js,There were errors,Il y a eu des erreurs
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Entrez l&#39;ID et le secret du client dans les paramètres Google.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Entrez l'ID et le secret du client dans les paramètres Google.
 apps/frappe/frappe/core/doctype/communication/communication.js,Close,Fermer
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 0 to 2,Impossible de changer le statut du document de 0 à 2
 DocType: File,Attached To Field,Attaché au champ
@@ -2294,7 +2294,7 @@ DocType: DocField,Fetch If Empty,Chercher si vide
 DocType: Data Migration Connector,Authentication Credentials,Informations d'Authentification
 DocType: Role,Two Factor Authentication,Authentification à Double Facteur
 apps/frappe/frappe/templates/pages/integrations/braintree_checkout.html,Pay,Payer
-DocType: Energy Point Settings,Point Allocation Periodicity,Périodicité d&#39;attribution de points
+DocType: Energy Point Settings,Point Allocation Periodicity,Périodicité d'attribution de points
 DocType: SMS Settings,SMS Gateway URL,URL de la Passerelle SMS
 apps/frappe/frappe/model/base_document.py,"{0} {1} cannot be ""{2}"". It should be one of ""{3}""","{0} {1} ne peut pas être ""{2}"". Il devrait être l'un de ""{3}"""
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,gained by {0} via automatic rule {1},gagné par {0} via la règle automatique {1}
@@ -2302,7 +2302,7 @@ apps/frappe/frappe/utils/data.py,{0} or {1},{0} ou {1}
 DocType: Workflow State,trash,corbeille
 DocType: System Settings,Older backups will be automatically deleted,Les anciennes sauvegardes seront automatiquement supprimées
 apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Invalid Access Key ID or Secret Access Key.,ID de clé d'accès ou clé d'accès secrète invalide.
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You lost some energy points,Vous avez perdu des points d&#39;énergie
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You lost some energy points,Vous avez perdu des points d'énergie
 DocType: Post,Is Globally Pinned,Est globalement épinglé
 apps/frappe/frappe/desk/page/user_profile/user_profile.html,Recent Activity,Activité récente
 DocType: Workflow Transition,Conditions,Conditions
@@ -2310,7 +2310,7 @@ DocType: Event,Leave blank to repeat always,Laissez vide pour répéter sans fin
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Confirmed,Confirmé
 DocType: Event,Ends on,Se termine le
 DocType: Payment Gateway,Gateway,Passerelle
-DocType: LDAP Settings,Path to Server Certificate,Chemin d&#39;accès au certificat de serveur
+DocType: LDAP Settings,Path to Server Certificate,Chemin d'accès au certificat de serveur
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Pas assez d'autorisations pour voir les liens
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Le Titre de l'Adresse est obligatoire.
 DocType: Google Contacts,Push to Google Contacts,Push to Google Contacts
@@ -2342,7 +2342,7 @@ apps/frappe/frappe/geo/doctype/currency/currency.js,This Currency is disabled. E
 DocType: Desktop Icon,Blocked,Bloqué
 DocType: Contact Us Settings,"Default: ""Contact Us""","Par Défaut: ""Contactez-nous"""
 DocType: Contact,Purchase Manager,Responsable des Achats
-DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Lorsque cette option est activée, les invités peuvent télécharger des fichiers dans votre application. Vous pouvez l&#39;activer si vous souhaitez collecter des fichiers auprès de l&#39;utilisateur sans qu&#39;ils aient à se connecter, par exemple dans le formulaire Web de candidature à un poste."
+DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Lorsque cette option est activée, les invités peuvent télécharger des fichiers dans votre application. Vous pouvez l'activer si vous souhaitez collecter des fichiers auprès de l'utilisateur sans qu'ils aient à se connecter, par exemple dans le formulaire Web de candidature à un poste."
 apps/frappe/frappe/public/js/frappe/ui/tags.js,toggle Tag,Afficher/Cacher la balise
 DocType: Custom Script,Sample,Échantillon
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,"For performance, only the first 100 rows were processed.","Pour la performance, seules les 100 premières lignes ont été traitées."
@@ -2350,11 +2350,11 @@ DocType: Braintree Settings,Private Key,Clé privée
 DocType: S3 Backup Settings,ap-northeast-2,ap-nord-est-2
 DocType: Custom Field,Is Mandatory Field,Est Champ obligatoire
 DocType: User,Website User,Utilisateur du Site Web
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,Certaines colonnes peuvent être coupées lors de l&#39;impression au format PDF. Essayez de garder le nombre de colonnes sous 10.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,Certaines colonnes peuvent être coupées lors de l'impression au format PDF. Essayez de garder le nombre de colonnes sous 10.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not equals,Non égaux
-DocType: Data Import Beta,Don't Send Emails,Ne pas envoyer d&#39;emails
+DocType: Data Import Beta,Don't Send Emails,Ne pas envoyer d'emails
 DocType: Integration Request,Integration Request Service,Service de Demande d'Intégration
-DocType: Access Log,Access Log,Journal d&#39;accès
+DocType: Access Log,Access Log,Journal d'accès
 DocType: Website Script,Script to attach to all web pages.,Script à joindre à toutes les pages web.
 DocType: Web Form,Allow Multiple,Autoriser Plusieurs
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Assign,Assigner
@@ -2366,7 +2366,7 @@ apps/frappe/frappe/templates/emails/auto_repeat_fail.html,This email is autogene
 DocType: Workflow State,Icon will appear on the button,L'icône apparaîtra sur le bouton
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Click to Set Filters,Cliquez pour définir les filtres
 DocType: Energy Point Log,Revert,Revenir
-apps/frappe/frappe/public/js/frappe/socketio_client.js,Socketio is not connected. Cannot upload,Socketio n&#39;est pas connecté. Impossible de télécharger
+apps/frappe/frappe/public/js/frappe/socketio_client.js,Socketio is not connected. Cannot upload,Socketio n'est pas connecté. Impossible de télécharger
 DocType: Website Settings,Website Settings,Paramètres du Site web
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Month,Mois
 DocType: Email Account,ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> to send document reference,ProTip: Ajouter <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> envoyer référence du document
@@ -2379,7 +2379,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options {1} must be the 
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Clear Cache and Reload,Vider le cache et recharger
 DocType: Portal Settings,Custom Sidebar Menu,Barre Latérale Personnalisée
 DocType: Workflow State,pencil,crayon
-apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,Discuter des messages et d&#39;autres notifications.
+apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,Discuter des messages et d'autres notifications.
 apps/frappe/frappe/public/js/frappe/social/Home.vue,Social Home,Maison sociale
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Insert After cannot be set as {0},Insérer Après ne peut être défini en tant que {0}
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Share {0} with,Partager {0} avec
@@ -2407,7 +2407,7 @@ apps/frappe/frappe/templates/emails/password_reset.html,Please click on the foll
 DocType: Notification,Days After,Jours Suivants
 apps/frappe/frappe/public/js/frappe/form/print.js,QZ Tray Connection Active!,Connexion bac QZ active!
 DocType: Contact Us Settings,Settings for Contact Us Page,Paramètres de la Page Contactez Nous
-DocType: Print Settings,Enable Print Server,Activer le serveur d&#39;impression
+DocType: Print Settings,Enable Print Server,Activer le serveur d'impression
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} weeks ago,Il y a {0} semaines
 DocType: Email Account,Footer,Pied de Page
 apps/frappe/frappe/config/integrations.py,Authentication,Authentification
@@ -2438,7 +2438,7 @@ DocType: Google Calendar,Pull from Google Calendar,Tirez de Google Agenda
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aide
 DocType: User,Login Before,Connexion Jusqu'à
 DocType: Web Page,Insert Style,Insérez le Style
-DocType: Prepared Report,Error Message,Message d&#39;erreur
+DocType: Prepared Report,Error Message,Message d'erreur
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,New Report name,Nouveau Nom de Rapport
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Hide Weekends,Masquer les week-ends
 apps/frappe/frappe/config/settings.py,Automatically generates recurring documents.,Génère automatiquement des documents récurrents.
@@ -2448,7 +2448,7 @@ apps/frappe/frappe/model/base_document.py,Value for {0} cannot be a list,Valeur 
 DocType: Currency,"How should this currency be formatted? If not set, will use system defaults","Comment cette devise doit-elle être formatée ? Si ce n’est pas défini, les paramètres par défaut du système seront utilisés"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Submit {0} documents?,Soumettre {0} documents ?
 apps/frappe/frappe/utils/response.py,You need to be logged in and have System Manager Role to be able to access backups.,Vous devez être connecté et avoir le Role Responsable Système pour pouvoir accéder aux sauvegardes.
-apps/frappe/frappe/public/js/frappe/form/print.js,Printer Mapping,Cartographie d&#39;imprimante
+apps/frappe/frappe/public/js/frappe/form/print.js,Printer Mapping,Cartographie d'imprimante
 apps/frappe/frappe/public/js/frappe/form/form.js,Please save before attaching.,Veuillez enregistrer avant de joindre une pièce.
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Added {0} ({1}),Ajouté {0} ({1})
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Fieldtype cannot be changed from {0} to {1} in row {2},"FieldType ne peut pas être modifié de {0} à {1}, à la ligne {2}"
@@ -2457,7 +2457,7 @@ DocType: Help Article,Intermediate,Intermédiaire
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} changed {1} to {2},{0} remplacé {1} par {2}
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Cancelled Document restored as Draft,Le document annulé a été restauré en tant que brouillon
 DocType: Data Migration Run,Start Time,Heure de Début
-apps/frappe/frappe/model/delete_doc.py,Cannot delete or cancel because {0} {1} is linked with {2} {3} {4},"Impossible de supprimer ou d&#39;annuler, car {0} {1} est associé à {2} {3} {4}"
+apps/frappe/frappe/model/delete_doc.py,Cannot delete or cancel because {0} {1} is linked with {2} {3} {4},"Impossible de supprimer ou d'annuler, car {0} {1} est associé à {2} {3} {4}"
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Read,Peut Lire
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,{0} Chart,Graphique {0}
 DocType: Custom Role,Response,Réponse
@@ -2465,7 +2465,7 @@ DocType: DocField,Geolocation,Géolocalisation
 DocType: Workflow,Emails will be sent with next possible workflow actions,Les e-mails seront envoyés lors des actions de workflow
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Workflow will start after saving.,Le Flux de Travail démarre après l'enregistrement.
 DocType: S3 Backup Settings,ap-northeast-1,ap-nord-est-1
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Quelque chose s&#39;est mal passé pendant la génération de jetons. Cliquez sur {0} pour en générer un nouveau.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Quelque chose s'est mal passé pendant la génération de jetons. Cliquez sur {0} pour en générer un nouveau.
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Share,Peut Partager
 apps/frappe/frappe/email/smtp.py,Invalid recipient address,Adresse de destinataire invalide
 DocType: Workflow State,step-forward,vers-l'avant
@@ -2476,7 +2476,7 @@ apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Direct room with {0} alre
 apps/frappe/frappe/core/doctype/user/user.js,Refreshing...,Actualisation...
 DocType: Event,Starts on,Commence le
 DocType: System Settings,System Settings,Paramètres Système
-DocType: GCalendar Settings,Google API Credentials,Informations d&#39;identification de l&#39;API Google
+DocType: GCalendar Settings,Google API Credentials,Informations d'identification de l'API Google
 apps/frappe/frappe/public/js/frappe/desk.js,Session Start Failed,Le Démarrage de la Session a Échoué
 apps/frappe/frappe/email/queue.py,This email was sent to {0} and copied to {1},Cet email a été envoyé à {0} et une copie à {1}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document {0},a soumis ce document {0}
@@ -2488,7 +2488,7 @@ DocType: GCalendar Account,GCalendar Account,Compte GCalendar
 DocType: Email Rule,Is Spam,Est Spam
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Report {0},Rapport {0}
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Open {0},Ouvrir {0}
-DocType: Data Import Beta,Import Warnings,Avertissements d&#39;importation
+DocType: Data Import Beta,Import Warnings,Avertissements d'importation
 DocType: OAuth Client,Default Redirect URI,URI de Redirection par Défaut
 DocType: Auto Repeat,Recipients,Destinataires
 DocType: System Settings,Choose authentication method to be used by all users,Choisissez la méthode d'authentification qui sera utilisée par tous les utilisateurs
@@ -2504,7 +2504,7 @@ apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your 
 DocType: Address,Andaman and Nicobar Islands,Îles Andaman et Nicobar
 DocType: Google Contacts,Pull from Google Contacts,Tirez de Google Contacts
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,Veuillez indiquer quel champ de valeur doit être vérifiée
-DocType: Event,Google Calendar Event ID,Identifiant d&#39;événement Google Agenda
+DocType: Event,Google Calendar Event ID,Identifiant d'événement Google Agenda
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added","""Parent"" indique la table parent dans laquelle cette ligne doit être ajouté"
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,Points de révision:
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,Partagé Avec
@@ -2525,11 +2525,11 @@ DocType: Comment,Assignment Completed,Affectation Terminée
 apps/frappe/frappe/public/js/frappe/form/grid.js,Bulk Edit {0},Modifier en Masse {0}
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Download Report,Télécharger le rapport
 apps/frappe/frappe/workflow/doctype/workflow/workflow_list.js,Not active,Non actif
-apps/frappe/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py,Only Administrator is allowed to create Dashboard Chart Sources,Seul l&#39;administrateur est autorisé à créer des sources de graphique de tableau de bord
+apps/frappe/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py,Only Administrator is allowed to create Dashboard Chart Sources,Seul l'administrateur est autorisé à créer des sources de graphique de tableau de bord
 DocType: About Us Settings,Settings for the About Us Page,Paramètres de la page À Propos
 apps/frappe/frappe/config/integrations.py,Stripe payment gateway settings,Paramètres de la passerelle de paiement Stripe
-apps/frappe/frappe/public/js/frappe/form/print.js,Print Sent to the printer!,Imprimer Envoyé à l&#39;imprimante!
-apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Energy Points,Points d&#39;énergie
+apps/frappe/frappe/public/js/frappe/form/print.js,Print Sent to the printer!,Imprimer Envoyé à l'imprimante!
+apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Energy Points,Points d'énergie
 DocType: Email Account,e.g. pop.gmail.com / imap.gmail.com,e.g. pop.gmail.com / imap.gmail.com
 DocType: User,Generate Keys,Générer des clés
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,This will permanently remove your data.,Cela supprimera définitivement vos données.
@@ -2565,7 +2565,7 @@ DocType: Data Import,Don't create new records,Ne pas créer de nouveaux enregist
 apps/frappe/frappe/utils/nestedset.py,Nested set error. Please contact the Administrator.,Erreur d'ensemble imbriqué. Veuillez contacter l'Administrateur.
 DocType: Workflow State,envelope,enveloppe
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 2,Option 2
-apps/frappe/frappe/utils/print_format.py,Printing failed,L&#39;impression a échoué
+apps/frappe/frappe/utils/print_format.py,Printing failed,L'impression a échoué
 apps/frappe/frappe/www/update-password.html,New Password Required.,Nouveau Mot de Passe Requis.
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with {1},{0} a partagé ce document avec {1}
 DocType: Website Settings,Brand Image,Logo
@@ -2574,8 +2574,8 @@ apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Googl
 apps/frappe/frappe/config/website.py,"Setup of top navigation bar, footer and logo.","Configuration de la barre de navigation en haut, du pied de page et du logo."
 DocType: Web Form Field,Max Value,Valeur Max
 apps/frappe/frappe/core/doctype/doctype/doctype.py,For {0} at level {1} in {2} in row {3},Pour {0} au niveau {1} dans {2} à la ligne {3}
-DocType: Auto Repeat,Preview Message,Message d&#39;aperçu
-DocType: User Social Login,User Social Login,Connexion sociale de l&#39;utilisateur
+DocType: Auto Repeat,Preview Message,Message d'aperçu
+DocType: User Social Login,User Social Login,Connexion sociale de l'utilisateur
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} criticized your work on {1} with {2} point,{0} a critiqué votre travail sur {1} avec {2} points
 DocType: Contact,All,Tous
 DocType: Email Queue,Recipient,Destinataire
@@ -2611,7 +2611,7 @@ apps/frappe/frappe/utils/data.py,Filter must be a tuple or list (in a list),Le F
 apps/frappe/frappe/core/doctype/report/report.js,Write a SELECT query. Note result is not paged (all data is sent in one go).,Écrire une requête SELECT. Remarque : le résultat n'est pas paginé (toutes les données sont transmises en une seule fois).
 DocType: Email Account,Attachment Limit (MB),Taille Maximale de la Pièce jointe (MB)
 DocType: Address,Arunachal Pradesh,Arunachal Pradesh
-DocType: DocType,Child Tables are shown as a Grid in other DocTypes,Les tables enfants sont affichées sous forme de grille dans d&#39;autres DocTypes
+DocType: DocType,Child Tables are shown as a Grid in other DocTypes,Les tables enfants sont affichées sous forme de grille dans d'autres DocTypes
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Setup Auto Email,Configuration Auto Email
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Down,Ctrl + Bas
 DocType: Chat Profile,Message Preview,Aperçu du message
@@ -2630,7 +2630,7 @@ DocType: Workflow State,th-list,th-list
 DocType: Web Page,Enable Comments,Activer Commentaires
 apps/frappe/frappe/desk/doctype/note/note_list.js,Notes,Remarques
 DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),Restreindre la connexion à partir de cette adresse IP uniquement. Plusieurs adresses IP peuvent être ajoutées en les séparant par des virgules. Les adresses IP partielles comme (111.111.111) sont acceptées
-DocType: Data Import Beta,Import Preview,Aperçu d&#39;importation
+DocType: Data Import Beta,Import Preview,Aperçu d'importation
 DocType: Communication,From,À partir de
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.,Sélectionner d'abord un noeud de groupe
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Find {0} in {1},Trouver {0} dans {1}
@@ -2657,7 +2657,7 @@ apps/frappe/frappe/config/integrations.py,"Enter keys to enable login via Facebo
 DocType: Event,Sent/Received Email,Email envoyé / reçu
 DocType: Data Import,Insert new records,Insérer de nouveaux enregistrements
 apps/frappe/frappe/core/doctype/file/file.py,Unable to read file format for {0},Impossible de lire le format de fichier pour {0}
-apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Seul l&#39;administrateur est autorisé à utiliser l&#39;enregistreur
+apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Seul l'administrateur est autorisé à utiliser l'enregistreur
 DocType: Auto Email Report,Filter Data,Filtrer les Données
 apps/frappe/frappe/public/js/frappe/form/controls/select.js,Please attach a file first.,Veuillez d’abord joindre un fichier.
 apps/frappe/frappe/templates/emails/download_data.html,Dear {0},Cher {0}
@@ -2667,14 +2667,14 @@ apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email acc
 apps/frappe/frappe/templates/includes/contact.js,"You seem to have written your name instead of your email. \
 				Please enter a valid email address so that we can get back.",Vous semblez avoir écrit votre nom au lieu de votre email. \ Veuillez entrer une adresse email valide afin que nous puissions revenir vers vous.
 DocType: Website Slideshow Item,Website Slideshow Item,Objet du Diaporama du Site Web
-apps/frappe/frappe/model/workflow.py,Self approval is not allowed,L&#39;auto-approbation n&#39;est pas autorisée
+apps/frappe/frappe/model/workflow.py,Self approval is not allowed,L'auto-approbation n'est pas autorisée
 DocType: GSuite Templates,Template ID,ID du Modèle
 apps/frappe/frappe/integrations/doctype/oauth_client/oauth_client.py,Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed,La combinaison du type de subvention ( <code>{0}</code> ) et du type de réponse ( <code>{1}</code> ) n'est pas autorisée
 apps/frappe/frappe/desk/form/assign_to.py,New Message from {0},Nouveau Message de {0}
 DocType: Portal Settings,Default Role at Time of Signup,Rôle au Moment de l’Inscription par Défaut
 DocType: DocType,Title Case,Casse du Titre
 apps/frappe/frappe/templates/emails/download_data.html,Click on the link below to download your data,Cliquez sur le lien ci-dessous pour télécharger vos données.
-apps/frappe/frappe/core/doctype/user/user.py,Enabled email inbox for user {0},Activé la boîte de réception électronique pour l&#39;utilisateur {0}
+apps/frappe/frappe/core/doctype/user/user.py,Enabled email inbox for user {0},Activé la boîte de réception électronique pour l'utilisateur {0}
 DocType: Data Migration Run,Data Migration Run,Lancement de la Migration de Données
 DocType: Blog Post,Email Sent,Email Envoyé
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Older,Plus âgée
@@ -2682,7 +2682,7 @@ DocType: DocField,Ignore XSS Filter,Ignorer le Filtre XSS
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,removed,retiré
 apps/frappe/frappe/config/integrations.py,Dropbox backup settings,Paramètres de sauvegarde Dropbox
 DocType: Webhook,Webhook Trigger,Déclencheur Webhook
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,{0} Google Calendar Events synced.,{0} Événements d&#39;agenda Google synchronisés.
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,{0} Google Calendar Events synced.,{0} Événements d'agenda Google synchronisés.
 DocType: Dashboard Chart,Time Series,Des séries chronologiques
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be disabled,Utilisateur {0} ne peut pas être désactivé
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Google Settings,Paramètres Google
@@ -2690,15 +2690,15 @@ apps/frappe/frappe/templates/emails/administrator_logged_in.html,"Dear System Ma
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} self assigned this task: {1},{0} auto-assigné à cette tâche: {1}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Your Country,Votre Pays
 DocType: Assignment Rule Day,Sunday,Dimanche
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: le nom de champ ne peut pas être l&#39;un des {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: le nom de champ ne peut pas être l'un des {1}
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Standings,Classement
 apps/frappe/frappe/core/doctype/doctype/doctype.js,In Grid View,Vue en Grille
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,No More Activity,Plus d&#39;activité
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,No More Activity,Plus d'activité
 DocType: Auto Repeat,Template,Modèle
 DocType: Address,Delhi,Delhi
 apps/frappe/frappe/desk/doctype/calendar_view/calendar_view.js,Show Calendar,Afficher le calendrier
 apps/frappe/frappe/config/integrations.py,LDAP Settings,Paramètres LDAP
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Name,Nom de l&#39;entité
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Name,Nom de l'entité
 apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Modification
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,Paramètres de la Passerelle de Paiement PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Joueur le plus performant
@@ -2718,7 +2718,7 @@ DocType: Email Account,Use ASCII encoding for password,Utiliser le codage ASCII 
 DocType: User,Karma,Karma
 DocType: Report,Custom Report,Rapport personnalisé
 DocType: Dashboard Chart,Bar,Bar
-apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Veuillez définir un mappage d&#39;imprimante pour ce format d&#39;impression dans les paramètres de l&#39;imprimante.
+apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Veuillez définir un mappage d'imprimante pour ce format d'impression dans les paramètres de l'imprimante.
 DocType: DocField,Table,Table
 DocType: File,File Size,Taille du Fichier
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You must login to submit this form,Vous devez vous connecter pour soumettre ce formulaire
@@ -2733,8 +2733,8 @@ DocType: Braintree Settings,Use Sandbox,Utiliser Sandbox
 apps/frappe/frappe/utils/goal.py,This month,Ce mois-ci
 apps/frappe/frappe/public/js/frappe/form/print.js,New Custom Print Format,Nouveau Format d'Impression Personnalisé
 DocType: Custom DocPerm,Create,Créer
-apps/frappe/frappe/public/js/frappe/web_form/web_form_list.js,No more items to display,Pas plus d&#39;articles à afficher
-apps/frappe/frappe/public/js/frappe/form/form.js,Go to previous record,Aller à l&#39;enregistrement précédent
+apps/frappe/frappe/public/js/frappe/web_form/web_form_list.js,No more items to display,Pas plus d'articles à afficher
+apps/frappe/frappe/public/js/frappe/form/form.js,Go to previous record,Aller à l'enregistrement précédent
 DocType: Email Account,no failed attempts,aucune tentative ratée
 DocType: GSuite Settings,refresh_token,refresh_token
 DocType: Dropbox Settings,App Access Key,Clé d'Accès de l'App
@@ -2770,7 +2770,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Document Restauré
 DocType: Data Export,Data Export,Export de données
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Choisir la Langue...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Vous ne pouvez pas configurer &#39;Options&#39; pour le champ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Vous ne pouvez pas configurer 'Options' pour le champ {0}
 DocType: Help Article,Author,Auteur
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Reprendre l’Envoi
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Ré-ouvrir
@@ -2801,14 +2801,14 @@ apps/frappe/frappe/config/integrations.py,Braintree payment gateway settings,Par
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Rebuild,Reconstruire
 apps/frappe/frappe/www/third_party_apps.html,This will log out {0} from all other devices,Cela déconnectera {0} de tous les autres périphériques
 apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Vous n'avez pas l'autorisation d'obtenir un rapport sur : {0}
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Agenda - Impossible d&#39;insérer un événement dans Google Agenda {0}, code d&#39;erreur {1}."
-DocType: System Settings,Apply Strict User Permissions,Appliquer des autorisations d&#39;utilisateur strictes
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Agenda - Impossible d'insérer un événement dans Google Agenda {0}, code d'erreur {1}."
+DocType: System Settings,Apply Strict User Permissions,Appliquer des autorisations d'utilisateur strictes
 DocType: S3 Backup Settings,us-west-1,us-west-1
 DocType: DocField,Allow Bulk Edit,Autoriser la Modification en Masse
 DocType: Blog Post,Blog Post,Article de Blog
 DocType: Access Log,Export From,Exporter de
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Advanced Search,Recherche Avancée
-apps/frappe/frappe/email/doctype/newsletter/newsletter.py,You are not permitted to view the newsletter.,Vous n&#39;êtes pas autorisé à consulter la newsletter.
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,You are not permitted to view the newsletter.,Vous n'êtes pas autorisé à consulter la newsletter.
 DocType: User,Interests,Intérêts
 apps/frappe/frappe/core/doctype/user/user.py,Password reset instructions have been sent to your email,Les Instructions de réinitialisation du mot de passe ont été envoyés à votre adresse Email
 DocType: Energy Point Rule,Allot Points To Assigned Users,Allouer des points à des utilisateurs assignés
@@ -2816,11 +2816,11 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.js,"Level 0 i
 								higher levels for field level permissions.","Le niveau 0 est pour les autorisations au niveau du document, \ les niveaux supérieurs pour les autorisations au niveau des champs."
 DocType: Contact Email,Is Primary,Est primaire
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,From Document Type,De type de document
-DocType: DocType,Tree structures are implemented using Nested Set,Les arborescences sont implémentées à l&#39;aide d&#39;un jeu imbriqué
+DocType: DocType,Tree structures are implemented using Nested Set,Les arborescences sont implémentées à l'aide d'un jeu imbriqué
 apps/frappe/frappe/core/doctype/data_import/data_import.py,Can't save the form as data import is in progress.,Impossible d'enregistrer le formulaire lorsque l'import de données est en cours.
 DocType: Workflow,States,États
 DocType: Notification,Attach Print,Joindre l'Impression
-DocType: Assignment Rule,Assignment Rule,Règle d&#39;assignation
+DocType: Assignment Rule,Assignment Rule,Règle d'assignation
 apps/frappe/frappe/core/doctype/user/user.py,Suggested Username: {0},Nom d'Utilisateur Suggérée : {0}
 DocType: Assignment Rule Day,Day,Jour
 apps/frappe/frappe/public/js/frappe/desk.js,Modules,Modules
@@ -2836,7 +2836,7 @@ DocType: Stripe Settings,Publishable Key,Clé Publiable
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Start Import,Démarrer l'import
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Type,Type d'Exportation
 DocType: Workflow State,circle-arrow-left,flèche-cercle-gauche
-DocType: System Settings,Force User to Reset Password,Forcer l&#39;utilisateur à réinitialiser le mot de passe
+DocType: System Settings,Force User to Reset Password,Forcer l'utilisateur à réinitialiser le mot de passe
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"To get the updated report, click on {0}.","Pour obtenir le rapport mis à jour, cliquez sur {0}."
 apps/frappe/frappe/sessions.py,Redis cache server not running. Please contact Administrator / Tech support,Le serveur de cache Redis ne fonctionne pas. Veuillez contacter l'administrateur / le support technique
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_header.html,Searching,Recherche
@@ -2867,17 +2867,17 @@ apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Get Items,Obteni
 DocType: Contact,Image,Image
 DocType: Workflow State,remove-sign,retirez-signe
 apps/frappe/frappe/printing/doctype/print_settings/print_settings.py,Failed to connect to server,échec de connexion au serveur
-apps/frappe/frappe/core/doctype/data_export/exporter.py,There is no data to be exported,Il n&#39;y a pas de données à exporter
+apps/frappe/frappe/core/doctype/data_export/exporter.py,There is no data to be exported,Il n'y a pas de données à exporter
 DocType: Domain Settings,Domains HTML,Domaines HTML
 apps/frappe/frappe/templates/includes/search_template.html,Type something in the search box to search,Tapez quelque chose dans la zone de recherche pour rechercher
 apps/frappe/frappe/config/settings.py,Define workflows for forms.,Définir des flux de travail pour les formulaires.
 DocType: Address,Other,Autre
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,Veuillez entrer l&#39;URL d&#39;autorisation
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,Veuillez entrer l'URL d'autorisation
 DocType: S3 Backup Settings,Access Key ID,ID de Clé d'Accès
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Misc,Divers
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Start new Format,Commencer un nouveau Format
 DocType: Workflow State,font,Police de Caractères
-DocType: DocType,Show Preview Popup,Afficher l&#39;aperçu Popup
+DocType: DocType,Show Preview Popup,Afficher l'aperçu Popup
 apps/frappe/frappe/utils/password_strength.py,This is a top-100 common password.,C’est un mot de passe commun dans le top-100.
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Please enable pop-ups,Veuillez autoriser les pop-ups
 DocType: Contact,Mobile No,N° Mobile
@@ -2901,7 +2901,7 @@ DocType: Data Import,Action,Action
 DocType: GSuite Settings,Script URL,URL du Script
 apps/frappe/frappe/www/update-password.html,Please enter the password,Veuillez entrer le mot de passe
 apps/frappe/frappe/www/printview.py,Not allowed to print cancelled documents,Non autorisé à imprimer des documents annulés
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,Vous n&#39;êtes pas autorisé à créer des colonnes
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,Vous n'êtes pas autorisé à créer des colonnes
 DocType: Data Import,If you don't want to create any new records while updating the older records.,Si vous ne souhaitez pas créer de nouveaux enregistrements lors de la mise à jour des anciens enregistrements.
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Info:,Info :
 DocType: Custom Field,Permission Level,Niveau d'Autorisation
@@ -2914,7 +2914,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Saving,En Cours d'Enregistremen
 DocType: Print Settings,Print Style Preview,Aperçu Style d'Impression
 apps/frappe/frappe/core/doctype/file/test_file.py,Test_Folder,Dossier_Test
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You are not allowed to update this Web Form Document,Vous n'êtes pas autorisé à mettre à jour ce formulaire Web
-apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Veuillez définir l&#39;URL de base dans la clé de connexion sociale pour Frappe
+apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Veuillez définir l'URL de base dans la clé de connexion sociale pour Frappe
 DocType: About Us Settings,About Us Settings,Paramétrages À Propos
 DocType: Website Settings,Website Theme,Thème du Site Web
 DocType: User,Api Access,Accès API
@@ -2957,7 +2957,7 @@ DocType: Web Form,Login Required,Connexion Requise
 DocType: Email Account,Email Login ID,ID de Connexion par Email
 apps/frappe/frappe/templates/pages/integrations/payment-cancel.html,Payment Cancelled,Paiement Annulé
 ,Addresses And Contacts,Adresses Et Contacts
-apps/frappe/frappe/core/doctype/data_import/data_import.js,Please select document type first.,Veuillez d&#39;abord sélectionner le type de document.
+apps/frappe/frappe/core/doctype/data_import/data_import.js,Please select document type first.,Veuillez d'abord sélectionner le type de document.
 apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Clear Error Logs,Effacer les Journaux d'Erreurs
 apps/frappe/frappe/core/doctype/user/user.js,Reset OTP Secret,Réinitialiser le Secret OTP
 DocType: Email Account,Notify if unreplied for (in mins),Notifier si aucune réponse dans (en min)
@@ -2972,13 +2972,13 @@ DocType: GSuite Settings,GSuite Settings,Paramètres GSuite
 DocType: Address,Links,Liens
 DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Utilise le nom d’adresse e-mail mentionné dans ce compte comme nom de l’expéditeur pour tous les courriels envoyés à l’aide de ce compte.
 DocType: Energy Point Rule,Field To Check,Champ à vérifier
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Google Contacts - Impossible de mettre à jour le contact dans Google Contacts {0}, code d&#39;erreur {1}."
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Google Contacts - Impossible de mettre à jour le contact dans Google Contacts {0}, code d'erreur {1}."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,Veuillez sélectionner le type de document.
 apps/frappe/frappe/model/base_document.py,Value missing for,Valeur manquante pour
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Ajouter une Sous-Catégorie
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Progression de l&#39;importation
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Progression de l'importation
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Si la condition est satisfaite, l&#39;utilisateur sera récompensé par les points. par exemple. doc.status == &#39;Fermé&#39;"
+","Si la condition est satisfaite, l'utilisateur sera récompensé par les points. par exemple. doc.status == 'Fermé'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Enregistrement Soumis ne peut pas être supprimé.
 DocType: GSuite Templates,Template Name,Nom du Modèle
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nouveau type de document
@@ -2999,7 +2999,7 @@ DocType: Address,Bihar,Bihar
 apps/frappe/frappe/desk/page/user_profile/user_profile_sidebar.html,User Settings,Paramètres utilisateur
 DocType: Report,Reference Report,Rapport de référence
 DocType: Activity Log,Link DocType,DocType du Lien
-apps/frappe/frappe/public/js/frappe/chat.js,You don't have any messages yet.,Vous n&#39;avez encore aucun message.
+apps/frappe/frappe/public/js/frappe/chat.js,You don't have any messages yet.,Vous n'avez encore aucun message.
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Remove all customizations?,Retirer toutes les personnalisations ?
 DocType: Website Slideshow,Slideshow Name,Nom du Diaporama
 DocType: Address,Andhra Pradesh,Andhra Pradesh
@@ -3008,14 +3008,14 @@ DocType: DocType,Allow Rename,Permettre le Renommage
 DocType: Activity Log,Full Name,Nom Complet
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,Nom du filtre en double
 DocType: Chat Room User,Chat Room User,Utilisateur de la salle de conversation
-apps/frappe/frappe/model/workflow.py,Workflow State not set,L&#39;état du workflow n&#39;est pas défini
-DocType: Google Calendar,Authorize Google Calendar Access,Autoriser l&#39;accès à Google Agenda
+apps/frappe/frappe/model/workflow.py,Workflow State not set,L'état du workflow n'est pas défini
+DocType: Google Calendar,Authorize Google Calendar Access,Autoriser l'accès à Google Agenda
 apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,La page que vous recherchez est manquante. Cela pourrait être dû au fait qu’elle a été déplacée ou il y a une faute de frappe dans le lien.
 apps/frappe/frappe/www/404.html,Error Code: {0},Code d'erreur : {0}
 DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Texte de description pour l'affichage en liste, quelques lignes seulement. (Max 140 caractères)"
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} are mandatory fields,{0} sont des champs obligatoires
-DocType: Workflow,Allow Self Approval,Autoriser l&#39;auto-approbation
-DocType: Event,Event Category,Catégorie d&#39;événement
+DocType: Workflow,Allow Self Approval,Autoriser l'auto-approbation
+DocType: Event,Event Category,Catégorie d'événement
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,John Doe,John Doe
 DocType: DocType,Name Case,Casse du Nom
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with everyone,Partagé avec tout le monde
@@ -3111,7 +3111,7 @@ DocType: Dashboard Chart,Chart Type,Type de graphique
 DocType: DocType,Auto Name,Nom Auto
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Évitez les séquences comme abc ou 6543 car elles sont faciles à deviner
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Veuillez réessayer
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',L&#39;URL doit commencer par &#39;http: //&#39; ou &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',L'URL doit commencer par 'http: //' ou 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Option 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Modifier
@@ -3119,7 +3119,7 @@ DocType: Website Settings,Chat Operators,Opérateurs du Chat
 DocType: S3 Backup Settings,ca-central-1,ca-central-1
 DocType: Contact Us Settings,Pincode,Code Postal
 apps/frappe/frappe/core/doctype/data_import/importer.py,Please make sure that there are no empty columns in the file.,Veuillez vous assurer qu'il n'y a pas de colonnes vides dans le fichier.
-apps/frappe/frappe/config/settings.py,Tracks milestones on the lifecycle of a document if it undergoes multiple stages.,Suit les jalons du cycle de vie d&#39;un document s&#39;il subit plusieurs étapes.
+apps/frappe/frappe/config/settings.py,Tracks milestones on the lifecycle of a document if it undergoes multiple stages.,Suit les jalons du cycle de vie d'un document s'il subit plusieurs étapes.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Renamed files and replaced code in controllers, please check!","Fichiers renommés et code remplacé dans les contrôleurs, veuillez vérifier!"
 apps/frappe/frappe/utils/oauth.py,Please ensure that your profile has an email address,Veuillez vous assurer que votre profil a une adresse email
 apps/frappe/frappe/public/js/frappe/model/create_new.js,You have unsaved changes in this form. Please save before you continue.,Vous avez des modifications non enregistrées dans ce formulaire. Veuillez enregistrer avant de continuer.
@@ -3136,15 +3136,15 @@ apps/frappe/frappe/config/integrations.py,Google Services,Services Google
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Up,Ctrl + Haut
 apps/frappe/frappe/utils/data.py,1 weeks ago,Il y a 1 semaine
 DocType: Communication,Error,Erreur
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Please setup a message first,Veuillez d&#39;abord configurer un message
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Please setup a message first,Veuillez d'abord configurer un message
 DocType: Auto Repeat,End Date,Date de Fin
-DocType: Data Import,Ignore encoding errors,Ignorer les erreurs d&#39;encodage
+DocType: Data Import,Ignore encoding errors,Ignorer les erreurs d'encodage
 DocType: Chat Profile,Notifications,Notifications
 DocType: DocField,Column Break,Saut de Colonne
 DocType: Assignment Rule Day,Thursday,Jeudi
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough review points,Vous n&#39;avez pas assez de points d&#39;examen
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough review points,Vous n'avez pas assez de points d'examen
 apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Vous n'avez pas l'autorisation d'accéder à ce fichier
-apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Enregistrer l&#39;API Secret:
+apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Enregistrer l'API Secret:
 apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},Impossible de lier le document annulé : {0}
 apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,Modification du rapport standard impossible. Veuillez le dupliquer et créer un nouveau rapport
 apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Société est obligatoire, car il s'agit de l'adresse de société"
@@ -3162,10 +3162,10 @@ DocType: Domain,Domain,Domaine
 DocType: Custom Field,Label Help,Aide d’Étiquette
 DocType: Workflow State,star-empty,étoile-vide
 apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,Les Dates sont souvent faciles à deviner.
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Google Contacts - Impossible de synchroniser les contacts depuis Google Contacts {0}, code d&#39;erreur {1}."
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Google Contacts - Impossible de synchroniser les contacts depuis Google Contacts {0}, code d'erreur {1}."
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Next actions,Prochaines actions
 apps/frappe/frappe/email/doctype/notification/notification.py,"Cannot edit Standard Notification. To edit, please disable this and duplicate it","Impossible de modifier une notification standard. Pour l'éditer, veuillez la désactiver et la dupliquer"
-apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,Courriel du code de vérification non envoyé. S&#39;il vous plaît contacter l&#39;administrateur.
+apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,Courriel du code de vérification non envoyé. S'il vous plaît contacter l'administrateur.
 DocType: Workflow State,ok,ok
 DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Ces valeurs seront automatiquement mises à jour dans les transactions et sera également utile pour restreindre les autorisations pour cet utilisateur sur les transactions contenant ces valeurs.
 apps/frappe/frappe/twofactor.py,Verfication Code,Code de Vérification
@@ -3184,7 +3184,7 @@ DocType: Data Import,If you are updating/overwriting already created records.,Si
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Is Global,Est Global
 DocType: Email Account,Use SSL,Utiliser SSL
 DocType: Workflow State,play-circle,cercle-jouer
-apps/frappe/frappe/public/js/frappe/views/interaction.js,The document could not be correctly assigned,Le document n&#39;a pas pu être attribué correctement
+apps/frappe/frappe/public/js/frappe/views/interaction.js,The document could not be correctly assigned,Le document n'a pas pu être attribué correctement
 apps/frappe/frappe/public/js/frappe/form/layout.js,"Invalid ""depends_on"" expression","Expression ""depends_on"" non valide"
 DocType: Communication,Keeps track of all communications,Garder une trace de toutes les communications
 apps/frappe/frappe/public/js/frappe/chat.js,Group Name,Nom de groupe
@@ -3230,7 +3230,7 @@ apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Submitted Document cann
 DocType: Assignment Rule,Assignment Days,Jours de mission
 apps/frappe/frappe/desk/reportview.py,Deleting {0},Suppression de {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Select an existing format to edit or start a new format.,Sélectionner un format existant pour le modifier ou pour démarrer un nouveau format.
-DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,Ignorer la vérification de l&#39;adresse IP restreinte si l&#39;authentification à deux facteurs est activée
+DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,Ignorer la vérification de l'adresse IP restreinte si l'authentification à deux facteurs est activée
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Created Custom Field {0} in {1},Crée un Champ Personnalisé {0} dans {1}
 DocType: System Settings,Time Zone,Fuseau Horaire
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Special Characters are not allowed,Les Caractères Spéciaux ne sont pas autorisés
@@ -3240,7 +3240,7 @@ DocType: Email Account,uidnext,uidnext
 DocType: User,Redirect URL,URL de Redirection
 DocType: SMS Settings,Enter url parameter for receiver nos,Entrez le paramètre url pour le nombre de destinataires
 DocType: Chat Profile,Online,En Ligne
-DocType: Email Account,Always use Account's Name as Sender's Name,Toujours utiliser le nom du compte comme nom de l&#39;expéditeur
+DocType: Email Account,Always use Account's Name as Sender's Name,Toujours utiliser le nom du compte comme nom de l'expéditeur
 apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,Seul l'Administrateur peut supprimer la File d'Attente d' Emails
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Setting this Address Template as default as there is no other default,"Définition de ce Modèle d'Adresse par défaut, car il n'y a pas d'autre défaut"
 DocType: Workflow State,Home,Accueil
@@ -3250,16 +3250,16 @@ DocType: Workflow State,question-sign,point-interrogation
 apps/frappe/frappe/model/base_document.py,{0} is disabled,{0} est désactivé
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",Le champ &quot;route&quot; est obligatoire pour les vues Web
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Insert Column Before {0},Insérer une colonne avant {0}
-DocType: Energy Point Rule,The user from this field will be rewarded points,L&#39;utilisateur de ce champ recevra des points
+DocType: Energy Point Rule,The user from this field will be rewarded points,L'utilisateur de ce champ recevra des points
 DocType: Assignment Rule,Close Condition,Condition proche
 DocType: Dropbox Settings,Number of DB Backups,Nombre de sauvegardes de la base de données
 DocType: Email Account,Add Signature,Ajouter une Signature
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Left this conversation,A quitté cette conversation
 DocType: Print Format,Raw Printing,Impression brute
 ,Background Jobs,Travaux en Arrière-plan
-apps/frappe/frappe/public/js/frappe/form/print.js,Printer Settings,Paramètres de l&#39;imprimante
+apps/frappe/frappe/public/js/frappe/form/print.js,Printer Settings,Paramètres de l'imprimante
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py,Time series based on is required to create a dashboard chart,Une série chronologique basée sur est requise pour créer un graphique de tableau de bord
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,Energy Points: ,Points d&#39;énergie:
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,Energy Points: ,Points d'énergie:
 DocType: ToDo,ToDo,ToDo
 DocType: DocField,No Copy,Aucune Copie
 DocType: Workflow State,qrcode,qrcode
@@ -3291,16 +3291,16 @@ apps/frappe/frappe/config/website.py,Knowledge Base,Base de Connaissances
 DocType: Workflow State,briefcase,malette (briefcase)
 apps/frappe/frappe/model/document.py,Value cannot be changed for {0},Valeur ne peut pas être modifiée pour {0}
 DocType: Workflow State,"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange","Style représente la couleur du bouton : Succès - Vert, Danger - Rouge, Inverse - Noir, Primaire - Bleu Foncé, Info - Bleu Clair, Avertissement - Orange"
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Cette demande n&#39;a pas encore été approuvée par l&#39;utilisateur.
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Cette demande n'a pas encore été approuvée par l'utilisateur.
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Please Install the ldap3 library via pip to use ldap functionality.,Veuillez installer la bibliothèque ldap3 via pip pour utiliser la fonctionnalité ldap.
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,État de la ligne
 DocType: S3 Backup Settings,sa-east-1,sa-est-1
 DocType: Workflow Transition,Workflow Transition,Transition du Flux de Travail
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,Il y a {0} mois
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Les champs personnalisés ne peuvent être ajoutés qu&#39;à un DocType standard.
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Les champs personnalisés ne peuvent être ajoutés qu'à un DocType standard.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Created By,Établi par
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Paramétrage Dropbox
-DocType: Assignment Rule Day,Assignment Rule Day,Jour de règle d&#39;affectation
+DocType: Assignment Rule Day,Assignment Rule Day,Jour de règle d'affectation
 DocType: Workflow State,resize-horizontal,redimensionner-horizontalement
 apps/frappe/frappe/templates/emails/download_data.html,Download Link,Lien de téléchargement
 DocType: Chat Message,Content,Contenu
@@ -3312,7 +3312,7 @@ DocType: Contact Phone,Contact Phone,Numéro du contact
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} appreciated {1},{0} apprécié {1}
 DocType: Milestone,Document,Document
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Series {0} already used in {1},Séries {0} déjà utilisé dans {1}
-apps/frappe/frappe/core/doctype/data_import/importer.py,Unsupported File Format,Ce format de fichier n&#39;est pas supporté
+apps/frappe/frappe/core/doctype/data_import/importer.py,Unsupported File Format,Ce format de fichier n'est pas supporté
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray...,Tenter de lancer QZ Tray ...
 DocType: Assignment Rule,Example: {{ subject }},Exemple: {{sujet}}
 DocType: DocField,Code,Code
@@ -3331,13 +3331,13 @@ apps/frappe/frappe/model/meta.py,No Label,Pas d'Étiquette
 DocType: System Settings,Use socketio to upload file,Utilisez socketio pour télécharger le fichier
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Refreshing,Rafraîchissant
 apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.js,Modified By,Modifié Par
-apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specified,Adresse e-mail d&#39;assistance non spécifiée
+apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specified,Adresse e-mail d'assistance non spécifiée
 DocType: Energy Point Log,Criticism,Critique
 DocType: Address,Tripura,Tripura
 DocType: About Us Settings,"""Company History""","""Historique de la Société"""
-apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Ce document a été modifié après l&#39;envoi de l&#39;e-mail.
-DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","Si cette case est cochée, ce champ ne sera pas écrasé en fonction de l&#39;extraction de si une valeur existe déjà."
-DocType: Access Log,Show Report,Rapport d&#39;émission
+apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Ce document a été modifié après l'envoi de l'e-mail.
+DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","Si cette case est cochée, ce champ ne sera pas écrasé en fonction de l'extraction de si une valeur existe déjà."
+DocType: Access Log,Show Report,Rapport d'émission
 DocType: Address,Tamil Nadu,Tamil Nadu
 DocType: Email Rule,Email Rule,Règle Email
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with everyone,{0} partagé ce document avec tout le monde
@@ -3349,7 +3349,7 @@ apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translate {0},T
 DocType: Notification,Send alert if this field's value changes,Envoyer une alerte si la valeur de ce champ change
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Couleurs Thématiques
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Sélectionner un DocType pour faire un nouveau format
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,L&#39;utilisateur n&#39;existe pas
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,L'utilisateur n'existe pas
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,«Destinataires» non spécifiés
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,juste maintenant
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Choisir
@@ -3377,7 +3377,7 @@ apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are updating, pl
 DocType: DocField,Translatable,Traduisible
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Syncing {0} of {1},Synchroniser {0} sur {1}
 DocType: Letter Head,Letter Head in HTML,En-Tête en HTML
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,User Profile,Profil de l&#39;utilisateur
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,User Profile,Profil de l'utilisateur
 DocType: Web Form,Web Form,Formulaire Web
 apps/frappe/frappe/public/js/frappe/form/controls/date.js,Date {0} must be in format: {1},La date {0} doit être au format: {1}
 DocType: About Us Settings,Org History Heading,Rubriques Histoire Org
@@ -3412,7 +3412,7 @@ apps/frappe/frappe/desk/query_report.py,{0} saved successfully,{0} enregistré a
 apps/frappe/frappe/desk/form/utils.py,No further records,Pas d'autre enregistrements
 DocType: DocField,Long Text,Texte Long
 DocType: Workflow State,Primary,Primaire
-DocType: User,Home Settings,Paramètres d&#39;accueil
+DocType: User,Home Settings,Paramètres d'accueil
 apps/frappe/frappe/core/doctype/data_import/importer.py,Please do not change the rows above {0},Veuillez ne pas modifier les lignes ci-dessus {0}
 DocType: Web Form,Go to this URL after completing the form (only for Guest users),Accéder à cette URL après avoir rempli le formulaire (uniquement pour les utilisateurs invités)
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,(Ctrl + G),(Ctrl + G)
@@ -3476,7 +3476,7 @@ DocType: Contact Phone,Is Primary Mobile,Est le mobile primaire
 DocType: Workflow Document State,Workflow Document State,État du Document du Flux de Travail
 apps/frappe/frappe/public/js/frappe/request.js,File too big,Fichier trop grand
 apps/frappe/frappe/core/doctype/user/user.py,Email Account added multiple times,Compte Email ajouté plusieurs fois
-DocType: Energy Point Settings,Last Point Allocation Date,Date d&#39;attribution du dernier point
+DocType: Energy Point Settings,Last Point Allocation Date,Date d'attribution du dernier point
 DocType: Payment Gateway,Payment Gateway,Passerelle de Paiement
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} appreciated your work on {1} with {2} point,{0} a apprécié votre travail sur {1} avec {2} points
 DocType: Milestone Tracker,Field to Track,Champ à suivre
@@ -3489,14 +3489,14 @@ apps/frappe/frappe/www/printview.py,Print Format {0} is disabled,Le Format d'Imp
 ,Address and Contacts,Adresse et Contacts
 DocType: Notification,Send days before or after the reference date,Envoyer jours avant ou après la date de référence
 DocType: User,Allow user to login only after this hour (0-24),Autoriser l'utilisateur à se connecter seulement après cette heure (0-24)
-apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,"Assign one by one, in sequence","Attribuer un par un, dans l&#39;ordre"
-DocType: Integration Request,Subscription Notification,Notification d&#39;abonnement
+apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,"Assign one by one, in sequence","Attribuer un par un, dans l'ordre"
+DocType: Integration Request,Subscription Notification,Notification d'abonnement
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,or attach a,ou attacher un
 DocType: Auto Repeat,Start Date,Date de Début
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Value,Valeur
 DocType: Dashboard Chart,Filters JSON,Filtres JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Cliquez ici pour vérifier
-DocType: Email Account,Disable SMTP server authentication,Désactiver l&#39;authentification du serveur SMTP
+DocType: Email Account,Disable SMTP server authentication,Désactiver l'authentification du serveur SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Copié dans le presse-papier.
 apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Les substitutions prévisibles comme '@' au lieu de 'a' n’aident pas beaucoup.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Assigné par moi
@@ -3520,13 +3520,13 @@ apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Saving...,Sauvegarde en 
 apps/frappe/frappe/www/update-password.html,Invalid Password,Mot de Passe Invalide
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record out of {1}.,Enregistrement {0} importé avec succès sur {1}.
 DocType: Contact,Purchase Master Manager,Responsable des Données d’Achats
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the lock icon to toggle public/private,Cliquez sur l&#39;icône de cadenas pour basculer entre public et privé.
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the lock icon to toggle public/private,Cliquez sur l'icône de cadenas pour basculer entre public et privé.
 DocType: Module Def,Module Name,Nom du Module
 DocType: S3 Backup Settings,eu-west-3,eu-west-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},Téléchargement de {0} sur {1}
 DocType: DocType,DocType is a Table / Form in the application.,DocType est un Tableau / Formulaire dans l'application.
-DocType: Social Login Key,Authorize URL,Autoriser l&#39;URL
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Agenda - Impossible d&#39;extraire l&#39;événement de Google Agenda, code d&#39;erreur {0}."
+DocType: Social Login Key,Authorize URL,Autoriser l'URL
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Agenda - Impossible d'extraire l'événement de Google Agenda, code d'erreur {0}."
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failed,La répétition automatique de la création de document a échoué
 DocType: Email Account,GMail,GMail
 DocType: Letter Head,Letter Head Image,Image en tête de lettre
@@ -3543,12 +3543,12 @@ DocType: Address,GST State Number,GST Numéro d'État
 DocType: Chat Message,Visitor,Visiteur
 DocType: User,Allow user to login only before this hour (0-24),Autoriser l'utilisateur à se connecter seulement après cette heure (0-24)
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"Drag and drop files, ","Glisser-déposer des fichiers,"
-DocType: Social Login Key,Access Token URL,URL du jeton d&#39;accès
+DocType: Social Login Key,Access Token URL,URL du jeton d'accès
 apps/frappe/frappe/config/integrations.py,Google Drive Backup.,Sauvegarde Google Drive.
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} assigned {1}: {2},{0} a assigné {1}: {2}
 apps/frappe/frappe/www/contact.py,New Message from Website Contact Page,Nouveau Message depuis la Page Contact du Site Web
 DocType: Notification,Reference Date,Date de Référence
-apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,La configuration d&#39;OTP à l&#39;aide d&#39;OTP App n&#39;était pas terminée. S&#39;il vous plaît contacter l&#39;administrateur.
+apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,La configuration d'OTP à l'aide d'OTP App n'était pas terminée. S'il vous plaît contacter l'administrateur.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Veuillez entrer des N° de mobiles valides
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Certaines des fonctionnalités peuvent ne pas fonctionner dans votre navigateur. Veuillez mettre à jour votre navigateur vers la dernière version.
 apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Vous ne savez pas, demandez de l’ ‘aide’"
@@ -3577,21 +3577,21 @@ DocType: Webhook,on_cancel,on_cancel
 DocType: Social Login Key,API Endpoint Args,Args de paramètres API
 apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,L'administrateur a accedé à {0} sur {1} avec l'Adresse IP {2}.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid fieldname,Le champ parent doit être un nom de champ valide
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Échec lors de la modification de l&#39;abonnement
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Échec lors de la modification de l'abonnement
 DocType: LDAP Settings,LDAP Group Field,Champ de groupe LDAP
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Égal à
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Les champs de type Options 'Lien Dynamique' doivent pointer vers un autre Champ Lié avec 'Doctype' pour options
 DocType: About Us Settings,Team Members Heading,Titre des Membres de l’Équipe
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Format CSV Invalide
-apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Erreur de connexion à l&#39;application QZ Tray ... <br><br> L&#39;application QZ Tray doit être installée et en cours d&#39;exécution pour que vous puissiez utiliser la fonction d&#39;impression brute. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Cliquez ici pour télécharger et installer QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Cliquez ici pour en savoir plus sur l&#39;impression brute</a> ."
+apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Erreur de connexion à l'application QZ Tray ... <br><br> L'application QZ Tray doit être installée et en cours d'exécution pour que vous puissiez utiliser la fonction d'impression brute. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Cliquez ici pour télécharger et installer QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Cliquez ici pour en savoir plus sur l'impression brute</a> ."
 apps/frappe/frappe/desk/page/backups/backups.js,Set Number of Backups,Définir Nombre de Sauvegardes
 DocType: DocField,Do not allow user to change after set the first time,Ne pas permettre à l'utilisateur de changer après avoir défini le premier paramétrage
 apps/frappe/frappe/utils/data.py,1 year ago,Il y a 1 an
-apps/frappe/frappe/config/users_and_permissions.py,"View Log of all print, download and export events","Voir le journal de tous les événements d&#39;impression, de téléchargement et d&#39;exportation"
+apps/frappe/frappe/config/users_and_permissions.py,"View Log of all print, download and export events","Voir le journal de tous les événements d'impression, de téléchargement et d'exportation"
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 month,1 mois
 DocType: Contact,Contact,Contact
 DocType: User,Third Party Authentication,Authentification Tierce
-apps/frappe/frappe/public/js/frappe/form/print.js,No Printer is Available.,Aucune imprimante n&#39;est disponible.
+apps/frappe/frappe/public/js/frappe/form/print.js,No Printer is Available.,Aucune imprimante n'est disponible.
 DocType: Website Settings,Banner is above the Top Menu Bar.,La Bannière est au-dessus de la Barre de Menu Supérieure.
 DocType: User,API Secret,Secret API
 DocType: Blog Post,Content Type,Type de Contenu
@@ -3620,7 +3620,7 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.js,This docu
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive Backup Successful.,Sauvegarde de Google Drive réussie.
 DocType: Workflow,DocType on which this Workflow is applicable.,DocType pour lequel ce Flux de Travail est applicable.
 DocType: User,Enabled,Activé
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,Échec de l&#39;installation
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,Échec de l'installation
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,New {0}: {1},Nouveau {0}: {1}
 DocType: Tag Category,Category Name,Nom de la Catégorie
 apps/frappe/frappe/model/db_query.py,Parent is required to get child table data,Le parent est requis pour obtenir les données de la table enfant
@@ -3628,11 +3628,11 @@ apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Subscribers,I
 DocType: Print Settings,PDF Settings,Paramètres PDF
 DocType: Kanban Board Column,Column Name,Nom de la Colonne
 DocType: Language,Based On,Basé Sur
-DocType: Email Account,"For more information, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">click here</a>.","Pour plus d&#39;informations, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">cliquez ici</a> ."
+DocType: Email Account,"For more information, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">click here</a>.","Pour plus d'informations, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">cliquez ici</a> ."
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Number of columns does not match with data,Le nombre de colonnes ne correspond pas aux données
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Make Default,Rendre Défaut
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Execution Time: {0} sec,Temps d&#39;exécution: {0} s
-apps/frappe/frappe/model/utils/__init__.py,Invalid include path,Chemin d&#39;inclusion non valide
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Execution Time: {0} sec,Temps d'exécution: {0} s
+apps/frappe/frappe/model/utils/__init__.py,Invalid include path,Chemin d'inclusion non valide
 DocType: Communication,Email Account,Compte Email
 DocType: Workflow State,Download,Télécharger
 DocType: Blog Post,Blog Intro,Intro du Blog
@@ -3735,7 +3735,7 @@ DocType: Property Setter,Set Value,Définir la Valeur
 DocType: Webhook,Webhook Data,Données Webhook
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Creating {0},Création de {0}
 DocType: Report,Disable Prepared Report,Désactiver le rapport préparé
-apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,L&#39;utilisateur {0} a demandé la suppression des données.
+apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,L'utilisateur {0} a demandé la suppression des données.
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,Jeton d'Accès Invalide. Veuillez réessayer
 apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","L'application a été mise à jour vers une nouvelle version, veuillez rafraîchir cette page"
 DocType: Notification,Optional: The alert will be sent if this expression is true,Optionel : L'alerte sera envoyée si cette expression est vraie
@@ -3744,12 +3744,12 @@ DocType: Print Settings,Print with letterhead,Imprimer avec en-tête
 apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,Attach a web link,Joindre un lien Web
 DocType: Unhandled Email,Raw Email,Email Brut
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select records for assignment,Sélectionner les dossiers pour attribution
-apps/frappe/frappe/www/printview.py,{0} is not a raw printing format.,{0} n&#39;est pas un format d&#39;impression brut.
+apps/frappe/frappe/www/printview.py,{0} is not a raw printing format.,{0} n'est pas un format d'impression brut.
 DocType: ToDo,Assigned By,Attribué Par
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,You can use Customize Form to set levels on fields.,Vous pouvez utiliser Personaliser le Formulaire pour définir les niveaux de champs.
 DocType: Dashboard Chart Source,Timeseries,Des séries chronologiques
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Select Your Region,Sélectionnez Votre Région
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} appreciation point for {1} {2},{0} point d&#39;appréciation pour {1} {2}
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} appreciation point for {1} {2},{0} point d'appréciation pour {1} {2}
 DocType: S3 Backup Settings,cn-northwest-1,cn-nord-ouest-1
 DocType: Dropbox Settings,Limit Number of DB Backups,Nombre limite de sauvegardes de base de données
 DocType: Custom DocPerm,Level,Niveau
@@ -3765,7 +3765,7 @@ apps/frappe/frappe/config/desk.py,Email Group List,Liste des Groupes Email
 DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],Un fichier d'icône avec l’extension .ico. Devrait être 16 x 16 px. Générer en utilisant un générateur de favicon. [favicon-generator.org]
 DocType: Auto Email Report,Format,Format
 DocType: Email Account,Email Addresses,Adresse Email
-DocType: Web Form,Allow saving if mandatory fields are not filled,Autoriser l&#39;enregistrement si les champs obligatoires ne sont pas remplis
+DocType: Web Form,Allow saving if mandatory fields are not filled,Autoriser l'enregistrement si les champs obligatoires ne sont pas remplis
 DocType: S3 Backup Settings,us-west-2,us-west-2
 apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Select Child Table,Sélectionnez la table des enfants
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Trigger Primary Action,Action primaire de déclenchement
@@ -3827,7 +3827,7 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,text in document t
 apps/frappe/frappe/core/doctype/test_runner/test_runner.js,Run Tests,Exécuter les Tests
 apps/frappe/frappe/handler.py,Logged Out,Déconnecté
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,More...,Plus...
-DocType: System Settings,User can login using Email id or Mobile number,L&#39;utilisateur peut se connecter en utilisant l&#39;identifiant de messagerie ou le numéro de téléphone mobile
+DocType: System Settings,User can login using Email id or Mobile number,L'utilisateur peut se connecter en utilisant l'identifiant de messagerie ou le numéro de téléphone mobile
 DocType: Bulk Update,Update Value,Mettre à Jour la valeur
 apps/frappe/frappe/core/doctype/communication/communication.js,Mark as {0},Marquer comme {0}
 apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,Veuillez sélectionner un nouveau nom pour renommer
@@ -3838,7 +3838,7 @@ apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Something went 
 DocType: System Settings,Number Format,Format Numérique
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record.,{0} enregistrement importé avec succès.
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Summary,Résumé
-DocType: Event,Event Participants,Participants à l&#39;événement
+DocType: Event,Event Participants,Participants à l'événement
 DocType: Auto Repeat,Frequency,Fréquence
 DocType: Custom Field,Insert After,Insérer Après
 DocType: Event,Sync with Google Calendar,Synchroniser avec Google Agenda
@@ -3846,18 +3846,18 @@ DocType: Access Log,Report Name,Nom du Rapport
 DocType: Desktop Icon,Reverse Icon Color,Inverser la Couleur de l'Icône
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Save,Enregistrer
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat_schedule.html,Next Scheduled Date,Prochaine date prévue
-apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,Assign to the one who has the least assignments,Attribuer à celui qui a le moins d&#39;affectations
+apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,Assign to the one who has the least assignments,Attribuer à celui qui a le moins d'affectations
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Section Heading,Titre de la Section
 DocType: Website Settings,Title Prefix,Préfixe de Titre
 DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,Les Notifications et Lots d’Emails seront envoyés à partir de ce serveur sortant.
-DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,Tous les langages d&#39;impression basés sur des chaînes peuvent être utilisés. L&#39;écriture de commandes brutes nécessite la connaissance de la langue maternelle de l&#39;imprimante fournie par le fabricant de l&#39;imprimante. Veuillez vous reporter au manuel du développeur fourni par le fabricant de l’imprimante pour savoir comment écrire leurs commandes natives. Ces commandes sont rendues côté serveur à l&#39;aide du langage de templates Jinja.
+DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,Tous les langages d'impression basés sur des chaînes peuvent être utilisés. L'écriture de commandes brutes nécessite la connaissance de la langue maternelle de l'imprimante fournie par le fabricant de l'imprimante. Veuillez vous reporter au manuel du développeur fourni par le fabricant de l’imprimante pour savoir comment écrire leurs commandes natives. Ces commandes sont rendues côté serveur à l'aide du langage de templates Jinja.
 DocType: Workflow State,cog,dent
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Sync on Migrate,Sync sur Migration
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently Viewing,Affichage Actuel
 DocType: DocField,Default,Par Défaut
 DocType: Translation,Verified,Vérifié
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} ajouté(e)
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Rechercher &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Rechercher '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Veuillez d’abord enregistrer le rapport
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonnés ajoutés
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Non Inclus
@@ -3886,20 +3886,20 @@ apps/frappe/frappe/desk/moduleview.py,Standard Reports,Rapports Standard
 DocType: Dashboard Chart Link,Dashboard Chart Link,Lien de tableau de bord
 DocType: User,Email Settings,Paramètres d'Email
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop Here,Déposer ici
-DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Si cette option est activée, l&#39;utilisateur peut se connecter à partir de n&#39;importe quelle adresse IP à l&#39;aide de l&#39;authentification à deux facteurs. Cette option peut également être définie pour tous les utilisateurs dans les paramètres système."
-apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Printer Settings...,Paramètres de l&#39;imprimante ...
+DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Si cette option est activée, l'utilisateur peut se connecter à partir de n'importe quelle adresse IP à l'aide de l'authentification à deux facteurs. Cette option peut également être définie pour tous les utilisateurs dans les paramètres système."
+apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Printer Settings...,Paramètres de l'imprimante ...
 apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Veuillez Entrer votre Mot de Passe pour Continuer
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Moi
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} pas un État valide
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Appliquer à tous les types de documents
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Point d&#39;énergie
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Point d'énergie
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Veuillez choisir un autre mode de paiement. PayPal ne supporte pas les transactions en monnaie ‘{0}’
 DocType: Chat Message,Room Type,Type de chambre
-DocType: Data Import Beta,Import Log Preview,Importer l&#39;aperçu du journal
+DocType: Data Import Beta,Import Log Preview,Importer l'aperçu du journal
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Champ de recherche {0} n'est pas valide
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,fichier téléchargé
 DocType: Workflow State,ok-circle,ok-cercle
-DocType: LDAP Settings,LDAP User Creation and Mapping,Création et mappage d&#39;utilisateurs LDAP
+DocType: LDAP Settings,LDAP User Creation and Mapping,Création et mappage d'utilisateurs LDAP
 apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Vous pouvez trouver des choses en demandant 'trouver orange dans clients'
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Désolé ! Les utilisateurs devraient avoir un accès complet à leur propre dossier.
 ,Usage Info,Infos d'Usage
@@ -3931,10 +3931,10 @@ DocType: GCalendar Settings,Enable,Activer
 DocType: Google Maps Settings,Home Address,Adresse du Domicile
 apps/frappe/frappe/core/doctype/data_export/exporter.py,You can only upload upto 5000 records in one go. (may be less in some cases),Vous pouvez seulement charger jusqu'à 5000 enregistrement en une seule fois. (peut-être moins dans certains cas)
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Applicable Document Types,Types de documents applicables
-apps/frappe/frappe/config/settings.py,Set up rules for user assignments.,Définissez des règles pour les affectations d&#39;utilisateurs.
+apps/frappe/frappe/config/settings.py,Set up rules for user assignments.,Définissez des règles pour les affectations d'utilisateurs.
 apps/frappe/frappe/model/document.py,Insufficient Permission for {0},Autorisation Insuffisante Pour {0}
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Report was not saved (there were errors),Le Rapport n'a pas été sauvegardé (il y a eu des erreurs)
-apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,Impossible de changer le contenu de l&#39;en-tête
+apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,Impossible de changer le contenu de l'en-tête
 DocType: Print Settings,Print Style,Style d'Impression
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not Linked to any record,Lié à aucun enregistrement
 DocType: Custom DocPerm,Import,Importer
@@ -3945,7 +3945,7 @@ DocType: Communication,To and CC,Pour et CC
 DocType: SMS Settings,Static Parameters,Paramètres Statiques
 DocType: Chat Message,Room,Chambre
 apps/frappe/frappe/public/js/frappe/change_log.html,updated to {0},mis à jour pour {0}
-apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,Les tâches en arrière-plan ne sont pas en cours d&#39;exécution. S&#39;il vous plaît contacter l&#39;administrateur
+apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,Les tâches en arrière-plan ne sont pas en cours d'exécution. S'il vous plaît contacter l'administrateur
 DocType: Portal Settings,Custom Menu Items,Éléments du Menu Personnalisés
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,Toutes les images jointes au diaporama du site Web doivent être publiques
 DocType: Workflow State,chevron-right,chevron-droit
@@ -3961,9 +3961,9 @@ apps/frappe/frappe/public/js/frappe/form/controls/multiselect_list.js,{0} values
 DocType: DocType,Allow Auto Repeat,Autoriser la répétition automatique
 apps/frappe/frappe/public/js/frappe/form/controls/multiselect_list.js,No values to show,Aucune valeur à afficher
 DocType: Desktop Icon,_doctype,_doctype
-DocType: Communication,Email Template,Modèle d&#39;email
+DocType: Communication,Email Template,Modèle d'email
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record.,{0} enregistrement mis à jour avec succès.
-apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},L&#39;utilisateur {0} n&#39;a pas d&#39;accès au type de document via l&#39;autorisation de rôle pour le document {1}.
+apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},L'utilisateur {0} n'a pas d'accès au type de document via l'autorisation de rôle pour le document {1}.
 apps/frappe/frappe/templates/includes/login/login.js,Both login and password required,Un login et un mot de passe sont requis
 apps/frappe/frappe/model/document.py,Please refresh to get the latest document.,Veuillez actualiser pour obtenir la dernière version du document.
 DocType: User,Security Settings,Paramètres de Sécurité
@@ -3985,16 +3985,16 @@ DocType: Dashboard Chart,Last Week,La semaine dernière
 DocType: System Settings,Bypass Two Factor Auth for users who login from restricted IP Address,Ignorer l'authentification à double facteur pour les utilisateurs qui se connectent à partir d'une adresse IP restreinte
 DocType: Event,Google Calendar,Google Agenda
 apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,{0} pour arrêter de recevoir des emails de ce type
-apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Ouvrez votre application d&#39;authentification sur votre téléphone portable.
+apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Ouvrez votre application d'authentification sur votre téléphone portable.
 apps/frappe/frappe/model/rename_doc.py,merged {0} into {1},fusionné {0} avec {1}
 DocType: System Settings,mm-dd-yyyy,mm-jj-aaaa
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.js,New Connection,Nouvelle Connexion
-apps/frappe/frappe/chat/__init__.py,"Sorry, you're not authorized.","Désolé, vous n&#39;êtes pas autorisé."
+apps/frappe/frappe/chat/__init__.py,"Sorry, you're not authorized.","Désolé, vous n'êtes pas autorisé."
 apps/frappe/frappe/core/doctype/activity_log/feed.py,{0} logged in,{0} connecté
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Make {0},Faire {0}
 DocType: Website Route Redirect,Website Route Redirect,Redirection de route de site Web
 apps/frappe/frappe/templates/emails/new_user.html,Your login id is,Votre id de connexion est
-apps/frappe/frappe/permissions.py,Document Type is not submittable,Le type de document n&#39;est pas soumis
+apps/frappe/frappe/permissions.py,Document Type is not submittable,Le type de document n'est pas soumis
 DocType: OAuth Client,Skip Authorization,Passer autorisation
 DocType: Web Form,Amount Field,Champ du Montant
 DocType: Dropbox Settings,Send Notifications To,Envoyer des Notifications À

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -1412,7 +1412,7 @@ DocType: User,System User,Utilisateur Système
 DocType: Report,Is Standard,Est Standard
 DocType: Desktop Icon,_report,_rapport
 DocType: Dashboard Chart,Full,Complet
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne pas encoder les balises HTML en HTML comme &lt;script> ou tout simplement des caractères comme &lt; ou >, car ils pourraient être utilisés intentionnellement dans ce champ"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ne pas encoder les balises HTML en HTML comme <script> ou tout simplement des caractères comme < ou >, car ils pourraient être utilisés intentionnellement dans ce champ"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} critiqué le {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Exécuter
@@ -1792,7 +1792,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Le pied de page n
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,En Attente
 DocType: System Settings,Allow only one session per user,Autoriser une seule session par utilisateur
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Accueil / Dossier Test 1 / Dossier Test 3
-DocType: Website Settings,&lt;head> HTML,HTML
+DocType: Website Settings,<head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Sélectionner ou glisser sur des intervalles de temps pour créer un nouvel événement.
 DocType: Contact,Contact Details,Coordonnées
 DocType: DocField,In Filter,Dans le Filtre
@@ -2314,7 +2314,7 @@ DocType: LDAP Settings,Path to Server Certificate,Chemin d&#39;accès au certifi
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Pas assez d'autorisations pour voir les liens
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Le Titre de l'Adresse est obligatoire.
 DocType: Google Contacts,Push to Google Contacts,Push to Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML ajouté dans la section   de la page web, utilisé principalement pour la vérification de site et le référencement"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML ajouté dans la section   de la page web, utilisé principalement pour la vérification de site et le référencement"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Rechuté
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,L'article ne peut être ajouté à ses propres descendants
 DocType: Session Default Settings,Session Defaults,Session par défaut
@@ -2433,7 +2433,7 @@ DocType: Workflow State,Warning,Avertissement
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Cela peut être imprimé sur plusieurs pages
 DocType: Data Migration Run,Percent Complete,Pourcentage d'Avancement
 DocType: Tag Category,Tag Category,Catégorie de balise
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pour comparaison, utilisez> 5, &lt;10 ou = 324. Pour les plages, utilisez 5:10 (pour les valeurs entre 5 et 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pour comparaison, utilisez> 5, <10 ou = 324. Pour les plages, utilisez 5:10 (pour les valeurs entre 5 et 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tirez de Google Agenda
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aide
 DocType: User,Login Before,Connexion Jusqu'à
@@ -3073,7 +3073,7 @@ DocType: DocField,Allow on Submit,Autoriser à la Soumission
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Type d'Exception
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Choisir des Colonnes
-DocType: Web Page,Add code as &lt;script>,Ajouter le code en tant que &lt;script>
+DocType: Web Page,Add code as <script>,Ajouter le code en tant que <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Effacer les autorisations utilisateur
 DocType: Webhook,Headers,En-Têtes
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Evénements à venir
@@ -3447,26 +3447,26 @@ DocType: Workflow State,share-alt,part-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},La Queue doit être parmi {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Modèle par défaut </ h4> 
  <p> <a Utilise href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> et tous les champs d'adresse ( y compris les champs personnalisés le cas échéant) sera disponible </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% si address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} 
- {{ville}} & lt; br & gt; 
- {% si l'état%} {{}} Etat & lt; br & gt; {% endif -%} {% if 
- code PIN%} PIN: {{code PIN}} & lt; br & gt; {% endif -%} 
- {{pays}} & lt; br & gt; 
- {% si le téléphone%} Téléphone: {{téléphone}} & lt; br & gt; { % endif -%} 
- {% if télécopieur%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% si email_id%} Email: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% si address_line2%} {{address_line2}} <br> { % endif -%} 
+ {{ville}} <br> 
+ {% si l'état%} {{}} Etat <br> {% endif -%} {% if 
+ code PIN%} PIN: {{code PIN}} <br> {% endif -%} 
+ {{pays}} <br> 
+ {% si le téléphone%} Téléphone: {{téléphone}} <br> { % endif -%} 
+ {% if télécopieur%} Fax: {{fax}} <br> {% endif -%} 
+ {% si email_id%} Email: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Date de début
 DocType: Role,Role Name,Nom du Rôle

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -743,7 +743,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,La sauvegar
 DocType: DocField,In Global Search,Dans la Recherche Globale
 DocType: System Settings,Brute Force Security,"Sécurité contre les attaques de type ""force brute"""
 DocType: Workflow State,indent-left,décaler-gauche
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} année (s)
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} année (s)
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Il est risqué de supprimer ce fichier : {0}. Veuillez contactez votre Administrateur Système.
 DocType: Currency,Currency Name,Nom de la Devise
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Aucun Email
@@ -1037,7 +1037,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Pas de {0} tr
 apps/frappe/frappe/config/customization.py,Add custom forms.,Ajouter des formulaires personnalisés.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0} : {1} à {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,a soumis ce document
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Configuration&gt; Autorisations utilisateur
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configuration> Autorisations utilisateur
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Le système offre de nombreux rôles prédéfinis. Vous pouvez ajouter de nouveaux rôles pour définir des autorisations plus fines .
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1257,7 +1257,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Si l'utilisateur a un rôle quelconque vérifié, il devient un ""Utilisateur Système"". L'""Utilisateur Système"" a accès au bureau"
 DocType: System Settings,Date and Number Format,Format de Date et Nombre
 apps/frappe/frappe/model/document.py,one of,l'un des
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Configuration&gt; Personnaliser le formulaire
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Configuration> Personnaliser le formulaire
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Vérification un moment
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Afficher les balises
 DocType: DocField,HTML Editor,Éditeur HTML
@@ -1265,7 +1265,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Facturation
 DocType: Email Queue,Not Sent,Non Envoyé
 DocType: Web Form,Actions,Actions
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Configuration&gt; Utilisateur
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Configuration> Utilisateur
 DocType: Workflow State,align-justify,aligné-justifié
 DocType: User,Middle Name (Optional),Deuxième Prénom (Optionnel)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Non Autorisé
@@ -1412,7 +1412,7 @@ DocType: User,System User,Utilisateur Système
 DocType: Report,Is Standard,Est Standard
 DocType: Desktop Icon,_report,_rapport
 DocType: Dashboard Chart,Full,Complet
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ne pas encoder les balises HTML en HTML comme &lt;script&gt; ou tout simplement des caractères comme &lt; ou &gt;, car ils pourraient être utilisés intentionnellement dans ce champ"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne pas encoder les balises HTML en HTML comme &lt;script> ou tout simplement des caractères comme &lt; ou >, car ils pourraient être utilisés intentionnellement dans ce champ"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} critiqué le {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Exécuter
@@ -1792,7 +1792,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Le pied de page n
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,En Attente
 DocType: System Settings,Allow only one session per user,Autoriser une seule session par utilisateur
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Accueil / Dossier Test 1 / Dossier Test 3
-DocType: Website Settings,&lt;head&gt; HTML,HTML
+DocType: Website Settings,&lt;head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Sélectionner ou glisser sur des intervalles de temps pour créer un nouvel événement.
 DocType: Contact,Contact Details,Coordonnées
 DocType: DocField,In Filter,Dans le Filtre
@@ -2024,7 +2024,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Connexion non autorisée pour le moment
 DocType: Data Migration Run,Current Mapping Action,Action de cartographie actuelle
 DocType: Dashboard Chart Source,Source Name,Nom de la Source
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Aucun compte de messagerie associé à l&#39;utilisateur. Veuillez ajouter un compte sous Utilisateur&gt; Boîte de réception par courrier électronique.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Aucun compte de messagerie associé à l&#39;utilisateur. Veuillez ajouter un compte sous Utilisateur> Boîte de réception par courrier électronique.
 DocType: Email Account,Email Sync Option,Option de Synchronisation d'Email
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rangée No
 DocType: Async Task,Runtime,Temps d’Exécution
@@ -2039,7 +2039,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Déjà da
 DocType: User Email,Enable Outgoing,Activer Sortant
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Balises personnalisées
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Compte de messagerie non configuré. Veuillez créer un nouveau compte de messagerie depuis Configuration&gt; E-mail&gt; Compte de messagerie
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Compte de messagerie non configuré. Veuillez créer un nouveau compte de messagerie depuis Configuration> E-mail> Compte de messagerie
 DocType: Comment,Submitted,Soumis
 DocType: Contact,Pulled from Google Contacts,Tiré de Google Contacts
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Requête invalide
@@ -2111,7 +2111,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Delai d'Expiration 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Ce champ apparaît uniquement si le nom de champ défini ici a une valeur OU les règles sont vérifiées.
+eval:doc.age>18",Ce champ apparaît uniquement si le nom de champ défini ici a une valeur OU les règles sont vérifiées.
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Aujourd'hui
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Une fois que vous avez défini ceci, les utilisateurs ne pourront accèder qu'aux documents (e.g. Article de Blog) où le lien existe (e.g. Blogger) ."
@@ -2125,7 +2125,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,MAJUSCULE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML Personnalisé
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Entrez le nom du dossier
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Aucun modèle d&#39;adresse par défaut trouvé. Veuillez en créer un nouveau depuis Configuration&gt; Impression et création de marque&gt; Modèle d&#39;adresse.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Aucun modèle d&#39;adresse par défaut trouvé. Veuillez en créer un nouveau depuis Configuration> Impression et création de marque> Modèle d&#39;adresse.
 apps/frappe/frappe/auth.py,Unknown User,Utilisateur Inconnu
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Sélectionner le Rôle
 DocType: Comment,Deleted,Supprimé
@@ -2314,7 +2314,7 @@ DocType: LDAP Settings,Path to Server Certificate,Chemin d&#39;accès au certifi
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Pas assez d'autorisations pour voir les liens
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Le Titre de l'Adresse est obligatoire.
 DocType: Google Contacts,Push to Google Contacts,Push to Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML ajouté dans la section   de la page web, utilisé principalement pour la vérification de site et le référencement"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML ajouté dans la section   de la page web, utilisé principalement pour la vérification de site et le référencement"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Rechuté
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,L'article ne peut être ajouté à ses propres descendants
 DocType: Session Default Settings,Session Defaults,Session par défaut
@@ -2433,7 +2433,7 @@ DocType: Workflow State,Warning,Avertissement
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Cela peut être imprimé sur plusieurs pages
 DocType: Data Migration Run,Percent Complete,Pourcentage d'Avancement
 DocType: Tag Category,Tag Category,Catégorie de balise
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pour comparaison, utilisez&gt; 5, &lt;10 ou = 324. Pour les plages, utilisez 5:10 (pour les valeurs entre 5 et 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pour comparaison, utilisez> 5, &lt;10 ou = 324. Pour les plages, utilisez 5:10 (pour les valeurs entre 5 et 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tirez de Google Agenda
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aide
 DocType: User,Login Before,Connexion Jusqu'à
@@ -2895,7 +2895,7 @@ DocType: Custom Script,Custom Script,Script Personnalisé
 DocType: Address,Address Line 2,Adresse Ligne 2
 DocType: Address,Reference,Référence
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Assigné À
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Veuillez configurer le compte de messagerie par défaut à partir de Configuration&gt; E-mail&gt; Compte de messagerie
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Veuillez configurer le compte de messagerie par défaut à partir de Configuration> E-mail> Compte de messagerie
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Détail du Mapping de Migration de Données
 DocType: Data Import,Action,Action
 DocType: GSuite Settings,Script URL,URL du Script
@@ -3073,7 +3073,7 @@ DocType: DocField,Allow on Submit,Autoriser à la Soumission
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Type d'Exception
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Choisir des Colonnes
-DocType: Web Page,Add code as &lt;script&gt;,Ajouter le code en tant que &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Ajouter le code en tant que &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Effacer les autorisations utilisateur
 DocType: Webhook,Headers,En-Têtes
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Evénements à venir
@@ -3447,15 +3447,15 @@ DocType: Workflow State,share-alt,part-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},La Queue doit être parmi {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Modèle par défaut </ h4> 
  <p> <a Utilise href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> et tous les champs d'adresse ( y compris les champs personnalisés le cas échéant) sera disponible </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/fr_ca.csv
+++ b/frappe/translations/fr_ca.csv
@@ -1,14 +1,14 @@
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> Modèle par défaut <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> et tous les champs d'adresse ( y compris les champs personnalisés le cas échéant) sera disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/fr_ca.csv
+++ b/frappe/translations/fr_ca.csv
@@ -1,14 +1,14 @@
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4> Modèle par défaut <!-- h4--> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> et tous les champs d'adresse ( y compris les champs personnalisés le cas échéant) sera disponible <!-- p--> 
  </p><pre> <code> {{address_line1}} &amp; lt; br &amp; gt; 

--- a/frappe/translations/gu.csv
+++ b/frappe/translations/gu.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,પિતૃ
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},અમને તમારી સાથે સંકળાયેલ તમારો {0} ડેટા ડાઉનલોડ કરવાની વિનંતી મળી છે: {1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","જો સક્ષમ હોય, તો પાસવર્ડ તાકાત ન્યુનત્તમ પાસવર્ડ સ્કોર કિંમત પર આધારિત લાગુ કરવામાં આવશે. 2 મૂલ્ય મધ્યમ મજબૂત છે અને 4 ખૂબ જ મજબૂત છે."
 DocType: About Us Settings,"""Team Members"" or ""Management""","""ટુકડી સભ્યો"" અથવા ""સંચાલન"""
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',ક્ષેત્રમાં &#39;તપાસો&#39; પ્રકાર માટે મૂળભૂત ક્યાં તો &#39;0&#39; અથવા &#39;1&#39; હોવા જ જોઈએ
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',ક્ષેત્રમાં 'તપાસો' પ્રકાર માટે મૂળભૂત ક્યાં તો '0' અથવા '1' હોવા જ જોઈએ
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,ગઈ કાલે
 DocType: Contact,Designation,હોદ્દો
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,સ્વચાલિત લિંકિંગ ફક્ત એક ઇમેઇલ એકાઉન્ટ માટે જ સક્રિય કરી શકાય છે.
@@ -250,7 +250,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,અક્ષમ 
 DocType: Translation,Contributed Translation Doctype Name,ફાળો આપ્યો અનુવાદ ડોકટાઇપ નામ
 DocType: PayPal Settings,Redirect To,રીડાયરેક્ટ
 DocType: Data Migration Mapping,Pull,ખેંચો
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},જાવાસ્ક્રિપ્ટ ફોર્મેટ: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},જાવાસ્ક્રિપ્ટ ફોર્મેટ: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,બલ્ક અપડેટ
 DocType: Workflow State,chevron-up,શેવરોન અપ
 DocType: DocType,Allow Guest to View,જુઓ કરવા માટે એક અતિથિ મંજૂરી આપો
@@ -550,7 +550,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),ગયા અઠવાડિયાના પ્રભાવ પર આધારિત આંકડા ({0} થી {1} થી)
 DocType: LDAP Settings,LDAP Phone Field,એલડીએપી ફોન ક્ષેત્ર
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",દસ્તાવેજ પ્રકારની ... દા.ત. ગ્રાહક
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,સ્થિતિ &#39;{0}&#39; અમાન્ય છે
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,સ્થિતિ '{0}' અમાન્ય છે
 DocType: Workflow State,barcode,બારકોડ
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,સબ-ક્વેરી અથવા ફંક્શનનો ઉપયોગ પ્રતિબંધિત છે
 apps/frappe/frappe/config/customization.py,Add your own translations,તમારા પોતાના અનુવાદો ઉમેરી
@@ -698,7 +698,7 @@ DocType: Slack Webhook URL,Webhook URL,વેબહુક URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,વપરાશકર્તા નામ {0} પહેલેથી હાજર જ છે
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} આયાત નથી તરીકે આયાત સેટ કરી શકાતો નથી
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},તમારા સરનામું ઢાંચો એક ભૂલ છે {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} &#39;પ્રાપ્તકર્તાઓ&#39; માં અયોગ્ય ઇમેઇલ સરનામું છે
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} 'પ્રાપ્તકર્તાઓ' માં અયોગ્ય ઇમેઇલ સરનામું છે
 DocType: Footer Item,"target = ""_blank""",લક્ષ્ય = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,યજમાન
@@ -740,7 +740,7 @@ DocType: Currency,Currency Name,કરન્સી નામ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,કોઈ ઇમેઇલ્સ
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,લિંક સમાપ્ત
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; માં &#39;{1}&#39; માટે લાંબી લંબાઈ {0}; લંબાઈને {3} તરીકે સેટ કરવાથી ડેટાને કાપી નાખવામાં આવશે.
+							Setting the length as {3} will cause truncation of data.",'{2}' માં '{1}' માટે લાંબી લંબાઈ {0}; લંબાઈને {3} તરીકે સેટ કરવાથી ડેટાને કાપી નાખવામાં આવશે.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,ફાઇલ ફોર્મેટ પસંદ કરો
 DocType: Report,Javascript,જાવાસ્ક્રિપ્ટ
 DocType: File,Content Hash,સામગ્રી હેશ
@@ -761,7 +761,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,દસ્તાવેજ શેર રિપોર્ટ
 DocType: Social Login Key,Base URL,બેઝ URL
 DocType: User,Last Login,છેલ્લું લૉગિન
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},તમે {0} ક્ષેત્ર માટે &#39;અનુવાદયોગ્ય&#39; સેટ કરી શકતા નથી
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},તમે {0} ક્ષેત્ર માટે 'અનુવાદયોગ્ય' સેટ કરી શકતા નથી
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,કૉલમ
 DocType: Chat Profile,Chat Profile,ચેટ પ્રોફાઇલ
 DocType: Custom Field,Adds a custom field to a DocType,એક Doctype માટે વૈવિધ્યપૂર્ણ ક્ષેત્ર ઉમેરે છે
@@ -770,7 +770,7 @@ DocType: File,Is Home Folder,મુખ્ય પૃષ્ઠ ફોલ્ડર 
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,નવબાર પ્રકાર
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} એ માન્ય ઇમેઇલ સરનામું નથી
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,છાપવા માટે ઓછામાં ઓછા 1 વિક્રમ પસંદ
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',વપરાશકર્તા &#39;{0}&#39; પહેલાથી જ ભૂમિકા છે &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',વપરાશકર્તા '{0}' પહેલાથી જ ભૂમિકા છે '{1}'
 DocType: System Settings,Two Factor Authentication method,બે પરિબળ પ્રમાણીકરણ પદ્ધતિ
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,પ્રથમ નામ સેટ કરો અને રેકોર્ડ સાચવો.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 રેકોર્ડ્સ
@@ -1015,7 +1015,7 @@ DocType: Property Setter,Property Setter,સંપત્તિ પ્રાશ�
 DocType: Web Form,Allow Print,પ્રિન્ટ માટે પરવાનગી આપે છે
 DocType: Communication,Clicked,વાપરો
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,અવગણવું
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},કોઈ પરવાનગી &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},કોઈ પરવાનગી '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,મોકલવા માટે અનુસૂચિત
 DocType: DocType,Track Seen,ટ્રેક દેખાય
 DocType: Dropbox Settings,File Backup,ફાઇલ બૅકઅપ
@@ -1042,7 +1042,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,પેજમાં HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,ભૂલવાળી પંક્તિઓ નિકાસ કરો
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,જૂથ નામ ખાલી હોઈ શકતું નથી.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,વધુ ગાંઠો માત્ર &#39;ગ્રુપ&#39; પ્રકાર ગાંઠો હેઠળ બનાવી શકાય છે
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,વધુ ગાંઠો માત્ર 'ગ્રુપ' પ્રકાર ગાંઠો હેઠળ બનાવી શકાય છે
 DocType: SMS Parameter,Header,મથાળું
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},અજ્ઞાત કૉલમ: {0}
 DocType: Notification Recipient,Email By Role,ઇમેઇલ ભૂમિકા દ્વારા
@@ -1421,7 +1421,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,ફરજિયાત ફીલ્ડ છે: સુયોજિત ભૂમિકા
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} ટીકા {1}
 DocType: Data Migration Mapping,Mapping Name,મેપિંગ નામ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ક્ષેત્ર &#39;{1}&#39; અનન્ય તરીકે સેટ કરી શકાતું નથી કારણ કે તેમાં અનન્ય-અનન્ય મૂલ્યો છે
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ક્ષેત્ર '{1}' અનન્ય તરીકે સેટ કરી શકાતું નથી કારણ કે તેમાં અનન્ય-અનન્ય મૂલ્યો છે
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,સૂચિ નીચે નેવિગેટ કરો
 DocType: Currency,A symbol for this currency. For e.g. $,આ ચલણ માટે એક પ્રતીક. દા.ત. $ માટે
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,અનુવાદોને સફળતાપૂર્વક અપડેટ કર્યાં
@@ -1929,7 +1929,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,એપી-દક્ષિણપૂર્વ -1
 DocType: DocType,"Must be of type ""Attach Image""",પ્રકાર હોવા જ જોઈએ &quot;છબી જોડો&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,બધા નાપસંદ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},તમે ક્ષેત્ર માટે સેટ કરેલી નથી &#39;ફક્ત વાંચવા માટે&#39; કરી શકો છો {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},તમે ક્ષેત્ર માટે સેટ કરેલી નથી 'ફક્ત વાંચવા માટે' કરી શકો છો {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,ઝીરો અર્થ એ થાય કોઈપણ સમયે અપડેટ રેકોર્ડ મોકલી
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,સેટઅપ પૂર્ણ
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,સફળતાપૂર્વક અપડેટ કર્યું
@@ -1972,7 +1972,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,ગૂગલ ફontન્ટ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","મદદરૂપ નથી, GitHub મુદ્દાઓ પર તમારા સૂચનો ઉમેરવા કૃપા કરીને જ્યાં આ સૂચનો છે."
 DocType: Workflow State,bookmark,બુકમાર્ક
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ફોલ્ડર નામ શામેલ ન જોઈએ &#39;/&#39; (સ્લેશ)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ફોલ્ડર નામ શામેલ ન જોઈએ '/' (સ્લેશ)
 DocType: Note,Note,નૉૅધ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,ભૂલ રિપોર્ટ
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel ફોર્મેટમાં ડેટા નિકાસ કરો.
@@ -2075,7 +2075,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,કલાક દા.
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",આ ક્ષેત્ર દેખાશે તો જ FIELDNAME અહીં વ્યાખ્યાયિત મૂલ્ય ધરાવે છે અથવા નિયમો સાચા (ઉદાહરણો) છે: myfield eval: doc.myfield == &#39;મારું કિંમત&#39; eval: doc.age> 18
+eval:doc.age>18",આ ક્ષેત્ર દેખાશે તો જ FIELDNAME અહીં વ્યાખ્યાયિત મૂલ્ય ધરાવે છે અથવા નિયમો સાચા (ઉદાહરણો) છે: myfield eval: doc.myfield == 'મારું કિંમત' eval: doc.age> 18
 DocType: Social Login Key,Office 365,ઓફિસ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,આજે
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","તમે આ સમૂહ છે એકવાર, વપરાશકર્તાઓ સક્ષમ વપરાશ દસ્તાવેજો હશે. (દા.ત. પોસ્ટ બ્લોગ) લિંક (દા.ત.. બ્લોગર) અસ્તિત્વમાં ���ે."
@@ -2114,7 +2114,7 @@ DocType: Data Migration Connector,Database Name,ડેટાબેઝ નામ
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,પુનઃતાજું ફોર્મ
 DocType: DocField,Select,પસંદ કરો
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,સંપૂર્ણ લોગ જુઓ
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","સરળ પાયથોન અભિવ્યક્તિ, ઉદાહરણ: સ્થિતિ == &#39;ખોલો&#39; અને પ્રકાર == &#39;બગ&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","સરળ પાયથોન અભિવ્યક્તિ, ઉદાહરણ: સ્થિતિ == 'ખોલો' અને પ્રકાર == 'બગ'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,ફાઇલ જોડાયેલ નથી
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,"સંમ્પર્ક તૂટવો, છૂટા પડી જવુ. કેટલીક સુવિધાઓ કાર્ય કરી શકશે નહીં"
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;એએએ&quot; જેવા પુનરાવર્તન ધારી માટે સરળ હોય છે
@@ -2242,7 +2242,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,ફક્ત ભૂલો બતાવો
 DocType: Website Settings,Banner HTML,બેનર HTML
 DocType: Workflow,Send Email Alert,ઇમેઇલ ચેતવણી મોકલો
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',કૃપા કરીને બીજી ચુકવણી પદ્ધતિ પસંદ કરો. Razorpay ચલણ વ્યવહારો ટેકો આપતાં નથી &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',કૃપા કરીને બીજી ચુકવણી પદ્ધતિ પસંદ કરો. Razorpay ચલણ વ્યવહારો ટેકો આપતાં નથી '{0}'
 DocType: Data Import,In Progress,પ્રગતિમાં
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,બેકઅપ માટે કતારબદ્ધ. તે એક કલાક માટે થોડી મિનિટો લાગી શકે છે.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2652,7 +2652,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,સુધારો
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,પેપાલ ચુકવણી ગેટવે સેટિંગ્સ
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,ટોચના પરફોર્મર
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,કોર ડોકટાઇપ્સમાં કસ્ટમ ફીલ્ડ્સ ઉમેરી શકાતા નથી.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) કાપવામાં મળશે, કારણ મંજૂરી મેક્સ અક્ષરો છે {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) કાપવામાં મળશે, કારણ મંજૂરી મેક્સ અક્ષરો છે {2}"
 DocType: OAuth Client,Response Type,પ્રતિભાવ પ્રકાર
 DocType: Contact Us Settings,Send enquiries to this email address,આ ઈમેઈલ સરનામાને પૂછપરછ મોકલો
 DocType: Letter Head,Letter Head Name,પત્ર હેડ નામ
@@ -2708,7 +2708,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,છબી જુઓ
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","લાગે છે કે કંઈક વ્યવહાર દરમિયાન ખોટું થયું હતું. અમે ચુકવણી પુષ્ટિ કરી નથી કારણ કે, પેપલ આપોઆપ તમે આ રકમ રિફંડ કરશે. તે ન હોય તો, કૃપા કરીને અમને એક ઇમેઇલ મોકલો અને સહસંબંધ આઈડી ઉલ્લેખ: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","પાસવર્ડ પ્રતિકો, સંખ્યાઓ અને મૂડી અક્ષરો શામેલ"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",ક્ષેત્ર &#39;{0}&#39; વૈવિધ્યપૂર્ણ ક્ષેત્રમાં ઉલ્લેખ કર્યા પછી દાખલ કરો &#39;{1}&#39; લેબલ સાથે &#39;{2}&#39; અસ્તિત્વમાં નથી
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",ક્ષેત્ર '{0}' વૈવિધ્યપૂર્ણ ક્ષેત્રમાં ઉલ્લેખ કર્યા પછી દાખલ કરો '{1}' લેબલ સાથે '{2}' અસ્તિત્વમાં નથી
 DocType: List Filter,List Filter,ફિલ્ટર યાદી
 DocType: Workflow State,signal,સંકેત
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,જોડાણો છે
@@ -2718,7 +2718,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,દસ્તાવેજ પુનઃપ્રકાશિત
 DocType: Data Export,Data Export,ડેટા નિકાસ
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ભાષા પસંદ કરો ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},તમે {0} ક્ષેત્ર માટે &#39;વિકલ્પો&#39; સેટ કરી શકતા નથી
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},તમે {0} ક્ષેત્ર માટે 'વિકલ્પો' સેટ કરી શકતા નથી
 DocType: Help Article,Author,લેખક
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,રેઝ્યૂમે મોકલવાનું
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,ફરીથી ખોલો
@@ -2732,14 +2732,14 @@ DocType: Web Page,Slideshow,સ્લાઇડ શો
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,મૂળભૂત સરનામું ઢાંચો કાઢી શકાતી નથી
 DocType: Contact,Maintenance Manager,જાળવણી વ્યવસ્થાપક
 DocType: Workflow State,Search,શોધ
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',કૃપા કરીને બીજી ચુકવણી પદ્ધતિ પસંદ કરો. ગેરુનો ચલણ વ્યવહારો ટેકો આપતાં નથી &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',કૃપા કરીને બીજી ચુકવણી પદ્ધતિ પસંદ કરો. ગેરુનો ચલણ વ્યવહારો ટેકો આપતાં નથી '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ટ્રેશમાં ખસેડો
 DocType: Web Form,Web Form Fields,વેબ ફોર્મ ફીલ્ડ્સ
 DocType: Data Import,Amended From,સુધારો
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},ચેતવણી: અક્ષમ શોધવા માટે {0} સંબંધિત કોઈ કોષ્ટકમાં {1}
 DocType: S3 Backup Settings,eu-north-1,ઇયુ-ઉત્તર -1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,આ દસ્તાવેજ હાલમાં અમલ માટે કતારમાં છે. મહેરબાની કરીને ફરીથી પ્રયતન કરો
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ફાઇલ &#39;{0}&#39; મળી નથી
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ફાઇલ '{0}' મળી નથી
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,વિભાગ દૂર
 DocType: User,Change Password,પાસવર્ડ બદલો
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,એક્સ એક્સિસ ફીલ્ડ
@@ -2921,7 +2921,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,કિંમત મ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,બાળ ઉમેરો
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,આયાત પ્રગતિ
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",જો સ્થિતિ સંતોષશે તો વપરાશકર્તાને પોઇન્ટ સાથે વળતર મળશે. દા.ત. doc.status == &#39;બંધ&#39;
+",જો સ્થિતિ સંતોષશે તો વપરાશકર્તાને પોઇન્ટ સાથે વળતર મળશે. દા.ત. doc.status == 'બંધ'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: અહેવાલ શાળાના કુલ રેકોર્ડ કાઢી શકાતી નથી.
 DocType: GSuite Templates,Template Name,નમૂના નામ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,દસ્તાવેજ નવી પ્રકાર
@@ -3049,7 +3049,7 @@ DocType: Dashboard Chart,Chart Type,ચાર્ટ પ્રકાર
 DocType: DocType,Auto Name,ઓટો નામ
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"એબીસી અથવા 6543 જેવી સિક્વન્સ ટાળો, કારણ કે તેઓ ધારી માટે સરળ હોય છે"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,મહેરબાની કરીને ફરીથી પ્રયતન કરો
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; અથવા &#39;https: //&#39; થી પ્રારંભ થવો આવશ્યક છે
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' અથવા 'https: //' થી પ્રારંભ થવો આવશ્યક છે
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,વિકલ્પ 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,સંપાદિત કરો
@@ -3283,7 +3283,7 @@ DocType: Notification,Send alert if this field's value changes,આ ક્ષે�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,થીમ કલર્સ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,એક નવા ફોર્મેટમાં બનાવવા માટે doctype પસંદ કરો
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,વપરાશકર્તા અસ્તિત્વમાં નથી
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;પ્રાપ્તકર્તાઓ&#39; ઉલ્લેખિત નથી
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'પ્રાપ્તકર્તાઓ' ઉલ્લેખિત નથી
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,હમણાજ
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,લાગુ પડે છે
 DocType: Footer Item,Policy,નીતિ
@@ -3330,7 +3330,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,કસ્ટમ �
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,પ્રગતિ
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,ભૂમિકા દ્વારા
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,ખૂટે ક્ષેત્રો
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname અમાન્ય FIELDNAME &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname અમાન્ય FIELDNAME '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,દસ્તાવેજ પ્રકારની શોધ
 DocType: Custom DocPerm,Role and Level,ભૂમિકા અને સ્તર
 DocType: File,Thumbnail URL,થંબનેલ URL
@@ -3416,11 +3416,11 @@ DocType: Dashboard Chart,Filters JSON,ગાળકો JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,ચકાસવા માટે અહીં ક્લિક કરો
 DocType: Email Account,Disable SMTP server authentication,SMTP સર્વર પ્રમાણીકરણને અક્ષમ કરો
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,ક્લિપબોર્ડ પર ક Copપિ કરેલું.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,જેમ ધારી ખેલાડીઓની ફેરબદલ &#39;@&#39; બદલે &#39;એ&#39; ખૂબ મદદ ન કરી શકું.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,જેમ ધારી ખેલાડીઓની ફેરબદલ '@' બદલે 'એ' ખૂબ મદદ ન કરી શકું.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,મારા દ્વારા સોંપાયેલ
 apps/frappe/frappe/utils/data.py,Zero,ઝીરો
 DocType: Google Drive,Backup Folder ID,બેકઅપ ફોલ્ડર ID
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,નથી વિકાસકર્તા મોડ માં! Site_config.json માં સુયોજિત અથવા &#39;વૈવિધ્યપૂર્ણ&#39; Doctype બનાવે છે.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,નથી વિકાસકર્તા મોડ માં! Site_config.json માં સુયોજિત અથવા 'વૈવિધ્યપૂર્ણ' Doctype બનાવે છે.
 DocType: Workflow State,globe,વિશ્વમાં
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,પ્રાધાન્યતા
@@ -3469,7 +3469,7 @@ DocType: Notification,Reference Date,સંદર્ભ તારીખ
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP એપ્લિકેશનનો ઉપયોગ કરીને OTP સેટઅપ પૂર્ણ થયું નથી. કૃપા કરીને સંચાલકનો સંપર્ક કરો.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,માન્ય મોબાઇલ અમે દાખલ કરો
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,કેટલીક લાક્ષણિકતાઓ તમારા બ્રાઉઝરમાં કામ ન કરી શકે છે. નવીનતમ સંસ્કરણ પર તમારા બ્રાઉઝર અપડેટ કરો.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","ખબર નથી, પૂછો &#39;સહાય&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","ખબર નથી, પૂછો 'સહાય'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},આ દસ્તાવેજ રદ કર્યો {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,ટિપ્પણીઓ અને કોમ્યુનિકેશન્સ આ કડી દસ્તાવેજ સાથે સંકળાયેલ હશે
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,ફિલ્ટર ...
@@ -3498,7 +3498,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,સબ્સ્ક્રિપ્શનમાં સુધારો કરતી વખતે નિષ્ફળ
 DocType: LDAP Settings,LDAP Group Field,એલડીએપી ગ્રુપ ક્ષેત્ર
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,સમકક્ષ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ક્ષેત્રમાં વિકલ્પો &#39;ડાયનેમિક કડી&#39; પ્રકાર &#39;Doctype&#39; તરીકે વિકલ્પો સાથે અન્ય લિંક ક્ષેત્ર માટે નિર્દેશ જ જોઈએ
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ક્ષેત્રમાં વિકલ્પો 'ડાયનેમિક કડી' પ્રકાર 'Doctype' તરીકે વિકલ્પો સાથે અન્ય લિંક ક્ષેત્ર માટે નિર્દેશ જ જોઈએ
 DocType: About Us Settings,Team Members Heading,મથાળું ટીમના સભ્યો
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,અમાન્ય CSV ફોર્મેટ
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","ક્યૂઝેડ ટ્રે એપ્લિકેશનથી કનેક્ટ કરવામાં ભૂલ ... <br><br> કાચો મુદ્રણ સુવિધા વાપરવા માટે તમારી પાસે ક્યૂઝેડ ટ્રે એપ્લિકેશન ઇન્સ્ટોલ અને ચાલુ હોવી જરૂરી છે. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">ક્યૂઝેડ ટ્રેને ડાઉનલોડ અને ઇન્સ્ટોલ કરવા અહીં ક્લિક કરો</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">કાચો છાપવા વિશે વધુ જાણવા માટે અહીં ક્લિક કરો</a> ."
@@ -3765,7 +3765,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,મૂળભૂત
 DocType: Translation,Verified,ચકાસણી
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} ઉમેરવામાં
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',માટે શોધ &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',માટે શોધ '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,કૃપા કરીને અહેવાલ પ્રથમ સેવ
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ગ્રાહકો ઉમેર્યા
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,નથી
@@ -3800,14 +3800,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,હું
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} માન્ય રાજ્ય
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,બધા દસ્તાવેજોના પ્રકારો પર લાગુ કરો
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Energyર્જા બિંદુ સુધારો
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',કૃપા કરીને બીજી ચુકવણી પદ્ધતિ પસંદ કરો. પેપાલ ચલણ વ્યવહારો ટેકો આપતાં નથી &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',કૃપા કરીને બીજી ચુકવણી પદ્ધતિ પસંદ કરો. પેપાલ ચલણ વ્યવહારો ટેકો આપતાં નથી '{0}'
 DocType: Chat Message,Room Type,ઓરડા નો પ્રકાર
 DocType: Data Import Beta,Import Log Preview,લ Importગ પૂર્વાવલોકન આયાત કરો
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,શોધ ક્ષેત્ર {0} માન્ય નથી
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,અપલોડ કરેલી ફાઇલ
 DocType: Workflow State,ok-circle,બરાબર વર્તુળ
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP વપરાશકર્તા બનાવટ અને મેપિંગ
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',તમે પૂછવા &#39;ગ્રાહકો નારંગી શોધવા&#39; દ્વારા વસ્તુઓ શોધી શકો છો
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',તમે પૂછવા 'ગ્રાહકો નારંગી શોધવા' દ્વારા વસ્તુઓ શોધી શકો છો
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,માફ કરશો! વપરાશકર્તા તેમની પોતાની રેકોર્ડ સંપૂર્ણ વપરાશ હોવો જોઈએ.
 ,Usage Info,વપરાશ માહિતી
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,કીબોર્ડ શોર્ટકટ્સ બતાવો

--- a/frappe/translations/gu.csv
+++ b/frappe/translations/gu.csv
@@ -1392,7 +1392,7 @@ DocType: User,System User,સિસ્ટમ વપરાશકર્તા
 DocType: Report,Is Standard,ધોરણ છે
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,પૂર્ણ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","શું ન ગમે &lt;સ્ક્રિપ્ટ> અથવા માત્ર અક્ષરો જેવા &lt;અથવા>, કારણ કે તેઓ ઈરાદાપૂર્વક આ ક્ષેત્રમાં ઉપયોગ કરી શકાય એચટીએમએલ બેવડી એચટીએમએલ ટૅગ્સ"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","શું ન ગમે <સ્ક્રિપ્ટ> અથવા માત્ર અક્ષરો જેવા <અથવા>, કારણ કે તેઓ ઈરાદાપૂર્વક આ ક્ષેત્રમાં ઉપયોગ કરી શકાય એચટીએમએલ બેવડી એચટીએમએલ ટૅગ્સ"
 DocType: Website Settings,FavIcon,ફેવિકોન
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ચલાવો
 DocType: Blog Post,Content (HTML),સામગ્રી (એચટીએમએલ)
@@ -1760,7 +1760,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ફૂટર ફ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,બાકી
 DocType: System Settings,Allow only one session per user,વપરાશકર્તા દીઠ માત્ર એક સત્ર માટે પરવાનગી આપે છે
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ઘર / ટેસ્ટ ફોલ્ડરમાં 1 / ટેસ્ટ ફોલ્ડરમાં 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
+DocType: Website Settings,<head> HTML,<Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,પસંદ કરો અથવા એક નવી ઇવેન્ટ બનાવો સમય સ્લોટ સમગ્ર ખેંચો.
 DocType: Contact,Contact Details,સંપર્ક વિગતો
 DocType: DocField,In Filter,ફિલ્ટર
@@ -2274,7 +2274,7 @@ DocType: LDAP Settings,Path to Server Certificate,સર્વર પ્રમ�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,લિંક્સ જોવા માટે પૂરતી પરવાનગી નથી
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,સરનામું શીર્ષક ફરજિયાત છે.
 DocType: Google Contacts,Push to Google Contacts,ગૂગલ સંપર્કો પર દબાણ કરો
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> માં ઉમેરાયેલ HTML વેબ પાનું ના વિભાગ મુખ્યત્વે વેબસાઇટ ચકાસણી અને એસઇઓ માટે વપરાય છે
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",<Head> માં ઉમેરાયેલ HTML વેબ પાનું ના વિભાગ મુખ્યત્વે વેબસાઇટ ચકાસણી અને એસઇઓ માટે વપરાય છે
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,હીનભાવનાની
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,આઇટમ તેના પોતાના વંશજ ઉમેરવામાં કરી શકાતી નથી
 DocType: Session Default Settings,Session Defaults,સત્ર ડિફોલ્ટ્સ
@@ -2390,7 +2390,7 @@ DocType: Workflow State,Warning,ચેતવણી
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,આ બહુવિધ પૃષ્ઠો પર છાપવામાં આવી શકે છે
 DocType: Data Migration Run,Percent Complete,ટકા પૂર્ણ
 DocType: Tag Category,Tag Category,ટેગ વર્ગ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","સરખામણી માટે,> 5, &lt;10 અથવા = 324 નો ઉપયોગ કરો. શ્રેણીઓ માટે, 5:10 (5 અને 10 ની કિંમતો માટે) નો ઉપયોગ કરો."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","સરખામણી માટે,> 5, <10 અથવા = 324 નો ઉપયોગ કરો. શ્રેણીઓ માટે, 5:10 (5 અને 10 ની કિંમતો માટે) નો ઉપયોગ કરો."
 DocType: Google Calendar,Pull from Google Calendar,ગૂગલ કેલેન્ડરમાંથી ખેંચો
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,મદદ
 DocType: User,Login Before,પ્રવેશ પહેલાં
@@ -3012,7 +3012,7 @@ DocType: DocField,Allow on Submit,સબમિટ પર પરવાનગી �
 DocType: DocField,HTML,એચટીએમએલ
 DocType: Error Snapshot,Exception Type,અપવાદ પ્રકાર
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,સ્તંભોને ચૂંટો
-DocType: Web Page,Add code as &lt;script>,&lt;Script> તરીકે કોડ ઉમેરો
+DocType: Web Page,Add code as <script>,<Script> તરીકે કોડ ઉમેરો
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,વપરાશકર્તા પરવાનગીને સાફ કરો
 DocType: Webhook,Headers,હેડર્સ
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,આવનારી પ્રવૃત્તિઓ
@@ -3377,16 +3377,16 @@ DocType: Workflow State,share-alt,શેર-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},કતાર આમાંનું એક હોવું જોઈએ {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> ડિફૉલ્ટ નમૂનો </h4><p> ઉપયોગ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> અને ઉપલબ્ધ હશે (જો કોઈ હોય તો કસ્ટમ ક્ષેત્રો સહિત) સરનામું તમામ ક્ષેત્રો </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> ડિફૉલ્ટ નમૂનો </h4><p> ઉપયોગ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> અને ઉપલબ્ધ હશે (જો કોઈ હોય તો કસ્ટમ ક્ષેત્રો સહિત) સરનામું તમામ ક્ષેત્રો </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,તારીખ ક્ષેત્ર પ્રારંભ કરો
 DocType: Role,Role Name,રોલ નામ
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ડેસ્ક પર સ્વિચ

--- a/frappe/translations/gu.csv
+++ b/frappe/translations/gu.csv
@@ -734,7 +734,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ફાઇ�
 DocType: DocField,In Global Search,વૈશ્વિક શોધ
 DocType: System Settings,Brute Force Security,બ્રુટ ફોર્સ સિક્યુરિટી
 DocType: Workflow State,indent-left,ઇન્ડેન્ટ ડાબી
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} વર્ષ (ઓ) પહેલાં
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} વર્ષ (ઓ) પહેલાં
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,તે આ ફાઇલ કાઢી જોખમી છે: {0}. તમારી સિસ્ટમ મેનેજરનો સંપર્ક કરો.
 DocType: Currency,Currency Name,કરન્સી નામ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,કોઈ ઇમેઇલ્સ
@@ -1024,7 +1024,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,કોઈ {0}
 apps/frappe/frappe/config/customization.py,Add custom forms.,વૈવિધ્યપૂર્ણ સ્વરૂપો ઉમેરો.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} માં {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,આ દસ્તાવેજ રજૂ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,સેટઅપ&gt; વપરાશકર્તા પરવાનગી
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,સેટઅપ> વપરાશકર્તા પરવાનગી
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,સિસ્ટમ ઘણા પૂર્વ નિર્ધારિત ભૂમિકા પૂરી પાડે છે. તમે ફાઇનર પરવાનગીઓ સુયોજિત કરવા માટે નવી ભૂમિકા ઉમેરી શકો છો.
 DocType: Communication,CC,સીસી
 DocType: Country,Geo,જીઓ
@@ -1241,7 +1241,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","વપરાશકર્તા કોઇ ભૂમિકા ચકાસાયેલ હોય, તો પછી વપરાશકર્તા &quot;સિસ્ટમ વપરાશકર્તા&quot; બની જાય છે. &quot;સિસ્ટમ વપરાશકર્તા&quot; ડેસ્કટોપ ઍક્સેસ છે"
 DocType: System Settings,Date and Number Format,તારીખ અને સંખ્યા ફોર્મેટ
 apps/frappe/frappe/model/document.py,one of,માનૂ એક
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,સેટઅપ&gt; ફોર્મ કસ્ટમાઇઝ કરો
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,સેટઅપ> ફોર્મ કસ્ટમાઇઝ કરો
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,એક ક્ષણ તપાસી
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,બતાવો ટૅગ્સ
 DocType: DocField,HTML Editor,એચટીએમએલ એડિટર
@@ -1249,7 +1249,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,બિલિંગ
 DocType: Email Queue,Not Sent,મોકલવામાં આવ્યો ન
 DocType: Web Form,Actions,ક્રિયાઓ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,સેટઅપ&gt; વપરાશકર્તા
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,સેટઅપ> વપરાશકર્તા
 DocType: Workflow State,align-justify,સંરેખિત-સર્મથન
 DocType: User,Middle Name (Optional),મધ્ય નામ (વૈકલ્પિક)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,પરવાનગી નથી
@@ -1392,7 +1392,7 @@ DocType: User,System User,સિસ્ટમ વપરાશકર્તા
 DocType: Report,Is Standard,ધોરણ છે
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,પૂર્ણ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","શું ન ગમે &lt;સ્ક્રિપ્ટ&gt; અથવા માત્ર અક્ષરો જેવા &lt;અથવા&gt;, કારણ કે તેઓ ઈરાદાપૂર્વક આ ક્ષેત્રમાં ઉપયોગ કરી શકાય એચટીએમએલ બેવડી એચટીએમએલ ટૅગ્સ"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","શું ન ગમે &lt;સ્ક્રિપ્ટ> અથવા માત્ર અક્ષરો જેવા &lt;અથવા>, કારણ કે તેઓ ઈરાદાપૂર્વક આ ક્ષેત્રમાં ઉપયોગ કરી શકાય એચટીએમએલ બેવડી એચટીએમએલ ટૅગ્સ"
 DocType: Website Settings,FavIcon,ફેવિકોન
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ચલાવો
 DocType: Blog Post,Content (HTML),સામગ્રી (એચટીએમએલ)
@@ -1760,7 +1760,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ફૂટર ફ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,બાકી
 DocType: System Settings,Allow only one session per user,વપરાશકર્તા દીઠ માત્ર એક સત્ર માટે પરવાનગી આપે છે
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ઘર / ટેસ્ટ ફોલ્ડરમાં 1 / ટેસ્ટ ફોલ્ડરમાં 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,પસંદ કરો અથવા એક નવી ઇવેન્ટ બનાવો સમય સ્લોટ સમગ્ર ખેંચો.
 DocType: Contact,Contact Details,સંપર્ક વિગતો
 DocType: DocField,In Filter,ફિલ્ટર
@@ -1989,7 +1989,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,આ સમય પર માન્ય નથી લૉગિન
 DocType: Data Migration Run,Current Mapping Action,વર્તમાન મેપિંગ ઍક્શન
 DocType: Dashboard Chart Source,Source Name,સોર્સ નામ
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,વપરાશકર્તા સાથે સંકળાયેલ કોઈ ઇમેઇલ એકાઉન્ટ નથી. કૃપા કરીને વપરાશકર્તા&gt; ઇમેઇલ ઇનબોક્સ હેઠળ એક એકાઉન્ટ ઉમેરો.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,વપરાશકર્તા સાથે સંકળાયેલ કોઈ ઇમેઇલ એકાઉન્ટ નથી. કૃપા કરીને વપરાશકર્તા> ઇમેઇલ ઇનબોક્સ હેઠળ એક એકાઉન્ટ ઉમેરો.
 DocType: Email Account,Email Sync Option,ઇમેઇલ સમન્વયન વિકલ્પ
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,પંક્તિ નં
 DocType: Async Task,Runtime,રનટાઈમ
@@ -2004,7 +2004,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,પહે
 DocType: User Email,Enable Outgoing,આઉટગોઇંગ સક્ષમ
 DocType: Address,Fax,ફેક્સ
 apps/frappe/frappe/config/customization.py,Custom Tags,કસ્ટમ ટૅગ્સ
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ઇમેઇલ એકાઉન્ટ સેટ નથી. કૃપા કરીને સેટઅપ&gt; ઇમેઇલ&gt; ઇમેઇલ એકાઉન્ટથી નવું ઇમેઇલ એકાઉન્ટ બનાવો
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ઇમેઇલ એકાઉન્ટ સેટ નથી. કૃપા કરીને સેટઅપ> ઇમેઇલ> ઇમેઇલ એકાઉન્ટથી નવું ઇમેઇલ એકાઉન્ટ બનાવો
 DocType: Comment,Submitted,સબમિટ
 DocType: Contact,Pulled from Google Contacts,ગૂગલ સંપર્કોમાંથી ખેંચાય છે
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,અમાન્ય વિનંતી
@@ -2075,10 +2075,10 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,કલાક દા.
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",આ ક્ષેત્ર દેખાશે તો જ FIELDNAME અહીં વ્યાખ્યાયિત મૂલ્ય ધરાવે છે અથવા નિયમો સાચા (ઉદાહરણો) છે: myfield eval: doc.myfield == &#39;મારું કિંમત&#39; eval: doc.age&gt; 18
+eval:doc.age>18",આ ક્ષેત્ર દેખાશે તો જ FIELDNAME અહીં વ્યાખ્યાયિત મૂલ્ય ધરાવે છે અથવા નિયમો સાચા (ઉદાહરણો) છે: myfield eval: doc.myfield == &#39;મારું કિંમત&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,ઓફિસ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,આજે
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","તમે આ સમૂહ છે એકવાર, વપરાશકર્તાઓ સક્ષમ વપરાશ દસ્તાવેજો હશે. (દા.ત. પોસ્ટ બ્લોગ) લિંક (દા.ત.. બ્લોગર) અસ્તિત્વમાં છે."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","તમે આ સમૂહ છે એકવાર, વપરાશકર્તાઓ સક્ષમ વપરાશ દસ્તાવેજો હશે. (દા.ત. પોસ્ટ બ્લોગ) લિંક (દા.ત.. બ્લોગર) અસ્તિત્વમાં ���ે."
 DocType: Data Import Beta,Submit After Import,આયાત પછી સબમિટ કરો
 DocType: Error Log,Log of Scheduler Errors,નિયોજક ભૂલો લોગ
 DocType: User,Bio,બાયો
@@ -2089,7 +2089,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,અપર કેસ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,કસ્ટમ HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ફોલ્ડર નામ દાખલ કરો
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,ડિફોલ્ટ સરનામું ટેમ્પલેટ મળ્યું નથી. કૃપા કરીને સેટઅપ&gt; પ્રિન્ટિંગ અને બ્રાંડિંગ&gt; સરનામાં ટેમ્પલેટમાંથી એક નવું બનાવો.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,ડિફોલ્ટ સરનામું ટેમ્પલેટ મળ્યું નથી. કૃપા કરીને સેટઅપ> પ્રિન્ટિંગ અને બ્રાંડિંગ> સરનામાં ટેમ્પલેટમાંથી એક નવું બનાવો.
 apps/frappe/frappe/auth.py,Unknown User,અજ્ઞાત વપરાશકર્તા
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,ભૂમિકા પસંદ કરો
 DocType: Comment,Deleted,ડિલીટ
@@ -2274,7 +2274,7 @@ DocType: LDAP Settings,Path to Server Certificate,સર્વર પ્રમ�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,લિંક્સ જોવા માટે પૂરતી પરવાનગી નથી
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,સરનામું શીર્ષક ફરજિયાત છે.
 DocType: Google Contacts,Push to Google Contacts,ગૂગલ સંપર્કો પર દબાણ કરો
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",&lt;Head&gt; માં ઉમેરાયેલ HTML વેબ પાનું ના વિભાગ મુખ્યત્વે વેબસાઇટ ચકાસણી અને એસઇઓ માટે વપરાય છે
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> માં ઉમેરાયેલ HTML વેબ પાનું ના વિભાગ મુખ્યત્વે વેબસાઇટ ચકાસણી અને એસઇઓ માટે વપરાય છે
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,હીનભાવનાની
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,આઇટમ તેના પોતાના વંશજ ઉમેરવામાં કરી શકાતી નથી
 DocType: Session Default Settings,Session Defaults,સત્ર ડિફોલ્ટ્સ
@@ -2390,7 +2390,7 @@ DocType: Workflow State,Warning,ચેતવણી
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,આ બહુવિધ પૃષ્ઠો પર છાપવામાં આવી શકે છે
 DocType: Data Migration Run,Percent Complete,ટકા પૂર્ણ
 DocType: Tag Category,Tag Category,ટેગ વર્ગ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","સરખામણી માટે,&gt; 5, &lt;10 અથવા = 324 નો ઉપયોગ કરો. શ્રેણીઓ માટે, 5:10 (5 અને 10 ની કિંમતો માટે) નો ઉપયોગ કરો."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","સરખામણી માટે,> 5, &lt;10 અથવા = 324 નો ઉપયોગ કરો. શ્રેણીઓ માટે, 5:10 (5 અને 10 ની કિંમતો માટે) નો ઉપયોગ કરો."
 DocType: Google Calendar,Pull from Google Calendar,ગૂગલ કેલેન્ડરમાંથી ખેંચો
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,મદદ
 DocType: User,Login Before,પ્રવેશ પહેલાં
@@ -2840,7 +2840,7 @@ DocType: Custom Script,Custom Script,કસ્ટમ સ્ક્રિપ્ટ
 DocType: Address,Address Line 2,સરનામું લાઇન 2
 DocType: Address,Reference,સંદર્ભ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,સોંપેલ
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,કૃપા કરીને સેટઅપ&gt; ઇમેઇલ&gt; ઇમેઇલ એકાઉન્ટમાંથી ડિફ defaultલ્ટ ઇમેઇલ એકાઉન્ટ સેટ કરો
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,કૃપા કરીને સેટઅપ> ઇમેઇલ> ઇમેઇલ એકાઉન્ટમાંથી ડિફ defaultલ્ટ ઇમેઇલ એકાઉન્ટ સેટ કરો
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ડેટા માઇગ્રેશન મેપિંગ વિગતવાર
 DocType: Data Import,Action,ક્રિયા
 DocType: GSuite Settings,Script URL,સ્ક્રિપ્ટ URL
@@ -3012,7 +3012,7 @@ DocType: DocField,Allow on Submit,સબમિટ પર પરવાનગી �
 DocType: DocField,HTML,એચટીએમએલ
 DocType: Error Snapshot,Exception Type,અપવાદ પ્રકાર
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,સ્તંભોને ચૂંટો
-DocType: Web Page,Add code as &lt;script&gt;,&lt;Script&gt; તરીકે કોડ ઉમેરો
+DocType: Web Page,Add code as &lt;script>,&lt;Script> તરીકે કોડ ઉમેરો
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,વપરાશકર્તા પરવાનગીને સાફ કરો
 DocType: Webhook,Headers,હેડર્સ
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,આવનારી પ્રવૃત્તિઓ
@@ -3098,7 +3098,7 @@ apps/frappe/frappe/public/js/frappe/views/treeview.js,Tree view not available fo
 DocType: DocType,Restrict To Domain,DOMAIN પર પ્રતિબંધિત
 DocType: Domain,Domain,ડોમેન
 DocType: Custom Field,Label Help,લેબલ મદદ
-DocType: Workflow State,star-empty,સ્ટાર ખાલી
+DocType: Workflow State,star-empty,સ્���ાર ખાલી
 apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,તારીખો ઘણીવાર અનુમાન કરવા માટે સરળ છે.
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Next actions,આગામી ક્રિયાઓ
 apps/frappe/frappe/email/doctype/notification/notification.py,"Cannot edit Standard Notification. To edit, please disable this and duplicate it","માનક સૂચનને સંપાદિત કરી શકાતું નથી સંપાદિત કરવા માટે, કૃપા કરીને આને અક્ષમ કરો અને તેને ડુપ્લિકેટ કરો"
@@ -3377,16 +3377,16 @@ DocType: Workflow State,share-alt,શેર-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},કતાર આમાંનું એક હોવું જોઈએ {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> ડિફૉલ્ટ નમૂનો </h4><p> ઉપયોગ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> અને ઉપલબ્ધ હશે (જો કોઈ હોય તો કસ્ટમ ક્ષેત્રો સહિત) સરનામું તમામ ક્ષેત્રો </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> ડિફૉલ્ટ નમૂનો </h4><p> ઉપયોગ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> અને ઉપલબ્ધ હશે (જો કોઈ હોય તો કસ્ટમ ક્ષેત્રો સહિત) સરનામું તમામ ક્ષેત્રો </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,તારીખ ક્ષેત્ર પ્રારંભ કરો
 DocType: Role,Role Name,રોલ નામ
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ડેસ્ક પર સ્વિચ

--- a/frappe/translations/he.csv
+++ b/frappe/translations/he.csv
@@ -67,7 +67,7 @@ apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,התקדמות
 DocType: Workflow State,random,אקראי
 DocType: Contact Email,Contact Email,"דוא""ל ליצירת קשר"
 apps/frappe/frappe/templates/emails/administrator_logged_in.html,"Dear System Manager,","מנהל מערכת יקר,"
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","האם לא תגי HTML קידוד HTML כמו &lt;script> או סתם דמויות כמו &lt;או>, כפי שיכלו לשמש במתכוון בתחום זה"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","האם לא תגי HTML קידוד HTML כמו <script> או סתם דמויות כמו <או>, כפי שיכלו לשמש במתכוון בתחום זה"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,בבקשה נסה שוב
 DocType: Error Snapshot,Pyver,Pyver
 apps/frappe/frappe/sessions.py,Cache Cleared,מטמון נוקה
@@ -870,7 +870,7 @@ DocType: System Settings,yyyy-mm-dd,yyyy-mm-dd
 apps/frappe/frappe/templates/emails/new_user.html,Your login id is,מזהה הכניסה שלך הוא
 DocType: User,Last Login,הביקור אחרון
 apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,לא ניתן לפתוח את הקובץ המצורף. האם אתה לייצא אותו כקובץ CSV?
-DocType: Web Page,Add code as &lt;script>,הוסף את הקוד כ& lt; תסריט & gt;
+DocType: Web Page,Add code as <script>,הוסף את הקוד כ<תסריט>
 apps/frappe/frappe/templates/includes/contact.js,Thank you for your message,תודה לך על ההודעה שלך
 apps/frappe/frappe/config/core.py,"Customized Formats for Printing, Email","פורמטים מותאמים להדפסה, דוא&quot;ל"
 DocType: Print Settings,A4,A4
@@ -1026,7 +1026,7 @@ DocType: Print Settings,PDF Settings,הגדרות PDF
 DocType: User,Block Modules,מודולים בלוק
 apps/frappe/frappe/website/doctype/website_settings/website_settings.py,{0} does not exist in row {1},{0} אינו קיים בשורת {1}
 DocType: Communication,Received,קיבלתי
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML הוסיף ב&lt; head> של דף האינטרנט, המשמש בעיקר לאימות אתר וקידום אתרים"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML הוסיף ב< head> של דף האינטרנט, המשמש בעיקר לאימות אתר וקידום אתרים"
 apps/frappe/frappe/utils/password_strength.py,Straight rows of keys are easy to guess,בשורות ישרות מפתחות קלות לנחש
 DocType: Web Page,Enable Comments,אפשר תגובות
 apps/frappe/frappe/model/rename_doc.py,Ignored: {0} to {1},להתעלם ממנו: {0} {1}
@@ -1342,16 +1342,16 @@ DocType: Workflow State,ok-circle,בסדר-המעגל
 DocType: DocType,Editable Grid,רשת לעריכה
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<H4> תבנית ברירת מחדל </ h4> <p> שימושים </a> <a href=""http://jinja.pocoo.org/docs/templates/""> ג'ינג'ה בניית תבנית וכל תחומי כתובת (כוללים שדות מותאמים אישית אם בכלל) יהיה זמין </ p> <pre> <code> {{}} address_line1 & lt; br & gt; {% אם address_line2%} {{}} address_line2 & lt; br & gt; {% endif -%} {{העיר}} & lt; br & gt; {% אם% מדינת} {{המדינה}} & lt; br & gt; {% endif -%} {% אם% pincode} PIN: {{pincode}} & lt; br & gt; {% endif -%} {{ארץ}} & lt ; Br & gt; {% אם% טלפון} טלפון: {{טלפון}} & lt; br & gt; {% endif -%} {% אם פקס%} פקס: {{פקס}} & lt; br & gt; {% endif -%} {% אם email_id % דוא""ל}: {{}} email_id & lt; br & gt; {endif% -%} </ code> </ pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<H4> תבנית ברירת מחדל </ h4> <p> שימושים </a> <a href=""http://jinja.pocoo.org/docs/templates/""> ג'ינג'ה בניית תבנית וכל תחומי כתובת (כוללים שדות מותאמים אישית אם בכלל) יהיה זמין </ p> <pre> <code> {{}} address_line1 <br> {% אם address_line2%} {{}} address_line2 <br> {% endif -%} {{העיר}} <br> {% אם% מדינת} {{המדינה}} <br> {% endif -%} {% אם% pincode} PIN: {{pincode}} <br> {% endif -%} {{ארץ}} & lt ; Br> {% אם% טלפון} טלפון: {{טלפון}} <br> {% endif -%} {% אם פקס%} פקס: {{פקס}} <br> {% endif -%} {% אם email_id % דוא""ל}: {{}} email_id <br> {endif% -%} </ code> </ pre>"
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,הוסף לילדים
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,שווה
 DocType: Workflow State,arrow-right,חץ ימני
@@ -1466,7 +1466,7 @@ DocType: Comment,Attachment Removed,הוסר Attachment
 apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,מנהל נצפה {0} על {1} באמצעות כתובת IP {2}.
 DocType: Email Account,Ignore attachments over this size,התעלם קבצים מצורפים מעל הגודל הזה
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit Custom HTML,עריכה המותאמת אישית HTML
-DocType: Website Settings,&lt;head> HTML,&lt;ראש> HTML
+DocType: Website Settings,<head> HTML,<ראש> HTML
 DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,הודעות ומיילים בתפוצה רחבה תישלחנה מהשרת דואר יוצא זה.
 DocType: Website Settings,Disable Customer Signup link in Login page,קישור הרשמה לקוחות השבת בדף כניסה
 DocType: Help Article,Likes,אוהב

--- a/frappe/translations/he.csv
+++ b/frappe/translations/he.csv
@@ -5,7 +5,7 @@ DocType: Event,Call,שיחה
 DocType: Email Account,GMail,GMail
 DocType: Auto Repeat,End Date,תאריך סיום
 DocType: Custom DocPerm,Apply this rule if the User is the Owner,"החל מכלל זה, אם המשתמש הוא בעל"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","הכנס לאחר שדה &#39;{0}&#39; המוזכר בשדה מותאם אישית &#39;{1}&#39;, עם התווית &#39;{2}&#39;, אינו קיים"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","הכנס לאחר שדה '{0}' המוזכר בשדה מותאם אישית '{1}', עם התווית '{2}', אינו קיים"
 DocType: Activity Log,Timeline DocType,DOCTYPE ציר הזמן
 DocType: ToDo,Assigned By,שהוקצה על ידי
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select All,בחר הכל
@@ -128,7 +128,7 @@ DocType: Address,Links,קישורים
 apps/frappe/frappe/utils/verified_command.py,Invalid Link,קישור לא חוקי
 DocType: Workflow State,Warning,אזהרה
 DocType: Comment,Comment Type,סוג התגובה
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,אתה יכול להוסיף תכונות דינמיות מהמסמך באמצעות בניית תבנית ג&#39;ינג&#39;ה.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,אתה יכול להוסיף תכונות דינמיות מהמסמך באמצעות בניית תבנית ג'ינג'ה.
 apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},יש קצת בעיה עם כתובת אתר הקובץ: {0}
 DocType: DocField,Collapsible,מתקפל
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Web Link,קישור אינטרנט
@@ -146,7 +146,7 @@ DocType: System Settings,Your organization name and address for the email footer
 DocType: Currency,Fraction Units,יחידות שבריר
 DocType: About Us Settings,"""Team Members"" or ""Management""","""חברי צוות"" או ""ניהול"""
 DocType: Top Bar Item,For top bar,לבר העליון
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,התנאי &#39;{0}&#39; אינו חוקי
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,התנאי '{0}' אינו חוקי
 DocType: Portal Settings,Portal Menu,תפריט פורטל
 DocType: Auto Repeat,Notification,הוֹדָעָה
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,"Check columns to select, drag to set order.","בדקו עמודות כדי לבחור, לגרור להגדיר סדר."
@@ -170,9 +170,9 @@ DocType: Comment,Assigned,שהוקצה
 apps/frappe/frappe/config/website.py,Single Post (article).,הודעה אחת (מאמר).
 DocType: Notification,"To add dynamic subject, use jinja tags like
 
-<div><pre><code>{{ doc.name }} Delivered</code></pre></div>","כדי להוסיף נושא דינמי, להשתמש בתגי ג&#39;ינג&#39;ה כמו <div style="";text-align:right;direction:rtl""><pre style="";text-align:right;direction:rtl""> <code>{{ doc.name }} Delivered</code> </pre> </div>"
+<div><pre><code>{{ doc.name }} Delivered</code></pre></div>","כדי להוסיף נושא דינמי, להשתמש בתגי ג'ינג'ה כמו <div style="";text-align:right;direction:rtl""><pre style="";text-align:right;direction:rtl""> <code>{{ doc.name }} Delivered</code> </pre> </div>"
 apps/frappe/frappe/config/settings.py,Drag and Drop tool to build and customize Print Formats.,גרור ושחררתם כלי לבנות ולהתאים אישית את תבניות הדפסה.
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},אין הרשאות ל&#39;{0} &#39;{1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},אין הרשאות ל'{0} '{1}
 DocType: User,Birth Date,תאריך לידה
 apps/frappe/frappe/public/js/frappe/form/save.js,Amending,הַתקָנָה
 apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,חייב לציין שאילתה לרוץ
@@ -206,7 +206,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"On
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",שדה זה יופיע רק אם fieldname מוגדר כאן יש ערך או כללים נכונים (דוגמאות): myfield eval: doc.myfield == &#39;ערך שלי&#39; eval: doc.age> 18
+eval:doc.age>18",שדה זה יופיע רק אם fieldname מוגדר כאן יש ערך או כללים נכונים (דוגמאות): myfield eval: doc.myfield == 'ערך שלי' eval: doc.age> 18
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select Columns,בחרו עמודות
 DocType: Footer Item,URL,כתובת האתר
 DocType: Address,City/Town,עיר / יישוב
@@ -449,7 +449,7 @@ DocType: Chat Message,Room,חֶדֶר
 DocType: DocShare,Notify by Email,להודיע באמצעות דוא&quot;ל
 DocType: User,System User,משתמש מערכת
 DocType: DocField,Text Editor,עורך טקסט
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,קובץ &#39;{0}&#39; לא נמצא
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,קובץ '{0}' לא נמצא
 apps/frappe/frappe/www/update-password.html,Old Password,סיסמא הישנה
 DocType: Workflow State,hand-right,יד ימין
 DocType: Custom DocPerm,Export,יצוא
@@ -710,7 +710,7 @@ DocType: Workflow State,Download,הורדה
 apps/frappe/frappe/core/doctype/user/user.js,Refreshing...,מרענן ...
 apps/frappe/frappe/core/doctype/file/test_file.py,Test_Folder,Test_Folder
 apps/frappe/frappe/public/js/frappe/web_form/webform_script.js,You are not permitted to access this page.,אינכם מורשים לגשת לדף זה.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,החלפות צפויות כמו &#39;@&#39; במקום &#39;a&#39; לא עזר לנו במיוחד.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,החלפות צפויות כמו '@' במקום 'a' לא עזר לנו במיוחד.
 apps/frappe/frappe/config/desktop.py,Users and Permissions,משתמשים והרשאות
 DocType: Email Account,Default Outgoing,יוצא ברירת מחדל
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify Password,אימות סיסמא
@@ -756,7 +756,7 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,לא מורשה
 DocType: Data Import Beta,Preview,תצוגה מקדימה
 DocType: User,Karma,קארמה
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},אתה לא יכול לבטל את הגדרה של &#39;קריאה בלבד&#39; לשדה {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},אתה לא יכול לבטל את הגדרה של 'קריאה בלבד' לשדה {0}
 apps/frappe/frappe/utils/password_strength.py,Recent years are easy to guess.,בשנים האחרונות קלות לנחש.
 apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},אין לך הרשאה על מנת לקבל דיווח על: {0}
 DocType: Communication,Marked As Spam,סומן כדואר זבל
@@ -1411,7 +1411,7 @@ DocType: Print Settings,PDF Page Size,גודל דף PDF
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Group Node,צומת קבוצה
 apps/frappe/frappe/config/website.py,Web Site,אתר אינטרנט
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Info:,מידע:
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',אתה יכול למצוא דברים בשאלה &#39;למצוא כתום לקוחות&#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',אתה יכול למצוא דברים בשאלה 'למצוא כתום לקוחות'
 DocType: Desktop Icon,Blocked,חָסוּם
 apps/frappe/frappe/config/customization.py,Add fields to forms.,הוספת שדות לצורות.
 DocType: Auto Repeat,Template,תבנית
@@ -1610,7 +1610,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,For {0} at level {1} in {2} i
 apps/frappe/frappe/public/js/frappe/views/communication.js,New Email,מייל חדש
 DocType: Social Login Key,GitHub,GitHub
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,use % as wildcard,להשתמש% ככלליים
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',משתמש &#39;{0}&#39; כבר יש את התפקיד &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',משתמש '{0}' כבר יש את התפקיד '{1}'
 DocType: Web Form,Login Required,כניסה לחשבון נדרש
 DocType: Data Import,Amended From,תוקן מ
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Left this conversation,עזב את השיחה הזאת
@@ -1727,7 +1727,7 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a comm
 DocType: Chat Message Attachment,Attachment,קובץ מצורף
 DocType: Assignment Rule Day,Sunday,יום ראשון
 apps/frappe/frappe/utils/jinja.py,Syntax error in template,שגיאת תחביר התבנית
-apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,הודעות צ&#39;אט והודעות אחרות.
+apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,הודעות צ'אט והודעות אחרות.
 DocType: Contact,Last Name,שם משפחה
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Save,שמור
 DocType: Bulk Update,Bulk Update,עדכון גורף

--- a/frappe/translations/he.csv
+++ b/frappe/translations/he.csv
@@ -67,7 +67,7 @@ apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,התקדמות
 DocType: Workflow State,random,אקראי
 DocType: Contact Email,Contact Email,"דוא""ל ליצירת קשר"
 apps/frappe/frappe/templates/emails/administrator_logged_in.html,"Dear System Manager,","מנהל מערכת יקר,"
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","האם לא תגי HTML קידוד HTML כמו &lt;script&gt; או סתם דמויות כמו &lt;או&gt;, כפי שיכלו לשמש במתכוון בתחום זה"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","האם לא תגי HTML קידוד HTML כמו &lt;script> או סתם דמויות כמו &lt;או>, כפי שיכלו לשמש במתכוון בתחום זה"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,בבקשה נסה שוב
 DocType: Error Snapshot,Pyver,Pyver
 apps/frappe/frappe/sessions.py,Cache Cleared,מטמון נוקה
@@ -206,7 +206,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"On
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",שדה זה יופיע רק אם fieldname מוגדר כאן יש ערך או כללים נכונים (דוגמאות): myfield eval: doc.myfield == &#39;ערך שלי&#39; eval: doc.age&gt; 18
+eval:doc.age>18",שדה זה יופיע רק אם fieldname מוגדר כאן יש ערך או כללים נכונים (דוגמאות): myfield eval: doc.myfield == &#39;ערך שלי&#39; eval: doc.age> 18
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select Columns,בחרו עמודות
 DocType: Footer Item,URL,כתובת האתר
 DocType: Address,City/Town,עיר / יישוב
@@ -870,7 +870,7 @@ DocType: System Settings,yyyy-mm-dd,yyyy-mm-dd
 apps/frappe/frappe/templates/emails/new_user.html,Your login id is,מזהה הכניסה שלך הוא
 DocType: User,Last Login,הביקור אחרון
 apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,לא ניתן לפתוח את הקובץ המצורף. האם אתה לייצא אותו כקובץ CSV?
-DocType: Web Page,Add code as &lt;script&gt;,הוסף את הקוד כ& lt; תסריט & gt;
+DocType: Web Page,Add code as &lt;script>,הוסף את הקוד כ& lt; תסריט & gt;
 apps/frappe/frappe/templates/includes/contact.js,Thank you for your message,תודה לך על ההודעה שלך
 apps/frappe/frappe/config/core.py,"Customized Formats for Printing, Email","פורמטים מותאמים להדפסה, דוא&quot;ל"
 DocType: Print Settings,A4,A4
@@ -1026,7 +1026,7 @@ DocType: Print Settings,PDF Settings,הגדרות PDF
 DocType: User,Block Modules,מודולים בלוק
 apps/frappe/frappe/website/doctype/website_settings/website_settings.py,{0} does not exist in row {1},{0} אינו קיים בשורת {1}
 DocType: Communication,Received,קיבלתי
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML הוסיף ב&lt; head&gt; של דף האינטרנט, המשמש בעיקר לאימות אתר וקידום אתרים"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML הוסיף ב&lt; head> של דף האינטרנט, המשמש בעיקר לאימות אתר וקידום אתרים"
 apps/frappe/frappe/utils/password_strength.py,Straight rows of keys are easy to guess,בשורות ישרות מפתחות קלות לנחש
 DocType: Web Page,Enable Comments,אפשר תגובות
 apps/frappe/frappe/model/rename_doc.py,Ignored: {0} to {1},להתעלם ממנו: {0} {1}
@@ -1342,15 +1342,15 @@ DocType: Workflow State,ok-circle,בסדר-המעגל
 DocType: DocType,Editable Grid,רשת לעריכה
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> תבנית ברירת מחדל </ h4> <p> שימושים </a> <a href=""http://jinja.pocoo.org/docs/templates/""> ג'ינג'ה בניית תבנית וכל תחומי כתובת (כוללים שדות מותאמים אישית אם בכלל) יהיה זמין </ p> <pre> <code> {{}} address_line1 & lt; br & gt; {% אם address_line2%} {{}} address_line2 & lt; br & gt; {% endif -%} {{העיר}} & lt; br & gt; {% אם% מדינת} {{המדינה}} & lt; br & gt; {% endif -%} {% אם% pincode} PIN: {{pincode}} & lt; br & gt; {% endif -%} {{ארץ}} & lt ; Br & gt; {% אם% טלפון} טלפון: {{טלפון}} & lt; br & gt; {% endif -%} {% אם פקס%} פקס: {{פקס}} & lt; br & gt; {% endif -%} {% אם email_id % דוא""ל}: {{}} email_id & lt; br & gt; {endif% -%} </ code> </ pre>"
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,הוסף לילדים
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,שווה
@@ -1466,7 +1466,7 @@ DocType: Comment,Attachment Removed,הוסר Attachment
 apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,מנהל נצפה {0} על {1} באמצעות כתובת IP {2}.
 DocType: Email Account,Ignore attachments over this size,התעלם קבצים מצורפים מעל הגודל הזה
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit Custom HTML,עריכה המותאמת אישית HTML
-DocType: Website Settings,&lt;head&gt; HTML,&lt;ראש&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;ראש> HTML
 DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,הודעות ומיילים בתפוצה רחבה תישלחנה מהשרת דואר יוצא זה.
 DocType: Website Settings,Disable Customer Signup link in Login page,קישור הרשמה לקוחות השבת בדף כניסה
 DocType: Help Article,Likes,אוהב

--- a/frappe/translations/hi.csv
+++ b/frappe/translations/hi.csv
@@ -556,7 +556,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),पिछले सप्ताह के प्रदर्शन ({0} से {1} तक) पर आधारित आँकड़े
 DocType: LDAP Settings,LDAP Phone Field,LDAP फ़ोन फ़ील्ड
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","दस्तावेज़ प्रकार ..., जैसे ग्राहक"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,स्थिति &#39;{0}&#39; अमान्य है
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,स्थिति '{0}' अमान्य है
 DocType: Workflow State,barcode,बारकोड
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,उप-क्वेरी या फ़ंक्शन का उपयोग प्रतिबंधित है
 apps/frappe/frappe/config/customization.py,Add your own translations,अपने खुद के अनुवाद जोड़े
@@ -705,7 +705,7 @@ DocType: Slack Webhook URL,Webhook URL,वेबहुक यूआरएल
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,प्रयोक्ता नाम {0} पहले से ही मौजूद है
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0} {1} आयात योग्य नहीं है के रूप में आयात सेट नहीं कर सकता
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},अपनी पता टेम्पलेट में कोई त्रुटि है {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} &#39;प्राप्तकर्ता&#39; में एक अमान्य ईमेल पता है
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} 'प्राप्तकर्ता' में एक अमान्य ईमेल पता है
 DocType: Footer Item,"target = ""_blank""",लक्ष्य = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,मेज़बान
@@ -747,7 +747,7 @@ DocType: Currency,Currency Name,मुद्रा का नाम
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,कोई ईमेल
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,लिंक की अवधि समाप्त हो
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; में &#39;{1}&#39; के लिए लंबाई को {0} पर वापस लाएं; लंबाई को सेट करने के रूप में {3} डेटा का छंटनी होगी।
+							Setting the length as {3} will cause truncation of data.",'{2}' में '{1}' के लिए लंबाई को {0} पर वापस लाएं; लंबाई को सेट करने के रूप में {3} डेटा का छंटनी होगी।
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,फ़ाइल प्रारूप का चयन करें
 DocType: Report,Javascript,जावास्क्रिप्ट
 DocType: File,Content Hash,सामग्री हैश
@@ -768,7 +768,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,दस्तावेज़ को साझा रिपोर्ट
 DocType: Social Login Key,Base URL,आधार URL
 DocType: User,Last Login,अंतिम लॉगिन
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},आप फ़ील्ड {0} के लिए &#39;ट्रांसलेट योग्य&#39; सेट नहीं कर सकते
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},आप फ़ील्ड {0} के लिए 'ट्रांसलेट योग्य' सेट नहीं कर सकते
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,स्तंभ
 DocType: Chat Profile,Chat Profile,चैट प्रोफ़ाइल
 DocType: Custom Field,Adds a custom field to a DocType,एक doctype के लिए एक कस्टम क्षेत्र जोड़ता है
@@ -777,7 +777,7 @@ DocType: File,Is Home Folder,होम फ़ोल्डर है
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,नवबर शैली
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} एक मान्य ईमेल पता नहीं है
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,मुद्रण के लिए कम से कम 1 रिकॉर्ड का चयन करें
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',उपयोगकर्ता &#39;{0}&#39; पहले से ही भूमिका है &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',उपयोगकर्ता '{0}' पहले से ही भूमिका है '{1}'
 DocType: System Settings,Two Factor Authentication method,दो फैक्टर प्रमाणीकरण विधि
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,पहले नाम सेट करें और रिकॉर्ड को सहेजें।
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 रिकॉर्ड
@@ -1440,7 +1440,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,अनिवार्य क्षेत्र: के लिए निर्धारित भूमिका
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} आलोचना की {1}
 DocType: Data Migration Mapping,Mapping Name,मैपिंग नाम
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: फ़ील्ड &#39;{1}&#39; को यूनिक के रूप में सेट नहीं किया जा सकता क्योंकि इसमें गैर-विशिष्ट मूल्य हैं
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: फ़ील्ड '{1}' को यूनिक के रूप में सेट नहीं किया जा सकता क्योंकि इसमें गैर-विशिष्ट मूल्य हैं
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,सूची को नीचे नेविगेट करें
 DocType: Currency,A symbol for this currency. For e.g. $,इस मुद्रा के लिए एक प्रतीक. उदाहरण के लिए $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,अनुवाद को सफलतापूर्वक अपडेट किया गया
@@ -1960,7 +1960,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,एपी-दक्षिण-पूर्व-1
 DocType: DocType,"Must be of type ""Attach Image""",प्रकार का होना चाहिए &quot;छवि संलग्न&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,सभी का चयन रद्द
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},आप क्षेत्र के लिए सेट नहीं नहीं &#39;केवल पढ़ने के लिए कर सकते हैं&#39; {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},आप क्षेत्र के लिए सेट नहीं नहीं 'केवल पढ़ने के लिए कर सकते हैं' {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,शून्य का मतलब किसी भी समय अपडेट रिकॉर्ड भेजना है
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,पूरा सेटअप
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,अद्यतन सफलतापूर्ण हो गया
@@ -2003,7 +2003,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google फ़ॉन्ट
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","इन निर्देशों जहां मददगार नहीं हैं, GitHub मुद्दे पर अपने सुझाव में जोड़ें."
 DocType: Workflow State,bookmark,बुकमार्क
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),फ़ोल्डर नाम में &#39;/&#39; (स्लैश) शामिल नहीं होना चाहिए
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),फ़ोल्डर नाम में '/' (स्लैश) शामिल नहीं होना चाहिए
 DocType: Note,Note,नोट
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,त्रुटि की रिपोर्ट
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,सीएसवी / एक्सेल प्रारूप में डेटा निर्यात करें
@@ -2107,7 +2107,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,घंटे मे�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",यह क्षेत्र केवल तभी दिखाई देगा FIELDNAME यहाँ परिभाषित महत्व है या नियमों के सच्चे (उदाहरण) कर रहे हैं: myfield eval: doc.myfield == &#39;मेरा मान&#39; eval: doc.age> 18
+eval:doc.age>18",यह क्षेत्र केवल तभी दिखाई देगा FIELDNAME यहाँ परिभाषित महत्व है या नियमों के सच्चे (उदाहरण) कर रहे हैं: myfield eval: doc.myfield == 'मेरा मान' eval: doc.age> 18
 DocType: Social Login Key,Office 365,ऑफिस 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,आज
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","आप इस सेट करने के बाद , उपयोगकर्ताओं को केवल सक्षम पहुँच दस्तावेजों लिंक मौजूद है, जहां (जैसे ब्लॉग पोस्ट) (जैसे ब्लॉगर ) हो जाएगा ."
@@ -2146,10 +2146,10 @@ DocType: Data Migration Connector,Database Name,डेटाबेस नाम
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,ताज़ा करे पर्चा
 DocType: DocField,Select,चयन
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,पूर्ण लॉग देखें
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","सरल पायथन अभिव्यक्ति, उदाहरण: स्थिति == &#39;खुला&#39; और प्रकार == &#39;बग&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","सरल पायथन अभिव्यक्ति, उदाहरण: स्थिति == 'खुला' और प्रकार == 'बग'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,फ़ाइल संलग्न नहीं
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,संपर्क टूट गया। कुछ सुविधाएं शायद काम न करें
-apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&#39;एएए&#39; की तरह दोहराता अनुमान लगाना आसान है
+apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",'एएए' की तरह दोहराता अनुमान लगाना आसान है
 apps/frappe/frappe/public/js/frappe/chat.js,New Chat,नई चैट
 DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","आप यह निर्धारित करते हैं, इस आइटम का चयन माता पिता के नीचे एक ड्रॉप डाउन में आ जाएगा ."
 DocType: Print Format,Show Section Headings,शो धारा शीर्षकों
@@ -2277,7 +2277,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,केवल त्रुटियों को दिखाएं
 DocType: Website Settings,Banner HTML,बैनर HTML
 DocType: Workflow,Send Email Alert,ईमेल अलर्ट भेजें
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',कृपया किसी अन्य भुगतान विधि चुनें। Razorpay मुद्रा में लेन-देन का समर्थन नहीं करता &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',कृपया किसी अन्य भुगतान विधि चुनें। Razorpay मुद्रा में लेन-देन का समर्थन नहीं करता '{0}'
 DocType: Data Import,In Progress,चालू
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,बैकअप के लिए कतारबद्ध। यह एक घंटे के लिए कुछ मिनट लग सकते हैं।
 DocType: Error Snapshot,Pyver,Pyver
@@ -2699,7 +2699,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,संशोधन
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,पेपैल भुगतान गेटवे सेटिंग्स
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,चोटी का कलाकार
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,कस्टम फ़ील्ड को कोर DocTypes में नहीं जोड़ा जा सकता है।
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) छोटा मिल जाएगा, के रूप में अनुमति दी अधिकतम वर्ण है {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) छोटा मिल जाएगा, के रूप में अनुमति दी अधिकतम वर्ण है {2}"
 DocType: OAuth Client,Response Type,रिस्पांस प्रकार
 DocType: Contact Us Settings,Send enquiries to this email address,इस ईमेल पते पर पूछताछ भेजें
 DocType: Letter Head,Letter Head Name,लेटर हेड का नाम
@@ -2756,7 +2756,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,छवि देखें
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","लग रहा है जैसे कुछ लेनदेन के दौरान गलत हो गया। हम भुगतान की पुष्टि नहीं की है के बाद से, पेपैल स्वचालित रूप से आप इस राशि वापस कर देंगे। यदि ऐसा नहीं होता, तो हमें एक ईमेल भेजने के लिए और सहसंबंध आईडी का उल्लेख है: {0}।"
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","पासवर्ड में प्रतीकों, संख्याएं और कैपिटल अक्षरों को शामिल करें"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","क्षेत्र &#39;{0}&#39; कस्टम क्षेत्र में उल्लेख के बाद डालें &#39;{1}&#39;, लेबल के साथ &#39;{2}&#39;, अस्तित्व में नहीं है"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","क्षेत्र '{0}' कस्टम क्षेत्र में उल्लेख के बाद डालें '{1}', लेबल के साथ '{2}', अस्तित्व में नहीं है"
 DocType: List Filter,List Filter,सूची फ़िल्टर
 DocType: Workflow State,signal,संकेत
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,संलग्नक हैं
@@ -2766,7 +2766,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,दस्तावेज़ बहाल
 DocType: Data Export,Data Export,डेटा निर्यात
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,भाषा चुनिए...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},आप फ़ील्ड {0} के लिए &#39;विकल्प&#39; सेट नहीं कर सकते
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},आप फ़ील्ड {0} के लिए 'विकल्प' सेट नहीं कर सकते
 DocType: Help Article,Author,लेखक
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,फिर से शुरू भेज
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,फिर से खोलना
@@ -2780,14 +2780,14 @@ DocType: Web Page,Slideshow,स्लाइड शो
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,डिफ़ॉल्ट पता खाका हटाया नहीं जा सकता
 DocType: Contact,Maintenance Manager,रखरखाव प्रबंधक
 DocType: Workflow State,Search,खोजें
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',कृपया कोई अन्य भुगतान विधि चुनें मुद्रा &#39;{0}&#39; में लेनदेन का समर्थन नहीं करता है
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',कृपया कोई अन्य भुगतान विधि चुनें मुद्रा '{0}' में लेनदेन का समर्थन नहीं करता है
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,रद्दी में डालें
 DocType: Web Form,Web Form Fields,वेब प्रपत्र फील्ड्स
 DocType: Data Import,Amended From,से संशोधित
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},चेतावनी: असमर्थ लगाने के लिए {0} से संबंधित किसी भी तालिका में {1}
 DocType: S3 Backup Settings,eu-north-1,यूरोपीय संघ और उत्तर 1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,इस दस्तावेज़ को वर्तमान में निष्पादन के लिए पंक्तिबद्ध है। कृपया पुन: प्रयास करें
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,फ़ाइल &#39;{0}&#39; नहीं मिला
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,फ़ाइल '{0}' नहीं मिला
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,धारा निकालें
 DocType: User,Change Password,पासवर्ड बदलें
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,एक्स अक्ष फ़ील्ड
@@ -2974,7 +2974,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,मूल्य क�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,बाल जोड़ें
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,आयात प्रगति
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",यदि हालत संतुष्ट है तो उपयोगकर्ता को अंकों के साथ पुरस्कृत किया जाएगा। जैसे। doc.status == &#39;बंद&#39;
+",यदि हालत संतुष्ट है तो उपयोगकर्ता को अंकों के साथ पुरस्कृत किया जाएगा। जैसे। doc.status == 'बंद'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: प्रेषित रिकार्ड नष्ट नहीं किया जा सकता है.
 DocType: GSuite Templates,Template Name,टेम्पलेट नाम
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,दस्तावेज़ के नए प्रकार
@@ -3107,7 +3107,7 @@ DocType: Dashboard Chart,Chart Type,चार्ट प्रकार
 DocType: DocType,Auto Name,ऑटो नाम
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,एबीसी या 6543 की तरह दृश्यों से बचें क्योंकि वे अनुमान लगाना आसान है
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,कृपया पुन: प्रयास करें
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; या &#39;https: //&#39; से शुरू होना चाहिए
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' या 'https: //' से शुरू होना चाहिए
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,विकल्प 3
 DocType: Communication,uid,यूआईडी
 DocType: Workflow State,Edit,संपादित करें
@@ -3346,7 +3346,7 @@ DocType: Notification,Send alert if this field's value changes,चेताव�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,थीम रंग
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,एक नया प्रारूप बनाने के लिए एक doctype का चयन करें
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,उपयोगकर्ता मौजूद नहीं है
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;प्राप्तकर्ता&#39; निर्दिष्ट नहीं है
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'प्राप्तकर्ता' निर्दिष्ट नहीं है
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,अभी
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,लागू करें
 DocType: Footer Item,Policy,नीति
@@ -3394,7 +3394,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,कस्टम �
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,प्रगति
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,भूमिका से
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,लापता फील्ड्स
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname में अमान्य FIELDNAME &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname में अमान्य FIELDNAME '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,एक दस्तावेज़ प्रकार मे खोजें
 DocType: Custom DocPerm,Role and Level,रोल और स्तर
 DocType: File,Thumbnail URL,थंबनेल URL
@@ -3494,7 +3494,7 @@ DocType: Dashboard Chart,Filters JSON,फिल्टर JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,सत्यापित करने के लिए यहां क्लिक करें
 DocType: Email Account,Disable SMTP server authentication,SMTP सर्वर प्रमाणीकरण अक्षम करें
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,क्लिपबोर्ड पर नकल।
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,की तरह उम्मीद के मुताबिक प्रतिस्थापन &#39;@&#39; के बजाय &#39;एक&#39; बहुत ज्यादा मदद नहीं करते।
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,की तरह उम्मीद के मुताबिक प्रतिस्थापन '@' के बजाय 'एक' बहुत ज्यादा मदद नहीं करते।
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,मेरे द्वारा आवंटित
 apps/frappe/frappe/utils/data.py,Zero,शून्य
 DocType: Google Drive,Backup Folder ID,बैकअप फ़ोल्डर आईडी
@@ -3547,7 +3547,7 @@ DocType: Notification,Reference Date,संदर्भ तिथि
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,ओटीपी ऐप का उपयोग करके ओटीपी सेटअप पूरा नहीं हुआ था। कृपया प्रशासक से संपर्क करें।
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,वैध मोबाइल नंबर दर्ज करें
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,हो सकता है कि कुछ विशेषताएं आपके ब्राउज़र में काम न करें। कृपया अपने ब्राउज़र को नवीनतम संस्करण में अपडेट करें।
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","पता नहीं है, पूछना &#39;मदद&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","पता नहीं है, पूछना 'मदद'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},इस दस्तावेज़ को रद्द कर दिया {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,टिप्पणियाँ और संचार से जुड़े इस दस्तावेज़ के साथ संबद्ध किया जाएगा
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,फ़िल्टर ...
@@ -3706,7 +3706,7 @@ DocType: Web Page,Web Page,वेब पेज
 DocType: Workflow Document State,Next Action Email Template,अगला एक्शन ईमेल टेम्पलेट
 DocType: Blog Category,Blogger,ब्लॉगर
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","यदि सक्षम किया गया है, तो दस्तावेज़ में परिवर्तन ट्रैक किए जाते हैं और समयरेखा में दिखाए जाते हैं"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},पंक्ति {1} में {0} प्रकार के लिए &#39;वैश्विक खोज में&#39; की अनुमति नहीं है
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},पंक्ति {1} में {0} प्रकार के लिए 'वैश्विक खोज में' की अनुमति नहीं है
 DocType: Energy Point Log,Appreciation,प्रशंसा
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,सूची देखें
 DocType: Workflow,Don't Override Status,स्थिति पर हावी नहीं है
@@ -3853,7 +3853,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,चूक
 DocType: Translation,Verified,सत्यापित
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} जोड़ा गया
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&#39;{0}&#39; के लिए खोजें
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}','{0}' के लिए खोजें
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,कृपया रिपोर्ट पहला बचा
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ग्राहक जोडा गया है
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,अंदर नही
@@ -3889,14 +3889,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,मुझ�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} नहीं एक वैध राज्य
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,सभी दस्तावेज़ प्रकारों पर लागू करें
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,एनर्जी पॉइंट अपडेट
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',कृपया किसी अन्य भुगतान विधि चुनें। पेपैल मुद्रा में लेन-देन का समर्थन नहीं करता &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',कृपया किसी अन्य भुगतान विधि चुनें। पेपैल मुद्रा में लेन-देन का समर्थन नहीं करता '{0}'
 DocType: Chat Message,Room Type,कमरे जैसा
 DocType: Data Import Beta,Import Log Preview,आयात लॉग पूर्वावलोकन
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,खोज के क्षेत्र {0} मान्य नहीं है
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,अपलोड की गई फ़ाइल
 DocType: Workflow State,ok-circle,ठीक चक्र
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP उपयोगकर्ता निर्माण और मानचित्रण
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',आप पूछ &#39;ग्राहकों में नारंगी पा&#39; से चीजें मिल सकता है
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',आप पूछ 'ग्राहकों में नारंगी पा' से चीजें मिल सकता है
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,सॉरी! उपयोगकर्ता अपने ही रिकॉर्ड करने के लिए पूरा उपयोग किया जाना चाहिए।
 ,Usage Info,उपयोग जानकारी
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,कीबोर्ड शॉर्टकट दिखाएं

--- a/frappe/translations/hi.csv
+++ b/frappe/translations/hi.csv
@@ -741,7 +741,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,फ़ा�
 DocType: DocField,In Global Search,वैश्विक खोज में
 DocType: System Settings,Brute Force Security,ब्रूट फोर्स सुरक्षा
 DocType: Workflow State,indent-left,इंडेंट - बाएँ
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} साल पहले
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} साल पहले
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,यह इस फ़ाइल को नष्ट करने के लिए जोखिम भरा है: {0}। अपने सिस्टम मैनेजर से संपर्क करें।
 DocType: Currency,Currency Name,मुद्रा का नाम
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,कोई ईमेल
@@ -1035,7 +1035,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,कोई {0}
 apps/frappe/frappe/config/customization.py,Add custom forms.,कस्टम प्रपत्र जोड़ें।
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} में {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,इस दस्तावेज प्रस्तुत
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,सेटअप&gt; उपयोगकर्ता अनुमतियाँ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,सेटअप> उपयोगकर्ता अनुमतियाँ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,प्रणाली कई पूर्व निर्धारित भूमिकाओं में हैं. आप महीन अनुमति सेट करने के लिए नई भूमिका में जोड़ सकते हैं .
 DocType: Communication,CC,सीसी
 DocType: Country,Geo,जियो
@@ -1254,7 +1254,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","उपयोगकर्ता किसी भी भूमिका की जाँच की है, तो यूजर को एक &quot;सिस्टम उपयोगकर्ता&quot; हो जाता है। &quot;सिस्टम उपयोगकर्ता&quot; डेस्कटॉप के लिए उपयोग किया है"
 DocType: System Settings,Date and Number Format,तिथि और संख्या स्वरूप
 apps/frappe/frappe/model/document.py,one of,में से एक
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,सेटअप&gt; फॉर्म को अनुकूलित करें
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,सेटअप> फॉर्म को अनुकूलित करें
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,एक पल जाँच हो रही है
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,टैग्स दिखाएं
 DocType: DocField,HTML Editor,एचटीएमएल संपादक
@@ -1262,7 +1262,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,बिलिंग
 DocType: Email Queue,Not Sent,नहीं भेजा गया
 DocType: Web Form,Actions,क्रियाएँ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,सेटअप&gt; उपयोगकर्ता
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,सेटअप> उपयोगकर्ता
 DocType: Workflow State,align-justify,संरेखित करें - का औचित्य साबित
 DocType: User,Middle Name (Optional),मध्य नाम (वैकल्पिक)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,अनुमति नहीं
@@ -1409,7 +1409,7 @@ DocType: User,System User,सिस्टम उपयोगकर्ता क�
 DocType: Report,Is Standard,मानक है
 DocType: Desktop Icon,_report,_प्रतिवेदन
 DocType: Dashboard Chart,Full,पूर्ण
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","ऐसा नहीं की तरह &lt;script&gt; या सिर्फ पात्रों की तरह &lt;या&gt;, के रूप में वे जानबूझकर इस क्षेत्र में इस्तेमाल किया जा सकता है HTML सांकेतिक शब्दों में बदलना एचटीएमएल टैग"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ऐसा नहीं की तरह &lt;script> या सिर्फ पात्रों की तरह &lt;या>, के रूप में वे जानबूझकर इस क्षेत्र में इस्तेमाल किया जा सकता है HTML सांकेतिक शब्दों में बदलना एचटीएमएल टैग"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} पर आलोचना की {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,रन
@@ -1789,7 +1789,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,केवल प�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,अपूर्ण
 DocType: System Settings,Allow only one session per user,प्रति उपयोगकर्ता केवल एक ही सत्र की अनुमति दें
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,घर / परीक्षण फ़ोल्डर 1 / परीक्षण फ़ोल्डर 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; एचटीएमएल
+DocType: Website Settings,&lt;head> HTML,&lt;Head> एचटीएमएल
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,का चयन करें या एक नई घटना बनाने के लिए टाइम स्लॉट भर में खींचें.
 DocType: Contact,Contact Details,जानकारी के लिए संपर्क
 DocType: DocField,In Filter,फिल्टर में
@@ -2020,7 +2020,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,लॉगइन इस समय की अनुमति नहीं
 DocType: Data Migration Run,Current Mapping Action,वर्तमान मैपिंग एक्शन
 DocType: Dashboard Chart Source,Source Name,स्रोत का नाम
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,उपयोगकर्ता के साथ कोई ईमेल खाता संबद्ध नहीं है। कृपया उपयोगकर्ता&gt; ईमेल इनबॉक्स के तहत एक खाता जोड़ें।
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,उपयोगकर्ता के साथ कोई ईमेल खाता संबद्ध नहीं है। कृपया उपयोगकर्ता> ईमेल इनबॉक्स के तहत एक खाता जोड़ें।
 DocType: Email Account,Email Sync Option,ईमेल सिंक विकल्प
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,पंक्ति संख्या नहीं
 DocType: Async Task,Runtime,क्रम
@@ -2035,7 +2035,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,पहल
 DocType: User Email,Enable Outgoing,निवर्तमान सक्षम करें
 DocType: Address,Fax,फैक्स
 apps/frappe/frappe/config/customization.py,Custom Tags,कस्टम टैग
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ईमेल खाता सेटअप नहीं। कृपया सेटअप&gt; ईमेल&gt; ईमेल खाते से एक नया ईमेल खाता बनाएं
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ईमेल खाता सेटअप नहीं। कृपया सेटअप> ईमेल> ईमेल खाते से एक नया ईमेल खाता बनाएं
 DocType: Comment,Submitted,पेश
 DocType: Contact,Pulled from Google Contacts,Google संपर्कों से खींचा गया
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,अमान्य अनुरोध
@@ -2107,7 +2107,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,घंटे मे�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",यह क्षेत्र केवल तभी दिखाई देगा FIELDNAME यहाँ परिभाषित महत्व है या नियमों के सच्चे (उदाहरण) कर रहे हैं: myfield eval: doc.myfield == &#39;मेरा मान&#39; eval: doc.age&gt; 18
+eval:doc.age>18",यह क्षेत्र केवल तभी दिखाई देगा FIELDNAME यहाँ परिभाषित महत्व है या नियमों के सच्चे (उदाहरण) कर रहे हैं: myfield eval: doc.myfield == &#39;मेरा मान&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,ऑफिस 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,आज
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","आप इस सेट करने के बाद , उपयोगकर्ताओं को केवल सक्षम पहुँच दस्तावेजों लिंक मौजूद है, जहां (जैसे ब्लॉग पोस्ट) (जैसे ब्लॉगर ) हो जाएगा ."
@@ -2121,7 +2121,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,अपरकेस
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,कस्टम HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,फ़ोल्डर का नाम दर्ज
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,कोई डिफ़ॉल्ट पता टेम्पलेट नहीं मिला। कृपया सेटअप&gt; प्रिंटिंग और ब्रांडिंग&gt; एड्रेस टेम्प्लेट से एक नया बनाएं।
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,कोई डिफ़ॉल्ट पता टेम्पलेट नहीं मिला। कृपया सेटअप> प्रिंटिंग और ब्रांडिंग> एड्रेस टेम्प्लेट से एक नया बनाएं।
 apps/frappe/frappe/auth.py,Unknown User,अज्ञात उपयोगकर्ता
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,रोल का चयन करें
 DocType: Comment,Deleted,हटाए गए
@@ -2310,7 +2310,7 @@ DocType: LDAP Settings,Path to Server Certificate,सर्वर प्रम�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,लिंक देखने की पर्याप्त अनुमति नहीं है
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,पता शीर्षक अनिवार्य है .
 DocType: Google Contacts,Push to Google Contacts,Google संपर्क में पुश करें
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","&lt;Head&gt; में जोड़ा गया HTML वेब पेज के अनुभाग में, मुख्य रूप से वेबसाइट सत्यापन और एसईओ के लिए इस्तेमाल किया"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","&lt;Head> में जोड़ा गया HTML वेब पेज के अनुभाग में, मुख्य रूप से वेबसाइट सत्यापन और एसईओ के लिए इस्तेमाल किया"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,आइटम अपने खुद के वंशजों को जोड़ा नहीं जा सकता
 DocType: Session Default Settings,Session Defaults,सत्र चूक
@@ -2429,7 +2429,7 @@ DocType: Workflow State,Warning,चेतावनी
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,यह कई पृष्ठों पर मुद्रित हो सकता है
 DocType: Data Migration Run,Percent Complete,पूर्ण प्रतिशत
 DocType: Tag Category,Tag Category,टैग श्रेणी
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलना के लिए,&gt; 5, &lt;10 या = 324 का उपयोग करें। श्रेणियों के लिए, 5:10 (5 और 10 के बीच मानों के लिए) का उपयोग करें।"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलना के लिए,> 5, &lt;10 या = 324 का उपयोग करें। श्रेणियों के लिए, 5:10 (5 और 10 के बीच मानों के लिए) का उपयोग करें।"
 DocType: Google Calendar,Pull from Google Calendar,Google कैलेंडर से खींचो
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,मदद
 DocType: User,Login Before,इससे पहले कीजिये
@@ -2504,7 +2504,7 @@ DocType: Event,Google Calendar Event ID,Google कैलेंडर ईवे�
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added","""पॅरेंट"" का अर्थ पॅरेंट टेबल जिसमें यह पंक्ति को जोड़ा जाना चाहिए"
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,अंक की समीक्षा करें:
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,इसके साथ साझा किया गया
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,फाइल / यूआरएल संलग्न करें और तालिका में जोड़ें।
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,फाइल / यूआरएल संलग्न करे��� और तालिका में जोड़ें।
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Message not setup,संदेश सेटअप नहीं है
 DocType: Help Category,Help Articles,सहायता आलेख
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Type:,प्रकार:
@@ -2891,7 +2891,7 @@ DocType: Custom Script,Custom Script,कस्टम स्क्रिप्ट
 DocType: Address,Address Line 2,पता पंक्ति 2
 DocType: Address,Reference,संदर्भ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,को सौंपा
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,कृपया सेटअप&gt; ईमेल&gt; ईमेल खाते से डिफ़ॉल्ट ईमेल खाता सेटअप करें
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,कृपया सेटअप> ईमेल> ईमेल खाते से डिफ़ॉल्ट ईमेल खाता सेटअप करें
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,डेटा माइग्रेशन मैपिंग विस्तार
 DocType: Data Import,Action,कार्रवाई
 DocType: GSuite Settings,Script URL,स्क्रिप्ट यूआरएल
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,भेजें पर अनुमति द�
 DocType: DocField,HTML,एचटीएमएल
 DocType: Error Snapshot,Exception Type,अपवाद प्रकार
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,स्तंभ उठाओ
-DocType: Web Page,Add code as &lt;script&gt;,&lt;script&gt; कोड के रूप में जोड़ें
+DocType: Web Page,Add code as &lt;script>,&lt;script> कोड के रूप में जोड़ें
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,उपयोगकर्ता अनुमतियाँ साफ़ करें
 DocType: Webhook,Headers,हेडर
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,आगामी कार्यक्रम
@@ -3443,15 +3443,15 @@ DocType: Workflow State,share-alt,शेयर Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},कतार {0} में से एक होना चाहिए
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> डिफ़ॉल्ट टेम्पलेट </ h4> 
  <P> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja templating </a> और पते के सभी क्षेत्रों (का उपयोग करता है {; br & gt; 
  {% अगर address_line2%} {{address_line2}} & lt; br & जीटी कस्टम फील्ड्स अगर कोई है) </ p> 

--- a/frappe/translations/hi.csv
+++ b/frappe/translations/hi.csv
@@ -1409,7 +1409,7 @@ DocType: User,System User,सिस्टम उपयोगकर्ता क�
 DocType: Report,Is Standard,मानक है
 DocType: Desktop Icon,_report,_प्रतिवेदन
 DocType: Dashboard Chart,Full,पूर्ण
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ऐसा नहीं की तरह &lt;script> या सिर्फ पात्रों की तरह &lt;या>, के रूप में वे जानबूझकर इस क्षेत्र में इस्तेमाल किया जा सकता है HTML सांकेतिक शब्दों में बदलना एचटीएमएल टैग"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","ऐसा नहीं की तरह <script> या सिर्फ पात्रों की तरह <या>, के रूप में वे जानबूझकर इस क्षेत्र में इस्तेमाल किया जा सकता है HTML सांकेतिक शब्दों में बदलना एचटीएमएल टैग"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} पर आलोचना की {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,रन
@@ -1789,7 +1789,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,केवल प�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,अपूर्ण
 DocType: System Settings,Allow only one session per user,प्रति उपयोगकर्ता केवल एक ही सत्र की अनुमति दें
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,घर / परीक्षण फ़ोल्डर 1 / परीक्षण फ़ोल्डर 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> एचटीएमएल
+DocType: Website Settings,<head> HTML,<Head> एचटीएमएल
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,का चयन करें या एक नई घटना बनाने के लिए टाइम स्लॉट भर में खींचें.
 DocType: Contact,Contact Details,जानकारी के लिए संपर्क
 DocType: DocField,In Filter,फिल्टर में
@@ -2310,7 +2310,7 @@ DocType: LDAP Settings,Path to Server Certificate,सर्वर प्रम�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,लिंक देखने की पर्याप्त अनुमति नहीं है
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,पता शीर्षक अनिवार्य है .
 DocType: Google Contacts,Push to Google Contacts,Google संपर्क में पुश करें
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","&lt;Head> में जोड़ा गया HTML वेब पेज के अनुभाग में, मुख्य रूप से वेबसाइट सत्यापन और एसईओ के लिए इस्तेमाल किया"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","<Head> में जोड़ा गया HTML वेब पेज के अनुभाग में, मुख्य रूप से वेबसाइट सत्यापन और एसईओ के लिए इस्तेमाल किया"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,आइटम अपने खुद के वंशजों को जोड़ा नहीं जा सकता
 DocType: Session Default Settings,Session Defaults,सत्र चूक
@@ -2429,7 +2429,7 @@ DocType: Workflow State,Warning,चेतावनी
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,यह कई पृष्ठों पर मुद्रित हो सकता है
 DocType: Data Migration Run,Percent Complete,पूर्ण प्रतिशत
 DocType: Tag Category,Tag Category,टैग श्रेणी
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलना के लिए,> 5, &lt;10 या = 324 का उपयोग करें। श्रेणियों के लिए, 5:10 (5 और 10 के बीच मानों के लिए) का उपयोग करें।"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलना के लिए,> 5, <10 या = 324 का उपयोग करें। श्रेणियों के लिए, 5:10 (5 और 10 के बीच मानों के लिए) का उपयोग करें।"
 DocType: Google Calendar,Pull from Google Calendar,Google कैलेंडर से खींचो
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,मदद
 DocType: User,Login Before,इससे पहले कीजिये
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,भेजें पर अनुमति द�
 DocType: DocField,HTML,एचटीएमएल
 DocType: Error Snapshot,Exception Type,अपवाद प्रकार
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,स्तंभ उठाओ
-DocType: Web Page,Add code as &lt;script>,&lt;script> कोड के रूप में जोड़ें
+DocType: Web Page,Add code as <script>,<script> कोड के रूप में जोड़ें
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,उपयोगकर्ता अनुमतियाँ साफ़ करें
 DocType: Webhook,Headers,हेडर
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,आगामी कार्यक्रम
@@ -3443,26 +3443,26 @@ DocType: Workflow State,share-alt,शेयर Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},कतार {0} में से एक होना चाहिए
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> डिफ़ॉल्ट टेम्पलेट </ h4> 
- <P> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja templating </a> और पते के सभी क्षेत्रों (का उपयोग करता है {; br & gt; 
- {% अगर address_line2%} {{address_line2}} & lt; br & जीटी कस्टम फील्ड्स अगर कोई है) </ p> 
+ <P> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja templating </a> और पते के सभी क्षेत्रों (का उपयोग करता है {; br> 
+ {% अगर address_line2%} {{address_line2}} <br & जीटी कस्टम फील्ड्स अगर कोई है) </ p> 
  <पूर्व> <कोड> {{address_line1}} व एलटी उपलब्ध हो जाएगा सहित % endif -%} 
- {{शहर}} और लेफ्टिनेंट; br & gt; 
- {% अगर राज्य%} {{राज्य}} और लेफ्टिनेंट; br & gt; {% endif -%} 
- {% अगर पिन कोड%} पिन: {{पिन कोड}} और लेफ्टिनेंट; br & gt; {% endif -%} 
- {{देश}} और लेफ्टिनेंट; br & gt; 
- {% अगर फोन%} फोन: {{फोन}} और लेफ्टिनेंट; br & gt; { % endif -%} 
- {% अगर फैक्स%} फैक्स: {{फैक्स}} और लेफ्टिनेंट; br & gt; {% endif -%} 
- {% अगर email_id%} ईमेल: {{email_id}} & lt; br & जी.टी. ; {% endif -%} 
+ {{शहर}} और लेफ्टिनेंट; br> 
+ {% अगर राज्य%} {{राज्य}} और लेफ्टिनेंट; br> {% endif -%} 
+ {% अगर पिन कोड%} पिन: {{पिन कोड}} और लेफ्टिनेंट; br> {% endif -%} 
+ {{देश}} और लेफ्टिनेंट; br> 
+ {% अगर फोन%} फोन: {{फोन}} और लेफ्टिनेंट; br> { % endif -%} 
+ {% अगर फैक्स%} फैक्स: {{फैक्स}} और लेफ्टिनेंट; br> {% endif -%} 
+ {% अगर email_id%} ईमेल: {{email_id}} <br & जी.टी. ; {% endif -%} 
  </ कोड> </ pre>"
 DocType: Calendar View,Start Date Field,प्रारंभ दिनांक फ़ील्ड
 DocType: Role,Role Name,भूमिका का नाम

--- a/frappe/translations/hr.csv
+++ b/frappe/translations/hr.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Sigurnosna 
 DocType: DocField,In Global Search,U Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,alineje-lijevo
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} prije (i) godine
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} prije (i) godine
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,To je rizično izbrisati ovu datoteku: {0}. Molimo kontaktirajte svog sustava Manageru.
 DocType: Currency,Currency Name,Valuta Ime
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,nema e-pošte
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Ne {0} prona�
 apps/frappe/frappe/config/customization.py,Add custom forms.,Dodaj prilagođene oblike.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} u {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,podnosi ovaj dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Postavljanje&gt; Korisnička dopuštenja
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Postavljanje> Korisnička dopuštenja
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sustav nudi brojne unaprijed definirane uloge . Možete dodavati nove uloge postaviti finije dozvole.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ako korisnik ima bilo kakvu ulogu provjeriti, a zatim korisnik postaje &quot;Korisnik sustava&quot;. &quot;Korisnik sustava&quot; ima pristup radnoj površini"
 DocType: System Settings,Date and Number Format,Datum i oblik brojeva
 apps/frappe/frappe/model/document.py,one of,Jedan od
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Postavljanje&gt; Prilagodi obrazac
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Postavljanje> Prilagodi obrazac
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Provjera jednom trenutku
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Pokaži oznake
 DocType: DocField,HTML Editor,HTML uređivač
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Naplata
 DocType: Email Queue,Not Sent,Ne poslano
 DocType: Web Form,Actions,Akcije
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Postavljanje&gt; Korisnik
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Postavljanje> Korisnik
 DocType: Workflow State,align-justify,Poravnajte-opravdati
 DocType: User,Middle Name (Optional),Krsno ime (opcionalno)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nije dopuštena
@@ -1410,7 +1410,7 @@ DocType: User,System User,Korisnik sustava
 DocType: Report,Is Standard,Je standardni
 DocType: Desktop Icon,_report,_izvješće
 DocType: Dashboard Chart,Full,puni
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ne HTML Šifriranje HTML oznake kao što su &lt;script&gt; ili samo likovi poput &lt;ili&gt;, kao što bi mogli biti namjerno koristiti u ovom području"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne HTML Šifriranje HTML oznake kao što su &lt;script> ili samo likovi poput &lt;ili>, kao što bi mogli biti namjerno koristiti u ovom području"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiziran na {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Trčanje
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer će prikaz
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Na čekanju
 DocType: System Settings,Allow only one session per user,Dopusti samo jednu sjednicu po korisniku
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Početna / Ispitni mapa 1 / Ispitna mapa 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Odaberite ili povucite preko minutaže stvoriti novi događaj.
 DocType: Contact,Contact Details,Kontakt podaci
 DocType: DocField,In Filter,U filtru
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Prijava nije dopuštena u ovom trenutku
 DocType: Data Migration Run,Current Mapping Action,Aktualna mapiranje
 DocType: Dashboard Chart Source,Source Name,source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Nije povezan račun s e-poštom s korisnikom. Dodajte račun u odjeljku Korisnik&gt; Inbox.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Nije povezan račun s e-poštom s korisnikom. Dodajte račun u odjeljku Korisnik> Inbox.
 DocType: Email Account,Email Sync Option,E-mail Mogućnost sinkronizacije
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Redak br
 DocType: Async Task,Runtime,Dužina trajanja
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Već u us
 DocType: User Email,Enable Outgoing,Omogući odlazni
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Prilagođeni Tagovi
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Račun e-pošte nije postavljan. Izradite novi račun e-pošte iz programa Setup&gt; Email&gt; račun e-pošte
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Račun e-pošte nije postavljan. Izradite novi račun e-pošte iz programa Setup> Email> račun e-pošte
 DocType: Comment,Submitted,Potvrđeno
 DocType: Contact,Pulled from Google Contacts,Preuzeto iz Google kontakata
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Neispravan zahtjev
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sjednica Rok u Hours
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Ovo polje će se pojaviti samo ako je FIELDNAME ovdje definirana je vrijednost ili pravila su pravi (primjeri): myfield eval: doc.myfield == &quot;Moj Vrijednost&quot; eval: doc.age&gt; 18
+eval:doc.age>18",Ovo polje će se pojaviti samo ako je FIELDNAME ovdje definirana je vrijednost ili pravila su pravi (primjeri): myfield eval: doc.myfield == &quot;Moj Vrijednost&quot; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Ured 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Danas
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Nakon što ste ovo postavili, korisnici će moći samo pristupiti dokumentima (npr. blog post) gdje veza postoji (npr. Blogger)."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,VELIKA SLOVA
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Prilagođeni HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Unesite naziv mape
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nije pronađen zadani predložak adrese. Izradite novu iz postavki Postavke&gt; Ispis i marke&gt; Predložak adresa.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nije pronađen zadani predložak adrese. Izradite novu iz postavki Postavke> Ispis i marke> Predložak adresa.
 apps/frappe/frappe/auth.py,Unknown User,Nepoznati korisnik
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Odaberite ulogu
 DocType: Comment,Deleted,Izbrisano
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Put do certifikata poslužitel
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nema dovoljno dopuštenja za prikazivanje veza
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Naziv adrese je obavezan.
 DocType: Google Contacts,Push to Google Contacts,Pritisnite &quot;Google kontakti&quot;
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Dodano HTML u &lt;head&gt; na web stranici, prvenstveno se koristi za web stranice provjere i SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML u &lt;head> na web stranici, prvenstveno se koristi za web stranice provjere i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relaps
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Proizvod ne može se dodati u svojim potomcima
 DocType: Session Default Settings,Session Defaults,Zadani zadaci sesije
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Upozorenje
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,To se može otisnuti na više stranica
 DocType: Data Migration Run,Percent Complete,Postotak dovršen
 DocType: Tag Category,Tag Category,oznaka kategorije
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite&gt; 5, &lt;10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite> 5, &lt;10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
 DocType: Google Calendar,Pull from Google Calendar,Povucite iz Google kalendara
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoć
 DocType: User,Login Before,Prijava prije
@@ -2891,7 +2891,7 @@ DocType: Custom Script,Custom Script,Prilagođena skripta
 DocType: Address,Address Line 2,Adresa - linija 2
 DocType: Address,Reference,Upućivanje
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Dodijeljeno
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Postavite zadani račun e-pošte iz programa Postavljanje&gt; E-pošta&gt; Račun e-pošte
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Postavite zadani račun e-pošte iz programa Postavljanje> E-pošta> Račun e-pošte
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Pojedinosti o mapiranju migracija podataka
 DocType: Data Import,Action,Akcija
 DocType: GSuite Settings,Script URL,URL skripte
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Dopusti pri potvrdi
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Iznimka Tip
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick stupce
-DocType: Web Page,Add code as &lt;script&gt;,Dodaj kod kao <skriptu>
+DocType: Web Page,Add code as &lt;script>,Dodaj kod kao <skriptu>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Očisti dopuštenja korisnika
 DocType: Webhook,Headers,zaglavlja
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Nadolazeći događaji
@@ -3442,15 +3442,15 @@ DocType: Workflow State,share-alt,Udio-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Red čekanja treba biti jedan od {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Zadani predložak </ h4> 
  <p> <a Koristi href=""http://jinja.pocoo.org/docs/templates/""> Jinja templating </a> i sve polja Adresa ( uključujući Custom Fields ako postoji) će biti dostupan </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/hr.csv
+++ b/frappe/translations/hr.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistika na temelju prošlogodišnjeg učinka (od {0} do {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP telefonsko polje
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","vrsta dokumenta ..., npr kupca"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Stanje &#39;{0}&#39; nije valjan
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Stanje '{0}' nije valjan
 DocType: Workflow State,barcode,Barkod
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Korištenje pod-upita ili funkcije ograničeno je
 apps/frappe/frappe/config/customization.py,Add your own translations,Dodajte svoje prijevode
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Valuta Ime
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,nema e-pošte
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Veza je istekla
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Vraćanje duljine do {0} za &#39;{1}&#39; u &#39;{2}&#39;; Postavljanje duljine kao {3} uzrokovat će skraćivanje podataka.
+							Setting the length as {3} will cause truncation of data.",Vraćanje duljine do {0} za '{1}' u '{2}'; Postavljanje duljine kao {3} uzrokovat će skraćivanje podataka.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Odaberite File Format
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Sadržaj Ljestve
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokument podijele prijava
 DocType: Social Login Key,Base URL,Osnovni URL
 DocType: User,Last Login,Zadnja prijava
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Ne možete postaviti &#39;Translatable&#39; za polje {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Ne možete postaviti 'Translatable' za polje {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Kolona
 DocType: Chat Profile,Chat Profile,Profil za chat
 DocType: Custom Field,Adds a custom field to a DocType,Dodaje prilagođeni polje na vrstu dokumenata
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Je Početna mapa
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar stil
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} nije valjana e-mail adresa
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Odaberite barem 1 zapis za ispis
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Korisnik &#39;{0}&#39; već ima ulogu &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Korisnik '{0}' već ima ulogu '{1}'
 DocType: System Settings,Two Factor Authentication method,Dva metoda autentifikacije faktora
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Najprije postavite ime i spremite zapis.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 zapisa
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obavezna polja: postavljanje uloga
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritiziran {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Polje &#39;{1}&#39; se ne može postaviti kao jedinstveno jer ima jedinstvene vrijednosti
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Polje '{1}' se ne može postaviti kao jedinstveno jer ima jedinstvene vrijednosti
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Pomicanje popisa prema dolje
 DocType: Currency,A symbol for this currency. For e.g. $,Simbol za ovu valutu. Kao npr. $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Uspješno ažurirani prijevodi
@@ -2004,7 +2004,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Ako ove upute gdje nije korisno , dodajte u svojim prijedlozima o GitHub pitanja ."
 DocType: Workflow State,bookmark,bookmark
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Naziv mape ne smije sadržavati &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Naziv mape ne smije sadržavati '/' (slash)
 DocType: Note,Note,Zabilješka
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Izvješće o pogrešci
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Izvoz podataka u formatu CSV / Excel.
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,Naziv baze podataka
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Osvježi obrazac
 DocType: DocField,Select,Odabrati
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Pogledajte cijeli dnevnik
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednostavan Python Expression, Primjer: status == &#39;Open&#39; i upišite == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednostavan Python Expression, Primjer: status == 'Open' i upišite == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Datoteka nije u prilogu
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Izgubljena veza. Neke značajke možda neće funkcionirati.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Ponavljanja kao &quot;AAA&quot; su lako pogoditi
@@ -2700,7 +2700,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Dopuna
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal postavke Payment Gateway
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Vrhunski izvođač
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Prilagođena polja se ne mogu dodati u osnovne DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) bi bio skraćen, kao max likovi ljubimaca je {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) bi bio skraćen, kao max likovi ljubimaca je {2}"
 DocType: OAuth Client,Response Type,tip odgovora
 DocType: Contact Us Settings,Send enquiries to this email address,Upite slati na ovu e-mail adresu
 DocType: Letter Head,Letter Head Name,Naziv zaglavlja
@@ -2756,7 +2756,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Prikaz slike
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Izgleda da je nešto pošlo po zlu za vrijeme transakcije. Budući da nismo potvrdili plaćanja, PayPal će se automatski vratiti vam taj iznos. Ako se to ne dogodi, molimo pošaljite nam e-mail i spomenuti korelacija ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","U lozinku uključite simbole, brojeve i velika slova"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",Umetnite Nakon polje &#39;{0}&#39; spominje u prilagođeno polje &#39;{1}&#39; s oznakom &#39;{2}&#39; ne postoji
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",Umetnite Nakon polje '{0}' spominje u prilagođeno polje '{1}' s oznakom '{2}' ne postoji
 DocType: List Filter,List Filter,Filtriranje popisa
 DocType: Workflow State,signal,signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ima privitke
@@ -2766,7 +2766,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokument je obnovljen
 DocType: Data Export,Data Export,Izvoz podataka
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Izaberi jezik...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Ne možete postaviti &#39;Opcije&#39; za polje {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Ne možete postaviti 'Opcije' za polje {0}
 DocType: Help Article,Author,Autor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Nastavi Slanje
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Ponovno otvori
@@ -2787,7 +2787,7 @@ DocType: Data Import,Amended From,Izmijenjena Od
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Upozorenje: Nije moguće pronaći {0} u bilo kojoj tablici se odnose na {1}
 DocType: S3 Backup Settings,eu-north-1,eu-sjever-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Ovaj dokument je trenutno čeka na izvršenje. Molim te pokušaj ponovno
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Datoteka &#39;{0}&#39; nije pronađena
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Datoteka '{0}' nije pronađena
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Izvadite odjeljak
 DocType: User,Change Password,Promijeni lozinku
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Polje x osovine
@@ -2974,7 +2974,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Vrijednost nestao
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Dodaj dijete
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Uvozi napredak
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Ako je uvjet zadovoljan, korisnik će biti nagrađen bodovima. npr. doc.status == &#39;Zatvoreno&#39;"
+","Ako je uvjet zadovoljan, korisnik će biti nagrađen bodovima. npr. doc.status == 'Zatvoreno'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Snimljeni zapis ne može biti brisan.
 DocType: GSuite Templates,Template Name,Naziv predloška
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Nova vrsta dokumenta
@@ -3394,7 +3394,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Prilagođeni Prij
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Napredak
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,prema ulozi
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Nedostaje Polja
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Pogrešna FIELDNAME &#39;{0}&#39; u autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Pogrešna FIELDNAME '{0}' u autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Traži u vrsti dokumenta
 DocType: Custom DocPerm,Role and Level,Uloga i razina ovlasti
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3546,7 +3546,7 @@ DocType: Notification,Reference Date,Referentni datum
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,Postavljanje OTP putem OTP aplikacije nije dovršeno. Molimo kontaktirajte administratora.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Unesite valjane mobilne br
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Neke značajke možda neće funkcionirati u vašem pregledniku. Ažurirajte preglednik na najnoviju verziju.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ne znam, pitaj &#39;pomoć&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ne znam, pitaj 'pomoć'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},otkazao ovaj dokument {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Komentari i komunikacije će biti povezani s ovom vezni dokument
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
@@ -3895,7 +3895,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,prenesena datoteka
 DocType: Workflow State,ok-circle,ok-krug
 DocType: LDAP Settings,LDAP User Creation and Mapping,Stvaranje i mapiranje LDAP korisnika
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Možete naći stvari tražeći &quot;pronaći naranče u kupcima &#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Možete naći stvari tražeći &quot;pronaći naranče u kupcima '
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Žao nam je! Korisnik treba imati potpuni pristup vlastitom rekord.
 ,Usage Info,Korištenje Info
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Pokaži prečace na tipkovnici

--- a/frappe/translations/hr.csv
+++ b/frappe/translations/hr.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Korisnik sustava
 DocType: Report,Is Standard,Je standardni
 DocType: Desktop Icon,_report,_izvješće
 DocType: Dashboard Chart,Full,puni
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne HTML Šifriranje HTML oznake kao što su &lt;script> ili samo likovi poput &lt;ili>, kao što bi mogli biti namjerno koristiti u ovom području"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ne HTML Šifriranje HTML oznake kao što su <script> ili samo likovi poput <ili>, kao što bi mogli biti namjerno koristiti u ovom području"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiziran na {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Trčanje
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer će prikaz
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Na čekanju
 DocType: System Settings,Allow only one session per user,Dopusti samo jednu sjednicu po korisniku
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Početna / Ispitni mapa 1 / Ispitna mapa 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Odaberite ili povucite preko minutaže stvoriti novi događaj.
 DocType: Contact,Contact Details,Kontakt podaci
 DocType: DocField,In Filter,U filtru
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Put do certifikata poslužitel
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nema dovoljno dopuštenja za prikazivanje veza
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Naziv adrese je obavezan.
 DocType: Google Contacts,Push to Google Contacts,Pritisnite &quot;Google kontakti&quot;
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML u &lt;head> na web stranici, prvenstveno se koristi za web stranice provjere i SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Dodano HTML u <head> na web stranici, prvenstveno se koristi za web stranice provjere i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relaps
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Proizvod ne može se dodati u svojim potomcima
 DocType: Session Default Settings,Session Defaults,Zadani zadaci sesije
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Upozorenje
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,To se može otisnuti na više stranica
 DocType: Data Migration Run,Percent Complete,Postotak dovršen
 DocType: Tag Category,Tag Category,oznaka kategorije
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite> 5, &lt;10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za usporedbu, koristite> 5, <10 ili = 324. Za raspone koristite 5:10 (za vrijednosti između 5 i 10)."
 DocType: Google Calendar,Pull from Google Calendar,Povucite iz Google kalendara
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoć
 DocType: User,Login Before,Prijava prije
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Dopusti pri potvrdi
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Iznimka Tip
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick stupce
-DocType: Web Page,Add code as &lt;script>,Dodaj kod kao <skriptu>
+DocType: Web Page,Add code as <script>,Dodaj kod kao <skriptu>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Očisti dopuštenja korisnika
 DocType: Webhook,Headers,zaglavlja
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Nadolazeći događaji
@@ -3442,26 +3442,26 @@ DocType: Workflow State,share-alt,Udio-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Red čekanja treba biti jedan od {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Zadani predložak </ h4> 
  <p> <a Koristi href=""http://jinja.pocoo.org/docs/templates/""> Jinja templating </a> i sve polja Adresa ( uključujući Custom Fields ako postoji) će biti dostupan </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% ako address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} 
- {{grad}} & lt; br & gt; 
- {%, ako država%} {{stanje}} & lt; br & gt; {% endif -%} {
-% ako pincode%} PIN: {{pincode}} & lt; br & gt; {% endif -%} 
- {{zemlja}} & lt; br & gt; 
- {% ako telefon%} Telefon: {{telefona}} & lt; br & gt; { % endif -%} 
- {% ako fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% ako email_id%} e: {{email_id}} & lt; br & gt {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% ako address_line2%} {{address_line2}} <br> { % endif -%} 
+ {{grad}} <br> 
+ {%, ako država%} {{stanje}} <br> {% endif -%} {
+% ako pincode%} PIN: {{pincode}} <br> {% endif -%} 
+ {{zemlja}} <br> 
+ {% ako telefon%} Telefon: {{telefona}} <br> { % endif -%} 
+ {% ako fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% ako email_id%} e: {{email_id}} <br & gt {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Polje datuma početka
 DocType: Role,Role Name,Naziv uloge

--- a/frappe/translations/hu.csv
+++ b/frappe/translations/hu.csv
@@ -1408,7 +1408,7 @@ DocType: User,System User,Rendszer felhasználó
 DocType: Report,Is Standard,Ez alapfelszereltség
 DocType: Desktop Icon,_report,_jelentés
 DocType: Dashboard Chart,Full,Tele
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne kódoljon HTML címkéket, mint &lt; script > vagy csak karaktereket, mint &lt; or >, HTML-be, mivel ezek nem használhatók fel ebben a mezőben"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ne kódoljon HTML címkéket, mint < script > vagy csak karaktereket, mint < or >, HTML-be, mivel ezek nem használhatók fel ebben a mezőben"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} bírálták a (z) {1} -on
 DocType: Website Settings,FavIcon,Kedvencekikon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Futtatás
@@ -1788,7 +1788,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,A lábléc csak P
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Függő
 DocType: System Settings,Allow only one session per user,Csak egyetlen munkamenet engedélyezése felhasználónként
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Kezdőlap / Teszt mappa 1 / Teszt mappa 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Válassza ki vagy húzza át az időkereteket egy új esemény létrehozásához.
 DocType: Contact,Contact Details,Kapcsolattartó részletei
 DocType: DocField,In Filter,Szűrőben
@@ -2308,7 +2308,7 @@ DocType: LDAP Settings,Path to Server Certificate,Út a kiszolgálói tanúsítv
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nincs elég Jogosultság a linkek megtekintéséhez
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Cím felirat kötelező.
 DocType: Google Contacts,Push to Google Contacts,Nyomja meg a Google Névjegyeket
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Hozzáadott HTML a fejléc részben a weboldalon, amit elsősorban a weboldal ellenőrzésére és SEO használja"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Hozzáadott HTML a fejléc részben a weboldalon, amit elsősorban a weboldal ellenőrzésére és SEO használja"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapszusos
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Tételt nem lehet hozzáadni a saját leszármazottaikhoz
 DocType: Session Default Settings,Session Defaults,Munkamenet alapértelmezései
@@ -2427,7 +2427,7 @@ DocType: Workflow State,Warning,Figyelmeztetés
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,"Előfordulhat, hogy több oldalra nyomtatják"
 DocType: Data Migration Run,Percent Complete,Százalék teljesítve
 DocType: Tag Category,Tag Category,Címke kategória
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Összehasonlításként használjon> 5, &lt;10 vagy = 324. A tartományokhoz használja az 5:10 értéket (az 5 és 10 közötti értékekhez)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Összehasonlításként használjon> 5, <10 vagy = 324. A tartományokhoz használja az 5:10 értéket (az 5 és 10 közötti értékekhez)."
 DocType: Google Calendar,Pull from Google Calendar,Húzza a Google Naptárból
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Súgó
 DocType: User,Login Before,Bejelentkezés előtt
@@ -3066,7 +3066,7 @@ DocType: DocField,Allow on Submit,Benyújtáson engedélyezés
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Kivétel típusa
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Oszlopok kiválasztása
-DocType: Web Page,Add code as &lt;script>,Kód mint  script  hozzáadása
+DocType: Web Page,Add code as <script>,Kód mint  script  hozzáadása
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Felhasználói engedélyek törlése
 DocType: Webhook,Headers,Fejlécek
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Közelgő események
@@ -3439,16 +3439,16 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Sorba állításnak ennek az egyikének kell lennie {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<H4> Default template </ h4> <p> a <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja-sablonok </a> és valamennyi területen Cím (Custom Fields ha van ilyen) lesz elérhető </ p> <pre> <code> {{address_line1}} & lt; br & gt; {% If address_line2%} {{address_line2}} & lt; br & gt; {% endif -%} {{city}} & lt; br & gt; {%, Ha az állami%} {{állapotban}} & lt; br & gt; {% endif -%} {% if PIN%} PIN: {{PIN}} & lt; br & gt; {% endif -%} {{country}} & lt ; br & gt; {%, Ha telefonon%} Telefon: {{telefonon}} & lt; br & gt; {% endif -%} {% faxon%} Fax: {{Fax}} & lt; br & gt; {% endif -%} {% if email_id %} E-mail: {{email_id}} & lt; br & gt; {% endif -%} </ code> </ pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<H4> Default template </ h4> <p> a <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja-sablonok </a> és valamennyi területen Cím (Custom Fields ha van ilyen) lesz elérhető </ p> <pre> <code> {{address_line1}} <br> {% If address_line2%} {{address_line2}} <br> {% endif -%} {{city}} <br> {%, Ha az állami%} {{állapotban}} <br> {% endif -%} {% if PIN%} PIN: {{PIN}} <br> {% endif -%} {{country}} & lt ; br> {%, Ha telefonon%} Telefon: {{telefonon}} <br> {% endif -%} {% faxon%} Fax: {{Fax}} <br> {% endif -%} {% if email_id %} E-mail: {{email_id}} <br> {% endif -%} </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Kezdő dátum mezője
 DocType: Role,Role Name,Beosztás neve
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Asztalra váltás

--- a/frappe/translations/hu.csv
+++ b/frappe/translations/hu.csv
@@ -741,7 +741,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,A fájl biz
 DocType: DocField,In Global Search,Globális keresésben
 DocType: System Settings,Brute Force Security,Brute Force biztonság
 DocType: Workflow State,indent-left,behúzás-balra
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} évvel ezelőtt
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} évvel ezelőtt
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Kockázatos törölni ezt a fájlt: {0}. Kérjük, forduljon a Rendszergazdához."
 DocType: Currency,Currency Name,Pénznem neve
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Nincsenek e-mailek
@@ -1035,7 +1035,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} sz. talá
 apps/frappe/frappe/config/customization.py,Add custom forms.,Egyéni űrlapok hozzáadása.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} ebben: {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,benyújtotta ezt a dokumentumot
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Beállítás&gt; Felhasználói engedélyek
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Beállítás> Felhasználói engedélyek
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,A rendszer számos előre meghatározott Beosztást ad. Felvehet új Beosztásokat finomabb jogosultság beállításokhoz.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1254,7 +1254,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ha a felhasználó ki van jelölve bármely beosztáshoz, akkor a felhasználó ""Rendszer felhasználó"" lesz. ""Rendszer felhasználó"" hozzáfér az asztalhoz"
 DocType: System Settings,Date and Number Format,Dátum és szám formátum
 apps/frappe/frappe/model/document.py,one of,az egyik
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Beállítás&gt; Az űrlap testreszabása
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Beállítás> Az űrlap testreszabása
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Ellenőrzés egy pillanat
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Címkék megjelenítése
 DocType: DocField,HTML Editor,HTML szerkesztő
@@ -1262,7 +1262,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Számlázás
 DocType: Email Queue,Not Sent,Elküldetlen
 DocType: Web Form,Actions,Műveletek
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Beállítás&gt; Felhasználó
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Beállítás> Felhasználó
 DocType: Workflow State,align-justify,igazítás-sorkizárt
 DocType: User,Middle Name (Optional),Középső név (opcionális)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nem engedélyezett
@@ -1408,7 +1408,7 @@ DocType: User,System User,Rendszer felhasználó
 DocType: Report,Is Standard,Ez alapfelszereltség
 DocType: Desktop Icon,_report,_jelentés
 DocType: Dashboard Chart,Full,Tele
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ne kódoljon HTML címkéket, mint &lt; script &gt; vagy csak karaktereket, mint &lt; or &gt;, HTML-be, mivel ezek nem használhatók fel ebben a mezőben"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne kódoljon HTML címkéket, mint &lt; script > vagy csak karaktereket, mint &lt; or >, HTML-be, mivel ezek nem használhatók fel ebben a mezőben"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} bírálták a (z) {1} -on
 DocType: Website Settings,FavIcon,Kedvencekikon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Futtatás
@@ -1788,7 +1788,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,A lábléc csak P
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Függő
 DocType: System Settings,Allow only one session per user,Csak egyetlen munkamenet engedélyezése felhasználónként
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Kezdőlap / Teszt mappa 1 / Teszt mappa 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Válassza ki vagy húzza át az időkereteket egy új esemény létrehozásához.
 DocType: Contact,Contact Details,Kapcsolattartó részletei
 DocType: DocField,In Filter,Szűrőben
@@ -2018,7 +2018,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,A bejelentkezés tilos ebben az időben
 DocType: Data Migration Run,Current Mapping Action,Aktuális leképzési művelet
 DocType: Dashboard Chart Source,Source Name,Forrá név
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,"Nincs e-mail fiók társítva a Felhasználóval. Kérjük, vegyen fel egy fiókot a Felhasználó&gt; E-mail beérkezett üzenetek csoportba."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Nincs e-mail fiók társítva a Felhasználóval. Kérjük, vegyen fel egy fiókot a Felhasználó> E-mail beérkezett üzenetek csoportba."
 DocType: Email Account,Email Sync Option,E-mail szinkronizálás lehetőség
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Sor sz.
 DocType: Async Task,Runtime,Runtime
@@ -2033,7 +2033,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Már a fe
 DocType: User Email,Enable Outgoing,Engedélyezze a kimenőt
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Egyedi címkék
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,"Az e-mail fiók nincs beállítva. Kérjük, hozzon létre egy új e-mail fiókot a Beállítás&gt; E-mail&gt; E-mail fiók közül"
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,"Az e-mail fiók nincs beállítva. Kérjük, hozzon létre egy új e-mail fiókot a Beállítás> E-mail> E-mail fiók közül"
 DocType: Comment,Submitted,Benyújtva
 DocType: Contact,Pulled from Google Contacts,A Google Névjegyekből vonult le
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Érvénytelen kérelem
@@ -2105,7 +2105,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Munkamenet lejárati
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Ez a mező csak akkor jelenik meg, ha a mezőnévnek itt megadott értéke van VAGY a szabályok igazak (példák): myfield eval:doc.myfield=='My Value'eval:doc.age&gt;18"
+eval:doc.age>18","Ez a mező csak akkor jelenik meg, ha a mezőnévnek itt megadott értéke van VAGY a szabályok igazak (példák): myfield eval:doc.myfield=='My Value'eval:doc.age>18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Ma
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Ha beállította ezt, a felhasználók csak akkor férhetnek hozzá a dokumentumokhoz (pl. Blogbejegyzés), ahol a link jelen van (pl. Blogger)."
@@ -2119,7 +2119,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,NAGYBETŰ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Egyedi HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Írja be a mappa nevét
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,"Nem található alapértelmezett címsablon. Kérjük, hozzon létre egy újat a Beállítás&gt; Nyomtatás és márkajelzés&gt; Címsablon menüpontból."
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"Nem található alapértelmezett címsablon. Kérjük, hozzon létre egy újat a Beállítás> Nyomtatás és márkajelzés> Címsablon menüpontból."
 apps/frappe/frappe/auth.py,Unknown User,Ismeretlen felhasználó
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Válasszon beosztást
 DocType: Comment,Deleted,Törölt
@@ -2308,7 +2308,7 @@ DocType: LDAP Settings,Path to Server Certificate,Út a kiszolgálói tanúsítv
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nincs elég Jogosultság a linkek megtekintéséhez
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Cím felirat kötelező.
 DocType: Google Contacts,Push to Google Contacts,Nyomja meg a Google Névjegyeket
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Hozzáadott HTML a fejléc részben a weboldalon, amit elsősorban a weboldal ellenőrzésére és SEO használja"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Hozzáadott HTML a fejléc részben a weboldalon, amit elsősorban a weboldal ellenőrzésére és SEO használja"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapszusos
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Tételt nem lehet hozzáadni a saját leszármazottaikhoz
 DocType: Session Default Settings,Session Defaults,Munkamenet alapértelmezései
@@ -2427,7 +2427,7 @@ DocType: Workflow State,Warning,Figyelmeztetés
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,"Előfordulhat, hogy több oldalra nyomtatják"
 DocType: Data Migration Run,Percent Complete,Százalék teljesítve
 DocType: Tag Category,Tag Category,Címke kategória
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Összehasonlításként használjon&gt; 5, &lt;10 vagy = 324. A tartományokhoz használja az 5:10 értéket (az 5 és 10 közötti értékekhez)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Összehasonlításként használjon> 5, &lt;10 vagy = 324. A tartományokhoz használja az 5:10 értéket (az 5 és 10 közötti értékekhez)."
 DocType: Google Calendar,Pull from Google Calendar,Húzza a Google Naptárból
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Súgó
 DocType: User,Login Before,Bejelentkezés előtt
@@ -2889,7 +2889,7 @@ DocType: Custom Script,Custom Script,Egyéni szkript
 DocType: Address,Address Line 2,2. cím sor
 DocType: Address,Reference,Hivatkozás
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Felelős érte
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,"Kérjük, állítsa be az alapértelmezett e-mail fiókot a Beállítás&gt; E-mail&gt; E-mail fiók menüben"
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,"Kérjük, állítsa be az alapértelmezett e-mail fiókot a Beállítás> E-mail> E-mail fiók menüben"
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Adatátvitel-leképezés részletek
 DocType: Data Import,Action,Művelet
 DocType: GSuite Settings,Script URL,Script URL
@@ -3066,7 +3066,7 @@ DocType: DocField,Allow on Submit,Benyújtáson engedélyezés
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Kivétel típusa
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Oszlopok kiválasztása
-DocType: Web Page,Add code as &lt;script&gt;,Kód mint  script  hozzáadása
+DocType: Web Page,Add code as &lt;script>,Kód mint  script  hozzáadása
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Felhasználói engedélyek törlése
 DocType: Webhook,Headers,Fejlécek
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Közelgő események
@@ -3439,15 +3439,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Sorba állításnak ennek az egyikének kell lennie {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default template </ h4> <p> a <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja-sablonok </a> és valamennyi területen Cím (Custom Fields ha van ilyen) lesz elérhető </ p> <pre> <code> {{address_line1}} & lt; br & gt; {% If address_line2%} {{address_line2}} & lt; br & gt; {% endif -%} {{city}} & lt; br & gt; {%, Ha az állami%} {{állapotban}} & lt; br & gt; {% endif -%} {% if PIN%} PIN: {{PIN}} & lt; br & gt; {% endif -%} {{country}} & lt ; br & gt; {%, Ha telefonon%} Telefon: {{telefonon}} & lt; br & gt; {% endif -%} {% faxon%} Fax: {{Fax}} & lt; br & gt; {% endif -%} {% if email_id %} E-mail: {{email_id}} & lt; br & gt; {% endif -%} </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Kezdő dátum mezője
 DocType: Role,Role Name,Beosztás neve

--- a/frappe/translations/hu.csv
+++ b/frappe/translations/hu.csv
@@ -1026,7 +1026,7 @@ DocType: Property Setter,Property Setter,Tulajdonságbeállító
 DocType: Web Form,Allow Print,Nyomtatás engedélyezése
 DocType: Communication,Clicked,Rákattintott
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,unfollow
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nincs engedélye a &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nincs engedélye a '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Ütemezett küldeni
 DocType: DocType,Track Seen,Követés megtekintve
 DocType: Dropbox Settings,File Backup,Fájl biztonsági mentés
@@ -1439,7 +1439,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Kötelező mező: szerep beállítás hozzá
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} bírálta {1}
 DocType: Data Migration Mapping,Mapping Name,Térképezés név
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: A (z) &#39;{1}&#39; mező nem állítható egyedi értékre, mivel nem egyedi értékeivel rendelkezik"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: A (z) '{1}' mező nem állítható egyedi értékre, mivel nem egyedi értékeivel rendelkezik"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Keresse meg a listát lefelé
 DocType: Currency,A symbol for this currency. For e.g. $,A szimbólum erre a pénznemre. Pl.: $$
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Sikeresen frissített fordítások
@@ -2144,7 +2144,7 @@ DocType: Data Migration Connector,Database Name,Adatbázis név
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Űrlap frissítése
 DocType: DocField,Select,Választás
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Teljes napló megtekintése
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Egyszerű Python kifejezés, példa: status == &#39;Megnyitás&#39; és gépelés == &#39;Hiba&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Egyszerű Python kifejezés, példa: status == 'Megnyitás' és gépelés == 'Hiba'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,A fájl nincs mellékelve
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,A kapcsolat megszakadt. Egyes funkciók nem működhetnek.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Megismétli, mint a &quot;AAA&quot; könnyű kitalálni"
@@ -2785,7 +2785,7 @@ DocType: Data Import,Amended From,Módosított feladója
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},"Figyelmeztetés: Nem sikerült megtalálni: {0}, bármely, ezzel kapcsolatos táblázatban: {1}"
 DocType: S3 Backup Settings,eu-north-1,eu-észak-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Ez a dokumentum jelenleg várakozikó a végrehajtásra. Kérjük próbálja újra
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Fájl &#39;{0}&#39; nem található
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Fájl '{0}' nem található
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Távolítsuk el szakasza
 DocType: User,Change Password,Változtass jelszót
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X tengely mező
@@ -2972,7 +2972,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Érték hiányzik er
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Al csoport hozzáadása
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Importálás haladás
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Ha a feltétel teljesül, a felhasználó megkapja a pontokat. például. doc.status == &#39;Bezárt&#39;"
+","Ha a feltétel teljesül, a felhasználó megkapja a pontokat. például. doc.status == 'Bezárt'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Beküldött Belyegyzést nem lehet törölni.
 DocType: GSuite Templates,Template Name,Sablon neve
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Új típusú dokumentum

--- a/frappe/translations/id.csv
+++ b/frappe/translations/id.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,File cadang
 DocType: DocField,In Global Search,Di Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,indent-kiri
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} tahun yang lalu
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} tahun yang lalu
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Hal ini berisiko untuk menghapus file ini: {0}. Silahkan hubungi System Manager Anda.
 DocType: Currency,Currency Name,Nama Mata Uang
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Tidak ada Email
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Tidak ada {0}
 apps/frappe/frappe/config/customization.py,Add custom forms.,Tambah formulir kustom.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} di {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,disampaikan dokumen ini
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Pengaturan&gt; Izin Pengguna
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Pengaturan> Izin Pengguna
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sistem ini menyediakan banyak peran yang telah ditentukan. Anda dapat menambahkan peran baru untuk mengatur hak akses lebih halus.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Jika pengguna memiliki peran apapun diperiksa, maka pengguna menjadi &quot;Sistem Pengguna&quot;. &quot;Sistem Pengguna&quot; memiliki akses ke desktop"
 DocType: System Settings,Date and Number Format,Tanggal dan Nomor Format
 apps/frappe/frappe/model/document.py,one of,Salah satu
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Pengaturan&gt; Kustomisasi Formulir
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Pengaturan> Kustomisasi Formulir
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Memeriksa satu saat
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Tampilkan tag
 DocType: DocField,HTML Editor,Editor HTML
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Penagihan
 DocType: Email Queue,Not Sent,Tidak Terkirim
 DocType: Web Form,Actions,Tindakan
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Pengaturan&gt; Pengguna
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Pengaturan> Pengguna
 DocType: Workflow State,align-justify,rata-kanan-kiri
 DocType: User,Middle Name (Optional),Nama Tengah (Opsional)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Tidak Diijinkan
@@ -1410,7 +1410,7 @@ DocType: User,System User,Sistem Pengguna
 DocType: Report,Is Standard,Adalah Standard
 DocType: Desktop Icon,_report,_laporan
 DocType: Dashboard Chart,Full,Penuh
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti &lt;script&gt; atau hanya karakter seperti &lt;atau&gt;, karena mereka dapat sengaja digunakan dalam bidang ini"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti &lt;script> atau hanya karakter seperti &lt;atau>, karena mereka dapat sengaja digunakan dalam bidang ini"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} dikritik pada {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Menjalankan
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer akan ditam
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Menunggu
 DocType: System Settings,Allow only one session per user,Hanya mengizinkan satu sesi per pengguna
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Rumah / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Pilih atau seret di slot waktu untuk membuat acara baru.
 DocType: Contact,Contact Details,Kontak Detail
 DocType: DocField,In Filter,Dalam Filter
@@ -2022,7 +2022,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Login tidak diizinkan untuk saat ini
 DocType: Data Migration Run,Current Mapping Action,Tindakan Pemetaan Saat Ini
 DocType: Dashboard Chart Source,Source Name,sumber Nama
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Tidak ada akun email yang dikaitkan dengan Pengguna. Silakan tambahkan akun di bawah Pengguna&gt; Kotak Masuk Email.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Tidak ada akun email yang dikaitkan dengan Pengguna. Silakan tambahkan akun di bawah Pengguna> Kotak Masuk Email.
 DocType: Email Account,Email Sync Option,Opsi Sinkronisasi Surel
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Baris No
 DocType: Async Task,Runtime,Runtime
@@ -2037,7 +2037,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Sudah di 
 DocType: User Email,Enable Outgoing,Aktifkan Keluar
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Tags kustom
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Akun Email tidak disiapkan. Harap buat Akun Email baru dari Pengaturan&gt; Email&gt; Akun Email
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Akun Email tidak disiapkan. Harap buat Akun Email baru dari Pengaturan> Email> Akun Email
 DocType: Comment,Submitted,Dikirim
 DocType: Contact,Pulled from Google Contacts,Ditarik dari Kontak Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Di Permintaan yang Valid
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesi kadaluarsa di J
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Bidang ini hanya akan muncul jika fieldname didefinisikan di sini memiliki nilai OR aturan yang benar (contoh): MyField eval: doc.myfield == &#39;Nilai saya&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Bidang ini hanya akan muncul jika fieldname didefinisikan di sini memiliki nilai OR aturan yang benar (contoh): MyField eval: doc.myfield == &#39;Nilai saya&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Kantor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hari ini
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Setelah Anda telah mengatur ini, pengguna hanya akan bisa mengakses dokumen (misalnya Blog Post) di mana link yang ada (misalnya Blogger)."
@@ -2123,7 +2123,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,HURUF BESAR
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Masukkan nama folder
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Templat Alamat default tidak ditemukan. Harap buat yang baru dari Setup&gt; Printing and Branding&gt; Address Template.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Templat Alamat default tidak ditemukan. Harap buat yang baru dari Setup> Printing and Branding> Address Template.
 apps/frappe/frappe/auth.py,Unknown User,Pengguna tidak dikenal
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Pilih Peran
 DocType: Comment,Deleted,Dihapus
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Jalur ke Sertifikat Server
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Tidak cukup izin untuk melihat link
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Wajib masukan Judul Alamat.
 DocType: Google Contacts,Push to Google Contacts,Dorong ke Kontak Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Ditambahkan HTML di bagian <head> dari halaman web, terutama digunakan untuk verifikasi situs dan SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Ditambahkan HTML di bagian <head> dari halaman web, terutama digunakan untuk verifikasi situs dan SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Kambuh
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item tidak dapat ditambahkan ke keturunan sendiri
 DocType: Session Default Settings,Session Defaults,Default Sesi
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Peringatan
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ini dapat dicetak pada beberapa halaman
 DocType: Data Migration Run,Percent Complete,Persen Lengkap
 DocType: Tag Category,Tag Category,Kategori Tanda
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Untuk perbandingan, gunakan&gt; 5, &lt;10 atau = 324. Untuk rentang, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Untuk perbandingan, gunakan> 5, &lt;10 atau = 324. Untuk rentang, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tarik dari Kalender Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Bantuan
 DocType: User,Login Before,Login Sebelum
@@ -2893,7 +2893,7 @@ DocType: Custom Script,Custom Script,Kustom Script
 DocType: Address,Address Line 2,Alamat Baris 2
 DocType: Address,Reference,Referensi
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Ditugaskan Kepada
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Silakan atur Akun Email default dari Pengaturan&gt; Email&gt; Akun Email
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Silakan atur Akun Email default dari Pengaturan> Email> Akun Email
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detail Pemetaan Migrasi Data
 DocType: Data Import,Action,Tindakan
 DocType: GSuite Settings,Script URL,URL skrip
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Izinkan Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Pengecualian Jenis
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pilih Kolom
-DocType: Web Page,Add code as &lt;script&gt;,Tambahkan kode sebagai
+DocType: Web Page,Add code as &lt;script>,Tambahkan kode sebagai
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Hapus Izin Pengguna
 DocType: Webhook,Headers,Judul
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Acara Mendatang
@@ -3445,15 +3445,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Antrian adalah salah satu dari {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> default Template </ h4> 
  <p> <a Menggunakan href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> dan semua bidang Alamat ( termasuk Custom Fields jika ada) akan tersedia </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/id.csv
+++ b/frappe/translations/id.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Sistem Pengguna
 DocType: Report,Is Standard,Adalah Standard
 DocType: Desktop Icon,_report,_laporan
 DocType: Dashboard Chart,Full,Penuh
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti &lt;script> atau hanya karakter seperti &lt;atau>, karena mereka dapat sengaja digunakan dalam bidang ini"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti <script> atau hanya karakter seperti <atau>, karena mereka dapat sengaja digunakan dalam bidang ini"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} dikritik pada {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Menjalankan
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer akan ditam
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Menunggu
 DocType: System Settings,Allow only one session per user,Hanya mengizinkan satu sesi per pengguna
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Rumah / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Pilih atau seret di slot waktu untuk membuat acara baru.
 DocType: Contact,Contact Details,Kontak Detail
 DocType: DocField,In Filter,Dalam Filter
@@ -2312,7 +2312,7 @@ DocType: LDAP Settings,Path to Server Certificate,Jalur ke Sertifikat Server
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Tidak cukup izin untuk melihat link
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Wajib masukan Judul Alamat.
 DocType: Google Contacts,Push to Google Contacts,Dorong ke Kontak Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Ditambahkan HTML di bagian <head> dari halaman web, terutama digunakan untuk verifikasi situs dan SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Ditambahkan HTML di bagian <head> dari halaman web, terutama digunakan untuk verifikasi situs dan SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Kambuh
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item tidak dapat ditambahkan ke keturunan sendiri
 DocType: Session Default Settings,Session Defaults,Default Sesi
@@ -2431,7 +2431,7 @@ DocType: Workflow State,Warning,Peringatan
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ini dapat dicetak pada beberapa halaman
 DocType: Data Migration Run,Percent Complete,Persen Lengkap
 DocType: Tag Category,Tag Category,Kategori Tanda
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Untuk perbandingan, gunakan> 5, &lt;10 atau = 324. Untuk rentang, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Untuk perbandingan, gunakan> 5, <10 atau = 324. Untuk rentang, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tarik dari Kalender Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Bantuan
 DocType: User,Login Before,Login Sebelum
@@ -3071,7 +3071,7 @@ DocType: DocField,Allow on Submit,Izinkan Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Pengecualian Jenis
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pilih Kolom
-DocType: Web Page,Add code as &lt;script>,Tambahkan kode sebagai
+DocType: Web Page,Add code as <script>,Tambahkan kode sebagai
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Hapus Izin Pengguna
 DocType: Webhook,Headers,Judul
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Acara Mendatang
@@ -3445,26 +3445,26 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Antrian adalah salah satu dari {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> default Template </ h4> 
  <p> <a Menggunakan href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> dan semua bidang Alamat ( termasuk Custom Fields jika ada) akan tersedia </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% jika% address_line2} {{address_line2}} & lt; br & gt; { % endif -%} 
- {{kota}} & lt; br & gt; 
- {% jika negara%} {{negara}} & lt; br & gt; {% endif -%} 
- {% jika kode PIN%} PIN: {{kode PIN}} & lt; br & gt; {% endif -%} 
- {{negara}} & lt; br & gt; 
- {% jika ponsel%} Telepon: {{ponsel}} & lt; br & gt; { % endif -%} 
- {% jika faks%} Fax: {{faks}} & lt; br & gt; {% endif -%} 
- {% jika email_id%} Email: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% jika% address_line2} {{address_line2}} <br> { % endif -%} 
+ {{kota}} <br> 
+ {% jika negara%} {{negara}} <br> {% endif -%} 
+ {% jika kode PIN%} PIN: {{kode PIN}} <br> {% endif -%} 
+ {{negara}} <br> 
+ {% jika ponsel%} Telepon: {{ponsel}} <br> { % endif -%} 
+ {% jika faks%} Fax: {{faks}} <br> {% endif -%} 
+ {% jika email_id%} Email: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Field Tanggal Mulai
 DocType: Role,Role Name,Nama Peran

--- a/frappe/translations/id.csv
+++ b/frappe/translations/id.csv
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistik berdasarkan kinerja minggu lalu (dari {0} hingga {1})
 DocType: LDAP Settings,LDAP Phone Field,Bidang Telepon LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","tipe dokumen ..., misalnya pelanggan"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Kondisi &#39;{0}&#39; tidak valid
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Kondisi '{0}' tidak valid
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Penggunaan sub-query atau fungsi dibatasi
 apps/frappe/frappe/config/customization.py,Add your own translations,Tambahkan terjemahan Anda sendiri
@@ -706,7 +706,7 @@ DocType: Slack Webhook URL,Webhook URL,URL Webhook
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Nama pengguna {0} sudah ada
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Tidak dapat melakukan impor karena {1} bukan data yang dapat diimpor
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Ada kesalahan dalam Template Alamat Anda {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} adalah alamat email yang tidak valid di &#39;Penerima&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} adalah alamat email yang tidak valid di 'Penerima'
 DocType: Footer Item,"target = ""_blank""","target = ""_blank"""
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,Tuan rumah
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Nama Mata Uang
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Tidak ada Email
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Tautan Kedaluwarsa
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Mengembalikan panjang ke {0} untuk &#39;{1}&#39; dalam &#39;{2}&#39;; Menyetel panjang sebagai {3} akan menyebabkan pemotongan data.
+							Setting the length as {3} will cause truncation of data.",Mengembalikan panjang ke {0} untuk '{1}' dalam '{2}'; Menyetel panjang sebagai {3} akan menyebabkan pemotongan data.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Pilih Format File
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Content Hash
@@ -769,7 +769,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokumen Saham Laporkan
 DocType: Social Login Key,Base URL,URL dasar
 DocType: User,Last Login,Terakhir Login
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Anda tidak dapat mengatur &#39;Translatable&#39; untuk field {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Anda tidak dapat mengatur 'Translatable' untuk field {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Kolom
 DocType: Chat Profile,Chat Profile,Profil Obrolan
 DocType: Custom Field,Adds a custom field to a DocType,Menambahkan custom field untuk DocType
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Apakah Home Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Gaya Navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} bukan Alamat Email valid
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Pilih minimal 1 record untuk pencetakan
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Pengguna {0} &#39;sudah memiliki peran&#39; {1} &#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Pengguna {0} 'sudah memiliki peran' {1} '
 DocType: System Settings,Two Factor Authentication method,Metode Two Factor Authentication
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Pertama-tama atur nama dan simpan catatannya.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 catatan
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,bidang wajib: menetapkan peran untuk
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} dikritik {1}
 DocType: Data Migration Mapping,Mapping Name,Nama pemetaan
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Field &#39;{1}&#39; tidak dapat ditetapkan sebagai Unik karena memiliki nilai-nilai non-unik
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Field '{1}' tidak dapat ditetapkan sebagai Unik karena memiliki nilai-nilai non-unik
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navigasikan daftar ke bawah
 DocType: Currency,A symbol for this currency. For e.g. $,Simbol untuk mata uang ini. Contoh $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Berhasil memperbarui terjemahan
@@ -2005,7 +2005,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Jika instruksi ini, jika tidak membantu, silakan tambahkan saran Anda pada GitHub Isu."
 DocType: Workflow State,bookmark,penanda
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Nama folder tidak boleh menyertakan &#39;/&#39; (garis miring)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Nama folder tidak boleh menyertakan '/' (garis miring)
 DocType: Note,Note,Catatan
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Laporan Kesalahan
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Ekspor Data dalam format CSV / Excel.
@@ -2109,7 +2109,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesi kadaluarsa di J
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Bidang ini hanya akan muncul jika fieldname didefinisikan di sini memiliki nilai OR aturan yang benar (contoh): MyField eval: doc.myfield == &#39;Nilai saya&#39; eval: doc.age> 18
+eval:doc.age>18",Bidang ini hanya akan muncul jika fieldname didefinisikan di sini memiliki nilai OR aturan yang benar (contoh): MyField eval: doc.myfield == 'Nilai saya' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Kantor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hari ini
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Setelah Anda telah mengatur ini, pengguna hanya akan bisa mengakses dokumen (misalnya Blog Post) di mana link yang ada (misalnya Blogger)."
@@ -2148,7 +2148,7 @@ DocType: Data Migration Connector,Database Name,Nama database
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Form Segarkan
 DocType: DocField,Select,Pilih
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Lihat Log Lengkap
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Ekspresi Python Sederhana, Contoh: status == &#39;Open&#39; dan ketik == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Ekspresi Python Sederhana, Contoh: status == 'Open' dan ketik == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Berkas tidak terpasang
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Koneksi terputus. Beberapa fitur mungkin tidak bekerja.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Mengulangi seperti &quot;aaa&quot; mudah ditebak
@@ -2279,7 +2279,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Tampilkan hanya kesalahan
 DocType: Website Settings,Banner HTML,Spanduk HTML
 DocType: Workflow,Send Email Alert,Kirim Notifikasi Email
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Pilih metode pembayaran yang lain. Razorpay tidak mendukung transaksi dalam mata uang &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Pilih metode pembayaran yang lain. Razorpay tidak mendukung transaksi dalam mata uang '{0}'
 DocType: Data Import,In Progress,Sedang berlangsung
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Diantrikan untuk dicadangan. Mungkin memakan waktu beberapa menit sampai satu jam.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2758,7 +2758,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Citra Tampilan
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Sepertinya ada kesalahan selama transaksi. Karena kami belum mengkonfirmasi pembayaran, Paypal akan otomatis mengembalikan Anda jumlah ini. Jika tidak, silahkan kirim email dan menyebutkan ID Korelasi: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Sertakan simbol, angka dan huruf kapital di password"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Masukkan Setelah bidang &#39;{0}&#39; disebutkan dalam Custom Field &#39;{1}&#39;, dengan label &#39;{2}&#39;, tidak ada"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Masukkan Setelah bidang '{0}' disebutkan dalam Custom Field '{1}', dengan label '{2}', tidak ada"
 DocType: List Filter,List Filter,Daftar filter
 DocType: Workflow State,signal,sinyal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Memiliki lampiran
@@ -2768,7 +2768,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokumen dipulihkan
 DocType: Data Export,Data Export,Ekspor Data
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Pilih bahasa...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Anda tidak dapat menyetel &#39;Pilihan&#39; untuk bidang {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Anda tidak dapat menyetel 'Pilihan' untuk bidang {0}
 DocType: Help Article,Author,Penulis
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Lanjutkan Mengirim
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Membuka lagi
@@ -2782,14 +2782,14 @@ DocType: Web Page,Slideshow,Rangkai Salindia
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Template Default Address tidak bisa dihapus
 DocType: Contact,Maintenance Manager,Manajer Pemeliharaan
 DocType: Workflow State,Search,Pencarian
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Silahkan pilih metode pembayaran lain. Stripe tidak mendukung transaksi dalam mata uang &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Silahkan pilih metode pembayaran lain. Stripe tidak mendukung transaksi dalam mata uang '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Pindah Untuk Sampah
 DocType: Web Form,Web Form Fields,Formulir web Fields
 DocType: Data Import,Amended From,Diubah Dari
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Peringatan: Tidak dapat menemukan {0} di setiap meja yang berkaitan dengan {1}
 DocType: S3 Backup Settings,eu-north-1,eu-north-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Dokumen ini saat antri untuk eksekusi. Silakan coba lagi
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File &#39;{0}&#39; tidak ditemukan
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File '{0}' tidak ditemukan
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Hapus Bagian
 DocType: User,Change Password,Ganti kata sandi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Bidang Axis X
@@ -2976,7 +2976,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Nilai hilang untuk
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Tambah Anak
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Kemajuan Impor
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Jika kondisinya puas, pengguna akan diberi poin. misalnya. doc.status == &#39;Ditutup&#39;"
+","Jika kondisinya puas, pengguna akan diberi poin. misalnya. doc.status == 'Ditutup'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Data yang sudah di-posting tidak dapat dihapus.
 DocType: GSuite Templates,Template Name,Nama template
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,jenis baru dokumen
@@ -3109,7 +3109,7 @@ DocType: Dashboard Chart,Chart Type,Jenis bagan
 DocType: DocType,Auto Name,Nama Otomatis
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Hindari urutan seperti abc atau 6543 karena hal itu mudah ditebak
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Silakan coba lagi
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL harus dimulai dengan &#39;http: //&#39; atau &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL harus dimulai dengan 'http: //' atau 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Opsi 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Ubah
@@ -3396,7 +3396,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Translations kust
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Kemajuan
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,berdasar Peran
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,hilang Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname tidak valid &#39;{0}&#39; di autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname tidak valid '{0}' di autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Cari dalam jenis dokumen
 DocType: Custom DocPerm,Role and Level,Peran dan Tingkat
 DocType: File,Thumbnail URL,URL thumbnail
@@ -3496,7 +3496,7 @@ DocType: Dashboard Chart,Filters JSON,Filter JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Klik di sini untuk memverifikasi
 DocType: Email Account,Disable SMTP server authentication,Nonaktifkan otentikasi server SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Disalin ke papan klip.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,substitusi diprediksi seperti &#39;@&#39; bukan &#39;a&#39; tidak membantu banyak.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,substitusi diprediksi seperti '@' bukan 'a' tidak membantu banyak.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Ditugaskan Olehku
 apps/frappe/frappe/utils/data.py,Zero,Nol
 DocType: Google Drive,Backup Folder ID,ID Folder Cadangan
@@ -3549,7 +3549,7 @@ DocType: Notification,Reference Date,Referensi Tanggal
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,Penyiapan OTP menggunakan Aplikasi OTP tidak selesai. Silakan hubungi Administrator.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Entrikan nos ponsel yang valid
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Beberapa fitur mungkin tidak bekerja di browser anda. Perbarui browser anda ke versi terbaru.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Tidak tahu, tanyakan &#39;bantuan&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Tidak tahu, tanyakan 'bantuan'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},membatalkan dokumen ini {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Komentar dan Komunikasi akan terkait dengan dokumen terkait ini
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
@@ -3855,7 +3855,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Standar
 DocType: Translation,Verified,Diverifikasi
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} ditambahkan
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cari &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cari '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Harap menyimpan laporan pertama
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} Pelanggan telah ditambahkan
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Tidak Masuk
@@ -3891,7 +3891,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Saya
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} bukan Keadaan yang berlaku
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Berlaku untuk semua Jenis Dokumen
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Pembaruan poin energi
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Pilih metode pembayaran yang lain. PayPal tidak mendukung transaksi dalam mata uang &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Pilih metode pembayaran yang lain. PayPal tidak mendukung transaksi dalam mata uang '{0}'
 DocType: Chat Message,Room Type,Tipe ruangan
 DocType: Data Import Beta,Import Log Preview,Impor Pratinjau Log
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,kolom pencarian {0} tidak valid

--- a/frappe/translations/is.csv
+++ b/frappe/translations/is.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Skrá varab
 DocType: DocField,In Global Search,Í Global Leita
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,inndráttur vinstri
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} ári
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} ári
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Það er áhættusamt að eyða þessari skrá: {0}. Vinsamlegast hafðu samband System Manager.
 DocType: Currency,Currency Name,Gjaldmiðill Name
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,engar póst
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Engin {0} fan
 apps/frappe/frappe/config/customization.py,Add custom forms.,Bæta sérsniðnum form.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} í {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,lögð þessu skjali
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Skipulag&gt; Notendaleyfi
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Skipulag> Notendaleyfi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Kerfið býður upp á ýmsa fyrirfram skilgreind hlutverk. Hægt er að bæta við nýjum hlutverkum að setja fínni heimildir.
 DocType: Communication,CC,CC
 DocType: Country,Geo,geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ef notandinn hefur hvaða hlutverk köflóttur, þá verður notandinn að &quot;System User&quot;. &quot;System Notandi&quot; hefur aðgang að skjáborðinu"
 DocType: System Settings,Date and Number Format,Dagsetning og Number Format
 apps/frappe/frappe/model/document.py,one of,einn af
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Skipulag&gt; Sérsníða form
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Skipulag> Sérsníða form
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Athugar eitt augnablik
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Sýna Tags
 DocType: DocField,HTML Editor,HTML ritstjóri
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,innheimtu
 DocType: Email Queue,Not Sent,ekki send
 DocType: Web Form,Actions,aðgerðir
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Skipulag&gt; Notandi
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Skipulag> Notandi
 DocType: Workflow State,align-justify,samræma-réttlæta
 DocType: User,Middle Name (Optional),Middle Name (Valfrjálst)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ekki leyfilegt
@@ -1410,7 +1410,7 @@ DocType: User,System User,System User
 DocType: Report,Is Standard,er Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Fullt
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ekki HTML Encode HTML tög eins &lt;script&gt; eða bara stafi eins &lt;eða&gt;, eins og þeir gætu verið notuð af ásetningi á þessu sviði"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ekki HTML Encode HTML tög eins &lt;script> eða bara stafi eins &lt;eða>, eins og þeir gætu verið notuð af ásetningi á þessu sviði"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} gagnrýndur á {1}
 DocType: Website Settings,FavIcon,síðumerkis
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Hlaupa
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer mun aðein
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Bíður
 DocType: System Settings,Allow only one session per user,Leyfa aðeins einn fundur á hvern notanda
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Forsíða / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Veldu eða draga yfir tímarásir til að búa til nýja atburði.
 DocType: Contact,Contact Details,Tengiliðaupplýsingar
 DocType: DocField,In Filter,í Sía
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Innskráning ekki leyfð á þessum tíma
 DocType: Data Migration Run,Current Mapping Action,Núverandi Kortlagning
 DocType: Dashboard Chart Source,Source Name,Source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Enginn tölvupóstreikningur tengdur notandanum. Vinsamlegast bættu reikningi við Notandi&gt; Netfang pósthólf.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Enginn tölvupóstreikningur tengdur notandanum. Vinsamlegast bættu reikningi við Notandi> Netfang pósthólf.
 DocType: Email Account,Email Sync Option,Tölvupóstur Sync Valkostur
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Röð nr
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Þegar í
 DocType: User Email,Enable Outgoing,Virkja Outgoing
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Custom Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Tölvupóstreikningur er ekki uppsettur. Vinsamlegast stofnaðu nýjan tölvupóstreikning frá Uppsetning&gt; Tölvupóstur&gt; Netfangareikningur
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Tölvupóstreikningur er ekki uppsettur. Vinsamlegast stofnaðu nýjan tölvupóstreikning frá Uppsetning> Tölvupóstur> Netfangareikningur
 DocType: Comment,Submitted,lögð
 DocType: Contact,Pulled from Google Contacts,Dregið úr Google tengiliðum
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ógild beiðni
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Session Lok í kluk
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Þessi reitur verður að birtast aðeins ef FIELDNAME skilgreint hér hefur gildi OR reglur eru sannir (dæmi): myfield eval: doc.myfield == &#39;Gildi minn&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Þessi reitur verður að birtast aðeins ef FIELDNAME skilgreint hér hefur gildi OR reglur eru sannir (dæmi): myfield eval: doc.myfield == &#39;Gildi minn&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Skrifstofa 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Í dag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Þegar þú hefur sett þetta, sem notendur munu aðeins vera fær aðgang skjöl (td. Bloggfærsluna) þar sem tengill er til (td. Blogger)."
@@ -2122,13 +2122,13 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,hástafi
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Sláðu inn heiti möppu
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Ekkert sjálfgefið netsniðmát fannst. Vinsamlegast búðu til nýtt úr Skipulag&gt; Prentun og vörumerki&gt; Heimilismát.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Ekkert sjálfgefið netsniðmát fannst. Vinsamlegast búðu til nýtt úr Skipulag> Prentun og vörumerki> Heimilismát.
 apps/frappe/frappe/auth.py,Unknown User,Óþekktur notandi
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Veldu hlutverk
 DocType: Comment,Deleted,eytt
 DocType: Workflow State,adjust,stilla
 DocType: Web Form,Sidebar Settings,Skenkur Stillingar
-DocType: DocType,"If enabled, document views are tracked, this can happen multiple times","Ef það er virkt er fylgst með skjalaskoðun, þetta getur gerst margoft"
+DocType: DocType,"If enabled, document views are tracked, this can happen multiple times","Ef þa�� er virkt er fylgst með skjalaskoðun, þetta getur gerst margoft"
 DocType: Website Settings,Disable Customer Signup link in Login page,Slökkva Viðskiptavinur Skilti tengilinn í Innskráning síðunni
 apps/frappe/frappe/desk/report/todo/todo.py,Assigned To/Owner,Úthlutað til / Eigandi
 DocType: Workflow State,arrow-left,arrow vinstri
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Slóð til netþjónsvottorðs
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ekki nóg leyfi til að sjá tengla
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Heimilisfang Titill er nauðsynlegur.
 DocType: Google Contacts,Push to Google Contacts,Ýttu á Google tengiliði
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Bætt við HTML í &lt;head&gt; hluta af the vefur blaðsíða, fyrst og fremst notað fyrir vefsvæðið sannprófun og SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Bætt við HTML í &lt;head> hluta af the vefur blaðsíða, fyrst og fremst notað fyrir vefsvæðið sannprófun og SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,endurkomið
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Atriði er ekki hægt að bæta við eigin afkomenda sinna
 DocType: Session Default Settings,Session Defaults,Sjálfgefin seta
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Viðvörun
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Þetta gæti verið prentað á mörgum síðum
 DocType: Data Migration Run,Percent Complete,Hlutfall lokið
 DocType: Tag Category,Tag Category,tag Flokkur
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til samanburðar, notaðu&gt; 5, &lt;10 eða = 324. Notaðu 5:10 (fyrir gildi á milli 5 og 10) fyrir svið."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til samanburðar, notaðu> 5, &lt;10 eða = 324. Notaðu 5:10 (fyrir gildi á milli 5 og 10) fyrir svið."
 DocType: Google Calendar,Pull from Google Calendar,Dragðu úr Google dagatalinu
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjálp
 DocType: User,Login Before,Innskráning Áður
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Custom Script
 DocType: Address,Address Line 2,Heimilisfang lína 2
 DocType: Address,Reference,Tilvísun
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Úthlutað til
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Vinsamlegast settu upp sjálfgefinn tölvupóstreikning frá Uppsetning&gt; Tölvupóstur&gt; Netfangareikningur
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Vinsamlegast settu upp sjálfgefinn tölvupóstreikning frá Uppsetning> Tölvupóstur> Netfangareikningur
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Gögn Flutningur Kortlagning Detail
 DocType: Data Import,Action,aðgerð
 DocType: GSuite Settings,Script URL,Slóð URL
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Leyfa á Senda
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,undantekning Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick Dálkar
-DocType: Web Page,Add code as &lt;script&gt;,Bæta kóða sem &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Bæta kóða sem &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Hreinsa leyfi notenda
 DocType: Webhook,Headers,Fyrirsagnir
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Viðburðir á næstunni
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,hlut-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Biðröð ætti að vera einn af {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Sjálfgefið sniðmát </h4><p> Notar <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> og öll svið Address (þ.mt Custom Fields ef einhver) verður í boði </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Sjálfgefið sniðmát </h4><p> Notar <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> og öll svið Address (þ.mt Custom Fields ef einhver) verður í boði </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Start Date Field
 DocType: Role,Role Name,hlutverk Name
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch Til Desk

--- a/frappe/translations/is.csv
+++ b/frappe/translations/is.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Parent
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Við höfum móttekið beiðni frá þér um að hala niður {0} gögnunum þínum sem tengjast: {1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Ef slökkt er á, verður lykilorðsstyrkurinn framfylgt miðað við lágmarksviðmiðið. Gildi 2 er miðlungs sterk og 4 er mjög sterk."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Team Members&quot; eða &quot;Management&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Sjálfgefið fyrir &#39;Athugaðu&#39; tegund sviði hlýtur að vera annað hvort &quot;0&quot; eða &quot;1&quot;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Sjálfgefið fyrir 'Athugaðu' tegund sviði hlýtur að vera annað hvort &quot;0&quot; eða &quot;1&quot;
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Í gær
 DocType: Contact,Designation,Tilnefning
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Sjálfvirk tenging er aðeins hægt að virkja fyrir einn tölvupóstreikning.
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Slökkva Report
 DocType: Translation,Contributed Translation Doctype Name,Framlag Þýðing Doctype nafn
 DocType: PayPal Settings,Redirect To,beina Til
 DocType: Data Migration Mapping,Pull,Dragðu
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [ &#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [ 'REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Magn Uppfæra
 DocType: Workflow State,chevron-up,Chevron upp
 DocType: DocType,Allow Guest to View,Leyfa Guest til að sjá
@@ -557,7 +557,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Tölfræði byggð á árangri síðustu viku (frá {0} til {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP símasvið
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","skjal tegund ..., td viðskiptavinur"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,The Ástand &#39;{0}&#39; er ógild
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,The Ástand '{0}' er ógild
 DocType: Workflow State,barcode,Barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Notkun undirfyrirsagnar eða aðgerða er takmörkuð
 apps/frappe/frappe/config/customization.py,Add your own translations,Bæta við eigin þýðingum
@@ -706,7 +706,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Notandanafn {0} er þegar til
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Get ekki stillt innflutning sem {1} er ekki importable
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Það er villa í sniðmáti netfangið þitt {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} er ógilt netfang í &#39;viðtakendum&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} er ógilt netfang í 'viðtakendum'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,Host
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,Gjaldmiðill Name
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,engar póst
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Tengill útrunninn
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Endurtaka lengd til {0} fyrir &#39;{1}&#39; í &#39;{2}&#39;; Ef lengdin er stillt sem {3} verður það að stytta gögnin.
+							Setting the length as {3} will cause truncation of data.",Endurtaka lengd til {0} fyrir '{1}' í '{2}'; Ef lengdin er stillt sem {3} verður það að stytta gögnin.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Veldu File Format
 DocType: Report,Javascript,javascript
 DocType: File,Content Hash,Efni Hash
@@ -763,13 +763,13 @@ apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standard DocType getur ekki haft sjálfgefið prenta snið, nota Customize Form"
 DocType: Report,Query,fyrirspurn
 DocType: Customize Form,Sort Order,Raða Order
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&quot;Í listayfirliti &#39;ekki leyfð tegund {0} í röð {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&quot;Í listayfirliti 'ekki leyfð tegund {0} í röð {1}
 DocType: Letter Head,Footer HTML,Footer HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,Veldu merkimiða eftir sem þú vilt að setja nýja sviði.
 ,Document Share Report,Skjal Share Skýrsla
 DocType: Social Login Key,Base URL,Undirstaða vefslóð
 DocType: User,Last Login,Last Login
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Þú getur ekki stillt &#39;translatable&#39; fyrir reit {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Þú getur ekki stillt 'translatable' fyrir reit {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,dálkur
 DocType: Chat Profile,Chat Profile,Spjall prófíl
 DocType: Custom Field,Adds a custom field to a DocType,Bætir við sérsniðnu svæði til DOCTYPE
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,Er Home Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Style
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} er ekki gilt netfang
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Veldu atleast 1 skrá til prentunar
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',User &#39;{0}&#39; þegar hefur það hlutverk &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',User '{0}' þegar hefur það hlutverk '{1}'
 DocType: System Settings,Two Factor Authentication method,Tvær þættir staðfestingaraðferð
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Settu fyrst nafnið og vistaðu skrána.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 met
@@ -1027,7 +1027,7 @@ DocType: Property Setter,Property Setter,Property Setter
 DocType: Web Form,Allow Print,leyfa Prenta
 DocType: Communication,Clicked,smellt
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Hætta að fylgjast með
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Engin heimild til að &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Engin heimild til að '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Áætlunarferðir til að senda
 DocType: DocType,Track Seen,Track Séð
 DocType: Dropbox Settings,File Backup,File Backup
@@ -1054,7 +1054,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Page HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Flytja út rangar raðir
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Heiti hóps getur ekki verið tómt.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Frekari hnútar geta verið aðeins búin undir &#39;group&#39; tegund hnúta
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Frekari hnútar geta verið aðeins búin undir 'group' tegund hnúta
 DocType: SMS Parameter,Header,haus
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Unknown Dálkur: {0}
 DocType: Notification Recipient,Email By Role,Tölvupóstur með hlutverk
@@ -1441,7 +1441,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Nauðsynlegur reitur: setja hlutverk að
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} gagnrýnt {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Ekki er hægt að stilla reitinn &#39;{1}&#39; sem Einstakur þar sem hann hefur óeðlileg gildi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Ekki er hægt að stilla reitinn '{1}' sem Einstakur þar sem hann hefur óeðlileg gildi
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Siglaðu lista niður
 DocType: Currency,A symbol for this currency. For e.g. $,Tákn fyrir þennan gjaldmiðil. t.d $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Uppfært nýjar þýðingar
@@ -2004,7 +2004,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google leturgerð
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Ef þessum leiðbeiningum þar ekki gagnlegt, vinsamlegast bætið í tillögur þínar á github málefni."
 DocType: Workflow State,bookmark,bókamerki
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Mappanafn ætti ekki að innihalda &#39;/&#39; (rista)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Mappanafn ætti ekki að innihalda '/' (rista)
 DocType: Note,Note,Note
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,villuskýrslu
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Flytja út gögn í CSV / Excel sniði.
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Session Lok í kluk
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Þessi reitur verður að birtast aðeins ef FIELDNAME skilgreint hér hefur gildi OR reglur eru sannir (dæmi): myfield eval: doc.myfield == &#39;Gildi minn&#39; eval: doc.age> 18
+eval:doc.age>18",Þessi reitur verður að birtast aðeins ef FIELDNAME skilgreint hér hefur gildi OR reglur eru sannir (dæmi): myfield eval: doc.myfield == 'Gildi minn' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Skrifstofa 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Í dag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Þegar þú hefur sett þetta, sem notendur munu aðeins vera fær aðgang skjöl (td. Bloggfærsluna) þar sem tengill er til (td. Blogger)."
@@ -2147,7 +2147,7 @@ DocType: Data Migration Connector,Database Name,Gagnasafn Nafn
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Uppfæra Form
 DocType: DocField,Select,Veldu
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Skoða fulla skrá
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Einföld Python-tjáning, dæmi: status == &#39;Open&#39; og tegund == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Einföld Python-tjáning, dæmi: status == 'Open' og tegund == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Skrá ekki fest
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Tenging tapað. Sumar aðgerðir virka ekki.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Endurtekur eins og &quot;AAA&quot; er auðvelt að giska
@@ -2278,7 +2278,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Sýna aðeins villur
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Senda tölvupóststilkynningu
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Vinsamlegast veldu annan greiðslumáta. Razorpay styður ekki viðskipti í mynt &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Vinsamlegast veldu annan greiðslumáta. Razorpay styður ekki viðskipti í mynt '{0}'
 DocType: Data Import,In Progress,Í vinnslu
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Biðröð fyrir öryggisafrit. Það getur tekið nokkrar mínútur til klukkutíma.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2700,7 +2700,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,um breytingu á
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal greiðsla hlið stillingar
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Toppleikari
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Sérsniðnum reitum er ekki hægt að bæta við kjarna DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) mun fá styttu, sem max stafir leyfð er {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) mun fá styttu, sem max stafir leyfð er {2}"
 DocType: OAuth Client,Response Type,svar Type
 DocType: Contact Us Settings,Send enquiries to this email address,Senda fyrirspurnir á þetta netfang
 DocType: Letter Head,Letter Head Name,Letter Head Name
@@ -2757,7 +2757,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Mynd View
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Lítur út eins og eitthvað fór úrskeiðis á viðskiptunum. Þar sem við höfum ekki staðfest greiðslu, Paypal sjálfkrafa endurgreiða þér þessa upphæð. Ef það virkar ekki, vinsamlegast sendu okkur tölvupóst og nefna fylgni ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Hafa tákn, tölur og hástafir í lykilorðinu"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Settu Eftir sviði &#39;{0}&#39; getið í Custom Field &#39;{1}&#39;, með merki &#39;{2}&#39;, er ekki til"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Settu Eftir sviði '{0}' getið í Custom Field '{1}', með merki '{2}', er ekki til"
 DocType: List Filter,List Filter,Listasía
 DocType: Workflow State,signal,merki
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Hefur Viðhengi
@@ -2767,7 +2767,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Skjal endurheimt
 DocType: Data Export,Data Export,Útflutningur gagna
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Veldu tungumál ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Þú getur ekki stillt &#39;Valkostir&#39; fyrir reit {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Þú getur ekki stillt 'Valkostir' fyrir reit {0}
 DocType: Help Article,Author,Höfundur
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,halda áfram að senda
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Enduropna
@@ -2781,14 +2781,14 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Sjálfgefið heimilisfang Snið getur ekki eytt
 DocType: Contact,Maintenance Manager,viðhald Manager
 DocType: Workflow State,Search,leit
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vinsamlegast veldu annan greiðsluaðferð. Rönd styður ekki viðskipti í gjaldmiðli &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vinsamlegast veldu annan greiðsluaðferð. Rönd styður ekki viðskipti í gjaldmiðli '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Henda í ruslið
 DocType: Web Form,Web Form Fields,Vefform Fields
 DocType: Data Import,Amended From,breytt Frá
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Viðvörun: Ekki er hægt að finna {0} í hvaða borð sem tengjast {1}
 DocType: S3 Backup Settings,eu-north-1,eu-norður-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Þetta skjal er nú biðröð fyrir framkvæmd. Vinsamlegast reyndu aftur
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Skráin &#39;{0}&#39; fannst ekki
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Skráin '{0}' fannst ekki
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,fjarlægja kafla
 DocType: User,Change Password,Breyta lykilorði
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X Axis Field
@@ -2975,7 +2975,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Gildi vantar fyrir
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Bæta Child
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Flytja framfarir
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",Ef skilyrðið er fullnægt verður notandi verðlaunaður með stigunum. td. doc.status == &#39;Lokað&#39;
+",Ef skilyrðið er fullnægt verður notandi verðlaunaður með stigunum. td. doc.status == 'Lokað'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Lagt Record ekki hægt að eyða.
 DocType: GSuite Templates,Template Name,Sniðmát Nafn
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Ný tegund skjals
@@ -3107,7 +3107,7 @@ DocType: Dashboard Chart,Chart Type,Myndategund
 DocType: DocType,Auto Name,Auto Name
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Forðastu raðir eins abc eða 6543 eins og þeir eru auðvelt að giska
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Vinsamlegast reyndu aftur
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',Vefslóð verður að byrja með &#39;http: //&#39; eða &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',Vefslóð verður að byrja með 'http: //' eða 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,valkostur 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,Breyta
@@ -3394,7 +3394,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Custom Þýðinga
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,progress
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,eftir Hlutverk
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,vantar Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ógild FIELDNAME &#39;{0}&#39; í autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ógild FIELDNAME '{0}' í autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Leita í skjali gerð
 DocType: Custom DocPerm,Role and Level,Hlutverk og Level
 DocType: File,Thumbnail URL,Smámynd URL
@@ -3483,11 +3483,11 @@ DocType: Dashboard Chart,Filters JSON,Síur JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Smelltu hér til að sannreyna
 DocType: Email Account,Disable SMTP server authentication,Slökkva á staðfestingu SMTP netþjóns
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Afritað á klemmuspjald.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Fyrirsjáanlegar útskiptingar eins &#39;@&#39; í stað &#39;a&#39; gera ekki hjálpa mjög mikið.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Fyrirsjáanlegar útskiptingar eins '@' í stað 'a' gera ekki hjálpa mjög mikið.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Úthlutað By Me
 apps/frappe/frappe/utils/data.py,Zero,Núll
 DocType: Google Drive,Backup Folder ID,Auðkenni öryggisafrita möppu
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ekki í forritarastillingu! Setja í site_config.json eða gera &#39;sérstakar&#39; DOCTYPE.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ekki í forritarastillingu! Setja í site_config.json eða gera 'sérstakar' DOCTYPE.
 DocType: Workflow State,globe,heim
 DocType: System Settings,dd.mm.yyyy,dd.mm.aaaa
 DocType: Assignment Rule,Priority,Forgangur
@@ -3536,7 +3536,7 @@ DocType: Notification,Reference Date,viðmiðunardagur
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP uppsetningu með OTP forriti var ekki lokið. Vinsamlegast hafðu samband við stjórnanda.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Vinsamlegast sláðu inn gilt farsímanúmer Nos
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Sumar aðgerðir virðast ekki virka í vafranum þínum. Vinsamlegast uppfærðu vafrann þinn í nýjustu útgáfuna.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Veit ekki, spyrja &#39;help&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Veit ekki, spyrja 'help'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},felldi niður þetta skjal {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Athugasemdir og Communications verður í tengslum við þetta tengda skjal
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Sía ...
@@ -3565,7 +3565,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Mistókst að breyta áskrift
 DocType: LDAP Settings,LDAP Group Field,LDAP hópsvið
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Jafnt
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Valkostir &#39;Dynamic Link&#39; tegund af sviði að benda á aðra Link Field með valkostum og &#39;DOCTYPE &quot;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Valkostir 'Dynamic Link' tegund af sviði að benda á aðra Link Field með valkostum og 'DOCTYPE &quot;
 DocType: About Us Settings,Team Members Heading,Liðsmenn Fyrirsögn
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Ógilt CSV snið
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Villa við tengingu við QZ bakkaforrit ... <br><br> Þú þarft að hafa QZ Tray forrit sett upp og keyra til að nota Raw Print aðgerðina. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Smelltu hér til að hlaða niður og setja upp QZ Bakki</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Smelltu hér til að læra meira um Hráprentun</a> ."
@@ -3695,7 +3695,7 @@ DocType: Web Page,Web Page,Vefsíða
 DocType: Workflow Document State,Next Action Email Template,Next Action Email Sniðmát
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline",Ef það er virkt er fylgst með breytingum á skjalinu og þær sýndar á tímalínu
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Global Search&#39; ekki leyfð fyrir tegund {0} í röð {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Global Search' ekki leyfð fyrir tegund {0} í röð {1}
 DocType: Energy Point Log,Appreciation,Þakklæti
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,view List
 DocType: Workflow,Don't Override Status,Ekki Hunsa Status
@@ -3842,7 +3842,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Sjálfgefið
 DocType: Translation,Verified,Staðfest
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} bætti við
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Leita að &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Leita að '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Vistaðu skýrsluna fyrst
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} áskrifendur bætt
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,ekki Í
@@ -3878,14 +3878,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Ég
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} ekki gilt State
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Gildir um allar skjalategundir
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Uppfærsla orkupunkta
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Vinsamlegast veldu annan greiðslumáta. PayPal styður ekki viðskipti í mynt &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Vinsamlegast veldu annan greiðslumáta. PayPal styður ekki viðskipti í mynt '{0}'
 DocType: Chat Message,Room Type,Herbergistegund
 DocType: Data Import Beta,Import Log Preview,Forskoðun innflutningsskrár
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Leita reit {0} er ekki gilt
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,hlaðið skrá
 DocType: Workflow State,ok-circle,OK-hring
 DocType: LDAP Settings,LDAP User Creation and Mapping,Notkun LDAP og kortlagning notanda
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Þú getur fundið það með því að spyrja &quot;finna appelsínu í viðskiptavini &#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Þú getur fundið það með því að spyrja &quot;finna appelsínu í viðskiptavini '
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Afsakið! Notandi ætti að hafa fullan aðgang að eigin met sitt.
 ,Usage Info,notkun Upplýsingar
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Sýna flýtilykla

--- a/frappe/translations/is.csv
+++ b/frappe/translations/is.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,System User
 DocType: Report,Is Standard,er Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Fullt
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ekki HTML Encode HTML tög eins &lt;script> eða bara stafi eins &lt;eða>, eins og þeir gætu verið notuð af ásetningi á þessu sviði"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ekki HTML Encode HTML tög eins <script> eða bara stafi eins <eða>, eins og þeir gætu verið notuð af ásetningi á þessu sviði"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} gagnrýndur á {1}
 DocType: Website Settings,FavIcon,síðumerkis
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Hlaupa
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer mun aðein
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Bíður
 DocType: System Settings,Allow only one session per user,Leyfa aðeins einn fundur á hvern notanda
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Forsíða / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
+DocType: Website Settings,<head> HTML,<Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Veldu eða draga yfir tímarásir til að búa til nýja atburði.
 DocType: Contact,Contact Details,Tengiliðaupplýsingar
 DocType: DocField,In Filter,í Sía
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Slóð til netþjónsvottorðs
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ekki nóg leyfi til að sjá tengla
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Heimilisfang Titill er nauðsynlegur.
 DocType: Google Contacts,Push to Google Contacts,Ýttu á Google tengiliði
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Bætt við HTML í &lt;head> hluta af the vefur blaðsíða, fyrst og fremst notað fyrir vefsvæðið sannprófun og SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Bætt við HTML í <head> hluta af the vefur blaðsíða, fyrst og fremst notað fyrir vefsvæðið sannprófun og SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,endurkomið
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Atriði er ekki hægt að bæta við eigin afkomenda sinna
 DocType: Session Default Settings,Session Defaults,Sjálfgefin seta
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Viðvörun
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Þetta gæti verið prentað á mörgum síðum
 DocType: Data Migration Run,Percent Complete,Hlutfall lokið
 DocType: Tag Category,Tag Category,tag Flokkur
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til samanburðar, notaðu> 5, &lt;10 eða = 324. Notaðu 5:10 (fyrir gildi á milli 5 og 10) fyrir svið."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til samanburðar, notaðu> 5, <10 eða = 324. Notaðu 5:10 (fyrir gildi á milli 5 og 10) fyrir svið."
 DocType: Google Calendar,Pull from Google Calendar,Dragðu úr Google dagatalinu
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjálp
 DocType: User,Login Before,Innskráning Áður
@@ -3069,7 +3069,7 @@ DocType: DocField,Allow on Submit,Leyfa á Senda
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,undantekning Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick Dálkar
-DocType: Web Page,Add code as &lt;script>,Bæta kóða sem &lt;script>
+DocType: Web Page,Add code as <script>,Bæta kóða sem <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Hreinsa leyfi notenda
 DocType: Webhook,Headers,Fyrirsagnir
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Viðburðir á næstunni
@@ -3443,16 +3443,16 @@ DocType: Workflow State,share-alt,hlut-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Biðröð ætti að vera einn af {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Sjálfgefið sniðmát </h4><p> Notar <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> og öll svið Address (þ.mt Custom Fields ef einhver) verður í boði </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Sjálfgefið sniðmát </h4><p> Notar <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> og öll svið Address (þ.mt Custom Fields ef einhver) verður í boði </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Start Date Field
 DocType: Role,Role Name,hlutverk Name
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch Til Desk

--- a/frappe/translations/it.csv
+++ b/frappe/translations/it.csv
@@ -1410,7 +1410,7 @@ DocType: User,System User,Utente di sistema
 DocType: Report,Is Standard,È standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Pieno
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Non tag HTML Codifica HTML come &lt;script> o solo caratteri come &lt;o>, in quanto potrebbero essere utilizzate intenzionalmente in questo campo"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Non tag HTML Codifica HTML come <script> o solo caratteri come <o>, in quanto potrebbero essere utilizzate intenzionalmente in questo campo"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticato su {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Correre
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Il piè di pagina
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,In attesa
 DocType: System Settings,Allow only one session per user,Consenti solo una sessione per utente
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home/Test Folder 1/Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selezionare o trascinare gli intervalli di tempo per creare un nuovo evento.
 DocType: Contact,Contact Details,Dettagli Contatto
 DocType: DocField,In Filter,In Filtro
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Percorso al certificato del se
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Non è sufficiente l&#39;autorizzazione per visualizzare i collegamenti
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Il titolo dell'indirizzo è obbligatorio.
 DocType: Google Contacts,Push to Google Contacts,Invia a Contatti Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML Aggiunto nella sezione &lt;head> della pagina web, utilizzato principalmente per la verifica sito web e SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML Aggiunto nella sezione <head> della pagina web, utilizzato principalmente per la verifica sito web e SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiva
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,L'articolo non può essere aggiunto ai propri discendenti
 DocType: Session Default Settings,Session Defaults,Sessioni predefinite
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Attenzione
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Questo può essere stampato su più pagine
 DocType: Data Migration Run,Percent Complete,Percentuale completa
 DocType: Tag Category,Tag Category,Tag Categoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per il confronto, utilizzare> 5, &lt;10 o = 324. Per gli intervalli, utilizzare 5:10 (per valori compresi tra 5 e 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per il confronto, utilizzare> 5, <10 o = 324. Per gli intervalli, utilizzare 5:10 (per valori compresi tra 5 e 10)."
 DocType: Google Calendar,Pull from Google Calendar,Estrai da Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aiuto
 DocType: User,Login Before,Accedi Prima
@@ -3070,7 +3070,7 @@ DocType: DocField,Allow on Submit,Consenti se Confermato
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipo eccezione
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Scegli Colonne
-DocType: Web Page,Add code as &lt;script>,Aggiungi codice come &lt;script>
+DocType: Web Page,Add code as <script>,Aggiungi codice come <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Cancella autorizzazioni utente
 DocType: Webhook,Headers,Intestazioni
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Prossimi eventi
@@ -3444,26 +3444,26 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},La coda dovrebbe essere una delle {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Modello predefinito </ h4> 
  <p> <a Usi href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> e tutti i campi di Indirizzo ( compresi campi personalizzati se presente) sarà disponibile </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% se address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} 
- {{city}} & lt; br & gt; 
- {% se lo stato%} {{stato}} & lt; br & gt; {% endif -%} 
- {% se pincode%} PIN: {{pincode}} & lt; br & gt; {% endif -%} 
- {{paese}} & lt; br & gt; 
- {% se il telefono%} Telefono: {{telefono}} & lt; br & gt; { % endif -%} 
- {% se il fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% se email_id%} E-mail: {{email_id}} & lt; br & gt ; {endif% -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% se address_line2%} {{address_line2}} <br> { % endif -%} 
+ {{city}} <br> 
+ {% se lo stato%} {{stato}} <br> {% endif -%} 
+ {% se pincode%} PIN: {{pincode}} <br> {% endif -%} 
+ {{paese}} <br> 
+ {% se il telefono%} Telefono: {{telefono}} <br> { % endif -%} 
+ {% se il fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% se email_id%} E-mail: {{email_id}} <br> {endif% -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Campo di data di inizio
 DocType: Role,Role Name,Nome Ruolo

--- a/frappe/translations/it.csv
+++ b/frappe/translations/it.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Il backup d
 DocType: DocField,In Global Search,Alla ricerca globale
 DocType: System Settings,Brute Force Security,Sicurezza contro Bruteforce
 DocType: Workflow State,indent-left,indent-left
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} anno / i fa
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} anno / i fa
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,E' rischioso cancellare questo file: {0}. Si prega di contattare il Responsabile di Sistema.
 DocType: Currency,Currency Name,Nome Valuta
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Nessuna email
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,No {0} trovat
 apps/frappe/frappe/config/customization.py,Add custom forms.,Aggiungi moduli personalizzati.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} in {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,presentato questo documento
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Config&gt; Autorizzazioni utente
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Config> Autorizzazioni utente
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Il sistema fornisce molti ruoli predefiniti . È possibile aggiungere nuovi ruoli per impostare le autorizzazioni più fini .
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1255,7 +1255,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Se l&#39;utente ha alcun ruolo controllato, l&#39;utente diventa un &quot;User System&quot;. &quot;Utente della rete&quot; ha accesso al desktop"
 DocType: System Settings,Date and Number Format,Formato dei numeri e delle date
 apps/frappe/frappe/model/document.py,one of,Uno di
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Config&gt; Personalizza modulo
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Config> Personalizza modulo
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Controllo un momento
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Mostra Tag
 DocType: DocField,HTML Editor,Editor HTML
@@ -1263,7 +1263,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Fatturazione
 DocType: Email Queue,Not Sent,Non Inviato
 DocType: Web Form,Actions,Azioni
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Config&gt; Utente
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Config> Utente
 DocType: Workflow State,align-justify,Giustifica
 DocType: User,Middle Name (Optional),Secondo Nome (facoltativo)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Non Consentito
@@ -1410,7 +1410,7 @@ DocType: User,System User,Utente di sistema
 DocType: Report,Is Standard,È standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Pieno
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Non tag HTML Codifica HTML come &lt;script&gt; o solo caratteri come &lt;o&gt;, in quanto potrebbero essere utilizzate intenzionalmente in questo campo"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Non tag HTML Codifica HTML come &lt;script> o solo caratteri come &lt;o>, in quanto potrebbero essere utilizzate intenzionalmente in questo campo"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticato su {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Correre
@@ -1790,7 +1790,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Il piè di pagina
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,In attesa
 DocType: System Settings,Allow only one session per user,Consenti solo una sessione per utente
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home/Test Folder 1/Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selezionare o trascinare gli intervalli di tempo per creare un nuovo evento.
 DocType: Contact,Contact Details,Dettagli Contatto
 DocType: DocField,In Filter,In Filtro
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Accesso non consentito in questo momento
 DocType: Data Migration Run,Current Mapping Action,Azioni correnti di mapping
 DocType: Dashboard Chart Source,Source Name,Source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Nessun account e-mail associato all&#39;utente. Aggiungi un account sotto Utente&gt; Posta in arrivo.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Nessun account e-mail associato all&#39;utente. Aggiungi un account sotto Utente> Posta in arrivo.
 DocType: Email Account,Email Sync Option,Email Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Riga n
 DocType: Async Task,Runtime,Runtime
@@ -2036,7 +2036,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Già pres
 DocType: User Email,Enable Outgoing,Abilita uscita
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Tags Personalizzati
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Account e-mail non impostato. Crea un nuovo account e-mail da Imposta&gt; E-mail&gt; Account e-mail
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Account e-mail non impostato. Crea un nuovo account e-mail da Imposta> E-mail> Account e-mail
 DocType: Comment,Submitted,Confermato
 DocType: Contact,Pulled from Google Contacts,Estratto da Contatti Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Richiesta non valida
@@ -2108,7 +2108,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Durata Sessione in 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Questo campo viene visualizzato solo se il nome del campo definito qui ha valore o le regole sono veri (esempi): eval myfield: doc.myfield == &#39;il mio valore&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Questo campo viene visualizzato solo se il nome del campo definito qui ha valore o le regole sono veri (esempi): eval myfield: doc.myfield == &#39;il mio valore&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Oggi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Dopo aver impostato questo, gli utenti potranno accedere al documento (es. post del blog ) solo se il link esiste (es. Blogger ) ."
@@ -2122,7 +2122,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,LETTERE MAIUSCOLE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML personalizzato
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Inserisci il nome della cartella
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nessun modello di indirizzo predefinito trovato. Creane uno nuovo da Imposta&gt; Stampa e personalizzazione&gt; Modello indirizzo.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nessun modello di indirizzo predefinito trovato. Creane uno nuovo da Imposta> Stampa e personalizzazione> Modello indirizzo.
 apps/frappe/frappe/auth.py,Unknown User,Utente sconosciuto
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Scegliere Ruolo
 DocType: Comment,Deleted,Eliminato
@@ -2311,7 +2311,7 @@ DocType: LDAP Settings,Path to Server Certificate,Percorso al certificato del se
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Non è sufficiente l&#39;autorizzazione per visualizzare i collegamenti
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Il titolo dell'indirizzo è obbligatorio.
 DocType: Google Contacts,Push to Google Contacts,Invia a Contatti Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML Aggiunto nella sezione &lt;head&gt; della pagina web, utilizzato principalmente per la verifica sito web e SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML Aggiunto nella sezione &lt;head> della pagina web, utilizzato principalmente per la verifica sito web e SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiva
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,L'articolo non può essere aggiunto ai propri discendenti
 DocType: Session Default Settings,Session Defaults,Sessioni predefinite
@@ -2430,7 +2430,7 @@ DocType: Workflow State,Warning,Attenzione
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Questo può essere stampato su più pagine
 DocType: Data Migration Run,Percent Complete,Percentuale completa
 DocType: Tag Category,Tag Category,Tag Categoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per il confronto, utilizzare&gt; 5, &lt;10 o = 324. Per gli intervalli, utilizzare 5:10 (per valori compresi tra 5 e 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Per il confronto, utilizzare> 5, &lt;10 o = 324. Per gli intervalli, utilizzare 5:10 (per valori compresi tra 5 e 10)."
 DocType: Google Calendar,Pull from Google Calendar,Estrai da Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Aiuto
 DocType: User,Login Before,Accedi Prima
@@ -2892,7 +2892,7 @@ DocType: Custom Script,Custom Script,Script Personalizzato
 DocType: Address,Address Line 2,Indirizzo 2
 DocType: Address,Reference,Riferimento
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Assegnato a
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Configura l&#39;account e-mail predefinito da Imposta&gt; E-mail&gt; Account e-mail
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Configura l&#39;account e-mail predefinito da Imposta> E-mail> Account e-mail
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Dati di mapping di migrazione dei dati
 DocType: Data Import,Action,Azione
 DocType: GSuite Settings,Script URL,URL dello script
@@ -3070,7 +3070,7 @@ DocType: DocField,Allow on Submit,Consenti se Confermato
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipo eccezione
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Scegli Colonne
-DocType: Web Page,Add code as &lt;script&gt;,Aggiungi codice come &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Aggiungi codice come &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Cancella autorizzazioni utente
 DocType: Webhook,Headers,Intestazioni
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Prossimi eventi
@@ -3444,15 +3444,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},La coda dovrebbe essere una delle {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Modello predefinito </ h4> 
  <p> <a Usi href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> e tutti i campi di Indirizzo ( compresi campi personalizzati se presente) sarà disponibile </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/it.csv
+++ b/frappe/translations/it.csv
@@ -58,7 +58,7 @@ apps/frappe/frappe/model/base_document.py,"{0}, Row {1}","{0}, Riga {1}"
 DocType: DocField,Markdown Editor,Markdown Editor
 apps/frappe/frappe/model/document.py,Beginning with,Inizia con
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Importazione dati Template
-apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,Si è verificato un errore durante l&#39;impostazione dei valori predefiniti della sessione
+apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,Si è verificato un errore durante l'impostazione dei valori predefiniti della sessione
 apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Genitore
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Abbiamo ricevuto una tua richiesta di scaricare i tuoi dati {0} associati a: {1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Se abilitato, la forza della password verrà eseguita in base al valore Punteggio minima password. Un valore di 2 è medio forte e 4 è molto forte."
@@ -83,12 +83,12 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Cancel {0} documents?,Canc
 DocType: DocType,Is Published Field,È pubblicato Campo
 DocType: GCalendar Settings,GCalendar Settings,Impostazioni GCalendar
 DocType: Email Group,Email Group,Email Group
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Calendar: impossibile eliminare l&#39;evento {0} da Google Calendar, codice errore {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Calendar: impossibile eliminare l'evento {0} da Google Calendar, codice errore {1}."
 DocType: Event,Pulled from Google Calendar,Estratto da Google Calendar
 DocType: Note,Seen By,Visto da
 apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Aggiunta multipla
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,Hai guadagnato alcuni punti energia
-apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,Immagine dell&#39;utente non valida.
+apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,Immagine dell'utente non valida.
 DocType: Energy Point Log,Reverted,ripristinata
 DocType: Success Action,First Success Message,Primo messaggio di successo
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Not Like,Non come
@@ -104,7 +104,7 @@ apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,Ritratto
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,Inserire
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Consentire Accesso Google Drive
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Select {0},Selezionare {0}
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Inserisci l&#39;URL di base
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Inserisci l'URL di base
 DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Se abilitato, il documento viene contrassegnato come visualizzato, la prima volta che un utente lo apre"
 DocType: Auto Repeat,Repeat on Day,Ripetere il giorno
 DocType: DocField,Color,Colore
@@ -156,7 +156,7 @@ apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified aft
 DocType: Address,Himachal Pradesh,Himachal Pradesh
 DocType: System Settings,"If not set, the currency precision will depend on number format","Se non è impostata, la precisione di valuta dipenderà dal formato del numero"
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Awesomebar,Apri Awesomebar
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Sembra che ci sia un problema con la configurazione delle strisce del server. In caso di fallimento, l&#39;importo verrà rimborsato sul tuo conto."
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Sembra che ci sia un problema con la configurazione delle strisce del server. In caso di fallimento, l'importo verrà rimborsato sul tuo conto."
 DocType: Data Import,Import Log,Log Importazione
 DocType: User Permission,Apply To All Document Types,Applica a tutti i tipi di documento
 apps/frappe/frappe/config/website.py,Embed image slideshows in website pages.,Includi slideshow di immagin nelle pagine del sito.
@@ -199,12 +199,12 @@ apps/frappe/frappe/twofactor.py,"Login session expired, refresh page to retry","
 DocType: Communication,BCC,BCC
 DocType: Unhandled Email,Reason,Motivo
 DocType: Email Unsubscribe,Email Unsubscribe,Cancella sottoscrizione E-mail
-DocType: Website Settings,Select an image of approx width 150px with a transparent background for best results.,Selezionare un&#39;immagine di circa larghezza 150px con sfondo trasparente per i migliori risultati.
+DocType: Website Settings,Select an image of approx width 150px with a transparent background for best results.,Selezionare un'immagine di circa larghezza 150px con sfondo trasparente per i migliori risultati.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,No activity,Nessuna attività
 apps/frappe/frappe/www/third_party_apps.html,Third Party Apps,Applicazioni di terze parti
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The first user will become the System Manager (you can change this later).,Il primo utente sarà il System Manager (è possibile cambiarlo in seguito).
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You cannot give review points to yourself,Non puoi dare punti di recensione a te stesso
-apps/frappe/frappe/integrations/doctype/webhook/webhook.py,DocType must be Submittable for the selected Doc Event,DocType deve essere sottomessa per l&#39;evento Doc selezionato
+apps/frappe/frappe/integrations/doctype/webhook/webhook.py,DocType must be Submittable for the selected Doc Event,DocType deve essere sottomessa per l'evento Doc selezionato
 DocType: Workflow State,circle-arrow-up,cerchio-freccia-up
 DocType: Email Domain,Email Domain,Dominio Email
 DocType: Workflow State,italic,corsivo
@@ -232,7 +232,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,Non hai i permessi per inviare e-mail relative a questo documento
 apps/frappe/frappe/model/db_query.py,Please select atleast 1 column from {0} to sort/group,Si prega di selezionare atleast 1 colonna da {0} per ordinare / gruppo
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1}. Restricted field: {2},Non consentito per {0}: {1}. Campo riservato: {2}
-DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Controllare questo se si sta testando il pagamento utilizzando l&#39;API Sandbox
+DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Controllare questo se si sta testando il pagamento utilizzando l'API Sandbox
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,Non è consentito eliminare un tema standard
 DocType: Data Import,Log Details,Dettagli del registro
 DocType: Workflow Transition,Example,Esempio
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Disabilita Repor
 DocType: Translation,Contributed Translation Doctype Name,Nome del doctype della traduzione fornita
 DocType: PayPal Settings,Redirect To,Redirect Per
 DocType: Data Migration Mapping,Pull,Tirare
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Formato JavaScript: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Formato JavaScript: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Aggiornamento massivo
 DocType: Workflow State,chevron-up,chevron-up
 DocType: DocType,Allow Guest to View,Consenti all'ospite di Visualizzare
@@ -313,7 +313,7 @@ apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add / Up
 apps/frappe/frappe/www/printview.py,Not allowed to print draft documents,Non è consentito di stampare i documenti in bozza
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Reset to defaults,Ripristina impostazioni predefinite
 DocType: Workflow,Transition Rules,Regole di transizione
-apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Showing only first {0} rows in preview,Mostra solo le prime {0} righe nell&#39;anteprima
+apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Showing only first {0} rows in preview,Mostra solo le prime {0} righe nell'anteprima
 apps/frappe/frappe/core/doctype/report/report.js,Example:,Esempio:
 DocType: Workflow,Defines workflow states and rules for a document.,Definisce gli stati del flusso di lavoro e le regole per un documento.
 DocType: Workflow State,Filter,Filtro
@@ -346,7 +346,7 @@ DocType: Kanban Board Column,purple,viola
 DocType: About Us Settings,Team Members,Membri del Team
 DocType: Assignment Rule,System Manager,System Manager
 DocType: Custom DocPerm,Permissions,Autorizzazioni
-apps/frappe/frappe/config/integrations.py,Slack Webhooks for internal integration,Slash Webhook per l&#39;integrazione interna
+apps/frappe/frappe/config/integrations.py,Slack Webhooks for internal integration,Slash Webhook per l'integrazione interna
 DocType: Dropbox Settings,Allow Dropbox Access,Consentire Accesso DropBox
 DocType: Print Format,Raw Commands,Comandi grezzi
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.js,Restore,Ristabilire
@@ -398,11 +398,11 @@ apps/frappe/frappe/public/js/frappe/barcode_scanner/quagga.js,Scan Barcode,Scans
 DocType: Email Flag Queue,Email Flag Queue,Coda Flag-mail
 DocType: Access Log,Columns / Fields,Colonne / Campi
 apps/frappe/frappe/config/settings.py,Stylesheets for Print Formats,Fogli di stile per i formati di stampa
-apps/frappe/frappe/utils/bot.py,Can't identify open {0}. Try something else.,Non è possibile identificare aperto {0}. Provare qualcos&#39;altro.
+apps/frappe/frappe/utils/bot.py,Can't identify open {0}. Try something else.,Non è possibile identificare aperto {0}. Provare qualcos'altro.
 apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Your information has been submitted,Le tue informazioni sono state presentate
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be deleted,Utente {0} non può essere eliminato
 DocType: System Settings,Currency Precision,Precisione valuta
-apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,Un&#39;altra operazione sta bloccando questo. Riprova in pochi secondi.
+apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,Un'altra operazione sta bloccando questo. Riprova in pochi secondi.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter_list.js,Clear filters,Cancella filtri
 DocType: Test Runner,App,App
 apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Gli allegati non possono essere collegati correttamente al nuovo documento
@@ -414,7 +414,7 @@ DocType: Assignment Rule,Assign To Users,Assegna agli utenti
 apps/frappe/frappe/public/js/frappe/utils/utils.js,or,oppure
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,module name...,nome del modulo ...
 apps/frappe/frappe/templates/pages/integrations/payment-success.html,Continue,Continuare
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,L&#39;integrazione di Google è disabilitata.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,L'integrazione di Google è disabilitata.
 DocType: Custom Field,Fieldname,Nome del campo
 DocType: Workflow State,certificate,certificato
 apps/frappe/frappe/templates/includes/login/login.js,Verifying...,Verifica in corso ...
@@ -426,7 +426,7 @@ DocType: Energy Point Log,Review,Revisione
 DocType: User,Restrict IP,Limitare IP
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,Cruscotto
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Impossibile inviare e-mail in questo momento
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Calendar: impossibile aggiornare l&#39;evento {0} in Google Calendar, codice errore {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Calendar: impossibile aggiornare l'evento {0} in Google Calendar, codice errore {1}."
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Cercare o digitare un comando
 DocType: Activity Log,Timeline Name,Nome Timeline
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,È possibile impostare solo uno {0} come primario.
@@ -514,7 +514,7 @@ DocType: Communication,Bounced,Bounced
 DocType: Deleted Document,Deleted Name,Nome eliminata
 apps/frappe/frappe/config/users_and_permissions.py,System and Website Users,Sistema e utenti del sito
 DocType: Workflow Document State,Doc Status,Stato Doc
-DocType: Data Migration Run,Pull Update,Tirare l&#39;aggiornamento
+DocType: Data Migration Run,Pull Update,Tirare l'aggiornamento
 DocType: Auto Email Report,No of Rows (Max 500),No di file (max 500)
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.html,Select Field...,Seleziona campo ...
 DocType: Language,Language Code,Codice lingua
@@ -526,7 +526,7 @@ apps/frappe/frappe/public/js/frappe/chat.js,Start a conversation.,Inizia una con
 DocType: Print Settings,"Always add ""Draft"" Heading for printing draft documents","Aggiungere sempre ""Bozza"" nell'intestazione per la stampa dei documenti"
 apps/frappe/frappe/email/doctype/notification/notification.py,Error in Notification: {},Errore nella notifica: {}
 DocType: Data Migration Run,Current Mapping Start,Inizio corrente di mapping
-apps/frappe/frappe/core/doctype/communication/communication.js,Email has been marked as spam,L&#39;email è stata contrassegnata come spam
+apps/frappe/frappe/core/doctype/communication/communication.js,Email has been marked as spam,L'email è stata contrassegnata come spam
 DocType: Comment,Website Manager,Responsabile sito web
 apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload Disconnected. Please try again.,Caricamento file scollegato. Riprova.
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translations,Traduzioni
@@ -550,16 +550,16 @@ DocType: Dashboard Chart,Half,Metà
 DocType: Desktop Icon,Link,Collegamento
 apps/frappe/frappe/utils/file_manager.py,No file attached,Nessun file allegato
 DocType: Version,Version,versione
-DocType: S3 Backup Settings,Endpoint URL,URL dell&#39;endpoint
+DocType: S3 Backup Settings,Endpoint URL,URL dell'endpoint
 DocType: Dashboard,Charts,Grafici
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions are automatically applied to Standard Reports and searches.,Le autorizzazioni vengono applicate automaticamente ai Report Standard e alle ricerche.
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,Caricamento fallito
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistiche basate sul rendimento della scorsa settimana (da {0} a {1})
 DocType: LDAP Settings,LDAP Phone Field,Campo telefono LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","tipo documento, p. es. cliente"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,La condizione &#39;{0}&#39; non è valido
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,La condizione '{0}' non è valido
 DocType: Workflow State,barcode,barcode
-apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,L&#39;uso della sotto-query o della funzione è limitato
+apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,L'uso della sotto-query o della funzione è limitato
 apps/frappe/frappe/config/customization.py,Add your own translations,Aggiungi le tue traduzioni
 DocType: Country,Country Name,Nome Nazione
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Blank Template,Modello vuoto
@@ -570,7 +570,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid f
 DocType: Chat Token,Token,Gettone
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} is restricted,Il nome campo {0} è limitato
 DocType: Property Setter,ID (name) of the entity whose property is to be set,ID (nome) dell'elemento la cui proprietà deve essere impostata
-DocType: Website Settings,Website Theme Image Link,Sito web dell&#39;associazione Tema immagine
+DocType: Website Settings,Website Theme Image Link,Sito web dell'associazione Tema immagine
 DocType: Web Form,Sidebar Items,articoli Sidebar
 DocType: Web Form,Show as Grid,Mostra come griglia
 apps/frappe/frappe/installer.py,App {0} already installed,App {0} già installata
@@ -595,7 +595,7 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log_list.js,View
 apps/frappe/frappe/public/js/frappe/desk.js,Places,posti
 DocType: Kanban Board Column,darkgrey,grigio scuro
 apps/frappe/frappe/model/rename_doc.py,Successful: {0} to {1},Riuscito: {0} a {1}
-apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,Non è possibile modificare i dettagli utente in demo. Per favore registrati per un nuovo account all&#39;indirizzo https://erpnext.com
+apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,Non è possibile modificare i dettagli utente in demo. Per favore registrati per un nuovo account all'indirizzo https://erpnext.com
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop,Far cadere
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please duplicate this to make changes,Si prega di duplicare questo per fare modifiche
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Press Enter to save,Premi Invio per salvare
@@ -604,7 +604,7 @@ DocType: Print Settings,Font Size,Dimensioni Font
 DocType: System Settings,Disable Standard Email Footer,Disabilitare standard Email Footer
 DocType: Workflow State,facetime-video,FaceTime-video
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,1 comment,1 commento
-DocType: Website Slideshow,"Note: For best results,  images must be of the same size and width must be greater than height.","Nota: per risultati ottimali, le immagini devono avere le stesse dimensioni e la larghezza deve essere maggiore dell&#39;altezza."
+DocType: Website Slideshow,"Note: For best results,  images must be of the same size and width must be greater than height.","Nota: per risultati ottimali, le immagini devono avere le stesse dimensioni e la larghezza deve essere maggiore dell'altezza."
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,viewed,consultati
 DocType: Notification,Days Before,Giorni Prima
 apps/frappe/frappe/desk/doctype/event/event.py,Daily Events should finish on the Same Day.,Gli eventi giornalieri dovrebbero concludersi nello stesso giorno.
@@ -625,7 +625,7 @@ DocType: Chat Profile,Settings,Impostazioni
 DocType: Print Format,Style Settings,Regolazioni
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Filter By,Filtra per
 apps/frappe/frappe/database/database.py,No conditions provided,Nessuna condizione fornita
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Campi dell&#39;asse Y.
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Campi dell'asse Y.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,Ordina campo {0} deve essere un nome di campo valido
 apps/frappe/frappe/public/js/frappe/list/base_list.js,More,Più
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Create a new record,Crea un nuovo record
@@ -660,7 +660,7 @@ apps/frappe/frappe/www/qrcode.html,Scan the QR Code and enter the resulting code
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Enable Gradients,Abilita gradienti
 DocType: System Settings,Minimum Password Score,Punteggio minimo password
 DocType: DocType,Fields,Campi
-DocType: System Settings,Your organization name and address for the email footer.,Il tuo nome dell&#39;organizzazione e l&#39;indirizzo e-mail per il piè di pagina.
+DocType: System Settings,Your organization name and address for the email footer.,Il tuo nome dell'organizzazione e l'indirizzo e-mail per il piè di pagina.
 apps/frappe/frappe/core/doctype/data_import/importer.py,Parent Table,Tabella padre
 apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js,S3 Backup complete!,S3 Backup completo!
 apps/frappe/frappe/config/desktop.py,Developer,Sviluppatore
@@ -697,7 +697,7 @@ apps/frappe/frappe/config/users_and_permissions.py,User Roles,Ruoli utente
 DocType: Property Setter,Property Setter overrides a standard DocType or Field property,Property Setter prevale un DOCTYPE standard o immobili Campo
 apps/frappe/frappe/core/doctype/user/user.py,Cannot Update: Incorrect / Expired Link.,Impossibile Aggiornare : Link Errato / Scaduto.
 apps/frappe/frappe/utils/password_strength.py,Better add a few more letters or another word,Meglio aggiungere qualche lettera o un'altra parola
-DocType: Auto Repeat,Repeat on Last Day of the Month,Ripeti l&#39;ultimo giorno del mese
+DocType: Auto Repeat,Repeat on Last Day of the Month,Ripeti l'ultimo giorno del mese
 apps/frappe/frappe/twofactor.py,One Time Password (OTP) Registration Code from {},Codice di registrazione di una password (OTP) da {}
 DocType: DocField,Set Only Once,Impostata una sola volta
 DocType: Email Queue Recipient,Email Queue Recipient,Destinatario Queue-mail
@@ -705,7 +705,7 @@ DocType: Address,Nagaland,Nagaland
 DocType: Slack Webhook URL,Webhook URL,URL Webhook
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Nome utente {0} già presente
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Impossibile impostare importazione dato che {1} non è importabile
-apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},C&#39;è un errore nel vostro indirizzo template {0}
+apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},C'è un errore nel vostro indirizzo template {0}
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} è un indirizzo email non valido nel campo 'Destinatari'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
@@ -748,14 +748,14 @@ DocType: Currency,Currency Name,Nome Valuta
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Nessuna email
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link scaduto
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Ripristino della lunghezza a {0} per &quot;{1}&quot; in &quot;{2}&quot;; L&#39;impostazione della lunghezza come {3} causerà il troncamento dei dati.
+							Setting the length as {3} will cause truncation of data.",Ripristino della lunghezza a {0} per &quot;{1}&quot; in &quot;{2}&quot;; L'impostazione della lunghezza come {3} causerà il troncamento dei dati.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Seleziona il formato del file
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash contenuto
-DocType: User,Stores the JSON of last known versions of various installed apps. It is used to show release notes.,Memorizza la JSON delle ultime versioni conosciute di varie applicazioni installate. E &#39;utilizzato per mostrare le note di rilascio.
+DocType: User,Stores the JSON of last known versions of various installed apps. It is used to show release notes.,Memorizza la JSON delle ultime versioni conosciute di varie applicazioni installate. E 'utilizzato per mostrare le note di rilascio.
 DocType: Energy Point Rule,User Field,Campo utente
 DocType: DocType,MyISAM,MyISAM
-DocType: Data Migration Run,Push Delete,Spingere l&#39;eliminazione
+DocType: Data Migration Run,Push Delete,Spingere l'eliminazione
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed for {1} {2},{0} iscrizione già cancellate per {1} {2}
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not remove,Non rimuovere
 apps/frappe/frappe/desk/like.py,Liked,Piaciuto
@@ -765,7 +765,7 @@ DocType: Report,Query,Query
 DocType: Customize Form,Sort Order,ordine
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'Modalità Lista' non consentito per il tipo {0} in riga {1}
 DocType: Letter Head,Footer HTML,Piè di pagina HTML
-DocType: Custom Field,Select the label after which you want to insert new field.,Selezionare l&#39;etichetta dopo la quale si desidera inserire nuovo campo.
+DocType: Custom Field,Select the label after which you want to insert new field.,Selezionare l'etichetta dopo la quale si desidera inserire nuovo campo.
 ,Document Share Report,"Report ""Condividi Documento"""
 DocType: Social Login Key,Base URL,URL di base
 DocType: User,Last Login,Ultimo Login
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,È Cartella Home
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Stile Navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} non è un indirizzo e-mail valido
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Selezionare atleast 1 record per la stampa
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Utente &#39;{0}&#39; già ha il ruolo &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Utente '{0}' già ha il ruolo '{1}'
 DocType: System Settings,Two Factor Authentication method,Metodo di autenticazione due fattori
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Prima imposta il nome e salva il record.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 registrazioni
@@ -865,7 +865,7 @@ DocType: Contact Phone,Number,Numero
 DocType: Web Form Field,Web Form Field,Campo modulo web
 apps/frappe/frappe/templates/emails/new_message.html,You have a new message from: ,Hai un nuovo messaggio da:
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_field.html,Edit HTML,Modifica HTML
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Inserisci l&#39;URL di reindirizzamento
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Inserisci l'URL di reindirizzamento
 apps/frappe/frappe/core/doctype/language/language.py,"{0} must begin and end with a letter and can only contain letters,
 				hyphen or underscore.","{0} deve iniziare e terminare con una lettera e può contenere solo lettere, trattino o trattino basso."
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Restore Original Permissions,Ripristina autorizzazioni originali
@@ -948,7 +948,7 @@ DocType: Role Profile,Role Profile,Profilo ruolo
 apps/frappe/frappe/permissions.py,Document Type is not importable,Il tipo di documento non è importabile
 DocType: LDAP Settings,LDAP Server Url,LDAP Server URL
 apps/frappe/frappe/public/js/frappe/form/form.js,Cannot open instance when its {0} is open,Impossibile aprire esempio quando il suo {0} è aperto
-apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Header HTML set from attachment {0},Intestazione HTML impostata dall&#39;allegato {0}
+apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Header HTML set from attachment {0},Intestazione HTML impostata dall'allegato {0}
 apps/frappe/frappe/config/desktop.py,Customization,Personalizzazione
 DocType: LDAP Settings,Organizational Unit for Users,Unità organizzativa per gli utenti
 ,Transaction Log Report,Rapporto del registro delle transazioni
@@ -959,23 +959,23 @@ DocType: Access Log,Method,Metodo
 DocType: Report,Script Report,Script Report
 DocType: OAuth Authorization Code,Scopes,Scopes
 DocType: About Us Settings,Company Introduction,Introduzione Azienda
-DocType: User,Last Password Reset Date,Data di reimpostazione dell&#39;ultima password
+DocType: User,Last Password Reset Date,Data di reimpostazione dell'ultima password
 DocType: DocField,Length,Lunghezza
 apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Ripristinare o eliminare definitivamente un documento.
-apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Il profilo di chat per l&#39;utente {0} esiste.
+apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Il profilo di chat per l'utente {0} esiste.
 apps/frappe/frappe/public/js/frappe/social/components/PostSidebar.vue,Frequently Visited Links,Link visitati di frequente
 DocType: Notification,"To add dynamic subject, use jinja tags like
 
 <div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Per aggiungere soggetto dinamico, utilizzare i tag Jinja come <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
 apps/frappe/frappe/desk/search.py,Invalid Search Field {0},Campo di ricerca non valido {0}
 DocType: User,Modules HTML,Moduli HTML
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Consenti l&#39;accesso a Google Calendar
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Consenti l'accesso a Google Calendar
 DocType: Assignment Rule,Higher priority rule will be applied first,La regola con priorità più alta verrà applicata per prima
 DocType: Email Account,"Track if your email has been opened by the recipient.
 <br>
-Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","Tieni traccia se la tua e-mail è stata aperta dal destinatario. <br> Nota. Se invii a più destinatari, anche se 1 destinatario legge l&#39;email, verrà considerato &quot;Aperto&quot;"
+Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","Tieni traccia se la tua e-mail è stata aperta dal destinatario. <br> Nota. Se invii a più destinatari, anche se 1 destinatario legge l'email, verrà considerato &quot;Aperto&quot;"
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Missing Values Required,Valori mancanti richiesti
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Consenti l&#39;accesso ai contatti di Google
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Consenti l'accesso ai contatti di Google
 DocType: Data Migration Connector,Frappe,Frappé
 apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Unread,Segna come non letto
 DocType: Activity Log,Operation,Operazione
@@ -1001,7 +1001,7 @@ apps/frappe/frappe/public/js/frappe/views/communication.js,"On {0}, {1} wrote:",
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Cannot delete standard field. You can hide it if you want,Impossibile eliminare campo standard. È possibile solo nasconderlo
 DocType: Top Bar Item,For top bar,Per i top bar
 DocType: Social Login Key,Auth URL Data,URL per Autenticazione Dati
-apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,In coda per il backup. Riceverai un&#39;e-mail con il link di download
+apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,In coda per il backup. Riceverai un'e-mail con il link di download
 apps/frappe/frappe/utils/bot.py,Could not identify {0},Impossibile identificare {0}
 DocType: Address,Address,Indirizzo
 apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,Pagamento fallito
@@ -1072,14 +1072,14 @@ DocType: Address,Other Territory,Altro Territorio
 apps/frappe/frappe/config/website.py,Portal,Portale
 DocType: Email Account,Use Different Email Login ID,Utilizzare un diverso ID di accesso alla posta elettronica
 apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,Necessario specificare una query per eseguire
-apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Sembra che ci sia un problema con la configurazione del braintree del server. Non preoccuparti, in caso di errore, l&#39;importo verrà rimborsato sul tuo conto."
+apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Sembra che ci sia un problema con la configurazione del braintree del server. Non preoccuparti, in caso di errore, l'importo verrà rimborsato sul tuo conto."
 apps/frappe/frappe/www/me.html,Manage Third Party Apps,Gestione applicazioni di terze parti
 DocType: Website Settings,Route Redirects,Reindirizzamenti del percorso
 apps/frappe/frappe/config/settings.py,"Language, Date and Time settings","Impostazioni di lingua , data e ora"
 DocType: User Email,User Email,user-mail
 DocType: Assignment Rule Day,Saturday,Sabato
 DocType: User,Represents a User in the system.,Rappresenta un utente nel sistema.
-DocType: List View Setting,Disable Auto Refresh,Disabilita l&#39;aggiornamento automatico
+DocType: List View Setting,Disable Auto Refresh,Disabilita l'aggiornamento automatico
 DocType: Comment,Label,Etichetta
 apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed.","L'attività {0}, assegnata a {1}, è stata chiusa."
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please close this window,Si prega di chiudere questa finestra
@@ -1135,11 +1135,11 @@ apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Madam,Signora
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Criticize,Criticare
 apps/frappe/frappe/desk/page/activity/activity_row.html,Updated {0}: {1},Aggiornato {0}: {1}
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Master,Maestro
-DocType: DocType,User Cannot Create,L&#39;utente non può creare
+DocType: DocType,User Cannot Create,L'utente non può creare
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Successfully Done,Fatto con successo
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox access is approved!,accesso Dropbox è approvato!
 DocType: Customize Form,Enter Form Type,Inserisci Tipo Modulo
-DocType: Google Drive,Authorize Google Drive Access,Autorizza l&#39;accesso a Google Drive
+DocType: Google Drive,Authorize Google Drive Access,Autorizza l'accesso a Google Drive
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Missing parameter Kanban Board Name,Parametro Kanban Board mancante
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_stat.html,No records tagged.,Nessun record marcato.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Field,Eliminare campo
@@ -1156,7 +1156,7 @@ apps/frappe/frappe/templates/includes/comments/comments.html,Login to comment,Ef
 apps/frappe/frappe/core/doctype/data_import/importer.py,Start entering data below this line,Avviare l'immissione di dati al di sotto di questa linea
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed values for {0},valori modificati per {0}
 apps/frappe/frappe/email/doctype/email_account/email_account.py,"Email ID must be unique, Email Account already exists \
-				for {0}","L&#39;ID email deve essere univoco, l&#39;account e-mail esiste già \ per {0}"
+				for {0}","L'ID email deve essere univoco, l'account e-mail esiste già \ per {0}"
 DocType: Workflow State,retweet,rispondi
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Customize...,Personalizzare...
 DocType: Print Format,Align Labels to the Right,Allinea le etichette a destra
@@ -1167,7 +1167,7 @@ apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For 
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,Repeats {0},Ripete {0}
 DocType: OAuth Provider Settings,OAuth Provider Settings,Impostazioni OAuth Provider
 DocType: Review Level,Review Points,Punti di revisione
-DocType: Workflow Document State,Workflow Action is not created for optional states,L&#39;azione del flusso di lavoro non è stata creata per gli stati opzionali
+DocType: Workflow Document State,Workflow Action is not created for optional states,L'azione del flusso di lavoro non è stata creata per gli stati opzionali
 DocType: Address,City/Town,Città/Paese
 DocType: Data Migration Connector,Connector Name,Nome del connettore
 DocType: Address,Is Your Company Address,È il vostro indirizzo azienda
@@ -1180,14 +1180,14 @@ apps/frappe/frappe/utils/data.py,only.,soltanto.
 DocType: Route History,Route History,Cronologia del percorso
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Give Review Points,Dai punti di recensione
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google Calendar: impossibile inserire il contatto nei Contatti Google {0}, codice errore {1}."
-apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,Il segreto OTP può essere resettato solo dall&#39;amministratore.
+apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,Il segreto OTP può essere resettato solo dall'amministratore.
 apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,Evita gli anni che sono associati a te.
-apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Limita l&#39;utente per un documento specifico
+apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Limita l'utente per un documento specifico
 DocType: GSuite Templates,GSuite Templates,Modelli di GSuite
 apps/frappe/frappe/utils/goal.py,Goal,Obiettivo
 apps/frappe/frappe/email/receive.py,Invalid Mail Server. Please rectify and try again.,Server di posta non valido. Si prega di correggere e riprovare.
 DocType: DocField,"For Links, enter the DocType as range.
-For Select, enter list of Options, each on a new line.","Per i collegamenti, inserire il DOCTYPE come gamma. Per Seleziona, immettere l&#39;elenco di opzioni, ciascuna su una nuova linea."
+For Select, enter list of Options, each on a new line.","Per i collegamenti, inserire il DOCTYPE come gamma. Per Seleziona, immettere l'elenco di opzioni, ciascuna su una nuova linea."
 DocType: Workflow State,film,pellicola
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Sync Calendar,Sincronizza calendario
 apps/frappe/frappe/model/db_query.py,No permission to read {0},Non autorizzato a leggere {0}
@@ -1226,7 +1226,7 @@ DocType: File,old_parent,old_parent
 apps/frappe/frappe/config/desk.py,"Newsletters to contacts, leads.",Newsletter a contatti (leads).
 DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","p. es. ""Supporto"",""Vendite"",""Mario Rossi"""
 apps/frappe/frappe/twofactor.py,Incorrect Verification code,Codice di verifica non corretto
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,L&#39;integrazione dei contatti di Google è disabilitata.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,L'integrazione dei contatti di Google è disabilitata.
 DocType: Assignment Rule,Description,Descrizione
 DocType: Print Settings,Repeat Header and Footer in PDF,Ripetere Intestazione e piè di pagina in PDF
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Failure,Fallimento
@@ -1245,21 +1245,21 @@ apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Columns based on
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Importing {0} of {1}, {2}","Importazione di {0} di {1}, {2}"
 DocType: Workflow State,move,Sposta
 apps/frappe/frappe/model/document.py,Action Failed,Azione Fallita
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,For User,per l&#39;utente
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,For User,per l'utente
 DocType: View Log,View log,Vista del registro
 DocType: Address,Assam,Assam
 apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,← Back to upload files,← Torna a caricare file
 apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Outgoing email account not correct,Account di posta in uscita non corretto
 DocType: Transaction Log,Chaining Hash,Chaining Hash
-apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,Si prega di impostare l&#39;indirizzo e-mail
-DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Se l&#39;utente ha alcun ruolo controllato, l&#39;utente diventa un &quot;User System&quot;. &quot;Utente della rete&quot; ha accesso al desktop"
+apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,Si prega di impostare l'indirizzo e-mail
+DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Se l'utente ha alcun ruolo controllato, l'utente diventa un &quot;User System&quot;. &quot;Utente della rete&quot; ha accesso al desktop"
 DocType: System Settings,Date and Number Format,Formato dei numeri e delle date
 apps/frappe/frappe/model/document.py,one of,Uno di
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Config> Personalizza modulo
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Controllo un momento
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Mostra Tag
 DocType: DocField,HTML Editor,Editor HTML
-DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Se l&#39;opzione Applica autorizzazione utente rigorosa è selezionata e la licenza utente è definita per un DocType per un utente, tutti i documenti in cui il valore del collegamento è vuoto non verranno visualizzati a tale utente"
+DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Se l'opzione Applica autorizzazione utente rigorosa è selezionata e la licenza utente è definita per un DocType per un utente, tutti i documenti in cui il valore del collegamento è vuoto non verranno visualizzati a tale utente"
 DocType: Address,Billing,Fatturazione
 DocType: Email Queue,Not Sent,Non Inviato
 DocType: Web Form,Actions,Azioni
@@ -1271,7 +1271,7 @@ apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,No Go
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Following fields have missing values:,Seguenti campi hanno valori mancanti:
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,via automatic rule {0} on {1},tramite la regola automatica {0} su {1}
 apps/frappe/frappe/core/report/transaction_log_report/transaction_log_report.py,First Transaction,Prima transazione
-apps/frappe/frappe/app.py,You do not have enough permissions to complete the action,Non si dispone di autorizzazioni sufficienti per completare l&#39;azione
+apps/frappe/frappe/app.py,You do not have enough permissions to complete the action,Non si dispone di autorizzazioni sufficienti per completare l'azione
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Single DocTypes cannot be customized.,I singoli DocTypes non possono essere personalizzati.
 DocType: User,Document Follow,Document Follow
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,No Results,Nessun risultato
@@ -1292,7 +1292,7 @@ DocType: PayPal Settings,PayPal Settings,Impostazioni PayPal
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Document Type,Seleziona tipo di documento
 apps/frappe/frappe/utils/nestedset.py,Cannot delete {0} as it has child nodes,Impossibile eliminare {0} come ha nodi figlio
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} minutes ago,{0} minuti fa
-apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Assignment Day {0} has been repeated.,Il giorno dell&#39;assegnazione {0} è stato ripetuto.
+apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Assignment Day {0} has been repeated.,Il giorno dell'assegnazione {0} è stato ripetuto.
 DocType: Kanban Board Column,lightblue,azzurro
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Same Field is entered more than once,Lo stesso campo è inserito più di una volta
 DocType: Print Settings,Enable Raw Printing,Abilita stampa raw
@@ -1330,7 +1330,7 @@ DocType: Workflow State,bullhorn,megafono
 apps/frappe/frappe/model/workflow.py,Not a valid Workflow Action,Azione non valida del flusso di lavoro
 DocType: Footer Item,Target,Obiettivo
 DocType: System Settings,Number of Backups,Numero di backup
-DocType: Dashboard Chart,Last Year,L&#39;anno scorso
+DocType: Dashboard Chart,Last Year,L'anno scorso
 DocType: Website Settings,Copyright,Copyright
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Go,Cerca
 DocType: OAuth Authorization Code,Invalid,Non valido
@@ -1348,9 +1348,9 @@ apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Aggiungi altro
 DocType: System Settings,Session Expiry Mobile,Durata Sessione Dispositivo Mobile
 apps/frappe/frappe/utils/password.py,Incorrect User or Password,Utente o password errati
 apps/frappe/frappe/templates/includes/search_box.html,Search results for,cerca risultati per
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Inserisci l&#39;URL del token di accesso
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Inserisci l'URL del token di accesso
 DocType: Notification,Slack,allentato
-DocType: Custom DocPerm,If user is the owner,Se l&#39;utente è il proprietario
+DocType: Custom DocPerm,If user is the owner,Se l'utente è il proprietario
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Follow,Seguire
 ,Activity,Attività
 DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Aiuto: Per creare un collegamento a un altro record nel sistema, utilizzare ""#Form/Note/[Nota Nome]"" come collegamento url. (Non usare ""http://"")"
@@ -1403,7 +1403,7 @@ apps/frappe/frappe/config/users_and_permissions.py,Report of all document shares
 apps/frappe/frappe/www/update-password.html,New Password,Nuova password
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Filter {0} missing,Filtro {0} mancante
 apps/frappe/frappe/core/doctype/activity_log/activity_log.py,Sorry! You cannot delete auto-generated comments,Scusate! Non è possibile eliminare i commenti generati automaticamente
-DocType: Google Settings,Used For Google Maps Integration.,Utilizzato per l&#39;integrazione di Google Maps.
+DocType: Google Settings,Used For Google Maps Integration.,Utilizzato per l'integrazione di Google Maps.
 apps/frappe/frappe/core/doctype/communication/communication.js,Reference DocType,Riferimento DocType
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,No records will be exported,Nessun record verrà esportato
 DocType: User,System User,Utente di sistema
@@ -1441,8 +1441,8 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Campo obbligatorio: ruolo impostato per
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} criticato {1}
 DocType: Data Migration Mapping,Mapping Name,Nome di mapping
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Il campo &#39;{1}&#39; non può essere impostato come Unico in quanto ha valori non univoci
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Naviga l&#39;elenco verso il basso
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Il campo '{1}' non può essere impostato come Unico in quanto ha valori non univoci
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Naviga l'elenco verso il basso
 DocType: Currency,A symbol for this currency. For e.g. $,Un simbolo per questa valuta. Per esempio $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Traduzioni aggiornate con successo
 apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Frappe Framework,Frappe Framework
@@ -1512,7 +1512,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Inb
 DocType: Review Level,Review Level,Livello di revisione
 DocType: Print Settings,PDF Page Size,Formato pagina PDF
 DocType: Energy Point Rule,Rule Name,Nome regola
-DocType: Data Import,Attach file for Import,Allega file per l&#39;importazione
+DocType: Data Import,Attach file for Import,Allega file per l'importazione
 DocType: Communication,Recipient Unsubscribed,Destinatario Sottoscritta
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,About,About
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"For updating, you can update only selective columns.","Per l'aggiornamento, è possibile aggiornare le colonne solo selettivi."
@@ -1585,7 +1585,7 @@ apps/frappe/frappe/templates/includes/comments/comments.html,Add Another Comment
 apps/frappe/frappe/core/doctype/data_import/importer.py,No data found in the file. Please reattach the new file with data.,Nessun dato trovato nel file. Riattaccare il nuovo file con i dati.
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Edit DocType,Modifica DocType
 apps/frappe/frappe/templates/emails/data_deletion_approval.html,Confirm Request,Richiesta di conferma
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Piegare deve venire prima di un&#39;interruzione di sezione
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Piegare deve venire prima di un'interruzione di sezione
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Under Development,In sviluppo
 apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Go to the document,Vai al documento
 apps/frappe/frappe/public/js/frappe/model/meta.js,Last Modified By,Ultima modifica Di
@@ -1670,8 +1670,8 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.js,No Permiss
 DocType: Auto Email Report,Auto Email Report,Invio Automatico Email Report
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Delete comment?,Elimina commento?
 DocType: Address Template,This format is used if country specific format is not found,Questo formato viene utilizzato se il formato specifico per il Paese non viene trovata
-DocType: System Settings,Allow Login using Mobile Number,Consenti l&#39;accesso utilizzando il numero di cellulare
-apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,Non si dispone di autorizzazioni sufficienti per accedere a questa risorsa. Si prega di contattare il responsabile per ottenere l&#39;accesso.
+DocType: System Settings,Allow Login using Mobile Number,Consenti l'accesso utilizzando il numero di cellulare
+apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,Non si dispone di autorizzazioni sufficienti per accedere a questa risorsa. Si prega di contattare il responsabile per ottenere l'accesso.
 DocType: Custom Field,Custom,Personalizzato
 DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Se abilitato, gli utenti che effettuano il login da Indirizzo IP limitato, non verranno richiesti Autori a due fattori"
 DocType: Auto Repeat,Get Contacts,Ottieni contatti
@@ -1699,14 +1699,14 @@ apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,now,adesso
 DocType: Workflow State,step-backward,passo indietro
 apps/frappe/frappe/utils/boilerplate.py,{app_title},{app_title}
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please set Dropbox access keys in your site config,Si prega di impostare tasti di accesso Dropbox nel tuo sito config
-apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete this record to allow sending to this email address,Eliminare questo record per consentire l&#39;invio a questo indirizzo email
+apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete this record to allow sending to this email address,Eliminare questo record per consentire l'invio a questo indirizzo email
 DocType: Email Account,"If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)","Se porta non standard (es. POP3: 995/110, IMAP: 993/143)"
 apps/frappe/frappe/public/js/frappe/views/components/DeskSection.vue,Customize Shortcuts,Personalizza le scorciatoie
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,"Solo campi obbligatori sono necessari per i nuovi record. È possibile eliminare le colonne non obbligatori, se lo si desidera."
 apps/frappe/frappe/desk/page/user_profile/user_profile.html,Show More Activity,Mostra più attività
-apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,Inserisci il codice visualizzato nell&#39;app OTP.
+apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,Inserisci il codice visualizzato nell'app OTP.
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Unable to update event,Impossibile aggiornare evento
-apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,Il codice di verifica è stato inviato all&#39;indirizzo di posta elettronica registrato.
+apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,Il codice di verifica è stato inviato all'indirizzo di posta elettronica registrato.
 apps/frappe/frappe/core/doctype/user/user.py,Throttled,strozzato
 apps/frappe/frappe/utils/data.py,"Filter must have 4 values (doctype, fieldname, operator, value): {0}","Il filtro deve avere 4 valori (doctype, nome di campo, operatore, valore): {0}"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Applica regola di assegnazione
@@ -1798,9 +1798,9 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Kanban,Kanban
 DocType: DocType,Show in Module Section,Mostra Modulo nella Sezione
 DocType: Workflow Document State,Is Optional State,È stato facoltativo
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,The {0} is already on auto repeat {1},{0} è già in ripetizione automatica {1}
-DocType: Letter Head,Header HTML,HTML dell&#39;intestazione
+DocType: Letter Head,Header HTML,HTML dell'intestazione
 apps/frappe/frappe/core/doctype/communication/communication.js,Relink,ricollegare
-apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,SMS non inviato. Si prega di contattare l&#39;amministratore.
+apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,SMS non inviato. Si prega di contattare l'amministratore.
 DocType: Web Page,"Page to show on the website
 ",Pagina da mostrare sul sito
 apps/frappe/frappe/config/settings.py,Create and manage newsletter,Crea e gestisci le newsletter
@@ -1814,7 +1814,7 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.py,Scheduler i
 DocType: Print Settings,Letter,Lettera
 DocType: DocType,"Naming Options:
 <ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>
-<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Opzioni di denominazione <ol><li> <b>campo: [nome campo]</b> - Per campo </li><li> <b>naming_series:</b> - Con Naming Series (il campo chiamato naming_series deve essere presente </li><li> <b>Prompt</b> : richiede all&#39;utente un nome </li><li> <b>[serie]</b> - Serie per prefisso (separato da un punto); per esempio PRE. ##### </li><li> <b>format: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - Sostituisce tutte le parole rinforzate (fieldnames, date words (DD, MM, YY), series) con il loro valore. Le parentesi graffe esterne possono essere utilizzate. </li></ol>"
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Opzioni di denominazione <ol><li> <b>campo: [nome campo]</b> - Per campo </li><li> <b>naming_series:</b> - Con Naming Series (il campo chiamato naming_series deve essere presente </li><li> <b>Prompt</b> : richiede all'utente un nome </li><li> <b>[serie]</b> - Serie per prefisso (separato da un punto); per esempio PRE. ##### </li><li> <b>format: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - Sostituisce tutte le parole rinforzate (fieldnames, date words (DD, MM, YY), series) con il loro valore. Le parentesi graffe esterne possono essere utilizzate. </li></ol>"
 apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,Si sono verificati errori durante la creazione del documento. Per favore riprova.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,Campo immagine deve essere di tipo Allega immagine
 apps/frappe/frappe/permissions.py,You are not allowed to export {} doctype,Non puoi esportare {} doctype
@@ -1893,7 +1893,7 @@ DocType: S3 Backup Settings,ap-northeast-3,ap-nord-est-3
 DocType: Data Migration Mapping,Remote Primary Key,Tasto principale remoto
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,In,In
 DocType: Notification,Value Change,Valore Change
-DocType: Google Contacts,Authorize Google Contacts Access,Autorizza l&#39;accesso ai contatti di Google
+DocType: Google Contacts,Authorize Google Contacts Access,Autorizza l'accesso ai contatti di Google
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Mostra solo i campi numerici da Report
 DocType: Data Import Beta,Import Type,Tipo di importazione
 DocType: Access Log,HTML Page,Pagina HTML
@@ -1912,7 +1912,7 @@ DocType: Customize Form,Use this fieldname to generate title,Utilizzare questo n
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Email From,Importa posta elettronica da
 apps/frappe/frappe/contacts/doctype/contact/contact.js,Invite as User,Invita come utente
 DocType: Data Migration Run,Started,Iniziato
-apps/frappe/frappe/permissions.py,User {0} does not have access to this document,L&#39;utente {0} non ha accesso a questo documento
+apps/frappe/frappe/permissions.py,User {0} does not have access to this document,L'utente {0} non ha accesso a questo documento
 DocType: Data Migration Run,End Time,Ora fine
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Select Attachments,Selezionare Allegati
 apps/frappe/frappe/model/naming.py, for {0},per {0}
@@ -2004,7 +2004,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Se queste istruzioni non sono state d'aiuto, si prega di aggiungere i vostri suggerimenti nelle Issues di GitHub."
 DocType: Workflow State,bookmark,segnalibro
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Il nome della cartella non dovrebbe includere &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Il nome della cartella non dovrebbe includere '/' (slash)
 DocType: Note,Note,Nota
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Report di Errore
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Esportare i dati in formato CSV / Excel.
@@ -2021,7 +2021,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Accesso non consentito in questo momento
 DocType: Data Migration Run,Current Mapping Action,Azioni correnti di mapping
 DocType: Dashboard Chart Source,Source Name,Source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Nessun account e-mail associato all&#39;utente. Aggiungi un account sotto Utente> Posta in arrivo.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Nessun account e-mail associato all'utente. Aggiungi un account sotto Utente> Posta in arrivo.
 DocType: Email Account,Email Sync Option,Email Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Riga n
 DocType: Async Task,Runtime,Runtime
@@ -2064,12 +2064,12 @@ DocType: Property Setter,DocType or Field,DocType Campo
 apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You unfollowed this document,Hai smesso di seguire questo documento
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Primary Color,Colore primario
 DocType: Communication,Soft-Bounced,Soft-Bounced
-DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Se abilitato, tutti gli utenti possono accedere da qualsiasi indirizzo IP usando l&#39;autenticazione a due fattori. Questo può anche essere impostato solo per utenti specifici nella Pagina utente"
+DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Se abilitato, tutti gli utenti possono accedere da qualsiasi indirizzo IP usando l'autenticazione a due fattori. Questo può anche essere impostato solo per utenti specifici nella Pagina utente"
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Seems Publishable Key or Secret Key is wrong !!!,Sembra chiave chiave pubblica o segreta è sbagliato !!!
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Quick Help for Setting Permissions,Guida rapida per Impostazione delle autorizzazioni
 DocType: Tag Doc Category,Doctype to Assign Tags,Doctype per assegnare tag
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.js,Show Relapses,Mostra ricadute
-apps/frappe/frappe/core/doctype/communication/communication.js,Email has been moved to trash,L&#39;email è stata spostata nel cestino
+apps/frappe/frappe/core/doctype/communication/communication.js,Email has been moved to trash,L'email è stata spostata nel cestino
 DocType: Report,Report Builder,Report Builder
 DocType: Async Task,Task Name,Nome Attività
 DocType: Website Route Meta,Meta Tags,Meta tags
@@ -2091,7 +2091,7 @@ apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Print Documents,Stam
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Jump to field,Vai al campo
 DocType: Contact Us Settings,Forward To Email Address,Inoltra a Indirizzo e-mail
 DocType: Contact Phone,Is Primary Phone,È il telefono principale
-apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,Invia un&#39;email a {0} per collegarla qui.
+apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,Invia un'email a {0} per collegarla qui.
 DocType: Auto Email Report,Weekdays,Nei giorni feriali
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} records will be exported,Verranno esportati {0} record
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Campo del titolo deve essere un nome di campo valido
@@ -2108,11 +2108,11 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Durata Sessione in 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Questo campo viene visualizzato solo se il nome del campo definito qui ha valore o le regole sono veri (esempi): eval myfield: doc.myfield == &#39;il mio valore&#39; eval: doc.age> 18
+eval:doc.age>18",Questo campo viene visualizzato solo se il nome del campo definito qui ha valore o le regole sono veri (esempi): eval myfield: doc.myfield == 'il mio valore' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Oggi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Dopo aver impostato questo, gli utenti potranno accedere al documento (es. post del blog ) solo se il link esiste (es. Blogger ) ."
-DocType: Data Import Beta,Submit After Import,Invia dopo l&#39;importazione
+DocType: Data Import Beta,Submit After Import,Invia dopo l'importazione
 DocType: Error Log,Log of Scheduler Errors,Log degli errori Scheduler
 DocType: User,Bio,Bio
 DocType: OAuth Client,App Client Secret,App client Secret
@@ -2192,9 +2192,9 @@ apps/frappe/frappe/database/schema.py,Length of {0} should be between 1 and 1000
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,Search for anything,Ricerca per nulla
 DocType: Data Migration Connector,Hostname,Hostname
 DocType: Data Migration Mapping,Condition Detail,Dettaglio stato
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"For currency {0}, the minimum transaction amount should be {1}","Per la valuta {0}, l&#39;importo minimo della transazione deve essere {1}"
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"For currency {0}, the minimum transaction amount should be {1}","Per la valuta {0}, l'importo minimo della transazione deve essere {1}"
 DocType: DocField,Print Hide,Stampa Hide
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,To User,All&#39;utente
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,To User,All'utente
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter Value,Immettere Valore
 DocType: Workflow State,tint,tinta
 DocType: DocField,In Preview,In anteprima
@@ -2239,11 +2239,11 @@ DocType: Integration Request,Reference DocName,Riferimento DocName
 DocType: Web Form,Success Message,Messaggio di conferma
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Export Customizations,esportare le personalizzazioni
 apps/frappe/frappe/website/doctype/web_page/web_page.py,End Date cannot be before Start Date!,La data di fine non può essere precedente alla data di inizio!
-DocType: DocType,User Cannot Search,L&#39;utente non può cercare
+DocType: DocType,User Cannot Search,L'utente non può cercare
 DocType: Communication Link,Communication Link,Link di comunicazione
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Invalid Output Format,Formato di uscita non valido
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Cannot {0} {1},Impossibile {0} {1}
-DocType: Custom DocPerm,Apply this rule if the User is the Owner,Applicare questa regola se l&#39;utente è il proprietario
+DocType: Custom DocPerm,Apply this rule if the User is the Owner,Applicare questa regola se l'utente è il proprietario
 DocType: Global Search Settings,Global Search Settings,Impostazioni di ricerca globale
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Will be your login ID,Sarà il tuo ID di login
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.js,Global Search Document Types Reset.,Ripristina tipi di documento di ricerca globale.
@@ -2278,11 +2278,11 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Mostra solo errori
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Invia avviso via email
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Si prega di selezionare un altro metodo di pagamento. Razorpay non supporta le transazioni in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Si prega di selezionare un altro metodo di pagamento. Razorpay non supporta le transazioni in valuta '{0}'
 DocType: Data Import,In Progress,In corso
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,In coda per il backup. Si può richiedere alcuni minuti a un&#39;ora.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,In coda per il backup. Si può richiedere alcuni minuti a un'ora.
 DocType: Error Snapshot,Pyver,Pyver
-apps/frappe/frappe/core/doctype/user_permission/user_permission.py,User permission already exists,Il permesso dell&#39;utente esiste già
+apps/frappe/frappe/core/doctype/user_permission/user_permission.py,User permission already exists,Il permesso dell'utente esiste già
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Mapping column {0} to field {1},Mappatura della colonna {0} al campo {1}
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,View {0},Visualizza {0}
 DocType: User,Hourly,ogni ora
@@ -2308,7 +2308,7 @@ apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Confirmed,Confermato
 DocType: Event,Ends on,Termina il
 DocType: Payment Gateway,Gateway,Ingresso
 DocType: LDAP Settings,Path to Server Certificate,Percorso al certificato del server
-apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Non è sufficiente l&#39;autorizzazione per visualizzare i collegamenti
+apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Non è sufficiente l'autorizzazione per visualizzare i collegamenti
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Il titolo dell'indirizzo è obbligatorio.
 DocType: Google Contacts,Push to Google Contacts,Invia a Contatti Google
 DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML Aggiunto nella sezione <head> della pagina web, utilizzato principalmente per la verifica sito web e SEO"
@@ -2339,7 +2339,7 @@ apps/frappe/frappe/geo/doctype/currency/currency.js,This Currency is disabled. E
 DocType: Desktop Icon,Blocked,Bloccato
 DocType: Contact Us Settings,"Default: ""Contact Us""","Predefinito: ""Contattaci"""
 DocType: Contact,Purchase Manager,Responsabile Acquisti
-DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Se abilitato, ciò consentirà agli ospiti di caricare file nella propria applicazione. È possibile abilitarlo se si desidera raccogliere file dall&#39;utente senza doverli accedere, ad esempio nel modulo Web delle applicazioni di lavoro."
+DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Se abilitato, ciò consentirà agli ospiti di caricare file nella propria applicazione. È possibile abilitarlo se si desidera raccogliere file dall'utente senza doverli accedere, ad esempio nel modulo Web delle applicazioni di lavoro."
 apps/frappe/frappe/public/js/frappe/ui/tags.js,toggle Tag,cambia tag
 DocType: Custom Script,Sample,Esempio
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,"For performance, only the first 100 rows were processed.","Per le prestazioni, sono state elaborate solo le prime 100 righe."
@@ -2417,7 +2417,7 @@ DocType: Property Setter,Property Type,Tipo di proprietà
 DocType: Workflow State,screenshot,screenshot
 apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,Solo l'amministratore può salvare un report standard. Si prega di rinominarlo e dopo salvare.
 DocType: System Settings,Background Workers,Servizi in background
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Nome di campo {0} in conflitto con l&#39;oggetto meta
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Nome di campo {0} in conflitto con l'oggetto meta
 DocType: Deleted Document,Data,Dati
 apps/frappe/frappe/public/js/frappe/model/model.js,Document Status,Stato Documento
 apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,Approval Required,Approvazione richiesta
@@ -2493,11 +2493,11 @@ apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Doctype required,Doc
 DocType: Workflow State,ok-sign,ok-sign
 apps/frappe/frappe/config/settings.py,Deleted Documents,Documenti eliminati
 apps/frappe/frappe/public/js/frappe/form/grid.js,The CSV format is case sensitive,Il formato CSV è sensibile al maiuscolo / minuscolo
-apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,L&#39;icona di Desktop esiste già
+apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,L'icona di Desktop esiste già
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Duplicate,Duplica
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} cannot be hidden and mandatory without default,{0}: il campo {1} nella riga {2} non può essere nascosto e obbligatorio senza impostazione predefinita
 DocType: Newsletter,Create and Send Newsletters,Creare e inviare newsletter
-apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,Grazie per il tuo commento. sarà pubblicato dopo l&#39;approvazione
+apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,Grazie per il tuo commento. sarà pubblicato dopo l'approvazione
 DocType: Address,Andaman and Nicobar Islands,Isole Andamane e Nicobar
 DocType: Google Contacts,Pull from Google Contacts,Estrai dai Contatti di Google
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,Si prega di specificare quale campo valore deve essere controllato
@@ -2522,7 +2522,7 @@ DocType: Comment,Assignment Completed,Assegnazione Completato
 apps/frappe/frappe/public/js/frappe/form/grid.js,Bulk Edit {0},Modifica massiva {0}
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Download Report,Scarica rapporto
 apps/frappe/frappe/workflow/doctype/workflow/workflow_list.js,Not active,Non attivo
-apps/frappe/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py,Only Administrator is allowed to create Dashboard Chart Sources,Solo l&#39;amministratore è autorizzato a creare origini grafico dashboard
+apps/frappe/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py,Only Administrator is allowed to create Dashboard Chart Sources,Solo l'amministratore è autorizzato a creare origini grafico dashboard
 DocType: About Us Settings,Settings for the About Us Page,Impostazioni per la pagina Chi Siamo
 apps/frappe/frappe/config/integrations.py,Stripe payment gateway settings,Impostazioni del gateway di pagamento della striscia
 apps/frappe/frappe/public/js/frappe/form/print.js,Print Sent to the printer!,Stampa inviata alla stampante!
@@ -2572,7 +2572,7 @@ apps/frappe/frappe/config/website.py,"Setup of top navigation bar, footer and lo
 DocType: Web Form Field,Max Value,Max Valore
 apps/frappe/frappe/core/doctype/doctype/doctype.py,For {0} at level {1} in {2} in row {3},Per {0} a livello {1} {2} in riga {3}
 DocType: Auto Repeat,Preview Message,Anteprima del messaggio
-DocType: User Social Login,User Social Login,Accesso sociale dell&#39;utente
+DocType: User Social Login,User Social Login,Accesso sociale dell'utente
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} criticized your work on {1} with {2} point,{0} ha criticato il tuo lavoro su {1} con {2} punti
 DocType: Contact,All,Tutto
 DocType: Email Queue,Recipient,Destinatario
@@ -2586,7 +2586,7 @@ apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Are you 
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Set,set
 apps/frappe/frappe/desk/search.py,This query style is discontinued,Questo stile di query è interrotto
 DocType: Notification,Trigger Method,Metodo di attivazione
-apps/frappe/frappe/utils/data.py,Operator must be one of {0},L&#39;operatore deve essere uno dei {0}
+apps/frappe/frappe/utils/data.py,Operator must be one of {0},L'operatore deve essere uno dei {0}
 DocType: Dropbox Settings,Dropbox Access Token,Token di accesso Dropbox
 DocType: Workflow State,align-right,Allinea a destra
 DocType: Auto Email Report,Email To,Invia una email a
@@ -2626,7 +2626,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Assign To,Assegna a
 DocType: Workflow State,th-list,th-list
 DocType: Web Page,Enable Comments,Attiva Commenti
 apps/frappe/frappe/desk/doctype/note/note_list.js,Notes,Note
-DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Limitare l&#39;utente da solo questo indirizzo IP. Più indirizzi IP possono essere aggiunti separando con virgole. Accetta anche gli indirizzi IP parziali, come (111.111.111)"
+DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Limitare l'utente da solo questo indirizzo IP. Più indirizzi IP possono essere aggiunti separando con virgole. Accetta anche gli indirizzi IP parziali, come (111.111.111)"
 DocType: Data Import Beta,Import Preview,Anteprima di importazione
 DocType: Communication,From,Da
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.,Selezionare un nodo primo gruppo.
@@ -2644,7 +2644,7 @@ DocType: Comment,Comment Type,Commento Type
 DocType: OAuth Client,OAuth Client,OAuth client
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,{0} criticized your work on {1} {2},{0} ha criticato il tuo lavoro su {1} {2}
 DocType: Assignment Rule,Users,Utenti
-DocType: Address,Odisha,dell&#39;Odisha
+DocType: Address,Odisha,dell'Odisha
 DocType: Report,Report Type,Tipo Report
 DocType: DocField,Signature,Firma
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Share With,Condividi con
@@ -2654,24 +2654,24 @@ apps/frappe/frappe/config/integrations.py,"Enter keys to enable login via Facebo
 DocType: Event,Sent/Received Email,Email inviata / ricevuta
 DocType: Data Import,Insert new records,Inserisci nuovi record
 apps/frappe/frappe/core/doctype/file/file.py,Unable to read file format for {0},Impossibile leggere il formato di file per {0}
-apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Solo l&#39;amministratore è autorizzato a utilizzare il registratore
+apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Solo l'amministratore è autorizzato a utilizzare il registratore
 DocType: Auto Email Report,Filter Data,Filtro Dati
 apps/frappe/frappe/public/js/frappe/form/controls/select.js,Please attach a file first.,Si prega di allegare un file.
 apps/frappe/frappe/templates/emails/download_data.html,Dear {0},Gentile {0}
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 week,1 settimana
 apps/frappe/frappe/model/naming.py,"There were some errors setting the name, please contact the administrator","Ci sono stati alcuni errori durante l'impostazione del nome, si prega di contattare l'amministratore"
-apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email account not correct,L&#39;account di posta in arrivo non è corretto
+apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email account not correct,L'account di posta in arrivo non è corretto
 apps/frappe/frappe/templates/includes/contact.js,"You seem to have written your name instead of your email. \
 				Please enter a valid email address so that we can get back.",Sembra che hai scritto il tuo nome anziché la tua email. \ Inserisci un indirizzo email valido in modo che possiamo tornare indietro.
 DocType: Website Slideshow Item,Website Slideshow Item,Sito Slideshow articolo
-apps/frappe/frappe/model/workflow.py,Self approval is not allowed,L&#39;autoapprovazione non è consentita
+apps/frappe/frappe/model/workflow.py,Self approval is not allowed,L'autoapprovazione non è consentita
 DocType: GSuite Templates,Template ID,ID del modello
 apps/frappe/frappe/integrations/doctype/oauth_client/oauth_client.py,Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed,La combinazione del tipo di sovvenzione ( <code>{0}</code> ) e del tipo di risposta ( <code>{1}</code> ) non è consentita
 apps/frappe/frappe/desk/form/assign_to.py,New Message from {0},Nuovo messaggio da {0}
 DocType: Portal Settings,Default Role at Time of Signup,Ruolo predefinito al momento della iscrizione
 DocType: DocType,Title Case,Titolo Caso
 apps/frappe/frappe/templates/emails/download_data.html,Click on the link below to download your data,Fai clic sul link in basso per scaricare i tuoi dati
-apps/frappe/frappe/core/doctype/user/user.py,Enabled email inbox for user {0},Posta in arrivo abilitata per l&#39;utente {0}
+apps/frappe/frappe/core/doctype/user/user.py,Enabled email inbox for user {0},Posta in arrivo abilitata per l'utente {0}
 DocType: Data Migration Run,Data Migration Run,Esegui la migrazione dei dati
 DocType: Blog Post,Email Sent,E-mail Inviata
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Older,Più vecchio
@@ -2695,7 +2695,7 @@ DocType: Auto Repeat,Template,Modelli
 DocType: Address,Delhi,Delhi
 apps/frappe/frappe/desk/doctype/calendar_view/calendar_view.js,Show Calendar,Mostra calendario
 apps/frappe/frappe/config/integrations.py,LDAP Settings,Impostazioni LDAP
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Name,Nome dell&#39;entità
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Name,Nome dell'entità
 apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Rettificativo
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,impostazioni di gateway di pagamento PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Il più performante
@@ -2736,7 +2736,7 @@ DocType: Email Account,no failed attempts,tentativi non riusciti
 DocType: GSuite Settings,refresh_token,refresh_token
 DocType: Dropbox Settings,App Access Key,App Access Key
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat failed for {0},Ripetizione automatica non riuscita per {0}
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Abilita l&#39;API di Google nelle Impostazioni di Google.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Abilita l'API di Google nelle Impostazioni di Google.
 DocType: Session Default,Session Default,Sessione predefinita
 DocType: Chat Room,Last Message,Ultimo messaggio
 DocType: OAuth Bearer Token,Access Token,Token di accesso
@@ -2749,15 +2749,15 @@ DocType: DocField,In Standard Filter,In Filtro standard
 DocType: Web Form,Allow Edit,Consenti Modifica
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Paste,Incolla
 DocType: Webhook,Doc Events,Doc Eventi
-DocType: Auto Email Report,Based on Permissions For User,Sulla base di autorizzazioni per l&#39;utente
+DocType: Auto Email Report,Based on Permissions For User,Sulla base di autorizzazioni per l'utente
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Cannot change state of Cancelled Document. Transition row {0},Impossibile modificare lo stato di un Documento Annullato. Riga transizione {0}
 DocType: Workflow,"Rules for how states are transitions, like next state and which role is allowed to change state etc.","Regole per come gli stati sono transizioni, come prossimo stato e quale ruolo può cambiare stato ecc"
 apps/frappe/frappe/desk/form/save.py,{0} {1} already exists,{0} {1} esiste già
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be one of {0},Aggiungere a può essere uno dei {0}
 DocType: Customize Form,Image View,Visualizza immagine
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Sembra che qualcosa è andato storto durante la transazione. Dal momento che non abbiamo confermato il pagamento, Paypal automaticamente vi rimborserà tale importo. In caso contrario, vi preghiamo di inviarci una e-mail e parlare l&#39;ID di correlazione: {0}."
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Sembra che qualcosa è andato storto durante la transazione. Dal momento che non abbiamo confermato il pagamento, Paypal automaticamente vi rimborserà tale importo. In caso contrario, vi preghiamo di inviarci una e-mail e parlare l'ID di correlazione: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Includi simboli, numeri e lettere maiuscole nella password"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Inserisci dopo campo &#39;{0}&#39; di cui al campo personalizzato &#39;{1}&#39;, con etichetta &#39;{2}&#39;, non esiste"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Inserisci dopo campo '{0}' di cui al campo personalizzato '{1}', con etichetta '{2}', non esiste"
 DocType: List Filter,List Filter,Filtro elenco
 DocType: Workflow State,signal,segnalare
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ha allegati
@@ -2767,9 +2767,9 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Documento ripristinato
 DocType: Data Export,Data Export,Esportazione dati
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Seleziona la lingua...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Non puoi impostare &#39;Opzioni&#39; per il campo {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Non puoi impostare 'Opzioni' per il campo {0}
 DocType: Help Article,Author,Autore
-apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,riprendere l&#39;invio
+apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,riprendere l'invio
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Riaprire
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Show Warnings,Mostra avvisi
 apps/frappe/frappe/core/doctype/communication/communication.js,Re: {0},Re: {0}
@@ -2781,24 +2781,24 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Indirizzo modello predefinito non può essere eliminato
 DocType: Contact,Maintenance Manager,Responsabile della manutenzione
 DocType: Workflow State,Search,Cerca
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Seleziona un altro metodo di pagamento. Stripe non supporta transazioni in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Seleziona un altro metodo di pagamento. Stripe non supporta transazioni in valuta '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Sposta nel cestino
 DocType: Web Form,Web Form Fields,Campi modulo web
 DocType: Data Import,Amended From,Corretto da
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Avviso: impossibile trovare {0} in qualsiasi tabella relativa a {1}
 DocType: S3 Backup Settings,eu-north-1,eu-nord-1
-apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Questo documento è attualmente in coda per l&#39;esecuzione. Riprova
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File &#39;{0}&#39; non trovato
+apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Questo documento è attualmente in coda per l'esecuzione. Riprova
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File '{0}' non trovato
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Rimuovere Sezione
 DocType: User,Change Password,Cambiare la password
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Campo dell&#39;asse X.
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Campo dell'asse X.
 apps/frappe/frappe/public/js/frappe/form/controls/data.js,Invalid Email: {0},Email non valida: {0}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Hello!,Ciao!
 apps/frappe/frappe/config/integrations.py,Braintree payment gateway settings,Impostazioni del gateway di pagamento Braintree
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Rebuild,Ricostruire
-apps/frappe/frappe/www/third_party_apps.html,This will log out {0} from all other devices,Questo verrà eseguito l&#39;accesso da {0} da tutti gli altri dispositivi
+apps/frappe/frappe/www/third_party_apps.html,This will log out {0} from all other devices,Questo verrà eseguito l'accesso da {0} da tutti gli altri dispositivi
 apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Non hai il permesso di ottenere una relazione su: {0}
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Calendar: impossibile inserire l&#39;evento in Google Calendar {0}, codice errore {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Calendar: impossibile inserire l'evento in Google Calendar {0}, codice errore {1}."
 DocType: System Settings,Apply Strict User Permissions,Applicare autorizzazioni utente rigorose
 DocType: S3 Backup Settings,us-west-1,noi-ovest-1
 DocType: DocField,Allow Bulk Edit,Consenti la modifica bulk
@@ -2814,7 +2814,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.js,"Level 0 i
 DocType: Contact Email,Is Primary,È primario
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,From Document Type,Dal tipo di documento
 DocType: DocType,Tree structures are implemented using Nested Set,Le strutture ad albero sono implementate usando Nested Set
-apps/frappe/frappe/core/doctype/data_import/data_import.py,Can't save the form as data import is in progress.,Impossibile salvare il modulo mentre è in corso l&#39;importazione dei dati.
+apps/frappe/frappe/core/doctype/data_import/data_import.py,Can't save the form as data import is in progress.,Impossibile salvare il modulo mentre è in corso l'importazione dei dati.
 DocType: Workflow,States,Stati
 DocType: Notification,Attach Print,Allega Stampa
 DocType: Assignment Rule,Assignment Rule,Regola di assegnazione
@@ -2833,7 +2833,7 @@ DocType: Stripe Settings,Publishable Key,Chiave pubblicabile
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Start Import,Inizia importazione
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Type,Tipo di esportazione
 DocType: Workflow State,circle-arrow-left,cerchio-freccia-sinistra
-DocType: System Settings,Force User to Reset Password,Forza l&#39;utente a reimpostare la password
+DocType: System Settings,Force User to Reset Password,Forza l'utente a reimpostare la password
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"To get the updated report, click on {0}.","Per avere un report aggiornato, clicca {0}."
 apps/frappe/frappe/sessions.py,Redis cache server not running. Please contact Administrator / Tech support,Il server di cache Redis non è in esecuzione. Si prega di contattare l'Amministratore o l'Assistenza Tecnica.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_header.html,Searching,Ricerca
@@ -2858,7 +2858,7 @@ DocType: Email Account,Initial Sync Count,Conte sincronizzazione iniziale
 DocType: Workflow State,glass,vetro
 DocType: DocType,Timeline Field,Timeline campo
 DocType: Country,Time Zones,Fusi Orari
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list up,Naviga l&#39;elenco in alto
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list up,Naviga l'elenco in alto
 apps/frappe/frappe/core/page/permission_manager/permission_manager.py,There must be atleast one permission rule.,Ci deve essere atleast regola un permesso.
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Get Items,Ottieni Articoli
 DocType: Contact,Image,Immagine
@@ -2892,14 +2892,14 @@ DocType: Custom Script,Custom Script,Script Personalizzato
 DocType: Address,Address Line 2,Indirizzo 2
 DocType: Address,Reference,Riferimento
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Assegnato a
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Configura l&#39;account e-mail predefinito da Imposta> E-mail> Account e-mail
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Configura l'account e-mail predefinito da Imposta> E-mail> Account e-mail
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Dati di mapping di migrazione dei dati
 DocType: Data Import,Action,Azione
 DocType: GSuite Settings,Script URL,URL dello script
 apps/frappe/frappe/www/update-password.html,Please enter the password,Si prega di inserire la password
 apps/frappe/frappe/www/printview.py,Not allowed to print cancelled documents,Non è consentito di stampare documenti annullati
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,Non sei autorizzato a creare colonne
-DocType: Data Import,If you don't want to create any new records while updating the older records.,Se non si desidera creare nuovi record durante l&#39;aggiornamento dei record precedenti.
+DocType: Data Import,If you don't want to create any new records while updating the older records.,Se non si desidera creare nuovi record durante l'aggiornamento dei record precedenti.
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Info:,Info:
 DocType: Custom Field,Permission Level,Livello di autorizzazione
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Cannot set Submit, Cancel, Amend without Write","{0}: Impossibile impostare Invia, Annulla, Modifica senza Scrivere"
@@ -2911,7 +2911,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Saving,Salvataggio
 DocType: Print Settings,Print Style Preview,Stile di stampa Anteprima
 apps/frappe/frappe/core/doctype/file/test_file.py,Test_Folder,Test_Folder
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You are not allowed to update this Web Form Document,Non hai i permessi per aggiornare questo modulo web
-apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Impostare l&#39;URL di base nella chiave di accesso social per Frappe
+apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Impostare l'URL di base nella chiave di accesso social per Frappe
 DocType: About Us Settings,About Us Settings,Chi siamo Impostazioni
 DocType: Website Settings,Website Theme,Sito tematico
 DocType: User,Api Access,Accesso Api
@@ -2923,7 +2923,7 @@ apps/frappe/frappe/config/customization.py,Add custom javascript to forms.,Aggiu
 ,Role Permissions Manager,Gestione Permessi
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Name of the new Print Format,Nome del nuovo formato di stampa
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Toggle Sidebar,Attiva barra laterale
-DocType: Data Migration Run,Pull Insert,Tirare l&#39;inserimento
+DocType: Data Migration Run,Pull Insert,Tirare l'inserimento
 DocType: Energy Point Rule,"Maximum points allowed after multiplying points with the multiplier value
 (Note: For no limit leave this field empty or set 0)","Punti massimi consentiti dopo aver moltiplicato i punti con il valore del moltiplicatore (Nota: per nessun limite, lasciare questo campo vuoto o impostare 0)"
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Invalid Template,Modello non valido
@@ -2967,15 +2967,15 @@ DocType: Custom Role,Permission Rules,Regole di autorizzazione
 DocType: Braintree Settings,Public Key,Chiave pubblica
 DocType: GSuite Settings,GSuite Settings,Impostazioni di GSuite
 DocType: Address,Links,Collegamenti
-DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Utilizza il nome dell&#39;indirizzo e-mail indicato in questo account come nome del mittente per tutte le e-mail inviate utilizzando questo account.
+DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Utilizza il nome dell'indirizzo e-mail indicato in questo account come nome del mittente per tutte le e-mail inviate utilizzando questo account.
 DocType: Energy Point Rule,Field To Check,Campo da controllare
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Contatti Google: impossibile aggiornare il contatto in Contatti Google {0}, codice errore {1}."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,Si prega di selezionare il tipo di documento.
 apps/frappe/frappe/model/base_document.py,Value missing for,Valore mancante per
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Aggiungi una sottovoce
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Progressi nell&#39;importazione
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Progressi nell'importazione
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Se la condizione è soddisfatta, l&#39;utente verrà premiato con i punti. per esempio. doc.status == &#39;Chiuso&#39;"
+","Se la condizione è soddisfatta, l'utente verrà premiato con i punti. per esempio. doc.status == 'Chiuso'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Record confermato non può essere eliminato.
 DocType: GSuite Templates,Template Name,Nome modello
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nuovo tipo di documento
@@ -3006,7 +3006,7 @@ DocType: Activity Log,Full Name,Nome Completo
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,Nome filtro duplicato
 DocType: Chat Room User,Chat Room User,Utente della chat room
 apps/frappe/frappe/model/workflow.py,Workflow State not set,Stato del flusso di lavoro non impostato
-DocType: Google Calendar,Authorize Google Calendar Access,Autorizza l&#39;accesso a Google Calendar
+DocType: Google Calendar,Authorize Google Calendar Access,Autorizza l'accesso a Google Calendar
 apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,La pagina che stai cercando non è presente. Questo potrebbe essere dovuto al fatto che viene spostato o vi è un errore di battitura nel collegamento.
 apps/frappe/frappe/www/404.html,Error Code: {0},Codice di errore: {0}
 DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Descrizione per la pagina di profilo, in testo normale, solo un paio di righe. (max 140 caratteri)"
@@ -3076,7 +3076,7 @@ DocType: Webhook,Headers,Intestazioni
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Prossimi eventi
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Please enter values for App Access Key and App Secret Key,Si prega di inserire i valori per App Access Key e App chiave segreta
 DocType: Web Form,Accept Payment,Accetta pagamento
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Select list item,Seleziona la voce dell&#39;elenco
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Select list item,Seleziona la voce dell'elenco
 apps/frappe/frappe/config/core.py,A log of request errors,Registro errori Request
 DocType: Report,Letter Head,Carta intestata
 DocType: DocType,Quick Entry,Inserimento rapido
@@ -3108,7 +3108,7 @@ DocType: Dashboard Chart,Chart Type,Tipo di grafico
 DocType: DocType,Auto Name,Nome Automatico
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Evitare sequenze come ABC o 6543 in quanto sono facili da indovinare
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Riprova
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',L&#39;URL deve iniziare con &#39;http: //&#39; o &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',L'URL deve iniziare con 'http: //' o 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Opzione 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Modifica
@@ -3121,7 +3121,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Renamed files and replaced c
 apps/frappe/frappe/utils/oauth.py,Please ensure that your profile has an email address,Assicurati che il tuo profilo ha un indirizzo di posta elettronica
 apps/frappe/frappe/public/js/frappe/model/create_new.js,You have unsaved changes in this form. Please save before you continue.,Hai delle modifiche non salvate in questo modulo. Prego salvare prima di procedere.
 DocType: Address,Telangana,Telangana
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for {0} must be an option,Predefinito per {0} deve essere un&#39;opzione
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for {0} must be an option,Predefinito per {0} deve essere un'opzione
 DocType: Tag Doc Category,Tag Doc Category,Tag Doc Categoria
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Report with more than 10 columns looks better in Landscape mode.,Il rapporto con più di 10 colonne ha un aspetto migliore in modalità orizzontale.
 apps/frappe/frappe/database/database.py,Invalid field name: {0},Nome campo non valido: {0}
@@ -3140,12 +3140,12 @@ DocType: Chat Profile,Notifications,notifiche
 DocType: DocField,Column Break,Interruzione Colonna
 DocType: Assignment Rule Day,Thursday,Giovedì
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough review points,Non hai abbastanza punti di recensione
-apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Non si dispone dell&#39;autorizzazione per accedere a questo file
-apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Salva segreto dell&#39;API:
+apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Non si dispone dell'autorizzazione per accedere a questo file
+apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Salva segreto dell'API:
 apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},Impossibile collegare documento annullato: {0}
 apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,Non è possibile modificare un rapporto standard. Si prega di duplicare e creare un nuovo report
 apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Società è obbligatoria, in quanto è la vostra ditta"
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,"For example: If you want to include the document ID, use {0}","Ad esempio: se si desidera includere l&#39;ID del documento, utilizzare {0}"
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,"For example: If you want to include the document ID, use {0}","Ad esempio: se si desidera includere l'ID del documento, utilizzare {0}"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Table Columns for {0},Seleziona colonne Tabella per {0}
 DocType: Custom Field,Options Help,Opzioni Aiuto
 DocType: Footer Item,Group Label,Label Group
@@ -3162,16 +3162,16 @@ apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,Le 
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Contatti Google: impossibile sincronizzare i contatti dai Contatti Google {0}, codice errore {1}."
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Next actions,Prossime azioni
 apps/frappe/frappe/email/doctype/notification/notification.py,"Cannot edit Standard Notification. To edit, please disable this and duplicate it","Impossibile modificare la notifica standard. Per modificare, si prega di disabilitare questo e duplicarlo"
-apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,Email del codice di verifica non inviata. Si prega di contattare l&#39;amministratore.
+apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,Email del codice di verifica non inviata. Si prega di contattare l'amministratore.
 DocType: Workflow State,ok,ok
-DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Questi valori saranno aggiornati automaticamente nelle transazioni e anche sarà utile per limitare le autorizzazioni per l&#39;utente sulle operazioni che contengono questi valori.
+DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Questi valori saranno aggiornati automaticamente nelle transazioni e anche sarà utile per limitare le autorizzazioni per l'utente sulle operazioni che contengono questi valori.
 apps/frappe/frappe/twofactor.py,Verfication Code,Codice di verifica
 DocType: Webhook,Webhook Request,Richiesta di Webhook
 apps/frappe/frappe/model/rename_doc.py,** Failed: {0} to {1}: {2},** Non riuscita: {0} a {1}: {2}
 DocType: Data Migration Mapping,Mapping Type,Tipo di mapping
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Select Mandatory,selezionare obbligatoria
 apps/frappe/frappe/public/js/frappe/ui/upload.html,Browse,Sfoglia
-apps/frappe/frappe/utils/password_strength.py,"No need for symbols, digits, or uppercase letters.","Non c&#39;è bisogno di simboli, cifre o lettere maiuscole."
+apps/frappe/frappe/utils/password_strength.py,"No need for symbols, digits, or uppercase letters.","Non c'è bisogno di simboli, cifre o lettere maiuscole."
 DocType: DocField,Currency,Valuta
 DocType: Async Task,Running,Di corsa
 DocType: DocType,Track Views,Traccia le viste
@@ -3201,7 +3201,7 @@ DocType: Letter Head,Letter Head Based On,Testa di lettera basata su
 apps/frappe/frappe/utils/oauth.py,Token is missing,Token mancante
 apps/frappe/frappe/www/update-password.html,Set Password,Imposta password
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records.,{0} record importati correttamente.
-apps/frappe/frappe/public/js/frappe/utils/utils.js,Note: Changing the Page Name will break previous URL to this page.,Nota: la modifica del nome della pagina interrompe l&#39;URL precedente a questa pagina.
+apps/frappe/frappe/public/js/frappe/utils/utils.js,Note: Changing the Page Name will break previous URL to this page.,Nota: la modifica del nome della pagina interrompe l'URL precedente a questa pagina.
 apps/frappe/frappe/utils/file_manager.py,Removed {0},Rimosso {0}
 DocType: SMS Settings,SMS Settings,Impostazioni SMS
 DocType: Company History,Highlight,Evidenziare
@@ -3227,7 +3227,7 @@ apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Submitted Document cann
 DocType: Assignment Rule,Assignment Days,Giorni di assegnazione
 apps/frappe/frappe/desk/reportview.py,Deleting {0},Eliminazione {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Select an existing format to edit or start a new format.,Selezionare un formato esistente per modificare o avviare un nuovo formato.
-DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,Ignora controllo indirizzo IP limitato se è abilitato l&#39;autenticazione a due fattori
+DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,Ignora controllo indirizzo IP limitato se è abilitato l'autenticazione a due fattori
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Created Custom Field {0} in {1},Creato Campo personalizzato {0} in {1}
 DocType: System Settings,Time Zone,Fuso Orario
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Special Characters are not allowed,I caratteri speciali non sono ammessi
@@ -3237,17 +3237,17 @@ DocType: Email Account,uidnext,uidnext
 DocType: User,Redirect URL,URL di reindirizzamento
 DocType: SMS Settings,Enter url parameter for receiver nos,Inserisci parametri url per NOS ricevuti
 DocType: Chat Profile,Online,Online
-DocType: Email Account,Always use Account's Name as Sender's Name,Usa sempre il nome dell&#39;account come nome del mittente
+DocType: Email Account,Always use Account's Name as Sender's Name,Usa sempre il nome dell'account come nome del mittente
 apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,Solo l'amministratore può cancellare la coda email
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Setting this Address Template as default as there is no other default,L'impostazione di questo modello di indirizzo di default perché non c'è altro difetto
 DocType: Workflow State,Home,Home
 DocType: OAuth Provider Settings,Auto,Auto
-DocType: System Settings,User can login using Email id or User Name,L&#39;utente può accedere utilizzando l&#39;ID e-mail o il nome utente
+DocType: System Settings,User can login using Email id or User Name,L'utente può accedere utilizzando l'ID e-mail o il nome utente
 DocType: Workflow State,question-sign,domanda-sign
 apps/frappe/frappe/model/base_document.py,{0} is disabled,{0} è disabilitato
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",Il campo &quot;percorso&quot; è obbligatorio per le viste Web
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Insert Column Before {0},Inserisci colonna prima di {0}
-DocType: Energy Point Rule,The user from this field will be rewarded points,All&#39;utente di questo campo verranno assegnati punti
+DocType: Energy Point Rule,The user from this field will be rewarded points,All'utente di questo campo verranno assegnati punti
 DocType: Assignment Rule,Close Condition,Chiudi condizioni
 DocType: Dropbox Settings,Number of DB Backups,Numero di backup del database
 DocType: Email Account,Add Signature,Aggiungi Firma
@@ -3261,7 +3261,7 @@ DocType: ToDo,ToDo,Da Fare
 DocType: DocField,No Copy,Copia Assente
 DocType: Workflow State,qrcode,QRCode
 DocType: Chat Token,IP Address,Indirizzo IP
-DocType: Data Import,Submit after importing,Invia dopo l&#39;importazione
+DocType: Data Import,Submit after importing,Invia dopo l'importazione
 apps/frappe/frappe/www/login.html,Login with LDAP,Accesso con LDAP
 DocType: Web Form,Breadcrumbs,Breadcrumbs
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Rank: ,Rango:
@@ -3288,7 +3288,7 @@ apps/frappe/frappe/config/website.py,Knowledge Base,base di conoscenza
 DocType: Workflow State,briefcase,ventiquattrore
 apps/frappe/frappe/model/document.py,Value cannot be changed for {0},Il valore non può essere cambiato per {0}
 DocType: Workflow State,"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange","Style rappresenta il colore del pulsante: Successo - Verde, Pericolo - Rosso, Inverse - Nero, primario - Dark Blue, Info - Light Blue, Warning - Arancione"
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Questa richiesta non è stata ancora approvata dall&#39;utente.
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Questa richiesta non è stata ancora approvata dall'utente.
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Please Install the ldap3 library via pip to use ldap functionality.,Installa la libreria ldap3 tramite pip per utilizzare la funzionalità ldap.
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,Stato fila
 DocType: S3 Backup Settings,sa-east-1,SA-est-1
@@ -3302,7 +3302,7 @@ DocType: Workflow State,resize-horizontal,resize-orizzontale
 apps/frappe/frappe/templates/emails/download_data.html,Download Link,Link per scaricare
 DocType: Chat Message,Content,Contenuto
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} reverted your point on {1},{0} ha ripristinato il tuo punto su {1}
-DocType: Data Migration Run,Push Insert,Spingere l&#39;inserimento
+DocType: Data Migration Run,Push Insert,Spingere l'inserimento
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Group Node,Nodo Group
 DocType: Auto Repeat,Notification,Notifica
 DocType: Contact Phone,Contact Phone,Contatto telefonico
@@ -3321,7 +3321,7 @@ DocType: Auto Repeat,Print Format,Formato Stampa
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Toggle Grid View,Attiva / disattiva visualizzazione griglia
 apps/frappe/frappe/public/js/frappe/form/form.js,Go to next record,Vai al record successivo
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Invalid payment gateway credentials,credenziali di gateway di pagamento non valide
-DocType: Data Import,This is the template file generated with only the rows having some error. You should use this file for correction and import.,Questo è il file modello generato con solo le righe con qualche errore. Dovresti usare questo file per la correzione e l&#39;importazione.
+DocType: Data Import,This is the template file generated with only the rows having some error. You should use this file for correction and import.,Questo è il file modello generato con solo le righe con qualche errore. Dovresti usare questo file per la correzione e l'importazione.
 apps/frappe/frappe/config/users_and_permissions.py,Set Permissions on Document Types and Roles,Impostare le autorizzazioni per tipi di documento e ruoli
 DocType: Data Migration Run,Remote ID,ID remoto
 apps/frappe/frappe/model/meta.py,No Label,Senza etichetta
@@ -3332,7 +3332,7 @@ apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specifi
 DocType: Energy Point Log,Criticism,Critica
 DocType: Address,Tripura,Tripura
 DocType: About Us Settings,"""Company History""",&quot;La storia della società&quot;
-apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Questo documento è stato modificato dopo l&#39;invio dell&#39;e-mail.
+apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Questo documento è stato modificato dopo l'invio dell'e-mail.
 DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","Se selezionato, questo campo non verrà sovrascritto in base a Fetch From se esiste già un valore."
 DocType: Access Log,Show Report,Mostra rapporto
 DocType: Address,Tamil Nadu,Tamil Nadu
@@ -3346,8 +3346,8 @@ apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translate {0},T
 DocType: Notification,Send alert if this field's value changes,Invia avviso se cambia il valore di questo campo
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Colori a tema
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Selezionare un DOCTYPE per fare un nuovo formato
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,l&#39;utente non esiste
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Destinatari&#39; non specificati
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,l'utente non esiste
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Destinatari' non specificati
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,proprio adesso
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Applica
 DocType: Footer Item,Policy,Politica
@@ -3395,7 +3395,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Traduzioni person
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Progresso
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,per Ruolo
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,campi mancanti
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname non valido &#39;{0}&#39; in Autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname non valido '{0}' in Autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Cerca in un tipo di documento
 DocType: Custom DocPerm,Role and Level,Ruolo e livello
 DocType: File,Thumbnail URL,URL Thumbnail
@@ -3425,7 +3425,7 @@ apps/frappe/frappe/utils/nestedset.py,{0} {1} cannot be a leaf node as it has ch
 DocType: Comment,Info,Info
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Add Attachment,Aggiungi allegato
 DocType: Data Migration Mapping,Sync,Sync
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client Secret before social login is enabled,Inserisci Client Secret prima che l&#39;accesso social sia abilitato
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client Secret before social login is enabled,Inserisci Client Secret prima che l'accesso social sia abilitato
 DocType: Communication,Email,Email
 apps/frappe/frappe/templates/includes/contact.js,Thank you for your message,Grazie per il tuo messaggio
 apps/frappe/frappe/public/js/frappe/views/communication.js,Send Read Receipt,Invia conferma di lettura
@@ -3473,7 +3473,7 @@ DocType: Contact Phone,Is Primary Mobile,È il cellulare principale
 DocType: Workflow Document State,Workflow Document State,Stato Documento del Workflow
 apps/frappe/frappe/public/js/frappe/request.js,File too big,File troppo grande
 apps/frappe/frappe/core/doctype/user/user.py,Email Account added multiple times,E-mail account aggiunto più volte
-DocType: Energy Point Settings,Last Point Allocation Date,Data di assegnazione dell&#39;ultimo punto
+DocType: Energy Point Settings,Last Point Allocation Date,Data di assegnazione dell'ultimo punto
 DocType: Payment Gateway,Payment Gateway,Gateway di pagamento
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} appreciated your work on {1} with {2} point,{0} ha apprezzato il tuo lavoro su {1} con il punto {2}
 DocType: Milestone Tracker,Field to Track,Campo da tracciare
@@ -3493,9 +3493,9 @@ DocType: Auto Repeat,Start Date,Data di inizio
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Value,Valore
 DocType: Dashboard Chart,Filters JSON,Filtri JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Clicca qui per verificare
-DocType: Email Account,Disable SMTP server authentication,Disabilita l&#39;autenticazione del server SMTP
+DocType: Email Account,Disable SMTP server authentication,Disabilita l'autenticazione del server SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Copiato negli appunti.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,sostituzioni prevedibili come &#39;@&#39; invece di &#39;un&#39; non aiutano molto.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,sostituzioni prevedibili come '@' invece di 'un' non aiutano molto.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Assegnato da me
 apps/frappe/frappe/utils/data.py,Zero,Zero
 DocType: Google Drive,Backup Folder ID,ID cartella di backup
@@ -3517,13 +3517,13 @@ apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Saving...,Salvataggio...
 apps/frappe/frappe/www/update-password.html,Invalid Password,Password non valida
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record out of {1}.,{0} importato correttamente su {1}.
 DocType: Contact,Purchase Master Manager,Direttore Acquisti
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the lock icon to toggle public/private,Fai clic sull&#39;icona del lucchetto per attivare / disattivare pubblico / privato
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the lock icon to toggle public/private,Fai clic sull'icona del lucchetto per attivare / disattivare pubblico / privato
 DocType: Module Def,Module Name,Nome Modulo
 DocType: S3 Backup Settings,eu-west-3,eu-ovest-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},Caricamento {0} di {1}
 DocType: DocType,DocType is a Table / Form in the application.,DocType è una tabella / form nell'applicazione.
 DocType: Social Login Key,Authorize URL,Autorizza URL
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Calendar: impossibile recuperare l&#39;evento da Google Calendar, codice di errore {0}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Calendar: impossibile recuperare l'evento da Google Calendar, codice di errore {0}."
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failed,Ripetizione automatica della creazione del documento non riuscita
 DocType: Email Account,GMail,GMail
 DocType: Letter Head,Letter Head Image,Immagine testa di lettera
@@ -3545,10 +3545,10 @@ apps/frappe/frappe/config/integrations.py,Google Drive Backup.,Google Drive Back
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} assigned {1}: {2},{0} assegnato {1}: {2}
 apps/frappe/frappe/www/contact.py,New Message from Website Contact Page,Nuovo messaggio dal sito Pagina contatto
 DocType: Notification,Reference Date,Data di riferimento
-apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,La configurazione OTP tramite l&#39;app OTP non è stata completata. Si prega di contattare l&#39;amministratore.
+apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,La configurazione OTP tramite l'app OTP non è stata completata. Si prega di contattare l'amministratore.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Inserisci nos mobili validi
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Alcune delle funzionalità potrebbero non funzionare nel tuo browser. Aggiorna il tuo browser alla versione più recente.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Non so, chiedere &#39;aiuto&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Non so, chiedere 'aiuto'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ha annullato questo documento {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Commenti e comunicazioni saranno associati a questo documento collegato
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filtro ...
@@ -3568,19 +3568,19 @@ apps/frappe/frappe/config/settings.py,Add / Manage Email Accounts.,Aggiungere / 
 DocType: Comment,Published,Pubblicato
 apps/frappe/frappe/templates/emails/auto_reply.html,Thank you for your email,Grazie per la vostra e-mail
 DocType: DocField,Small Text,Testo piccolo
-DocType: Workflow,Allow approval for creator of the document,Consenti l&#39;approvazione per il creatore del documento
+DocType: Workflow,Allow approval for creator of the document,Consenti l'approvazione per il creatore del documento
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Save Report,Salva report
 DocType: Webhook,on_cancel,on_cancel
-DocType: Social Login Key,API Endpoint Args,Argomenti dell&#39;endpoint API
+DocType: Social Login Key,API Endpoint Args,Argomenti dell'endpoint API
 apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,Accesso amministratore {0} il {1} tramite indirizzo IP {2}.
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid fieldname,Il campo padre deve essere un nome campo valido
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Errore durante la modifica dell&#39;abbonamento
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Errore durante la modifica dell'abbonamento
 DocType: LDAP Settings,LDAP Group Field,Campo gruppo LDAP
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,uguale
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Opzioni 'Dynamic Link' il tipo di campo deve puntare ad un altro campo Link con opzioni come 'DocType'
 DocType: About Us Settings,Team Members Heading,Membri del team Rubrica
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Invalid Formato CSV
-apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Errore durante la connessione all&#39;applicazione vassoio QZ ... <br><br> È necessario disporre dell&#39;applicazione QZ Tray installata e in esecuzione, per utilizzare la funzione Raw Print. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Fare clic qui per scaricare e installare il vassoio QZ</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Fai clic qui per ulteriori informazioni sulla stampa raw</a> ."
+apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Errore durante la connessione all'applicazione vassoio QZ ... <br><br> È necessario disporre dell'applicazione QZ Tray installata e in esecuzione, per utilizzare la funzione Raw Print. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Fare clic qui per scaricare e installare il vassoio QZ</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Fai clic qui per ulteriori informazioni sulla stampa raw</a> ."
 apps/frappe/frappe/desk/page/backups/backups.js,Set Number of Backups,Imposta il numero di backup
 DocType: DocField,Do not allow user to change after set the first time,Non permettere all'utente di cambiare dopo impostare la prima volta
 apps/frappe/frappe/utils/data.py,1 year ago,1 anno fa
@@ -3594,11 +3594,11 @@ DocType: User,API Secret,API Secret
 DocType: Blog Post,Content Type,Tipo Contenuto
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,{0} Calendar,{0} Calendario
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Export Report: ,Rapporto Export:
-DocType: Data Migration Run,Push Update,Spingere l&#39;aggiornamento
+DocType: Data Migration Run,Push Update,Spingere l'aggiornamento
 DocType: Email Account,Port,Porta
 DocType: Print Format,Arial,Arial
 apps/frappe/frappe/auth.py,Incomplete login details,Dettagli di accesso incompleto
-apps/frappe/frappe/config/core.py,Models (building blocks) of the Application,Modelli (blocchi) dell&#39;Applicazione
+apps/frappe/frappe/config/core.py,Models (building blocks) of the Application,Modelli (blocchi) dell'Applicazione
 DocType: Website Slideshow,Slideshow like display for the website,Slideshow come visualizzazione per il sito web
 apps/frappe/frappe/config/settings.py,Setup Notifications based on various criteria.,Imposta notifiche in base a vari criteri.
 DocType: Comment,Updated,Aggiornato
@@ -3617,7 +3617,7 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.js,This docu
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive Backup Successful.,Backup di Google Drive riuscito.
 DocType: Workflow,DocType on which this Workflow is applicable.,DocType su cui questo flusso di lavoro è applicabile
 DocType: User,Enabled,Attivato
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,Impossibile completare l&#39;installazione
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,Impossibile completare l'installazione
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,New {0}: {1},Nuovo {0}: {1}
 DocType: Tag Category,Category Name,Nome Categoria
 apps/frappe/frappe/model/db_query.py,Parent is required to get child table data,È richiesto il genitore per ottenere i dati della tabella figlio
@@ -3635,7 +3635,7 @@ DocType: Workflow State,Download,Scarica
 DocType: Blog Post,Blog Intro,Introduzione Blog
 DocType: Async Task,Result,Risultato
 DocType: Webhook,on_update_after_submit,on_update_after_submit
-DocType: System Settings,Allow Login using User Name,Consenti l&#39;accesso utilizzando il nome utente
+DocType: System Settings,Allow Login using User Name,Consenti l'accesso utilizzando il nome utente
 apps/frappe/frappe/core/doctype/report/report.js,Enable Report,Abilita Report
 DocType: DocField,Display Depends On,Visualizzazione dipende
 DocType: Social Login Key,API Endpoint,Endpoint API
@@ -3707,7 +3707,7 @@ DocType: Web Page,Web Page,Pagina Web
 DocType: Workflow Document State,Next Action Email Template,Modello di email della prossima azione
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Se abilitato, le modifiche al documento vengono tracciate e visualizzate nella sequenza temporale"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;In ricerca globale&#39; non consentito per il tipo {0} nella riga {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'In ricerca globale' non consentito per il tipo {0} nella riga {1}
 DocType: Energy Point Log,Appreciation,Apprezzamento
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Visualizza elenco
 DocType: Workflow,Don't Override Status,Non override Stato
@@ -3732,15 +3732,15 @@ DocType: Property Setter,Set Value,Imposta valore
 DocType: Webhook,Webhook Data,Dati Webhook
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Creating {0},Creazione di {0}
 DocType: Report,Disable Prepared Report,Disabilita rapporto preparato
-apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,L&#39;utente {0} ha richiesto l&#39;eliminazione dei dati
+apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,L'utente {0} ha richiesto l'eliminazione dei dati
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,Illegal token di accesso. Riprova
-apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","L&#39;applicazione è stata aggiornata a una nuova versione, è necessario ricaricare la pagina"
+apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","L'applicazione è stata aggiornata a una nuova versione, è necessario ricaricare la pagina"
 DocType: Notification,Optional: The alert will be sent if this expression is true,Facoltativo: L'avviso sarà inviato se questa espressione è vera
 DocType: Data Migration Plan,Plan Name,Nome piano
 DocType: Print Settings,Print with letterhead,Stampa con carta intestata
 apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,Attach a web link,Allegare un collegamento Web
 DocType: Unhandled Email,Raw Email,Raw-mail
-apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select records for assignment,Seleziona le schede per l&#39;assegnazione
+apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select records for assignment,Seleziona le schede per l'assegnazione
 apps/frappe/frappe/www/printview.py,{0} is not a raw printing format.,{0} non è un formato di stampa non elaborato.
 DocType: ToDo,Assigned By,Assegnato da
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,You can use Customize Form to set levels on fields.,È possibile utilizzare Personalizza modulo per impostare i livelli sui campi .
@@ -3752,7 +3752,7 @@ DocType: Dropbox Settings,Limit Number of DB Backups,Limita il numero di backup 
 DocType: Custom DocPerm,Level,Livello
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Last 30 days,Ultimi 30 giorni
 DocType: Custom DocPerm,Report,Report
-apps/frappe/frappe/website/doctype/web_form/web_form.py,Amount must be greater than 0.,L&#39;importo deve essere maggiore di 0.
+apps/frappe/frappe/website/doctype/web_form/web_form.py,Amount must be greater than 0.,L'importo deve essere maggiore di 0.
 apps/frappe/frappe/public/js/frappe/form/print.js,Connected to QZ Tray!,Collegato al vassoio QZ!
 apps/frappe/frappe/desk/reportview.py,{0} is saved,{0} è salvato
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be renamed,Utente {0} non può essere rinominato
@@ -3772,7 +3772,7 @@ DocType: Contact Email,Contact Email,Email Contatto
 DocType: Kanban Board Column,Order,Ordine
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No results found for {0} in Global Search,Nessun risultato trovato per {0} nella Ricerca globale
 DocType: Report,Ref DocType,DocType Rif.
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client ID before social login is enabled,Inserisci l&#39;ID cliente prima che l&#39;accesso social sia abilitato
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client ID before social login is enabled,Inserisci l'ID cliente prima che l'accesso social sia abilitato
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Amend without Cancel,{0}: Impossibile impostare Modifica senza Annulla
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Full Page,Pagina completa
 DocType: DocType,Is Child Table,È Tabella Figlio
@@ -3803,14 +3803,14 @@ apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} rever
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Check Request URL,Controlla URL Richiesta
 apps/frappe/frappe/client.py,Only 200 inserts allowed in one request,Solo 200 inserimenti ammessi in una sola richiesta
 DocType: Footer Item,URL,URL
-apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,Ritorna alla schermata Verifica e inserisci il codice visualizzato dall&#39;applicazione di autenticazione
+apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,Ritorna alla schermata Verifica e inserisci il codice visualizzato dall'applicazione di autenticazione
 DocType: ToDo,Reference Type,Tipo di riferimento
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Please enable developer mode to create new connection,Abilita la modalità sviluppatore per creare una nuova connessione
 DocType: Event,Repeat On,Ripetere On
 DocType: SMS Parameter,SMS Parameter,SMS Parametro
 DocType: Auto Email Report,Half Yearly,Semestrale
 DocType: Communication,Marked As Spam,Marcato come spam
-apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},C&#39;è qualche problema con il file url: {0}
+apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},C'è qualche problema con il file url: {0}
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Tree,Albero
 apps/frappe/frappe/public/js/frappe/views/treeview.js,You are not allowed to print this report,Non sei autorizzato a stampare questo report
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions,Autorizzazioni utente
@@ -3824,7 +3824,7 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,text in document t
 apps/frappe/frappe/core/doctype/test_runner/test_runner.js,Run Tests,Esegui test
 apps/frappe/frappe/handler.py,Logged Out,Disconnesso
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,More...,Di Più...
-DocType: System Settings,User can login using Email id or Mobile number,L&#39;utente può accedere usando ID e-mail o numero di cellulare
+DocType: System Settings,User can login using Email id or Mobile number,L'utente può accedere usando ID e-mail o numero di cellulare
 DocType: Bulk Update,Update Value,Aggiornamento del valore
 apps/frappe/frappe/core/doctype/communication/communication.js,Mark as {0},Contrassegna come {0}
 apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,Seleziona un nuovo nome per rinominare
@@ -3835,7 +3835,7 @@ apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Something went 
 DocType: System Settings,Number Format,Formato numero
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record.,{0} record importato correttamente.
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Summary,Sommario
-DocType: Event,Event Participants,Partecipanti all&#39;evento
+DocType: Event,Event Participants,Partecipanti all'evento
 DocType: Auto Repeat,Frequency,Frequenza
 DocType: Custom Field,Insert After,Inserisci Dopo
 DocType: Event,Sync with Google Calendar,Sincronizza con Google Calendar
@@ -3854,7 +3854,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Predefinito
 DocType: Translation,Verified,verificata
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} aggiunto
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cerca &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cerca '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Si prega di salvare il rapporto prima
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abbonati aggiunti
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Non In
@@ -3883,14 +3883,14 @@ apps/frappe/frappe/desk/moduleview.py,Standard Reports,Report Standard
 DocType: Dashboard Chart Link,Dashboard Chart Link,Link grafico dashboard
 DocType: User,Email Settings,Impostazioni E-mail
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop Here,Drop Here
-DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Se abilitato, l&#39;utente può accedere da qualsiasi indirizzo IP utilizzando Two Factor Auth, questo può anche essere impostato per tutti gli utenti in Impostazioni di sistema"
+DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Se abilitato, l'utente può accedere da qualsiasi indirizzo IP utilizzando Two Factor Auth, questo può anche essere impostato per tutti gli utenti in Impostazioni di sistema"
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Printer Settings...,Impostazioni della stampante ...
 apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Si prega di inserire la password per continuare
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Me
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} non è uno Stato valido
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Applica a tutti i tipi di documenti
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Aggiornamento del punto di energia
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Si prega di selezionare un altro metodo di pagamento. PayPal non supporta le transazioni in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Si prega di selezionare un altro metodo di pagamento. PayPal non supporta le transazioni in valuta '{0}'
 DocType: Chat Message,Room Type,Tipo di stanza
 DocType: Data Import Beta,Import Log Preview,Importa anteprima registro
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Cerca campo {0} non è valido
@@ -3931,7 +3931,7 @@ apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Applicab
 apps/frappe/frappe/config/settings.py,Set up rules for user assignments.,Imposta le regole per le assegnazioni degli utenti.
 apps/frappe/frappe/model/document.py,Insufficient Permission for {0},Autorizzazione insufficiente per {0}
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Report was not saved (there were errors),Report non salvato (si sono verificati degli errori)
-apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,Impossibile modificare il contenuto dell&#39;intestazione
+apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,Impossibile modificare il contenuto dell'intestazione
 DocType: Print Settings,Print Style,Stile di stampa
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not Linked to any record,Non è collegato a alcun record
 DocType: Custom DocPerm,Import,Importazione
@@ -3942,7 +3942,7 @@ DocType: Communication,To and CC,Per e CC
 DocType: SMS Settings,Static Parameters,Parametri statici
 DocType: Chat Message,Room,Camera
 apps/frappe/frappe/public/js/frappe/change_log.html,updated to {0},aggiornato a {0}
-apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,I lavori in background non sono in esecuzione. Si prega di contattare l&#39;amministratore
+apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,I lavori in background non sono in esecuzione. Si prega di contattare l'amministratore
 DocType: Portal Settings,Custom Menu Items,Voci di menu personalizzate
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,Tutte le immagini allegate alla presentazione del sito web devono essere pubbliche
 DocType: Workflow State,chevron-right,chevron-destra
@@ -3960,7 +3960,7 @@ apps/frappe/frappe/public/js/frappe/form/controls/multiselect_list.js,No values 
 DocType: Desktop Icon,_doctype,_doctype
 DocType: Communication,Email Template,Modello di email
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record.,Record {0} aggiornato correttamente.
-apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},L&#39;utente {0} non ha accesso al tipo di documento tramite l&#39;autorizzazione del ruolo per il documento {1}
+apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},L'utente {0} non ha accesso al tipo di documento tramite l'autorizzazione del ruolo per il documento {1}
 apps/frappe/frappe/templates/includes/login/login.js,Both login and password required,Sono richiesti login e password
 apps/frappe/frappe/model/document.py,Please refresh to get the latest document.,Si prega di aggiornare per ottenere l'ultimo documento.
 DocType: User,Security Settings,Impostazioni di sicurezza
@@ -3982,7 +3982,7 @@ DocType: Dashboard Chart,Last Week,La settimana scorsa
 DocType: System Settings,Bypass Two Factor Auth for users who login from restricted IP Address,Bypassa l'autenticazione a due fattori per gli utenti che accedono da un indirizzo IP limitato
 DocType: Event,Google Calendar,Google Calendar
 apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,{0} per interrompere la ricezione di email di questo tipo
-apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Apri l&#39;applicazione di autenticazione sul tuo cellulare.
+apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Apri l'applicazione di autenticazione sul tuo cellulare.
 apps/frappe/frappe/model/rename_doc.py,merged {0} into {1},accorpato {0} in {1}
 DocType: System Settings,mm-dd-yyyy,gg-mm-aaaa
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.js,New Connection,Nuova connessione
@@ -4001,6 +4001,6 @@ DocType: Communication,Meeting,Incontro
 apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,Impossibile aprire il file allegato. E' stato esportato in formato CSV?
 DocType: DocField,Ignore User Permissions,Ignora autorizzazioni utente
 apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Saved Successfully,Salvato con successo
-apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,Si prega di chiedere all&#39;amministratore di verificare la tua iscrizione
+apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,Si prega di chiedere all'amministratore di verificare la tua iscrizione
 DocType: Domain Settings,Active Domains,Domini attivi
 apps/frappe/frappe/public/js/integrations/razorpay.js,Show Log,Mostra registro

--- a/frappe/translations/ja.csv
+++ b/frappe/translations/ja.csv
@@ -742,7 +742,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ファイ�
 DocType: DocField,In Global Search,グローバル検索内
 DocType: System Settings,Brute Force Security,ブルートフォースセキュリティ
 DocType: Workflow State,indent-left,インデント左
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0}年前
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0}年前
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,このファイル {0} を削除することは危険です。システム管理者にお問い合わせください。
 DocType: Currency,Currency Name,通貨名
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,メールがありません
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0}が見つ�
 apps/frappe/frappe/config/customization.py,Add custom forms.,カスタムフォームを追加
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}：{1} {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,この文書を提出
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,設定&gt;ユーザー権限
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,設定>ユーザー権限
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,このシステムは、多くの事前定義された役割を提供しています。細かい権限を設定するための新しい役割を追加することができます。
 DocType: Communication,CC,CC
 DocType: Country,Geo,地理
@@ -1256,7 +1256,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",ユーザーがチェック任意の役割を持っている場合、ユーザは、「システム・ユーザー」になります。 「システム・ユーザーは、「デスクトップへのアクセス権を持っています
 DocType: System Settings,Date and Number Format,日付と番号の書式
 apps/frappe/frappe/model/document.py,one of,一部
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,[設定]&gt; [フォームのカスタマイズ]
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,[設定]> [フォームのカスタマイズ]
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,一瞬の確認
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,ショータグ
 DocType: DocField,HTML Editor,HTMLエディタ
@@ -1264,7 +1264,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,請求
 DocType: Email Queue,Not Sent,送信されていません
 DocType: Web Form,Actions,動作
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,設定&gt;ユーザー
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,設定>ユーザー
 DocType: Workflow State,align-justify,均等割付
 DocType: User,Middle Name (Optional),ミドルネーム（任意）
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,許可されていません
@@ -1411,7 +1411,7 @@ DocType: User,System User,システムユーザー
 DocType: Report,Is Standard,標準
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,フル
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",&lt;script&gt; や単に &lt; または &gt; などの文字は、このフィールドでは意図的に使用されるため、HTMLエンコードしないでください。
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",&lt;script> や単に &lt; または > などの文字は、このフィールドでは意図的に使用されるため、HTMLエンコードしないでください。
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}は{1}を批判しました
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,実行
@@ -1792,7 +1792,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,フッターはPD
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,保留
 DocType: System Settings,Allow only one session per user,ユーザーごとに1つだけのセッションを許可します
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ホーム/テスト フォルダ1 /テスト フォルダ3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt;HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head>HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,新規イベントを作成するには時間スロットを選択するかドラッグしてください
 DocType: Contact,Contact Details,連絡先の詳細
 DocType: DocField,In Filter,フィルター内
@@ -2024,7 +2024,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,この時点でログインは許可されていません。
 DocType: Data Migration Run,Current Mapping Action,現在のマッピングアクション
 DocType: Dashboard Chart Source,Source Name,ソース名
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,ユーザーに関連付けられたメールアカウントはありません。 [ユーザー]&gt; [メール受信ボックス]でアカウントを追加してください。
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,ユーザーに関連付けられたメールアカウントはありません。 [ユーザー]> [メール受信ボックス]でアカウントを追加してください。
 DocType: Email Account,Email Sync Option,メール同期オプション
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,行番号
 DocType: Async Task,Runtime,実行時間
@@ -2039,7 +2039,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,既にユ
 DocType: User Email,Enable Outgoing,送信を有効にする
 DocType: Address,Fax,FAX
 apps/frappe/frappe/config/customization.py,Custom Tags,カスタムタグ
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,メールアカウントが設定されていません。 [設定]&gt; [メール]&gt; [メールアカウント]から新しいメールアカウントを作成してください
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,メールアカウントが設定されていません。 [設定]> [メール]> [メールアカウント]から新しいメールアカウントを作成してください
 DocType: Comment,Submitted,提出済
 DocType: Contact,Pulled from Google Contacts,Googleコンタクトから取得
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,無効なリクエスト
@@ -2111,7 +2111,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,セッション有�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",ここで定義されたフィールド名が値を持っているかのルールが真（例）である場合にのみ、このフィールドが表示されます：myFieldでのeval：doc.myfield == &#39;マイ値&#39;のeval：doc.age&gt; 18
+eval:doc.age>18",ここで定義されたフィールド名が値を持っているかのルールが真（例）である場合にのみ、このフィールドが表示されます：myFieldでのeval：doc.myfield == &#39;マイ値&#39;のeval：doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,今日
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",この設定によりユーザーはリンクのあるドキュメント（ブログ記事など）にアクセス可能となります（例：Blogger）。
@@ -2125,7 +2125,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,大文字
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,カスタムHTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,フォルダ名を入力
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,デフォルトのアドレステンプレートが見つかりません。 [設定]&gt; [印刷とブランディング]&gt; [アドレステンプレート]から新しいものを作成してください。
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,デフォルトのアドレステンプレートが見つかりません。 [設定]> [印刷とブランディング]> [アドレステンプレート]から新しいものを作成してください。
 apps/frappe/frappe/auth.py,Unknown User,未知のユーザ
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,役割を選択
 DocType: Comment,Deleted,削除済
@@ -2314,7 +2314,7 @@ DocType: LDAP Settings,Path to Server Certificate,サーバー証明書へのパ
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,リンクを表示する権限がありません
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,住所タイトルは必須です。
 DocType: Google Contacts,Push to Google Contacts,Googleコンタクトにプッシュ
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",主にWebサイトの検証とSEOのために使用するHTMLを<head>セクションに追加
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",主にWebサイトの検証とSEOのために使用するHTMLを<head>セクションに追加
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,再発しました
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,アイテムは自身の子孫に追加することはできません
 DocType: Session Default Settings,Session Defaults,セッションのデフォルト
@@ -2433,7 +2433,7 @@ DocType: Workflow State,Warning,警告
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,これは複数のページに印刷されるかもしれません
 DocType: Data Migration Run,Percent Complete,完了率
 DocType: Tag Category,Tag Category,カテゴリーにタグ付け
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",比較のために、&gt; 5、&lt;10または= 324を使用します。範囲の場合、5：10を使用します（5〜10の値の場合）。
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",比較のために、> 5、&lt;10または= 324を使用します。範囲の場合、5：10を使用します（5〜10の値の場合）。
 DocType: Google Calendar,Pull from Google Calendar,Googleカレンダーから取得
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ヘルプ
 DocType: User,Login Before,ログイン前
@@ -2566,7 +2566,7 @@ apps/frappe/frappe/utils/nestedset.py,Nested set error. Please contact the Admin
 管理者に連絡してください。"
 DocType: Workflow State,envelope,封筒
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 2,オプション2
-apps/frappe/frappe/utils/print_format.py,Printing failed,印刷に失敗しました
+apps/frappe/frappe/utils/print_format.py,Printing failed,���刷に失敗しました
 apps/frappe/frappe/www/update-password.html,New Password Required.,新しいパスワードが必要です。
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with {1},{0} がこの文書を{1}と共有
 DocType: Website Settings,Brand Image,ブランド画像
@@ -2898,7 +2898,7 @@ DocType: Custom Script,Custom Script,カスタムスクリプト
 DocType: Address,Address Line 2,住所2行目
 DocType: Address,Reference,リファレンス
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,割当先
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,[設定]&gt; [メール]&gt; [メールアカウント]からデフォルトのメールアカウントを設定してください
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,[設定]> [メール]> [メールアカウント]からデフォルトのメールアカウントを設定してください
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,データ移行マッピングの詳細
 DocType: Data Import,Action,アクション
 DocType: GSuite Settings,Script URL,スクリプトURL
@@ -3075,7 +3075,7 @@ DocType: DocField,Allow on Submit,提出を許可
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,例外タイプ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,列を選択
-DocType: Web Page,Add code as &lt;script&gt;,&#060;script&#062;としてコード追加
+DocType: Web Page,Add code as &lt;script>,&#060;script&#062;としてコード追加
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ユーザー権限の消去
 DocType: Webhook,Headers,ヘッダー
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,今後のイベント
@@ -3449,15 +3449,15 @@ DocType: Workflow State,share-alt,共有
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},キューは{0}のいずれかでなければなりません
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4>デフォルトのテンプレート</ H4> 
  <P>は（<a href=""http://jinja.pocoo.org/docs/templates/"">神社テンプレート化</a>と住所のすべてのフィールドを使用します{; BR＆GT; 
  {％ならaddress_line2％} {{address_line2}}＆LT; BRの＆GTカスタムフィールドもしあれば）</ P> 

--- a/frappe/translations/ja.csv
+++ b/frappe/translations/ja.csv
@@ -748,7 +748,7 @@ DocType: Currency,Currency Name,通貨名
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,メールがありません
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,リンクが切れた
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39;の &#39;{1}&#39;の長さを{0}に戻します。長さを{3}に設定すると、データが切り捨てられます。
+							Setting the length as {3} will cause truncation of data.",'{2}'の '{1}'の長さを{0}に戻します。長さを{3}に設定すると、データが切り捨てられます。
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,ファイル形式を選択
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,コンテンツハッシュ
@@ -1442,7 +1442,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,必須フィールド：役割設定先
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0}が{1}を批判しました
 DocType: Data Migration Mapping,Mapping Name,マッピング名
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}：フィールド &#39;{1}&#39;は一意でない値を持つため、一意に設定できません
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}：フィールド '{1}'は一意でない値を持つため、一意に設定できません
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,リストを下に移動
 DocType: Currency,A symbol for this currency. For e.g. $,この通貨のシンボル（例：＄）
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,翻訳を正常に更新しました
@@ -2007,7 +2007,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Googleフォント
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",これらの説明が役に立たなかった場合は、GitHubのIssueに提案を追加してください。
 DocType: Workflow State,bookmark,ブックマーク
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),フォルダ名に &#39;/&#39;（スラッシュ）を含めないでください
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),フォルダ名に '/'（スラッシュ）を含めないでください
 DocType: Note,Note,ノート
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,エラーレポート
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel形式でデータをエクスポートします。
@@ -2111,7 +2111,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,セッション有�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",ここで定義されたフィールド名が値を持っているかのルールが真（例）である場合にのみ、このフィールドが表示されます：myFieldでのeval：doc.myfield == &#39;マイ値&#39;のeval：doc.age> 18
+eval:doc.age>18",ここで定義されたフィールド名が値を持っているかのルールが真（例）である場合にのみ、このフィールドが表示されます：myFieldでのeval：doc.myfield == 'マイ値'のeval：doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,今日
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",この設定によりユーザーはリンクのあるドキュメント（ブログ記事など）にアクセス可能となります（例：Blogger）。
@@ -2150,7 +2150,7 @@ DocType: Data Migration Connector,Database Name,データベース名
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,フォームを更新
 DocType: DocField,Select,選択
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,完全なログを表示
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",単純なPython表現、例：status == &#39;Open&#39;、type == &#39;Bug&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",単純なPython表現、例：status == 'Open'、type == 'Bug'
 apps/frappe/frappe/utils/csvutils.py,File not attached,ファイルが添付されていません
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,接続切断。一部の機能が動作しない可能性があります。
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",「AAA」のような繰り返しは容易に推測されます
@@ -2794,7 +2794,7 @@ DocType: Data Import,Amended From,修正元
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},警告：{1}に関連するすべてのテーブルに{0}を見つけることができません。
 DocType: S3 Backup Settings,eu-north-1,EU北1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,この文書では、現在の実行のためにキューイングされます。もう一度やり直してください
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ファイル &#39;{0}&#39;が見つかりません
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ファイル '{0}'が見つかりません
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,セクションを削除
 DocType: User,Change Password,パスワードを変更する
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X軸フィールド
@@ -2981,7 +2981,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,値の記入漏れ
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,子を追加
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,インポートの進行状況
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",条件が満たされればユーザーはポイントで報われます。例えば。 doc.status == &#39;終了&#39;
+",条件が満たされればユーザーはポイントで報われます。例えば。 doc.status == '終了'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}：提出済レコードを削除することはできません。
 DocType: GSuite Templates,Template Name,テンプレート名
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,文書の新しいタイプ
@@ -3400,7 +3400,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,カスタム翻�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,進捗
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,役割
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,行方不明のフィールド
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,AUTONAMEに無効なフィールド名 &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,AUTONAMEに無効なフィールド名 '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,文書タイプで検索
 DocType: Custom DocPerm,Role and Level,役割とレベル
 DocType: File,Thumbnail URL,サムネイルのURL
@@ -3500,7 +3500,7 @@ DocType: Dashboard Chart,Filters JSON,フィルタJSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,クリックして認証
 DocType: Email Account,Disable SMTP server authentication,SMTPサーバー認証を無効にする
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,クリップボードにコピーしました。
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,予測可能なように置換 &#39;@&#39;の代わりに &#39;&#39;あまり役立ちません。
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,予測可能なように置換 '@'の代わりに ''あまり役立ちません。
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,自分に割当
 apps/frappe/frappe/utils/data.py,Zero,ゼロ
 DocType: Google Drive,Backup Folder ID,バックアップフォルダID
@@ -3712,7 +3712,7 @@ DocType: Web Page,Web Page,ウェブページ
 DocType: Workflow Document State,Next Action Email Template,次のアクション電子メールテンプレート
 DocType: Blog Category,Blogger,ブロガー
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline",有効にすると、ドキュメントへの変更が追跡され、タイムラインに表示されます。
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},行{1}の{0}型に対して &#39;グローバル検索中&#39;が許可されていません
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},行{1}の{0}型に対して 'グローバル検索中'が許可されていません
 DocType: Energy Point Log,Appreciation,感謝
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,リスト表示
 DocType: Workflow,Don't Override Status,ステータスを上書きしないでください

--- a/frappe/translations/ja.csv
+++ b/frappe/translations/ja.csv
@@ -1411,7 +1411,7 @@ DocType: User,System User,システムユーザー
 DocType: Report,Is Standard,標準
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,フル
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",&lt;script> や単に &lt; または > などの文字は、このフィールドでは意図的に使用されるため、HTMLエンコードしないでください。
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",<script> や単に < または > などの文字は、このフィールドでは意図的に使用されるため、HTMLエンコードしないでください。
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}は{1}を批判しました
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,実行
@@ -1792,7 +1792,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,フッターはPD
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,保留
 DocType: System Settings,Allow only one session per user,ユーザーごとに1つだけのセッションを許可します
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ホーム/テスト フォルダ1 /テスト フォルダ3
-DocType: Website Settings,&lt;head> HTML,&lt;head>HTML
+DocType: Website Settings,<head> HTML,<head>HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,新規イベントを作成するには時間スロットを選択するかドラッグしてください
 DocType: Contact,Contact Details,連絡先の詳細
 DocType: DocField,In Filter,フィルター内
@@ -2314,7 +2314,7 @@ DocType: LDAP Settings,Path to Server Certificate,サーバー証明書へのパ
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,リンクを表示する権限がありません
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,住所タイトルは必須です。
 DocType: Google Contacts,Push to Google Contacts,Googleコンタクトにプッシュ
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",主にWebサイトの検証とSEOのために使用するHTMLを<head>セクションに追加
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",主にWebサイトの検証とSEOのために使用するHTMLを<head>セクションに追加
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,再発しました
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,アイテムは自身の子孫に追加することはできません
 DocType: Session Default Settings,Session Defaults,セッションのデフォルト
@@ -2433,7 +2433,7 @@ DocType: Workflow State,Warning,警告
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,これは複数のページに印刷されるかもしれません
 DocType: Data Migration Run,Percent Complete,完了率
 DocType: Tag Category,Tag Category,カテゴリーにタグ付け
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",比較のために、> 5、&lt;10または= 324を使用します。範囲の場合、5：10を使用します（5〜10の値の場合）。
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",比較のために、> 5、<10または= 324を使用します。範囲の場合、5：10を使用します（5〜10の値の場合）。
 DocType: Google Calendar,Pull from Google Calendar,Googleカレンダーから取得
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ヘルプ
 DocType: User,Login Before,ログイン前
@@ -3075,7 +3075,7 @@ DocType: DocField,Allow on Submit,提出を許可
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,例外タイプ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,列を選択
-DocType: Web Page,Add code as &lt;script>,&#060;script&#062;としてコード追加
+DocType: Web Page,Add code as <script>,&#060;script&#062;としてコード追加
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ユーザー権限の消去
 DocType: Webhook,Headers,ヘッダー
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,今後のイベント
@@ -3449,15 +3449,15 @@ DocType: Workflow State,share-alt,共有
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},キューは{0}のいずれかでなければなりません
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4>デフォルトのテンプレート</ H4> 
  <P>は（<a href=""http://jinja.pocoo.org/docs/templates/"">神社テンプレート化</a>と住所のすべてのフィールドを使用します{; BR＆GT; 
  {％ならaddress_line2％} {{address_line2}}＆LT; BRの＆GTカスタムフィールドもしあれば）</ P> 

--- a/frappe/translations/km.csv
+++ b/frappe/translations/km.csv
@@ -945,7 +945,7 @@ apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Header HTML set f
 apps/frappe/frappe/config/desktop.py,Customization,ការប្តូរតាមបំណង។
 DocType: LDAP Settings,Organizational Unit for Users,អង្គភាពរៀបចំសម្រាប់អ្នកប្រើប្រាស់។
 ,Transaction Log Report,របាយការណ៍កំណត់ហេតុប្រតិបត្តិការ
-DocType: Custom DocPerm,Custom DocPerm,DocPerm ផ្ទាល់ខ្លួន
+DocType: Custom DocPerm,Custom DocPerm,DocPerm ���្ទាល់ខ្លួន
 DocType: Newsletter,Send Unsubscribe Link,ផ្ញើឈប់ជាវតំណ
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,There are some linked records which needs to be created before we can import your file. Do you want to create the following missing records automatically?,មានកំណត់ត្រាភ្ជាប់មួយចំនួនដែលត្រូវការបង្កើតមុនពេលដែលយើងអាចនាំចូលឯកសាររបស់អ្នក។ តើអ្នកចង់បង្កើតកំណត់ត្រាបាត់ដូចខាងក្រោមដោយស្វ័យប្រវត្តិទេ?
 DocType: Access Log,Method,វិធីសាស្រ្ត
@@ -1029,7 +1029,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,គ្មា�
 apps/frappe/frappe/config/customization.py,Add custom forms.,បន្ថែមទម្រង់បែបបទផ្ទាល់ខ្លួន។
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} នៅក្នុង {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,បានដាក់ស្នើឯកសារនេះ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,តំឡើង&gt; សិទ្ធិអ្នកប្រើប្រាស់
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,តំឡើង> សិទ្ធិអ្នកប្រើប្រាស់
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,ប្រព័ន្ធនេះបានផ្ដល់នូវតួនាទីដែលបានកំណត់ជាមុនជាច្រើន។ អ្នកអាចបន្ថែមតួនាទីថ្មីកំណត់សិទ្ធិស្តើង។
 DocType: Communication,CC,ចម្លងជូន
 DocType: Country,Geo,ភូមិសាស្ត្រ
@@ -1246,7 +1246,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",ប្រសិនបើអ្នកប្រើមានតួនាទីអ្វីបានគូសធីកនោះអ្នកប្រើក្លាយជា &quot;អ្នកប្រើប្រាស់ប្រព័ន្ធ&quot; ។ &quot;អ្នកប្រើប្រាស់ប្រព័ន្ធ&quot; មានសិទ្ធិចូលដំណើរការទៅផ្ទៃតុ
 DocType: System Settings,Date and Number Format,លេខទ្រង់ទ្រាយកាលបរិច្ឆេទនិង
 apps/frappe/frappe/model/document.py,one of,មួយក្នុងចំណោម
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,រៀបចំ&gt; ទម្រង់បែបបទតាមតម្រូវការ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,រៀបចំ> ទម្រង់បែបបទតាមតម្រូវការ
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,កំពុងពិនិត្យមើលមួយពេល
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,បង្ហាញស្លាក
 DocType: DocField,HTML Editor,កម្មវិធីនិពន្ធ HTML
@@ -1254,7 +1254,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,វិក័យប័ត្រ
 DocType: Email Queue,Not Sent,មិនបានផ្ញើរ
 DocType: Web Form,Actions,ការប្រព្រឹត្ដ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,តំឡើង&gt; អ្នកប្រើប្រាស់
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,តំឡើង> អ្នកប្រើប្រាស់
 DocType: Workflow State,align-justify,តម្រឹម-បង្ហាញអំពីភាពត្រឹមត្រូវ
 DocType: User,Middle Name (Optional),ឈ្មោះពាក់កណ្តាល (ជាជម្រើស)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,មិនអនុញ្ញាត
@@ -1397,7 +1397,7 @@ DocType: User,System User,អ្នកប្រើប្រព័ន្ធ
 DocType: Report,Is Standard,គឺ Standard
 DocType: Desktop Icon,_report,_របាយការណ៏
 DocType: Dashboard Chart,Full,ពេញ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","ស្លាក HTML ដែលបានធ្វើមិនអ៊ិនកូដរបស់ HTML ដូច &lt;script&gt; ឬគ្រាន់តែតួអក្សរដែលដូច &lt;ឬ&gt;, ដូចដែលពួកគេអាចត្រូវបានប្រើដោយចេតនានៅក្នុងវាលនេះ"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ស្លាក HTML ដែលបានធ្វើមិនអ៊ិនកូដរបស់ HTML ដូច &lt;script> ឬគ្រាន់តែតួអក្សរដែលដូច &lt;ឬ>, ដូចដែលពួកគេអាចត្រូវបានប្រើដោយចេតនានៅក្នុងវាលនេះ"
 DocType: Website Settings,FavIcon,favicons
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,រត់
 DocType: Blog Post,Content (HTML),មាតិកា (HTML)
@@ -1442,7 +1442,7 @@ DocType: Communication,Phone No.,លេខទូរស័ព្ទ
 DocType: Personal Data Deletion Request,Pending Approval,ការអនុម័តមិនទាន់សម្រេច។
 DocType: Workflow State,fire,ភ្លើង
 apps/frappe/frappe/www/update-password.html,Success! You are good to go 👍,ជោគជ័យ! អ្នកពូកែទៅ👍។
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,; not allowed in condition,; មិនត្រូវបានអនុញ្ញាតក្នុងលក្ខខណ្ឌ
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,; not allowed in condition,; មិនត្រូវបានអន���ញ្ញាតក្នុងលក្ខខណ្ឌ
 DocType: Async Task,Async Task,Async ការងារ
 DocType: Workflow State,picture,រូបភាព
 apps/frappe/frappe/www/complete_signup.html,Complete,ពេញលេញ
@@ -1767,7 +1767,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,បាតកថ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,ឡុងេពល
 DocType: System Settings,Allow only one session per user,អនុញ្ញាតឱ្យបានតែមួយសម័យអ្នកប្រើ
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ថតទំព័រដើម / ការធ្វើតេស្ត 1 / ការធ្វើតេស្តថត 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;ក្បាល&gt; របស់ HTML
+DocType: Website Settings,&lt;head> HTML,&lt;ក្បាល> របស់ HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ជ្រើសឬអូសកាត់រន្ធពេលវេលាដើម្បីបង្កើតព្រឹត្តិការណ៍ថ្មី។
 DocType: Contact,Contact Details,ពត៌មានទំនាក់ទំនង
 DocType: DocField,In Filter,ក្នុងតម្រង
@@ -1997,7 +1997,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,មិនអនុញ្ញាតឱ្យចូលនៅពេលនេះ
 DocType: Data Migration Run,Current Mapping Action,សកម្មភាពផ្គូផ្គងបច្ចុប្បន្ន
 DocType: Dashboard Chart Source,Source Name,ឈ្មោះប្រភព
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,គ្មានគណនីអ៊ីមែលដែលទាក់ទងនឹងអ្នកប្រើប្រាស់។ សូមបន្ថែមគណនីនៅក្រោមអ្នកប្រើ&gt; ប្រអប់ទទួលអ៊ីម៉ែល។
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,គ្មានគណនីអ៊ីមែលដែលទាក់ទងនឹងអ្នកប្រើប្រាស់។ សូមបន្ថែមគណនីនៅក្រោមអ្នកប្រើ> ប្រអប់ទទួលអ៊ីម៉ែល។
 DocType: Email Account,Email Sync Option,ធ្វើសមកាលកម្មជម្រើសអ៊ីម៉ែល
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,ជួរដេកលេខ
 DocType: Async Task,Runtime,ពេលរត់
@@ -2012,7 +2012,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,រួច
 DocType: User Email,Enable Outgoing,អនុញ្ញាតឱ្យចេញ
 DocType: Address,Fax,ទូរសារ
 apps/frappe/frappe/config/customization.py,Custom Tags,ស្លាកផ្ទាល់ខ្លួន
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,គណនីអ៊ីមែលមិនត្រូវបានរៀបចំទេ។ សូមបង្កើតគណនីអ៊ីម៉ែលថ្មីពីតំឡើង&gt; អ៊ីមែល&gt; គណនីអ៊ីម៉ែល
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,គណនីអ៊ីមែលមិនត្រូវបានរៀបចំទេ។ សូមបង្កើតគណនីអ៊ីម៉ែលថ្មីពីតំឡើង> អ៊ីមែល> គណនីអ៊ីម៉ែល
 DocType: Comment,Submitted,ផ្តល់ជូន
 DocType: Contact,Pulled from Google Contacts,ទាញចេញពី Google ទំនាក់ទំនង។
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,ក្នុងសំណើត្រឹមត្រូវ
@@ -2084,7 +2084,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,សម័យដែ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",វាលនេះនឹងបង្ហាញតែប៉ុណ្ណោះប្រសិនបើបានកំណត់នៅទីនេះ fieldname តម្លៃឬច្បាប់ដែលមាននេះគឺជាការពិត (ឧទាហរណ៍): myfield eval: doc.myfield == &#39;តម្លៃរបស់ខ្ញុំ&#39; eval: doc.age&gt; 18
+eval:doc.age>18",វាលនេះនឹងបង្ហាញតែប៉ុណ្ណោះប្រសិនបើបានកំណត់នៅទីនេះ fieldname តម្លៃឬច្បាប់ដែលមាននេះគឺជាការពិត (ឧទាហរណ៍): myfield eval: doc.myfield == &#39;តម្លៃរបស់ខ្ញុំ&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,ការិយាល័យ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ថ្ងៃនេះ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",នៅពេលដែលអ្នកបានកំណត់នេះអ្នកប្រើនឹងត្រូវបានចូលដំណើរការឯកសារដែលអាច (ឧ។ ប្រកាសកំណត់ហេតុបណ្ដាញ) ដែលជាកន្លែងដែលតំណនេះមាន (អ្នកសរសេរប្លុកឧ។ ) ។
@@ -2098,7 +2098,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,អក្សរធំ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML ផ្ទាល់ខ្លួន
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,បញ្ចូលឈ្មោះឱ្យថត
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,រកមិនឃើញគំរូអាសយដ្ឋានលំនាំដើម។ សូមបង្កើតថ្មីមួយពីការតំឡើង&gt; បោះពុម្ពនិងយីហោ&gt; គំរូអាសយដ្ឋាន។
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,រកមិនឃើញគំរូអាសយដ្ឋានលំនាំដើម។ សូមបង្កើតថ្មីមួយពីការតំឡើង> បោះពុម្ពនិងយីហោ> គំរូអាសយដ្ឋាន។
 apps/frappe/frappe/auth.py,Unknown User,អ្នកប្រើមិនស្គាល់
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,ជ្រើសតួនាទី
 DocType: Comment,Deleted,ដែលបានលុប
@@ -2285,7 +2285,7 @@ DocType: LDAP Settings,Path to Server Certificate,ផ្លូវទៅវិញ
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,មិនមានសិទ្ធិគ្រប់គ្រាន់ក្នុងការមើលឃើញតំណភ្ជាប់
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,អាសយដ្ឋានចំណងជើងគឺជាចាំបាច់។
 DocType: Google Contacts,Push to Google Contacts,រុញទៅទំនាក់ទំនង Google ។
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML ដែលបានបន្ថែមនៅក្នុង &lt;ក្បាល&gt; ផ្នែកនៃទំព័រតំបន់បណ្ដាញ, ជាចម្បងដែលបានប្រើសម្រាប់ការផ្ទៀងផ្ទាត់វែបសាយនិង Seo"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML ដែលបានបន្ថែមនៅក្នុង &lt;ក្បាល> ផ្នែកនៃទំព័រតំបន់បណ្ដាញ, ជាចម្បងដែលបានប្រើសម្រាប់ការផ្ទៀងផ្ទាត់វែបសាយនិង Seo"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,លាប់ឡើងវិញ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ធាតុមិនអាចត្រូវបានបន្ថែមទៅជនជាតិផ្ទាល់របស់ខ្លួន
 DocType: Session Default Settings,Session Defaults,លំនាំដើមវេន។
@@ -2387,7 +2387,7 @@ DocType: Chat Message,Direct,ផ្ទាល់
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname {1} appears multiple times in rows {2},{0}៖ ឈ្មោះវាល {1} លេចឡើងច្រើនដងក្នុងជួរដេក {2}
 DocType: Property Setter,Property Type,ប្រភេទអចលនទ្រព្យ
 DocType: Workflow State,screenshot,រូបថតអេក្រង់
-apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,មានតែអ្នកគ្រប់គ្រងអាចរក្សាទុករបាយការណ៍ស្តង់ដារមួយ។ សូមប្តូរឈ្មោះនិងរក្សាទុក។
+apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,មានតែអ្នកគ្រប់គ្រងអាចរក្សាទុករបាយការណ៍ស្តង់ដារមួយ។ ���ូមប្តូរឈ្មោះនិងរក្សាទុក។
 DocType: System Settings,Background Workers,កម្មករផ្ទៃខាងក្រោយ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Fieldname {0} ការប៉ះទង្គិចជាមួយវត្ថុមេតា
 DocType: Deleted Document,Data,ទិន្នន័យដែលបាន
@@ -2402,7 +2402,7 @@ DocType: Workflow State,Warning,ព្រមាន &amp; ‧;
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,វាអាចត្រូវបានបោះពុម្ពលើទំព័រជាច្រើន។
 DocType: Data Migration Run,Percent Complete,ភាគរយពេញលេញ
 DocType: Tag Category,Tag Category,ប្រភេទស្លាក
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","សម្រាប់ការប្រៀបធៀបប្រើ&gt; 5, &lt;10 ឬ = 324 ។ សម្រាប់ជួរប្រើ 5:10 (សម្រាប់តម្លៃចន្លោះពី 5 និង 10) ។"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","សម្រាប់ការប្រៀបធៀបប្រើ> 5, &lt;10 ឬ = 324 ។ សម្រាប់ជួរប្រើ 5:10 (សម្រាប់តម្លៃចន្លោះពី 5 និង 10) ។"
 DocType: Google Calendar,Pull from Google Calendar,ទាញពី Google ប្រតិទិន។
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,សូមជួយ
 DocType: User,Login Before,ចូលមុនពេល
@@ -2845,7 +2845,7 @@ apps/frappe/frappe/templates/includes/search_template.html,Type something in the
 apps/frappe/frappe/config/settings.py,Define workflows for forms.,កំណត់លំហូរការងារសម្រាប់សំណុំបែបបទ។
 DocType: Address,Other,ផ្សេងទៀត
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,សូមបញ្ចូល URL សិទ្ធិអ្នកនិពន្ធ
-DocType: S3 Backup Settings,Access Key ID,ចូលប្រើលេខសម្គាល់សោ
+DocType: S3 Backup Settings,Access Key ID,ចូលប���រើលេខសម្គាល់សោ
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Misc,misc
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Start new Format,ចាប់ផ្តើមការទ្រង់ទ្រាយថ្មី
 DocType: Workflow State,font,ពុម្ពអក្សរ
@@ -2867,7 +2867,7 @@ DocType: Custom Script,Custom Script,ស្គ្រីបផ្ទាល់ខ�
 DocType: Address,Address Line 2,អាសយដ្ឋានបន្ទាត់ទី 2
 DocType: Address,Reference,ឯកសារយោង
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,បានផ្ដល់តម្លៃទៅ
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,សូមរៀបចំគណនីអ៊ីមែលលំនាំដើមពីតំឡើង&gt; អ៊ីមែល&gt; គណនីអ៊ីមែល
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,សូមរៀបចំគណនីអ៊ីមែលលំនាំដើមពីតំឡើង> អ៊ីមែល> គណនីអ៊ីមែល
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ពត៌មានលំអិតផែនទីអន្តោប្រវេសន៍ទិន្នន័យ
 DocType: Data Import,Action,សកម្មភាព
 DocType: GSuite Settings,Script URL,URL ស្គ្រីប
@@ -3043,7 +3043,7 @@ DocType: DocField,Allow on Submit,អនុញ្ញាតឱ្យនៅលើ�
 DocType: DocField,HTML,របស់ HTML
 DocType: Error Snapshot,Exception Type,ប្រភេទករណីលើកលែង
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,ជ្រើសយកជួរឈរ
-DocType: Web Page,Add code as &lt;script&gt;,បន្ថែមកូដជា &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,បន្ថែមកូដជា &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,សម្អាតសិទ្ធិអ្នកប្រើប្រាស់។
 DocType: Webhook,Headers,បឋមកថា
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ព្រឹត្តិការណ៍ជិតមកដល់
@@ -3413,16 +3413,16 @@ DocType: Workflow State,share-alt,ចំណែក Alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ជួរគួរជាផ្នែកមួយនៃ {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> ទំព័រគំរូលំនាំដើម </h4><p> ប្រើ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja ពុម្ព</a> និងវាលទាំងអស់នៃអាសយដ្ឋាន (រួមទាំងវាលផ្ទាល់ខ្លួនបើមាន) នឹងអាចរកបាន </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> ទំព័រគំរូលំនាំដើម </h4><p> ប្រើ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja ពុម្ព</a> និងវាលទាំងអស់នៃអាសយដ្ឋាន (រួមទាំងវាលផ្ទាល់ខ្លួនបើមាន) នឹងអាចរកបាន </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ចាប់ផ្តើមវាលកាលបរិច្ឆេទ
 DocType: Role,Role Name,ឈ្មោះតួនាទី
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ប្តូរទៅតុ
@@ -3804,7 +3804,7 @@ DocType: Website Settings,Title Prefix,ចំណងជើងបុព្វប�
 DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,ការជូនដំណឹងនិងអ៊ីភាគច្រើននឹងត្រូវបានផ្ញើពីម៉ាស៊ីនបម្រើចេញនេះ។
 DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,ភាសាព្រីនដែលផ្អែកលើខ្សែអក្សរណាមួយអាចត្រូវបានប្រើ។ ការសរសេរពាក្យបញ្ជាឆៅទាមទារចំណេះដឹងអំពីភាសាកំណើតរបស់ព្រីនធ័រដែលផ្តល់ដោយក្រុមហ៊ុនផលិតព្រីនធ័រ។ សូមមើលសៀវភៅដៃអ្នកអភិវឌ្ឍន៍ដែលផ្តល់ដោយក្រុមហ៊ុនផលិតព្រីនធ័រអំពីរបៀបសរសេរពាក្យបញ្ជាកំណើតរបស់ពួកគេ។ ពាក្យបញ្ជាទាំងនេះត្រូវបានបង្ហាញនៅផ្នែកខាងម៉ាស៊ីនមេដោយប្រើភាសា Templating Jinja ។
 DocType: Workflow State,cog,កត្តា
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Sync on Migrate,ធ្វើសមកាលកម្មស្តីពីអន្តោប្រវេសន៍
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Sync on Migrate,ធ���វើសមកាលកម្មស្តីពីអន្តោប្រវេសន៍
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently Viewing,បច្ចុប្បន្ននេះការមើល
 DocType: DocField,Default,លំនាំដើម
 DocType: Translation,Verified,បានផ្ទៀងផ្ទាត់។

--- a/frappe/translations/km.csv
+++ b/frappe/translations/km.csv
@@ -1397,7 +1397,7 @@ DocType: User,System User,អ្នកប្រើប្រព័ន្ធ
 DocType: Report,Is Standard,គឺ Standard
 DocType: Desktop Icon,_report,_របាយការណ៏
 DocType: Dashboard Chart,Full,ពេញ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ស្លាក HTML ដែលបានធ្វើមិនអ៊ិនកូដរបស់ HTML ដូច &lt;script> ឬគ្រាន់តែតួអក្សរដែលដូច &lt;ឬ>, ដូចដែលពួកគេអាចត្រូវបានប្រើដោយចេតនានៅក្នុងវាលនេះ"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","ស្លាក HTML ដែលបានធ្វើមិនអ៊ិនកូដរបស់ HTML ដូច <script> ឬគ្រាន់តែតួអក្សរដែលដូច <ឬ>, ដូចដែលពួកគេអាចត្រូវបានប្រើដោយចេតនានៅក្នុងវាលនេះ"
 DocType: Website Settings,FavIcon,favicons
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,រត់
 DocType: Blog Post,Content (HTML),មាតិកា (HTML)
@@ -1767,7 +1767,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,បាតកថ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,ឡុងេពល
 DocType: System Settings,Allow only one session per user,អនុញ្ញាតឱ្យបានតែមួយសម័យអ្នកប្រើ
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ថតទំព័រដើម / ការធ្វើតេស្ត 1 / ការធ្វើតេស្តថត 3
-DocType: Website Settings,&lt;head> HTML,&lt;ក្បាល> របស់ HTML
+DocType: Website Settings,<head> HTML,<ក្បាល> របស់ HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ជ្រើសឬអូសកាត់រន្ធពេលវេលាដើម្បីបង្កើតព្រឹត្តិការណ៍ថ្មី។
 DocType: Contact,Contact Details,ពត៌មានទំនាក់ទំនង
 DocType: DocField,In Filter,ក្នុងតម្រង
@@ -2285,7 +2285,7 @@ DocType: LDAP Settings,Path to Server Certificate,ផ្លូវទៅវិញ
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,មិនមានសិទ្ធិគ្រប់គ្រាន់ក្នុងការមើលឃើញតំណភ្ជាប់
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,អាសយដ្ឋានចំណងជើងគឺជាចាំបាច់។
 DocType: Google Contacts,Push to Google Contacts,រុញទៅទំនាក់ទំនង Google ។
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML ដែលបានបន្ថែមនៅក្នុង &lt;ក្បាល> ផ្នែកនៃទំព័រតំបន់បណ្ដាញ, ជាចម្បងដែលបានប្រើសម្រាប់ការផ្ទៀងផ្ទាត់វែបសាយនិង Seo"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML ដែលបានបន្ថែមនៅក្នុង <ក្បាល> ផ្នែកនៃទំព័រតំបន់បណ្ដាញ, ជាចម្បងដែលបានប្រើសម្រាប់ការផ្ទៀងផ្ទាត់វែបសាយនិង Seo"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,លាប់ឡើងវិញ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ធាតុមិនអាចត្រូវបានបន្ថែមទៅជនជាតិផ្ទាល់របស់ខ្លួន
 DocType: Session Default Settings,Session Defaults,លំនាំដើមវេន។
@@ -2402,7 +2402,7 @@ DocType: Workflow State,Warning,ព្រមាន &amp; ‧;
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,វាអាចត្រូវបានបោះពុម្ពលើទំព័រជាច្រើន។
 DocType: Data Migration Run,Percent Complete,ភាគរយពេញលេញ
 DocType: Tag Category,Tag Category,ប្រភេទស្លាក
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","សម្រាប់ការប្រៀបធៀបប្រើ> 5, &lt;10 ឬ = 324 ។ សម្រាប់ជួរប្រើ 5:10 (សម្រាប់តម្លៃចន្លោះពី 5 និង 10) ។"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","សម្រាប់ការប្រៀបធៀបប្រើ> 5, <10 ឬ = 324 ។ សម្រាប់ជួរប្រើ 5:10 (សម្រាប់តម្លៃចន្លោះពី 5 និង 10) ។"
 DocType: Google Calendar,Pull from Google Calendar,ទាញពី Google ប្រតិទិន។
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,សូមជួយ
 DocType: User,Login Before,ចូលមុនពេល
@@ -3043,7 +3043,7 @@ DocType: DocField,Allow on Submit,អនុញ្ញាតឱ្យនៅលើ�
 DocType: DocField,HTML,របស់ HTML
 DocType: Error Snapshot,Exception Type,ប្រភេទករណីលើកលែង
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,ជ្រើសយកជួរឈរ
-DocType: Web Page,Add code as &lt;script>,បន្ថែមកូដជា &lt;script>
+DocType: Web Page,Add code as <script>,បន្ថែមកូដជា <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,សម្អាតសិទ្ធិអ្នកប្រើប្រាស់។
 DocType: Webhook,Headers,បឋមកថា
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ព្រឹត្តិការណ៍ជិតមកដល់
@@ -3413,16 +3413,16 @@ DocType: Workflow State,share-alt,ចំណែក Alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ជួរគួរជាផ្នែកមួយនៃ {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> ទំព័រគំរូលំនាំដើម </h4><p> ប្រើ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja ពុម្ព</a> និងវាលទាំងអស់នៃអាសយដ្ឋាន (រួមទាំងវាលផ្ទាល់ខ្លួនបើមាន) នឹងអាចរកបាន </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> ទំព័រគំរូលំនាំដើម </h4><p> ប្រើ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja ពុម្ព</a> និងវាលទាំងអស់នៃអាសយដ្ឋាន (រួមទាំងវាលផ្ទាល់ខ្លួនបើមាន) នឹងអាចរកបាន </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ចាប់ផ្តើមវាលកាលបរិច្ឆេទ
 DocType: Role,Role Name,ឈ្មោះតួនាទី
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ប្តូរទៅតុ

--- a/frappe/translations/km.csv
+++ b/frappe/translations/km.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,មាតាឬបិ�
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},យើងបានទទួលសំណើពីអ្នកដើម្បីទាញយកទិន្នន័យ {0} របស់អ្នកដែលទាក់ទងនឹង៖ {1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.",ប្រសិនបើបានបើកកម្លាំងពាក្យសម្ងាត់នឹងត្រូវបានអនុវត្តដោយផ្អែកលើតម្លៃអប្បបរមាពាក្យសម្ងាត់ពិន្ទុ។ តម្លៃនៃការក្លាយជារឹងមាំ 2 និង 4 ក្លាយជាមធ្យមខ្លាំងណាស់។
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;សមាជិកក្រុម&quot; ឬ &quot;ការគ្រប់គ្រង&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',លំនាំដើមសម្រាប់ &#39;ធីក&#39; ប្រភេទនៃវាលត្រូវតែមានទាំង &#39;0&#39; ឬ &#39;1&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',លំនាំដើមសម្រាប់ 'ធីក' ប្រភេទនៃវាលត្រូវតែមានទាំង '0' ឬ '1'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,កាលពីម្សិលមិញ
 DocType: Contact,Designation,ការរចនា
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,ការភ្ជាប់ដោយស្វ័យប្រវត្តិអាចដំណើរការបានតែគណនីអ៊ីម៉ែលមួយប៉ុណ្ណោះ។
@@ -250,7 +250,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,របាយក�
 DocType: Translation,Contributed Translation Doctype Name,ឈ្មោះការបកប្រែភាសាវិភាគលេខកូដ។
 DocType: PayPal Settings,Redirect To,ប្តូរទិសទៅ
 DocType: Data Migration Mapping,Pull,ទាញ
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript ទ្រង់ទ្រាយ: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript ទ្រង់ទ្រាយ: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,បច្ចុប្បន្នភាពច្រើន
 DocType: Workflow State,chevron-up,ក្រុមហ៊ុន Chevron ឡើង
 DocType: DocType,Allow Guest to View,អនុញ្ញាតឱ្យភ្ញៀវដើម្បីមើល
@@ -552,7 +552,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,ការផ្ទុកឡើងបានបរាជ័យ
 DocType: LDAP Settings,LDAP Phone Field,វាលទូរស័ព្ទអិលភីភី។
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",ប្រភេទឯកសារ ... ឧអតិថិជន
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,លក្ខខណ្ឌ &#39;{0}&#39; មិនត្រឹមត្រូវ
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,លក្ខខណ្ឌ '{0}' មិនត្រឹមត្រូវ
 DocType: Workflow State,barcode,លេខកូដ
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,ការប្រើពាក្យរងឬអនុគមន៍ត្រូវបានហាមឃាត់
 apps/frappe/frappe/config/customization.py,Add your own translations,បន្ថែមបកប្រែផ្ទាល់ខ្លួនរបស់អ្នក
@@ -700,7 +700,7 @@ DocType: Slack Webhook URL,Webhook URL,URL គេហទំព័រ
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,ឈ្មោះអ្នកប្រើ {0} មានរួចហើយ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: មិនអាចកំណត់ការនាំចូលជា {1} គឺមិនសំខាន់
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},មានកំហុសក្នុងការអាសយដ្ឋានទំព័រគំរូរបស់អ្នកគឺ {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} គឺជាអាសយដ្ឋានអ៊ីមែលមិនត្រឹមត្រូវនៅក្នុង &#39;អ្នកទទួល&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} គឺជាអាសយដ្ឋានអ៊ីមែលមិនត្រឹមត្រូវនៅក្នុង 'អ្នកទទួល'
 DocType: Footer Item,"target = ""_blank""",គោលដៅ = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,ម៉ាស៊ីន
@@ -741,7 +741,7 @@ DocType: Currency,Currency Name,ឈ្មោះរូបិយប័ណ្ណ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,គ្មានអ៊ីម៉ែល
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,តំណបានផុតកំណត់
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",ត្រឡប់ប្រវែងទៅ {0} សម្រាប់ &#39;{1}&#39; នៅក្នុង &#39;{2}&#39;; ការកំណត់ប្រវែងជា {3} នឹងបណ្ដាលឱ្យកាត់ទិន្នន័យ។
+							Setting the length as {3} will cause truncation of data.",ត្រឡប់ប្រវែងទៅ {0} សម្រាប់ '{1}' នៅក្នុង '{2}'; ការកំណត់ប្រវែងជា {3} នឹងបណ្ដាលឱ្យកាត់ទិន្នន័យ។
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,ជ្រើសទ្រង់ទ្រាយឯកសារ
 DocType: Report,Javascript,javascript
 DocType: File,Content Hash,ហាស់មាតិការ
@@ -756,13 +756,13 @@ apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","ស្ដង់ដារប្រភេទឯកសារមិនអាចមានទ្រង់ទ្រាយម៉ាស៊ីនបោះពុម្ពលំនាំដើម, ប្រើទម្រង់បែបបទប្តូរតាមបំណង"
 DocType: Report,Query,សំណួរ
 DocType: Customize Form,Sort Order,តម្រៀបតាមលំដាប់
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},«នៅក្នុងទិដ្ឋភាពបញ្ជី &#39;មិនបានអនុញ្ញាតសម្រាប់ប្រភេទ {0} នៅក្នុងជួរដេក {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},«នៅក្នុងទិដ្ឋភាពបញ្ជី 'មិនបានអនុញ្ញាតសម្រាប់ប្រភេទ {0} នៅក្នុងជួរដេក {1}
 DocType: Letter Head,Footer HTML,បាតកថា HTML ។
 DocType: Custom Field,Select the label after which you want to insert new field.,ជ្រើសស្លាកបន្ទាប់ពីការដែលអ្នកចង់បញ្ចូលវាលថ្មី។
 ,Document Share Report,ឯកសារដែលបានចែករំលែករបាយការណ៍
 DocType: Social Login Key,Base URL,URL មូលដ្ឋាន
 DocType: User,Last Login,ចូលចុងក្រោយ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},អ្នកមិនអាចកំណត់ &#39;Translatable&#39; សម្រាប់វាល {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},អ្នកមិនអាចកំណត់ 'Translatable' សម្រាប់វាល {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,ជួរឈរ
 DocType: Chat Profile,Chat Profile,ប្រវត្តិរូបជជែកកំសាន្ត
 DocType: Custom Field,Adds a custom field to a DocType,បន្ថែមវាលផ្ទាល់ខ្លួនមួយដើម្បីចង្អុលបង្ហាញមួយ
@@ -771,7 +771,7 @@ DocType: File,Is Home Folder,នេះគឺជាថតផ្ទះ
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,រចនាប័ទ្មរបារ។
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} គឺមិនមែនជាអាសយដ្ឋានអ៊ីមែលដែលមានសុពលភាព
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,ជ្រើសយ៉ាងហោចណាស់ 1 កំណត់ត្រាសម្រាប់ការបោះពុម្ព
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',អ្នកប្រើ &#39;{0}&#39; ដែលមានតួនាទីរួចទៅហើយ &quot;{1} &#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',អ្នកប្រើ '{0}' ដែលមានតួនាទីរួចទៅហើយ &quot;{1} '
 DocType: System Settings,Two Factor Authentication method,វិធីសាស្ត្រផ្ទៀងផ្ទាត់ភាពត្រឹមត្រូវពីរ
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,ដំបូងកំណត់ឈ្មោះនិងរក្សាទុកកំណត់ត្រា។
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,៥ កំណត់ត្រា។
@@ -1020,7 +1020,7 @@ DocType: Property Setter,Property Setter,អចលនទ្រព្យក្ន
 DocType: Web Form,Allow Print,អនុញ្ញាតឱ្យបោះពុម្ព
 DocType: Communication,Clicked,ចុច
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,មិនបំពេញ។
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},គ្មានសិទ្ធិ &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},គ្មានសិទ្ធិ '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,គ្រោងនឹងផ្ញើ
 DocType: DocType,Track Seen,បទឃើញ
 DocType: Dropbox Settings,File Backup,ឯកសារបម្រុងទុក
@@ -1047,7 +1047,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,HTML ដែលទំព័រ
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,នាំចេញជួរដេក Errored ។
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,ឈ្មោះក្រុមមិនអាចទទេបានទេ។
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,ថ្នាំងបន្ថែមទៀតអាចត្រូវបានបង្កើតក្រោមការថ្នាំងប្រភេទ &#39;ក្រុម
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,ថ្នាំងបន្ថែមទៀតអាចត្រូវបានបង្កើតក្រោមការថ្នាំងប្រភេទ 'ក្រុម
 DocType: SMS Parameter,Header,បឋមកថា
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},មិនស្គាល់ជួរឈរ: {0}
 DocType: Notification Recipient,Email By Role,អ៊ីម៉ែលដោយតួនាទី
@@ -1980,7 +1980,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,ពុម្ពអក្សរហ្គូហ្គល។
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",ប្រសិនបើមានការណែនាំទាំងនេះដែលជាកន្លែងដែលមិនមានប្រយោជន៍ទេសូមបន្ថែមក្នុងការផ្ដល់យោបល់របស់អ្នកនៅលើបញ្ហា GitHub ។
 DocType: Workflow State,bookmark,កំណត់ចំណាំ
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ឈ្មោះថតមិនគួរតែរួមបញ្ចូល &#39;/&#39; (សញ្ញា)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ឈ្មោះថតមិនគួរតែរួមបញ្ចូល '/' (សញ្ញា)
 DocType: Note,Note,ចំណាំ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,របាយការណ៍កំហុស &amp; ‧;
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,នាំទិន្នន័យចេញជាទ្រង់ទ្រាយ CSV / Excel ។
@@ -2084,7 +2084,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,សម័យដែ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",វាលនេះនឹងបង្ហាញតែប៉ុណ្ណោះប្រសិនបើបានកំណត់នៅទីនេះ fieldname តម្លៃឬច្បាប់ដែលមាននេះគឺជាការពិត (ឧទាហរណ៍): myfield eval: doc.myfield == &#39;តម្លៃរបស់ខ្ញុំ&#39; eval: doc.age> 18
+eval:doc.age>18",វាលនេះនឹងបង្ហាញតែប៉ុណ្ណោះប្រសិនបើបានកំណត់នៅទីនេះ fieldname តម្លៃឬច្បាប់ដែលមាននេះគឺជាការពិត (ឧទាហរណ៍): myfield eval: doc.myfield == 'តម្លៃរបស់ខ្ញុំ' eval: doc.age> 18
 DocType: Social Login Key,Office 365,ការិយាល័យ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ថ្ងៃនេះ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",នៅពេលដែលអ្នកបានកំណត់នេះអ្នកប្រើនឹងត្រូវបានចូលដំណើរការឯកសារដែលអាច (ឧ។ ប្រកាសកំណត់ហេតុបណ្ដាញ) ដែលជាកន្លែងដែលតំណនេះមាន (អ្នកសរសេរប្លុកឧ។ ) ។
@@ -2123,7 +2123,7 @@ DocType: Data Migration Connector,Database Name,ឈ្មោះមូលដ្�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,សំណុំបែបបទធ្វើឱ្យស្រស់
 DocType: DocField,Select,ជ្រើស
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,មើលកំណត់ហេតុពេញ។
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",កន្សោមពស់ថ្លាន់សាមញ្ញឧទាហរណ៍៖ ស្ថានភាព == &#39;បើក&#39; ហើយវាយ == &#39;កំហុស&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",កន្សោមពស់ថ្លាន់សាមញ្ញឧទាហរណ៍៖ ស្ថានភាព == 'បើក' ហើយវាយ == 'កំហុស'
 apps/frappe/frappe/utils/csvutils.py,File not attached,ឯកសារមិនបានភ្ជាប់
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,ការតភ្ជាប់បានដាច់។ លក្ខណៈមួយចំនួនប្រហែលជាមិនដំណើរការ។
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",ម្តងទៀតដូចជា &quot;AAA&quot; គឺជាការងាយស្រួលក្នុងការទាយ
@@ -2253,7 +2253,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,បង្ហាញតែកំហុស
 DocType: Website Settings,Banner HTML,បដារបស់ HTML
 DocType: Workflow,Send Email Alert,ផ្ញើការជូនដំណឹងតាមអ៊ីម៉ែល
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ Razorpay មិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ Razorpay មិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ '{0}'
 DocType: Data Import,In Progress,កំពុងដំណើរការ
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,បានដាក់ជាជួរសម្រាប់ការបម្រុងទុក។ វាអាចចំណាយពេលពីរបីនាទីទៅមួយម៉ោង។
 DocType: Error Snapshot,Pyver,Pyver
@@ -2671,7 +2671,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,ការធ្វើ�
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,ការកំណត់ការទូទាត់បានតាមរយៈ
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,កំពូលអ្នកសំដែង។
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,វាលផ្ទាល់ខ្លួនមិនអាចត្រូវបានបន្ថែមទៅក្នុងឯកសារ DocTypes ទេ។
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) នឹងទទួលបានកាត់ឱ្យខ្លី, ដែលជាតួអក្សរអតិបរមាដែលត្រូវបានអនុញ្ញាតគឺ {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) នឹងទទួលបានកាត់ឱ្យខ្លី, ដែលជាតួអក្សរអតិបរមាដែលត្រូវបានអនុញ្ញាតគឺ {2}"
 DocType: OAuth Client,Response Type,ប្រភេទឆ្លើយតប
 DocType: Contact Us Settings,Send enquiries to this email address,ផ្ញើការសួរសំណួរទៅកាន់អាសយដ្ឋានអ៊ីមែលនេះ
 DocType: Letter Head,Letter Head Name,ឈ្មោះលិខិតនាយក
@@ -2728,7 +2728,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,មើលរូបភាព
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","មើលទៅដូចជាមានអ្វីមួយខុសក្នុងអំឡុងពេលប្រតិបត្តិការនេះ។ ចាប់តាំងពីពេលដែលយើងបានមិនបានបញ្ជាក់ថាការទូទាត់, PayPal នឹងបង្វិលសងវិញអ្នកដោយស្វ័យប្រវត្តិចំនួននេះ។ ប្រសិនបើវាមិន, សូមផ្ញើអ៊ីម៉ែលនិងការនិយាយអំពីការជាប់ទាក់ទងគ្នាលេខសម្គាល់: {0} ។"
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password",រួមបញ្ចូលនិមិត្តសញ្ញាលេខនិងអក្សរមូលធននៅក្នុងពាក្យសម្ងាត់
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",បញ្ចូលបន្ទាប់ពីវាល &#39;{0}&#39; បានរៀបរាប់នៅក្នុងវាលផ្ទាល់ខ្លួន &#39;{1}&#39; ដោយមានស្លាក &#39;{2} &quot;មិនមាន
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",បញ្ចូលបន្ទាប់ពីវាល '{0}' បានរៀបរាប់នៅក្នុងវាលផ្ទាល់ខ្លួន '{1}' ដោយមានស្លាក '{2} &quot;មិនមាន
 DocType: List Filter,List Filter,តម្រងបញ្ជី
 DocType: Workflow State,signal,សញ្ញា
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,មានឯកសារភ្ជាប់
@@ -2738,7 +2738,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,ឯកសារស្ដារ
 DocType: Data Export,Data Export,នាំចេញទិន្នន័យ
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ជ្រើសរើសភាសា...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},អ្នកមិនអាចកំណត់ &#39;ជម្រើស&#39; សម្រាប់វាល {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},អ្នកមិនអាចកំណត់ 'ជម្រើស' សម្រាប់វាល {0}
 DocType: Help Article,Author,អ្នកនិពន្ធ
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,បន្តការផ្ញើ
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,បើកជាថ្មី
@@ -2752,15 +2752,15 @@ DocType: Web Page,Slideshow,ការបញ្ចាំងស្លាយ
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,អាសយដ្ឋានលំនាំដើមទំព័រគំរូមិនអាចត្រូវបានលុប
 DocType: Contact,Maintenance Manager,កម្មវិធីគ្រប់គ្រងថែទាំ
 DocType: Workflow State,Search,ស្វែងរក
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ ឆ្នូតមិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ ឆ្នូតមិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ ឆ្នូតមិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ ឆ្នូតមិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ផ្លាស់ទីទៅធុងសំរាម
 DocType: Web Form,Web Form Fields,វាលសំណុំបែបបទបណ្ដាញ
 DocType: Data Import,Amended From,ធ្វើវិសោធនកម្មពី
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},ព្រមាន &amp; ‧;: មិនអាចរកឃើញ {0} ក្នុងតារាងណាមួយដែលទាក់ទងទៅនឹង {1}
 DocType: S3 Backup Settings,eu-north-1,អឺ - ខាងជើង -១
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,ឯកសារនេះត្រូវបានរៀបជាជួរសម្រាប់ការប្រតិបត្តិ។ សូមព្យាយាមម្ដងទៀត
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ឯកសារ &#39;{0} &quot;រកមិនឃើញ
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ឯកសារ '{0} &quot;រកមិនឃើញ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,យកផ្នែកទី
 DocType: User,Change Password,ផ្លាស់ប្តូរពាក្យសម្ងាត់
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,វាលអ័ក្ស X
@@ -2950,7 +2950,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,តម្លៃរ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,បន្ថែមកុមារ
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,វឌ្ឍនភាពនាំចូល។
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",ប្រសិនបើលក្ខខណ្ឌអ្នកប្រើប្រាស់ពេញចិត្តអ្នកនឹងទទួលបានរង្វាន់។ ឧ។ doc.status == &#39;បានបិទ&#39;
+",ប្រសិនបើលក្ខខណ្ឌអ្នកប្រើប្រាស់ពេញចិត្តអ្នកនឹងទទួលបានរង្វាន់។ ឧ។ doc.status == 'បានបិទ'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: កំណត់ត្រាផ្តល់ជូនមិនអាចលុបបាន។
 DocType: GSuite Templates,Template Name,ឈ្មោះពុម្ព
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ប្រភេទថ្មីមួយនៃឯកសារ
@@ -3080,7 +3080,7 @@ DocType: Dashboard Chart,Chart Type,ប្រភេទគំនូសតាង
 DocType: DocType,Auto Name,ឈ្មោះដោយស្វ័យប្រវត្តិ
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,ជៀសវាងការលំដាប់ដូច ABC ឬ 6543 ដូចដែលពួកគេគឺមានភាពងាយស្រួលក្នុងការស្មាន
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,សូមព្យាយាមម្ដងទៀត
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL ត្រូវតែចាប់ផ្តើមជាមួយ &#39;http: //&#39; ឬ &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL ត្រូវតែចាប់ផ្តើមជាមួយ 'http: //' ឬ 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,ជម្រើសទី 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,កែសម្រួល
@@ -3317,7 +3317,7 @@ DocType: Notification,Send alert if this field's value changes,ផ្ញើក�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,ពណ៌ស្បែក។
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,ជ្រើសចង្អុលបង្ហាញមួយដើម្បីធ្វើឱ្យទ្រង់ទ្រាយថ្មី
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,អ្នកប្រើមិនមានទេ។
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;អ្នកទទួល&#39; មិនបានបញ្ជាក់
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'អ្នកទទួល' មិនបានបញ្ជាក់
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,គ្រាន់តែឥឡូវនេះ
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,អនុវត្ត
 DocType: Footer Item,Policy,គោលនយោបាយ
@@ -3364,7 +3364,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,ការបក�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,ការរីកចំរើន
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,ទៅតាមតួនាទី
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,វាលបាត់ខ្លួន
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname មិនត្រឹមត្រូវ &#39;{0} &quot;នៅក្នុង autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname មិនត្រឹមត្រូវ '{0} &quot;នៅក្នុង autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ស្វែងរកក្នុងប្រភេទឯកសារ
 DocType: Custom DocPerm,Role and Level,តួនាទីនិងកំរិត
 DocType: File,Thumbnail URL,URL ដែលកូនរូបភាព
@@ -3452,7 +3452,7 @@ DocType: Dashboard Chart,Filters JSON,តម្រង JSON ។
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,សូមចុចទីនេះដើម្បីផ្ទៀងផ្ទាត់
 DocType: Email Account,Disable SMTP server authentication,បិទដំណើរការការសម្គាល់អត្តសញ្ញាណម៉ាស៊ីនមេ SMTP ។
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,បានចម្លងទៅក្តារតម្បៀតខ្ទាស់។
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ជំនួសព្យាករបានដូចជា &#39;@&#39; ជំនួសឱ្យ &quot;មួយ&quot; មិនអាចជួយបានច្រើនណាស់។
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ជំនួសព្យាករបានដូចជា '@' ជំនួសឱ្យ &quot;មួយ&quot; មិនអាចជួយបានច្រើនណាស់។
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,ដែលបានផ្ដល់ដោយខ្ញុំ
 apps/frappe/frappe/utils/data.py,Zero,សូន្យ
 DocType: Google Drive,Backup Folder ID,លេខសម្គាល់ថតឯកសារបម្រុងទុក។
@@ -3534,7 +3534,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,បានបរាជ័យក្នុងពេលកែប្រែការជាវប្រចាំ
 DocType: LDAP Settings,LDAP Group Field,អិលឌីភីក្រុមគ្រុប។
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,ស្មើ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ប្រភេទជម្រើស &#39;គេហទំព័រភ្ជាប់ជាថាមវន្ត &quot;របស់វាលត្រូវតែចង្អុលទៅវាលតំណផ្សេងទៀតជាមួយនឹងជម្រើសជា&#39; ចង្អុលបង្ហាញ&quot;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ប្រភេទជម្រើស 'គេហទំព័រភ្ជាប់ជាថាមវន្ត &quot;របស់វាលត្រូវតែចង្អុលទៅវាលតំណផ្សេងទៀតជាមួយនឹងជម្រើសជា' ចង្អុលបង្ហាញ&quot;
 DocType: About Us Settings,Team Members Heading,សមាជិកក្រុមក្បាល
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,ទ្រង់ទ្រាយជា CSV មិនត្រឹមត្រូវ
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","កំហុសក្នុងការភ្ជាប់ទៅ QZ ថាសកម្មវិធី ... <br><br> អ្នកត្រូវមានកម្មវិធីតំឡើង QZ ថាសនិងតំឡើងដើម្បីប្រើមុខងារព្រីនព្រីន។ <br><br> <a href=""https://qz.io/download/"" target=""_blank"">ចុចត្រង់នេះដើម្បីទាញយកនិងតំឡើង QZ ថាស</a> ។ <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">សូមចុចនៅទីនេះដើម្បីស្វែងយល់បន្ថែមអំពីការបោះពុម្ពឆៅ</a> ។"
@@ -3662,7 +3662,7 @@ DocType: Workflow Document State,Next Action Email Template,គំរូសក�
 DocType: Blog Category,Blogger,អ្នកសរសេរប្លុក
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline",ប្រសិនបើបានអនុញ្ញាតការផ្លាស់ប្តូរឯកសារត្រូវបានតាមដាននិងបង្ហាញនៅក្នុងពេលវេលា។
 apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},"""ស្វែងរកសកល 'មិនត្រូវបានអនុញ្ញាតសម្រាប់ប្រភេទ {0} នៅក្នុងជួរដេក {1}"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&quot;នៅក្នុងការស្វែងរកសកល &#39;មិនត្រូវបានអនុញ្ញាតសម្រាប់ប្រភេទ {0} នៅក្នុងជួរដេក {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&quot;នៅក្នុងការស្វែងរកសកល 'មិនត្រូវបានអនុញ្ញាតសម្រាប់ប្រភេទ {0} នៅក្នុងជួរដេក {1}
 DocType: Energy Point Log,Appreciation,ការកោតសរសើរ
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,ទិដ្ឋភាពបញ្ជី
 DocType: Workflow,Don't Override Status,កុំបដិសេធស្ថានភាព
@@ -3809,7 +3809,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,លំនាំដើម
 DocType: Translation,Verified,បានផ្ទៀងផ្ទាត់។
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} បានបន្ថែម
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ស្វែងរក &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ស្វែងរក '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,សូមរក្សាទុករបាយការណ៍ជាលើកដំបូង
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} អតិថិជនបន្ថែមទៀត
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,មិននៅក្នុង
@@ -3846,7 +3846,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,ខ្ញ�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} មិនមែនជារដ្ឋដែលមានសុពលភាព
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,អនុវត្តចំពោះប្រភេទឯកសារទាំងអស់។
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,ការធ្វើបច្ចុប្បន្នភាពចំណុចថាមពល។
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ បានតាមរយៈការមិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',សូមជ្រើសវិធីសាស្ត្រទូទាត់ផ្សេងទៀត។ បានតាមរយៈការមិនគាំទ្រការតិបត្តិការនៅក្នុងរូបិយប័ណ្ណ '{0}'
 DocType: Chat Message,Room Type,ប្រភេទបន្ទប់
 DocType: Data Import Beta,Import Log Preview,ការនាំចូលកំណត់ហេតុមើលជាមុន។
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,វាលស្វែងរក {0} មិនត្រឹមត្រូវ

--- a/frappe/translations/kn.csv
+++ b/frappe/translations/kn.csv
@@ -737,7 +737,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ಫೈ�
 DocType: DocField,In Global Search,ಜಾಗತಿಕ ಸರ್ಚ್
 DocType: System Settings,Brute Force Security,ಬ್ರೂಟ್ ಫೋರ್ಸ್ ಸೆಕ್ಯುರಿಟಿ
 DocType: Workflow State,indent-left,ಇಂಡೆಂಟ್ ಎಡ
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} ವರ್ಷ (ಗಳು) ಹಿಂದೆ
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} ವರ್ಷ (ಗಳು) ಹಿಂದೆ
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,ಇದು ಈ ಕಡತ ಅಳಿಸಲು ಅಪಾಯಕಾರಿ: {0}. ನಿಮ್ಮ ಸಿಸ್ಟಂ ನಿರ್ವಾಹಕರನ್ನು ಸಂಪರ್ಕಿಸಿ.
 DocType: Currency,Currency Name,CurrencyName
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ಯಾವುದೇ ಇಮೇಲ್ಗಳನ್ನು
@@ -1032,7 +1032,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,ಯಾವು�
 apps/frappe/frappe/config/customization.py,Add custom forms.,ಕಸ್ಟಮ್ ರೂಪಗಳು ಸೇರಿಸಿ.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} ನಲ್ಲಿ {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ಈ ಡಾಕ್ಯುಮೆಂಟ್ ಸಲ್ಲಿಸಿದ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,ಸೆಟಪ್&gt; ಬಳಕೆದಾರರ ಅನುಮತಿಗಳು
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,ಸೆಟಪ್> ಬಳಕೆದಾರರ ಅನುಮತಿಗಳು
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,ವ್ಯವಸ್ಥೆಯ ಅನೇಕ ಪೂರ್ವ ನಿರ್ಧಾರಿತ ಪಾತ್ರಗಳನ್ನು ಒದಗಿಸುತ್ತದೆ . ನೀವು ಸೂಕ್ಷ್ಮ ಅನುಮತಿಗಳನ್ನು ಹೊಂದಿಸಲು ಹೊಸ ಪಾತ್ರಗಳನ್ನು ಸೇರಿಸಬಹುದು.
 DocType: Communication,CC,ಸಿಸಿ
 DocType: Country,Geo,ಜಿಯೋ
@@ -1247,7 +1247,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","ಬಳಕೆದಾರ ಪರಿಶೀಲಿಸಿದ ಯಾವುದೇ ಪಾತ್ರವನ್ನು ಹೊಂದಿದೆ, ನಂತರ ಬಳಕೆದಾರರು &quot;ವ್ಯವಸ್ಥೆ ಬಳಕೆದಾರ&quot; ಆಗುತ್ತದೆ. &quot;ಸಿಸ್ಟಮ್ ಬಳಕೆದಾರ&quot; ಡೆಸ್ಕ್ಟಾಪ್ ಪ್ರವೇಶವನ್ನು ಹೊಂದಿದೆ"
 DocType: System Settings,Date and Number Format,ದಿನಾಂಕ ಮತ್ತು ಸಂಖ್ಯೆ ಸ್ವರೂಪ
 apps/frappe/frappe/model/document.py,one of,ಒಂದು
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,ಸೆಟಪ್&gt; ಫಾರ್ಮ್ ಅನ್ನು ಕಸ್ಟಮೈಸ್ ಮಾಡಿ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,ಸೆಟಪ್> ಫಾರ್ಮ್ ಅನ್ನು ಕಸ್ಟಮೈಸ್ ಮಾಡಿ
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,ಒಂದು ಕ್ಷಣ ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,ತೋರಿಸು ಟ್ಯಾಗ್ಗಳು
 DocType: DocField,HTML Editor,ಎಚ್ಟಿಎಮ್ಎಲ್ ಎಡಿಟರ್
@@ -1255,7 +1255,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,ಬಿಲ್ಲಿಂಗ್
 DocType: Email Queue,Not Sent,ಕಳುಹಿಸಲಾಗಿಲ್ಲ
 DocType: Web Form,Actions,ಕ್ರಿಯೆಗಳು
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,ಸೆಟಪ್&gt; ಬಳಕೆದಾರ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,ಸೆಟಪ್> ಬಳಕೆದಾರ
 DocType: Workflow State,align-justify,ಸಮರ್ಥಿಸಿಕೊಳ್ಳಲು align
 DocType: User,Middle Name (Optional),ಮಧ್ಯ ಹೆಸರು (ಐಚ್ಛಿಕ)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,ಅನುಮತಿಯಿಲ್ಲ
@@ -1401,7 +1401,7 @@ DocType: Report,Is Standard,ಸ್ಟ್ಯಾಂಡರ್ಡ್
 DocType: Desktop Icon,_report,_ವರದಿ
 DocType: Desktop Icon,_report,_ವರದಿ
 DocType: Dashboard Chart,Full,ಪೂರ್ಣ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",ಹಾಗೆ ಹಾಗೆ &lt;ಸ್ಕ್ರಿಪ್ಟ್&gt; ಅಥವಾ ಕೇವಲ ಅವರು ಎಂದು ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಬಳಸಲಾಗುತ್ತದೆ ನಂತಹ &lt;ಅಥವಾ&gt; ಪಾತ್ರಗಳು ಎಚ್ಟಿಎಮ್ಎಲ್ ಎನ್ಕೋಡ್ HTML ಟ್ಯಾಗ್ಗಳನ್ನು
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",ಹಾಗೆ ಹಾಗೆ &lt;ಸ್ಕ್ರಿಪ್ಟ್> ಅಥವಾ ಕೇವಲ ಅವರು ಎಂದು ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಬಳಸಲಾಗುತ್ತದೆ ನಂತಹ &lt;ಅಥವಾ> ಪಾತ್ರಗಳು ಎಚ್ಟಿಎಮ್ಎಲ್ ಎನ್ಕೋಡ್ HTML ಟ್ಯಾಗ್ಗಳನ್ನು
 DocType: Website Settings,FavIcon,ಫೆವಿಕಾನ್
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ರನ್
 DocType: Blog Post,Content (HTML),ವಿಷಯ (HTML)
@@ -1770,7 +1770,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ಅಡಿಟಿ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,ಬಾಕಿ
 DocType: System Settings,Allow only one session per user,ಬಳಕೆದಾರ ಕೇವಲ ಒಂದು ಸೆಷನ್ ಅನುಮತಿಸಿ
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ಮುಖಪುಟ / ಟೆಸ್ಟ್ ಫೋಲ್ಡರ್ 1 / ಟೆಸ್ಟ್ ಫೋಲ್ಡರ್ 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; ಎಚ್ಟಿಎಮ್ಎಲ್
+DocType: Website Settings,&lt;head> HTML,&lt;head> ಎಚ್ಟಿಎಮ್ಎಲ್
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ಆಯ್ಕೆ ಅಥವಾ ಹೊಸ ಈವೆಂಟ್ ರಚಿಸಲು ಸಮಯಾವಧಿಗಳ ಅಡ್ಡಲಾಗಿ ಎಳೆಯಿರಿ .
 DocType: Contact,Contact Details,ಸಂಪರ್ಕ ವಿವರಗಳು
 DocType: DocField,In Filter,ಶೋಧಕಗಳು ರಲ್ಲಿ
@@ -2001,7 +2001,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,ಲಾಗಿನ್ ಈ ಸಮಯದಲ್ಲಿ ಅನುಮತಿಸಲಾಗುವುದಿಲ್ಲ
 DocType: Data Migration Run,Current Mapping Action,ಪ್ರಸ್ತುತ ಮ್ಯಾಪಿಂಗ್ ಕ್ರಿಯೆ
 DocType: Dashboard Chart Source,Source Name,ಮೂಲ ಹೆಸರು
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,ಬಳಕೆದಾರರೊಂದಿಗೆ ಯಾವುದೇ ಇಮೇಲ್ ಖಾತೆ ಸಂಯೋಜಿತವಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ಬಳಕೆದಾರ&gt; ಇಮೇಲ್ ಇನ್‌ಬಾಕ್ಸ್ ಅಡಿಯಲ್ಲಿ ಖಾತೆಯನ್ನು ಸೇರಿಸಿ.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,ಬಳಕೆದಾರರೊಂದಿಗೆ ಯಾವುದೇ ಇಮೇಲ್ ಖಾತೆ ಸಂಯೋಜಿತವಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ಬಳಕೆದಾರ> ಇಮೇಲ್ ಇನ್‌ಬಾಕ್ಸ್ ಅಡಿಯಲ್ಲಿ ಖಾತೆಯನ್ನು ಸೇರಿಸಿ.
 DocType: Email Account,Email Sync Option,ಇಮೇಲ್ ಸಿಂಕ್ ಆಯ್ಕೆ
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,ಸಾಲು ಇಲ್ಲ
 DocType: Async Task,Runtime,ಚಾಲನಾಸಮಯ
@@ -2016,7 +2016,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ಈಗಾ
 DocType: User Email,Enable Outgoing,ಹೊರಹೋಗುವ ಸಕ್ರಿಯಗೊಳಿಸಿ
 DocType: Address,Fax,ಫ್ಯಾಕ್ಸ್
 apps/frappe/frappe/config/customization.py,Custom Tags,ಕಸ್ಟಮ್ ಟ್ಯಾಗ್ಗಳು
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ಇಮೇಲ್ ಖಾತೆಯನ್ನು ಹೊಂದಿಸಲಾಗಿಲ್ಲ. ಸೆಟಪ್&gt; ಇಮೇಲ್&gt; ಇಮೇಲ್ ಖಾತೆಯಿಂದ ದಯವಿಟ್ಟು ಹೊಸ ಇಮೇಲ್ ಖಾತೆಯನ್ನು ರಚಿಸಿ
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ಇಮೇಲ್ ಖಾತೆಯನ್ನು ಹೊಂದಿಸಲಾಗಿಲ್ಲ. ಸೆಟಪ್> ಇಮೇಲ್> ಇಮೇಲ್ ಖಾತೆಯಿಂದ ದಯವಿಟ್ಟು ಹೊಸ ಇಮೇಲ್ ಖಾತೆಯನ್ನು ರಚಿಸಿ
 DocType: Comment,Submitted,ಒಪ್ಪಿಸಿದ
 DocType: Contact,Pulled from Google Contacts,Google ಸಂಪರ್ಕಗಳಿಂದ ಎಳೆಯಲಾಗಿದೆ
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,ಅಮಾನ್ಯ ವಿನಂತಿ
@@ -2089,7 +2089,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ಗಂಟೆಗಳ �
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",ಇಲ್ಲಿ ವ್ಯಾಖ್ಯಾನಿಸಲಾಗಿದೆ FIELDNAME ಮೌಲ್ಯವನ್ನು ಹೊಂದಿದೆ ಮಾತ್ರ ಅಥವಾ ನಿಯಮಗಳನ್ನು ನೈಜ (ಉದಾಹರಣೆಗಳು) ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಕಾಣಿಸುತ್ತದೆ: myfield eval: doc.myfield == &#39;ನನ್ನ ಮೌಲ್ಯ&#39; eval: doc.age&gt; 18
+eval:doc.age>18",ಇಲ್ಲಿ ವ್ಯಾಖ್ಯಾನಿಸಲಾಗಿದೆ FIELDNAME ಮೌಲ್ಯವನ್ನು ಹೊಂದಿದೆ ಮಾತ್ರ ಅಥವಾ ನಿಯಮಗಳನ್ನು ನೈಜ (ಉದಾಹರಣೆಗಳು) ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಕಾಣಿಸುತ್ತದೆ: myfield eval: doc.myfield == &#39;ನನ್ನ ಮೌಲ್ಯ&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,ಕಚೇರಿ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ಇಂದು
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ಇಂದು
@@ -2104,7 +2104,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ಅಪ್ಪರ್ ಕೇಸ್
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,ಕಸ್ಟಮ್ HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ನಿರ್ದೇಶಿಕೆಯಹೆಸರನ್ನುನಮೂದಿಸಿ
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,ಡೀಫಾಲ್ಟ್ ವಿಳಾಸ ಟೆಂಪ್ಲೇಟ್ ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಸೆಟಪ್&gt; ಪ್ರಿಂಟಿಂಗ್ ಮತ್ತು ಬ್ರ್ಯಾಂಡಿಂಗ್&gt; ವಿಳಾಸ ಟೆಂಪ್ಲೇಟ್‌ನಿಂದ ಹೊಸದನ್ನು ರಚಿಸಿ.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,ಡೀಫಾಲ್ಟ್ ವಿಳಾಸ ಟೆಂಪ್ಲೇಟ್ ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಸೆಟಪ್> ಪ್ರಿಂಟಿಂಗ್ ಮತ್ತು ಬ್ರ್ಯಾಂಡಿಂಗ್> ವಿಳಾಸ ಟೆಂಪ್ಲೇಟ್‌ನಿಂದ ಹೊಸದನ್ನು ರಚಿಸಿ.
 apps/frappe/frappe/auth.py,Unknown User,ಅಜ್ಞಾತ ಬಳಕೆದಾರ
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,ಆಯ್ಕೆ ಪಾತ್ರ
 DocType: Comment,Deleted,ಅಳಿಸಲಾಗಿದೆ
@@ -2290,7 +2290,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ಕೊಂಡಿಗಳು ನೋಡಲು ಸಾಕಷ್ಟು ಅನುಮತಿಯನ್ನು
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ವಿಳಾಸ ಶೀರ್ಷಿಕೆ ಕಡ್ಡಾಯ.
 DocType: Google Contacts,Push to Google Contacts,Google ಸಂಪರ್ಕಗಳಿಗೆ ತಳ್ಳಿರಿ
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",&lt;Head&gt; ಸೇರಿಸಲಾಗಿದೆ HTML ವೆಬ್ ಪುಟ ಸೆಕ್ಷನ್ ಪ್ರಾಥಮಿಕವಾಗಿ ವೆಬ್ಸೈಟ್ ಪರಿಶೀಲನೆ ಮತ್ತು ಎಸ್ಇಒ ಬಳಸಲಾಗುತ್ತದೆ
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> ಸೇರಿಸಲಾಗಿದೆ HTML ವೆಬ್ ಪುಟ ಸೆಕ್ಷನ್ ಪ್ರಾಥಮಿಕವಾಗಿ ವೆಬ್ಸೈಟ್ ಪರಿಶೀಲನೆ ಮತ್ತು ಎಸ್ಇಒ ಬಳಸಲಾಗುತ್ತದೆ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ಮರುಕಳಿಸಿತ್ತು
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ಐಟಂ ತನ್ನದೇ ಸಂತತಿಯವರು ಸೇರಿಸಲಾಗಿದೆ ಸಾಧ್ಯವಿಲ್ಲ
 DocType: Session Default Settings,Session Defaults,ಸೆಷನ್ ಡೀಫಾಲ್ಟ್‌ಗಳು
@@ -2407,7 +2407,7 @@ DocType: Workflow State,Warning,ಎಚ್ಚರಿಕೆ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ಇದನ್ನು ಬಹು ಪುಟಗಳಲ್ಲಿ ಮುದ್ರಿಸಬಹುದು
 DocType: Data Migration Run,Percent Complete,ಪೂರ್ಣಗೊಂಡ ಶೇಕಡಾ
 DocType: Tag Category,Tag Category,ಟ್ಯಾಗ್ ವರ್ಗ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ಹೋಲಿಕೆಗಾಗಿ,&gt; 5, &lt;10 ಅಥವಾ = 324 ಬಳಸಿ. ಶ್ರೇಣಿಗಳಿಗಾಗಿ, 5:10 ಬಳಸಿ (5 ಮತ್ತು 10 ರ ನಡುವಿನ ಮೌಲ್ಯಗಳಿಗೆ)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ಹೋಲಿಕೆಗಾಗಿ,> 5, &lt;10 ಅಥವಾ = 324 ಬಳಸಿ. ಶ್ರೇಣಿಗಳಿಗಾಗಿ, 5:10 ಬಳಸಿ (5 ಮತ್ತು 10 ರ ನಡುವಿನ ಮೌಲ್ಯಗಳಿಗೆ)."
 DocType: Google Calendar,Pull from Google Calendar,Google ಕ್ಯಾಲೆಂಡರ್‌ನಿಂದ ಎಳೆಯಿರಿ
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ಸಹಾಯ
 DocType: User,Login Before,ಮೊದಲು ಲಾಗಿನ್ ಆಗಿ
@@ -2865,14 +2865,14 @@ DocType: Custom Script,Custom Script,ಕಸ್ಟಮ್ ಲಿಪಿ
 DocType: Address,Address Line 2,ಲೈನ್ 2 ವಿಳಾಸ
 DocType: Address,Reference,ರೆಫರೆನ್ಸ್
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,ನಿಯೋಜಿಸಲಾಗಿದೆ
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,ದಯವಿಟ್ಟು ಸೆಟಪ್&gt; ಇಮೇಲ್&gt; ಇಮೇಲ್ ಖಾತೆಯಿಂದ ಡೀಫಾಲ್ಟ್ ಇಮೇಲ್ ಖಾತೆಯನ್ನು ಹೊಂದಿಸಿ
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,ದಯವಿಟ್ಟು ಸೆಟಪ್> ಇಮೇಲ್> ಇಮೇಲ್ ಖಾತೆಯಿಂದ ಡೀಫಾಲ್ಟ್ ಇಮೇಲ್ ಖಾತೆಯನ್ನು ಹೊಂದಿಸಿ
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ಡೇಟಾ ವಲಸೆ ಮ್ಯಾಪಿಂಗ್ ವಿವರ
 DocType: Data Import,Action,ಕ್ರಿಯೆ
 DocType: GSuite Settings,Script URL,ಸ್ಕ್ರಿಪ್ಟ್ URL
 apps/frappe/frappe/www/update-password.html,Please enter the password,ಪಾಸ್ವರ್ಡ್ ನಮೂದಿಸಿ
 apps/frappe/frappe/www/printview.py,Not allowed to print cancelled documents,ಮಾಡಿರುವುದಿಲ್ಲ ರದ್ದು ದಾಖಲೆಗಳನ್ನು ಮುದ್ರಿಸಲು ಅವಕಾಶ
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,ನೀವು ಕಾಲಮ್ಗಳನ್ನು ರಚಿಸಲು ಅನುಮತಿ ಇಲ್ಲ
-DocType: Data Import,If you don't want to create any new records while updating the older records.,ಹಳೆಯ ದಾಖಲೆಗಳನ್ನು ನವೀಕರಿಸುವಾಗ ನೀವು ಯಾವುದೇ ಹೊಸ ದಾಖಲೆಗಳನ್ನು ರಚಿಸಲು ಬಯಸದಿದ್ದರೆ.
+DocType: Data Import,If you don't want to create any new records while updating the older records.,ಹಳೆಯ ದಾಖಲೆಗಳನ್ನು ನವೀಕರಿಸುವ���ಗ ನೀವು ಯಾವುದೇ ಹೊಸ ದಾಖಲೆಗಳನ್ನು ರಚಿಸಲು ಬಯಸದಿದ್ದರೆ.
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Info:,ಮಾಹಿತಿ:
 DocType: Custom Field,Permission Level,ಅನುಮತಿ ಮಟ್ಟ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Cannot set Submit, Cancel, Amend without Write","{0} : ಬರೆಯಿರಿ ಇಲ್ಲದೆ ಮಾಡಿರಿ , ರದ್ದು , ಸಲ್ಲಿಸಿ ಹೊಂದಿಸಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ"
@@ -3040,7 +3040,7 @@ DocType: DocField,Allow on Submit,ಸಲ್ಲಿಸಿ ಮೇಲೆ ಅನ�
 DocType: DocField,HTML,ಎಚ್ಟಿಎಮ್ಎಲ್
 DocType: Error Snapshot,Exception Type,ಎಕ್ಸೆಪ್ಶನ್
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,ಕಾಲಮ್ಗಳು ಆರಿಸಿ
-DocType: Web Page,Add code as &lt;script&gt;,<script> ಮಾಹಿತಿ ಕೋಡ್ ಸೇರಿಸಿ
+DocType: Web Page,Add code as &lt;script>,<script> ಮಾಹಿತಿ ಕೋಡ್ ಸೇರಿಸಿ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ಬಳಕೆದಾರರ ಅನುಮತಿಗಳನ್ನು ತೆರವುಗೊಳಿಸಿ
 DocType: Webhook,Headers,ಶೀರ್ಷಿಕೆಗಳು
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ಮುಂಬರುವ ಕಾರ್ಯಕ್ರಮಗಳು
@@ -3409,15 +3409,15 @@ DocType: Workflow State,share-alt,ಷೇರು ಹಳೆಯ
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ಕ್ಯೂ ಒಂದು ಆಗಿರಬೇಕು {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> ಡೀಫಾಲ್ಟ್ ಟೆಂಪ್ಲೇಟು </ H4> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> ಜಿಂಜ Templating </a> ಮತ್ತು ವಿಳಾಸ ಎಲ್ಲಾ ಜಾಗ (ಉಪಯೋಗಗಳು {; ಬಿಆರ್; & gt; 
  {% ವೇಳೆ address_line2%} {{address_line2}} & lt; br & gt ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ಸ್ ಯಾವುದಾದರೂ ಇದ್ದರೆ) </ p> 

--- a/frappe/translations/kn.csv
+++ b/frappe/translations/kn.csv
@@ -1401,7 +1401,7 @@ DocType: Report,Is Standard,ಸ್ಟ್ಯಾಂಡರ್ಡ್
 DocType: Desktop Icon,_report,_ವರದಿ
 DocType: Desktop Icon,_report,_ವರದಿ
 DocType: Dashboard Chart,Full,ಪೂರ್ಣ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",ಹಾಗೆ ಹಾಗೆ &lt;ಸ್ಕ್ರಿಪ್ಟ್> ಅಥವಾ ಕೇವಲ ಅವರು ಎಂದು ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಬಳಸಲಾಗುತ್ತದೆ ನಂತಹ &lt;ಅಥವಾ> ಪಾತ್ರಗಳು ಎಚ್ಟಿಎಮ್ಎಲ್ ಎನ್ಕೋಡ್ HTML ಟ್ಯಾಗ್ಗಳನ್ನು
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",ಹಾಗೆ ಹಾಗೆ <ಸ್ಕ್ರಿಪ್ಟ್> ಅಥವಾ ಕೇವಲ ಅವರು ಎಂದು ಉದ್ದೇಶಪೂರ್ವಕವಾಗಿ ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಬಳಸಲಾಗುತ್ತದೆ ನಂತಹ <ಅಥವಾ> ಪಾತ್ರಗಳು ಎಚ್ಟಿಎಮ್ಎಲ್ ಎನ್ಕೋಡ್ HTML ಟ್ಯಾಗ್ಗಳನ್ನು
 DocType: Website Settings,FavIcon,ಫೆವಿಕಾನ್
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ರನ್
 DocType: Blog Post,Content (HTML),ವಿಷಯ (HTML)
@@ -1770,7 +1770,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ಅಡಿಟಿ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,ಬಾಕಿ
 DocType: System Settings,Allow only one session per user,ಬಳಕೆದಾರ ಕೇವಲ ಒಂದು ಸೆಷನ್ ಅನುಮತಿಸಿ
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ಮುಖಪುಟ / ಟೆಸ್ಟ್ ಫೋಲ್ಡರ್ 1 / ಟೆಸ್ಟ್ ಫೋಲ್ಡರ್ 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> ಎಚ್ಟಿಎಮ್ಎಲ್
+DocType: Website Settings,<head> HTML,<head> ಎಚ್ಟಿಎಮ್ಎಲ್
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ಆಯ್ಕೆ ಅಥವಾ ಹೊಸ ಈವೆಂಟ್ ರಚಿಸಲು ಸಮಯಾವಧಿಗಳ ಅಡ್ಡಲಾಗಿ ಎಳೆಯಿರಿ .
 DocType: Contact,Contact Details,ಸಂಪರ್ಕ ವಿವರಗಳು
 DocType: DocField,In Filter,ಶೋಧಕಗಳು ರಲ್ಲಿ
@@ -2290,7 +2290,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ಕೊಂಡಿಗಳು ನೋಡಲು ಸಾಕಷ್ಟು ಅನುಮತಿಯನ್ನು
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ವಿಳಾಸ ಶೀರ್ಷಿಕೆ ಕಡ್ಡಾಯ.
 DocType: Google Contacts,Push to Google Contacts,Google ಸಂಪರ್ಕಗಳಿಗೆ ತಳ್ಳಿರಿ
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> ಸೇರಿಸಲಾಗಿದೆ HTML ವೆಬ್ ಪುಟ ಸೆಕ್ಷನ್ ಪ್ರಾಥಮಿಕವಾಗಿ ವೆಬ್ಸೈಟ್ ಪರಿಶೀಲನೆ ಮತ್ತು ಎಸ್ಇಒ ಬಳಸಲಾಗುತ್ತದೆ
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",<Head> ಸೇರಿಸಲಾಗಿದೆ HTML ವೆಬ್ ಪುಟ ಸೆಕ್ಷನ್ ಪ್ರಾಥಮಿಕವಾಗಿ ವೆಬ್ಸೈಟ್ ಪರಿಶೀಲನೆ ಮತ್ತು ಎಸ್ಇಒ ಬಳಸಲಾಗುತ್ತದೆ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ಮರುಕಳಿಸಿತ್ತು
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ಐಟಂ ತನ್ನದೇ ಸಂತತಿಯವರು ಸೇರಿಸಲಾಗಿದೆ ಸಾಧ್ಯವಿಲ್ಲ
 DocType: Session Default Settings,Session Defaults,ಸೆಷನ್ ಡೀಫಾಲ್ಟ್‌ಗಳು
@@ -2407,7 +2407,7 @@ DocType: Workflow State,Warning,ಎಚ್ಚರಿಕೆ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ಇದನ್ನು ಬಹು ಪುಟಗಳಲ್ಲಿ ಮುದ್ರಿಸಬಹುದು
 DocType: Data Migration Run,Percent Complete,ಪೂರ್ಣಗೊಂಡ ಶೇಕಡಾ
 DocType: Tag Category,Tag Category,ಟ್ಯಾಗ್ ವರ್ಗ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ಹೋಲಿಕೆಗಾಗಿ,> 5, &lt;10 ಅಥವಾ = 324 ಬಳಸಿ. ಶ್ರೇಣಿಗಳಿಗಾಗಿ, 5:10 ಬಳಸಿ (5 ಮತ್ತು 10 ರ ನಡುವಿನ ಮೌಲ್ಯಗಳಿಗೆ)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ಹೋಲಿಕೆಗಾಗಿ,> 5, <10 ಅಥವಾ = 324 ಬಳಸಿ. ಶ್ರೇಣಿಗಳಿಗಾಗಿ, 5:10 ಬಳಸಿ (5 ಮತ್ತು 10 ರ ನಡುವಿನ ಮೌಲ್ಯಗಳಿಗೆ)."
 DocType: Google Calendar,Pull from Google Calendar,Google ಕ್ಯಾಲೆಂಡರ್‌ನಿಂದ ಎಳೆಯಿರಿ
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ಸಹಾಯ
 DocType: User,Login Before,ಮೊದಲು ಲಾಗಿನ್ ಆಗಿ
@@ -3040,7 +3040,7 @@ DocType: DocField,Allow on Submit,ಸಲ್ಲಿಸಿ ಮೇಲೆ ಅನ�
 DocType: DocField,HTML,ಎಚ್ಟಿಎಮ್ಎಲ್
 DocType: Error Snapshot,Exception Type,ಎಕ್ಸೆಪ್ಶನ್
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,ಕಾಲಮ್ಗಳು ಆರಿಸಿ
-DocType: Web Page,Add code as &lt;script>,<script> ಮಾಹಿತಿ ಕೋಡ್ ಸೇರಿಸಿ
+DocType: Web Page,Add code as <script>,<script> ಮಾಹಿತಿ ಕೋಡ್ ಸೇರಿಸಿ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ಬಳಕೆದಾರರ ಅನುಮತಿಗಳನ್ನು ತೆರವುಗೊಳಿಸಿ
 DocType: Webhook,Headers,ಶೀರ್ಷಿಕೆಗಳು
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ಮುಂಬರುವ ಕಾರ್ಯಕ್ರಮಗಳು
@@ -3409,26 +3409,26 @@ DocType: Workflow State,share-alt,ಷೇರು ಹಳೆಯ
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ಕ್ಯೂ ಒಂದು ಆಗಿರಬೇಕು {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> ಡೀಫಾಲ್ಟ್ ಟೆಂಪ್ಲೇಟು </ H4> 
- <p> <a href=""http://jinja.pocoo.org/docs/templates/""> ಜಿಂಜ Templating </a> ಮತ್ತು ವಿಳಾಸ ಎಲ್ಲಾ ಜಾಗ (ಉಪಯೋಗಗಳು {; ಬಿಆರ್; & gt; 
- {% ವೇಳೆ address_line2%} {{address_line2}} & lt; br & gt ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ಸ್ ಯಾವುದಾದರೂ ಇದ್ದರೆ) </ p> 
+ <p> <a href=""http://jinja.pocoo.org/docs/templates/""> ಜಿಂಜ Templating </a> ಮತ್ತು ವಿಳಾಸ ಎಲ್ಲಾ ಜಾಗ (ಉಪಯೋಗಗಳು {; ಬಿಆರ್;> 
+ {% ವೇಳೆ address_line2%} {{address_line2}} <br & gt ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ಸ್ ಯಾವುದಾದರೂ ಇದ್ದರೆ) </ p> 
  <pre> <ಕೋಡ್> {{address_line1}} & lt ಲಭ್ಯವಾಗುತ್ತದೆ ಸೇರಿದಂತೆ % endif -%} 
- {{ನಗರದ}} & lt; br & gt; 
- {% ವೇಳೆ ರಾಜ್ಯದ%} {{ರಾಜ್ಯದ}} & lt; br & gt; {% endif -%} 
- {% ವೇಳೆ ಪಿನ್%} ಪಿನ್: {{ಪಿನ್}} & lt; br & gt; {% endif -%} 
- {{ದೇಶದ}} & lt; br & gt; 
- {% ವೇಳೆ ಫೋನ್%} ದೂರವಾಣಿ: {{ಫೋನ್}} & lt; br & gt; { % endif -%} 
- {% ವೇಳೆ ಫ್ಯಾಕ್ಸ್%} ಫ್ಯಾಕ್ಸ್: {{ಫ್ಯಾಕ್ಸ್}} & lt; br & gt; {% endif -%} 
- {% ವೇಳೆ email_id%} ಇಮೇಲ್: {{email_id}} & lt; br & gt {% endif -%} 
+ {{ನಗರದ}} <br> 
+ {% ವೇಳೆ ರಾಜ್ಯದ%} {{ರಾಜ್ಯದ}} <br> {% endif -%} 
+ {% ವೇಳೆ ಪಿನ್%} ಪಿನ್: {{ಪಿನ್}} <br> {% endif -%} 
+ {{ದೇಶದ}} <br> 
+ {% ವೇಳೆ ಫೋನ್%} ದೂರವಾಣಿ: {{ಫೋನ್}} <br> { % endif -%} 
+ {% ವೇಳೆ ಫ್ಯಾಕ್ಸ್%} ಫ್ಯಾಕ್ಸ್: {{ಫ್ಯಾಕ್ಸ್}} <br> {% endif -%} 
+ {% ವೇಳೆ email_id%} ಇಮೇಲ್: {{email_id}} <br & gt {% endif -%} 
  </ code> </ ಪೂರ್ವ>"
 DocType: Calendar View,Start Date Field,ಪ್ರಾರಂಭ ದಿನಾಂಕ ಕ್ಷೇತ್ರ
 DocType: Role,Role Name,ಪಾತ್ರ ಹೆಸರು

--- a/frappe/translations/kn.csv
+++ b/frappe/translations/kn.csv
@@ -553,7 +553,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,ಅಪ್ಲೋಡ್ ವಿಫಲವಾಗಿದೆ
 DocType: LDAP Settings,LDAP Phone Field,LDAP ಫೋನ್ ಕ್ಷೇತ್ರ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","ದಾಖಲೆ ಪ್ರಕಾರ ..., ಉದಾ ಗ್ರಾಹಕ"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,ಕಂಡಿಶನ್ &#39;{0}&#39; ಅಮಾನ್ಯವಾಗಿದೆ
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,ಕಂಡಿಶನ್ '{0}' ಅಮಾನ್ಯವಾಗಿದೆ
 DocType: Workflow State,barcode,ಬಾರ್ಕೋಡ್
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,ಉಪ-ಪ್ರಶ್ನೆ ಅಥವಾ ಕ್ರಿಯೆಯ ಬಳಕೆಯನ್ನು ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ
 apps/frappe/frappe/config/customization.py,Add your own translations,ನಿಮ್ಮ ಸ್ವಂತ ಅನುವಾದಗಳು ಸೇರಿಸಬಹುದು
@@ -701,7 +701,7 @@ DocType: Slack Webhook URL,Webhook URL,ವೆಬ್ಹುಕ್ URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,ಬಳಕೆದಾರ ಹೆಸರು {0} ಈಗಾಗಲೇ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0} : {1} importable ಅಲ್ಲ ಆಮದು ಹೊಂದಿಸಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},ನಿಮ್ಮ ವಿಳಾಸ ಟೆಂಪ್ಲೇಟು ದೋಷ {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} &#39;ಸ್ವೀಕರಿಸುವವರಲ್ಲಿ&#39; ಅಮಾನ್ಯ ಇಮೇಲ್ ವಿಳಾಸವಾಗಿದೆ
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} 'ಸ್ವೀಕರಿಸುವವರಲ್ಲಿ' ಅಮಾನ್ಯ ಇಮೇಲ್ ವಿಳಾಸವಾಗಿದೆ
 DocType: Footer Item,"target = ""_blank""","ಗುರಿ = ""_blank"""
 DocType: Workflow State,hdd,ಎಚ್ಡಿಡಿ
 DocType: Integration Request,Host,ಹೋಸ್ಟ್
@@ -743,7 +743,7 @@ DocType: Currency,Currency Name,CurrencyName
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ಯಾವುದೇ ಇಮೇಲ್ಗಳನ್ನು
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,ಲಿಂಕ್ ಮುಕ್ತಾಯಗೊಂಡಿದೆ
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; ನಲ್ಲಿ &#39;{1}&#39; ಗೆ {0} ಉದ್ದವನ್ನು ಹಿಂತಿರುಗಿಸುತ್ತದೆ; ಉದ್ದವನ್ನು {3} ಎಂದು ಹೊಂದಿಸುವುದು ಡೇಟಾದ ಮೊಟಕುಗೊಳಿಸುವಿಕೆಗೆ ಕಾರಣವಾಗುತ್ತದೆ.
+							Setting the length as {3} will cause truncation of data.",'{2}' ನಲ್ಲಿ '{1}' ಗೆ {0} ಉದ್ದವನ್ನು ಹಿಂತಿರುಗಿಸುತ್ತದೆ; ಉದ್ದವನ್ನು {3} ಎಂದು ಹೊಂದಿಸುವುದು ಡೇಟಾದ ಮೊಟಕುಗೊಳಿಸುವಿಕೆಗೆ ಕಾರಣವಾಗುತ್ತದೆ.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,ಫೈಲ್ ಫಾರ್ಮ್ಯಾಟ್ ಆಯ್ಕೆಮಾಡಿ
 DocType: Report,Javascript,ಜಾವಾಸ್ಕ್ರಿಪ್ಟ್
 DocType: File,Content Hash,ವಿಷಯ ಹ್ಯಾಷ್
@@ -765,7 +765,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,ಡಾಕ್ಯುಮೆಂಟ್ ಪಾಲಿನ ವರದಿಯು
 DocType: Social Login Key,Base URL,ಮೂಲ URL
 DocType: User,Last Login,ಕೊನೆಯ ಲಾಗಿನ್
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ನೀವು ಕ್ಷೇತ್ರಕ್ಕೆ &#39;ಅನುವಾದಿಸಬಹುದಾದ&#39; ಅನ್ನು ಹೊಂದಿಸಲಾಗುವುದಿಲ್ಲ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ನೀವು ಕ್ಷೇತ್ರಕ್ಕೆ 'ಅನುವಾದಿಸಬಹುದಾದ' ಅನ್ನು ಹೊಂದಿಸಲಾಗುವುದಿಲ್ಲ {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,ಅಂಕಣ
 DocType: Chat Profile,Chat Profile,ಚಾಟ್ ಪ್ರೊಫೈಲ್
 DocType: Custom Field,Adds a custom field to a DocType,ಒಂದು DOCTYPE ಕಸ್ಟಮ್ ಕ್ಷೇತ್ರ ಸೇರಿಸುತ್ತದೆ
@@ -774,7 +774,7 @@ DocType: File,Is Home Folder,ಮುಖಪುಟ ಫೋಲ್ಡರ್
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,ನವ್ಬಾರ್ ಶೈಲಿ
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ಮಾನ್ಯ ಇಮೇಲ್ ವಿಳಾಸ ಅಲ್ಲ
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,ಮುದ್ರಣಕ್ಕೆ ಕನಿಷ್ಠ 1 ದಾಖಲೆ ಆಯ್ಕೆಮಾಡಿ
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ಬಳಕೆದಾರ &#39;{0}&#39; ಈಗಾಗಲೇ ಪಾತ್ರವನ್ನು ಹೊಂದಿದೆ &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ಬಳಕೆದಾರ '{0}' ಈಗಾಗಲೇ ಪಾತ್ರವನ್ನು ಹೊಂದಿದೆ '{1}'
 DocType: System Settings,Two Factor Authentication method,ಎರಡು ಫ್ಯಾಕ್ಟರ್ ದೃಢೀಕರಣ ವಿಧಾನ
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,ಮೊದಲ ಹೆಸರನ್ನು ಹೊಂದಿಸಿ ಮತ್ತು ದಾಖಲೆಯನ್ನು ಉಳಿಸಿ.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 ದಾಖಲೆಗಳು
@@ -1430,7 +1430,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,ಕಡ್ಡಾಯ: ಸೆಟ್ ಪಾತ್ರ
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} ಟೀಕಿಸಿದ್ದಾರೆ {1}
 DocType: Data Migration Mapping,Mapping Name,ಮ್ಯಾಪಿಂಗ್ ಹೆಸರು
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: &#39;{1}&#39; ಕ್ಷೇತ್ರವು ಅನನ್ಯವಲ್ಲದ ಮೌಲ್ಯಗಳನ್ನು ಹೊಂದಿರುವುದರಿಂದ ಅದನ್ನು ವಿಶಿಷ್ಟ ಎಂದು ಹೊಂದಿಸಲಾಗುವುದಿಲ್ಲ
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: '{1}' ಕ್ಷೇತ್ರವು ಅನನ್ಯವಲ್ಲದ ಮೌಲ್ಯಗಳನ್ನು ಹೊಂದಿರುವುದರಿಂದ ಅದನ್ನು ವಿಶಿಷ್ಟ ಎಂದು ಹೊಂದಿಸಲಾಗುವುದಿಲ್ಲ
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,ಪಟ್ಟಿಯನ್ನು ಕೆಳಗೆ ನ್ಯಾವಿಗೇಟ್ ಮಾಡಿ
 DocType: Currency,A symbol for this currency. For e.g. $,ಈ ಕರೆನ್ಸಿ ಒಂದು ಸಂಕೇತ. ಇ ಜಿ ಫಾರ್ $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,ಅನುವಾದಗಳನ್ನು ಯಶಸ್ವಿಯಾಗಿ ನವೀಕರಿಸಲಾಗಿದೆ
@@ -1940,7 +1940,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-ಆಗ್ನೇಯ -1
 DocType: DocType,"Must be of type ""Attach Image""",ಮಾದರಿ ಇರಬೇಕು &quot;ಚಿತ್ರ ಲಗತ್ತಿಸಿ&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,ಆಯ್ಕೆ ಮಾಡದ ಎಲ್ಲಾ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ನೀವು ಕ್ಷೇತ್ರಕ್ಕೆ ಹೊಂದಿಸದೆ ಅಲ್ಲ &#39;ಓದಲು ಮಾತ್ರ&#39; ಮಾಡಬಹುದು {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ನೀವು ಕ್ಷೇತ್ರಕ್ಕೆ ಹೊಂದಿಸದೆ ಅಲ್ಲ 'ಓದಲು ಮಾತ್ರ' ಮಾಡಬಹುದು {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,ಶೂನ್ಯ ದಾಖಲೆಗಳನ್ನು ಯಾವ ಸಮಯದಲ್ಲಾದರೂ ಅಪ್ಡೇಟ್ಗೊಳಿಸಲಾಗಿದೆ ಕಳುಹಿಸಿ ಅರ್ಥ
 DocType: Auto Email Report,Zero means send records updated at anytime,ಶೂನ್ಯ ದಾಖಲೆಗಳನ್ನು ಯಾವ ಸಮಯದಲ್ಲಾದರೂ ಅಪ್ಡೇಟ್ಗೊಳಿಸಲಾಗಿದೆ ಕಳುಹಿಸಿ ಅರ್ಥ
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,ಕಂಪ್ಲೀಟ್ ಸೆಟಪ್
@@ -1984,7 +1984,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,ಗೂಗಲ್ ಫಾಂಟ್
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","ಸಂಶ್ಲೇಷಣೆ ಸೂಚನೆಗಳನ್ನು ಅಲ್ಲಿ ಉಪಯುಕ್ತ ಅಲ್ಲ, GitHub ಸಮಸ್ಯೆಗಳು ನಿಮ್ಮ ಸಲಹೆಗಳನ್ನು ಸೇರಿಸಿ ದಯವಿಟ್ಟು ."
 DocType: Workflow State,bookmark,ಓದು - ಗುರುತು
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ಫೋಲ್ಡರ್ ಹೆಸರು ಒಳಗೊಂಡಿರಬೇಕು &#39;/&#39; (ಕಡಿದು)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ಫೋಲ್ಡರ್ ಹೆಸರು ಒಳಗೊಂಡಿರಬೇಕು '/' (ಕಡಿದು)
 DocType: Note,Note,ನೋಡು
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,ದೋಷ ವರದಿ
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel ಸ್ವರೂಪದಲ್ಲಿ ಡೇಟಾವನ್ನು ರಫ್ತು ಮಾಡಿ.
@@ -2089,7 +2089,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ಗಂಟೆಗಳ �
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",ಇಲ್ಲಿ ವ್ಯಾಖ್ಯಾನಿಸಲಾಗಿದೆ FIELDNAME ಮೌಲ್ಯವನ್ನು ಹೊಂದಿದೆ ಮಾತ್ರ ಅಥವಾ ನಿಯಮಗಳನ್ನು ನೈಜ (ಉದಾಹರಣೆಗಳು) ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಕಾಣಿಸುತ್ತದೆ: myfield eval: doc.myfield == &#39;ನನ್ನ ಮೌಲ್ಯ&#39; eval: doc.age> 18
+eval:doc.age>18",ಇಲ್ಲಿ ವ್ಯಾಖ್ಯಾನಿಸಲಾಗಿದೆ FIELDNAME ಮೌಲ್ಯವನ್ನು ಹೊಂದಿದೆ ಮಾತ್ರ ಅಥವಾ ನಿಯಮಗಳನ್ನು ನೈಜ (ಉದಾಹರಣೆಗಳು) ಈ ಕ್ಷೇತ್ರದಲ್ಲಿ ಕಾಣಿಸುತ್ತದೆ: myfield eval: doc.myfield == 'ನನ್ನ ಮೌಲ್ಯ' eval: doc.age> 18
 DocType: Social Login Key,Office 365,ಕಚೇರಿ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ಇಂದು
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ಇಂದು
@@ -2129,7 +2129,7 @@ DocType: Data Migration Connector,Database Name,ಡೇಟಾಬೇಸ್ ಹೆ�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,ರಿಫ್ರೆಶ್ ಫಾರ್ಮ್
 DocType: DocField,Select,ಆರಿಸು
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,ಪೂರ್ಣ ಲಾಗ್ ವೀಕ್ಷಿಸಿ
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ಸರಳ ಪೈಥಾನ್ ಅಭಿವ್ಯಕ್ತಿ, ಉದಾಹರಣೆ: ಸ್ಥಿತಿ == &#39;ತೆರೆಯಿರಿ&#39; ಮತ್ತು == &#39;ದೋಷ&#39; ಎಂದು ಟೈಪ್ ಮಾಡಿ"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ಸರಳ ಪೈಥಾನ್ ಅಭಿವ್ಯಕ್ತಿ, ಉದಾಹರಣೆ: ಸ್ಥಿತಿ == 'ತೆರೆಯಿರಿ' ಮತ್ತು == 'ದೋಷ' ಎಂದು ಟೈಪ್ ಮಾಡಿ"
 apps/frappe/frappe/utils/csvutils.py,File not attached,ಫೈಲ್ ಲಗತ್ತಿಸಲಾದ
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,ಸಂಪರ್ಕ ಕಳೆದುಹೋಗಿದೆ. ಕೆಲವು ವೈಶಿಷ್ಟ್ಯಗಳು ಕಾರ್ಯನಿರ್ವಹಿಸದೇ ಇರಬಹುದು.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; ನಂತಹ ಪುನರಾವರ್ತನೆಗಳು ಊಹಿಸುವುದು ಸುಲಭ
@@ -2258,7 +2258,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,ದೋಷಗಳನ್ನು ಮಾತ್ರ ತೋರಿಸು
 DocType: Website Settings,Banner HTML,ಬ್ಯಾನರ್ ಎಚ್ಟಿಎಮ್ಎಲ್
 DocType: Workflow,Send Email Alert,ಇಮೇಲ್ ಎಚ್ಚರಿಕೆ ಕಳುಹಿಸಿ
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. Razorpay ಚಲಾವಣೆಯ ವ್ಯವಹಾರದಲ್ಲಿ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. Razorpay ಚಲಾವಣೆಯ ವ್ಯವಹಾರದಲ್ಲಿ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ '{0}'
 DocType: Data Import,In Progress,ಪ್ರಗತಿಯಲ್ಲಿದೆ
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,ಬ್ಯಾಕ್ಅಪ್ ಸರತಿಯಲ್ಲಿ. ಅದು ಗಂಟೆ ಕೆಲವು ನಿಮಿಷಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳಬಹುದು.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2674,7 +2674,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,ಸಂಬಂಧಿಸ�
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,ಪೇಪಾಲ್ ಪಾವತಿ ಗೇಟ್ವೇ ಸೆಟ್ಟಿಂಗ್ಗಳನ್ನು
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,ಉನ್ನತ ಸಾಧಕ
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,ಕಸ್ಟಮ್ ಕ್ಷೇತ್ರಗಳನ್ನು ಕೋರ್ ಡಾಕ್ಟೈಪ್‌ಗಳಿಗೆ ಸೇರಿಸಲಾಗುವುದಿಲ್ಲ.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} &#39;({3}) ಅವಕಾಶ ಮ್ಯಾಕ್ಸ್ ಅಕ್ಷರಗಳ ಎಂದು, ಮೊಟಕುಗೊಂಡ ಪಡೆಯುತ್ತಾನೆ {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} '({3}) ಅವಕಾಶ ಮ್ಯಾಕ್ಸ್ ಅಕ್ಷರಗಳ ಎಂದು, ಮೊಟಕುಗೊಂಡ ಪಡೆಯುತ್ತಾನೆ {2}"
 DocType: OAuth Client,Response Type,ಪ್ರತಿಕ್ರಿಯೆ ಪ್ರಕಾರ
 DocType: Contact Us Settings,Send enquiries to this email address,ಈ ಇಮೇಲ್ ವಿಳಾಸಕ್ಕೆ ಕಳುಹಿಸಿ ವಿಚಾರಣೆಯಲ್ಲಿ
 DocType: Letter Head,Letter Head Name,ತಲೆಬರಹ ಹೆಸರು
@@ -2730,7 +2730,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,ImageView
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","ಏನೋ ವ್ಯವಹಾರ ಸಮಯದಲ್ಲಿ ತಪ್ಪಾಗಿದೆ ತೋರುತ್ತಿದೆ. ನಾವು ಪಾವತಿ ದೃಢಪಡಿಸಿದರು ಕಾರಣ, ಪೇಪಾಲ್ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಈ ಪ್ರಮಾಣದ ಮರುಪಾವತಿ ಮಾಡುತ್ತದೆ. ಇದು ಇದ್ದರೆ, ನಮಗೆ ಇಮೇಲ್ ಕಳುಹಿಸಲು ಮತ್ತು ಪರಸ್ಪರ ID ಯನ್ನು ಸೂಚಿಸಿ: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","ಪಾಸ್ವರ್ಡ್ ಚಿಹ್ನೆಗಳು, ಸಂಖ್ಯೆಗಳು ಮತ್ತು ಅಕ್ಷರಗಳಲ್ಲಿ ಸೇರಿಸಿ"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ಕ್ಷೇತ್ರದಲ್ಲಿ &#39;{0}&#39; ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ ಉಲ್ಲೇಖಿಸಲಾಗಿದೆ ನಂತರ ಸೇರಿಸಿ &#39;{1}&#39;, ಲೇಬಲ್ &#39;{2}&#39; ಅಸ್ತಿತ್ವದಲ್ಲಿಲ್ಲ"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ಕ್ಷೇತ್ರದಲ್ಲಿ '{0}' ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ ಉಲ್ಲೇಖಿಸಲಾಗಿದೆ ನಂತರ ಸೇರಿಸಿ '{1}', ಲೇಬಲ್ '{2}' ಅಸ್ತಿತ್ವದಲ್ಲಿಲ್ಲ"
 DocType: List Filter,List Filter,ಪಟ್ಟಿ ಫಿಲ್ಟರ್
 DocType: Workflow State,signal,ಸಂಕೇತ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,ಲಗತ್ತುಗಳನ್ನು ಹೊಂದಿದೆ
@@ -2740,7 +2740,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,ಡಾಕ್ಯುಮೆಂಟ್ ಮರುಸ್ಥಾಪಿಸಲಾಯಿತು
 DocType: Data Export,Data Export,ಡೇಟಾ ರಫ್ತು
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ಭಾಷೆಯನ್ನು ಆಯ್ಕೆಮಾಡಿ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},ನೀವು ಕ್ಷೇತ್ರಕ್ಕಾಗಿ &#39;ಆಯ್ಕೆಗಳು&#39; ಹೊಂದಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},ನೀವು ಕ್ಷೇತ್ರಕ್ಕಾಗಿ 'ಆಯ್ಕೆಗಳು' ಹೊಂದಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ {0}
 DocType: Help Article,Author,ಲೇಖಕ
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,ಪುನರಾರಂಭಿಸು ಕಳುಹಿಸಲಾಗುತ್ತಿದೆ
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,ಪುನಾರಂಭಿಸುವ
@@ -2754,15 +2754,15 @@ DocType: Web Page,Slideshow,ಸ್ಲೈಡ್ಶೋ
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,ಡೀಫಾಲ್ಟ್ ವಿಳಾಸ ಟೆಂಪ್ಲೇಟು ಅಳಿಸಲಾಗಿಲ್ಲ
 DocType: Contact,Maintenance Manager,ನಿರ್ವಹಣೆ ಮ್ಯಾನೇಜರ್
 DocType: Workflow State,Search,ಹುಡುಕು
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. ಪಟ್ಟಿ ಚಲಾವಣೆಯ ವ್ಯವಹಾರದಲ್ಲಿ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. ಪಟ್ಟಿ ಚಲಾವಣೆಯ ವ್ಯವಹಾರದಲ್ಲಿ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. ಪಟ್ಟಿ ಚಲಾವಣೆಯ ವ್ಯವಹಾರದಲ್ಲಿ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. ಪಟ್ಟಿ ಚಲಾವಣೆಯ ವ್ಯವಹಾರದಲ್ಲಿ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ಕಸಬುಟ್ಟಿಗೆ
 DocType: Web Form,Web Form Fields,ವೆಬ್ ಫಾರ್ಮ್ ಫೀಲ್ಡ್ಸ್
 DocType: Data Import,Amended From,ಗೆ ತಿದ್ದುಪಡಿ
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},ಎಚ್ಚರಿಕೆ: ಸಾಧ್ಯವಾಗಲಿಲ್ಲ ಹುಡುಕಲು {0} ಸಂಬಂಧಿಸಿದ ಯಾವುದೇ ಕೋಷ್ಟಕದಲ್ಲಿ {1}
 DocType: S3 Backup Settings,eu-north-1,eu-north-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,ಈ ಡಾಕ್ಯುಮೆಂಟ್ ಪ್ರಸ್ತುತ ಮರಣದಂಡನೆ ಸರತಿಯಲ್ಲಿ. ದಯವಿಟ್ಟು ಪುನಃ ಪ್ರಯತ್ನಿಸಿ
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ಫೈಲ್ &#39;{0}&#39; ಕಂಡುಬಂದಿಲ್ಲ
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ಫೈಲ್ '{0}' ಕಂಡುಬಂದಿಲ್ಲ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,ವಿಭಾಗ ತೆಗೆದುಹಾಕಿ
 DocType: User,Change Password,ಗುಪ್ತಪದವನ್ನು ಬದಲಿಸಿ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,ಎಕ್ಸ್ ಆಕ್ಸಿಸ್ ಫೀಲ್ಡ್
@@ -2946,7 +2946,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,ಮೌಲ್ಯ ಕ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,ಮಕ್ಕಳ ಸೇರಿಸಿ
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,ಆಮದು ಪ್ರಗತಿ
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",ಷರತ್ತು ತೃಪ್ತಿ ಹೊಂದಿದ್ದರೆ ಬಳಕೆದಾರರಿಗೆ ಅಂಕಗಳೊಂದಿಗೆ ಬಹುಮಾನ ನೀಡಲಾಗುತ್ತದೆ. ಉದಾ. doc.status == &#39;ಮುಚ್ಚಲಾಗಿದೆ&#39;
+",ಷರತ್ತು ತೃಪ್ತಿ ಹೊಂದಿದ್ದರೆ ಬಳಕೆದಾರರಿಗೆ ಅಂಕಗಳೊಂದಿಗೆ ಬಹುಮಾನ ನೀಡಲಾಗುತ್ತದೆ. ಉದಾ. doc.status == 'ಮುಚ್ಚಲಾಗಿದೆ'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: ಸಲ್ಲಿಸಲಾಗಿದೆ ರೆಕಾರ್ಡ್ ಅಳಿಸಲಾಗುವುದಿಲ್ಲ.
 DocType: GSuite Templates,Template Name,ಟೆಂಪ್ಲೇಟ್ ಹೆಸರು
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ದಸ್ತಾವೇಜಿನ ಹೊಸ ರೀತಿಯ
@@ -3077,7 +3077,7 @@ DocType: Dashboard Chart,Chart Type,ಚಾರ್ಟ್ ಪ್ರಕಾರ
 DocType: DocType,Auto Name,ಕಾರು ಹೆಸರು
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,ಅವರು ಊಹಿಸಲು ಸುಲಭ ಎಂದು ಎಬಿಸಿ ಅಥವಾ 6543 ನಂತಹ ಅನುಕ್ರಮಗಳನ್ನು ತಪ್ಪಿಸಿ
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,ದಯವಿಟ್ಟು ಪುನಃ ಪ್ರಯತ್ನಿಸಿ
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; ಅಥವಾ &#39;https: //&#39; ನೊಂದಿಗೆ ಪ್ರಾರಂಭವಾಗಬೇಕು
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' ಅಥವಾ 'https: //' ನೊಂದಿಗೆ ಪ್ರಾರಂಭವಾಗಬೇಕು
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,ಆಯ್ಕೆ 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,ಸಂಪಾದಿಸು
@@ -3313,7 +3313,7 @@ DocType: Notification,Send alert if this field's value changes,ಎಚ್ಚರ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,ಥೀಮ್ ಬಣ್ಣಗಳು
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,ಹೊಸ ರೂಪದಲ್ಲಿ ಮಾಡಲು ಒಂದು DOCTYPE ಆಯ್ಕೆ
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,ಬಳಕೆದಾರರು ಅಸ್ತಿತ್ವದಲ್ಲಿಲ್ಲ
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;ಸ್ವೀಕರಿಸುವವರು&#39; ಅನ್ನು ನಿರ್ದಿಷ್ಟಪಡಿಸಲಾಗಿಲ್ಲ
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'ಸ್ವೀಕರಿಸುವವರು' ಅನ್ನು ನಿರ್ದಿಷ್ಟಪಡಿಸಲಾಗಿಲ್ಲ
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,ಈಗ ತಾನೆ
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,ಅನ್ವಯಿಸು
 DocType: Footer Item,Policy,ನೀತಿ
@@ -3360,7 +3360,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,ಕಸ್ಟಮ�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,ಪ್ರೋಗ್ರೆಸ್
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,ಪಾತ್ರ
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,ಮಿಸ್ಸಿಂಗ್ ಫೀಲ್ಡ್ಸ್
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname ನಲ್ಲಿ ಅಮಾನ್ಯ FIELDNAME &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname ನಲ್ಲಿ ಅಮಾನ್ಯ FIELDNAME '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ಒಂದು ದಾಖಲೆ ಪ್ರಕಾರ ನಲ್ಲಿ ಹುಡುಕಾಟ
 DocType: Custom DocPerm,Role and Level,ಪಾತ್ರ ಮತ್ತು ಮಟ್ಟ
 DocType: File,Thumbnail URL,ಥಂಬ್ನೇಲ್ URL
@@ -3459,7 +3459,7 @@ DocType: Dashboard Chart,Filters JSON,ಫಿಲ್ಟರ್‌ಗಳು JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,ಪರಿಶೀಲಿಸಲು ಇಲ್ಲಿ ಕ್ಲಿಕ್ ಮಾಡಿ
 DocType: Email Account,Disable SMTP server authentication,SMTP ಸರ್ವರ್ ದೃ hentic ೀಕರಣವನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿ
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಲಾಗಿದೆ.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ಹಾಗೆ ಊಹಿಸಬಹುದಾದ ಬದಲಿ &#39;@&#39; ಬದಲಿಗೆ &#39;ಒಂದು&#39; ತುಂಬಾ ಸಹಾಯ ಇಲ್ಲ.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ಹಾಗೆ ಊಹಿಸಬಹುದಾದ ಬದಲಿ '@' ಬದಲಿಗೆ 'ಒಂದು' ತುಂಬಾ ಸಹಾಯ ಇಲ್ಲ.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,ನನ್ನ ಅದಕ್ಕೆ
 apps/frappe/frappe/utils/data.py,Zero,ಝೀರೋ
 DocType: Google Drive,Backup Folder ID,ಬ್ಯಾಕಪ್ ಫೋಲ್ಡರ್ ID
@@ -3510,7 +3510,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,ಮಾನ್ಯ ಮೊಬೈಲ್ ಸೂಲ ನಮೂದಿಸಿ
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,ಕೆಲವು ವೈಶಿಷ್ಟ್ಯಗಳು ನಿಮ್ಮ ಬ್ರೌಸರ್ನಲ್ಲಿ ಕೆಲಸ ಇರಬಹುದು. ಇತ್ತೀಚಿನ ಆವೃತ್ತಿಗೆ ನಿಮ್ಮ ಬ್ರೌಸರ್ ಅಪ್ಡೇಟ್.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,ಕೆಲವು ವೈಶಿಷ್ಟ್ಯಗಳು ನಿಮ್ಮ ಬ್ರೌಸರ್ನಲ್ಲಿ ಕೆಲಸ ಇರಬಹುದು. ಇತ್ತೀಚಿನ ಆವೃತ್ತಿಗೆ ನಿಮ್ಮ ಬ್ರೌಸರ್ ಅಪ್ಡೇಟ್.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","ಕೇಳಿ, ಗೊತ್ತಿಲ್ಲ &#39;ಸಹಾಯ&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","ಕೇಳಿ, ಗೊತ್ತಿಲ್ಲ 'ಸಹಾಯ'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ಈ ಡಾಕ್ಯುಮೆಂಟ್ ಅನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗಿದೆ {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,ಪ್ರತಿಕ್ರಿಯೆಗಳು ಮತ್ತು ಸಂಪರ್ಕ ಈ ದಾಖಲೆಯಲ್ಲಿ ಸಂಬಂಧ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,ಫಿಲ್ಟರ್ ...
@@ -3665,8 +3665,8 @@ DocType: Web Page,Web Page,ವೆಬ್ ಪುಟ
 DocType: Workflow Document State,Next Action Email Template,ಮುಂದಿನ ಆಕ್ಷನ್ ಇಮೇಲ್ ಟೆಂಪ್ಲೇಟು
 DocType: Blog Category,Blogger,ಬ್ಲಾಗರ್
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","ಸಕ್ರಿಯಗೊಳಿಸಿದ್ದರೆ, ಡಾಕ್ಯುಮೆಂಟ್‌ನ ಬದಲಾವಣೆಗಳನ್ನು ಟ್ರ್ಯಾಕ್ ಮಾಡಲಾಗುತ್ತದೆ ಮತ್ತು ಟೈಮ್‌ಲೈನ್‌ನಲ್ಲಿ ತೋರಿಸಲಾಗುತ್ತದೆ"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ಗ್ಲೋಬಲ್ ಸರ್ಚ್&#39; ಮಾದರಿ ಅನುಮತಿಸಲಾಗುವುದಿಲ್ಲ {0} ಸತತವಾಗಿ {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ಗ್ಲೋಬಲ್ ಸರ್ಚ್&#39; ಮಾದರಿ ಅನುಮತಿಸಲಾಗುವುದಿಲ್ಲ {0} ಸತತವಾಗಿ {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ಗ್ಲೋಬಲ್ ಸರ್ಚ್' ಮಾದರಿ ಅನುಮತಿಸಲಾಗುವುದಿಲ್ಲ {0} ಸತತವಾಗಿ {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ಗ್ಲೋಬಲ್ ಸರ್ಚ್' ಮಾದರಿ ಅನುಮತಿಸಲಾಗುವುದಿಲ್ಲ {0} ಸತತವಾಗಿ {1}
 DocType: Energy Point Log,Appreciation,ಮೆಚ್ಚುಗೆ
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,ಪಟ್ಟಿ ವೀಕ್ಷಣೆ
 DocType: Workflow,Don't Override Status,ಸ್ಥಿತಿ ಬದಲಾಯಿಸಬೇಡಿ
@@ -3809,7 +3809,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,ಡೀಫಾಲ್ಟ್
 DocType: Translation,Verified,ಪರಿಶೀಲಿಸಲಾಗಿದೆ
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} ಸೇರಿಸಲಾಗಿದೆ
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ಹುಡುಕು &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ಹುಡುಕು '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,ಮೊದಲು ವರದಿ ಉಳಿಸಲು
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ಗ್ರಾಹಕರನ್ನು ಸೇರ್ಪಡೆ
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,ಅಲ್ಲ
@@ -3845,14 +3845,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,ನಾನ�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} ಒಂದು ಮಾನ್ಯವಾದ ರಾಜ್ಯ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,ಎಲ್ಲಾ ಡಾಕ್ಯುಮೆಂಟ್ ಪ್ರಕಾರಗಳಿಗೆ ಅನ್ವಯಿಸಿ
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,ಎನರ್ಜಿ ಪಾಯಿಂಟ್ ನವೀಕರಣ
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. ಪೇಪಾಲ್ ಕರೆನ್ಸಿ ವ್ಯವಹಾರಗಳ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',ಮತ್ತೊಂದು ಪಾವತಿ ವಿಧಾನವನ್ನು ಅನುಸರಿಸಿ. ಪೇಪಾಲ್ ಕರೆನ್ಸಿ ವ್ಯವಹಾರಗಳ ಬೆಂಬಲಿಸದಿರುವುದರಿಂದ '{0}'
 DocType: Chat Message,Room Type,ಕೋಣೆ ಪ್ರಕಾರ
 DocType: Data Import Beta,Import Log Preview,ಲಾಗ್ ಪೂರ್ವವೀಕ್ಷಣೆಯನ್ನು ಆಮದು ಮಾಡಿ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,ಹುಡುಕಾಟ ಕ್ಷೇತ್ರದಲ್ಲಿ {0} ಮಾನ್ಯವಾಗಿಲ್ಲ
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,ಅಪ್‌ಲೋಡ್ ಮಾಡಿದ ಫೈಲ್
 DocType: Workflow State,ok-circle,ಸರಿ ವೃತ್ತ
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP ಬಳಕೆದಾರರ ರಚನೆ ಮತ್ತು ಮ್ಯಾಪಿಂಗ್
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',ನೀವು ಗ್ರಾಹಕರು ಕಿತ್ತಳೆ ಹೇಗೆ &#39;ಕೇಳುವ ಮೂಲಕ ವಸ್ತುಗಳನ್ನು ಕಾಣಬಹುದು
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',ನೀವು ಗ್ರಾಹಕರು ಕಿತ್ತಳೆ ಹೇಗೆ 'ಕೇಳುವ ಮೂಲಕ ವಸ್ತುಗಳನ್ನು ಕಾಣಬಹುದು
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,ಕ್ಷಮಿಸಿ! ಬಳಕೆದಾರರು ತಮ್ಮ ದಾಖಲೆ ಸಂಪೂರ್ಣ ಪ್ರವೇಶವನ್ನು ಇರಬೇಕು.
 ,Usage Info,ಬಳಕೆ ಮಾಹಿತಿ
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,ಕೀಬೋರ್ಡ್ ಶಾರ್ಟ್‌ಕಟ್‌ಗಳನ್ನು ತೋರಿಸಿ

--- a/frappe/translations/ko.csv
+++ b/frappe/translations/ko.csv
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),지난 주 실적 ({0}에서 {1}까지)에 기반한 통계
 DocType: LDAP Settings,LDAP Phone Field,LDAP 전화 필드
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","문서 유형 ..., 예를 들어, 고객"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,조건은 &#39;{0}&#39;무효
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,조건은 '{0}'무효
 DocType: Workflow State,barcode,바코드
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,하위 쿼리 또는 기능의 사용이 제한됩니다.
 apps/frappe/frappe/config/customization.py,Add your own translations,자신의 번역을 추가
@@ -714,7 +714,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,사용자 이름은 {0} 이미 존재
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0} {1} 가져올 수 없습니다로 가져 오기를 설정할 수 없습니다
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},당신의 주소 템플릿에 오류가 있습니다 {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0}은 (는) &#39;수신자&#39;의 이메일 주소가 잘못되었습니다.
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0}은 (는) '수신자'의 이메일 주소가 잘못되었습니다.
 DocType: Footer Item,"target = ""_blank""","대상 = ""_blank"""
 DocType: Workflow State,hdd,하드 디스크
 DocType: Integration Request,Host,주인
@@ -756,7 +756,7 @@ DocType: Currency,Currency Name,통화 명
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,어떤 이메일 없습니다
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,링크 만료 됨
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39;의 &#39;{1}&#39;에 대한 길이를 {0} (으)로 되돌립니다. 길이를 {3}으로 설정하면 데이터가 잘립니다.
+							Setting the length as {3} will cause truncation of data.",'{2}'의 '{1}'에 대한 길이를 {0} (으)로 되돌립니다. 길이를 {3}으로 설정하면 데이터가 잘립니다.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,파일 형식 선택
 DocType: Report,Javascript,자바스크립트
 DocType: File,Content Hash,콘텐츠 해시
@@ -778,7 +778,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,문서 공유 보고서
 DocType: Social Login Key,Base URL,기본 URL
 DocType: User,Last Login,마지막 로그인
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},{0} 필드에 &#39;번역 가능&#39;을 설정할 수 없습니다.
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},{0} 필드에 '번역 가능'을 설정할 수 없습니다.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,기둥
 DocType: Chat Profile,Chat Profile,채팅 프로필
 DocType: Custom Field,Adds a custom field to a DocType,문서 타입에 사용자 정의 필드를 추가합니다
@@ -787,7 +787,7 @@ DocType: File,Is Home Folder,홈 폴더입니다
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar 스타일
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} 유효한 이메일 주소가 아닙니다
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,인쇄이어야 1 개 레코드를 선택
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',사용자는 &#39;{0}&#39;이미 역할이 &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',사용자는 '{0}'이미 역할이 '{1}'
 DocType: System Settings,Two Factor Authentication method,2 요소 인증 방법
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,먼저 이름을 설정하고 레코드를 저장하십시오.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 기록
@@ -1458,7 +1458,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,필수 필드 : 대한 설정 역할
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} 비평 {1}
 DocType: Data Migration Mapping,Mapping Name,매핑 이름
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0} : 필드 &#39;{1}&#39;이 고유하지 않은 값을 가지기 때문에 고유로 설정할 수 없습니다.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0} : 필드 '{1}'이 고유하지 않은 값을 가지기 때문에 고유로 설정할 수 없습니다.
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,목록 탐색
 DocType: Currency,A symbol for this currency. For e.g. $,이 통화에 대한 기호.예를 들어 $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,번역본을 성공적으로 업데이트했습니다.
@@ -1981,7 +1981,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,남동 - 1
 DocType: DocType,"Must be of type ""Attach Image""",&quot;이미지 첨부&quot;유형이어야합니다
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,모두 선택 해제
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},당신은 필드에 해제하지 &#39;읽기 전용&#39;수 {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},당신은 필드에 해제하지 '읽기 전용'수 {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,0은 언제든지 레코드를 업데이트 함을 의미합니다.
 DocType: Auto Email Report,Zero means send records updated at anytime,0은 언제든지 레코드를 업데이트 함을 의미합니다.
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,설정 완료
@@ -2026,7 +2026,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google 글꼴
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","이 지침 곳에 도움이되지 않으면, GitHub의 문제에 대한 당신의 제안에 추가하십시오."
 DocType: Workflow State,bookmark,북마크
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),폴더 이름에 &#39;/&#39;(슬래시)가 없어야합니다.
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),폴더 이름에 '/'(슬래시)가 없어야합니다.
 DocType: Note,Note,정보
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,오류 보고서
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel 형식으로 데이터를 내 보냅니다.
@@ -2132,7 +2132,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"6시 예를 들어,
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",여기에 정의 된 필드 이름 값을 가지고 또는 규칙이 참 (예) 경우에만이 필드가 나타납니다 myfield 평가 : doc.myfield == &#39;나의 가치&#39;평가 : doc.age> (18)
+eval:doc.age>18",여기에 정의 된 필드 이름 값을 가지고 또는 규칙이 참 (예) 경우에만이 필드가 나타납니다 myfield 평가 : doc.myfield == '나의 가치'평가 : doc.age> (18)
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,오늘
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,오늘
@@ -2172,7 +2172,7 @@ DocType: Data Migration Connector,Database Name,데이터베이스 이름
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,새로 고침 양식
 DocType: DocField,Select,고르기
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,전체 로그보기
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","간단한 파이썬 표현식, 예 : 상태 == &#39;열기&#39;와 타입 == &#39;버그&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","간단한 파이썬 표현식, 예 : 상태 == '열기'와 타입 == '버그'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,파일이 첨부되지 않았습니다
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,연결이 끊어졌습니다. 일부 기능이 작동하지 않을 수 있습니다.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot;와 같은 반복은 추측하기 쉬운
@@ -2304,7 +2304,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,오류 만 표시
 DocType: Website Settings,Banner HTML,배너 HTML
 DocType: Workflow,Send Email Alert,이메일 경고 보내기
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',다른 지불 방법을 선택하세요. Razorpay은 &#39;{0}&#39;통화 트랜잭션을 지원하지 않습니다
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',다른 지불 방법을 선택하세요. Razorpay은 '{0}'통화 트랜잭션을 지원하지 않습니다
 DocType: Data Import,In Progress,진행 중
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,백업을 위해 대기 중. 이 시간에 몇 분 정도 걸릴 수 있습니다.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2731,7 +2731,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,개정
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,페이팔 지불 게이트웨이 설정
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,최고 출연자
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,사용자 정의 필드는 핵심 DocTypes에 추가 될 수 없습니다.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0} : 허용 최대 문자 그대로 &#39;{1}&#39;({3}), 절단 얻을 것이다 {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0} : 허용 최대 문자 그대로 '{1}'({3}), 절단 얻을 것이다 {2}"
 DocType: OAuth Client,Response Type,응답 유형
 DocType: Contact Us Settings,Send enquiries to this email address,이 이메일 주소로 문의를 보내
 DocType: Letter Head,Letter Head Name,레터 헤드 이름
@@ -2788,7 +2788,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,이미지보기
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","뭔가 트랜잭션 동안 잘못된 것 같습니다. 우리가 지불을 확인하지 않았으므로, 페이팔이 자동으로이 금액을 환불 해드립니다. 그렇지 않은 경우, 우리에게 이메일을 보내 상관 관계 ID를 언급 해주십시오 : {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","암호에 기호, 숫자 및 대문자를 포함하십시오."
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","필드 &#39;{0}&#39;사용자 정의 필드에서 언급 한 후 삽입 &#39;{1}&#39;, 라벨 &#39;{2}&#39;존재하지 않는"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","필드 '{0}'사용자 정의 필드에서 언급 한 후 삽입 '{1}', 라벨 '{2}'존재하지 않는"
 DocType: List Filter,List Filter,목록 필터
 DocType: Workflow State,signal,신호
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,첨부 파일 있음
@@ -2798,7 +2798,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,복원 된 문서
 DocType: Data Export,Data Export,데이터 내보내기
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,언어 선택 ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},필드 {0}에 대해 &#39;옵션&#39;을 설정할 수 없습니다.
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},필드 {0}에 대해 '옵션'을 설정할 수 없습니다.
 DocType: Help Article,Author,저자
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,전송 재개
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,다시 열다
@@ -2812,15 +2812,15 @@ DocType: Web Page,Slideshow,슬라이드쇼
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,기본 주소 템플릿을 삭제할 수 없습니다
 DocType: Contact,Maintenance Manager,유지 관리 관리자
 DocType: Workflow State,Search,{0}{/0}{1}검색 {/1}
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',다른 지불 방법을 선택하십시오. Stripe은 통화 &#39;{0}&#39;의 트랜잭션을 지원하지 않습니다.
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',다른 지불 방법을 선택하십시오. Stripe은 통화 &#39;{0}&#39;의 트랜잭션을 지원하지 않습니다.
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',다른 지불 방법을 선택하십시오. Stripe은 통화 '{0}'의 트랜잭션을 지원하지 않습니다.
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',다른 지불 방법을 선택하십시오. Stripe은 통화 '{0}'의 트랜잭션을 지원하지 않습니다.
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,휴지통으로 이동
 DocType: Web Form,Web Form Fields,웹 폼 필드
 DocType: Data Import,Amended From,개정
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},경고 : 없음은 찾을 수 {0} 관련된 테이블 {1}
 DocType: S3 Backup Settings,eu-north-1,서북 1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,이 문서는 현재 실행을 위해 대기한다. 다시 시도하십시오
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,파일 &#39;{0}&#39;을 (를) 찾을 수 없습니다
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,파일 '{0}'을 (를) 찾을 수 없습니다
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,섹션을 제거
 DocType: User,Change Password,암호 변경
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X 축 필드
@@ -3011,7 +3011,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,값을 누락
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,자식 추가
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,가져 오기 진행
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",조건이 충족되면 사용자는 포인트로 보상 받게됩니다. 예 : doc.status == &#39;닫힘&#39;
+",조건이 충족되면 사용자는 포인트로 보상 받게됩니다. 예 : doc.status == '닫힘'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1} : 제출 된 기록은 삭제할 수 없습니다.
 DocType: GSuite Templates,Template Name,템플릿 이름
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,문서의 새로운 유형
@@ -3144,7 +3144,7 @@ DocType: Dashboard Chart,Chart Type,차트 유형
 DocType: DocType,Auto Name,자동차 이름
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,그들이 추측하기 쉬운만큼 ABC 나 6543 같은 시퀀스를 피하십시오
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,다시 시도하십시오
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL은 &#39;http : //&#39;또는 &#39;https : //&#39;로 시작해야합니다.
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL은 'http : //'또는 'https : //'로 시작해야합니다.
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,옵션 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,편집
@@ -3281,7 +3281,7 @@ DocType: OAuth Provider Settings,Auto,자동
 DocType: System Settings,User can login using Email id or User Name,사용자는 이메일 ID 또는 사용자 이름을 사용하여 로그인 할 수 있습니다.
 DocType: Workflow State,question-sign,질문 서명
 apps/frappe/frappe/model/base_document.py,{0} is disabled,{0}이 비활성화되었습니다
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",웹 조회에는 &#39;경로&#39;입력란이 필수 항목입니다.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",웹 조회에는 '경로'입력란이 필수 항목입니다.
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Insert Column Before {0},{0} 앞에 열 삽입
 DocType: Energy Point Rule,The user from this field will be rewarded points,이 필드의 사용자는 보상 포인트가됩니다.
 DocType: Assignment Rule,Close Condition,닫기 조건
@@ -3384,7 +3384,7 @@ DocType: Notification,Send alert if this field's value changes,경고를 보내�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,테마 색
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,새로운 형식을 만들어 문서 타입을 선택
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,사용자가 존재하지 않습니다
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;수신자&#39;가 지정되지 않았습니다.
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'수신자'가 지정되지 않았습니다.
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,방금
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,대다
 DocType: Footer Item,Policy,정책
@@ -3433,7 +3433,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,사용자 정의 
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,진행
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,역할별
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,누락 된 필드
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname에 잘못된 필드 이름 &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname에 잘못된 필드 이름 '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,문서 유형의 검색
 DocType: Custom DocPerm,Role and Level,역할과 수준
 DocType: File,Thumbnail URL,미리보기 URL
@@ -3534,7 +3534,7 @@ DocType: Dashboard Chart,Filters JSON,JSON 필터
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,확인하려면 여기를 클릭하십시오
 DocType: Email Account,Disable SMTP server authentication,SMTP 서버 인증 사용 안 함
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,클립 보드에 복사되었습니다.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,예측과 같은 대체 &#39;@&#39;대신 &#39;A&#39;는 매우 도움이되지 않습니다.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,예측과 같은 대체 '@'대신 'A'는 매우 도움이되지 않습니다.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,나에 의해 할당
 apps/frappe/frappe/utils/data.py,Zero,제로
 DocType: Google Drive,Backup Folder ID,백업 폴더 ID
@@ -3588,7 +3588,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,유효 모바일 NOS를 입력 해주십시오
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,일부 기능은 브라우저에서 작동하지 않을 수 있습니다. 브라우저를 최신 버전으로 업데이트하십시오.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,일부 기능은 브라우저에서 작동하지 않을 수 있습니다. 브라우저를 최신 버전으로 업데이트하십시오.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",물어 몰라 &#39;도움&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",물어 몰라 '도움'
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},이 문서 {0}을 (를) 취소했습니다
 DocType: DocType,Comments and Communications will be associated with this linked document,댓글과 통신이 링크 된 문서로 연결됩니다
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,필터 ...
@@ -3747,8 +3747,8 @@ DocType: Web Page,Web Page,웹 페이지
 DocType: Workflow Document State,Next Action Email Template,다음 작업 전자 메일 템플릿
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline",이 옵션을 사용하면 문서에 대한 변경 사항이 추적되어 타임 라인에 표시됩니다.
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},{1} 행의 {0} 유형에는 &#39;전체 검색에서&#39;가 허용되지 않습니다.
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},{1} 행의 {0} 유형에는 &#39;전체 검색에서&#39;가 허용되지 않습니다.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},{1} 행의 {0} 유형에는 '전체 검색에서'가 허용되지 않습니다.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},{1} 행의 {0} 유형에는 '전체 검색에서'가 허용되지 않습니다.
 DocType: Energy Point Log,Appreciation,감사
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,목록보기
 DocType: Workflow,Don't Override Status,상태를 무시하지 마십시오
@@ -3896,7 +3896,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,기본값
 DocType: Translation,Verified,검증 됨
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} 추가
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&#39;{0}&#39;검색
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}','{0}'검색
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,먼저 보고서를 저장하십시오
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} 가입자는 추가
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,하지에서
@@ -3933,14 +3933,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,나를
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0}은 유효한 상태
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,모든 문서 유형에 적용
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,에너지 포인트 업데이트
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',다른 지불 방법을 선택하세요. 페이팔은 &#39;{0}&#39;통화 트랜잭션을 지원하지 않습니다
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',다른 지불 방법을 선택하세요. 페이팔은 '{0}'통화 트랜잭션을 지원하지 않습니다
 DocType: Chat Message,Room Type,객실 유형
 DocType: Data Import Beta,Import Log Preview,가져 오기 로그 미리보기
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,검색 필드 {0} 유효하지 않습니다
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,업로드 된 파일
 DocType: Workflow State,ok-circle,OK-원
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP 사용자 생성 및 매핑
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',당신은 &#39;고객에 오렌지를 찾아&#39;요구에 의해 물건을 찾을 수 있습니다
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',당신은 '고객에 오렌지를 찾아'요구에 의해 물건을 찾을 수 있습니다
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,죄송합니다!사용자는 자신의 기록에 대한 완전한 액세스 권한이 있어야합니다.
 ,Usage Info,사용 정보
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,키보드 단축키 표시

--- a/frappe/translations/ko.csv
+++ b/frappe/translations/ko.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,표준입니다
 DocType: Desktop Icon,_report,_보고서
 DocType: Desktop Icon,_report,_보고서
 DocType: Dashboard Chart,Full,완전한
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","안 &lt;스크립트> 또는 그냥 문자가 의도적으로이 분야에 사용될 수있는 바와 같이, 같은 &lt;또는>와 같은 HTML 인코딩 HTML 태그"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","안 <스크립트> 또는 그냥 문자가 의도적으로이 분야에 사용될 수있는 바와 같이, 같은 <또는>와 같은 HTML 인코딩 HTML 태그"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}이 (가) {1}에 대해 비판했습니다.
 DocType: Website Settings,FavIcon,파비콘
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,운영
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,꼬리말은 PDF�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,대기 중
 DocType: System Settings,Allow only one session per user,사용자 당 하나의 세션 만 허용
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,홈 / 테스트 폴더 1 / 테스트 폴더 3
-DocType: Website Settings,&lt;head> HTML,&lt;HEAD> HTML
+DocType: Website Settings,<head> HTML,<HEAD> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,선택하거나 새 이벤트를 만들 시간 슬롯을 가로 질러 드래그합니다.
 DocType: Contact,Contact Details,연락처 세부 사항
 DocType: DocField,In Filter,필터
@@ -2338,7 +2338,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,링크를 볼 권한이 없습니다.
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,주소 제목은 필수입니다.
 DocType: Google Contacts,Push to Google Contacts,Google 주소록으로 푸시
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;헤드>에서 추가 된 HTML 웹 페이지의 섹션은 주로 웹 사이트 확인 및 검색 엔진 최적화에 사용
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",<헤드>에서 추가 된 HTML 웹 페이지의 섹션은 주로 웹 사이트 확인 및 검색 엔진 최적화에 사용
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,재발
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,항목은 자체 하위에 추가 할 수없는
 DocType: Session Default Settings,Session Defaults,세션 기본값
@@ -2458,7 +2458,7 @@ DocType: Workflow State,Warning,경고
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,여러 페이지에 인쇄 될 수 있습니다.
 DocType: Data Migration Run,Percent Complete,완료율
 DocType: Tag Category,Tag Category,태그 카테고리
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","비교하려면> 5, &lt;10 또는 = 324를 사용하십시오. 범위의 경우 5:10을 사용하십시오 (5와 10 사이의 값)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","비교하려면> 5, <10 또는 = 324를 사용하십시오. 범위의 경우 5:10을 사용하십시오 (5와 10 사이의 값)."
 DocType: Google Calendar,Pull from Google Calendar,Google 캘린더에서 가져 오기
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,도움말
 DocType: User,Login Before,전에 로그인
@@ -3106,7 +3106,7 @@ DocType: DocField,Allow on Submit,제출에 허용
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,예외 유형
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,열 선택
-DocType: Web Page,Add code as &lt;script>,<SCRIPT>과 같은 코드를 추가
+DocType: Web Page,Add code as <script>,<SCRIPT>과 같은 코드를 추가
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,사용자 권한 지우기
 DocType: Webhook,Headers,헤더
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,다가오는 이벤트
@@ -3483,15 +3483,15 @@ DocType: Workflow State,share-alt,공유 - 고도
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},대기열은 {0} 중 하나 여야합니다.
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> 기본 템플릿 </ H4>는 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> 신사 템플릿 생성 </A> 및 주소의 모든 필드를 (사용 {; BR한다; 
  {% 경우 address_line2 %} {{address_line2}} & LT; BR된다 사용자 정의 필드 경우) </ P> 

--- a/frappe/translations/ko.csv
+++ b/frappe/translations/ko.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,파일 백�
 DocType: DocField,In Global Search,글로벌 검색
 DocType: System Settings,Brute Force Security,무차별 공격 보안
 DocType: Workflow State,indent-left,들여 쓰기 왼쪽
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} 년 전
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} 년 전
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,그것은이 파일을 삭제하는 위험 : {0}. 시스템 관리자에게 문의하시기 바랍니다.
 DocType: Currency,Currency Name,통화 명
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,어떤 이메일 없습니다
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,없음 {0} �
 apps/frappe/frappe/config/customization.py,Add custom forms.,사용자 지정 양식을 추가합니다.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0} : {1}에서 {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,이 문서를 제출
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,설정&gt; 사용자 권한
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,설정> 사용자 권한
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,이 시스템은 많은 사전 정의 된 역할을 제공합니다.당신은 미세한 권한을 설정하는 새로운 역할을 추가 할 수 있습니다.
 DocType: Communication,CC,CC
 DocType: Country,Geo,지오
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","사용자가 확인하는 역할을한다면, 사용자는 &quot;시스템 사용자&quot;가된다. &quot;시스템 사용자는&quot;데스크톱에 액세스 할 수 있습니다"
 DocType: System Settings,Date and Number Format,날짜 및 숫자 형식
 apps/frappe/frappe/model/document.py,one of,하나의
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,설정&gt; 양식 사용자 정의
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,설정> 양식 사용자 정의
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,한 순간 확인
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,보기 태그
 DocType: DocField,HTML Editor,HTML 편집기
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,청구
 DocType: Email Queue,Not Sent,보낼 수 없습니다
 DocType: Web Form,Actions,수행
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,설정&gt; 사용자
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,설정> 사용자
 DocType: Workflow State,align-justify,정렬 정당화
 DocType: User,Middle Name (Optional),중간 이름 (선택 사항)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,허용하지 않음
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,표준입니다
 DocType: Desktop Icon,_report,_보고서
 DocType: Desktop Icon,_report,_보고서
 DocType: Dashboard Chart,Full,완전한
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","안 &lt;스크립트&gt; 또는 그냥 문자가 의도적으로이 분야에 사용될 수있는 바와 같이, 같은 &lt;또는&gt;와 같은 HTML 인코딩 HTML 태그"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","안 &lt;스크립트> 또는 그냥 문자가 의도적으로이 분야에 사용될 수있는 바와 같이, 같은 &lt;또는>와 같은 HTML 인코딩 HTML 태그"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}이 (가) {1}에 대해 비판했습니다.
 DocType: Website Settings,FavIcon,파비콘
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,운영
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,꼬리말은 PDF�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,대기 중
 DocType: System Settings,Allow only one session per user,사용자 당 하나의 세션 만 허용
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,홈 / 테스트 폴더 1 / 테스트 폴더 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;HEAD&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;HEAD> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,선택하거나 새 이벤트를 만들 시간 슬롯을 가로 질러 드래그합니다.
 DocType: Contact,Contact Details,연락처 세부 사항
 DocType: DocField,In Filter,필터
@@ -2043,7 +2043,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,로그인이 시간에 허용되지
 DocType: Data Migration Run,Current Mapping Action,현재 매핑 작업
 DocType: Dashboard Chart Source,Source Name,원본 이름
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,사용자와 연결된 이메일 계정이 없습니다. 사용자&gt; 이메일받은 편지함에 계정을 추가하십시오.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,사용자와 연결된 이메일 계정이 없습니다. 사용자> 이메일받은 편지함에 계정을 추가하십시오.
 DocType: Email Account,Email Sync Option,이메일 동기화 옵션
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,행 번호
 DocType: Async Task,Runtime,런타임
@@ -2058,7 +2058,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,사용자
 DocType: User Email,Enable Outgoing,보내는 사용
 DocType: Address,Fax,팩스
 apps/frappe/frappe/config/customization.py,Custom Tags,사용자 정의 태그
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,이메일 계정이 설정되지 않았습니다. 설정&gt; 이메일&gt; 이메일 계정에서 새 이메일 계정을 만드십시오
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,이메일 계정이 설정되지 않았습니다. 설정> 이메일> 이메일 계정에서 새 이메일 계정을 만드십시오
 DocType: Comment,Submitted,제출
 DocType: Contact,Pulled from Google Contacts,Google 주소록에서 가져옴
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,잘못된 요청
@@ -2132,7 +2132,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"6시 예를 들어,
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",여기에 정의 된 필드 이름 값을 가지고 또는 규칙이 참 (예) 경우에만이 필드가 나타납니다 myfield 평가 : doc.myfield == &#39;나의 가치&#39;평가 : doc.age&gt; (18)
+eval:doc.age>18",여기에 정의 된 필드 이름 값을 가지고 또는 규칙이 참 (예) 경우에만이 필드가 나타납니다 myfield 평가 : doc.myfield == &#39;나의 가치&#39;평가 : doc.age> (18)
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,오늘
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,오늘
@@ -2147,7 +2147,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,대문자
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,사용자 정의 HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,폴더 이름을 입력합니다
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,기본 주소 템플릿이 없습니다. 설정&gt; 인쇄 및 브랜딩&gt; 주소 템플릿에서 새로 만드십시오.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,기본 주소 템플릿이 없습니다. 설정> 인쇄 및 브랜딩> 주소 템플릿에서 새로 만드십시오.
 apps/frappe/frappe/auth.py,Unknown User,알 수없는 사용자
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,역할 선택
 DocType: Comment,Deleted,삭제
@@ -2338,7 +2338,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,링크를 볼 권한이 없습니다.
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,주소 제목은 필수입니다.
 DocType: Google Contacts,Push to Google Contacts,Google 주소록으로 푸시
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",&lt;헤드&gt;에서 추가 된 HTML 웹 페이지의 섹션은 주로 웹 사이트 확인 및 검색 엔진 최적화에 사용
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;헤드>에서 추가 된 HTML 웹 페이지의 섹션은 주로 웹 사이트 확인 및 검색 엔진 최적화에 사용
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,재발
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,항목은 자체 하위에 추가 할 수없는
 DocType: Session Default Settings,Session Defaults,세션 기본값
@@ -2458,7 +2458,7 @@ DocType: Workflow State,Warning,경고
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,여러 페이지에 인쇄 될 수 있습니다.
 DocType: Data Migration Run,Percent Complete,완료율
 DocType: Tag Category,Tag Category,태그 카테고리
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","비교하려면&gt; 5, &lt;10 또는 = 324를 사용하십시오. 범위의 경우 5:10을 사용하십시오 (5와 10 사이의 값)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","비교하려면> 5, &lt;10 또는 = 324를 사용하십시오. 범위의 경우 5:10을 사용하십시오 (5와 10 사이의 값)."
 DocType: Google Calendar,Pull from Google Calendar,Google 캘린더에서 가져 오기
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,도움말
 DocType: User,Login Before,전에 로그인
@@ -2927,7 +2927,7 @@ DocType: Custom Script,Custom Script,사용자 정의 스크립트
 DocType: Address,Address Line 2,2 호선 주소
 DocType: Address,Reference,참고
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,담당자
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,설정&gt; 이메일&gt; 이메일 계정에서 기본 이메일 계정을 설정하십시오
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,설정> 이메일> 이메일 계정에서 기본 이메일 계정을 설정하십시오
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,데이터 마이그레이션 매핑 세부 정보
 DocType: Data Import,Action,수행
 DocType: GSuite Settings,Script URL,스크립트 URL
@@ -3106,7 +3106,7 @@ DocType: DocField,Allow on Submit,제출에 허용
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,예외 유형
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,열 선택
-DocType: Web Page,Add code as &lt;script&gt;,<SCRIPT>과 같은 코드를 추가
+DocType: Web Page,Add code as &lt;script>,<SCRIPT>과 같은 코드를 추가
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,사용자 권한 지우기
 DocType: Webhook,Headers,헤더
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,다가오는 이벤트
@@ -3483,15 +3483,15 @@ DocType: Workflow State,share-alt,공유 - 고도
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},대기열은 {0} 중 하나 여야합니다.
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> 기본 템플릿 </ H4>는 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> 신사 템플릿 생성 </A> 및 주소의 모든 필드를 (사용 {; BR한다; 
  {% 경우 address_line2 %} {{address_line2}} & LT; BR된다 사용자 정의 필드 경우) </ P> 

--- a/frappe/translations/ku.csv
+++ b/frappe/translations/ku.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Heke hilbijartî be, hêza vê şîfreya dê li ser bingeha herî kêm nirxê Password Score bi zorê. A value of 2 bûyîna navîn bi hêz û 4 ku pir xurt."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Heke hilbijartî be, hêza vê şîfreya dê li ser bingeha herî kêm nirxê Password Score bi zorê. A value of 2 bûyîna navîn bi hêz û 4 ku pir xurt."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Tîma Endam&quot; an &quot;Management&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',"Default bo type &#39;Check&#39; yên zeviyê, divê yan jî &#39;0&#39; an jî &#39;1&#39; be"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',"Default bo type 'Check' yên zeviyê, divê yan jî '0' an jî '1' be"
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Do
 DocType: Contact,Designation,teklîfê
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Girêdana otomatîk dikare ji bo yek hesabek Email-ê were çalak kirin.
@@ -251,7 +251,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Disable Report
 DocType: Translation,Contributed Translation Doctype Name,Navê Doctype Wergerê Beşdar
 DocType: PayPal Settings,Redirect To,Beralîkirina To
 DocType: Data Migration Mapping,Pull,Kişandin
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [ &#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [ 'REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Update Gir
 DocType: Workflow State,chevron-up,chevron-up
 DocType: DocType,Allow Guest to View,Destûrê bide Mêvan ji bo View
@@ -550,7 +550,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Stranên li ser bingeha performansa hefteya borî (ji {0} heta {1})
 DocType: LDAP Settings,LDAP Phone Field,Qada Telefonê LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","cureyê pelgeyê ..., wek nimûne mişterî"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Rewşa &#39;{0}&#39; nederbasdar e
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Rewşa '{0}' nederbasdar e
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Bikaranîna sub-query an fonksiyonê qedexe ye
 apps/frappe/frappe/config/customization.py,Add your own translations,"Zêde dikin, xwe bi xwe"
@@ -695,10 +695,10 @@ DocType: DocField,Set Only Once,Set Tenê Careke
 DocType: Email Queue Recipient,Email Queue Recipient,Email Recipient Dorê
 DocType: Address,Nagaland,Nagaland
 DocType: Slack Webhook URL,Webhook URL,Webhook URL
-apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Username {0} &#39;jixwe heye
+apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Username {0} 'jixwe heye
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Can import set ne wek {1} e importable ne
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},e an error li Address Şablon xwe li wir {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} Navnîşa e-nameyek e ku li &#39;Recipients&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} Navnîşa e-nameyek e ku li 'Recipients'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,Mazûban
@@ -740,7 +740,7 @@ DocType: Currency,Currency Name,Navê Exchange
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No Emails
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Girêdanê derbas bûn
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Bi &quot;{2} &#39;di dirêjahiya {0} ji&#39; {1} &#39;veguherîne; Sermaseya dirêj {3} dê ji bo danûstandina daneyên dane.
+							Setting the length as {3} will cause truncation of data.",Bi &quot;{2} 'di dirêjahiya {0} ji' {1} 'veguherîne; Sermaseya dirêj {3} dê ji bo danûstandina daneyên dane.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Format Format Hilbijêre
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash Content
@@ -756,13 +756,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standard DOCTYPE ne dikarin format print standard heye, bi kar tînin Form Customize"
 DocType: Report,Query,Pirs
 DocType: Customize Form,Sort Order,Sort Order
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},ji bo cureyê {0} li row &#39;Li List View&#39; destûr ne {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},ji bo cureyê {0} li row 'Li List View' destûr ne {1}
 DocType: Letter Head,Footer HTML,Footer HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,li label piştî ku tu dixwazî têxe nav zeviyê ya nû hilbijêre.
 ,Document Share Report,Dokumentê Share Report
 DocType: Social Login Key,Base URL,Navnîşa bingehîn
 DocType: User,Last Login,Last Login
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Tu dikarî ji bo qada &#39;Translatable&#39; set not set {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Tu dikarî ji bo qada 'Translatable' set not set {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Ling
 DocType: Chat Profile,Chat Profile,Chat Profile
 DocType: Custom Field,Adds a custom field to a DocType,Dixe nav zeviyê adeta ji bo DocType
@@ -771,7 +771,7 @@ DocType: File,Is Home Folder,E Home Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Style
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} e a Email Address ne derbasdar e
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Li Hindîstan 1 record ji bo çapkirinê Select
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Bikarhêner &#39;{0}&#39; jixwe rola heye &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Bikarhêner '{0}' jixwe rola heye '{1}'
 DocType: System Settings,Two Factor Authentication method,Method Mîhengkirina Du Factor
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Yekem navê xwe danîne û tomar bike.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 records
@@ -932,7 +932,7 @@ DocType: DocType,Is Single,Single e
 apps/frappe/frappe/core/doctype/user/user.py,Sign Up is disabled,Sign Up neçalakirin
 apps/frappe/frappe/email/queue.py,{0} has left the conversation in {1} {2},{0} axaftina li çepê hatiye {1} {2}
 DocType: Access Log,Show Document,Belge nîşan bide
-DocType: Blogger,User ID of a Blogger,ID&#39;ya bikarhêner ji Blogger
+DocType: Blogger,User ID of a Blogger,ID'ya bikarhêner ji Blogger
 apps/frappe/frappe/core/doctype/user/user.py,There should remain at least one System Manager,divê bi kêmanî yek Manager System li wir bimînin
 DocType: GCalendar Account,Authorization Code,Code Authorization
 DocType: PayPal Settings,Mention transaction completion page URL,Behsa mêjera URL rûpel temamkirina
@@ -1021,7 +1021,7 @@ DocType: Property Setter,Property Setter,Taybetmendiyên Setter
 DocType: Web Form,Allow Print,Destûrê bide bo çapkirinê
 DocType: Communication,Clicked,bi opsîyona
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Ragihîn
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},No destûr ji bo &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},No destûr ji bo '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Scheduled bişînin
 DocType: DocType,Track Seen,Track Ruiz
 DocType: Dropbox Settings,File Backup,Backup
@@ -1048,7 +1048,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Page HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Rêzên çewt hatine derxistin
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Navê navnîşê vala nebe.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,hucûma berfireh dikarin bi tenê di bin &#39;Group&#39; type hucûma tên afirandin
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,hucûma berfireh dikarin bi tenê di bin 'Group' type hucûma tên afirandin
 DocType: SMS Parameter,Header,header
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Stûna Unknown: {0}
 DocType: Notification Recipient,Email By Role,Email By Role
@@ -1097,7 +1097,7 @@ DocType: Data Migration Mapping,Condition,Rewş
 apps/frappe/frappe/utils/data.py,{0} hours ago,{0} hours ago
 apps/frappe/frappe/utils/data.py,1 month ago,1 مانگ لەمەوبەر
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Not Specified,Ne diyar e
-DocType: Contact,User ID,ID&#39;ya bikarhêner
+DocType: Contact,User ID,ID'ya bikarhêner
 DocType: Communication,Sent,şandin
 DocType: Address,Kerala,kerala
 apps/frappe/frappe/public/js/frappe/desk.js,Administration,Birêvebirî
@@ -1430,7 +1430,7 @@ apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Customize Form,
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Type Type
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,warê Mandatory: rola danîn ji bo
 DocType: Data Migration Mapping,Mapping Name,Navê Mapping
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Zevî &#39;{1}&#39; nikare wekî bêhempa bête binav kirin ji ber ku ew xwedî nirxên ne-yekta ye
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Zevî '{1}' nikare wekî bêhempa bête binav kirin ji ber ku ew xwedî nirxên ne-yekta ye
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navnîşa navnîşê dakêşin
 DocType: Currency,A symbol for this currency. For e.g. $,"A sembola ji bo vê currency. Ji bo nimûne, $"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Bi serkeftî wergerandin
@@ -1938,7 +1938,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-başûr-1
 DocType: DocType,"Must be of type ""Attach Image""",Divê ji type be &quot;Attach Image&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Tu Tiştî Hilnebijêre
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Tu wê werine ne &#39;Read Tenê ji bo qada {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Tu wê werine ne 'Read Tenê ji bo qada {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,Zero wateya bişîne records ve hate kisandin
 DocType: Auto Email Report,Zero means send records updated at anytime,Zero wateya bişîne records ve hate kisandin
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,Setup Complete
@@ -1983,7 +1983,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Eger ev talîmat ku ne alîkar e, ji kerema xwe ve lê zêde bike li pêşniyarên xwe li ser Issues GitHub."
 DocType: Workflow State,bookmark,bookmark
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Navê Folder divê ne &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Navê Folder divê ne '/' (slash)
 DocType: Note,Note,Not
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Error Report
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Dabeşkirina Danûstandinê di formata CSV / Excel.
@@ -2087,7 +2087,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Session di zemanê H
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Ev qada wê derkevin, wê bi tenê dikarî eger fieldname danasîn li vir heye nirxa an jî qaîdeyên rasteqîn (wergerandî) in: myfield eval: doc.myfield == &#39;Nirx My&#39; eval: doc.age> 18"
+eval:doc.age>18","Ev qada wê derkevin, wê bi tenê dikarî eger fieldname danasîn li vir heye nirxa an jî qaîdeyên rasteqîn (wergerandî) in: myfield eval: doc.myfield == 'Nirx My' eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Îro
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Îro
@@ -2126,7 +2126,7 @@ DocType: Data Migration Connector,Database Name,Navê Navnîşê
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Form Refresh
 DocType: DocField,Select,Neqandin
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Log Full
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Xuyangkirina Python hêsan, Mînak: statû == &#39;Vebijêrk&#39; û celeb == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Xuyangkirina Python hêsan, Mînak: statû == 'Vebijêrk' û celeb == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,File girêdayî ne
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Têkilî winda kir. Hin taybetmendiyên ku ne kar dikin.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Dubareyên wek &quot;aaa&quot; ne hêsan texmîn
@@ -2254,7 +2254,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Tenê çewtiyê nîşan bide
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Send Email Alert
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. Razorpay nade muamele li currency piştgiriya ne &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. Razorpay nade muamele li currency piştgiriya ne '{0}'
 DocType: Data Import,In Progress,Ez teslîm nabim
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Li hêvîya bo hilanînê. Ev dibe ku çend deqîqan li ser wê saetê de bigirin.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2597,7 +2597,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Assign To,Assign To
 DocType: Workflow State,th-list,th-list
 DocType: Web Page,Enable Comments,çalak Comments
 apps/frappe/frappe/desk/doctype/note/note_list.js,Notes,Notes
-DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),Teng bike user from tenê ev Adresa IP&#39;yê. navnîşanên IP Multiple dikare veqetîne û bi hev biqetîne added. Jî qebûl adresên bi qismî wek (111.111.111)
+DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),Teng bike user from tenê ev Adresa IP'yê. navnîşanên IP Multiple dikare veqetîne û bi hev biqetîne added. Jî qebûl adresên bi qismî wek (111.111.111)
 DocType: Data Import Beta,Import Preview,Preview Import
 DocType: Communication,From,Ji
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.,a node koma pêşîn hilbijêrî.
@@ -2670,7 +2670,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Derbarê Guherîn
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal settings peredana derîyek
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Performansa Top
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Zeviyên Custom-ê li DocTypesên bingehîn nayê zêdekirin.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) kêm bibin, wek tîp destûr e {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) kêm bibin, wek tîp destûr e {2}"
 DocType: OAuth Client,Response Type,Type Response
 DocType: Contact Us Settings,Send enquiries to this email address,Send pirsên ji bo vê navnîşana email
 DocType: Letter Head,Letter Head Name,Navê nameya Serokê
@@ -2725,7 +2725,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Wêne View
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Dişibe tiştek di dema mêjera xelet çû. Ji ber ku em ji bo tezmînatê piştrast nekirîye, Paypal jî wê bixweber hûn vê hejmarê re bişînin. Ger ev ne, ji kerema xwe ji me re email bişînin û behsa ID Correlation li: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Usa jî sembol, hejmar û tîpên ku di şîfreya"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Insert Piştî zeviyê &#39;{0}&#39; de behsa li Custom Field &#39;{1}&#39;, bi label &#39;{2}&#39;, does not exist"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Insert Piştî zeviyê '{0}' de behsa li Custom Field '{1}', bi label '{2}', does not exist"
 DocType: List Filter,List Filter,Peldanka Lîsteya
 DocType: Workflow State,signal,nîşan
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Têkilî ye
@@ -2735,7 +2735,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokumentê Keçikê
 DocType: Data Export,Data Export,Export Data
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Ziman hilbijêre ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Tu nikarî qada &#39;Options&#39; hilbijêre {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Tu nikarî qada 'Options' hilbijêre {0}
 DocType: Help Article,Author,Nivîskar
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Şandina
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,diket
@@ -2749,15 +2749,15 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Default Address Şablon ne jêbirin
 DocType: Contact,Maintenance Manager,Manager Maintenance
 DocType: Workflow State,Search,Gerr
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. Stripe nade muamele li currency piştgiriya ne &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. Stripe nade muamele li currency piştgiriya ne &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. Stripe nade muamele li currency piştgiriya ne '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. Stripe nade muamele li currency piştgiriya ne '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Bavêje gilêşê
 DocType: Web Form,Web Form Fields,Fields Form Web
 DocType: Data Import,Amended From,de guherîn From
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Hişyarî: Nikare bibînin {0} di tu sifrê related to {1}
 DocType: S3 Backup Settings,eu-north-1,eu-bakur-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Ev belge niha ji bo darvekirinê weşandinê. Ji kerema xwe re dîsa biceribîne
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Wêne &#39;{0}&#39; nehate dîtin
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Wêne '{0}' nehate dîtin
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,jê Beþ
 DocType: User,Change Password,Şîfre Biguherîne
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X Axis Field
@@ -2940,7 +2940,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Nirx wenda bo
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,lê zêde bike Zarokan
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Pêşkêşkirina Import
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",Heke şert têr dibe bikarhêner dê bi pûanan were xelat kirin. wek mînak doc.status == &#39;Girtî&#39;
+",Heke şert têr dibe bikarhêner dê bi pûanan were xelat kirin. wek mînak doc.status == 'Girtî'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Record Submitted ne jêbirin.
 DocType: GSuite Templates,Template Name,Navê Şablon
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,type nû ya document
@@ -3068,7 +3068,7 @@ DocType: Dashboard Chart,Chart Type,Tîpa Çartê
 DocType: DocType,Auto Name,Navê Auto
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Dûr Rêzkirinên wek abc an 6543, wek ku hêsan tên texmîn"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Ji kerema xwe re dîsa biceribîne
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',Divê URL bi &#39;http: //&#39; an &#39;https: //&#39; dest pê bike.
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',Divê URL bi 'http: //' an 'https: //' dest pê bike.
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Vebijarka 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Weşandin
@@ -3215,7 +3215,7 @@ apps/frappe/frappe/desk/page/user_profile/user_profile.js,Energy Points: ,Points
 DocType: ToDo,ToDo,Kirin
 DocType: DocField,No Copy,No Copy
 DocType: Workflow State,qrcode,QRCode
-DocType: Chat Token,IP Address,Navnîşana IP&#39;yê
+DocType: Chat Token,IP Address,Navnîşana IP'yê
 DocType: Data Import,Submit after importing,Piştî hilberandinê
 apps/frappe/frappe/www/login.html,Login with LDAP,Login bi LDAP
 DocType: Web Form,Breadcrumbs,Menûyên
@@ -3303,7 +3303,7 @@ DocType: Notification,Send alert if this field's value changes,Send hişyar eger
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Colors Theme
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Select a DocType to make a format nû
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Bikarhêner nabe
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Recipients&#39; ne diyar kirin
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Recipients' ne diyar kirin
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,niha
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Bikaranîn
 DocType: Footer Item,Policy,Tektîk
@@ -3351,7 +3351,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Wergerên Custom
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Pêşverûtî
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,destê Role
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Fields wenda
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname Invalid &#39;{0}&#39; li BixweberNAME
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname Invalid '{0}' li BixweberNAME
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Search di cureyê pelgeyê
 DocType: Custom DocPerm,Role and Level,Role û Level
 DocType: File,Thumbnail URL,URL Thumbnail
@@ -3439,11 +3439,11 @@ DocType: Dashboard Chart,Filters JSON,Filters JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Ji bo rastkirina li vir bitikîne
 DocType: Email Account,Disable SMTP server authentication,Nasnameya servera SMTP-ê nekêşînin
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Li clipboard kopî kirin.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Substitutions kerban wek &#39;@&#39; li şûna &#39;a&#39; ji gelek alîkariya ne.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Substitutions kerban wek '@' li şûna 'a' ji gelek alîkariya ne.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Rêdan By Me
 apps/frappe/frappe/utils/data.py,Zero,Sifir
 DocType: Google Drive,Backup Folder ID,IDya Peldanka Bişkêş
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ne li Mode Developer! Set li site_config.json an bide DocType &#39;Custom&#39;.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ne li Mode Developer! Set li site_config.json an bide DocType 'Custom'.
 DocType: Workflow State,globe,dinyagog
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,Pêşeyî
@@ -3488,9 +3488,9 @@ apps/frappe/frappe/www/contact.py,New Message from Website Contact Page,Peyama N
 DocType: Notification,Reference Date,Date: Çavkanî
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,Damezrandina OTP-ê bi karanîna OTP-ê App temam nekir. Ji kerema xwe rêvebirê têkiliyê.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Ji kerema xwe ve nos mobile derbasdar têkeve
-apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Hin taybetiyan rêzkirina kombersê di geroka te kar ne. Tikaye browser&#39;î xwe ji bo guhertoya dawî rojane bike.
-apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Hin taybetiyan rêzkirina kombersê di geroka te kar ne. Tikaye browser&#39;î xwe ji bo guhertoya dawî rojane bike.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nizanin, bipirsin &#39;help&#39;"
+apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Hin taybetiyan rêzkirina kombersê di geroka te kar ne. Tikaye browser'î xwe ji bo guhertoya dawî rojane bike.
+apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Hin taybetiyan rêzkirina kombersê di geroka te kar ne. Tikaye browser'î xwe ji bo guhertoya dawî rojane bike.
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nizanin, bipirsin 'help'"
 DocType: DocType,Comments and Communications will be associated with this linked document,Comments û Communications dê bi vê belgeya girêdayî têkildarkirin
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Parzûn...
 DocType: Workflow State,bold,hesabî
@@ -3518,7 +3518,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Dema ku endamê şandina rûniştinê tê kirin
 DocType: LDAP Settings,LDAP Group Field,Qada Group LDAP
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,li beramberî
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',"type &#39;Dînamîk Link&#39; Vebijêrkên yên zeviyê, divê ji bo Link din Field bi options wek &#39;DocType&#39; dîrektîfa"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',"type 'Dînamîk Link' Vebijêrkên yên zeviyê, divê ji bo Link din Field bi options wek 'DocType' dîrektîfa"
 DocType: About Us Settings,Team Members Heading,Endam Team Berev
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Format CSV Invalid
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Connewtiya di girêdana serîlêdanê ya QZ Tray de têkildar e ... <br><br> Hûn hewce ne ku serîlêdana QZ Tray-ê saz bikin û bisekinin, da ku taybetmendiya Raw çapkirinê bikar bînin. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Vira bikirtînin û QZ Tray bikirtînin</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Vira bikirtînin da ku di derbarê çapkirina Raw de bêtir fêr bibin</a> ."
@@ -3645,8 +3645,8 @@ DocType: Web Page,Web Page,Page Web
 DocType: Workflow Document State,Next Action Email Template,Belgeya Bersîvê Next Next
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Heke were gengaz kirin, guharîn li belgeyê hatî şopandin û di demê de têne xuyang kirin"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Li Global Search&#39; ji bo cureyê destûr ne {0} li row {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Li Global Search&#39; ji bo cureyê destûr ne {0} li row {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Li Global Search' ji bo cureyê destûr ne {0} li row {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Li Global Search' ji bo cureyê destûr ne {0} li row {1}
 DocType: Energy Point Log,Appreciation,Rûmetdanî
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,View List
 DocType: Workflow,Don't Override Status,Ma Status Override ne
@@ -3789,7 +3789,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Destçûnî
 DocType: Translation,Verified,Verast kirin
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} added
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Search for &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Search for '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Ji kerema xwe re vê raporê xilas yekem
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} aboneyên added
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,ne In
@@ -3826,14 +3826,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Min
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} ne Dewletê derbasdar
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Li ser Hemî Tîpên Belgeyê bicîh bikin
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Rojanebûna enerjiyê
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. PayPal nade muamele li currency piştgiriya ne &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Tikaye din rêbaza dayina hilbijêre. PayPal nade muamele li currency piştgiriya ne '{0}'
 DocType: Chat Message,Room Type,Tenduristiyê
 DocType: Data Import Beta,Import Log Preview,Pêşniyara têketinê ya Log
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,warê Search {0} ne derbasdar e
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,pelê hilandin
 DocType: Workflow State,ok-circle,ok-circle
 DocType: LDAP Settings,LDAP User Creation and Mapping,Afirandina û Nexşeya Bikarhênerê LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Tu tişt bi pirs &#39;bibînin porteqalan di mişterî&#39; bibînin
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Tu tişt bi pirs 'bibînin porteqalan di mişterî' bibînin
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,"Bibore! User, divê bi temamî ji bo qeyda xwe bi xwe heye."
 ,Usage Info,Info Bikaranîna
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Kurtikên Pêl bişkoka nîşan bikin

--- a/frappe/translations/ku.csv
+++ b/frappe/translations/ku.csv
@@ -1401,7 +1401,7 @@ DocType: Report,Is Standard,e Standard
 DocType: Desktop Icon,_report,_nûçe
 DocType: Desktop Icon,_report,_nûçe
 DocType: Dashboard Chart,Full,Tije
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ma ne tags HTML Encode HTML mîna &lt;script>, yan jî tenê characters wek &lt;an>, çawa ew dibe bê bi zanebûn di vê qadê de bi kar"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ma ne tags HTML Encode HTML mîna <script>, yan jî tenê characters wek <an>, çawa ew dibe bê bi zanebûn di vê qadê de bi kar"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} li ser {1} hate rexnekirin
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Rev
@@ -1770,7 +1770,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer dê tenê 
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Nexelas
 DocType: System Settings,Allow only one session per user,Destûrê bide tenê yek session per user
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folder Home / Test 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
+DocType: Website Settings,<head> HTML,<Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Select an nîr û li seranserî slots dem ji bo bûyereke nû.
 DocType: Contact,Contact Details,Contact Details
 DocType: DocField,In Filter,li Filter
@@ -2286,7 +2286,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Bi destûr bes ji bo dîtina girêdan
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Address Title bivênevê ye.
 DocType: Google Contacts,Push to Google Contacts,Pêdivî ye ku Têkilî Google bike
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Ev babete ji layê HTML di &lt;head> beşa web page de, di serî de ji bo piştrastkirin malpera û SEO bikaranîn"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Ev babete ji layê HTML di <head> beşa web page de, di serî de ji bo piştrastkirin malpera û SEO bikaranîn"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Petzäll
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Babetê dikarin ji bo neviyên xwe bi xwe ne bê added
 DocType: Session Default Settings,Session Defaults,Session Defaults
@@ -2403,7 +2403,7 @@ DocType: Workflow State,Warning,Gazî
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dibe ku ev li gelek rûpelan were çap kirin
 DocType: Data Migration Run,Percent Complete,Perî Têr
 DocType: Tag Category,Tag Category,Tag Kategorî
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ji bo berhevdanê,> 5, &lt;10 an = 324 bikar bînin. Ji bo rêzan, 5:10 bikar bînin (ji bo nirxên di navbera 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ji bo berhevdanê,> 5, <10 an = 324 bikar bînin. Ji bo rêzan, 5:10 bikar bînin (ji bo nirxên di navbera 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Ji Salnameya Google-ê dakêşin
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Alîkarî
 DocType: User,Login Before,Login Berî
@@ -3031,7 +3031,7 @@ DocType: DocField,Allow on Submit,Destûrê bide li ser Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Type îstîsna
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick Stûn
-DocType: Web Page,Add code as &lt;script>,Lê zêde bike koda wek &lt;script>
+DocType: Web Page,Add code as <script>,Lê zêde bike koda wek <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Destûrên bikarhênerê zelal bikin
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Upcoming Events
@@ -3399,16 +3399,16 @@ DocType: Workflow State,share-alt,re-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},"Raweste, divê yek ji yên bê {0}"
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4 style=""""> Default Şablon </h4><p style=""""> Zimên <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> û di hemû waran de ji Address (di nav wan de Fields Custom, eger) peyda bibin </p><pre style=""""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4 style=""""> Default Şablon </h4><p style=""""> Zimên <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> û di hemû waran de ji Address (di nav wan de Fields Custom, eger) peyda bibin </p><pre style=""""> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Dest Dîroka Destpêk
 DocType: Role,Role Name,Navê rola
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch To Desk

--- a/frappe/translations/ku.csv
+++ b/frappe/translations/ku.csv
@@ -734,7 +734,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Barkirinê 
 DocType: DocField,In Global Search,Di Global Search
 DocType: System Settings,Brute Force Security,Ewlekariya Hêza Brute
 DocType: Workflow State,indent-left,indent-çepê
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} sal (sal) berê
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} sal (sal) berê
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Ev metirsiyek e li vê pelê jê bibî: {0}. Ji kerema xwe ve Manager Pergala xwe re bikeve têkiliyê.
 DocType: Currency,Currency Name,Navê Exchange
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No Emails
@@ -1030,7 +1030,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,No {0} dîtin
 apps/frappe/frappe/config/customization.py,Add custom forms.,Lê zêde bike formên adeta.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} li {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,şandin ku ev belge
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Setup&gt; Destûrên bikarhêner
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Setup> Destûrên bikarhêner
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sîstema gelek ristên pre-danasîn pêşkêş dike. Tu fonksiyoneke nû ji bo danîna destûrên bihéné lê zêde bike.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1246,7 +1246,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ger user ti rola kontrol heye, piştre bikarhêner &quot;System User&quot; dibe. &quot;Pergala User&quot; access to the desktop heye"
 DocType: System Settings,Date and Number Format,Dîrok û Number Format
 apps/frappe/frappe/model/document.py,one of,yek ji
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Setup&gt; Forma Sêwiranê
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Setup> Forma Sêwiranê
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Dinêre yek gavê
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Show Tags
 DocType: DocField,HTML Editor,Edîtora HTML
@@ -1254,7 +1254,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Billing
 DocType: Email Queue,Not Sent,Sent ne
 DocType: Web Form,Actions,Actions
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Setup&gt; Bikarhêner
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Setup> Bikarhêner
 DocType: Workflow State,align-justify,align-mafdar
 DocType: User,Middle Name (Optional),Navê Navîn (Li gorî daxwazê)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,destûrdayî ne
@@ -1401,7 +1401,7 @@ DocType: Report,Is Standard,e Standard
 DocType: Desktop Icon,_report,_nûçe
 DocType: Desktop Icon,_report,_nûçe
 DocType: Dashboard Chart,Full,Tije
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ma ne tags HTML Encode HTML mîna &lt;script&gt;, yan jî tenê characters wek &lt;an&gt;, çawa ew dibe bê bi zanebûn di vê qadê de bi kar"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ma ne tags HTML Encode HTML mîna &lt;script>, yan jî tenê characters wek &lt;an>, çawa ew dibe bê bi zanebûn di vê qadê de bi kar"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} li ser {1} hate rexnekirin
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Rev
@@ -1770,7 +1770,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer dê tenê 
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Nexelas
 DocType: System Settings,Allow only one session per user,Destûrê bide tenê yek session per user
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folder Home / Test 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Select an nîr û li seranserî slots dem ji bo bûyereke nû.
 DocType: Contact,Contact Details,Contact Details
 DocType: DocField,In Filter,li Filter
@@ -2000,7 +2000,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Têketinê di vê demê de destûr ne
 DocType: Data Migration Run,Current Mapping Action,Çalakiya Mapping Current
 DocType: Dashboard Chart Source,Source Name,Navê Source
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Ne hesabek e-nameyê bi bikarhênerê re têkildar e. Ji kerema xwe hesabek di bin Bikarhêner&gt; E-nameya Emailê de zêde bikin.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Ne hesabek e-nameyê bi bikarhênerê re têkildar e. Ji kerema xwe hesabek di bin Bikarhêner> E-nameya Emailê de zêde bikin.
 DocType: Email Account,Email Sync Option,Email Syncê Vebijarka
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Row No
 DocType: Async Task,Runtime,Runtime
@@ -2014,7 +2014,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Jixwe di 
 DocType: User Email,Enable Outgoing,çalak Afganî
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Custom Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Hesabê e-nameyê nehatiye saz kirin. Ji kerema xwe ji Sîstema&gt; E-name&gt; Hesaba E-nameyê hesabek e-nameyek nû biafirînin
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Hesabê e-nameyê nehatiye saz kirin. Ji kerema xwe ji Sîstema> E-name> Hesaba E-nameyê hesabek e-nameyek nû biafirînin
 DocType: Comment,Submitted,şandin
 DocType: Contact,Pulled from Google Contacts,Ji Têkiliyên Google vekişand
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Di daxwaza rast de
@@ -2087,7 +2087,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Session di zemanê H
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Ev qada wê derkevin, wê bi tenê dikarî eger fieldname danasîn li vir heye nirxa an jî qaîdeyên rasteqîn (wergerandî) in: myfield eval: doc.myfield == &#39;Nirx My&#39; eval: doc.age&gt; 18"
+eval:doc.age>18","Ev qada wê derkevin, wê bi tenê dikarî eger fieldname danasîn li vir heye nirxa an jî qaîdeyên rasteqîn (wergerandî) in: myfield eval: doc.myfield == &#39;Nirx My&#39; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Îro
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Îro
@@ -2101,7 +2101,7 @@ apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of th
 DocType: DocType,UPPER CASE,Upper Case
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML Custom
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Navê peldankê binivîse
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Temablonê navnîşa xwerû nehat dîtin. Ji kerema xwe ji Modela Sêwiranê&gt; çapkirin û Berfirehkirina&gt; Navnîşek nû çêbikin.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Temablonê navnîşa xwerû nehat dîtin. Ji kerema xwe ji Modela Sêwiranê> çapkirin û Berfirehkirina> Navnîşek nû çêbikin.
 apps/frappe/frappe/auth.py,Unknown User,Bikarhêner
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Hilbijêre Role
 DocType: Comment,Deleted,deleted
@@ -2286,7 +2286,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Bi destûr bes ji bo dîtina girêdan
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Address Title bivênevê ye.
 DocType: Google Contacts,Push to Google Contacts,Pêdivî ye ku Têkilî Google bike
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Ev babete ji layê HTML di &lt;head&gt; beşa web page de, di serî de ji bo piştrastkirin malpera û SEO bikaranîn"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Ev babete ji layê HTML di &lt;head> beşa web page de, di serî de ji bo piştrastkirin malpera û SEO bikaranîn"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Petzäll
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Babetê dikarin ji bo neviyên xwe bi xwe ne bê added
 DocType: Session Default Settings,Session Defaults,Session Defaults
@@ -2403,7 +2403,7 @@ DocType: Workflow State,Warning,Gazî
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dibe ku ev li gelek rûpelan were çap kirin
 DocType: Data Migration Run,Percent Complete,Perî Têr
 DocType: Tag Category,Tag Category,Tag Kategorî
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ji bo berhevdanê,&gt; 5, &lt;10 an = 324 bikar bînin. Ji bo rêzan, 5:10 bikar bînin (ji bo nirxên di navbera 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Ji bo berhevdanê,> 5, &lt;10 an = 324 bikar bînin. Ji bo rêzan, 5:10 bikar bînin (ji bo nirxên di navbera 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Ji Salnameya Google-ê dakêşin
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Alîkarî
 DocType: User,Login Before,Login Berî
@@ -2859,7 +2859,7 @@ DocType: Custom Script,Custom Script,Script Custom
 DocType: Address,Address Line 2,Line Address 2
 DocType: Address,Reference,Balkêşî
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,rêdan û To
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Ji kerema xwe ji Sîstema&gt; E-name&gt; Hesabê E-nameya Rast Ji Bila Hesabê E-nameyê saz bike
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Ji kerema xwe ji Sîstema> E-name> Hesabê E-nameya Rast Ji Bila Hesabê E-nameyê saz bike
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Migration Detailed Data Data
 DocType: Data Import,Action,Çalakî
 DocType: GSuite Settings,Script URL,URL script
@@ -3031,7 +3031,7 @@ DocType: DocField,Allow on Submit,Destûrê bide li ser Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Type îstîsna
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick Stûn
-DocType: Web Page,Add code as &lt;script&gt;,Lê zêde bike koda wek &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Lê zêde bike koda wek &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Destûrên bikarhênerê zelal bikin
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Upcoming Events
@@ -3399,16 +3399,16 @@ DocType: Workflow State,share-alt,re-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},"Raweste, divê yek ji yên bê {0}"
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4 style=""""> Default Şablon </h4><p style=""""> Zimên <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> û di hemû waran de ji Address (di nav wan de Fields Custom, eger) peyda bibin </p><pre style=""""> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4 style=""""> Default Şablon </h4><p style=""""> Zimên <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> û di hemû waran de ji Address (di nav wan de Fields Custom, eger) peyda bibin </p><pre style=""""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Dest Dîroka Destpêk
 DocType: Role,Role Name,Navê rola
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch To Desk

--- a/frappe/translations/lo.csv
+++ b/frappe/translations/lo.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,ແມ່ນມາດຕະຖານ
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,ເຕັມ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ບໍ່ tags HTML ເຂົ້າລະຫັດ HTML ຄື &lt;script> ຫຼືພຽງແຕ່ລັກສະນະຄ້າຍຄື &lt;ຫຼື>, ຍ້ອນວ່າເຂົາເຈົ້າສາມາດໄດ້ຮັບການນໍາໃຊ້ເຈດຕະນາໃນພາກສະຫນາມນີ້"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","ບໍ່ tags HTML ເຂົ້າລະຫັດ HTML ຄື <script> ຫຼືພຽງແຕ່ລັກສະນະຄ້າຍຄື <ຫຼື>, ຍ້ອນວ່າເຂົາເຈົ້າສາມາດໄດ້ຮັບການນໍາໃຊ້ເຈດຕະນາໃນພາກສະຫນາມນີ້"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} ຖືກວິພາກວິຈານໃນ {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ແລ່ນ
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer ຈະສ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,ທີ່ຍັງຄ້າງ
 DocType: System Settings,Allow only one session per user,ອະນຸຍາດໃຫ້ພຽງແຕ່ກອງປະຊຸມຫນຶ່ງຕໍ່ຜູ້ໃຊ້
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ຫນ້າທໍາອິດ / ການທົດສອບ Folder 1 / ການທົດສອບ Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ເລືອກຫຼືລາກຂ້າມຊ່ວງເວລາທີ່ຈະສ້າງເປັນເຫດການໃຫມ່.
 DocType: Contact,Contact Details,ລາຍລະອຽດການຕິດຕໍ່
 DocType: DocField,In Filter,ໃນ Filter
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ບໍ່ອະນຸຍາດພຽງພໍທີ່ຈະເຫັນການເຊື່ອມຕໍ່
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ທີ່ຢູ່ Title ແມ່ນບັງຄັບ.
 DocType: Google Contacts,Push to Google Contacts,ຍູ້ໄປຫາລາຍຊື່ຜູ້ຕິດຕໍ່ Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","ເພີ່ມ HTML ໃນ &lt;head> ພາກສ່ວນຂອງຫນ້າເວັບໄຊຕ໌, ການນໍາໃຊ້ຕົ້ນຕໍສໍາລັບການຢັ້ງຢືນເວັບໄຊທ໌ແລະ SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","ເພີ່ມ HTML ໃນ <head> ພາກສ່ວນຂອງຫນ້າເວັບໄຊຕ໌, ການນໍາໃຊ້ຕົ້ນຕໍສໍາລັບການຢັ້ງຢືນເວັບໄຊທ໌ແລະ SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ຊຶ່ງໄດ້ກໍາເລີບ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ລາຍການບໍ່ສາມາດໄດ້ຮັບການເພີ່ມລູກຫລານຂອງຕົນເອງ
 DocType: Session Default Settings,Session Defaults,ຄ່າເລີ່ມຕົ້ນຂອງກອງປະຊຸມ
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,ການເຕືອນໄພ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ສິ່ງນີ້ອາດຈະຖືກພິມລົງໃນຫລາຍໆ ໜ້າ
 DocType: Data Migration Run,Percent Complete,ອັດຕາສ່ວນສໍາເລັດ
 DocType: Tag Category,Tag Category,Tag Category
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ສຳ ລັບການປຽບທຽບ, ໃຊ້> 5, &lt;10 ຫລື = 324. ສຳ ລັບຂອບເຂດ, ໃຫ້ໃຊ້ 5:10 (ສຳ ລັບຄ່າລະຫວ່າງ 5 ແລະ 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ສຳ ລັບການປຽບທຽບ, ໃຊ້> 5, <10 ຫລື = 324. ສຳ ລັບຂອບເຂດ, ໃຫ້ໃຊ້ 5:10 (ສຳ ລັບຄ່າລະຫວ່າງ 5 ແລະ 10)."
 DocType: Google Calendar,Pull from Google Calendar,ດຶງຈາກ Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ຊ່ວຍເຫຼືອ
 DocType: User,Login Before,ເຂົ້າສູ່ລະບົບກ່ອນ
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,ອະນຸຍາດໃຫ້ຢູ່ໃນ�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,ປະເພດຍົກເວັ້ນ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,ເອົາຄໍລໍາ
-DocType: Web Page,Add code as &lt;script>,ເພີ່ມລະຫັດເປັນ &lt;script>
+DocType: Web Page,Add code as <script>,ເພີ່ມລະຫັດເປັນ <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ອະນຸຍາດອະນຸຍາດໃຫ້ຜູ້ໃຊ້
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ເຫດການ upcoming
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,ສ່ວນ alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ຄິວຄວນຈະເປັນຫນຶ່ງໃນ {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> ແມ່ແບບມາດຕະຖານ </h4><p> ການນໍາໃຊ້ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ແລະທົ່ງນາທັງຫມົດຂອງທີ່ຢູ່ (ລວມເຖິງຂໍ້ມູນ Custom ຖ້າມີ) ຈະສາມາດໃຊ້ໄດ້ </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> ແມ່ແບບມາດຕະຖານ </h4><p> ການນໍາໃຊ້ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ແລະທົ່ງນາທັງຫມົດຂອງທີ່ຢູ່ (ລວມເຖິງຂໍ້ມູນ Custom ຖ້າມີ) ຈະສາມາດໃຊ້ໄດ້ </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Start Date Field
 DocType: Role,Role Name,ຊື່ພາລະບົດບາດ
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ສະຫຼັບກັບລະ Desk

--- a/frappe/translations/lo.csv
+++ b/frappe/translations/lo.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","ຖ້າເປີດການ, ມີຄວາມເຂັ້ມແຂງລະຫັດຜ່ານຈະຖືກບັງຄັບໃຊ້ໂດຍອີງໃສ່ມູນຄ່າຕໍາ່ສຸດທີ່ຄະແນນລະຫັດຜ່ານ. A ຄ່າຂອງ 2 ເປັນທີ່ເຂັ້ມແຂງຂະຫນາດກາງແລະ 4 ເປັນທີ່ເຂັ້ມແຂງທີ່ສຸດ."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","ຖ້າເປີດການ, ມີຄວາມເຂັ້ມແຂງລະຫັດຜ່ານຈະຖືກບັງຄັບໃຊ້ໂດຍອີງໃສ່ມູນຄ່າຕໍາ່ສຸດທີ່ຄະແນນລະຫັດຜ່ານ. A ຄ່າຂອງ 2 ເປັນທີ່ເຂັ້ມແຂງຂະຫນາດກາງແລະ 4 ເປັນທີ່ເຂັ້ມແຂງທີ່ສຸດ."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;ສະພາ&quot; ຫຼື &quot;ການຈັດການ&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',ມາດຕະຖານສໍາລັບປະເພດ &#39;ກວດສອບຂອງພາກສະຫນາມຈະຕ້ອງບໍ່ວ່າຈະ&#39; 0 &#39;ຫລື&#39; 1 &#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',ມາດຕະຖານສໍາລັບປະເພດ 'ກວດສອບຂອງພາກສະຫນາມຈະຕ້ອງບໍ່ວ່າຈະ' 0 'ຫລື' 1 '
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,ໃນມື້ວານນີ້
 DocType: Contact,Designation,ການອອກແບບ
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,ການເຊື່ອມໂຍງແບບອັດຕະໂນມັດສາມາດເປີດໃຊ້ໄດ້ ສຳ ລັບບັນຊີ Email ດຽວເທົ່ານັ້ນ.
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,ປິດກາ�
 DocType: Translation,Contributed Translation Doctype Name,ປະກອບສ່ວນຊື່ການແປພາສາ Doctype
 DocType: PayPal Settings,Redirect To,ປ່ຽນເສັ້ນທາງໄປ
 DocType: Data Migration Mapping,Pull,ດຶງ
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [ &#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [ 'REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,ປັບປຸງຫຼາຍ
 DocType: Workflow State,chevron-up,ວົງຢືມຊ້ອນຂຶ້ນ
 DocType: DocType,Allow Guest to View,ອະນຸຍາດໃຫ້ບຸກຄົນທົ່ວໄປທີ່ຈະເບິ່ງ
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),ສະຖິຕິໂດຍອີງໃສ່ຜົນງານຂອງອາທິດທີ່ຜ່ານມາ (ຈາກ {0} ເຖິງ {1})
 DocType: LDAP Settings,LDAP Phone Field,ສະ ໜາມ ໂທລະສັບ LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","ປະເພດເອກະສານ ... , ຕົວຢ່າງລູກຄ້າ"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,ສະພາບ &#39;{0}&#39; ແມ່ນບໍ່ຖືກຕ້ອງ
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,ສະພາບ '{0}' ແມ່ນບໍ່ຖືກຕ້ອງ
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,ການນໍາໃຊ້ຄໍາຖາມຍ່ອຍຫຼືຫນ້າທີ່ຖືກຈໍາກັດ
 apps/frappe/frappe/config/customization.py,Add your own translations,ເພີ່ມການແປພາສາຂອງຕົນເອງ
@@ -714,7 +714,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,ຊື່ຜູ້ໃຊ້ {0} ມີຢູ່ແລ້ວ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,"{0}: ບໍ່ສາມາດກໍານົດການນໍາເຂົ້າ {1}, ບໍ່ແມ່ນການທີ່ສໍາຄັນ"
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},ມີຂໍ້ຜິດພາດໃນແມ່ແບບທີ່ຢູ່ຂອງທ່ານແມ່ນ {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} ເປັນທີ່ຢູ່ອີເມວທີ່ບໍ່ຖືກຕ້ອງໃນ &#39;ຜູ້ຮັບ&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} ເປັນທີ່ຢູ່ອີເມວທີ່ບໍ່ຖືກຕ້ອງໃນ 'ຜູ້ຮັບ'
 DocType: Footer Item,"target = ""_blank""",ເປົ້າຫມາຍ = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,ການເປັນເຈົ້າພາບ
@@ -756,7 +756,7 @@ DocType: Currency,Currency Name,ຊື່ສະກຸນເງິນ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No ອີເມວ
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,ການເຊື່ອມໂຍງຫມົດອາຍຸ
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",ກັບຄືນໄປບ່ອນຄວາມຍາວກັບ {0} ສໍາລັບ &#39;{1}&#39; ໃນ &#39;{2}&#39; ການຕັ້ງຄ່າຄວາມຍາວເປັນ {3} ຈະເຮັດໃຫ້ຂໍ້ມູນລ້າໆ.
+							Setting the length as {3} will cause truncation of data.",ກັບຄືນໄປບ່ອນຄວາມຍາວກັບ {0} ສໍາລັບ '{1}' ໃນ '{2}' ການຕັ້ງຄ່າຄວາມຍາວເປັນ {3} ຈະເຮັດໃຫ້ຂໍ້ມູນລ້າໆ.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,ເລືອກຮູບແບບໄຟລ໌
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash ເນື້ອໃນ
@@ -772,13 +772,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","ມາດຕະຖານ DocType ບໍ່ສາມາດມີຮູບແບບການພິມໃນຕອນຕົ້ນ, ການນໍາໃຊ້ແບບຟອມທີ່ກໍາຫນົດເອງ"
 DocType: Report,Query,ການສອບຖາມ
 DocType: Customize Form,Sort Order,ຮຽງ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;ໃນຊີ View&#39; ບໍ່ອະນຸຍາດໃຫ້ສໍາລັບປະເພດ {0} ຕິດຕໍ່ກັນ {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'ໃນຊີ View' ບໍ່ອະນຸຍາດໃຫ້ສໍາລັບປະເພດ {0} ຕິດຕໍ່ກັນ {1}
 DocType: Letter Head,Footer HTML,Footer HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,ເລືອກເອົາປ້າຍຫຼັງຈາກທີ່ທ່ານຕ້ອງການທີ່ຈະສະແດງກິ່ງງ່າພາກສະຫນາມໃຫມ່.
 ,Document Share Report,ເອກະສານລາຍວຽກ
 DocType: Social Login Key,Base URL,Base URL
 DocType: User,Last Login,ລະບົບຫຼ້າສຸດ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ທ່ານບໍ່ສາມາດຕັ້ງ &#39;Translatable&#39; ສໍາລັບພາກ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},ທ່ານບໍ່ສາມາດຕັ້ງ 'Translatable' ສໍາລັບພາກ {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,ຄໍລໍາ
 DocType: Chat Profile,Chat Profile,Chat Profile
 DocType: Custom Field,Adds a custom field to a DocType,ເພີ້ມພາກສະຫນາມ custom ເພື່ອ DocType ເປັນ
@@ -787,7 +787,7 @@ DocType: File,Is Home Folder,ແມ່ນຫນ້າທໍາອິດ Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,ແບບ Navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ບໍ່ແມ່ນທີ່ຢູ່ອີເມວທີ່ຖືກຕ້ອງ
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,ເລືອກ atleast 1 ບັນທຶກສໍາລັບການພິມ
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ຜູ້ໃຊ້ {0} &#39;ແລ້ວມີພາລະບົດບາດ&#39; {1} &#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ຜູ້ໃຊ້ {0} 'ແລ້ວມີພາລະບົດບາດ' {1} '
 DocType: System Settings,Two Factor Authentication method,ວິທີການສອງກວດສອບປັດໄຈ
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,ທໍາອິດກໍານົດຊື່ແລະບັນທຶກຂໍ້ມູນ.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 ບັນທຶກ
@@ -1040,7 +1040,7 @@ DocType: Property Setter,Property Setter,ຄຸນສົມບັດ Setter
 DocType: Web Form,Allow Print,ອະນຸຍາດໃຫ້ພິມ
 DocType: Communication,Clicked,ຄິກ
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,ບໍ່ຕິດ
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},ບໍ່ອະນຸຍາດໃຫ້ &#39;{0} {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},ບໍ່ອະນຸຍາດໃຫ້ '{0} {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,ກໍານົດທີ່ຈະສົ່ງ
 DocType: DocType,Track Seen,ຕິດຕາມຄັ້ງ
 DocType: Dropbox Settings,File Backup,File Backup
@@ -1067,7 +1067,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,ຫນ້າ HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,ສົ່ງອອກແຖວ Errored
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,ຊື່ກຸ່ມບໍ່ສາມາດຫວ່າງໄດ້.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,ຂໍ້ເພີ່ມເຕີມສາມາດໄດ້ຮັບການສ້າງຕັ້ງພຽງແຕ່ພາຍໃຕ້ &#39;ຂອງກຸ່ມຂໍ້ປະເພດ
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,ຂໍ້ເພີ່ມເຕີມສາມາດໄດ້ຮັບການສ້າງຕັ້ງພຽງແຕ່ພາຍໃຕ້ 'ຂອງກຸ່ມຂໍ້ປະເພດ
 DocType: SMS Parameter,Header,Header
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},ຮູ້ຈັກຄໍລໍາ: {0}
 DocType: Notification Recipient,Email By Role,Email ໂດຍພາລະບົດບາດ
@@ -1458,7 +1458,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,ພາກສະຫນາມບັງຄັບ: ກໍານົດພາລະບົດບາດສໍາລັບການ
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} ວິພາກວິຈານ {1}
 DocType: Data Migration Mapping,Mapping Name,ຊື່ແຜນທີ່
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ພາກສະ ໜາມ &#39;{1}&#39; ບໍ່ສາມາດ ກຳ ນົດເປັນເອກະລັກເພາະມັນມີຄຸນຄ່າທີ່ບໍ່ແມ່ນເອກະລັກ
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ພາກສະ ໜາມ '{1}' ບໍ່ສາມາດ ກຳ ນົດເປັນເອກະລັກເພາະມັນມີຄຸນຄ່າທີ່ບໍ່ແມ່ນເອກະລັກ
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,ນຳ ທາງລາຍຊື່ລົງລຸ່ມ
 DocType: Currency,A symbol for this currency. For e.g. $,ເປັນສັນຍາລັກສໍາລັບການສະກຸນເງິນນີ້. ສໍາລັບຕົວຢ່າງ: $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,ການແປພາສາປັບປຸງສົບຜົນສໍາເລັດ
@@ -1980,7 +1980,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-ເວັນອອກສ່ຽງໃຕ້ -1
 DocType: DocType,"Must be of type ""Attach Image""",ຈະຕ້ອງເປັນຂອງປະເພດ &quot;ຄັດຕິດຮູບພາບ&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,ຍົກເລີກທັງຫມົດ
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ທ່ານບໍ່ສາມາດລ້າງ &#39;ອ່ານພຽງແຕ່ສໍາລັບພາກສະຫນາມ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ທ່ານບໍ່ສາມາດລ້າງ 'ອ່ານພຽງແຕ່ສໍາລັບພາກສະຫນາມ {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,ສູນມີຄວາມຫມາຍສົ່ງການບັນທຶກການປັບປຸງຕະຫຼອດເວລາ
 DocType: Auto Email Report,Zero means send records updated at anytime,ສູນມີຄວາມຫມາຍສົ່ງການບັນທຶກການປັບປຸງຕະຫຼອດເວລາ
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,ການຕິດຕັ້ງສໍາເລັດສົມບູນ
@@ -2025,7 +2025,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","ຖ້າຫາກວ່າຄໍາແນະນໍາເຫຼົ່ານີ້ທີ່ບໍ່ເປັນປະໂຫຍດ, ກະລຸນາຕື່ມໃນຄໍາແນະນໍາຂອງທ່ານກ່ຽວກັບບັນຫາ GitHub."
 DocType: Workflow State,bookmark,Bookmark
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ຊື່ Folder ບໍ່ຄວນປະກອບມີ &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ຊື່ Folder ບໍ່ຄວນປະກອບມີ '/' (slash)
 DocType: Note,Note,ຫມາຍເຫດ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,ບົດລາຍງານຄວາມຜິດພາດ
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,ສົ່ງຂໍ້ມູນໃນຮູບແບບ CSV / Excel.
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ກອງປະຊ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",ພາກສະຫນາມນີ້ຈະໄປປາກົດພຽງແຕ່ຖ້າວ່າ fieldname ທີ່ກໍາຫນົດໄວ້ທີ່ນີ້ມີມູນຄ່າ OR ກົດລະບຽບແມ່ນຄວາມຈິງ (ຕົວຢ່າງ): myfield eval: doc.myfield == &#39;ຄ່າຂອງຂ້າພະເຈົ້າ&#39; eval: doc.age> 18
+eval:doc.age>18",ພາກສະຫນາມນີ້ຈະໄປປາກົດພຽງແຕ່ຖ້າວ່າ fieldname ທີ່ກໍາຫນົດໄວ້ທີ່ນີ້ມີມູນຄ່າ OR ກົດລະບຽບແມ່ນຄວາມຈິງ (ຕົວຢ່າງ): myfield eval: doc.myfield == 'ຄ່າຂອງຂ້າພະເຈົ້າ' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ໃນມື້ນີ້
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ໃນມື້ນີ້
@@ -2171,7 +2171,7 @@ DocType: Data Migration Connector,Database Name,ຊື່ຖານຂໍ້ມ�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,ໃນແບບຟອມການໂຫຼດຫນ້າຈໍຄືນ
 DocType: DocField,Select,ເລືອກ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,ເບິ່ງບັນທຶກເຕັມ
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ການສະແດງອອກ Python ແບບງ່າຍດາຍ, ຕົວຢ່າງ: ສະຖານະພາບ == &#39;ເປີດ&#39; ແລະພິມ == &#39;ບັກ&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ການສະແດງອອກ Python ແບບງ່າຍດາຍ, ຕົວຢ່າງ: ສະຖານະພາບ == 'ເປີດ' ແລະພິມ == 'ບັກ'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,ເອກະສານບໍ່ໄດ້ຕິດ
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,ການເຊື່ອມຕໍ່ສູນເສຍ. ບາງຄຸນສົມບັດອາດຈະບໍ່ເຮັດວຽກ.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",ຊ້ໍາຄື &quot;AAA&quot; ແມ່ນງ່າຍທີ່ຈະເດົາ
@@ -2303,7 +2303,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,ສະແດງຂໍ້ຜິດພາດເທົ່ານັ້ນ
 DocType: Website Settings,Banner HTML,ປ້າຍໂຄສະນາ HTML
 DocType: Workflow,Send Email Alert,ສົ່ງອີເມວ Alert
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. Razorpay ບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. Razorpay ບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ '{0}'
 DocType: Data Import,In Progress,ໃນຄວາມຄືບຫນ້າ
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,ຄິວສໍາລັບການສໍາຮອງຂໍ້ມູນ. ມັນອາດຈະໃຊ້ເວລາສອງສາມນາທີເພື່ອຊົ່ວໂມງ.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2730,7 +2730,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,ສະບັບປັ�
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,ການຕັ້ງຄ່າຕູການຈ່າຍເງິນ PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,ນັກສະແດງຍອດນິຍົມ
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,ຊ່ອງຂໍ້ມູນທີ່ ກຳ ນົດເອງບໍ່ສາມາດເພີ່ມເຂົ້າໄປໃນ DocTypes ຫຼັກ.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) ຈະໄດ້ຮັບການຕັດ, ເປັນລັກສະນະນ້ໍາອະນຸຍາດໃຫ້ເປັນ {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) ຈະໄດ້ຮັບການຕັດ, ເປັນລັກສະນະນ້ໍາອະນຸຍາດໃຫ້ເປັນ {2}"
 DocType: OAuth Client,Response Type,ປະເພດໃນການຕອບໂຕ້
 DocType: Contact Us Settings,Send enquiries to this email address,ສອບຖາມຂໍ້ມູນກັບທີ່ຢູ່ອີເມວນີ້
 DocType: Letter Head,Letter Head Name,ຊື່ຈົດຫມາຍສະບັບຫົວຫນ້າ
@@ -2787,7 +2787,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,ຮູບພາບເບິ່ງ
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","ຄ້າຍຄືບາງສິ່ງບາງຢ່າງເອງເຮັດຜິດພາດໃນໄລຍະການໄດ້. ນັບຕັ້ງແຕ່ພວກເຮົາຍັງບໍ່ທັນໄດ້ຮັບການຢັ້ງຢືນການຊໍາລະເງິນ, Paypal ອັດຕະໂນມັດຈະຄືນເງິນຈໍານວນນີ້. ຖ້າຫາກວ່າມັນບໍ່ໄດ້, ກະລຸນາສົ່ງໃຫ້ພວກເຮົາອີເມວແລະລະບຸ ID ພັນໄດ້:. {0}"
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","ລວມສັນຍາລັກ, ຕົວເລກແລະຕົວອັກສອນນະຄອນຫຼວງໃນລະຫັດຜ່ານ"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ສະແດງກິ່ງງ່າຫຼັງຈາກພາກສະຫນາມ &#39;{0}&#39; ທີ່ໄດ້ກ່າວມາໃນພາກສະຫນາມ Custom &#39;{1}, ມີປ້າຍ&#39; {2} &#39;, ບໍ່ມີ"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ສະແດງກິ່ງງ່າຫຼັງຈາກພາກສະຫນາມ '{0}' ທີ່ໄດ້ກ່າວມາໃນພາກສະຫນາມ Custom '{1}, ມີປ້າຍ' {2} ', ບໍ່ມີ"
 DocType: List Filter,List Filter,List Filter
 DocType: Workflow State,signal,ສັນຍານ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,ມີເອກະສານຕິດຄັດ
@@ -2797,7 +2797,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,ເອກະສານຄືນ
 DocType: Data Export,Data Export,Data Export
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ເລືອກພາສາ ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},ທ່ານບໍ່ສາມາດຕັ້ງຄ່າ &#39;ຕົວເລືອກຕ່າງໆສໍາລັບພາກສະຫນາມ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},ທ່ານບໍ່ສາມາດຕັ້ງຄ່າ 'ຕົວເລືອກຕ່າງໆສໍາລັບພາກສະຫນາມ {0}
 DocType: Help Article,Author,Author
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,ສືບຕໍ່ສົ່ງ
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,ດໍາເນີນການ
@@ -2811,15 +2811,15 @@ DocType: Web Page,Slideshow,slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,ແມ່ແບບມາດຕະຖານທີ່ຢູ່ບໍ່ສາມາດໄດ້ຮັບການລຶບ
 DocType: Contact,Maintenance Manager,ຜູ້ຈັດການບໍາລຸງຮັກສາ
 DocType: Workflow State,Search,ຄົ້ນຫາ
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. ເສັ້ນດ່າງບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. ເສັ້ນດ່າງບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. ເສັ້ນດ່າງບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. ເສັ້ນດ່າງບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ຍ້າຍໄປຖັງຂີ້ເຫຍື້ອ
 DocType: Web Form,Web Form Fields,ແບບຟອມ Web
 DocType: Data Import,Amended From,ສະບັບປັບປຸງຈາກ
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},ການເຕືອນໄພ: ບໍ່ສາມາດຊອກຫາ {0} ໃນຕາຕະລາງທີ່ກ່ຽວຂ້ອງກັບ {1}
 DocType: S3 Backup Settings,eu-north-1,eu-north-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,ເອກະສານນີ້ແມ່ນຄິວສໍາລັບການປະຕິບັດໃນປັດຈຸບັນ. ກະລຸນາພະຍາຍາມອີກເທື່ອຫນຶ່ງ
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File &#39;{0}&#39; ບໍ່ໄດ້ພົບເຫັນ
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File '{0}' ບໍ່ໄດ້ພົບເຫັນ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,ເອົາ Section
 DocType: User,Change Password,ປ່ຽນລະຫັດຜ່ານ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X Axis Field
@@ -3010,7 +3010,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,ຄ່າທີ່�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,ເພີ່ມເດັກ
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,ຄວາມຄືບ ໜ້າ ການ ນຳ ເຂົ້າ
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",ຖ້າເງື່ອນໄຂທີ່ຜູ້ໃຊ້ພໍໃຈຈະໄດ້ຮັບລາງວັນຕາມຈຸດຕ່າງໆ. ຕົວຢ່າງ. doc.status == &#39;ປິດ&#39;
+",ຖ້າເງື່ອນໄຂທີ່ຜູ້ໃຊ້ພໍໃຈຈະໄດ້ຮັບລາງວັນຕາມຈຸດຕ່າງໆ. ຕົວຢ່າງ. doc.status == 'ປິດ'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: ບັນທຶກສະບໍ່ສາມາດໄດ້ຮັບການລຶບ.
 DocType: GSuite Templates,Template Name,ຊື່ສິນຄ້າ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ປະເພດໃຫມ່ຂອງເອກະສານ
@@ -3142,7 +3142,7 @@ DocType: Dashboard Chart,Chart Type,ປະເພດຕາຕະລາງ
 DocType: DocType,Auto Name,ຊື່ Auto
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,ຫຼີກເວັ້ນການລໍາດັບຄື abc ຫລື 6543 ຍ້ອນວ່າເຂົາເຈົ້າແມ່ນງ່າຍທີ່ຈະເດົາ
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,ກະລຸນາພະຍາຍາມອີກເທື່ອຫນຶ່ງ
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL ຕ້ອງເລີ່ມຕົ້ນດ້ວຍ &#39;http: //&#39; ຫລື &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL ຕ້ອງເລີ່ມຕົ້ນດ້ວຍ 'http: //' ຫລື 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,ທາງເລືອກ 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,ດັດແກ້
@@ -3382,7 +3382,7 @@ DocType: Notification,Send alert if this field's value changes,ສົ່ງກ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,ສີສັນຫົວຂໍ້
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,ເລືອກ DocType ເພື່ອເຮັດໃຫ້ເປັນຮູບແບບໃຫມ່
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,ຜູ້ໃຊ້ບໍ່ມີ
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;ຜູ້ຮັບ&#39; ບໍ່ໄດ້ກໍານົດ
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'ຜູ້ຮັບ' ບໍ່ໄດ້ກໍານົດ
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,ດຽວນີ້
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,ສະຫມັກຂໍເອົາ
 DocType: Footer Item,Policy,ນະໂຍບາຍ
@@ -3431,7 +3431,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,ການແປ C
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,ຄວາມຄືບຫນ້າ
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,ໂດຍພາລະບົດບາດ
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,ໄຮ່ຫາຍ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname ບໍ່ຖືກຕ້ອງ &#39;{0}&#39; ໃນ autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname ບໍ່ຖືກຕ້ອງ '{0}' ໃນ autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ຄົ້ນຫາໃນປະເພດເອກະສານ
 DocType: Custom DocPerm,Role and Level,ພາລະບົດບາດແລະລະດັບ
 DocType: File,Thumbnail URL,URL Thumbnail
@@ -3521,11 +3521,11 @@ DocType: Dashboard Chart,Filters JSON,ຕົວກອງ JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,ຄລິກທີ່ນີ້ເພື່ອກວດສອບ
 DocType: Email Account,Disable SMTP server authentication,ປິດການໃຊ້ງານການກວດສອບເຊີບເວີ SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,ຄັດລອກໄປທີ່ clipboard.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ການທົດແທນທີ່ຄາດຫມາຍໄວ້ຄື &#39;@&#39; ແທນທີ່ຈະເປັນຂອງ &#39;&#39; ບໍ່ໄດ້ຊ່ວຍຫຼາຍ.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,ການທົດແທນທີ່ຄາດຫມາຍໄວ້ຄື '@' ແທນທີ່ຈະເປັນຂອງ '' ບໍ່ໄດ້ຊ່ວຍຫຼາຍ.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,ການມອບຫມາຍຂອງຂ້າພະເຈົ້າ
 apps/frappe/frappe/utils/data.py,Zero,Zero
 DocType: Google Drive,Backup Folder ID,ID Folder ສຳ ຮອງຂໍ້ມູນ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,ບໍ່ໄດ້ຢູ່ໃນຮູບແບບການພັດທະນາ! ທີ່ກໍານົດໄວ້ໃນ site_config.json ຫຼືເຮັດໃຫ້ &#39;Custom&#39; DocType.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,ບໍ່ໄດ້ຢູ່ໃນຮູບແບບການພັດທະນາ! ທີ່ກໍານົດໄວ້ໃນ site_config.json ຫຼືເຮັດໃຫ້ 'Custom' DocType.
 DocType: Workflow State,globe,ໂລກ
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,ບູລິມະສິດ
@@ -3604,7 +3604,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,ລົ້ມເຫຼວໃນຂະນະທີ່ແກ້ໄຂການຈອງ
 DocType: LDAP Settings,LDAP Group Field,ສະ ໜາມ LDAP ກຸ່ມ
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,ເທົ່າກັບ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ປະເພດຂອງການພາກສະຫນາມທາງເລືອກ &#39;Dynamic Link&#39; ຕ້ອງຊີ້ໃຫ້ເຫັນເຖິງການເຊື່ອມຕໍ່ພາກສະຫນາມອື່ນທີ່ມີທາງເລືອກເປັນ &#39;DocType&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ປະເພດຂອງການພາກສະຫນາມທາງເລືອກ 'Dynamic Link' ຕ້ອງຊີ້ໃຫ້ເຫັນເຖິງການເຊື່ອມຕໍ່ພາກສະຫນາມອື່ນທີ່ມີທາງເລືອກເປັນ 'DocType'
 DocType: About Us Settings,Team Members Heading,ທີມງານສະມາຊິກຫົວຂໍ້
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,ຮູບແບບ CSV ບໍ່ຖືກຕ້ອງ
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","ມີຂໍ້ຜິດພາດໃນການເຊື່ອມຕໍ່ QZ Tray Application ... <br><br> ທ່ານ ຈຳ ເປັນຕ້ອງມີການຕິດຕັ້ງແລະແລ່ນ QZ Tray, ເພື່ອໃຊ້ຄຸນລັກສະນະ Raw Print. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">ກົດບ່ອນນີ້ເພື່ອດາວໂຫລດແລະຕິດຕັ້ງ QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">ກົດບ່ອນນີ້ເພື່ອຮຽນຮູ້ເພີ່ມເຕີມກ່ຽວກັບການພິມດິບ</a> ."
@@ -3734,8 +3734,8 @@ DocType: Web Page,Web Page,ຫນ້າເວັບ
 DocType: Workflow Document State,Next Action Email Template,ຕົວແບບອີເມວປະຕິບັດຕໍ່ໄປ
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","ຖ້າເປີດໃຊ້ງານ, ການປ່ຽນແປງເອກະສານຈະຖືກຕິດຕາມແລະສະແດງຕາມ ກຳ ນົດເວລາ"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ໃນການຊອກຫາ Global&#39; ບໍ່ອະນຸຍາດໃຫ້ສໍາລັບປະເພດ {0} ຕິດຕໍ່ກັນ {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ໃນການຊອກຫາ Global&#39; ບໍ່ອະນຸຍາດໃຫ້ສໍາລັບປະເພດ {0} ຕິດຕໍ່ກັນ {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ໃນການຊອກຫາ Global' ບໍ່ອະນຸຍາດໃຫ້ສໍາລັບປະເພດ {0} ຕິດຕໍ່ກັນ {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ໃນການຊອກຫາ Global' ບໍ່ອະນຸຍາດໃຫ້ສໍາລັບປະເພດ {0} ຕິດຕໍ່ກັນ {1}
 DocType: Energy Point Log,Appreciation,ການຍົກຍ້ອງ
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,ບັນຊີ View
 DocType: Workflow,Don't Override Status,ບໍ່ແທນສະຖານະ
@@ -3883,7 +3883,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,ມາດຕະຖານ
 DocType: Translation,Verified,ຢັ້ງຢືນແລ້ວ
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} ເພີ່ມ
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ຄົ້ນຫາສໍາລັບ &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ຄົ້ນຫາສໍາລັບ '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,ກະລຸນາຊ່ວຍປະຢັດບົດລາຍງານຄັ້ງທໍາອິດ
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ຈອງເຂົ້າມາ
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,ບໍ່ໃນ
@@ -3920,14 +3920,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,ຂ້ອ�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} ບໍ່ State ຖືກຕ້ອງ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,ນຳ ໃຊ້ກັບທຸກປະເພດເອກະສານ
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,ການປັບປຸງຈຸດພະລັງງານ
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. PayPal ບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',ກະລຸນາເລືອກວິທີການຊໍາລະເງິນອື່ນ. PayPal ບໍ່ສະຫນັບສະຫນູນທຸລະກໍາໃນສະກຸນເງິນ '{0}'
 DocType: Chat Message,Room Type,ປະເພດຫ້ອງພັກ
 DocType: Data Import Beta,Import Log Preview,ການ ນຳ ເຂົ້າບັນທຶກການ ນຳ ເຂົ້າ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,ພາກສະຫນາມຄົ້ນຫາ {0} ບໍ່ຖືກຕ້ອງ
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,ໄຟລ໌ທີ່ອັບໂຫລດແລ້ວ
 DocType: Workflow State,ok-circle,"ok, ແຜ່ນປ້າຍວົງກົມ"
 DocType: LDAP Settings,LDAP User Creation and Mapping,ການສ້າງແລະສ້າງແຜນທີ່ຜູ້ໃຊ້ LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',ທ່ານສາມາດຊອກຫາສິ່ງທີ່ໂດຍສະເຫນີຂໍ &#39;ຊອກຫາສີສົ້ມໃນຂອງລູກຄ້າ
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',ທ່ານສາມາດຊອກຫາສິ່ງທີ່ໂດຍສະເຫນີຂໍ 'ຊອກຫາສີສົ້ມໃນຂອງລູກຄ້າ
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,ຂໍໂທດ! ຜູ້ໃຊ້ຄວນຈະມີການເຂົ້າເຖິງສໍາເລັດໃນການບັນທຶກຂອງຕົນເອງຂອງເຂົາເຈົ້າ.
 ,Usage Info,ຂໍ້ມູນການນໍາໃຊ້
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,ສະແດງທາງລັດແປ້ນພິມ

--- a/frappe/translations/lo.csv
+++ b/frappe/translations/lo.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,າຮອ�
 DocType: DocField,In Global Search,ໃນການຊອກຫາ Global
 DocType: System Settings,Brute Force Security,Brute Force Force ຄວາມປອດໄພ
 DocType: Workflow State,indent-left,indent ຊ້າຍ
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} ປີທີ່ຜ່ານມາ
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} ປີທີ່ຜ່ານມາ
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,ມັນເປັນຄວາມສ່ຽງສູງທີ່ຈະລຶບເອກະສານນີ້:. {0} ກະລຸນາຕິດຕໍ່ຈັດການລະບົບຂອງທ່ານ.
 DocType: Currency,Currency Name,ຊື່ສະກຸນເງິນ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,No ອີເມວ
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,ບໍ່ມ�
 apps/frappe/frappe/config/customization.py,Add custom forms.,ເພີ່ມຮູບແບບ custom.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} ໃນ {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ສົ່ງເອກະສານນີ້
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,ຕັ້ງຄ່າ&gt; ການອະນຸຍາດຂອງຜູ້ໃຊ້
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,ຕັ້ງຄ່າ> ການອະນຸຍາດຂອງຜູ້ໃຊ້
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,ລະບົບການສະຫນອງພາລະບົດບາດທາງສ່ວນຫນ້າຂອງທີ່ກໍານົດຈໍານວນຫຼາຍ. ທ່ານສາມາດເພີ່ມພາລະບົດບາດໃຫມ່ໃນການກໍານົດການອະນຸຍາດ finer.
 DocType: Communication,CC,CC
 DocType: Country,Geo,ພູມິສາດ
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","ຖ້າຫາກວ່າຜູ້ໃຊ້ທີ່ມີພາລະບົດບາດການກວດກາ, ຫຼັງຈາກນັ້ນຜູ້ໃຊ້ຈະກາຍເປັນ &quot;ລະບົບຜູ້ໃຊ້&quot;. &quot;ລະບົບຜູ້ໃຊ້&quot; ມີການເຂົ້າເຖິງ desktop ໄດ້"
 DocType: System Settings,Date and Number Format,ວັນແລະຈໍານວນຮູບແບບ
 apps/frappe/frappe/model/document.py,one of,ຫນຶ່ງໃນ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,ຕັ້ງຄ່າ&gt; ປັບແຕ່ງແບບຟອມ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,ຕັ້ງຄ່າ> ປັບແຕ່ງແບບຟອມ
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,ການກວດສອບແຕ່ປັດຈຸບັນ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,ສະແດງໃຫ້ເຫັນ Tags
 DocType: DocField,HTML Editor,HTML Editor
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Billing
 DocType: Email Queue,Not Sent,ບໍ່ໄດ້ສົ່ງ
 DocType: Web Form,Actions,ການກະທໍາ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,ຕັ້ງຄ່າ&gt; ຜູ້ໃຊ້
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,ຕັ້ງຄ່າ> ຜູ້ໃຊ້
 DocType: Workflow State,align-justify,"ວາງ, ປັບ"
 DocType: User,Middle Name (Optional),ຊື່ກາງ (ຖ້າຕ້ອງການ)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,ບໍ່ອະນຸຍາດ
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,ແມ່ນມາດຕະຖານ
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,ເຕັມ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","ບໍ່ tags HTML ເຂົ້າລະຫັດ HTML ຄື &lt;script&gt; ຫຼືພຽງແຕ່ລັກສະນະຄ້າຍຄື &lt;ຫຼື&gt;, ຍ້ອນວ່າເຂົາເຈົ້າສາມາດໄດ້ຮັບການນໍາໃຊ້ເຈດຕະນາໃນພາກສະຫນາມນີ້"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ບໍ່ tags HTML ເຂົ້າລະຫັດ HTML ຄື &lt;script> ຫຼືພຽງແຕ່ລັກສະນະຄ້າຍຄື &lt;ຫຼື>, ຍ້ອນວ່າເຂົາເຈົ້າສາມາດໄດ້ຮັບການນໍາໃຊ້ເຈດຕະນາໃນພາກສະຫນາມນີ້"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} ຖືກວິພາກວິຈານໃນ {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ແລ່ນ
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer ຈະສ�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,ທີ່ຍັງຄ້າງ
 DocType: System Settings,Allow only one session per user,ອະນຸຍາດໃຫ້ພຽງແຕ່ກອງປະຊຸມຫນຶ່ງຕໍ່ຜູ້ໃຊ້
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ຫນ້າທໍາອິດ / ການທົດສອບ Folder 1 / ການທົດສອບ Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ເລືອກຫຼືລາກຂ້າມຊ່ວງເວລາທີ່ຈະສ້າງເປັນເຫດການໃຫມ່.
 DocType: Contact,Contact Details,ລາຍລະອຽດການຕິດຕໍ່
 DocType: DocField,In Filter,ໃນ Filter
@@ -2042,7 +2042,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,ເຂົ້າສູ່ລະບົບບໍ່ອະນຸຍາດໃຫ້ຢູ່ໃນເວລານີ້
 DocType: Data Migration Run,Current Mapping Action,Action Mapping ປັດຈຸບັນ
 DocType: Dashboard Chart Source,Source Name,ແຫຼ່ງຊື່
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,ບໍ່ມີບັນຊີອີເມວທີ່ກ່ຽວຂ້ອງກັບຜູ້ໃຊ້. ກະລຸນາເພີ່ມບັນຊີພາຍໃຕ້ຜູ້ໃຊ້&gt; Inbox Email.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,ບໍ່ມີບັນຊີອີເມວທີ່ກ່ຽວຂ້ອງກັບຜູ້ໃຊ້. ກະລຸນາເພີ່ມບັນຊີພາຍໃຕ້ຜູ້ໃຊ້> Inbox Email.
 DocType: Email Account,Email Sync Option,Email Option Sync
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Row No
 DocType: Async Task,Runtime,Runtime
@@ -2057,7 +2057,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ແລ້
 DocType: User Email,Enable Outgoing,ເຮັດໃຫ້ລາຍຈ່າຍ
 DocType: Address,Fax,ແຟໍກ
 apps/frappe/frappe/config/customization.py,Custom Tags,Tags Custom
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ບັນຊີອີເມວບໍ່ໄດ້ຕິດຕັ້ງ. ກະລຸນາສ້າງບັນຊີອີເມວ ໃໝ່ ຈາກການຕັ້ງຄ່າ&gt; ອີເມວ&gt; ບັນຊີອີເມວ
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ບັນຊີອີເມວບໍ່ໄດ້ຕິດຕັ້ງ. ກະລຸນາສ້າງບັນຊີອີເມວ ໃໝ່ ຈາກການຕັ້ງຄ່າ> ອີເມວ> ບັນຊີອີເມວ
 DocType: Comment,Submitted,ສົ່ງ
 DocType: Contact,Pulled from Google Contacts,ດຶງຈາກ Google Contacts
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,ໃນການຮ້ອງຂໍທີ່ຖືກຕ້ອງ
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ກອງປະຊ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",ພາກສະຫນາມນີ້ຈະໄປປາກົດພຽງແຕ່ຖ້າວ່າ fieldname ທີ່ກໍາຫນົດໄວ້ທີ່ນີ້ມີມູນຄ່າ OR ກົດລະບຽບແມ່ນຄວາມຈິງ (ຕົວຢ່າງ): myfield eval: doc.myfield == &#39;ຄ່າຂອງຂ້າພະເຈົ້າ&#39; eval: doc.age&gt; 18
+eval:doc.age>18",ພາກສະຫນາມນີ້ຈະໄປປາກົດພຽງແຕ່ຖ້າວ່າ fieldname ທີ່ກໍາຫນົດໄວ້ທີ່ນີ້ມີມູນຄ່າ OR ກົດລະບຽບແມ່ນຄວາມຈິງ (ຕົວຢ່າງ): myfield eval: doc.myfield == &#39;ຄ່າຂອງຂ້າພະເຈົ້າ&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ໃນມື້ນີ້
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ໃນມື້ນີ້
@@ -2146,7 +2146,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ເທິງກໍລະນີ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML Custom
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ກະລຸນາໃສ່ຊື່ໂຟເດີ
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,ບໍ່ພົບແມ່ແບບທີ່ຢູ່ເລີ່ມຕົ້ນ. ກະລຸນາສ້າງແບບ ໃໝ່ ຈາກການຕິດຕັ້ງ&gt; ການພິມແລະການສ້າງຍີ່ຫໍ້&gt; ແມ່ແບບທີ່ຢູ່.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,ບໍ່ພົບແມ່ແບບທີ່ຢູ່ເລີ່ມຕົ້ນ. ກະລຸນາສ້າງແບບ ໃໝ່ ຈາກການຕິດຕັ້ງ> ການພິມແລະການສ້າງຍີ່ຫໍ້> ແມ່ແບບທີ່ຢູ່.
 apps/frappe/frappe/auth.py,Unknown User,ຮູ້ຈັກ User
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,ເລືອກພາລະບົດບາດ
 DocType: Comment,Deleted,ລຶບ
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ບໍ່ອະນຸຍາດພຽງພໍທີ່ຈະເຫັນການເຊື່ອມຕໍ່
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ທີ່ຢູ່ Title ແມ່ນບັງຄັບ.
 DocType: Google Contacts,Push to Google Contacts,ຍູ້ໄປຫາລາຍຊື່ຜູ້ຕິດຕໍ່ Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","ເພີ່ມ HTML ໃນ &lt;head&gt; ພາກສ່ວນຂອງຫນ້າເວັບໄຊຕ໌, ການນໍາໃຊ້ຕົ້ນຕໍສໍາລັບການຢັ້ງຢືນເວັບໄຊທ໌ແລະ SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","ເພີ່ມ HTML ໃນ &lt;head> ພາກສ່ວນຂອງຫນ້າເວັບໄຊຕ໌, ການນໍາໃຊ້ຕົ້ນຕໍສໍາລັບການຢັ້ງຢືນເວັບໄຊທ໌ແລະ SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ຊຶ່ງໄດ້ກໍາເລີບ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ລາຍການບໍ່ສາມາດໄດ້ຮັບການເພີ່ມລູກຫລານຂອງຕົນເອງ
 DocType: Session Default Settings,Session Defaults,ຄ່າເລີ່ມຕົ້ນຂອງກອງປະຊຸມ
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,ການເຕືອນໄພ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ສິ່ງນີ້ອາດຈະຖືກພິມລົງໃນຫລາຍໆ ໜ້າ
 DocType: Data Migration Run,Percent Complete,ອັດຕາສ່ວນສໍາເລັດ
 DocType: Tag Category,Tag Category,Tag Category
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ສຳ ລັບການປຽບທຽບ, ໃຊ້&gt; 5, &lt;10 ຫລື = 324. ສຳ ລັບຂອບເຂດ, ໃຫ້ໃຊ້ 5:10 (ສຳ ລັບຄ່າລະຫວ່າງ 5 ແລະ 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ສຳ ລັບການປຽບທຽບ, ໃຊ້> 5, &lt;10 ຫລື = 324. ສຳ ລັບຂອບເຂດ, ໃຫ້ໃຊ້ 5:10 (ສຳ ລັບຄ່າລະຫວ່າງ 5 ແລະ 10)."
 DocType: Google Calendar,Pull from Google Calendar,ດຶງຈາກ Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ຊ່ວຍເຫຼືອ
 DocType: User,Login Before,ເຂົ້າສູ່ລະບົບກ່ອນ
@@ -2926,7 +2926,7 @@ DocType: Custom Script,Custom Script,Script Custom
 DocType: Address,Address Line 2,ທີ່ຢູ່ Line 2
 DocType: Address,Reference,ກະສານອ້າງອີງ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,ການມອບຫມາຍໃຫ້
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,ກະລຸນາຕັ້ງຄ່າບັນຊີອີເມວເລີ່ມຕົ້ນຈາກການຕັ້ງຄ່າ&gt; ອີເມວ&gt; ບັນຊີອີເມວ
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,ກະລຸນາຕັ້ງຄ່າບັນຊີອີເມວເລີ່ມຕົ້ນຈາກການຕັ້ງຄ່າ> ອີເມວ> ບັນຊີອີເມວ
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ລາຍະລະອຽດແຜນທີ່ການຍ້າຍຖິ່ນຖານຂໍ້ມູນ
 DocType: Data Import,Action,ການປະຕິບັດ
 DocType: GSuite Settings,Script URL,URL script
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,ອະນຸຍາດໃຫ້ຢູ່ໃນ�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,ປະເພດຍົກເວັ້ນ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,ເອົາຄໍລໍາ
-DocType: Web Page,Add code as &lt;script&gt;,ເພີ່ມລະຫັດເປັນ &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,ເພີ່ມລະຫັດເປັນ &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ອະນຸຍາດອະນຸຍາດໃຫ້ຜູ້ໃຊ້
 DocType: Webhook,Headers,Headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ເຫດການ upcoming
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,ສ່ວນ alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ຄິວຄວນຈະເປັນຫນຶ່ງໃນ {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> ແມ່ແບບມາດຕະຖານ </h4><p> ການນໍາໃຊ້ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ແລະທົ່ງນາທັງຫມົດຂອງທີ່ຢູ່ (ລວມເຖິງຂໍ້ມູນ Custom ຖ້າມີ) ຈະສາມາດໃຊ້ໄດ້ </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> ແມ່ແບບມາດຕະຖານ </h4><p> ການນໍາໃຊ້ <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ແລະທົ່ງນາທັງຫມົດຂອງທີ່ຢູ່ (ລວມເຖິງຂໍ້ມູນ Custom ຖ້າມີ) ຈະສາມາດໃຊ້ໄດ້ </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Start Date Field
 DocType: Role,Role Name,ຊື່ພາລະບົດບາດ
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ສະຫຼັບກັບລະ Desk
@@ -4033,6 +4033,6 @@ DocType: Communication,Meeting,ກອງປະຊຸມ
 apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,ບໍ່ສາມາດເປີດເອກະສານທີ່ຕິດຄັດມາ. ທ່ານຍັງບໍ່ໄດ້ສົ່ງອອກມັນເປັນ CSV?
 DocType: DocField,Ignore User Permissions,ບໍ່ສົນໃຈການອະນຸຍາດຂອງຜູ້ໃຊ້
 apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Saved Successfully,ບັນທຶກຢ່າງ ສຳ ເລັດຜົນ
-apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,ກະລຸນາຂໍໃຫ້ຜູ້ບໍລິຫານຂອງທ່ານເພື່ອກວດສອບການເຂົ້າລະບົບຂຶ້ນ
+apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,ກະລຸນາຂ���ໃຫ້ຜູ້ບໍລິຫານຂອງທ່ານເພື່ອກວດສອບການເຂົ້າລະບົບຂຶ້ນ
 DocType: Domain Settings,Active Domains,Domains Active
 apps/frappe/frappe/public/js/integrations/razorpay.js,Show Log,ສະແດງໃຫ້ເຫັນເຂົ້າສູ່ລະບົບ

--- a/frappe/translations/lt.csv
+++ b/frappe/translations/lt.csv
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Išjungti ataska
 DocType: Translation,Contributed Translation Doctype Name,Pridėtas vertimo „Doctype“ vardas
 DocType: PayPal Settings,Redirect To,nukreipti į
 DocType: Data Migration Mapping,Pull,Traukti
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Formatas: frappe.query_reports [ &#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Formatas: frappe.query_reports [ 'REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Masiniai Atnaujinti
 DocType: Workflow State,chevron-up,&quot;Chevron viršų
 DocType: DocType,Allow Guest to View,Leiskite Svečių to Peržiūrėti
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sesijos pabaiga val
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Šis laukas bus rodomas tik tada, jei čia apibrėžta nazwapola turi vertę arba taisyklės yra tikri (pavyzdžiai): myfield eval: doc.myfield == &#39;Mano vertė &quot;eval: doc.age> 18"
+eval:doc.age>18","Šis laukas bus rodomas tik tada, jei čia apibrėžta nazwapola turi vertę arba taisyklės yra tikri (pavyzdžiai): myfield eval: doc.myfield == 'Mano vertė &quot;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šiandien
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šiandien
@@ -2171,7 +2171,7 @@ DocType: Data Migration Connector,Database Name,Duomenų bazės pavadinimas
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Atnaujinti forma
 DocType: DocField,Select,pasirinkti
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Žiūrėti visą žurnalą
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Paprastas Python išraiška, pavyzdys: status == &#39;Open&#39; ir įveskite == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Paprastas Python išraiška, pavyzdys: status == 'Open' ir įveskite == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Failo neuždėtas
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Nutrūko ryšys. Kai kurios funkcijos gali neveikti.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Pakartoja, kaip &quot;AAA&quot; yra lengva atspėti"
@@ -2303,7 +2303,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Rodyti tik klaidas
 DocType: Website Settings,Banner HTML,Reklaminis HTML
 DocType: Workflow,Send Email Alert,Siųsti el. Įspėjimą
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. Razorpay nepalaiko sandoriams valiuta &quot;{0} &#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. Razorpay nepalaiko sandoriams valiuta &quot;{0} '
 DocType: Data Import,In Progress,&quot;Progress&quot;
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Eilėje atsarginę kopiją. Tai gali užtrukti keletą minučių iki valandos.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2730,7 +2730,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,iš dalies keičiantis
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal mokėjimų vartai nustatymai
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Geriausias atlikėjas
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Pasirinktinių laukų negalima pridėti prie pagrindinių „DocTypes“.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} &#39;({3}) bus sutrumpintas, nes max leidžiamas simbolių yra {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} '({3}) bus sutrumpintas, nes max leidžiamas simbolių yra {2}"
 DocType: OAuth Client,Response Type,Atsako tipas
 DocType: Contact Us Settings,Send enquiries to this email address,Siųsti užklausas į šį elektroninio pašto adresą
 DocType: Letter Head,Letter Head Name,Laiškas vadovas Vardas
@@ -2787,7 +2787,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Vaizdo Peržiūrėti
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Atrodo, kad kažkas negerai sandorio metu. Kadangi mes nepatvirtino mokėjimo, PayPal automatiškai grąžinsime Jums šią sumą. Jei ne, atsiųskite mums elektroninį laišką ir paminėti koreliacijos ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Įtraukti simbolius, skaičius ir didžiųjų raidžių slaptažodį"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Įdėkite Po srityje &quot;{0}&quot; paminėta Custom Field &quot;{1} &#39;, su etikete&quot; {2} &quot;neegzistuoja"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Įdėkite Po srityje &quot;{0}&quot; paminėta Custom Field &quot;{1} ', su etikete&quot; {2} &quot;neegzistuoja"
 DocType: List Filter,List Filter,Sąrašo filtras
 DocType: Workflow State,signal,signalas
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Turi priedų
@@ -2811,15 +2811,15 @@ DocType: Web Page,Slideshow,Skaidrės
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Numatytasis adresas Šablonas ištrinti negalima
 DocType: Contact,Maintenance Manager,priežiūra direktorius
 DocType: Workflow State,Search,Paieška
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. Juostele nepalaiko sandoriams valiuta &quot;{0} &#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. Juostele nepalaiko sandoriams valiuta &quot;{0} &#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. Juostele nepalaiko sandoriams valiuta &quot;{0} '
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. Juostele nepalaiko sandoriams valiuta &quot;{0} '
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Išmesti
 DocType: Web Form,Web Form Fields,Interneto formos laukus
 DocType: Data Import,Amended From,Iš dalies pakeistas Nuo
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},"Įspėjimas: nepavyko rasti {0} bet lentelę, susijusią su {1}"
 DocType: S3 Backup Settings,eu-north-1,eu-šiaurė-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,"Šis dokumentas yra šiuo metu eilėje vykdymą. Prašau, pabandykite dar kartą"
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Failo &#39;{0} &quot;nerastas
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Failo '{0} &quot;nerastas
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,pašalinti skyrius
 DocType: User,Change Password,Pakeisti slaptažodį
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X ašies laukas
@@ -3431,7 +3431,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Individualizuotos
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Progresas
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,pagal Pareigas
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Trūksta laukai
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neteisingas nazwapola &#39;{0} &quot;į autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neteisingas nazwapola '{0} &quot;į autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Ieškoti dokumento tipą
 DocType: Custom DocPerm,Role and Level,Vaidmuo ir lygis
 DocType: File,Thumbnail URL,Miniatiūra adresas
@@ -3920,7 +3920,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Aš
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} neleistina Būsena
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Taikyti visiems dokumentų tipams
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Energijos taško atnaujinimas
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. &quot;PayPal&quot; nepalaiko sandoriams valiuta &quot;{0} &#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Prašome pasirinkti kitą mokėjimo būdą. &quot;PayPal&quot; nepalaiko sandoriams valiuta &quot;{0} '
 DocType: Chat Message,Room Type,Kambario tipas
 DocType: Data Import Beta,Import Log Preview,Importuoti žurnalo peržiūrą
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Paieška laukas {0} negalioja

--- a/frappe/translations/lt.csv
+++ b/frappe/translations/lt.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Failo atsar
 DocType: DocField,In Global Search,Global paieška
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,įtrauka kairiajame
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; Prieš {0} metus (-ių)
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> Prieš {0} metus (-ių)
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Tai rizikinga ištrinti šį failą: {0}. Prašome susisiekti su savo sistemos valdytojas.
 DocType: Currency,Currency Name,valiutos pavadinimas
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Nieko Parašyta
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Nėra {0} ner
 apps/frappe/frappe/config/customization.py,Add custom forms.,Pridėti užsakymą formas.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} iš {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,pateikė šį dokumentą
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Sąranka&gt; Vartotojo leidimai
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Sąranka> Vartotojo leidimai
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sistema suteikia daug iš anksto apibrėžtų vaidmenis. Jūs galite pridėti naujus vaidmenis nustatyti subtilius leidimus.
 DocType: Communication,CC,CK
 DocType: Country,Geo,geo
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Jei vartotojas turi visi tikrinti vaidmenį, tada vartotojas tampa &quot;sistemos naudotojas&quot;. &quot;Sistemos vartotojas&quot; turi prieigą prie darbastalio"
 DocType: System Settings,Date and Number Format,Data ir numeris Formatas
 apps/frappe/frappe/model/document.py,one of,vienas iš
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Sąranka&gt; Tinkinti formą
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Sąranka> Tinkinti formą
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Tikrinti vieną momentą
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Rodyti Žymos
 DocType: DocField,HTML Editor,HTML redaktorius
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,atsiskaitymo
 DocType: Email Queue,Not Sent,nesiunčiamas
 DocType: Web Form,Actions,Veiksmai
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Sąranka&gt; vartotojas
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Sąranka> vartotojas
 DocType: Workflow State,align-justify,lygiavimas-išlyginti
 DocType: User,Middle Name (Optional),Vidurio pavadinimas (neprivalomas)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Neleistina
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Ar Standartinė
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Visas
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ar ne HTML kodavimas HTML žymes kaip &lt;script&gt; arba tiesiog simbolių, pavyzdžiui, &lt;arba&gt;, nes jie gali būti sąmoningai naudojama šioje srityje"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ar ne HTML kodavimas HTML žymes kaip &lt;script> arba tiesiog simbolių, pavyzdžiui, &lt;arba>, nes jie gali būti sąmoningai naudojama šioje srityje"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritikuojamas dėl {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Paleisti
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Poraštė teising
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,kol
 DocType: System Settings,Allow only one session per user,Leisti tik vieną sesiją vienam vartotojui
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Pagrindinis / Testas Aplankas 1 / Testas Aplankas 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Pasirinkite arba vilkite visoje laiko tarpsnius sukurti naują įvykį.
 DocType: Contact,Contact Details,Kontaktiniai duomenys
 DocType: DocField,In Filter,filtro
@@ -2042,7 +2042,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Prisijungti neleidžiama šiuo metu
 DocType: Data Migration Run,Current Mapping Action,Dabartinis kartografavimo veiksmas
 DocType: Dashboard Chart Source,Source Name,šaltinis Vardas
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Su vartotoju nesusieta jokia el. Pašto paskyra. Pridėkite abonementą skiltyje Vartotojas&gt; El. Pašto dėžutė.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Su vartotoju nesusieta jokia el. Pašto paskyra. Pridėkite abonementą skiltyje Vartotojas> El. Pašto dėžutė.
 DocType: Email Account,Email Sync Option,Paštas Sync &quot;variantas
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Eilutė Nr
 DocType: Async Task,Runtime,Trukmė
@@ -2057,7 +2057,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Jau varto
 DocType: User Email,Enable Outgoing,Įjungti išeinantis
 DocType: Address,Fax,faksas
 apps/frappe/frappe/config/customization.py,Custom Tags,Individualizuotos Žymos
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,El. Pašto sąskaita nėra nustatyta. Sukurkite naują el. Pašto paskyrą apsilankę Sąranka&gt; El. Paštas&gt; El. Pašto abonementas
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,El. Pašto sąskaita nėra nustatyta. Sukurkite naują el. Pašto paskyrą apsilankę Sąranka> El. Paštas> El. Pašto abonementas
 DocType: Comment,Submitted,pateikė
 DocType: Contact,Pulled from Google Contacts,Ištraukta iš „Google“ kontaktų
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Neteisingas Prašymas
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sesijos pabaiga val
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Šis laukas bus rodomas tik tada, jei čia apibrėžta nazwapola turi vertę arba taisyklės yra tikri (pavyzdžiai): myfield eval: doc.myfield == &#39;Mano vertė &quot;eval: doc.age&gt; 18"
+eval:doc.age>18","Šis laukas bus rodomas tik tada, jei čia apibrėžta nazwapola turi vertę arba taisyklės yra tikri (pavyzdžiai): myfield eval: doc.myfield == &#39;Mano vertė &quot;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šiandien
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šiandien
@@ -2146,7 +2146,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,RAIDÉMIS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Ypatingas HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Įveskite aplanko vardą
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nerastas numatytasis adreso šablonas. Sukurkite naują iš sąrankos&gt; Spausdinimas ir prekės ženklo kūrimas&gt; Adreso šablonas.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nerastas numatytasis adreso šablonas. Sukurkite naują iš sąrankos> Spausdinimas ir prekės ženklo kūrimas> Adreso šablonas.
 apps/frappe/frappe/auth.py,Unknown User,Nežinomas naudotojas
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Pasirinkite vaidmuo
 DocType: Comment,Deleted,ištrinta
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nepakanka leidimo matyti nuorodas
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresas Pavadinimas yra privalomas.
 DocType: Google Contacts,Push to Google Contacts,Prisijunkite prie „Google“ kontaktų
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Pridėta HTML &lt;head&gt; sritį interneto puslapyje, daugiausia naudojama svetainės tikrinimo ir SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Pridėta HTML &lt;head> sritį interneto puslapyje, daugiausia naudojama svetainės tikrinimo ir SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,recidyvas
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Prekė negali būti įtraukta į savo palikuonims
 DocType: Session Default Settings,Session Defaults,Sesijos numatytieji nustatymai
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,įspėjimas
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Tai gali būti atspausdinta keliuose puslapiuose
 DocType: Data Migration Run,Percent Complete,Procentas baigtas
 DocType: Tag Category,Tag Category,Gairė Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Palyginimui naudokite&gt; 5, &lt;10 arba = 324. Jei norite diapazonų, naudokite 5:10 (reikšmėms nuo 5 iki 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Palyginimui naudokite> 5, &lt;10 arba = 324. Jei norite diapazonų, naudokite 5:10 (reikšmėms nuo 5 iki 10)."
 DocType: Google Calendar,Pull from Google Calendar,Ištraukti iš „Google“ kalendoriaus
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pagalba
 DocType: User,Login Before,Vartotojas Prieš
@@ -2926,7 +2926,7 @@ DocType: Custom Script,Custom Script,Pasirinktinis scenarijus
 DocType: Address,Address Line 2,Adreso eilutė 2
 DocType: Address,Reference,Nuoroda
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Priskirtas
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Nustatykite numatytąją el. Pašto paskyrą iš sąrankos&gt; El. Paštas&gt; El. Pašto abonementas
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Nustatykite numatytąją el. Pašto paskyrą iš sąrankos> El. Paštas> El. Pašto abonementas
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Duomenų migracijos žemėlapių detalės
 DocType: Data Import,Action,veiksmas
 DocType: GSuite Settings,Script URL,scenarijaus URL
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Leisti Pateikti
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,išimtis tipas
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pasirinkite stulpelius
-DocType: Web Page,Add code as &lt;script&gt;,"Pridėti kodą, &lt;script&gt;"
+DocType: Web Page,Add code as &lt;script>,"Pridėti kodą, &lt;script>"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Išvalyti vartotojo leidimus
 DocType: Webhook,Headers,Antraštės
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Artimiausi renginiai
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,dalis-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Eilėje turėtų būti vienas iš {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> numatytąjį šabloną </h4><p> Naudoja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja šablonų</a> ir visus Adresas laukus (įskaitant pasirinktinius laukus, jei toks yra) bus galima </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> numatytąjį šabloną </h4><p> Naudoja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja šablonų</a> ir visus Adresas laukus (įskaitant pasirinktinius laukus, jei toks yra) bus galima </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Pradžios data laukas
 DocType: Role,Role Name,vaidmuo Vardas
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Perjungti į Desk

--- a/frappe/translations/lt.csv
+++ b/frappe/translations/lt.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Ar Standartinė
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Visas
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ar ne HTML kodavimas HTML žymes kaip &lt;script> arba tiesiog simbolių, pavyzdžiui, &lt;arba>, nes jie gali būti sąmoningai naudojama šioje srityje"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ar ne HTML kodavimas HTML žymes kaip <script> arba tiesiog simbolių, pavyzdžiui, <arba>, nes jie gali būti sąmoningai naudojama šioje srityje"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritikuojamas dėl {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Paleisti
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Poraštė teising
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,kol
 DocType: System Settings,Allow only one session per user,Leisti tik vieną sesiją vienam vartotojui
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Pagrindinis / Testas Aplankas 1 / Testas Aplankas 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
+DocType: Website Settings,<head> HTML,<Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Pasirinkite arba vilkite visoje laiko tarpsnius sukurti naują įvykį.
 DocType: Contact,Contact Details,Kontaktiniai duomenys
 DocType: DocField,In Filter,filtro
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nepakanka leidimo matyti nuorodas
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresas Pavadinimas yra privalomas.
 DocType: Google Contacts,Push to Google Contacts,Prisijunkite prie „Google“ kontaktų
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Pridėta HTML &lt;head> sritį interneto puslapyje, daugiausia naudojama svetainės tikrinimo ir SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Pridėta HTML <head> sritį interneto puslapyje, daugiausia naudojama svetainės tikrinimo ir SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,recidyvas
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Prekė negali būti įtraukta į savo palikuonims
 DocType: Session Default Settings,Session Defaults,Sesijos numatytieji nustatymai
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,įspėjimas
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Tai gali būti atspausdinta keliuose puslapiuose
 DocType: Data Migration Run,Percent Complete,Procentas baigtas
 DocType: Tag Category,Tag Category,Gairė Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Palyginimui naudokite> 5, &lt;10 arba = 324. Jei norite diapazonų, naudokite 5:10 (reikšmėms nuo 5 iki 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Palyginimui naudokite> 5, <10 arba = 324. Jei norite diapazonų, naudokite 5:10 (reikšmėms nuo 5 iki 10)."
 DocType: Google Calendar,Pull from Google Calendar,Ištraukti iš „Google“ kalendoriaus
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pagalba
 DocType: User,Login Before,Vartotojas Prieš
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Leisti Pateikti
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,išimtis tipas
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pasirinkite stulpelius
-DocType: Web Page,Add code as &lt;script>,"Pridėti kodą, &lt;script>"
+DocType: Web Page,Add code as <script>,"Pridėti kodą, <script>"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Išvalyti vartotojo leidimus
 DocType: Webhook,Headers,Antraštės
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Artimiausi renginiai
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,dalis-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Eilėje turėtų būti vienas iš {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> numatytąjį šabloną </h4><p> Naudoja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja šablonų</a> ir visus Adresas laukus (įskaitant pasirinktinius laukus, jei toks yra) bus galima </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> numatytąjį šabloną </h4><p> Naudoja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja šablonų</a> ir visus Adresas laukus (įskaitant pasirinktinius laukus, jei toks yra) bus galima </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Pradžios data laukas
 DocType: Role,Role Name,vaidmuo Vardas
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Perjungti į Desk

--- a/frappe/translations/lv.csv
+++ b/frappe/translations/lv.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Failu dubl�
 DocType: DocField,In Global Search,In Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,ievilkums kreisajā
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; Pirms {0} gada (-iem)
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> Pirms {0} gada (-iem)
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Tas ir riskanti, lai izdzēstu šo failu: {0}. Lūdzu, sazinieties ar sistēmas pārzini."
 DocType: Currency,Currency Name,Valūtu Name
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Nav e-pasta
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} nav atras
 apps/frappe/frappe/config/customization.py,Add custom forms.,Pievienot pielāgotus formas.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} ir {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,iesniedza šo dokumentu
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Iestatīšana&gt; Lietotāja atļaujas
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Iestatīšana> Lietotāja atļaujas
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,"Sistēma piedāvā daudz iepriekš noteiktas funkcijas. Jūs varat pievienot jaunas lomas, lai uzstādītu smalkākās atļaujas."
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1269,7 +1269,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ja lietotājs ir kāda loma pārbauda, tad lietotājs kļūst par &quot;sistēmas lietotājs&quot;. &quot;Sistēmas lietotājs&quot; ir piekļuve darbvirsmas"
 DocType: System Settings,Date and Number Format,Datums un numurs Format
 apps/frappe/frappe/model/document.py,one of,viens no
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Iestatīšana&gt; Pielāgot veidlapu
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Iestatīšana> Pielāgot veidlapu
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,vienu brīdi Pārbaude
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Rādīt birkas
 DocType: DocField,HTML Editor,HTML redaktors
@@ -1277,7 +1277,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Norēķinu
 DocType: Email Queue,Not Sent,Nav nosūtīts
 DocType: Web Form,Actions,Darbības
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Iestatīšana&gt; Lietotājs
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Iestatīšana> Lietotājs
 DocType: Workflow State,align-justify,saskaņot-pamatot
 DocType: User,Middle Name (Optional),Middle Name (pēc izvēles)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nav atļauts
@@ -1425,7 +1425,7 @@ DocType: User,System User,System User
 DocType: Report,Is Standard,Vai Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Pilna
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Vai nav HTML kodēt HTML tagus, piemēram, &lt;script&gt; vai tikai rakstzīmes, piemēram, &lt;vai&gt;, jo tie varētu tikt apzināti izmantot šajā jomā"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Vai nav HTML kodēt HTML tagus, piemēram, &lt;script> vai tikai rakstzīmes, piemēram, &lt;vai>, jo tie varētu tikt apzināti izmantot šajā jomā"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} tika kritizēts par {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Palaist
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Kājene tiks pare
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Līdz
 DocType: System Settings,Allow only one session per user,Atļaut tikai vienu sesiju katram lietotājam
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test mape 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Izvēlieties vai velciet pāri laika nišām, lai izveidotu jaunu notikumu."
 DocType: Contact,Contact Details,Kontaktinformācija
 DocType: DocField,In Filter,In Filtrs
@@ -2040,7 +2040,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Ienākt nav atļauts šajā laikā
 DocType: Data Migration Run,Current Mapping Action,Pašreizējā kartēšanas darbība
 DocType: Dashboard Chart Source,Source Name,Source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,"Ar Lietotāju nav saistīts neviens e-pasta konts. Lūdzu, pievienojiet kontu sadaļā Lietotājs&gt; E-pasta iesūtne."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Ar Lietotāju nav saistīts neviens e-pasta konts. Lūdzu, pievienojiet kontu sadaļā Lietotājs> E-pasta iesūtne."
 DocType: Email Account,Email Sync Option,E-Sync variants
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rinda Nr
 DocType: Async Task,Runtime,Runtime
@@ -2055,7 +2055,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Jau lieto
 DocType: User Email,Enable Outgoing,Ieslēgt Izejošie
 DocType: Address,Fax,Fakss
 apps/frappe/frappe/config/customization.py,Custom Tags,Custom birkas
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,"E-pasta konts nav iestatīts. Lūdzu, izveidojiet jaunu e-pasta kontu sadaļā Iestatīšana&gt; E-pasts&gt; E-pasta konts"
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,"E-pasta konts nav iestatīts. Lūdzu, izveidojiet jaunu e-pasta kontu sadaļā Iestatīšana> E-pasts> E-pasta konts"
 DocType: Comment,Submitted,Iesniegtie
 DocType: Contact,Pulled from Google Contacts,Iegūts no Google kontaktpersonām
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Nederīgs pieprasījums
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sesija Derīguma st
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Šis lauks parādīsies tikai tad, ja šeit noteikts fieldname ir vērtība vai noteikumi ir taisnība (piemēri): myfield eval: doc.myfield == &#39;Mans Value &quot;eval: doc.age&gt; 18"
+eval:doc.age>18","Šis lauks parādīsies tikai tad, ja šeit noteikts fieldname ir vērtība vai noteikumi ir taisnība (piemēri): myfield eval: doc.myfield == &#39;Mans Value &quot;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šodien
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šodien
@@ -2144,7 +2144,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,LIELAIS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Ievadiet mapes nosaukumu
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,"Netika atrasta noklusējuma adreses veidne. Lūdzu, izveidojiet jaunu no Iestatīšana&gt; Drukāšana un zīmolu veidošana&gt; Adreses veidne."
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"Netika atrasta noklusējuma adreses veidne. Lūdzu, izveidojiet jaunu no Iestatīšana> Drukāšana un zīmolu veidošana> Adreses veidne."
 apps/frappe/frappe/auth.py,Unknown User,Nezināmais lietotājs
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Izvēlieties loma
 DocType: Comment,Deleted,Svītrots
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,"Nepietiek atļauju, lai redzētu saites"
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adrese sadaļa ir obligāta.
 DocType: Google Contacts,Push to Google Contacts,Piespiediet Google kontaktpersonām
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Pievienots HTML in &lt;head&gt; sadaļā mājas lapā, galvenokārt izmanto mājas pārbaudei un SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Pievienots HTML in &lt;head> sadaļā mājas lapā, galvenokārt izmanto mājas pārbaudei un SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidīvs
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Posteni nevar pievienot saviem pēcnācējiem
 DocType: Session Default Settings,Session Defaults,Sesijas noklusējumi
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,Brīdinājums
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Tas var tikt izdrukāts uz vairākām lappusēm
 DocType: Data Migration Run,Percent Complete,Procenti pabeigts
 DocType: Tag Category,Tag Category,Tag Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Salīdzinājumam izmantojiet&gt; 5, &lt;10 vai = 324. Diapazoniem izmantojiet 5:10 (vērtībām no 5 līdz 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Salīdzinājumam izmantojiet> 5, &lt;10 vai = 324. Diapazoniem izmantojiet 5:10 (vērtībām no 5 līdz 10)."
 DocType: Google Calendar,Pull from Google Calendar,Izvilkt no Google kalendāra
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Palīdzēt
 DocType: User,Login Before,Login Pirms
@@ -2924,7 +2924,7 @@ DocType: Custom Script,Custom Script,Custom Script
 DocType: Address,Address Line 2,Adrese Line 2
 DocType: Address,Reference,Atsauces
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Norīkoti
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,"Lūdzu, iestatiet noklusējuma e-pasta kontu no Iestatīšana&gt; E-pasts&gt; E-pasta konts"
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,"Lūdzu, iestatiet noklusējuma e-pasta kontu no Iestatīšana> E-pasts> E-pasta konts"
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Datu migrācijas kartēšanas detaļas
 DocType: Data Import,Action,Darbība
 DocType: GSuite Settings,Script URL,Script URL
@@ -3102,7 +3102,7 @@ DocType: DocField,Allow on Submit,Atļaut apstiprināšanas
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Izņēmums Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick slejas
-DocType: Web Page,Add code as &lt;script&gt;,"Pievienot kodu, & lt; script & gt;"
+DocType: Web Page,Add code as &lt;script>,"Pievienot kodu, & lt; script & gt;"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Notīrīt lietotāja atļaujas
 DocType: Webhook,Headers,Galvenes
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Gaidāmie notikumi
@@ -3479,15 +3479,15 @@ DocType: Workflow State,share-alt,akciju alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Rinda vajadzētu būt viens no {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> <p> Izmanto <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja šablonu </a> un visi lauki adrese (ieskaitot Custom Fields ja tādi ir), būs pieejams </ p> <pre> <code> {{address_line1}} & lt; br & gt; {%, Ja address_line2%}{{address_line2}} & lt; br & gt; {% endif -%}{{pilsētas}} & lt; br & gt; {%, Ja valsts%}{{valsts}} & lt; br & gt; {% endif -%}{%, ja Pasta indeksa%} PIN: {{Pasta indeksa}} & lt; br & gt; {% endif -%}{{valsts}} & lt ; br & gt; {%, Ja tālrunis%} Tālrunis: {{tālrunis}} & lt; br & gt; {% endif -%}{%, ja fakss%} Fakss: {{fakss}} & lt; br & gt; {% endif -%}{%, ja email_id %} E-pasts: {{email_id}} & lt; br & gt; {% endif -%} </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Sākuma datums lauks
 DocType: Role,Role Name,Loma Name

--- a/frappe/translations/lv.csv
+++ b/frappe/translations/lv.csv
@@ -1425,7 +1425,7 @@ DocType: User,System User,System User
 DocType: Report,Is Standard,Vai Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Pilna
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Vai nav HTML kodēt HTML tagus, piemēram, &lt;script> vai tikai rakstzīmes, piemēram, &lt;vai>, jo tie varētu tikt apzināti izmantot šajā jomā"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Vai nav HTML kodēt HTML tagus, piemēram, <script> vai tikai rakstzīmes, piemēram, <vai>, jo tie varētu tikt apzināti izmantot šajā jomā"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} tika kritizēts par {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Palaist
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Kājene tiks pare
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Līdz
 DocType: System Settings,Allow only one session per user,Atļaut tikai vienu sesiju katram lietotājam
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test mape 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Izvēlieties vai velciet pāri laika nišām, lai izveidotu jaunu notikumu."
 DocType: Contact,Contact Details,Kontaktinformācija
 DocType: DocField,In Filter,In Filtrs
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,"Nepietiek atļauju, lai redzētu saites"
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adrese sadaļa ir obligāta.
 DocType: Google Contacts,Push to Google Contacts,Piespiediet Google kontaktpersonām
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Pievienots HTML in &lt;head> sadaļā mājas lapā, galvenokārt izmanto mājas pārbaudei un SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Pievienots HTML in <head> sadaļā mājas lapā, galvenokārt izmanto mājas pārbaudei un SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidīvs
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Posteni nevar pievienot saviem pēcnācējiem
 DocType: Session Default Settings,Session Defaults,Sesijas noklusējumi
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,Brīdinājums
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Tas var tikt izdrukāts uz vairākām lappusēm
 DocType: Data Migration Run,Percent Complete,Procenti pabeigts
 DocType: Tag Category,Tag Category,Tag Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Salīdzinājumam izmantojiet> 5, &lt;10 vai = 324. Diapazoniem izmantojiet 5:10 (vērtībām no 5 līdz 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Salīdzinājumam izmantojiet> 5, <10 vai = 324. Diapazoniem izmantojiet 5:10 (vērtībām no 5 līdz 10)."
 DocType: Google Calendar,Pull from Google Calendar,Izvilkt no Google kalendāra
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Palīdzēt
 DocType: User,Login Before,Login Pirms
@@ -3102,7 +3102,7 @@ DocType: DocField,Allow on Submit,Atļaut apstiprināšanas
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Izņēmums Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick slejas
-DocType: Web Page,Add code as &lt;script>,"Pievienot kodu, & lt; script & gt;"
+DocType: Web Page,Add code as <script>,"Pievienot kodu, <script>"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Notīrīt lietotāja atļaujas
 DocType: Webhook,Headers,Galvenes
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Gaidāmie notikumi
@@ -3479,16 +3479,16 @@ DocType: Workflow State,share-alt,akciju alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Rinda vajadzētu būt viens no {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<H4> Default Template </ h4> <p> Izmanto <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja šablonu </a> un visi lauki adrese (ieskaitot Custom Fields ja tādi ir), būs pieejams </ p> <pre> <code> {{address_line1}} & lt; br & gt; {%, Ja address_line2%}{{address_line2}} & lt; br & gt; {% endif -%}{{pilsētas}} & lt; br & gt; {%, Ja valsts%}{{valsts}} & lt; br & gt; {% endif -%}{%, ja Pasta indeksa%} PIN: {{Pasta indeksa}} & lt; br & gt; {% endif -%}{{valsts}} & lt ; br & gt; {%, Ja tālrunis%} Tālrunis: {{tālrunis}} & lt; br & gt; {% endif -%}{%, ja fakss%} Fakss: {{fakss}} & lt; br & gt; {% endif -%}{%, ja email_id %} E-pasts: {{email_id}} & lt; br & gt; {% endif -%} </ code> </ pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<H4> Default Template </ h4> <p> Izmanto <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja šablonu </a> un visi lauki adrese (ieskaitot Custom Fields ja tādi ir), būs pieejams </ p> <pre> <code> {{address_line1}} <br> {%, Ja address_line2%}{{address_line2}} <br> {% endif -%}{{pilsētas}} <br> {%, Ja valsts%}{{valsts}} <br> {% endif -%}{%, ja Pasta indeksa%} PIN: {{Pasta indeksa}} <br> {% endif -%}{{valsts}} & lt ; br> {%, Ja tālrunis%} Tālrunis: {{tālrunis}} <br> {% endif -%}{%, ja fakss%} Fakss: {{fakss}} <br> {% endif -%}{%, ja email_id %} E-pasts: {{email_id}} <br> {% endif -%} </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Sākuma datums lauks
 DocType: Role,Role Name,Loma Name
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Pārslēgt uz Desk

--- a/frappe/translations/lv.csv
+++ b/frappe/translations/lv.csv
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistika balstās uz pagājušās nedēļas sniegumu (no {0} līdz {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP tālruņa lauks
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","dokumenta veids ..., piemēram, klientu"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Nosacījums &#39;{0}&#39; ir nederīgs
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Nosacījums '{0}' ir nederīgs
 DocType: Workflow State,barcode,svītrkoda
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Apakšprasījuma vai funkcijas izmantošana ir ierobežota
 apps/frappe/frappe/config/customization.py,Add your own translations,Pievienojiet savu tulkojumu
@@ -787,7 +787,7 @@ DocType: File,Is Home Folder,Vai Mājas mape
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar stils
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} nav derīgs e-pasta adrese
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Izvēlieties Vismaz 1 rekordu drukāšanai
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Lietotājs &#39;{0}&#39; jau ir nozīme &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Lietotājs '{0}' jau ir nozīme '{1}'
 DocType: System Settings,Two Factor Authentication method,Divu faktoru autentifikācijas metode
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Vispirms iestatiet nosaukumu un saglabājiet ierakstu.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 ieraksti
@@ -1040,7 +1040,7 @@ DocType: Property Setter,Property Setter,Īpašuma seters
 DocType: Web Form,Allow Print,atļaut drukāt
 DocType: Communication,Clicked,Uzklikšķināt
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Neizsekot
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nav atļaujas &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nav atļaujas '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Plānotais sūtīt
 DocType: DocType,Track Seen,Track Seen
 DocType: Dropbox Settings,File Backup,Failu dublējums
@@ -1456,7 +1456,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obligāts lauks: noteikt loma
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritizēja {1}
 DocType: Data Migration Mapping,Mapping Name,Kartēšanas nosaukums
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Lauku &#39;{1}&#39; nevar iestatīt kā unikālu, jo tam ir unikālas vērtības"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Lauku '{1}' nevar iestatīt kā unikālu, jo tam ir unikālas vērtības"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Pārvietojieties sarakstā uz leju
 DocType: Currency,A symbol for this currency. For e.g. $,"Simbols šajā valūtā. Lai, piemēram, $$"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Veiksmīgi atjaunināti tulkojumi
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sesija Derīguma st
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Šis lauks parādīsies tikai tad, ja šeit noteikts fieldname ir vērtība vai noteikumi ir taisnība (piemēri): myfield eval: doc.myfield == &#39;Mans Value &quot;eval: doc.age> 18"
+eval:doc.age>18","Šis lauks parādīsies tikai tad, ja šeit noteikts fieldname ir vērtība vai noteikumi ir taisnība (piemēri): myfield eval: doc.myfield == 'Mans Value &quot;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šodien
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,šodien
@@ -2169,7 +2169,7 @@ DocType: Data Migration Connector,Database Name,Datubāzes nosaukums
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Atsvaidzināt Form
 DocType: DocField,Select,Atlasīt
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Skatīt pilnu žurnālu
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",Vienkāršs Python izteiksmes piemērs: status == &#39;Open&#39; un ierakstiet == &#39;Bug&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",Vienkāršs Python izteiksmes piemērs: status == 'Open' un ierakstiet == 'Bug'
 apps/frappe/frappe/utils/csvutils.py,File not attached,Fails nav pievienots
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Savienojums zaudēts. Dažas funkcijas var nedarboties.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Atkārtojas, piemēram, &quot;AAA&quot; ir viegli uzminēt"
@@ -2301,7 +2301,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Rādīt tikai kļūdas
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Nosūtīt e-pasta brīdinājumu
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. Razorpay neatbalsta darījumus valūtā &#39;{0}&#39;"
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. Razorpay neatbalsta darījumus valūtā '{0}'"
 DocType: Data Import,In Progress,Gaitā
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Rindā backup. Tas var ilgt dažas minūtes līdz stundai.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2728,7 +2728,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Ar ko groza
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal maksājumu vārteja iestatījumi
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Labākais izpildītājs
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Pielāgotos laukus nevar pievienot galvenajiem DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) tiks saīsināts, jo max atļautās rakstzīmes ir {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) tiks saīsināts, jo max atļautās rakstzīmes ir {2}"
 DocType: OAuth Client,Response Type,Response Type
 DocType: Contact Us Settings,Send enquiries to this email address,Nosūtīt pieprasījumus uz šo e-pasta adresi
 DocType: Letter Head,Letter Head Name,Vēstule Head Name
@@ -2785,7 +2785,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Image View
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Izskatās kaut kas nogāja greizi darījuma laikā. Tā kā mēs neesam apstiprinājuši maksājumu, Paypal automātiski atdosim šo summu. Ja tas tā nav, lūdzu, sūtiet mums e-pastu un pieminēt korelācija ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Iekļaut simbolus, ciparus un ar lielajiem burtiem paroli"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Ievietojiet Pēc lauka &#39;{0}&#39; minēts Custom Field &#39;{1}&#39;, ar marķējumu &#39;{2}&#39;, neeksistē"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Ievietojiet Pēc lauka '{0}' minēts Custom Field '{1}', ar marķējumu '{2}', neeksistē"
 DocType: List Filter,List Filter,Saraksta filtrs
 DocType: Workflow State,signal,signāls
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ir pielikumi
@@ -2795,7 +2795,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokumentu Atjaunota
 DocType: Data Export,Data Export,Datu eksportēšana
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Izvēlēties valodu...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Laukā {0} nevar iestatīt opcijas &#39;Opcijas&#39;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Laukā {0} nevar iestatīt opcijas 'Opcijas'
 DocType: Help Article,Author,autors
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,atsākt sūtīšana
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Atjaunot
@@ -2809,8 +2809,8 @@ DocType: Web Page,Slideshow,Slaidrādi
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Default Adrese Template nevar izdzēst
 DocType: Contact,Maintenance Manager,Uzturēšana vadītājs
 DocType: Workflow State,Search,Meklēšana
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. Stripe neatbalsta darījumus valūtā &#39;{0}&#39;"
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. Stripe neatbalsta darījumus valūtā &#39;{0}&#39;"
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. Stripe neatbalsta darījumus valūtā '{0}'"
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. Stripe neatbalsta darījumus valūtā '{0}'"
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Pārvietot uz miskasti
 DocType: Web Form,Web Form Fields,Web Form Fields
 DocType: Data Import,Amended From,Grozīts No
@@ -3008,7 +3008,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Vērtība pazudis
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Pievienot Child
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Importēšanas progress
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Ja nosacījums ir izpildīts, lietotājs tiks apbalvots ar saņemtajiem punktiem. piem. doc.status == &#39;Slēgts&#39;"
+","Ja nosacījums ir izpildīts, lietotājs tiks apbalvots ar saņemtajiem punktiem. piem. doc.status == 'Slēgts'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0}{1}: Iesniegtie Record nevar izdzēst.
 DocType: GSuite Templates,Template Name,Veidnes nosaukums
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,jauna tipa dokumenta
@@ -3429,7 +3429,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Custom Translatio
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,progress
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,pēc lomas
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Trūkst Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Nederīga fieldname &#39;{0}&#39; in autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Nederīga fieldname '{0}' in autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Meklēt pēc dokumenta veida
 DocType: Custom DocPerm,Role and Level,Loma un Level
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3881,7 +3881,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Pēc noklusējuma
 DocType: Translation,Verified,Pārbaudīts
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} pievienots
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Meklēt &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Meklēt '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Lūdzu, vispirms saglabājiet ziņojumu"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonenti pievienotās
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Not In
@@ -3918,7 +3918,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Es
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} nav derīgs valsts
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Piemērot visiem dokumentu veidiem
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Enerģijas punkta atjaunināšana
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. PayPal neatbalsta darījumus valūtā &#39;{0}&#39;"
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',"Lūdzu, izvēlieties citu maksājuma veidu. PayPal neatbalsta darījumus valūtā '{0}'"
 DocType: Chat Message,Room Type,Istabas tips
 DocType: Data Import Beta,Import Log Preview,Importēt žurnāla priekšskatījumu
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Meklēt lauks {0} nav derīgs

--- a/frappe/translations/mk.csv
+++ b/frappe/translations/mk.csv
@@ -250,7 +250,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Оневозмо
 DocType: Translation,Contributed Translation Doctype Name,Придонесено име на докторски превод
 DocType: PayPal Settings,Redirect To,За пренасочување
 DocType: Data Migration Mapping,Pull,Повлечете
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Го вклучите Javascript-формат: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Го вклучите Javascript-формат: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,рефус ажурирање
 DocType: Workflow State,chevron-up,Шеврон-up
 DocType: DocType,Allow Guest to View,Дозволете гостот да ги
@@ -551,7 +551,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Статистика заснована на минатонеделниот настап (од {0} до {1})
 DocType: LDAP Settings,LDAP Phone Field,Телефонски поле за LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","за типот на документот ..., на пример, клиент"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Состојбата &#39;{0}&#39; не е валиден
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Состојбата '{0}' не е валиден
 DocType: Workflow State,barcode,баркод
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Употребата на под-прашање или функција е ограничена
 apps/frappe/frappe/config/customization.py,Add your own translations,Додади свои преводи
@@ -700,7 +700,7 @@ DocType: Slack Webhook URL,Webhook URL,Веб-URL адреса
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Корисничко име {0} веќе постои
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Не може да се постави увоз како {1} не е importable
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Има грешка во Вашата адреса шаблонот {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} е неважечка е-поштенска адреса во &#39;Примачи&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} е неважечка е-поштенска адреса во 'Примачи'
 DocType: Footer Item,"target = ""_blank""",целни = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,домаќинот
@@ -741,7 +741,7 @@ DocType: Currency,Currency Name,Валута Име
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Нема пораки
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Линкот е истечен
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Враќање на должина до {0} за &#39;{1}&#39; во &#39;{2}&#39;; Поставувањето на должината како {3} ќе предизвика скратување на податоците.
+							Setting the length as {3} will cause truncation of data.",Враќање на должина до {0} за '{1}' во '{2}'; Поставувањето на должината како {3} ќе предизвика скратување на податоците.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Изберете File Format
 DocType: Report,Javascript,Javascript-от
 DocType: File,Content Hash,Содржина Hash
@@ -763,7 +763,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Документ Сподели Извештај
 DocType: Social Login Key,Base URL,Основен URL
 DocType: User,Last Login,Најнови најавување
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Не можете да поставите &#39;Translatable&#39; за полето {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Не можете да поставите 'Translatable' за полето {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Колона
 DocType: Chat Profile,Chat Profile,Профил за разговор
 DocType: Custom Field,Adds a custom field to a DocType,Додава сопствен поле на DOCTYPE
@@ -772,7 +772,7 @@ DocType: File,Is Home Folder,Е Домашнапапка
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Стил на навигација
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} не е валидна е-мејл адреса
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Изберете барем 1 рекорд за печатење
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Корисникот &#39;{0}&#39; веќе има улога &quot;{1}&quot;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Корисникот '{0}' веќе има улога &quot;{1}&quot;
 DocType: System Settings,Two Factor Authentication method,Два фактори за проверка на автентичност
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Прво поставете го името и зачувајте го рекордот.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 рекорди
@@ -1022,7 +1022,7 @@ DocType: Property Setter,Property Setter,Сопственост сетер
 DocType: Web Form,Allow Print,Дозволи за печатење
 DocType: Communication,Clicked,Кликнато
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Неуспешно
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Нема дозвола за &#39;{0} {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Нема дозвола за '{0} {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Треба да се испрати
 DocType: DocType,Track Seen,песна Гледано
 DocType: Dropbox Settings,File Backup,Датотека резервна копија
@@ -1981,7 +1981,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Фонт на Google
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Ако овие инструкции каде што не е од помош, ве молиме додадете во вашите предлози на GitHub прашања."
 DocType: Workflow State,bookmark,обележувач
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Име на папка не треба да содржи &#39;/&#39; (коса црта)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Име на папка не треба да содржи '/' (коса црта)
 DocType: Note,Note,Забелешка
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Пријави грешка
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Извоз на податоци во CSV / Excel формат.
@@ -2085,7 +2085,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Сесија Важ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Ова поле ќе се појави само ако fieldname дефинирани овде има вредност или правилата се точни (примери): eval myfield: doc.myfield == &quot;Мојот вредност &#39;eval: doc.age> 18
+eval:doc.age>18",Ова поле ќе се појави само ако fieldname дефинирани овде има вредност или правилата се точни (примери): eval myfield: doc.myfield == &quot;Мојот вредност 'eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,денес
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,денес
@@ -2124,7 +2124,7 @@ DocType: Data Migration Connector,Database Name,Име на базата
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Refresh Форма
 DocType: DocField,Select,Изберете
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Прикажи целосен дневник
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Едноставно изразување на Питон, Пример: статус == &#39;Отвори&#39; и тип == &#39;Бубачка&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Едноставно изразување на Питон, Пример: статус == 'Отвори' и тип == 'Бубачка'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Датотеката не е спроведен
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Изгубена конекција. Некои функции можеби нема да работат.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Се повторува како &quot;ААА&quot; се лесно да се погоди
@@ -2252,7 +2252,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Покажи само грешки
 DocType: Website Settings,Banner HTML,Банер HTML
 DocType: Workflow,Send Email Alert,Испрати е-мејл сигнализација
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. Razorpay не поддржува трансакции во валута &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. Razorpay не поддржува трансакции во валута '{0}'
 DocType: Data Import,In Progress,Во тек
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Чекаат на ред за резервна копија. Тоа може да потрае неколку минути до еден час.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2722,7 +2722,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Слика Види
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Изгледа дека нешто не беше во ред за време на трансакцијата. Бидејќи ние не се потврди за плаќање, PayPal автоматски ќе рефундирање на овој износ. Ако не е така, ве молиме испратете ни e-mail и наведете проект Корелација: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Вклучуваат симболи, броеви и големи букви во лозинката"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Вметнете по полето &#39;{0}&#39; споменати во сопствено поле &quot;{1} &#39;, со ознака&quot; {2}&#39;, не постои"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Вметнете по полето '{0}' споменати во сопствено поле &quot;{1} ', со ознака&quot; {2}', не постои"
 DocType: List Filter,List Filter,Филтер со листа
 DocType: Workflow State,signal,сигнал
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Има прилози
@@ -2732,7 +2732,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Вратен на документот
 DocType: Data Export,Data Export,Извоз на податоци
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Избери јазик ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Не можете да поставите &#39;Опции&#39; за полето {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Не можете да поставите 'Опции' за полето {0}
 DocType: Help Article,Author,автор
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,продолжите со испраќање на
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Повторно отворање
@@ -2746,15 +2746,15 @@ DocType: Web Page,Slideshow,Слајдшоу
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Стандардно адреса Шаблон не може да се избришат
 DocType: Contact,Maintenance Manager,Одржување менаџер
 DocType: Workflow State,Search,Барај
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. Лента не поддржува трансакции во валута &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. Лента не поддржува трансакции во валута &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. Лента не поддржува трансакции во валута '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. Лента не поддржува трансакции во валута '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Премести во корпата
 DocType: Web Form,Web Form Fields,Веб образец Полињата
 DocType: Data Import,Amended From,Изменет Од
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Предупредување: Не можам да најдам {0} во секоја маса во врска со {1}
 DocType: S3 Backup Settings,eu-north-1,еу-север-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Овој документ е во чекаат на ред за извршување. Ве молиме обидете се повторно
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,&#39;{0} &quot;не е пронајдена датотека
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,'{0} &quot;не е пронајдена датотека
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Отстрани Дел
 DocType: User,Change Password,Промени го пасвордот
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X оска поле
@@ -2938,7 +2938,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Недостасув
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Додади детето
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Напредок во увозот
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Доколку состојбата е задоволена, корисникот ќе биде награден со бодовите. на пр. doc.status == &#39;Затворено&#39;"
+","Доколку состојбата е задоволена, корисникот ќе биде награден со бодовите. на пр. doc.status == 'Затворено'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Поднесени рекорд не може да се избрише.
 DocType: GSuite Templates,Template Name,шаблон Име
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,нов тип на документ
@@ -3297,7 +3297,7 @@ DocType: Notification,Send alert if this field's value changes,Испрати п
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Тематски бои
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Изберете DOCTYPE да се направи нов формат
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Корисникот не постои
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Не е наведено примачот&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Не е наведено примачот'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,само сега
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,применуваат
 DocType: Footer Item,Policy,политика
@@ -3343,7 +3343,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Прилагод�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,напредок
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,по улога
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,недостасува сфера
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Невалиден fieldname &#39;{0}&#39; во autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Невалиден fieldname '{0}' во autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Барај во типот на документот
 DocType: Custom DocPerm,Role and Level,Улогата и ниво
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3480,7 +3480,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Ве молиме внесете валидна мобилен бр
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Некои од карактеристиките не би можеле да работат во вашиот интернет пребарувач. Ве молиме обновете го вашиот интернет пребарувач со најновата верзија.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Некои од карактеристиките не би можеле да работат во вашиот интернет пребарувач. Ве молиме обновете го вашиот интернет пребарувач со најновата верзија.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Не знам, прашајте &#39;помош&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Не знам, прашајте 'помош'"
 DocType: DocType,Comments and Communications will be associated with this linked document,Коментари и врски ќе биде поврзан со овој поврзани документ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Филтер ...
 DocType: Workflow State,bold,задебелени букви
@@ -3781,7 +3781,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Стандардно
 DocType: Translation,Verified,Потврдено
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} додаде
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Барањето за &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Барањето за '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Чувајте го првиот извештај
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,Додадени {0} претплатници
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,А не во
@@ -3817,7 +3817,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Јас
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} не е валиден држава
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Аплицирајте на сите типови документи
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Ажурирање на енергетската точка
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. PayPal не поддржува трансакции во валута &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Ве молам изберете друг начин на плаќање. PayPal не поддржува трансакции во валута '{0}'
 DocType: Chat Message,Room Type,Вид на соба
 DocType: Data Import Beta,Import Log Preview,Внесете преглед преглед
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,полето за пребарување {0} не е валиден

--- a/frappe/translations/mk.csv
+++ b/frappe/translations/mk.csv
@@ -1401,7 +1401,7 @@ DocType: Report,Is Standard,Е стандард
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Целосно
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не HTML Кодираат HTML-ознаки како &lt;script> или само карактери како &lt;и>, како што може да се намерно употребени во оваа област"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Не HTML Кодираат HTML-ознаки како <script> или само карактери како <и>, како што може да се намерно употребени во оваа област"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} критикуван на {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Стартувај
@@ -1768,7 +1768,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Подножје�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Во очекување
 DocType: System Settings,Allow only one session per user,Дозволи само на една седница на корисник
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Почетна / Тест папка 1 / Тест Папка 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Одберете или повлечете низ времето слотови да се создаде нов настан.
 DocType: Contact,Contact Details,Податоци за контакт
 DocType: DocField,In Filter,Во филтерот
@@ -2284,7 +2284,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Не е доволно дозволи за да ја видите линкови
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Наслов адреса е задолжително.
 DocType: Google Contacts,Push to Google Contacts,Притиснете кон Контактите на Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Додадени HTML во &lt;head> секција на веб-страница, се користи првенствено за верификација вебсајт и SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Додадени HTML во <head> секција на веб-страница, се користи првенствено за верификација вебсајт и SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Релапс
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Точка не може да се додаде свои потомци
 DocType: Session Default Settings,Session Defaults,Сесија стандардно
@@ -2401,7 +2401,7 @@ DocType: Workflow State,Warning,Предупредување
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ова може да се печати на повеќе страници
 DocType: Data Migration Run,Percent Complete,Процент е комплетен
 DocType: Tag Category,Tag Category,таг Категорија
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За споредба, користете> 5, &lt;10 или = 324. За опсег, користете 5:10 (за вредности помеѓу 5 и 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За споредба, користете> 5, <10 или = 324. За опсег, користете 5:10 (за вредности помеѓу 5 и 10)."
 DocType: Google Calendar,Pull from Google Calendar,Повлечете од Календарот на Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помош
 DocType: User,Login Before,Влези Пред
@@ -3030,7 +3030,7 @@ DocType: DocField,Allow on Submit,Им овозможи на Поднесете
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Исклучок Тип
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Трансферот Колони
-DocType: Web Page,Add code as &lt;script>,Додади код како &lt;script>
+DocType: Web Page,Add code as <script>,Додади код како <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Исчистете ги дозволите за корисниците
 DocType: Webhook,Headers,Заглавија
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Престојни настани
@@ -3390,16 +3390,16 @@ DocType: Workflow State,share-alt,на акции alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Дното треба да биде еден од {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Стандардно Шаблон </h4><p> Користи <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> и сите области на адресата (вклучувајќи сопствени полиња, ако ги има) ќе биде достапен </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Стандардно Шаблон </h4><p> Користи <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> и сите области на адресата (вклучувајќи сопствени полиња, ако ги има) ќе биде достапен </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Почетно поле за датум
 DocType: Role,Role Name,Улогата Име
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Префрли се на маса

--- a/frappe/translations/mk.csv
+++ b/frappe/translations/mk.csv
@@ -1031,7 +1031,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Нема {0} 
 apps/frappe/frappe/config/customization.py,Add custom forms.,Додадете сопствени форми.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} на {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,поднесено овој документ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Поставување&gt; Кориснички дозволи
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Поставување> Кориснички дозволи
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Системот обезбедува многу пред-дефинирани улоги. Можете да додавате нови улоги за да го поставите пофини дозволи.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Гео
@@ -1246,7 +1246,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ако корисникот има било провери улога, тогаш корисникот ќе стане &quot;Систем за корисникот&quot;. &quot;Систем за корисникот&quot; има пристап на работната површина"
 DocType: System Settings,Date and Number Format,Датум и број формат
 apps/frappe/frappe/model/document.py,one of,еден од
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Поставување&gt; Персонализирајте форма
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Поставување> Персонализирајте форма
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Проверка еден момент
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Прикажи Тагови
 DocType: DocField,HTML Editor,HTML Editor
@@ -1254,7 +1254,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Платежна
 DocType: Email Queue,Not Sent,Не Испратени
 DocType: Web Form,Actions,Активности
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Поставување&gt; Корисник
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Поставување> Корисник
 DocType: Workflow State,align-justify,усогласат-оправдаат
 DocType: User,Middle Name (Optional),Татково име (опционално)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Не е дозволено
@@ -1401,7 +1401,7 @@ DocType: Report,Is Standard,Е стандард
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Целосно
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Не HTML Кодираат HTML-ознаки како &lt;script&gt; или само карактери како &lt;и&gt;, како што може да се намерно употребени во оваа област"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не HTML Кодираат HTML-ознаки како &lt;script> или само карактери како &lt;и>, како што може да се намерно употребени во оваа област"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} критикуван на {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Стартувај
@@ -1768,7 +1768,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Подножје�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Во очекување
 DocType: System Settings,Allow only one session per user,Дозволи само на една седница на корисник
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Почетна / Тест папка 1 / Тест Папка 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Одберете или повлечете низ времето слотови да се создаде нов настан.
 DocType: Contact,Contact Details,Податоци за контакт
 DocType: DocField,In Filter,Во филтерот
@@ -1998,7 +1998,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Пријавата не е дозволено во овој момент
 DocType: Data Migration Run,Current Mapping Action,Тековна акција за мапирање
 DocType: Dashboard Chart Source,Source Name,извор Име
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,"Нема сметка за е-пошта поврзана со Корисникот. Ве молиме, додадете сметка под Корисникот&gt; Е-пошта во пошта."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Нема сметка за е-пошта поврзана со Корисникот. Ве молиме, додадете сметка под Корисникот> Е-пошта во пошта."
 DocType: Email Account,Email Sync Option,Е-Sync Опција
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Ред бр
 DocType: Async Task,Runtime,Траење
@@ -2012,7 +2012,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Веќе 
 DocType: User Email,Enable Outgoing,Овозможи заминување
 DocType: Address,Fax,Факс
 apps/frappe/frappe/config/customization.py,Custom Tags,Прилагодено Тагови
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,"Не е поставена сметка за е-пошта. Ве молиме, креирајте нова сметка за е-пошта од Поставување&gt; Е-пошта&gt; Сметка за е-пошта"
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,"Не е поставена сметка за е-пошта. Ве молиме, креирајте нова сметка за е-пошта од Поставување> Е-пошта> Сметка за е-пошта"
 DocType: Comment,Submitted,Поднесени
 DocType: Contact,Pulled from Google Contacts,Извлечено од Контактите на Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Во валидно барање
@@ -2085,7 +2085,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Сесија Важ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Ова поле ќе се појави само ако fieldname дефинирани овде има вредност или правилата се точни (примери): eval myfield: doc.myfield == &quot;Мојот вредност &#39;eval: doc.age&gt; 18
+eval:doc.age>18",Ова поле ќе се појави само ако fieldname дефинирани овде има вредност или правилата се точни (примери): eval myfield: doc.myfield == &quot;Мојот вредност &#39;eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,денес
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,денес
@@ -2099,7 +2099,7 @@ apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of th
 DocType: DocType,UPPER CASE,ГОЛЕМИ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Прилагодено HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Внесете име на папка
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,"Не е пронајдена стандардна образец за адреса. Ве молиме, создадете нова од Поставување&gt; Печатење и брендирање&gt; Шаблон за адреса."
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"Не е пронајдена стандардна образец за адреса. Ве молиме, создадете нова од Поставување> Печатење и брендирање> Шаблон за адреса."
 apps/frappe/frappe/auth.py,Unknown User,Непознат корисник
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Изберете Улогата
 DocType: Comment,Deleted,Избришани
@@ -2284,7 +2284,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Не е доволно дозволи за да ја видите линкови
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Наслов адреса е задолжително.
 DocType: Google Contacts,Push to Google Contacts,Притиснете кон Контактите на Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Додадени HTML во &lt;head&gt; секција на веб-страница, се користи првенствено за верификација вебсајт и SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Додадени HTML во &lt;head> секција на веб-страница, се користи првенствено за верификација вебсајт и SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Релапс
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Точка не може да се додаде свои потомци
 DocType: Session Default Settings,Session Defaults,Сесија стандардно
@@ -2401,7 +2401,7 @@ DocType: Workflow State,Warning,Предупредување
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ова може да се печати на повеќе страници
 DocType: Data Migration Run,Percent Complete,Процент е комплетен
 DocType: Tag Category,Tag Category,таг Категорија
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За споредба, користете&gt; 5, &lt;10 или = 324. За опсег, користете 5:10 (за вредности помеѓу 5 и 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За споредба, користете> 5, &lt;10 или = 324. За опсег, користете 5:10 (за вредности помеѓу 5 и 10)."
 DocType: Google Calendar,Pull from Google Calendar,Повлечете од Календарот на Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помош
 DocType: User,Login Before,Влези Пред
@@ -2857,7 +2857,7 @@ DocType: Custom Script,Custom Script,Прилагодено сценарио
 DocType: Address,Address Line 2,Адреса Линија 2
 DocType: Address,Reference,Референтен
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Доделени
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Ве молиме поставете ја стандардната сметка за е-пошта од Поставување&gt; Е-пошта&gt; Сметка за е-пошта
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Ве молиме поставете ја стандардната сметка за е-пошта од Поставување> Е-пошта> Сметка за е-пошта
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Детали за картирање на миграција на податоци
 DocType: Data Import,Action,Акција
 DocType: GSuite Settings,Script URL,Script URL
@@ -3030,7 +3030,7 @@ DocType: DocField,Allow on Submit,Им овозможи на Поднесете
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Исклучок Тип
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Трансферот Колони
-DocType: Web Page,Add code as &lt;script&gt;,Додади код како &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Додади код како &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Исчистете ги дозволите за корисниците
 DocType: Webhook,Headers,Заглавија
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Престојни настани
@@ -3390,16 +3390,16 @@ DocType: Workflow State,share-alt,на акции alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Дното треба да биде еден од {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Стандардно Шаблон </h4><p> Користи <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> и сите области на адресата (вклучувајќи сопствени полиња, ако ги има) ќе биде достапен </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Стандардно Шаблон </h4><p> Користи <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> и сите области на адресата (вклучувајќи сопствени полиња, ако ги има) ќе биде достапен </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Почетно поле за датум
 DocType: Role,Role Name,Улогата Име
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Префрли се на маса

--- a/frappe/translations/ml.csv
+++ b/frappe/translations/ml.csv
@@ -1396,7 +1396,7 @@ DocType: Report,Is Standard,സ്റ്റാൻഡേർഡ് Is
 DocType: Desktop Icon,_report,_രെപൊര്ത്
 DocType: Desktop Icon,_report,_രെപൊര്ത്
 DocType: Dashboard Chart,Full,പൂർണ്ണമായ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",അവർ ബോധപൂർവം ഈ ഫീൽഡ് ഉപയോഗിക്കാനുമാകും പോലെ &lt;സ്ക്രിപ്റ്റ്> അല്ലെങ്കിൽ അക്ഷരങ്ങൾ പോലെ &lt;അല്ലെങ്കിൽ> പോലെയല്ല എച്ച്ടിഎംഎൽ എൻകോഡ് HTML ടാഗുകൾ ചെയ്ക
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",അവർ ബോധപൂർവം ഈ ഫീൽഡ് ഉപയോഗിക്കാനുമാകും പോലെ <സ്ക്രിപ്റ്റ്> അല്ലെങ്കിൽ അക്ഷരങ്ങൾ പോലെ <അല്ലെങ്കിൽ> പോലെയല്ല എച്ച്ടിഎംഎൽ എൻകോഡ് HTML ടാഗുകൾ ചെയ്ക
 DocType: Website Settings,FavIcon,ഫെവിക്കോൺ
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,പ്രവർത്തിപ്പിക്കുക
 DocType: Blog Post,Content (HTML),ഉള്ളടക്കം (HTML)
@@ -1765,7 +1765,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,അടിക്�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,തീർച്ചപ്പെടുത്തിയിട്ടില്ല
 DocType: System Settings,Allow only one session per user,ഓരോ ഉപയോക്താവിനും ഒരേയൊരു സെഷന് അനുവദിക്കുക
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ഹോം / ടെസ്റ്റ് ഫോള്ഡര് 1 / ടെസ്റ്റ് ഫോൾഡർ 3
-DocType: Website Settings,&lt;head> HTML,&lt;തല> HTML
+DocType: Website Settings,<head> HTML,<തല> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,തിരഞ്ഞെടുക്കുക അല്ലെങ്കിൽ ഒരു പുതിയ ഇവന്റ് സൃഷ്ടിക്കാൻ സമയം സ്ലോട്ടുകൾ കുറുകെ ഡ്രാഗ്.
 DocType: Contact,Contact Details,കോൺടാക്റ്റ് വിശദാംശങ്ങൾ
 DocType: DocField,In Filter,ഫിൽറ്റർ ൽ
@@ -2283,7 +2283,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ലിങ്കുകൾ കാണുന്നതിന് ആവശ്യമായ അനുമതി
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,വിലാസം ശീർഷകം നിർബന്ധമാണ്.
 DocType: Google Contacts,Push to Google Contacts,Google കോൺ‌ടാക്റ്റുകളിലേക്ക് പുഷ് ചെയ്യുക
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","പ്രാഥമികമായി വെബ്സൈറ്റ് സ്ഥിരീകരണം, എസ്.ഇ.ഒ. ഉപയോഗിക്കുന്ന വെബ് പേജിന്റെ &lt;തല> വിഭാഗത്തിൽ, ചേർത്തു എച്ച്ടിഎംഎൽ"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","പ്രാഥമികമായി വെബ്സൈറ്റ് സ്ഥിരീകരണം, എസ്.ഇ.ഒ. ഉപയോഗിക്കുന്ന വെബ് പേജിന്റെ <തല> വിഭാഗത്തിൽ, ചേർത്തു എച്ച്ടിഎംഎൽ"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ഇനം അതിന്റേതായ descendents ചേർക്കില്ല കഴിയില്ല
 DocType: Session Default Settings,Session Defaults,സെഷൻ സ്ഥിരസ്ഥിതികൾ
@@ -2401,7 +2401,7 @@ DocType: Workflow State,Warning,മുന്നറിയിപ്പ്
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ഇത് ഒന്നിലധികം പേജുകളിൽ അച്ചടിച്ചേക്കാം
 DocType: Data Migration Run,Percent Complete,പൂർത്തിയായി
 DocType: Tag Category,Tag Category,ടാഗ് വർഗ്ഗം
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","താരതമ്യത്തിന്,> 5, &lt;10 അല്ലെങ്കിൽ = 324 ഉപയോഗിക്കുക. ശ്രേണികൾക്കായി, 5:10 ഉപയോഗിക്കുക (5 നും 10 നും ഇടയിലുള്ള മൂല്യങ്ങൾക്ക്)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","താരതമ്യത്തിന്,> 5, <10 അല്ലെങ്കിൽ = 324 ഉപയോഗിക്കുക. ശ്രേണികൾക്കായി, 5:10 ഉപയോഗിക്കുക (5 നും 10 നും ഇടയിലുള്ള മൂല്യങ്ങൾക്ക്)."
 DocType: Google Calendar,Pull from Google Calendar,Google കലണ്ടറിൽ നിന്ന് വലിക്കുക
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,സഹായിക്കൂ
 DocType: User,Login Before,"മുമ്പ്, ലോഗിൻ"
@@ -3032,7 +3032,7 @@ DocType: DocField,Allow on Submit,സമർപ്പിക്കുക അനു
 DocType: DocField,HTML,എച്ച്ടിഎംഎൽ
 DocType: Error Snapshot,Exception Type,ഒഴിവാക്കൽ തരം
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,നിരകൾ തിരഞ്ഞെടുക്കുക
-DocType: Web Page,Add code as &lt;script>,&lt;സ്ക്രിപ്റ്റ്> പോലെ കോഡ് ചേർക്കുക
+DocType: Web Page,Add code as <script>,<സ്ക്രിപ്റ്റ്> പോലെ കോഡ് ചേർക്കുക
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ഉപയോക്തൃ അനുമതികൾ മായ്‌ക്കുക
 DocType: Webhook,Headers,തലക്കെട്ടുകൾ
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,വരാനിരിക്കുന്ന
@@ -3402,16 +3402,16 @@ DocType: Workflow State,share-alt,പങ്ക്-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ക്യൂ {0} ഒന്നായിരിക്കണം
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> സ്ഥിരസ്ഥിതി ഫലകം </h4><p> ഉപയോഗിക്കുന്നു <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ആൻഡ് (കസ്റ്റം ഫീൽഡ് എന്തെങ്കിലും ഉണ്ടെങ്കിൽ ഉൾപ്പെടെ) വിലാസം എല്ലാ നിലങ്ങളും ലഭ്യമാകും </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> സ്ഥിരസ്ഥിതി ഫലകം </h4><p> ഉപയോഗിക്കുന്നു <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ആൻഡ് (കസ്റ്റം ഫീൽഡ് എന്തെങ്കിലും ഉണ്ടെങ്കിൽ ഉൾപ്പെടെ) വിലാസം എല്ലാ നിലങ്ങളും ലഭ്യമാകും </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ആരംഭിക്കുന്ന ഫീൽഡ് ഫീൽഡ്
 DocType: Role,Role Name,റോൾ പേര്
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,പഴകിയ മാറുക

--- a/frappe/translations/ml.csv
+++ b/frappe/translations/ml.csv
@@ -736,7 +736,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ഫയൽ �
 DocType: DocField,In Global Search,ആഗോള തിരയലിൽ
 DocType: System Settings,Brute Force Security,ബ്രൂട്ട് ഫോഴ്സ് സെക്യൂരിറ്റി
 DocType: Workflow State,indent-left,ഇൻഡന്റ്-ഇടത്
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} വർഷം (ങ്ങൾ) മുമ്പ്
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} വർഷം (ങ്ങൾ) മുമ്പ്
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,{0}: അതു ഈ ചിത്രം ഇല്ലാതാക്കാൻ മാറഡോണ. നിങ്ങളുടെ സിസ്റ്റം മാനേജർ ബന്ധപ്പെടുക.
 DocType: Currency,Currency Name,നാണയ പേര്
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ഇമെയിലുകൾ
@@ -1027,7 +1027,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} കണ്
 apps/frappe/frappe/config/customization.py,Add custom forms.,ഇച്ഛാനുസൃത ഫോമുകൾ ചേർക്കുക.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} ൽ {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ഈ പ്രമാണം സമർപ്പിച്ചു
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,സജ്ജീകരണം&gt; ഉപയോക്തൃ അനുമതികൾ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,സജ്ജീകരണം> ഉപയോക്തൃ അനുമതികൾ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,സിസ്റ്റം പല പ്രീ-നിർവചിക്കപ്പെട്ട വേഷങ്ങൾ നൽകുന്നു. നിങ്ങൾ മാളിക അനുമതികൾ സജ്ജീകരിക്കാൻ പുതിയ വേഷങ്ങൾ ചേർക്കാൻ കഴിയും.
 DocType: Communication,CC,സിസി
 DocType: Country,Geo,ജിയോ
@@ -1243,7 +1243,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","ഉപയോക്താവ് ചെക്കുചെയ്തിരിക്കുന്ന എന്തെങ്കിലും പങ്കുണ്ടോ ഉണ്ട്, ഉപയോക്താവിന് ഒരു &quot;സിസ്റ്റം ഉപയോക്തൃ&quot; മാറുന്നു. &quot;സിസ്റ്റം ഉപയോക്താവ്&quot; ഡെസ്ക്ടോപ്പ് ആക്സസ് ഉണ്ട്"
 DocType: System Settings,Date and Number Format,തീയതിയും നമ്പർ ഫോർമാറ്റ്
 apps/frappe/frappe/model/document.py,one of,ഒരുത്തൻ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,സജ്ജീകരണം&gt; ഫോം ഇച്ഛാനുസൃതമാക്കുക
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,സജ്ജീകരണം> ഫോം ഇച്ഛാനുസൃതമാക്കുക
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,ഒറ്റ നിമിഷം പരിശോധിക്കുന്നു
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,കാണിക്കുക ടാഗുകൾ
 DocType: DocField,HTML Editor,HTML എഡിറ്റർ
@@ -1251,7 +1251,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,ബില്ലിംഗ്
 DocType: Email Queue,Not Sent,അയച്ചിട്ടില്ല
 DocType: Web Form,Actions,ക്രിയകൾ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,സജ്ജീകരണം&gt; ഉപയോക്താവ്
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,സജ്ജീകരണം> ഉപയോക്താവ്
 DocType: Workflow State,align-justify,വിന്യസിക്കുക-ന്യായീകരിക്കാൻ
 DocType: User,Middle Name (Optional),മിഡിൽ പേര് (ഓപ്ഷണൽ)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,അനുവദനീയമല്ല
@@ -1372,7 +1372,7 @@ DocType: OAuth Client,A list of resources which the Client App will have access 
 DocType: Translation,Translated Text,വിവർത്തനം ചെയ്ത വാചകം
 DocType: Contact Us Settings,Query Options,അന്വേഷണം ഓപ്ഷനുകൾ
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,Fetching posts...,പോസ്റ്റുകൾ നേടുന്നു ...
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Contact Synced with Google Contacts.,കോൺ‌ടാക്റ്റ് Google കോൺ‌ടാക്റ്റുകളുമായി സമന്വയിപ്പിച്ചു.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Contact Synced with Google Contacts.,കോൺ‌ടാക്റ്റ് Google കോൺ‌ടാക്റ്റുകളുമായി സമന്വയിപ്പിച���ചു.
 DocType: Access Log,Timestamp,ടൈംസ്റ്റാംപ്
 DocType: Patch Log,Patch Log,പാച്ച് ലോഗ്
 DocType: Data Migration Mapping,Local Primary Key,പ്രാദേശിക പ്രാഥമിക കീ
@@ -1396,7 +1396,7 @@ DocType: Report,Is Standard,സ്റ്റാൻഡേർഡ് Is
 DocType: Desktop Icon,_report,_രെപൊര്ത്
 DocType: Desktop Icon,_report,_രെപൊര്ത്
 DocType: Dashboard Chart,Full,പൂർണ്ണമായ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",അവർ ബോധപൂർവം ഈ ഫീൽഡ് ഉപയോഗിക്കാനുമാകും പോലെ &lt;സ്ക്രിപ്റ്റ്&gt; അല്ലെങ്കിൽ അക്ഷരങ്ങൾ പോലെ &lt;അല്ലെങ്കിൽ&gt; പോലെയല്ല എച്ച്ടിഎംഎൽ എൻകോഡ് HTML ടാഗുകൾ ചെയ്ക
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",അവർ ബോധപൂർവം ഈ ഫീൽഡ് ഉപയോഗിക്കാനുമാകും പോലെ &lt;സ്ക്രിപ്റ്റ്> അല്ലെങ്കിൽ അക്ഷരങ്ങൾ പോലെ &lt;അല്ലെങ്കിൽ> പോലെയല്ല എച്ച്ടിഎംഎൽ എൻകോഡ് HTML ടാഗുകൾ ചെയ്ക
 DocType: Website Settings,FavIcon,ഫെവിക്കോൺ
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,പ്രവർത്തിപ്പിക്കുക
 DocType: Blog Post,Content (HTML),ഉള്ളടക്കം (HTML)
@@ -1765,7 +1765,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,അടിക്�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,തീർച്ചപ്പെടുത്തിയിട്ടില്ല
 DocType: System Settings,Allow only one session per user,ഓരോ ഉപയോക്താവിനും ഒരേയൊരു സെഷന് അനുവദിക്കുക
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ഹോം / ടെസ്റ്റ് ഫോള്ഡര് 1 / ടെസ്റ്റ് ഫോൾഡർ 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;തല&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;തല> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,തിരഞ്ഞെടുക്കുക അല്ലെങ്കിൽ ഒരു പുതിയ ഇവന്റ് സൃഷ്ടിക്കാൻ സമയം സ്ലോട്ടുകൾ കുറുകെ ഡ്രാഗ്.
 DocType: Contact,Contact Details,കോൺടാക്റ്റ് വിശദാംശങ്ങൾ
 DocType: DocField,In Filter,ഫിൽറ്റർ ൽ
@@ -1994,7 +1994,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,ലോഗ് ഈ സമയം അനുവദിച്ചിട്ടില്ല
 DocType: Data Migration Run,Current Mapping Action,നിലവിലെ മാപ്പിംഗ് ആക്ഷൻ
 DocType: Dashboard Chart Source,Source Name,ഉറവിട പേര്
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,ഉപയോക്താവുമായി ബന്ധപ്പെട്ട ഇമെയിൽ അക്കൗണ്ടുകളൊന്നുമില്ല. ഉപയോക്താവ്&gt; ഇമെയിൽ ഇൻ‌ബോക്‌സിന് കീഴിൽ ഒരു അക്കൗണ്ട് ചേർക്കുക.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,ഉപയോക്താവുമായി ബന്ധപ്പെട്ട ഇമെയിൽ അക്കൗണ്ടുകളൊന്നുമില്ല. ഉപയോക്താവ്> ഇമെയിൽ ഇൻ‌ബോക്‌സിന് കീഴിൽ ഒരു അക്കൗണ്ട് ചേർക്കുക.
 DocType: Email Account,Email Sync Option,ഇമെയിൽ സമന്വയിപ്പിക്കുക ഓപ്ഷൻ
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,വരി നം
 DocType: Async Task,Runtime,പ്രവർത്തനസമയം
@@ -2009,7 +2009,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ഇതി
 DocType: User Email,Enable Outgoing,അയയ്ക്കുന്ന പ്രവർത്തനക്ഷമമാക്കുക
 DocType: Address,Fax,ഫാക്സ്
 apps/frappe/frappe/config/customization.py,Custom Tags,കസ്റ്റം ടാഗുകൾ
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ഇമെയിൽ അക്കൗണ്ട് സജ്ജീകരിക്കുന്നില്ല. സജ്ജീകരണം&gt; ഇമെയിൽ&gt; ഇമെയിൽ അക്ക from ണ്ടിൽ നിന്ന് ദയവായി ഒരു പുതിയ ഇമെയിൽ അക്ക create ണ്ട് സൃഷ്ടിക്കുക
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ഇമെയിൽ അക്കൗണ്ട് സജ്ജീകരിക്കുന്നില്ല. സജ്ജീകരണം> ഇമെയിൽ> ഇമെയിൽ അക്ക from ണ്ടിൽ നിന്ന് ദയവായി ഒരു പുതിയ ഇമെയിൽ അക്ക create ണ്ട് സൃഷ്ടിക്കുക
 DocType: Comment,Submitted,സമർപ്പിച്ച
 DocType: Contact,Pulled from Google Contacts,Google കോൺടാക്റ്റുകളിൽ നിന്ന് വലിച്ചെടുത്തു
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,അസാധുവായ അഭ്യർത്ഥന
@@ -2082,7 +2082,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,06:00 ഉദാ മ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",myfield .പൗരോഹിത്യം: doc.myfield == &#39;എന്റെ value&#39; .പൗരോഹിത്യം: doc.age&gt; 18 ഇവിടെ വ്യക്തമാക്കുമ്പോൾ FIELDNAME മൂല്യം ഉണ്ടെങ്കിൽ മാത്രമേ അല്ലെങ്കിൽ നിയമങ്ങൾ സത്യം ആകുന്നു (ഉദാഹരണങ്ങൾ) ഈ ഫീൽഡ് ദൃശ്യമാകും
+eval:doc.age>18",myfield .പൗരോഹിത്യം: doc.myfield == &#39;എന്റെ value&#39; .പൗരോഹിത്യം: doc.age> 18 ഇവിടെ വ്യക്തമാക്കുമ്പോൾ FIELDNAME മൂല്യം ഉണ്ടെങ്കിൽ മാത്രമേ അല്ലെങ്കിൽ നിയമങ്ങൾ സത്യം ആകുന്നു (ഉദാഹരണങ്ങൾ) ഈ ഫീൽഡ് ദൃശ്യമാകും
 DocType: Social Login Key,Office 365,ഓഫീസ് 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ഇന്ന്
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ഇന്ന്
@@ -2097,7 +2097,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,അപ്പർ കേസ്
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,കസ്റ്റം എച്ച്ടിഎംഎൽ
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ഫോൾഡർ പേര് നൽകുക
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,"സ്ഥിരസ്ഥിതി വിലാസ ടെംപ്ലേറ്റൊന്നും കണ്ടെത്തിയില്ല. സജ്ജീകരണം&gt; അച്ചടി, ബ്രാൻഡിംഗ്&gt; വിലാസ ടെംപ്ലേറ്റിൽ നിന്ന് പുതിയൊരെണ്ണം സൃഷ്ടിക്കുക."
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"സ്ഥിരസ്ഥിതി വിലാസ ടെംപ്ലേറ്റൊന്നും കണ്ടെത്തിയില്ല. സജ്ജീകരണം> അച്ചടി, ബ്രാൻഡിംഗ്> വിലാസ ടെംപ്ലേറ്റിൽ നിന്ന് പുതിയൊരെണ്ണം സൃഷ്ടിക്കുക."
 apps/frappe/frappe/auth.py,Unknown User,അജ്ഞാത ഉപയോക്താവ്
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,റോൾ തിരഞ്ഞെടുക്കുക
 DocType: Comment,Deleted,ഇല്ലാതാക്കിയ
@@ -2283,7 +2283,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ലിങ്കുകൾ കാണുന്നതിന് ആവശ്യമായ അനുമതി
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,വിലാസം ശീർഷകം നിർബന്ധമാണ്.
 DocType: Google Contacts,Push to Google Contacts,Google കോൺ‌ടാക്റ്റുകളിലേക്ക് പുഷ് ചെയ്യുക
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","പ്രാഥമികമായി വെബ്സൈറ്റ് സ്ഥിരീകരണം, എസ്.ഇ.ഒ. ഉപയോഗിക്കുന്ന വെബ് പേജിന്റെ &lt;തല&gt; വിഭാഗത്തിൽ, ചേർത്തു എച്ച്ടിഎംഎൽ"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","പ്രാഥമികമായി വെബ്സൈറ്റ് സ്ഥിരീകരണം, എസ്.ഇ.ഒ. ഉപയോഗിക്കുന്ന വെബ് പേജിന്റെ &lt;തല> വിഭാഗത്തിൽ, ചേർത്തു എച്ച്ടിഎംഎൽ"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,ഇനം അതിന്റേതായ descendents ചേർക്കില്ല കഴിയില്ല
 DocType: Session Default Settings,Session Defaults,സെഷൻ സ്ഥിരസ്ഥിതികൾ
@@ -2401,7 +2401,7 @@ DocType: Workflow State,Warning,മുന്നറിയിപ്പ്
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ഇത് ഒന്നിലധികം പേജുകളിൽ അച്ചടിച്ചേക്കാം
 DocType: Data Migration Run,Percent Complete,പൂർത്തിയായി
 DocType: Tag Category,Tag Category,ടാഗ് വർഗ്ഗം
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","താരതമ്യത്തിന്,&gt; 5, &lt;10 അല്ലെങ്കിൽ = 324 ഉപയോഗിക്കുക. ശ്രേണികൾക്കായി, 5:10 ഉപയോഗിക്കുക (5 നും 10 നും ഇടയിലുള്ള മൂല്യങ്ങൾക്ക്)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","താരതമ്യത്തിന്,> 5, &lt;10 അല്ലെങ്കിൽ = 324 ഉപയോഗിക്കുക. ശ്രേണികൾക്കായി, 5:10 ഉപയോഗിക്കുക (5 നും 10 നും ഇടയിലുള്ള മൂല്യങ്ങൾക്ക്)."
 DocType: Google Calendar,Pull from Google Calendar,Google കലണ്ടറിൽ നിന്ന് വലിക്കുക
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,സഹായിക്കൂ
 DocType: User,Login Before,"മുമ്പ്, ലോഗിൻ"
@@ -2859,7 +2859,7 @@ DocType: Custom Script,Custom Script,കസ്റ്റം സ്ക്രിപ
 DocType: Address,Address Line 2,വിലാസം വരി 2
 DocType: Address,Reference,റഫറൻസ്
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,നിയോഗിച്ചിട്ടുള്ള
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,സജ്ജീകരണം&gt; ഇമെയിൽ&gt; ഇമെയിൽ അക്ക from ണ്ടിൽ നിന്ന് സ്ഥിരസ്ഥിതി ഇമെയിൽ അക്കൗണ്ട് സജ്ജമാക്കുക
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,സജ്ജീകരണം> ഇമെയിൽ> ഇമെയിൽ അക്ക from ണ്ടിൽ നിന്ന് സ്ഥിരസ്ഥിതി ഇമെയിൽ അക്കൗണ്ട് സജ്ജമാക്കുക
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ഡാറ്റ മൈഗ്രേഷൻ മാപ്പിംഗ് വിശദാംശം
 DocType: Data Import,Action,ആക്ഷൻ
 DocType: GSuite Settings,Script URL,സ്ക്രിപ്റ്റ് URL
@@ -3032,7 +3032,7 @@ DocType: DocField,Allow on Submit,സമർപ്പിക്കുക അനു
 DocType: DocField,HTML,എച്ച്ടിഎംഎൽ
 DocType: Error Snapshot,Exception Type,ഒഴിവാക്കൽ തരം
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,നിരകൾ തിരഞ്ഞെടുക്കുക
-DocType: Web Page,Add code as &lt;script&gt;,&lt;സ്ക്രിപ്റ്റ്&gt; പോലെ കോഡ് ചേർക്കുക
+DocType: Web Page,Add code as &lt;script>,&lt;സ്ക്രിപ്റ്റ്> പോലെ കോഡ് ചേർക്കുക
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ഉപയോക്തൃ അനുമതികൾ മായ്‌ക്കുക
 DocType: Webhook,Headers,തലക്കെട്ടുകൾ
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,വരാനിരിക്കുന്ന
@@ -3194,7 +3194,7 @@ DocType: Comment,Relinked,-മായി
 DocType: Print Settings,Compact Item Print,കോംപാക്റ്റ് ഇനം പ്രിന്റ്
 DocType: Email Account,uidnext,uidnext
 DocType: User,Redirect URL,റീഡയറക്റ്റ് URL
-DocType: SMS Settings,Enter url parameter for receiver nos,റിസീവർ എണ്ണം വേണ്ടി URL പാരമീറ്റർ നൽകുക
+DocType: SMS Settings,Enter url parameter for receiver nos,റിസീവർ എണ���ണം വേണ്ടി URL പാരമീറ്റർ നൽകുക
 DocType: Chat Profile,Online,ഓൺലൈൻ
 DocType: Email Account,Always use Account's Name as Sender's Name,അയച്ചയാളുടെ പേരായി എല്ലായ്പ്പോഴും അക്കൗണ്ടിന്റെ പേര് ഉപയോഗിക്കുക
 apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,മാത്രം അഡ്മിനിസ്ട്രേറ്റർ ഇമെയിൽ ക്യൂ ഇല്ലാതാക്കാൻ കഴിയൂ
@@ -3402,16 +3402,16 @@ DocType: Workflow State,share-alt,പങ്ക്-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},ക്യൂ {0} ഒന്നായിരിക്കണം
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> സ്ഥിരസ്ഥിതി ഫലകം </h4><p> ഉപയോഗിക്കുന്നു <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ആൻഡ് (കസ്റ്റം ഫീൽഡ് എന്തെങ്കിലും ഉണ്ടെങ്കിൽ ഉൾപ്പെടെ) വിലാസം എല്ലാ നിലങ്ങളും ലഭ്യമാകും </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> സ്ഥിരസ്ഥിതി ഫലകം </h4><p> ഉപയോഗിക്കുന്നു <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> ആൻഡ് (കസ്റ്റം ഫീൽഡ് എന്തെങ്കിലും ഉണ്ടെങ്കിൽ ഉൾപ്പെടെ) വിലാസം എല്ലാ നിലങ്ങളും ലഭ്യമാകും </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ആരംഭിക്കുന്ന ഫീൽഡ് ഫീൽഡ്
 DocType: Role,Role Name,റോൾ പേര്
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,പഴകിയ മാറുക

--- a/frappe/translations/ml.csv
+++ b/frappe/translations/ml.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെങ്കിൽ, പാസ്വേഡ് ശക്തി കുറഞ്ഞ പാസ്വേഡ് സ്കോർ മൂല്യം അടിസ്ഥാനമാക്കി നടപ്പിലാക്കും. 2 ഒരു മൂല്യം ഇടത്തരം ശക്തമായ ഒരാളായി 4 വളരെ ശക്തമായ ഒരാളായി."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെങ്കിൽ, പാസ്വേഡ് ശക്തി കുറഞ്ഞ പാസ്വേഡ് സ്കോർ മൂല്യം അടിസ്ഥാനമാക്കി നടപ്പിലാക്കും. 2 ഒരു മൂല്യം ഇടത്തരം ശക്തമായ ഒരാളായി 4 വളരെ ശക്തമായ ഒരാളായി."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;ടീം അംഗങ്ങൾ&quot; അല്ലെങ്കിൽ &quot;മാനേജ്മെന്റ്&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',വയലിലെ &#39;പരിശോധിക്കുക&#39; തരം &#39;0&#39; അല്ലെങ്കിൽ &#39;1&#39; ഒന്നുകിൽ ആയിരിക്കണം സ്ഥിരസ്ഥിതി
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',വയലിലെ 'പരിശോധിക്കുക' തരം '0' അല്ലെങ്കിൽ '1' ഒന്നുകിൽ ആയിരിക്കണം സ്ഥിരസ്ഥിതി
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,ഇന്നലെ
 DocType: Contact,Designation,പദവിയും
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,ഒരു ഇമെയിൽ അക്കൗണ്ടിനായി മാത്രമേ യാന്ത്രിക ലിങ്കിംഗ് സജീവമാക്കാനാകൂ.
@@ -98,7 +98,7 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Appreciate,അഭി�
 DocType: Workflow State,lock,ലോക്ക്
 apps/frappe/frappe/config/website.py,Settings for Contact Us Page.,ഞങ്ങളെ ബന്ധപ്പെടുക പേജ് വേണ്ടി ക്രമീകരണങ്ങൾ.
 apps/frappe/frappe/core/doctype/user/user.py,Administrator Logged In,അഡ്മിനിസ്ട്രേറ്റർ ലോഗിൻ ചെയ്ത ൽ
-DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","&quot;സെയിൽസ് ക്വറി, പിന്തുണ ക്വറി &#39;തുടങ്ങിയ കോൺടാക്റ്റ് ഓപ്ഷനുകൾ, ഒരു പുതിയ വരിയിൽ ഓരോ അല്ലെങ്കിൽ കോമ ഉപയോഗിച്ച് വേർതിരിച്ച്."
+DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","&quot;സെയിൽസ് ക്വറി, പിന്തുണ ക്വറി 'തുടങ്ങിയ കോൺടാക്റ്റ് ഓപ്ഷനുകൾ, ഒരു പുതിയ വരിയിൽ ഓരോ അല്ലെങ്കിൽ കോമ ഉപയോഗിച്ച് വേർതിരിച്ച്."
 apps/frappe/frappe/public/js/frappe/ui/tag_editor.js,Add a tag ...,ഒരു ടാഗ് ചേർക്കുക ...
 apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,ഛായാചിത്രം
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,ഇടയ്ക്കു്ചേര്ക്കുക
@@ -251,7 +251,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,അപ്രാ�
 DocType: Translation,Contributed Translation Doctype Name,സംഭാവന ചെയ്ത വിവർത്തന ഡോക്റ്റൈപ്പ് പേര്
 DocType: PayPal Settings,Redirect To,റീഡയറക്ട്
 DocType: Data Migration Mapping,Pull,വലിക്കുക
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},ജാവാസ്ക്രിപ്റ്റ് ഫോർമാറ്റ്: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},ജാവാസ്ക്രിപ്റ്റ് ഫോർമാറ്റ്: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,ബൾക്ക് അപ്ഡേറ്റ്
 DocType: Workflow State,chevron-up,ഷെവ്റോൺ-അപ്പ്
 DocType: DocType,Allow Guest to View,അതിഥി കാണൂ അനുവദിക്കുക
@@ -552,7 +552,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,അപ്ലോഡ് പരാജയപ്പെട്ടു
 DocType: LDAP Settings,LDAP Phone Field,LDAP ഫോൺ ഫീൽഡ്
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","ഡോക്യുമെന്റ് ..., ഉദാ ഉപഭോക്താവ്"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,കണ്ടീഷൻ &#39;{0}&#39; അസാധുവാണ്
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,കണ്ടീഷൻ '{0}' അസാധുവാണ്
 DocType: Workflow State,barcode,ബാർകോഡ്
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,ഉപ-അന്വേഷണത്തിന്റെയോ ഫംഗ്ഷന്റെയോ ഉപയോഗം നിയന്ത്രിതമാണ്
 apps/frappe/frappe/config/customization.py,Add your own translations,നിങ്ങളുടെ സ്വന്തം വിവർത്തനങ്ങൾ ചേർക്കുക
@@ -700,7 +700,7 @@ DocType: Slack Webhook URL,Webhook URL,വെബ്ബുക്ക് URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,ഉപയോക്തൃനാമം {0} ഇതിനകം നിലവിലുണ്ട്
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} importable അല്ല പോലെ ഇറക്കുമതിയും സജ്ജീകരിക്കാൻ കഴിയില്ല
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},നിങ്ങളുടെ വിലാസ ഫലകം {0} ഒരു പിശക് ഉണ്ട്
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} എന്നത് &#39;സ്വീകർത്താക്കളുടെ&#39; അസാധുവായ ഇമെയിൽ വിലാസമാണ്
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} എന്നത് 'സ്വീകർത്താക്കളുടെ' അസാധുവായ ഇമെയിൽ വിലാസമാണ്
 DocType: Footer Item,"target = ""_blank""",ലക്ഷ്യം = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,ഹോസ്റ്റ്
@@ -756,7 +756,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","സ്റ്റാൻഡേർഡ് ദൊച്ത്യ്പെ, സ്ഥിര പ്രിന്റ് ഫോർമാറ്റിൽ കഴിയില്ല ഇഷ്ടാനുസൃതമാക്കുക ഫോം ഉപയോഗിക്കുക"
 DocType: Report,Query,അന്വേഷണം
 DocType: Customize Form,Sort Order,ക്രമീകരണം
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;പട്ടിക കാഴ്ചയിൽ&#39; വരി ടൈപ്പ് {0} അനുവദിച്ചിട്ടില്ല {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'പട്ടിക കാഴ്ചയിൽ' വരി ടൈപ്പ് {0} അനുവദിച്ചിട്ടില്ല {1}
 DocType: Letter Head,Footer HTML,അടിക്കുറിപ്പ് HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,നിങ്ങൾ പുതിയ ഫീൽഡ് തിരുകാൻ ആഗ്രഹിക്കുന്ന ശേഷം ലേബൽ തിരഞ്ഞെടുക്കുക.
 ,Document Share Report,ഡോക്യുമെന്റ് പങ്കിടുക റിപ്പോർട്ട്
@@ -770,7 +770,7 @@ DocType: File,Is Home Folder,ഹോം ഫോൾഡർ Is
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,നവ്ബാർ ശൈലി
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} സാധുവായ ഇമെയിൽ വിലാസം അല്ല
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,അച്ചടിക്കാനുള്ള കുറയാതെ 1 റെക്കോഡ് തിരഞ്ഞെടുക്കുക
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ഉപയോക്താവ് &#39;{0}&#39; ഇതിനകം പങ്ക് &#39;{1}&#39; ഉണ്ട്
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ഉപയോക്താവ് '{0}' ഇതിനകം പങ്ക് '{1}' ഉണ്ട്
 DocType: System Settings,Two Factor Authentication method,രണ്ട് ഫാക്ടർ പ്രാമാണീകരണ രീതി
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,ആദ്യം പേര് സജ്ജമാക്കി റെക്കോർഡ് സംരക്ഷിക്കുക.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 റെക്കോർഡുകൾ
@@ -1018,7 +1018,7 @@ DocType: Property Setter,Property Setter,പ്രോപ്പർട്ടി
 DocType: Web Form,Allow Print,പ്രിന്റ് അനുവദിക്കുക
 DocType: Communication,Clicked,ക്ലിക്കുചെയ്ത
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,പിന്തുടരരുത്
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},ഇതിനായി &#39;{0}&#39; {1} അനുമതിയില്ല
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},ഇതിനായി '{0}' {1} അനുമതിയില്ല
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,അയയ്ക്കാൻ ഷെഡ്യൂൾ
 DocType: DocType,Track Seen,ട്രാക്ക് കാണുന്നത്
 DocType: Dropbox Settings,File Backup,ഫയൽ ബാക്കപ്പ്
@@ -1045,7 +1045,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,പേജ് എച്ച്ടിഎംഎൽ
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,തെറ്റായ വരികൾ കയറ്റുമതി ചെയ്യുക
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,ഗ്രൂപ്പ് നാമം ശൂന്യമായിരിക്കരുത്.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,കൂടുതലായ നോഡുകൾ മാത്രം &#39;ഗ്രൂപ്പ്&#39; ടൈപ്പ് നോഡുകൾ പ്രകാരം സൃഷ്ടിക്കാൻ കഴിയും
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,കൂടുതലായ നോഡുകൾ മാത്രം 'ഗ്രൂപ്പ്' ടൈപ്പ് നോഡുകൾ പ്രകാരം സൃഷ്ടിക്കാൻ കഴിയും
 DocType: SMS Parameter,Header,തലക്കുറി
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},അറിയപ്പെടാത്ത നിരയുടെ: {0}
 DocType: Notification Recipient,Email By Role,റോൾ പ്രകാരം ഇമെയിൽ
@@ -1425,7 +1425,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,നിർബന്ധമായ ഒരു ഫീൽഡ്: വെച്ചിരിക്കുന്നു പങ്ക്
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} വിമർശിച്ചു {1}
 DocType: Data Migration Mapping,Mapping Name,മാപ്പിംഗ് നെയിം
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ഫീൽഡ് &#39;{1}&#39; അദ്വിതീയമല്ലാത്ത മൂല്യങ്ങളുള്ളതിനാൽ അതുല്യമായി സജ്ജമാക്കാൻ കഴിയില്ല
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ഫീൽഡ് '{1}' അദ്വിതീയമല്ലാത്ത മൂല്യങ്ങളുള്ളതിനാൽ അതുല്യമായി സജ്ജമാക്കാൻ കഴിയില്ല
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,പട്ടിക താഴേക്ക് നാവിഗേറ്റുചെയ്യുക
 DocType: Currency,A symbol for this currency. For e.g. $,ഈ കറൻസി പ്രതീകമായി. ഉദാ $ വേണ്ടി
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,വിവർത്തനങ്ങൾ വിജയകരമായി അപ്ഡേറ്റുചെയ്തു
@@ -1933,7 +1933,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-തെക്കുകിഴക്ക് -1
 DocType: DocType,"Must be of type ""Attach Image""",തരം ആയിരിക്കണം &quot;ഇമേജ് അറ്റാച്ച്&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,തെരഞ്ഞെടുത്തവയെല്ലാംവേണ്ടെന്നു്വയ്ക്കുക
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},നിങ്ങൾ വിടേണ്ടതാണ് ചെയ്യാൻ കഴിയില്ലെന്നും {0} നിലത്തിന്റെ &#39;വായന മാത്രം&#39;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},നിങ്ങൾ വിടേണ്ടതാണ് ചെയ്യാൻ കഴിയില്ലെന്നും {0} നിലത്തിന്റെ 'വായന മാത്രം'
 DocType: Auto Email Report,Zero means send records updated at anytime,സീറോ എപ്പോൾ വേണമെങ്കിലും അപ്ഡേറ്റ് രേഖകൾ അയയ്ക്കാൻ എന്നാണ്
 DocType: Auto Email Report,Zero means send records updated at anytime,സീറോ എപ്പോൾ വേണമെങ്കിലും അപ്ഡേറ്റ് രേഖകൾ അയയ്ക്കാൻ എന്നാണ്
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,പൂർത്തിയാക്കുക സെറ്റപ്പ്
@@ -1977,7 +1977,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google ഫോണ്ട്
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","ഈ നിർദ്ദേശങ്ങൾ എവിടെ അല്ല സഹായകരമായ എങ്കിൽ, സാമൂഹികം പ്രശ്നങ്ങൾ നിങ്ങളുടെ നിർദ്ദേശങ്ങളിൽ ചേർക്കുക."
 DocType: Workflow State,bookmark,ബുക്ക്മാർക്ക്
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ഫോൾഡർ പേര് &#39;/&#39; (സ്ലാഷ്) ഉൾപ്പെടുത്തരുത്
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ഫോൾഡർ പേര് '/' (സ്ലാഷ്) ഉൾപ്പെടുത്തരുത്
 DocType: Note,Note,കുറിപ്പ്
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,പിശക് റിപ്പോർട്ട്
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel ഫോർമാറ്റിൽ ഡാറ്റ എക്സ്പോർട്ട് ചെയ്യുക.
@@ -2082,7 +2082,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,06:00 ഉദാ മ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",myfield .പൗരോഹിത്യം: doc.myfield == &#39;എന്റെ value&#39; .പൗരോഹിത്യം: doc.age> 18 ഇവിടെ വ്യക്തമാക്കുമ്പോൾ FIELDNAME മൂല്യം ഉണ്ടെങ്കിൽ മാത്രമേ അല്ലെങ്കിൽ നിയമങ്ങൾ സത്യം ആകുന്നു (ഉദാഹരണങ്ങൾ) ഈ ഫീൽഡ് ദൃശ്യമാകും
+eval:doc.age>18",myfield .പൗരോഹിത്യം: doc.myfield == 'എന്റെ value' .പൗരോഹിത്യം: doc.age> 18 ഇവിടെ വ്യക്തമാക്കുമ്പോൾ FIELDNAME മൂല്യം ഉണ്ടെങ്കിൽ മാത്രമേ അല്ലെങ്കിൽ നിയമങ്ങൾ സത്യം ആകുന്നു (ഉദാഹരണങ്ങൾ) ഈ ഫീൽഡ് ദൃശ്യമാകും
 DocType: Social Login Key,Office 365,ഓഫീസ് 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ഇന്ന്
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ഇന്ന്
@@ -2122,7 +2122,7 @@ DocType: Data Migration Connector,Database Name,ഡാറ്റാബേസ് �
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,ഫോം പുതുക്കുക
 DocType: DocField,Select,തിരഞ്ഞെടുക്കുക
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,പൂർണ്ണ ലോഗ് കാണുക
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ലളിതമായ പൈത്തൺ എക്‌സ്‌പ്രഷൻ, ഉദാഹരണം: സ്റ്റാറ്റസ് == &#39;ഓപ്പൺ&#39; എന്ന് ടൈപ്പ് ചെയ്യുക == &#39;ബഗ്&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ലളിതമായ പൈത്തൺ എക്‌സ്‌പ്രഷൻ, ഉദാഹരണം: സ്റ്റാറ്റസ് == 'ഓപ്പൺ' എന്ന് ടൈപ്പ് ചെയ്യുക == 'ബഗ്'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,പ്രമാണം അറ്റാച്ചുചെയ്തില്ല
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,ബന്ധം വിച്ഛേദിക്കപ്പെട്ടു. ചില സവിശേഷതകൾ പ്രവർത്തിച്ചേക്കില്ല.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; പോലെ ആവർത്തനങ്ങൾ ഊഹിക്കാൻ എളുപ്പമാണ്
@@ -2251,7 +2251,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,പിശകുകൾ മാത്രം കാണിക്കുക
 DocType: Website Settings,Banner HTML,ബാനർ എച്ച്ടിഎംഎൽ
 DocType: Workflow,Send Email Alert,ഇമെയിൽ അലേർട്ട് അയയ്ക്കുക
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. രജൊര്പയ് കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. രജൊര്പയ് കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല '{0}'
 DocType: Data Import,In Progress,പുരോഗതിയിൽ
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,ബാക്കപ്പ് ക്യൂവിലാക്കി. ഇതിന് ഒരു മണിക്കൂർ കുറച്ച് മിനിറ്റുകൾ എടുത്തേക്കാം.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2487,7 +2487,7 @@ apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,{0}: {1} 
 DocType: User,Location,സ്ഥാനം
 apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move to Row Number,വരി നമ്പറിലേക്ക് നീക്കുക
 ,Permitted Documents For User,ഉപയോക്താവ് അനുവാദം പ്രമാണങ്ങൾ
-apps/frappe/frappe/core/doctype/docshare/docshare.py,"You need to have ""Share"" permission",നിങ്ങൾ &#39;പങ്കിടുക &quot;അനുമതിയില്ല ചെയ്യേണ്ടതുണ്ട്
+apps/frappe/frappe/core/doctype/docshare/docshare.py,"You need to have ""Share"" permission",നിങ്ങൾ 'പങ്കിടുക &quot;അനുമതിയില്ല ചെയ്യേണ്ടതുണ്ട്
 DocType: Comment,Assignment Completed,അസൈൻമെന്റ് പൂർത്തിയായത്
 apps/frappe/frappe/public/js/frappe/form/grid.js,Bulk Edit {0},ബൾക്ക് എഡിറ്റ് {0}
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Download Report,റിപ്പോർട്ട് ഡൗൺലോഡ് ചെയ്യുക
@@ -2668,7 +2668,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,.ദി
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,പേപാൽ പേയ്മെന്റ് ഗേറ്റ്വേ ക്രമീകരണങ്ങൾ
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,മികച്ച പ്രകടനം
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,പ്രധാന ഡോക്‍ടൈപ്പുകളിലേക്ക് ഇഷ്‌ടാനുസൃത ഫീൽഡുകൾ ചേർക്കാൻ കഴിയില്ല.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: &#39;{1}&#39; ({3}) പരമാവധി പ്രതീകങ്ങൾ അനുവദനീയമല്ല പോലെ ഫയലിന് ലഭിക്കും {2} ആണ്
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: '{1}' ({3}) പരമാവധി പ്രതീകങ്ങൾ അനുവദനീയമല്ല പോലെ ഫയലിന് ലഭിക്കും {2} ആണ്
 DocType: OAuth Client,Response Type,പ്രതികരണ തരം
 DocType: Contact Us Settings,Send enquiries to this email address,ഈ ഇമെയിൽ വിലാസത്തിലേക്ക് അയയ്ക്കുക
 DocType: Letter Head,Letter Head Name,കത്ത് ഹെഡ് പേര്
@@ -2724,7 +2724,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,ചിത്രം കാണുക
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","എന്തോ ഇടപാട് സമയത്ത് തെറ്റായി സംഭവിച്ചതുപോലെ തോന്നുന്നു. ഞങ്ങൾ പേയ്മെന്റ് സ്ഥിരീകരിച്ചു വരാത്തതിനാൽ, പേപാൽ യാന്ത്രികമായി ഈ തുക തിരികെ നൽകും. ഇല്ലെങ്കിൽ, ഞങ്ങളെ ഒരു ഇമെയിൽ അയയ്ക്കുക ഒപ്പം മറന്ന കോറിലേഷൻ ഐഡി: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","പാസ്വേഡ് ചിഹ്നങ്ങൾ, അക്കങ്ങൾ മൂലധന അക്ഷരങ്ങൾ ഉൾപ്പെടുത്തുക"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ഫീൽഡ് കസ്റ്റം ഫീൽഡ് പരാമർശിച്ചു, ലേബലുള്ള &#39;{2}&#39; ചേർക്കൽ &#39;{0}&#39; &#39;{1}&#39;, നിലവിലില്ല"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ഫീൽഡ് കസ്റ്റം ഫീൽഡ് പരാമർശിച്ചു, ലേബലുള്ള '{2}' ചേർക്കൽ '{0}' '{1}', നിലവിലില്ല"
 DocType: List Filter,List Filter,ലിസ്റ്റ് ഫിൽട്ടർ
 DocType: Workflow State,signal,സിഗ്നൽ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,അറ്റാച്ചുമെൻറുകൾ ഉണ്ട്
@@ -2734,7 +2734,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,പ്രമാണം പുനഃസ്ഥാപിച്ചു
 DocType: Data Export,Data Export,ഡാറ്റ എക്സ്പോർട്ട്
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ഭാഷ തിരഞ്ഞെടുക്കുക...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},നിങ്ങൾക്ക് {0} ഫീൽഡിനായി &#39;ഓപ്ഷനുകൾ&#39; സെറ്റ് ചെയ്യുവാൻ സാധിക്കില്ല
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},നിങ്ങൾക്ക് {0} ഫീൽഡിനായി 'ഓപ്ഷനുകൾ' സെറ്റ് ചെയ്യുവാൻ സാധിക്കില്ല
 DocType: Help Article,Author,സ്രഷ്ടാവ്
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,അയയ്ക്കുന്നു പുനരാരംഭിക്കുക
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,വീണ്ടും തുറക്കുക
@@ -2742,21 +2742,21 @@ apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Show Warnings,
 apps/frappe/frappe/core/doctype/communication/communication.js,Re: {0},മറു: {0}
 DocType: Address,Purchase User,വാങ്ങൽ ഉപയോക്താവ്
 DocType: Data Migration Run,Push Failed,പുഷ് പരാജയപ്പെട്ടു
-DocType: Workflow,"Different ""States"" this document can exist in. Like ""Open"", ""Pending Approval"" etc.","വ്യത്യസ്ത &#39;എസ്&#39; ഈ പ്രമാണത്തിൽ നിലനിൽക്കാൻ കഴിയൂ. &quot;തുറക്കുക&quot;, &quot;അംഗീകാരം&quot; തുടങ്ങിയ"
+DocType: Workflow,"Different ""States"" this document can exist in. Like ""Open"", ""Pending Approval"" etc.","വ്യത്യസ്ത 'എസ്' ഈ പ്രമാണത്തിൽ നിലനിൽക്കാൻ കഴിയൂ. &quot;തുറക്കുക&quot;, &quot;അംഗീകാരം&quot; തുടങ്ങിയ"
 apps/frappe/frappe/utils/verified_command.py,This link is invalid or expired. Please make sure you have pasted correctly.,ഈ ലിങ്ക് അസാധുവാണ് അല്ലെങ്കിൽ കാലഹരണപ്പെട്ടു. ശരിയായി ഒട്ടിച്ചു ദയവായി ഉറപ്പാക്കുക.
 DocType: Web Page,Slideshow,സ്ലൈഡ്ഷോ
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,സ്ഥിരസ്ഥിതി വിലാസം ഫലകം ഇല്ലാതാക്കാൻ കഴിയില്ല
 DocType: Contact,Maintenance Manager,മെയിൻറനൻസ് മാനേജർ
 DocType: Workflow State,Search,തിരച്ചിൽ
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. വര കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. വര കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. വര കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. വര കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ചവറ്റുകൊട്ടയിലേക്ക് നീക്കുക
 DocType: Web Form,Web Form Fields,വെബ് ഫോം ഫീൾഡുകൾ
 DocType: Data Import,Amended From,നിന്ന് ഭേദഗതി
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},മുന്നറിയിപ്പ്: ലേക്കുള്ള {1} ബന്ധപ്പെട്ട പട്ടികയിൽ കണ്ടെത്താൻ {0} കഴിയുന്നില്ല
 DocType: S3 Backup Settings,eu-north-1,eu-north-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,ഈ പ്രമാണം നിലവിൽ വധശിക്ഷ ക്യൂവിലായതിനാൽ. വീണ്ടും ശ്രമിക്കുക
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,പ്രമാണം &#39;{0}&#39; കണ്ടെത്തിയില്ല
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,പ്രമാണം '{0}' കണ്ടെത്തിയില്ല
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,വിഭാഗം നീക്കംചെയ്യുക
 DocType: User,Change Password,പാസ്വേഡ് മാറ്റുക
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,എക്സ് ആക്സിസ് ഫീൽഡ്
@@ -2940,7 +2940,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,നഷ്ടമാ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,ശിശു ചേർക്കുക
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,ഇറക്കുമതി പുരോഗതി
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",നിബന്ധന തൃപ്‌തികരമാണെങ്കിൽ ഉപയോക്താവിന് പോയിന്റുകൾ നൽകും. ഉദാ. doc.status == &#39;അടച്ചു&#39;
+",നിബന്ധന തൃപ്‌തികരമാണെങ്കിൽ ഉപയോക്താവിന് പോയിന്റുകൾ നൽകും. ഉദാ. doc.status == 'അടച്ചു'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: സമർപ്പിച്ചു റിക്കോർഡ് ഇല്ലാതാക്കാൻ കഴിയില്ല.
 DocType: GSuite Templates,Template Name,ടെംപ്ലേറ്റ് നാമം
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,പ്രമാണത്തിൻറെ പുതിയ തരം
@@ -3069,7 +3069,7 @@ DocType: Dashboard Chart,Chart Type,ചാർട്ട് തരം
 DocType: DocType,Auto Name,ഓട്ടോ പേര്
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,അവർ ഊഹിക്കാൻ എളുപ്പമാണ് പോലെ എബിസി അല്ലെങ്കിൽ 6543 പോലുള്ള സീക്വൻസുകൾ ഒഴിവാക്കുക
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,വീണ്ടും ശ്രമിക്കുക
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; അല്ലെങ്കിൽ &#39;https: //&#39; ഉപയോഗിച്ച് ആരംഭിക്കണം
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' അല്ലെങ്കിൽ 'https: //' ഉപയോഗിച്ച് ആരംഭിക്കണം
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,ഓപ്ഷൻ 3
 DocType: Communication,uid,യു.ഐ.ഡി
 DocType: Workflow State,Edit,എഡിറ്റ്
@@ -3271,7 +3271,7 @@ apps/frappe/frappe/core/doctype/data_import/importer.py,Unsupported File Format,
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray...,QZ ട്രേ സമാരംഭിക്കാൻ ശ്രമിക്കുന്നു ...
 DocType: Assignment Rule,Example: {{ subject }},ഉദാഹരണം: {{വിഷയം}}
 DocType: DocField,Code,കോഡ്
-DocType: Workflow,"All possible Workflow States and roles of the workflow. Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","എല്ലാ സാധ്യമായ വർക്ക്ഫ്ലോ എസ് ആൻഡ് വർക്ക്ഫ്ലോ വേഷത്തിൽ. Docstatus ഓപ്ഷനുകൾ: 0 &quot;സംരക്ഷിച്ച&quot;, 1 &quot;സമർപ്പിച്ചു&quot; ആണ്, 2 &quot;റദ്ദാക്കി &#39;ആണ് ആണ്"
+DocType: Workflow,"All possible Workflow States and roles of the workflow. Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","എല്ലാ സാധ്യമായ വർക്ക്ഫ്ലോ എസ് ആൻഡ് വർക്ക്ഫ്ലോ വേഷത്തിൽ. Docstatus ഓപ്ഷനുകൾ: 0 &quot;സംരക്ഷിച്ച&quot;, 1 &quot;സമർപ്പിച്ചു&quot; ആണ്, 2 &quot;റദ്ദാക്കി 'ആണ് ആണ്"
 apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} are required,{0} ആവശ്യമാണ്
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Last Modified On,അവസാനം പുതുക്കപ്പെട്ടത്
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document.","അവർക്ക് പ്രമാണം ആക്സസ് പ്രാഥമിക ആകുന്നു അതായത് തലത്തിൽ 0 ന് അനുമതികൾ, ഡോക്യുമെന്റ് ലെവൽ അനുമതികൾ ആകുന്നു."
@@ -3306,7 +3306,7 @@ DocType: Notification,Send alert if this field's value changes,ഈ ഫീൽഡ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,തീം നിറങ്ങൾ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,ഒരു പുതിയ ഫോർമാറ്റ് ഉണ്ടാക്കുവാൻ ഒരു DocType തിരഞ്ഞെടുക്കുക
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,ഉപയോക്താവ് നിലവിലില്ല
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;സ്വീകർത്താക്കൾ&#39; വ്യക്തമാക്കിയിട്ടില്ല
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'സ്വീകർത്താക്കൾ' വ്യക്തമാക്കിയിട്ടില്ല
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,ഇപ്പോള്
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,അപേക്ഷിക്കുക
 DocType: Footer Item,Policy,നയം
@@ -3353,7 +3353,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,കസ്റ്�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,പുരോഗതി
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,റോൾ എന്നയാളുടെ
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,കാണാതായ ഫീൽഡുകൾ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,അസാധുവായ FIELDNAME &#39;{0}&#39; autoname ലെ
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,അസാധുവായ FIELDNAME '{0}' autoname ലെ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ഒരു ഡോക്യുമെന്റ് തരം തിരച്ചിൽ
 DocType: Custom DocPerm,Role and Level,പങ്കും ലെവൽ
 DocType: File,Thumbnail URL,ലഘുചിത്രം യുആർഎൽ
@@ -3441,11 +3441,11 @@ DocType: Dashboard Chart,Filters JSON,JSON ഫിൽട്ടറുകൾ
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,സ്ഥിരീകരിക്കുന്നതിന് ഇവിടെ ക്ലിക്ക്
 DocType: Email Account,Disable SMTP server authentication,SMTP സെർവർ പ്രാമാണീകരണം അപ്രാപ്തമാക്കുക
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,ക്ലിപ്പ്ബോർഡിലേക്ക് പകർത്തി.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,പകരം &#39;ഒരു&#39; വളരെ സഹായിക്കാൻ ഇല്ല എന്ന &#39;@&#39; പോലുള്ള പ്രവചിക്കാൻ പകരക്കാരെ.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,പകരം 'ഒരു' വളരെ സഹായിക്കാൻ ഇല്ല എന്ന '@' പോലുള്ള പ്രവചിക്കാൻ പകരക്കാരെ.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,എന്നെക്കൊണ്ടു അസൈൻഡ്
 apps/frappe/frappe/utils/data.py,Zero,സീറോ
 DocType: Google Drive,Backup Folder ID,ബാക്കപ്പ് ഫോൾഡർ ഐഡി
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,"എന്നല്ല, ഡവലപ്പർ മോഡിൽ! Site_config.json ൽ സജ്ജമാക്കുക അല്ലെങ്കിൽ &#39;കസ്റ്റം&#39; DocType ഉണ്ടാക്കുക."
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,"എന്നല്ല, ഡവലപ്പർ മോഡിൽ! Site_config.json ൽ സജ്ജമാക്കുക അല്ലെങ്കിൽ 'കസ്റ്റം' DocType ഉണ്ടാക്കുക."
 DocType: Workflow State,globe,ഭൂഗോളം
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,മുൻഗണന
@@ -3493,7 +3493,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,സാധുവായ മൊബൈൽ നമ്പറുകൾ നൽകുക
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,ചില സവിശേഷതകൾ നിങ്ങളുടെ ബ്രൗസറിൽ പ്രവർത്തിച്ചേക്കില്ല. പുതിയ പതിപ്പിലേക്ക് നിങ്ങളുടെ ബ്രൗസർ അപ്ഡേറ്റ് ചെയ്യുക.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,ചില സവിശേഷതകൾ നിങ്ങളുടെ ബ്രൗസറിൽ പ്രവർത്തിച്ചേക്കില്ല. പുതിയ പതിപ്പിലേക്ക് നിങ്ങളുടെ ബ്രൗസർ അപ്ഡേറ്റ് ചെയ്യുക.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","അറിയില്ല, ചോദിക്കുന്നു &#39;സഹായം&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","അറിയില്ല, ചോദിക്കുന്നു 'സഹായം'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ഈ പ്രമാണം റദ്ദാക്കി {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,അഭിപ്രായങ്ങള് ആശയവിനിമയവും ഈ ലിങ്കുചെയ്ത പ്രമാണം സഹകരിക്കുകയും ചെയ്യും
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,ഫിൽറ്റർ ...
@@ -3522,7 +3522,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,സബ്സ്ക്രിപ്ഷൻ മാറ്റുന്നതിനിടെ പരാജയപ്പെട്ടു
 DocType: LDAP Settings,LDAP Group Field,LDAP ഗ്രൂപ്പ് ഫീൽഡ്
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,സമമായവ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',വയലിലെ ഓപ്ഷനുകൾ &#39;ഡൈനാമിക് ലിങ്ക്&#39; ടൈപ്പ് &#39;DocType&#39; ഉപാധികൾ മറ്റൊരു ലിങ്ക് ഫീൽഡ് നയിക്കേണ്ടത്
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',വയലിലെ ഓപ്ഷനുകൾ 'ഡൈനാമിക് ലിങ്ക്' ടൈപ്പ് 'DocType' ഉപാധികൾ മറ്റൊരു ലിങ്ക് ഫീൽഡ് നയിക്കേണ്ടത്
 DocType: About Us Settings,Team Members Heading,ടീം അംഗങ്ങൾ ശീർഷകം
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,അസാധുവായ CSV ഫോർമാറ്റ്
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ ട്രേ അപ്ലിക്കേഷനിലേക്ക് കണക്റ്റുചെയ്യുന്നതിൽ പിശക് ... <br><br> അസംസ്കൃത പ്രിന്റ് സവിശേഷത ഉപയോഗിക്കുന്നതിന് നിങ്ങൾ QZ ട്രേ ആപ്ലിക്കേഷൻ ഇൻസ്റ്റാൾ ചെയ്ത് പ്രവർത്തിപ്പിക്കേണ്ടതുണ്ട്. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ ട്രേ ഡ Download ൺലോഡ് ചെയ്ത് ഇൻസ്റ്റാൾ ചെയ്യുന്നതിന് ഇവിടെ ക്ലിക്കുചെയ്യുക</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">അസംസ്കൃത പ്രിന്റിംഗിനെക്കുറിച്ച് കൂടുതലറിയാൻ ഇവിടെ ക്ലിക്കുചെയ്യുക</a> ."
@@ -3648,8 +3648,8 @@ DocType: Web Page,Web Page,വെബ് പേജ്
 DocType: Workflow Document State,Next Action Email Template,അടുത്ത ആക്ഷൻ ഇമെയിൽ ടെംപ്ലേറ്റ്
 DocType: Blog Category,Blogger,ബ്ലോഗർ
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെങ്കിൽ, പ്രമാണത്തിലെ മാറ്റങ്ങൾ ട്രാക്കുചെയ്യുകയും ടൈംലൈനിൽ കാണിക്കുകയും ചെയ്യും"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ആഗോള തിരയൽ ൽ&#39; തുടർച്ചയായി തരം {0} അനുവദനീയമല്ല {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ആഗോള തിരയൽ ൽ&#39; തുടർച്ചയായി തരം {0} അനുവദനീയമല്ല {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ആഗോള തിരയൽ ൽ' തുടർച്ചയായി തരം {0} അനുവദനീയമല്ല {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ആഗോള തിരയൽ ൽ' തുടർച്ചയായി തരം {0} അനുവദനീയമല്ല {1}
 DocType: Energy Point Log,Appreciation,അഭിനന്ദനം
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,കാണുക പട്ടിക
 DocType: Workflow,Don't Override Status,സ്റ്റാറ്റസ് നിസ്തേജമാക്കരുത്
@@ -3792,7 +3792,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,സ്ഥിരസ്ഥിതി
 DocType: Translation,Verified,പരിശോധിച്ചുറപ്പിച്ചു
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} ചേർത്തു
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&#39;{0}&#39; തിരയുക
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}','{0}' തിരയുക
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,ആദ്യം റിപ്പോർട്ട് സംരക്ഷിക്കാൻ ദയവായി
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,ചേർത്തു {0} വരിക്കാരുടെ
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,അകത്തു
@@ -3828,14 +3828,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,ഞാൻ
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} ഒരു സാധുവായ സംസ്ഥാനം
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,എല്ലാ പ്രമാണ തരങ്ങൾക്കും പ്രയോഗിക്കുക
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,എനർജി പോയിന്റ് അപ്‌ഡേറ്റ്
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. പേപാൽ കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',മറ്റൊരു പെയ്മെന്റ് രീതി തിരഞ്ഞെടുക്കുക. പേപാൽ കറൻസി ഇടപാടുകളും പിന്തുണയ്ക്കുന്നില്ല '{0}'
 DocType: Chat Message,Room Type,റൂം തരം
 DocType: Data Import Beta,Import Log Preview,ലോഗ് പ്രിവ്യൂ ഇറക്കുമതി ചെയ്യുക
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,തിരയൽ ഫീൽഡ് {0} സാധുവല്ല
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,അപ്‌ലോഡ് ചെയ്ത ഫയൽ
 DocType: Workflow State,ok-circle,OK-സർക്കിൾ
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP ഉപയോക്തൃ സൃഷ്ടിയും മാപ്പിംഗും
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',നിങ്ങൾ ആവശ്യപ്പെട്ട് &#39;ഉപഭോക്താക്കളിൽ ഓറഞ്ച് കണ്ടെത്താൻ&#39; കാര്യങ്ങൾ കണ്ടെത്താനാകും
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',നിങ്ങൾ ആവശ്യപ്പെട്ട് 'ഉപഭോക്താക്കളിൽ ഓറഞ്ച് കണ്ടെത്താൻ' കാര്യങ്ങൾ കണ്ടെത്താനാകും
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,ക്ഷമിക്കണം! ഉപയോക്താവ് അവരുടെ സ്വന്തം റെക്കോർഡ് പൂർണ്ണ പ്രവേശനം ഉണ്ടായിരിക്കണം.
 ,Usage Info,ഉപയോഗം വിവരങ്ങളും
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,കീബോർഡ് കുറുക്കുവഴികൾ കാണിക്കുക

--- a/frappe/translations/mr.csv
+++ b/frappe/translations/mr.csv
@@ -741,7 +741,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,फाई�
 DocType: DocField,In Global Search,ग्लोबल शोध घ्या
 DocType: System Settings,Brute Force Security,ब्रूट फोर्स सिक्युरिटी
 DocType: Workflow State,indent-left,मागणीपत्र-डाव्या
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} वर्षापूर्वी
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} वर्षापूर्वी
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,हि  फाइल तुम्ही डिलीट करणे  धोकादायक आहे: {0}. तुमची प्रणाली व्यवस्थापकाशी संपर्क साधा.
 DocType: Currency,Currency Name,चलन नाव
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ईमेल नाही
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,क्रम�
 apps/frappe/frappe/config/customization.py,Add custom forms.,सानुकूल फॉर्म जोडा.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} मध्ये {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,या दस्तऐवज सादर केला
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,सेटअप&gt; वापरकर्त्याच्या परवानग्या
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,सेटअप> वापरकर्त्याच्या परवानग्या
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,प्रणालीमधे  अनेक पूर्व परिभाषित भूमिका उपलब्ध आहे. आपण चांगल्या परवानगी सेट नवीन भूमिका जोडू शकता.
 DocType: Communication,CC,सीसी
 DocType: Country,Geo,भौगोलिक
@@ -1256,7 +1256,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","वापरकर्ता तपासले कोणत्याही भूमिका आहे, तर वापरकर्ता &quot;प्रणाली वापरकर्ता&quot; होते. &quot;प्रणाली वापरकर्ता&quot; डेस्कटॉपवरील प्रवेश आहे"
 DocType: System Settings,Date and Number Format,तारीख आणि क्रमांक स्वरूप
 apps/frappe/frappe/model/document.py,one of,एका पैकी
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,सेटअप&gt; फॉर्म सानुकूलित करा
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,सेटअप> फॉर्म सानुकूलित करा
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,एक क्षण तपासणी
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,टॅग्ज दर्शवा
 DocType: DocField,HTML Editor,एचटीएमएल संपादक
@@ -1264,7 +1264,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,बिलिंग
 DocType: Email Queue,Not Sent,पाठविलेला नाही
 DocType: Web Form,Actions,क्रिया
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,सेटअप&gt; वापरकर्ता
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,सेटअप> वापरकर्ता
 DocType: Workflow State,align-justify,संरेखित-समायोजित
 DocType: User,Middle Name (Optional),मध्य नाव (पर्यायी)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,परवानगी नाही
@@ -1408,7 +1408,7 @@ DocType: Report,Is Standard,मानक आहे
 DocType: Desktop Icon,_report,_अहवाल द्या
 DocType: Desktop Icon,_report,_अहवाल द्या
 DocType: Dashboard Chart,Full,पूर्ण
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",साध्या भाषेतील &lt;script&gt; सारखे HTML टॅग  किंवा &lt; or &gt; सारखे वर्ण वापरू नका कारण ते हेतुपुरस्सर या क्षेत्रात वापरले जाऊ शकतात
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",साध्या भाषेतील &lt;script> सारखे HTML टॅग  किंवा &lt; or > सारखे वर्ण वापरू नका कारण ते हेतुपुरस्सर या क्षेत्रात वापरले जाऊ शकतात
 DocType: Website Settings,FavIcon,फेविकॉन
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,चालवा
 DocType: Blog Post,Content (HTML),सामग्री (एचटीएमएल)
@@ -1565,7 +1565,7 @@ DocType: GSuite Settings,Script Code,स्क्रिप्ट कोड
 apps/frappe/frappe/core/doctype/user/user.js,Create User Email,वापरकर्ता ईमेल तयार करा
 apps/frappe/frappe/core/doctype/user/user.js,Create User Email,वापरकर्ता ईमेल तयार करा
 apps/frappe/frappe/core/doctype/doctype/doctype.py,No Permissions Specified,कोणतीही परवानगी निर्दिष्ट
-apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,{0} not found,{0} आढळले नाही
+apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,{0} not found,{0} आढळले न���ही
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} records deleted,{0} रेकॉर्ड हटविली
 DocType: Custom Role,Custom Role,सानुकूल भूमिका
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 2,मुख्यपृष्ठ / कसोटी फोल्डर 2
@@ -1778,7 +1778,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,फुटर क�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,प्रलंबित
 DocType: System Settings,Allow only one session per user,प्रति वापरकर्ता फक्त एक सत्र परवानगी द्या
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,मुख्यपृष्ठ / कसोटी फोल्डर 1 / कसोटी फोल्डर 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; एचटीएमएल
+DocType: Website Settings,&lt;head> HTML,&lt;head> एचटीएमएल
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,नवीन कार्यक्रम तयार करण्याची वेळ स्लॉट ओलांडून  ड्रॅग करा किंवा निवडा.
 DocType: Contact,Contact Details,संपर्क माहिती
 DocType: DocField,In Filter,फिल्टर
@@ -2010,7 +2010,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,या वेळी लॉगीन करण्याची  परवानगी नाही
 DocType: Data Migration Run,Current Mapping Action,वर्तमान मॅपिंग क्रिया
 DocType: Dashboard Chart Source,Source Name,स्रोत नाव
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,वापरकर्त्याशी संबंधित कोणतेही ईमेल खाते नाही. कृपया वापरकर्ता&gt; ईमेल इनबॉक्स अंतर्गत खाते जोडा.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,वापरकर्त्याशी संबंधित कोणतेही ईमेल खाते नाही. कृपया वापरकर्ता> ईमेल इनबॉक्स अंतर्गत खाते जोडा.
 DocType: Email Account,Email Sync Option,ईमेल समक्रमण पर्याय
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,पंक्ती संख्या
 DocType: Async Task,Runtime,रनटाइम
@@ -2025,7 +2025,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,आधी
 DocType: User Email,Enable Outgoing,जाणारे सक्षम
 DocType: Address,Fax,फॅक्स
 apps/frappe/frappe/config/customization.py,Custom Tags,सानुकूल टॅग
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ईमेल खाते सेटअप केलेले नाही. कृपया सेटअप&gt; ईमेल&gt; ईमेल खाते वरून नवीन ईमेल खाते तयार करा
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ईमेल खाते सेटअप केलेले नाही. कृपया सेटअप> ईमेल> ईमेल खाते वरून नवीन ईमेल खाते तयार करा
 DocType: Comment,Submitted,सबमिट
 DocType: Contact,Pulled from Google Contacts,Google संपर्कातून खेचले
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,अवैध विनंती
@@ -2098,7 +2098,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,सत्र का�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",येथे परिभाषित FIELDNAMEला  मूल्य आहे किंवा नियम खरे  आहेत (उदाहरणे)  तरच या क्षेत्रात दिसून येईल: myfield eval: doc.myfield == 'माझे मूल्य' eval: doc.age&gt; 18
+eval:doc.age>18",येथे परिभाषित FIELDNAMEला  मूल्य आहे किंवा नियम खरे  आहेत (उदाहरणे)  तरच या क्षेत्रात दिसून येईल: myfield eval: doc.myfield == 'माझे मूल्य' eval: doc.age> 18
 DocType: Social Login Key,Office 365,ऑफिस 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,आज
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,आज
@@ -2113,7 +2113,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,अप्पर केस
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,सानुकूल HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,फोल्डर नाव प्रविष्ट करा
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,डीफॉल्ट अ‍ॅड्रेस टेम्पलेट आढळला नाही. कृपया सेटअप&gt; मुद्रण आणि ब्रांडिंग&gt; अ‍ॅड्रेस टेम्पलेट वरून नवीन तयार करा.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,डीफॉल्ट अ‍ॅड्रेस टेम्पलेट आढळला नाही. कृपया सेटअप> मुद्रण आणि ब्रांडिंग> अ‍ॅड्रेस टेम्पलेट वरून नवीन तयार करा.
 apps/frappe/frappe/auth.py,Unknown User,अज्ञात वापरकर्ता
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,भूमिका निवडा
 DocType: Comment,Deleted,हटविले
@@ -2300,7 +2300,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,दुवे पहाण्यासाठी पुरेसे परवानगी
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,पत्ता शीर्षक आवश्यक आहे.
 DocType: Google Contacts,Push to Google Contacts,Google संपर्कांवर ढकलणे
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","वेब पृष्ठ च्या  विभागमध्ये HTML जोडले, प्रामुख्याने वेबसाइट सत्यापन आणि SEO साठी  वापरले"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","वेब पृष्ठ च्या  विभागमध्ये HTML जोडले, प्रामुख्याने वेबसाइट सत्यापन आणि SEO साठी  वापरले"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,हे जाणवले
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,आयटम त्याच्या स्वत: च्या descendents ला  जोडला  जाऊ शकत नाही
 DocType: Session Default Settings,Session Defaults,सत्र डीफॉल्ट
@@ -2417,7 +2417,7 @@ DocType: Workflow State,Warning,चेतावणी
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,हे एकाधिक पृष्ठांवर मुद्रित होऊ शकते
 DocType: Data Migration Run,Percent Complete,पूर्ण टक्के
 DocType: Tag Category,Tag Category,टॅग वर्ग
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलनासाठी,&gt; 5, &lt;10 किंवा = 324 वापरा. श्रेणीसाठी, 5:10 वापरा (5 आणि 10 मधील मूल्यांसाठी)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलनासाठी,> 5, &lt;10 किंवा = 324 वापरा. श्रेणीसाठी, 5:10 वापरा (5 आणि 10 मधील मूल्यांसाठी)."
 DocType: Google Calendar,Pull from Google Calendar,Google कॅलेंडरमधून खेचा
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,मदत
 DocType: User,Login Before,लॉग-इन करण्यापूर्वी
@@ -2875,7 +2875,7 @@ DocType: Custom Script,Custom Script,सानुकूल स्क्रिप
 DocType: Address,Address Line 2,पत्ता ओळ 2
 DocType: Address,Reference,संदर्भ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,नियुक्त
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,कृपया सेटअप&gt; ईमेल&gt; ईमेल खाते वरून डीफॉल्ट ईमेल खाते सेट करा
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,कृपया सेटअप> ईमेल> ईमेल खाते वरून डीफॉल्ट ईमेल खाते सेट करा
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,डेटा माइग्रेशन मॅपिंग तपशील
 DocType: Data Import,Action,क्रिया
 DocType: GSuite Settings,Script URL,स्क्रिप्ट URL
@@ -3047,7 +3047,7 @@ DocType: DocField,Allow on Submit,सबमिट परवानगी द्�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,अपवाद प्रकार
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,स्तंभ निवडा
-DocType: Web Page,Add code as &lt;script&gt;,&lt;Script&gt; म्हणून कोड जोडा
+DocType: Web Page,Add code as &lt;script>,&lt;Script> म्हणून कोड जोडा
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,वापरकर्त्याच्या परवानग्या साफ करा
 DocType: Webhook,Headers,शीर्षलेख
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,पुढील कार्यक्रम
@@ -3415,16 +3415,16 @@ DocType: Workflow State,share-alt,शेअर-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},रांग एक असावे {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> डीफॉल्ट टेम्पलेट </h4><p> उपयोग <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> आणि उपलब्ध असेल (जर असेल तर सानुकूल फील्ड समावेश) पत्ता सर्व फील्ड </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> डीफॉल्ट टेम्पलेट </h4><p> उपयोग <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> आणि उपलब्ध असेल (जर असेल तर सानुकूल फील्ड समावेश) पत्ता सर्व फील्ड </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,प्रारंभ तारीख फील्ड
 DocType: Role,Role Name,भूमिका नाव
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,डेस्क स्विच

--- a/frappe/translations/mr.csv
+++ b/frappe/translations/mr.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","सक्षम केले असल्यास, संकेतशब्द सामर्थ्य किमान पासवर्ड धावसंख्या मूल्य आधारित अंमलबजावणी केली जाईल. 2 एक मूल्य मध्यम मजबूत असल्याने आणि 4 फार मजबूत आहे."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","सक्षम केले असल्यास, संकेतशब्द सामर्थ्य किमान पासवर्ड धावसंख्या मूल्य आधारित अंमलबजावणी केली जाईल. 2 एक मूल्य मध्यम मजबूत असल्याने आणि 4 फार मजबूत आहे."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;टीम सदस्य&quot; किंवा &quot;व्यवस्थापन&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',शेतातील &#39;तपासा&#39; प्रकार करीता मुलभूत एकतर &#39;0&#39; किंवा &#39;1&#39; असणे आवश्यक आहे
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',शेतातील 'तपासा' प्रकार करीता मुलभूत एकतर '0' किंवा '1' असणे आवश्यक आहे
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,काल
 DocType: Contact,Designation,पदनाम
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,स्वयंचलित दुवा केवळ एका ईमेल खात्यासाठी सक्रिय केला जाऊ शकतो.
@@ -251,7 +251,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,अक्षम 
 DocType: Translation,Contributed Translation Doctype Name,सहयोगी भाषांतर दस्तऐवजाचे नाव
 DocType: PayPal Settings,Redirect To,पुनर्निर्देशित
 DocType: Data Migration Mapping,Pull,खेचणे
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},जावास्क्रिप्ट स्वरूप: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},जावास्क्रिप्ट स्वरूप: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,मोठ्या प्रमाणात अद्यतन
 DocType: Workflow State,chevron-up,शेवरॉन -वर
 DocType: DocType,Allow Guest to View,अतिथी पहा परवानगी द्या
@@ -556,7 +556,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),मागील आठवड्याच्या कामगिरीवर आधारित आकडेवारी ({0} ते {1} पर्यंत)
 DocType: LDAP Settings,LDAP Phone Field,एलडीएपी फोन फील्ड
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","दस्तऐवज प्रकार ..., उदा ग्राहक"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,अट &#39;{0}&#39; अवैध आहे
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,अट '{0}' अवैध आहे
 DocType: Workflow State,barcode,बारकोड
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,उप-चौकशी किंवा फंक्शनचा वापर प्रतिबंधित आहे
 apps/frappe/frappe/config/customization.py,Add your own translations,आपल्या स्वत: च्या भाषांतरे जोडा
@@ -705,7 +705,7 @@ DocType: Slack Webhook URL,Webhook URL,वेबहूक URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,वापरकर्तानाव {0} आधिपासूनच अस्तित्वात आहे
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} आयात नाही म्हणून आयात सेट करू शकत नाही
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},तुमच्या पत्ता साचा {0} मधे  त्रुटी आहे
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} &#39;प्राप्तकर्ते&#39; मध्ये अवैध ईमेल पत्ता आहे
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} 'प्राप्तकर्ते' मध्ये अवैध ईमेल पत्ता आहे
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,यजमान
@@ -747,7 +747,7 @@ DocType: Currency,Currency Name,चलन नाव
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ईमेल नाही
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,दुवा कालबाह्य
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; मधील &#39;{1}&#39; साठी लांबी परत करणे {0}; {3} म्हणून लांबी सेट केल्याने डेटा छेडछाड होईल.
+							Setting the length as {3} will cause truncation of data.",'{2}' मधील '{1}' साठी लांबी परत करणे {0}; {3} म्हणून लांबी सेट केल्याने डेटा छेडछाड होईल.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,फाइल स्वरूप निवडा
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,सामग्री हॅश
@@ -763,13 +763,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","मानक DocType, मुलभूत प्रिंट स्वरूप असू शकत नाही सानुकूलित फॉर्म वापर"
 DocType: Report,Query,क्वेरी
 DocType: Customize Form,Sort Order,अनुक्रम
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;यादी पहा मध्ये&#39; सलग प्रकार {0} परवानगी नाही {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'यादी पहा मध्ये' सलग प्रकार {0} परवानगी नाही {1}
 DocType: Letter Head,Footer HTML,तळटीप एचटीएमएल
 DocType: Custom Field,Select the label after which you want to insert new field.,ज्यानंतर नवीन क्षेत्रात समाविष्ट करायचे असेल ते  लेबल निवडा.
 ,Document Share Report,दस्तऐवज  अहवाल सामायिक करा
 DocType: Social Login Key,Base URL,मूळ URL
 DocType: User,Last Login,अखेरचे लॉगिन
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},आपण {0} फील्डसाठी &#39;भाषांतरयोग्य&#39; सेट करू शकत नाही
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},आपण {0} फील्डसाठी 'भाषांतरयोग्य' सेट करू शकत नाही
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,स्तंभ
 DocType: Chat Profile,Chat Profile,चॅट प्रोफाइल
 DocType: Custom Field,Adds a custom field to a DocType,एक DocType एक सानुकूल फील्ड जोडते
@@ -778,7 +778,7 @@ DocType: File,Is Home Folder,होम फोल्डर आहे
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,नवबार शैली
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} एक वैध ई-मेल पत्ता नाही
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,मुद्रणासाठी किमान 1 रेकॉर्ड निवडा
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',वापरकर्ता &#39;{0}&#39; आधीच भूमिका आहे &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',वापरकर्ता '{0}' आधीच भूमिका आहे '{1}'
 DocType: System Settings,Two Factor Authentication method,दोन घटक प्रमाणीकरण पद्धत
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,प्रथम नाव सेट करा आणि रेकॉर्ड सेव्ह करा.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 रेकॉर्ड
@@ -1054,7 +1054,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,पृष्ठ HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,चुकीच्या पंक्ती निर्यात करा
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,गट नाव रिक्त असू शकत नाही.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,पुढील नोडस् फक्त &#39;ग्रुप प्रकार नोडस् अंतर्गत तयार केले जाऊ शकते
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,पुढील नोडस् फक्त 'ग्रुप प्रकार नोडस् अंतर्गत तयार केले जाऊ शकते
 DocType: SMS Parameter,Header,शीर्षलेख
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},अज्ञात स्तंभ: {0}
 DocType: Notification Recipient,Email By Role,भूमिका इमेल
@@ -1585,7 +1585,7 @@ apps/frappe/frappe/public/js/frappe/model/meta.js,Last Modified By,करून 
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Customizations Reset,सानुकूलने रीसेट
 DocType: Workflow State,hand-down,हात-खाली
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type ""Select"".",कानबन स्तंभ म्हणून वापरली जाऊ शकणारी कोणतीही फील्ड आढळली नाहीत. &quot;निवडा&quot; प्रकाराचे सानुकूल फील्ड जोडण्यासाठी सानुकूलित फॉर्म वापरा.
-DocType: Address,GST State,&#39;जीएसटी&#39; राज्य
+DocType: Address,GST State,'जीएसटी' राज्य
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0}:  रद्द करा सादर केल्याशियाय सेट करू शकत नाही
 DocType: Website Theme,Theme,थीम
 DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,URI प्रमाणिकरण कोड बांधील पुनर्निर्देशित
@@ -1895,7 +1895,7 @@ DocType: Custom DocPerm,Write,लिहा
 apps/frappe/frappe/core/doctype/report/report.py,Only Administrator allowed to create Query / Script Reports,फक्त प्रशासक क्वेरी / स्क्रिप्ट अहवाल तयार करण्यास परवानगी
 apps/frappe/frappe/public/js/frappe/form/save.js,Updating,अद्यतनित करीत आहे
 DocType: Data Import Beta,Preview,पूर्वावलोकन
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated",शेत &#39;मूल्य &quot;आवश्यक आहे. अद्ययावत करणे मूल्य निर्दिष्ट करा
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated",शेत 'मूल्य &quot;आवश्यक आहे. अद्ययावत करणे मूल्य निर्दिष्ट करा
 DocType: Customize Form,Use this fieldname to generate title,शीर्षक निर्माण करण्यासाठी हे  FIELDNAME वापरा
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Email From,ईमेल पासून  आयात
 apps/frappe/frappe/contacts/doctype/contact/contact.js,Invite as User,वापरकर्ता म्हणून आमंत्रित करा
@@ -1993,7 +1993,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,गूगल फॉन्ट
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",जर या सूचना उपयुक्त नसतील तर कृपया GitHub मुद्दे आपल्या सूचना मध्ये जोडा
 DocType: Workflow State,bookmark,बुकमार्क
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),"&#39;/&#39; (स्लॅश) फोल्डर नाव समाविष्ट करू नये,"
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),"'/' (स्लॅश) फोल्डर नाव समाविष्ट करू नये,"
 DocType: Note,Note,टीप
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,त्रुटी अहवाल
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel स्वरूपात डेटा निर्यात करा.
@@ -2138,7 +2138,7 @@ DocType: Data Migration Connector,Database Name,डेटाबेस नाव
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,रिफ्रेश फॉर्म
 DocType: DocField,Select,निवडा
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,पूर्ण लॉग पहा
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","साधे पायथन एक्सप्रेशन, उदाहरण: स्थिती == &#39;उघडा&#39; आणि टाइप करा == &#39;बग&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","साधे पायथन एक्सप्रेशन, उदाहरण: स्थिती == 'उघडा' आणि टाइप करा == 'बग'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,फाइल संलग्न नाही
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,संपर्क तूटला. काही वैशिष्ट्ये कदाचित कार्य करणार नाहीत
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",सारखे &quot;एएए&quot; पुनरावृत्ती अंदाज लावणे सोपे आहे
@@ -2267,7 +2267,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,केवळ त्रुटी दर्शवा
 DocType: Website Settings,Banner HTML,बॅनर HTML
 DocType: Workflow,Send Email Alert,ईमेल अलर्ट पाठवा
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. Razorpay चलन व्यवहार समर्थन देत नाही &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. Razorpay चलन व्यवहार समर्थन देत नाही '{0}'
 DocType: Data Import,In Progress,प्रगतीपथावर
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,बॅकअप साठी रांगेत. तो एक तास काही मिनिटे लागू शकतात.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2683,7 +2683,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,दुरूस्त�
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,पोपल पेमेंट गेटवे सेटिंग्ज
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,शीर्ष परफॉर्मर
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,मुख्य डॉकटाइपमध्ये सानुकूल फील्ड जोडली जाऊ शकत नाहीत.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) परवानगी कमाल वर्ण आहे, काटले होईल {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) परवानगी कमाल वर्ण आहे, काटले होईल {2}"
 DocType: OAuth Client,Response Type,प्रतिसाद प्रकार
 DocType: Contact Us Settings,Send enquiries to this email address,या ई-मेल पत्त्यावर  चौकशी पाठवा
 DocType: Letter Head,Letter Head Name,लेटरहेड नाव
@@ -2739,7 +2739,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,प्रतिमा पहा
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","काहीतरी व्यवहार चूक झाली असे दिसते. आम्ही पैसे पुष्टी केलेली नाही आहे, पेपल आपोआप ही रक्कम परत करेल. जर ती करत नाही, कृपया आम्हाला ईमेल पाठवा आणि परस्परसंबंध आयडी उल्लेख: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","प्रतीक, संख्या आणि पासवर्ड राजधानी अक्षरे समाविष्ट करा"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","शेतात &#39;{0}&#39; सानुकूल फील्ड मध्ये नमूद केलेल्या केल्यानंतर समाविष्ट करा &#39;{1}&#39;, लेबल असलेल्या &#39;{2}&#39; अस्तित्वात नाही"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","शेतात '{0}' सानुकूल फील्ड मध्ये नमूद केलेल्या केल्यानंतर समाविष्ट करा '{1}', लेबल असलेल्या '{2}' अस्तित्वात नाही"
 DocType: List Filter,List Filter,सूची फिल्टर
 DocType: Workflow State,signal,सिग्नल
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,संलग्नक आहेत
@@ -2749,7 +2749,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,दस्तऐवज पुनर्संचयित
 DocType: Data Export,Data Export,डेटा निर्यात
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,भाषा निवडा...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},आपण {0} फील्डसाठी &#39;पर्याय&#39; सेट करू शकत नाही
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},आपण {0} फील्डसाठी 'पर्याय' सेट करू शकत नाही
 DocType: Help Article,Author,लेखक
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,पाठवत आहे पुन्हा सुरु करा
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,पुन्हा उघडा
@@ -2763,15 +2763,15 @@ DocType: Web Page,Slideshow,स्लाइडशो
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,मुलभूत पत्ता साचा हटविला  जाऊ शकत नाही
 DocType: Contact,Maintenance Manager,देखभाल व्यवस्थापक
 DocType: Workflow State,Search,शोध
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. पट्टी चलन व्यवहार समर्थन देत नाही &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. पट्टी चलन व्यवहार समर्थन देत नाही &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. पट्टी चलन व्यवहार समर्थन देत नाही '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. पट्टी चलन व्यवहार समर्थन देत नाही '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,कचर्यात हलवा
 DocType: Web Form,Web Form Fields,वेब फॉर्म फील्ड
 DocType: Data Import,Amended From,पासून दुरुस्ती
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},चेतावणी: अक्षम शोधण्यासाठी {0} संबंधित कोणत्याही टेबल मध्ये {1}
 DocType: S3 Backup Settings,eu-north-1,ईयू-उत्तर -1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,हा दस्तऐवज सध्या अंमलबजावणी करण्यासाठी रांगेत लावली आहे. कृपया पुन्हा प्रयत्न करा
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,फाइल &#39;{0}&#39; आढळले नाही
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,फाइल '{0}' आढळले नाही
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,कलम काढा
 DocType: User,Change Password,पासवर्ड बदला
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,एक्स अक्ष फील्ड
@@ -2957,7 +2957,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,मूल्य ग�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,child जोडा
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,आयात प्रगती
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",जर स्थिती समाधानी असेल तर वापरकर्त्यास गुणांसह बक्षीस दिले जाईल. उदा. doc.status == &#39;बंद&#39;
+",जर स्थिती समाधानी असेल तर वापरकर्त्यास गुणांसह बक्षीस दिले जाईल. उदा. doc.status == 'बंद'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: सादर नोंद हटविले जाऊ शकत नाही.
 DocType: GSuite Templates,Template Name,साचा नाव
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,दस्तऐवजाचा  नवीन प्रकार
@@ -3085,7 +3085,7 @@ DocType: Dashboard Chart,Chart Type,चार्ट प्रकार
 DocType: DocType,Auto Name,ऑटो नाव
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,त्यांचा अंदाज बांधणे सोपे आहेत म्हणून abc किंवा 6543 सारखे क्रम टाळा
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,कृपया पुन्हा प्रयत्न करा
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; किंवा &#39;https: //&#39; ने प्रारंभ होणे आवश्यक आहे
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' किंवा 'https: //' ने प्रारंभ होणे आवश्यक आहे
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,पर्याय 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,संपादित करा
@@ -3319,7 +3319,7 @@ DocType: Notification,Send alert if this field's value changes,या क्ष�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,थीम कलर्स
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,नवीन स्वरूप करण्यासाठी DocType निवडा
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,वापरकर्ता विद्यमान नाही
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;प्राप्तकर्ते&#39; निर्दिष्ट नाहीत
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'प्राप्तकर्ते' निर्दिष्ट नाहीत
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,फक्त आता
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,लागू करा
 DocType: Footer Item,Policy,धोरण
@@ -3367,7 +3367,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,सानुक�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,प्रगती
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,भूमिका
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,गहाळ फील्ड
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,अवैध FIELDNAME &#39;{0}&#39; autoname मध्ये
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,अवैध FIELDNAME '{0}' autoname मध्ये
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,दस्तऐवज प्रकार मधे  शोधा
 DocType: Custom DocPerm,Role and Level,भूमिका आणि स्तर
 DocType: File,Thumbnail URL,लघुप्रतिमा URL
@@ -3454,7 +3454,7 @@ DocType: Dashboard Chart,Filters JSON,फिल्टर JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,सत्यापित करण्यासाठी येथे क्लिक करा
 DocType: Email Account,Disable SMTP server authentication,एसएमटीपी सर्व्हर प्रमाणीकरण अक्षम करा
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,क्लिपबोर्डवर कॉपी केले.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,सारखे अंदाज बदली &#39;@&#39; ऐवजी &#39;अ&#39; खूप मदत करत नाहीत.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,सारखे अंदाज बदली '@' ऐवजी 'अ' खूप मदत करत नाहीत.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,माझ्याबद्दल नियुक्त
 apps/frappe/frappe/utils/data.py,Zero,शून्य
 DocType: Google Drive,Backup Folder ID,बॅकअप फोल्डर आयडी
@@ -3494,7 +3494,7 @@ DocType: DocType,Web View,वेब पहा
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Totals,एकूण
 DocType: DocField,Print Width,मुद्रण रूंदी
 ,Setup Wizard,सेटअप सहाय्यक
-DocType: Address,GST State Number,&#39;जीएसटी&#39; राज्य क्रमांक
+DocType: Address,GST State Number,'जीएसटी' राज्य क्रमांक
 DocType: Chat Message,Visitor,अभ्यागत
 DocType: User,Allow user to login only before this hour (0-24),वापरकर्ता केवळ या तास आधी लॉग इन करण्यासाठी (0-24) अनुमती द्या
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"Drag and drop files, ","फायली ड्रॅग आणि ड्रॉप करा,"
@@ -3507,7 +3507,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,वैध मोबाईल क्र प्रविष्ट करा
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,काही वैशिष्ट्ये आपल्या ब्राउझरमध्ये काम करू शकत नाही. नवीनतम आवृत्ती आपले ब्राउझर अद्यतनित करा.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,काही वैशिष्ट्ये आपल्या ब्राउझरमध्ये काम करू शकत नाही. नवीनतम आवृत्ती आपले ब्राउझर अद्यतनित करा.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",माहित नाही विचारू &#39;मदत&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",माहित नाही विचारू 'मदत'
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},हा कागदजत्र रद्द केला {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,टिप्पण्या आणि संचार या लिंक दस्तऐवजला  संबोधित  केले जाईल
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,फिल्टर ...
@@ -3664,8 +3664,8 @@ DocType: Web Page,Web Page,वेब पृष्ठ
 DocType: Workflow Document State,Next Action Email Template,पुढील क्रिया ईमेल टेम्पलेट
 DocType: Blog Category,Blogger,ब्लॉगर
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","सक्षम असल्यास, कागदजत्रातील बदल ट्रॅक केले जातात आणि टाइमलाइनमध्ये दर्शविले जातात"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ग्लोबल शोध घ्या&#39; प्रकार परवानगी नाही {0} सलग {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ग्लोबल शोध घ्या&#39; प्रकार परवानगी नाही {0} सलग {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ग्लोबल शोध घ्या' प्रकार परवानगी नाही {0} सलग {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ग्लोबल शोध घ्या' प्रकार परवानगी नाही {0} सलग {1}
 DocType: Energy Point Log,Appreciation,कौतुक
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,सूची दृश्य
 DocType: Workflow,Don't Override Status,स्थिती अधिलिखित करू नका
@@ -3809,7 +3809,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,मुलभूत
 DocType: Translation,Verified,सत्यापित
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} जोडले
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',शोधा &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',शोधा '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,पहिल्या अहवाल जतन करा
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ग्राहक जोडले
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,नाही
@@ -3846,14 +3846,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,मी
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} हे वैध राज्य नाही
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,सर्व कागदपत्रांच्या प्रकारांवर अर्ज करा
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,उर्जा बिंदू अद्यतन
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. पोपल चलन व्यवहार समर्थन देत नाही &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',कृपया दुसरी देयक पद्धत निवडा. पोपल चलन व्यवहार समर्थन देत नाही '{0}'
 DocType: Chat Message,Room Type,खोली प्रकार
 DocType: Data Import Beta,Import Log Preview,लॉग पूर्वावलोकन आयात करा
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,शोध क्षेत्रात {0} वैध नाही
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,अपलोड केलेली फाईल
 DocType: Workflow State,ok-circle,ठीक-मंडळ
 DocType: LDAP Settings,LDAP User Creation and Mapping,एलडीएपी वापरकर्त्याची निर्मिती आणि मॅपिंग
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',आपण &#39;ग्राहक मध्ये संत्रा शोधण्यासाठी&#39; विचारून गोष्टी शोधू शकता
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',आपण 'ग्राहक मध्ये संत्रा शोधण्यासाठी' विचारून गोष्टी शोधू शकता
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,क्षमस्व! सदस्य त्यांच्या स्वत: च्या रेकॉर्डला  पूर्ण प्रवेश असणे आवश्यक आहे.
 ,Usage Info,वापर माहिती
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,कीबोर्ड शॉर्टकट दर्शवा

--- a/frappe/translations/mr.csv
+++ b/frappe/translations/mr.csv
@@ -1408,7 +1408,7 @@ DocType: Report,Is Standard,मानक आहे
 DocType: Desktop Icon,_report,_अहवाल द्या
 DocType: Desktop Icon,_report,_अहवाल द्या
 DocType: Dashboard Chart,Full,पूर्ण
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",साध्या भाषेतील &lt;script> सारखे HTML टॅग  किंवा &lt; or > सारखे वर्ण वापरू नका कारण ते हेतुपुरस्सर या क्षेत्रात वापरले जाऊ शकतात
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",साध्या भाषेतील <script> सारखे HTML टॅग  किंवा < or > सारखे वर्ण वापरू नका कारण ते हेतुपुरस्सर या क्षेत्रात वापरले जाऊ शकतात
 DocType: Website Settings,FavIcon,फेविकॉन
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,चालवा
 DocType: Blog Post,Content (HTML),सामग्री (एचटीएमएल)
@@ -1778,7 +1778,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,फुटर क�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,प्रलंबित
 DocType: System Settings,Allow only one session per user,प्रति वापरकर्ता फक्त एक सत्र परवानगी द्या
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,मुख्यपृष्ठ / कसोटी फोल्डर 1 / कसोटी फोल्डर 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> एचटीएमएल
+DocType: Website Settings,<head> HTML,<head> एचटीएमएल
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,नवीन कार्यक्रम तयार करण्याची वेळ स्लॉट ओलांडून  ड्रॅग करा किंवा निवडा.
 DocType: Contact,Contact Details,संपर्क माहिती
 DocType: DocField,In Filter,फिल्टर
@@ -2300,7 +2300,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,दुवे पहाण्यासाठी पुरेसे परवानगी
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,पत्ता शीर्षक आवश्यक आहे.
 DocType: Google Contacts,Push to Google Contacts,Google संपर्कांवर ढकलणे
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","वेब पृष्ठ च्या  विभागमध्ये HTML जोडले, प्रामुख्याने वेबसाइट सत्यापन आणि SEO साठी  वापरले"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","वेब पृष्ठ च्या  विभागमध्ये HTML जोडले, प्रामुख्याने वेबसाइट सत्यापन आणि SEO साठी  वापरले"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,हे जाणवले
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,आयटम त्याच्या स्वत: च्या descendents ला  जोडला  जाऊ शकत नाही
 DocType: Session Default Settings,Session Defaults,सत्र डीफॉल्ट
@@ -2417,7 +2417,7 @@ DocType: Workflow State,Warning,चेतावणी
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,हे एकाधिक पृष्ठांवर मुद्रित होऊ शकते
 DocType: Data Migration Run,Percent Complete,पूर्ण टक्के
 DocType: Tag Category,Tag Category,टॅग वर्ग
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलनासाठी,> 5, &lt;10 किंवा = 324 वापरा. श्रेणीसाठी, 5:10 वापरा (5 आणि 10 मधील मूल्यांसाठी)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","तुलनासाठी,> 5, <10 किंवा = 324 वापरा. श्रेणीसाठी, 5:10 वापरा (5 आणि 10 मधील मूल्यांसाठी)."
 DocType: Google Calendar,Pull from Google Calendar,Google कॅलेंडरमधून खेचा
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,मदत
 DocType: User,Login Before,लॉग-इन करण्यापूर्वी
@@ -3047,7 +3047,7 @@ DocType: DocField,Allow on Submit,सबमिट परवानगी द्�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,अपवाद प्रकार
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,स्तंभ निवडा
-DocType: Web Page,Add code as &lt;script>,&lt;Script> म्हणून कोड जोडा
+DocType: Web Page,Add code as <script>,<Script> म्हणून कोड जोडा
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,वापरकर्त्याच्या परवानग्या साफ करा
 DocType: Webhook,Headers,शीर्षलेख
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,पुढील कार्यक्रम
@@ -3415,16 +3415,16 @@ DocType: Workflow State,share-alt,शेअर-Alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},रांग एक असावे {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> डीफॉल्ट टेम्पलेट </h4><p> उपयोग <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> आणि उपलब्ध असेल (जर असेल तर सानुकूल फील्ड समावेश) पत्ता सर्व फील्ड </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> डीफॉल्ट टेम्पलेट </h4><p> उपयोग <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> आणि उपलब्ध असेल (जर असेल तर सानुकूल फील्ड समावेश) पत्ता सर्व फील्ड </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,प्रारंभ तारीख फील्ड
 DocType: Role,Role Name,भूमिका नाव
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,डेस्क स्विच

--- a/frappe/translations/ms.csv
+++ b/frappe/translations/ms.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Adalah Standard
 DocType: Desktop Icon,_report,_Lapor
 DocType: Desktop Icon,_report,_Lapor
 DocType: Dashboard Chart,Full,Penuh
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti &lt;script> atau hanya watak-watak seperti &lt;atau>, kerana mereka boleh sengaja digunakan dalam bidang ini"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti <script> atau hanya watak-watak seperti <atau>, kerana mereka boleh sengaja digunakan dalam bidang ini"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} dikritik di {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Jalankan
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer akan dipap
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Sementara menunggu
 DocType: System Settings,Allow only one session per user,Benarkan hanya satu sesi setiap pengguna
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Ujian Folder 1 / Ujian Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Pilih atau seret di seluruh slot masa untuk mewujudkan satu acara baru.
 DocType: Contact,Contact Details,Butiran Hubungi
 DocType: DocField,In Filter,Dalam Penapis
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Tidak kebenaran yang cukup untuk melihat pautan
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Alamat Tajuk adalah wajib.
 DocType: Google Contacts,Push to Google Contacts,Tolak ke Kenalan Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML ditambah dalam &lt;head> halaman web, terutamanya digunakan untuk pengesahan laman web dan SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML ditambah dalam <head> halaman web, terutamanya digunakan untuk pengesahan laman web dan SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Kambuh
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item tidak boleh ditambah kepada keturunan sendiri
 DocType: Session Default Settings,Session Defaults,Default Sesi
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,Amaran
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ini mungkin boleh dicetak pada berbilang halaman
 DocType: Data Migration Run,Percent Complete,Peratus Selesai
 DocType: Tag Category,Tag Category,tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Sebagai perbandingan, gunakan> 5, &lt;10 atau = 324. Untuk julat, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Sebagai perbandingan, gunakan> 5, <10 atau = 324. Untuk julat, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tarik dari Kalendar Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Bantuan
 DocType: User,Login Before,Log masuk Sebelum
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Benarkan di Hantar
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Pengecualian Jenis
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pilih Kolum
-DocType: Web Page,Add code as &lt;script>,Tambah kod sebagai &lt;script>
+DocType: Web Page,Add code as <script>,Tambah kod sebagai <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Hapuskan Kebenaran Pengguna
 DocType: Webhook,Headers,Tajuk
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Acara akan datang
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,saham alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Giliran harus menjadi salah satu {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Templat lalai </h4><p> Menggunakan <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja template</a> dan semua bidang Alamat (termasuk Custom Fields jika ada) boleh didapati </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Templat lalai </h4><p> Menggunakan <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja template</a> dan semua bidang Alamat (termasuk Custom Fields jika ada) boleh didapati </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Mula Tarikh Bidang
 DocType: Role,Role Name,Nama Peranan
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Tukar Ke Meja

--- a/frappe/translations/ms.csv
+++ b/frappe/translations/ms.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Backup fail
 DocType: DocField,In Global Search,Dalam Pencarian Global
 DocType: System Settings,Brute Force Security,Keselamatan Force Brute
 DocType: Workflow State,indent-left,inden kiri
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} tahun yang lalu
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} tahun yang lalu
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Ia adalah berisiko untuk memadam fail ini: {0}. Sila hubungi Pengurus Sistem anda.
 DocType: Currency,Currency Name,Nama Mata Wang
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Tiada E-mel
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Tiada {0} dit
 apps/frappe/frappe/config/customization.py,Add custom forms.,Tambah bentuk adat.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} dalam {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,mengemukakan dokumen ini
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Persediaan&gt; Kebenaran Pengguna
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Persediaan> Kebenaran Pengguna
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sistem ini menyediakan banyak peranan yang telah ditetapkan. Anda boleh menambah tugas baru untuk menetapkan kebenaran yang lebih halus.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Jika pengguna mempunyai apa-apa peranan diperiksa, maka pengguna menjadi &quot;Sistem Pengguna&quot;. &quot;Sistem Pengguna&quot; mempunyai akses ke desktop"
 DocType: System Settings,Date and Number Format,Format Tarikh dan Nombor
 apps/frappe/frappe/model/document.py,one of,salah satu
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Persediaan&gt; Peribadikan Borang
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Persediaan> Peribadikan Borang
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Semakan satu masa
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Show Tags
 DocType: DocField,HTML Editor,Editor HTML
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Bil
 DocType: Email Queue,Not Sent,Tidak Dihantar
 DocType: Web Form,Actions,Tindakan-tindakan
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Persediaan&gt; Pengguna
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Persediaan> Pengguna
 DocType: Workflow State,align-justify,menyelaraskan-mewajarkan
 DocType: User,Middle Name (Optional),Nama Tengah (Pilihan)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Tidak Dibenarkan
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Adalah Standard
 DocType: Desktop Icon,_report,_Lapor
 DocType: Desktop Icon,_report,_Lapor
 DocType: Dashboard Chart,Full,Penuh
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti &lt;script&gt; atau hanya watak-watak seperti &lt;atau&gt;, kerana mereka boleh sengaja digunakan dalam bidang ini"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Jangan tag HTML Encode HTML seperti &lt;script> atau hanya watak-watak seperti &lt;atau>, kerana mereka boleh sengaja digunakan dalam bidang ini"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} dikritik di {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Jalankan
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer akan dipap
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Sementara menunggu
 DocType: System Settings,Allow only one session per user,Benarkan hanya satu sesi setiap pengguna
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Ujian Folder 1 / Ujian Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Pilih atau seret di seluruh slot masa untuk mewujudkan satu acara baru.
 DocType: Contact,Contact Details,Butiran Hubungi
 DocType: DocField,In Filter,Dalam Penapis
@@ -2042,7 +2042,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Log Masuk tidak dibenarkan pada masa ini
 DocType: Data Migration Run,Current Mapping Action,Tindakan pemetaan semasa
 DocType: Dashboard Chart Source,Source Name,Nama Source
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Tiada akaun e-mel yang berkaitan dengan Pengguna. Sila tambahkan akaun di bawah Pengguna&gt; Peti Masuk E-mel.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Tiada akaun e-mel yang berkaitan dengan Pengguna. Sila tambahkan akaun di bawah Pengguna> Peti Masuk E-mel.
 DocType: Email Account,Email Sync Option,E-mel Pilihan Sync
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Baris Tidak
 DocType: Async Task,Runtime,Runtime
@@ -2057,7 +2057,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Sudah pad
 DocType: User Email,Enable Outgoing,Membolehkan Keluar
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Custom Tag
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Akaun E-mel bukan persediaan. Sila buat Akaun E-mel baru dari Persediaan&gt; E-mel&gt; Akaun E-mel
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Akaun E-mel bukan persediaan. Sila buat Akaun E-mel baru dari Persediaan> E-mel> Akaun E-mel
 DocType: Comment,Submitted,Dihantar
 DocType: Contact,Pulled from Google Contacts,Ditarik dari Kenalan Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Permintaan tidak sah
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesi tamat di Waktu 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Bidang ini akan dipaparkan hanya jika FIELDNAME yang ditakrifkan di sini mempunyai nilai OR kaedah-kaedah yang benar (contoh): myfield eval: doc.myfield == &#39;Value Saya&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Bidang ini akan dipaparkan hanya jika FIELDNAME yang ditakrifkan di sini mempunyai nilai OR kaedah-kaedah yang benar (contoh): myfield eval: doc.myfield == &#39;Value Saya&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,hari ini
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,hari ini
@@ -2146,7 +2146,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,KES UPPER
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Masukkan nama folder
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Tiada Templat Alamat lalai yang ditemui. Sila buat yang baru dari Persediaan&gt; Percetakan dan Penjenamaan&gt; Template Alamat.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Tiada Templat Alamat lalai yang ditemui. Sila buat yang baru dari Persediaan> Percetakan dan Penjenamaan> Template Alamat.
 apps/frappe/frappe/auth.py,Unknown User,Pengguna tidak diketahui
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Pilih Peranan
 DocType: Comment,Deleted,Dihapuskan
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Tidak kebenaran yang cukup untuk melihat pautan
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Alamat Tajuk adalah wajib.
 DocType: Google Contacts,Push to Google Contacts,Tolak ke Kenalan Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML ditambah dalam &lt;head&gt; halaman web, terutamanya digunakan untuk pengesahan laman web dan SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML ditambah dalam &lt;head> halaman web, terutamanya digunakan untuk pengesahan laman web dan SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Kambuh
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item tidak boleh ditambah kepada keturunan sendiri
 DocType: Session Default Settings,Session Defaults,Default Sesi
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,Amaran
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ini mungkin boleh dicetak pada berbilang halaman
 DocType: Data Migration Run,Percent Complete,Peratus Selesai
 DocType: Tag Category,Tag Category,tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Sebagai perbandingan, gunakan&gt; 5, &lt;10 atau = 324. Untuk julat, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Sebagai perbandingan, gunakan> 5, &lt;10 atau = 324. Untuk julat, gunakan 5:10 (untuk nilai antara 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tarik dari Kalendar Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Bantuan
 DocType: User,Login Before,Log masuk Sebelum
@@ -2926,7 +2926,7 @@ DocType: Custom Script,Custom Script,Skrip Custom
 DocType: Address,Address Line 2,Alamat 2
 DocType: Address,Reference,Rujukan
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Ditugaskan Untuk
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Sila persiapkan Akaun E-mel lalai dari Persediaan&gt; E-mel&gt; Akaun E-mel
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Sila persiapkan Akaun E-mel lalai dari Persediaan> E-mel> Akaun E-mel
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detil Pemetaan Migrasi Data
 DocType: Data Import,Action,Tindakan
 DocType: GSuite Settings,Script URL,URL skrip
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Benarkan di Hantar
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Pengecualian Jenis
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pilih Kolum
-DocType: Web Page,Add code as &lt;script&gt;,Tambah kod sebagai &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Tambah kod sebagai &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Hapuskan Kebenaran Pengguna
 DocType: Webhook,Headers,Tajuk
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Acara akan datang
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,saham alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Giliran harus menjadi salah satu {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Templat lalai </h4><p> Menggunakan <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja template</a> dan semua bidang Alamat (termasuk Custom Fields jika ada) boleh didapati </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Templat lalai </h4><p> Menggunakan <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja template</a> dan semua bidang Alamat (termasuk Custom Fields jika ada) boleh didapati </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Mula Tarikh Bidang
 DocType: Role,Role Name,Nama Peranan
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Tukar Ke Meja

--- a/frappe/translations/ms.csv
+++ b/frappe/translations/ms.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Jika didayakan, kekuatan kata laluan akan dikuatkuasakan berdasarkan nilai Kata laluan Skor Minimum. A nilai 2 yang sederhana kuat dan 4 yang sangat kuat."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Jika didayakan, kekuatan kata laluan akan dikuatkuasakan berdasarkan nilai Kata laluan Skor Minimum. A nilai 2 yang sederhana kuat dan 4 yang sangat kuat."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Ahli-ahli Pasukan&quot; atau &quot;Pengurusan&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Default untuk jenis &#39;Semak&#39; di padang mestilah sama ada &#39;0&#39; atau &#39;1&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Default untuk jenis 'Semak' di padang mestilah sama ada '0' atau '1'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Semalam
 DocType: Contact,Designation,Jawatan
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Pemaut automatik boleh diaktifkan hanya untuk satu Akaun E-mel.
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Laporan Disable
 DocType: Translation,Contributed Translation Doctype Name,Terjemahan Terjemahan Doktor
 DocType: PayPal Settings,Redirect To,redirect To
 DocType: Data Migration Mapping,Pull,Tarik
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Update Bulk
 DocType: Workflow State,chevron-up,chevron-up
 DocType: DocType,Allow Guest to View,Membolehkan tetamu untuk Lihat
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistik berdasarkan prestasi minggu lepas (dari {0} hingga {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP Phone Field
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","jenis dokumen ..., contohnya pelanggan"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,The Keadaan &#39;{0}&#39; tidak sah
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,The Keadaan '{0}' tidak sah
 DocType: Workflow State,barcode,kod bar
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Penggunaan sub-query atau fungsi adalah terhad
 apps/frappe/frappe/config/customization.py,Add your own translations,Menambah terjemahan anda sendiri
@@ -714,7 +714,7 @@ DocType: Slack Webhook URL,Webhook URL,URL Webhook
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Nama pengguna {0} sudah wujud
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,"{0}: Tidak boleh menetapkan import, kerana {1} tidak boleh diimport"
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Terdapat ralat dalam Template Alamat anda {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} adalah alamat e-mel yang tidak sah dalam &#39;Penerima&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} adalah alamat e-mel yang tidak sah dalam 'Penerima'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,Host
@@ -756,7 +756,7 @@ DocType: Currency,Currency Name,Nama Mata Wang
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Tiada E-mel
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Pautan telah tamat
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Mengembalikan panjang kepada {0} untuk &#39;{1}&#39; dalam &#39;{2}&#39;; Menetapkan panjang sebagai {3} akan menyebabkan pemotongan data.
+							Setting the length as {3} will cause truncation of data.",Mengembalikan panjang kepada {0} untuk '{1}' dalam '{2}'; Menetapkan panjang sebagai {3} akan menyebabkan pemotongan data.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Pilih Format Fail
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash kandungan
@@ -778,7 +778,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokumen Laporan Share
 DocType: Social Login Key,Base URL,URL Asas
 DocType: User,Last Login,Log masuk lepas
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Anda tidak boleh menetapkan &#39;Translatable&#39; untuk medan {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Anda tidak boleh menetapkan 'Translatable' untuk medan {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Ruangan
 DocType: Chat Profile,Chat Profile,Profil Sembang
 DocType: Custom Field,Adds a custom field to a DocType,Menambah medan tersuai untuk DOCTYPE yang
@@ -787,7 +787,7 @@ DocType: File,Is Home Folder,Adakah Rumah Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Style
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} tidak Alamat E-mel yang sah
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Pilih atleast 1 rekod untuk mencetak
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Pengguna &#39;{0}&#39; sudah mempunyai peranan &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Pengguna '{0}' sudah mempunyai peranan '{1}'
 DocType: System Settings,Two Factor Authentication method,Kaedah Pengesahan Dua Faktor
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Mula-mula tetapkan nama dan simpan rekod.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Rekod
@@ -1040,7 +1040,7 @@ DocType: Property Setter,Property Setter,Harta Setter
 DocType: Web Form,Allow Print,Benarkan Cetak
 DocType: Communication,Clicked,Klik
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Unfollow
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Tiada kebenaran untuk &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Tiada kebenaran untuk '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Dijadual menghantar
 DocType: DocType,Track Seen,Track Seen
 DocType: Dropbox Settings,File Backup,Backup Fail
@@ -1067,7 +1067,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Page HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Baris Kesalahan Eksport
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Nama kumpulan tidak boleh kosong.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Nod lagi hanya boleh diwujudkan di bawah nod jenis &#39;Kumpulan
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Nod lagi hanya boleh diwujudkan di bawah nod jenis 'Kumpulan
 DocType: SMS Parameter,Header,Tandukan
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Ruang yang tidak diketahui: {0}
 DocType: Notification Recipient,Email By Role,Email Oleh Peranan
@@ -1458,7 +1458,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,medan mandatori: peranan ditetapkan untuk
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} dikritik {1}
 DocType: Data Migration Mapping,Mapping Name,Nama pemetaan
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Bidang &#39;{1}&#39; tidak boleh ditetapkan sebagai Unik kerana ia mempunyai nilai yang tidak unik
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Bidang '{1}' tidak boleh ditetapkan sebagai Unik kerana ia mempunyai nilai yang tidak unik
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navigasi senarai ke bawah
 DocType: Currency,A symbol for this currency. For e.g. $,Satu simbol untuk mata wang ini. Contohnya: $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Terjemahan yang berjaya dikemas kini
@@ -1980,7 +1980,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-tenggara-1
 DocType: DocType,"Must be of type ""Attach Image""",Mestilah jenis &quot;Lampirkan Image&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,nyahpilih Semua
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Anda tidak boleh tanpa ditetapkan &#39;Baca Sahaja&#39; untuk medan {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Anda tidak boleh tanpa ditetapkan 'Baca Sahaja' untuk medan {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,Sifar bermakna menghantar rekod dikemaskini pada bila-bila masa
 DocType: Auto Email Report,Zero means send records updated at anytime,Sifar bermakna menghantar rekod dikemaskini pada bila-bila masa
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,Persediaan yang lengkap
@@ -2025,7 +2025,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Jika arahan ini di mana tidak membantu, sila masukkan cadangan anda mengenai Isu-isu GitHub."
 DocType: Workflow State,bookmark,penanda buku
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Nama folder tidak boleh mengandungi &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Nama folder tidak boleh mengandungi '/' (slash)
 DocType: Note,Note,Nota
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Laporan ralat
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Data Eksport dalam format CSV / Excel.
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesi tamat di Waktu 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Bidang ini akan dipaparkan hanya jika FIELDNAME yang ditakrifkan di sini mempunyai nilai OR kaedah-kaedah yang benar (contoh): myfield eval: doc.myfield == &#39;Value Saya&#39; eval: doc.age> 18
+eval:doc.age>18",Bidang ini akan dipaparkan hanya jika FIELDNAME yang ditakrifkan di sini mempunyai nilai OR kaedah-kaedah yang benar (contoh): myfield eval: doc.myfield == 'Value Saya' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,hari ini
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,hari ini
@@ -2171,7 +2171,7 @@ DocType: Data Migration Connector,Database Name,Nama Pangkalan Data
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Borang Muat semula
 DocType: DocField,Select,Pilih
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Lihat Log Penuh
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Ekspresi Python Mudah, Contoh: status == &#39;Terbuka&#39; dan ketik == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Ekspresi Python Mudah, Contoh: status == 'Terbuka' dan ketik == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Fail tidak dilampirkan
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Sambungan hilang. Sesetengah ciri mungkin tidak berfungsi.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Ulangan seperti &quot;aaa&quot; adalah mudah untuk meneka
@@ -2303,7 +2303,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Tunjukkan ralat sahaja
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Hantar E-mel Alert
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. Razorpay tidak menyokong urus niaga dalam mata wang &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. Razorpay tidak menyokong urus niaga dalam mata wang '{0}'
 DocType: Data Import,In Progress,Dalam Kemajuan
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Beratur untuk sandaran. Ia mungkin mengambil masa beberapa minit hingga satu jam.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2730,7 +2730,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Yang meminda
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal tetapan gerbang pembayaran
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Pelakon Teratas
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Bidang Tersuai tidak boleh ditambahkan ke DocTypes teras.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1} ({3}) dipangkas, kerana watak-watak max dibenarkan adalah {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1} ({3}) dipangkas, kerana watak-watak max dibenarkan adalah {2}"
 DocType: OAuth Client,Response Type,Jenis Response
 DocType: Contact Us Settings,Send enquiries to this email address,Hantar pertanyaan ke alamat e-mel ini
 DocType: Letter Head,Letter Head Name,Nama surat Ketua
@@ -2787,7 +2787,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Lihat imej
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Kelihatan seperti sesuatu yang tidak kena semasa transaksi. Oleh kerana kita telah tidak disahkan pembayaran, Paypal secara automatik akan membayar balik jumlah ini. Jika tidak, sila hantar e-mel dan menyebut ID Korelasi yang: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Termasuk simbol, nombor dan huruf besar dalam kata laluan"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Masukkan Selepas bidang &#39;{0}&#39; yang disebut dalam Custom Field &#39;{1}&#39;, dengan label &#39;{2}&#39;, tidak wujud"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Masukkan Selepas bidang '{0}' yang disebut dalam Custom Field '{1}', dengan label '{2}', tidak wujud"
 DocType: List Filter,List Filter,Senaraikan Penapis
 DocType: Workflow State,signal,isyarat
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Mempunyai Lampiran
@@ -2797,7 +2797,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,dokumen Dipulihkan
 DocType: Data Export,Data Export,Eksport Data
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Pilih Bahasa...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Anda tidak boleh menetapkan &#39;Pilihan&#39; untuk medan {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Anda tidak boleh menetapkan 'Pilihan' untuk medan {0}
 DocType: Help Article,Author,Pengarang
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Resume Menghantar
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Buka semula
@@ -2811,15 +2811,15 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Templat Alamat lalai tidak boleh dipadam
 DocType: Contact,Maintenance Manager,Pengurus Penyelenggaraan
 DocType: Workflow State,Search,Carian
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. Jalur tidak menyokong urus niaga dalam mata wang &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. Jalur tidak menyokong urus niaga dalam mata wang &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. Jalur tidak menyokong urus niaga dalam mata wang '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. Jalur tidak menyokong urus niaga dalam mata wang '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Pindah ke tong sampah
 DocType: Web Form,Web Form Fields,Borang Web Fields
 DocType: Data Import,Amended From,Pindaan Dari
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Amaran: Tidak dapat mencari {0} dalam mana-mana jadual yang berkaitan dengan {1}
 DocType: S3 Backup Settings,eu-north-1,eu-utara-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Dokumen ini kini pesanan yang akan dilaksanakan. Sila cuba lagi
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Fail &#39;{0}&#39; tidak dijumpai
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Fail '{0}' tidak dijumpai
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Buang Seksyen
 DocType: User,Change Password,Tukar kata laluan
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X Axis Field
@@ -3010,7 +3010,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Nilai hilang
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Tambah Anak
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Kemajuan Import
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",Sekiranya syarat pengguna berpuas hati akan diberi ganjaran dengan mata. contohnya. doc.status == &#39;Tertutup&#39;
+",Sekiranya syarat pengguna berpuas hati akan diberi ganjaran dengan mata. contohnya. doc.status == 'Tertutup'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Rekod Dihantar tidak boleh dihapuskan.
 DocType: GSuite Templates,Template Name,Nama template
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Jenis baru dokumen
@@ -3142,7 +3142,7 @@ DocType: Dashboard Chart,Chart Type,Jenis Carta
 DocType: DocType,Auto Name,Nama Auto
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Elakkan urutan seperti abc atau 6543 kerana mereka adalah mudah untuk meneka
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Sila cuba lagi
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL mesti bermula dengan &#39;http: //&#39; atau &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL mesti bermula dengan 'http: //' atau 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Pilihan 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Edit
@@ -3382,7 +3382,7 @@ DocType: Notification,Send alert if this field's value changes,Hantar amaran jik
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Warna Tema
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Pilih DOCTYPE untuk membuat format baru
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Pengguna tidak wujud
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Penerima&#39; tidak ditentukan
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Penerima' tidak ditentukan
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,sebentar tadi
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,memohon
 DocType: Footer Item,Policy,Dasar
@@ -3431,7 +3431,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Custom Terjemahan
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,kemajuan
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,mengikut Peranan
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Fields hilang
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,FIELDNAME tidak sah &#39;{0}&#39; dalam autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,FIELDNAME tidak sah '{0}' dalam autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Cari dalam dokumen jenis
 DocType: Custom DocPerm,Role and Level,Peranan dan Tahap
 DocType: File,Thumbnail URL,URL thumbnail
@@ -3521,11 +3521,11 @@ DocType: Dashboard Chart,Filters JSON,Penapis JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Klik di sini untuk mengesahkan
 DocType: Email Account,Disable SMTP server authentication,Lumpuhkan pengesahan pelayan SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Disalin ke papan keratan.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,penggantian diramal seperti &#39;@&#39; dan bukan &#39;a&#39; tidak membantu sangat.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,penggantian diramal seperti '@' dan bukan 'a' tidak membantu sangat.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Ditugaskan By Me
 apps/frappe/frappe/utils/data.py,Zero,Zero
 DocType: Google Drive,Backup Folder ID,ID Folder Sandaran
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Tidak dalam Mod Pemaju! Terletak di site_config.json atau membuat DOCTYPE &#39;Custom&#39;.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Tidak dalam Mod Pemaju! Terletak di site_config.json atau membuat DOCTYPE 'Custom'.
 DocType: Workflow State,globe,dunia
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,Keutamaan
@@ -3575,7 +3575,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Sila masukkan nos bimbit sah
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Antara ciri-ciri mungkin tidak berfungsi dalam pelayar anda. Sila kemas kini pelayar anda kepada versi terkini.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Antara ciri-ciri mungkin tidak berfungsi dalam pelayar anda. Sila kemas kini pelayar anda kepada versi terkini.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Tidak tahu, tanya &#39;membantu&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Tidak tahu, tanya 'membantu'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},membatalkan dokumen ini {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Komen dan Komunikasi akan dikaitkan dengan dokumen berkaitan ini
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Menapis ...
@@ -3604,7 +3604,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Gagal semasa meminda langganan
 DocType: LDAP Settings,LDAP Group Field,LDAP Group Field
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Sama
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Jenis &#39;Dynamic Link&#39; Pilihan medan mesti menunjukkan satu lagi Bidang Link dengan pilihan &#39;DOCTYPE&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Jenis 'Dynamic Link' Pilihan medan mesti menunjukkan satu lagi Bidang Link dengan pilihan 'DOCTYPE'
 DocType: About Us Settings,Team Members Heading,Ahli-ahli pasukan Tajuk
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Format CSV tidak sah
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Kesalahan menyambung ke Aplikasi QZ Tray ... <br><br> Anda perlu memasang dan menjalankan aplikasi QZ Tray, untuk menggunakan ciri Cetak Raw. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Klik di sini untuk Muat turun dan pasang QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Klik di sini untuk mengetahui lebih lanjut mengenai Percetakan Raw</a> ."
@@ -3734,8 +3734,8 @@ DocType: Web Page,Web Page,Web Page
 DocType: Workflow Document State,Next Action Email Template,Templat E-mel Tindakan Seterusnya
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Jika diaktifkan, perubahan pada dokumen dikesan dan ditunjukkan dalam garis masa"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;In Search Global&#39; tidak dibenarkan untuk jenis {0} berturut-turut {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;In Search Global&#39; tidak dibenarkan untuk jenis {0} berturut-turut {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'In Search Global' tidak dibenarkan untuk jenis {0} berturut-turut {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'In Search Global' tidak dibenarkan untuk jenis {0} berturut-turut {1}
 DocType: Energy Point Log,Appreciation,Penghargaan
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Senarai View
 DocType: Workflow,Don't Override Status,Jangan Override Status
@@ -3883,7 +3883,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Default
 DocType: Translation,Verified,Disahkan
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} telah ditambah
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cari &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Cari '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Sila simpan laporan pertama
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} pelanggan ditambah
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Tidak Dalam
@@ -3920,14 +3920,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Saya
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} bukan Negeri yang sah
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Memohon kepada semua Jenis Dokumen
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Kemas kini titik tenaga
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. PayPal tidak menyokong urus niaga dalam mata wang &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Sila pilih kaedah pembayaran yang lain. PayPal tidak menyokong urus niaga dalam mata wang '{0}'
 DocType: Chat Message,Room Type,Jenis bilik
 DocType: Data Import Beta,Import Log Preview,Import Preview Log
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,medan carian {0} tidak sah
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,fail yang dimuat naik
 DocType: Workflow State,ok-circle,ok bulatan
 DocType: LDAP Settings,LDAP User Creation and Mapping,Penciptaan dan Pemetaan Pengguna LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Anda boleh mencari sesuatu dengan bertanya &#39;mencari jingga pelanggan
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Anda boleh mencari sesuatu dengan bertanya 'mencari jingga pelanggan
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Maaf! Pengguna perlu mempunyai akses yang lengkap untuk rekod mereka sendiri.
 ,Usage Info,Maklumat penggunaan
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Tunjukkan Pintasan Papan Kekunci

--- a/frappe/translations/my.csv
+++ b/frappe/translations/my.csv
@@ -458,7 +458,7 @@ apps/frappe/frappe/desk/page/user_profile/user_profile.js,Monthly Rank: ,လစ�
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select multiple list items,မျိုးစုံစာရင်းကိုပစ္စည်းများကို Select လုပ်ပါ
 DocType: Event,Repeat Till,Repeat မှီတိုငျအောငျ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New,နယူး
-apps/frappe/frappe/public/js/frappe/views/components/ModuleLinkItem.vue,You need to create these first: ,သင်တို့သည်ဤပထမဦးဆုံးဖန်တီးရန်လိုအပ်:
+apps/frappe/frappe/public/js/frappe/views/components/ModuleLinkItem.vue,You need to create these first: ,သင်���ို့သည်ဤပထမဦးဆုံးဖန်တီးရန်လိုအပ်:
 DocType: Google Maps Settings,Google Maps Settings,Google Maps ကိုချိန်ညှိမှုများ
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Loading ...
 DocType: DocField,Password,Password ကို
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,file ကိ
 DocType: DocField,In Global Search,ကမ္တာ့ရှာရန်အတွက်
 DocType: System Settings,Brute Force Security,brute တပ်ဖွဲ့လုံခြုံရေး
 DocType: Workflow State,indent-left,ကုန်အမှာစာ-လက်ဝဲ
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} လွန်ခဲ့သောနှစ်က
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} လွန်ခဲ့သောနှစ်က
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,{0}: ဒါဟာဒီဖိုင်ကိုဖျက်ပစ်ရန်အန္တရာယ်များသည်။ သင့်ရဲ့ System ကို Manager ကဆက်သွယ်နိုင်ပါသည်။
 DocType: Currency,Currency Name,ငွေကြေးအမည်
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,အဘယ်သူမျှမထားတဲ့အီးမေးလ်
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} မျှ
 apps/frappe/frappe/config/customization.py,Add custom forms.,ထုံးစံပုံစံများကိုထည့်ပေါင်းပါ။
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} {2} အတွက်
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ဤစာရွက်စာတမ်းတင်သွင်း
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,setup ကို&gt; အသုံးပြုသူခွင့်ပြုချက်
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,setup ကို> အသုံးပြုသူခွင့်ပြုချက်
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,အဆိုပါစနစ်အများအပြား Pre-defined အခန်းကဏ္ဍပေးပါသည်။ သင်ကအနုစိတ်ခွင့်ပြုချက်တင်ထားရန်အသစ်အခန်းကဏ္ဍထည့်နိုင်သည်။
 DocType: Communication,CC,CC ကို
 DocType: Country,Geo,Geo
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","အသုံးပြုသူကို check မဆိုအခန်းကဏ္ဍရှိပါတယ်လျှင်, အသုံးပြုသူတစ်ဦး &quot;System ကိုအသုံးပြုသူတို့၏&quot; ဖြစ်လာသည်။ &quot;စနစ်အသုံးပြုသူက&quot; desktop ပေါ်မှာလက်လှမ်းမီရှိပါတယ်"
 DocType: System Settings,Date and Number Format,ရက်စွဲနှင့်နံပါတ် Format ကို
 apps/frappe/frappe/model/document.py,one of,တယောက်
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Setup&gt; Customize Form ကို
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Setup> Customize Form ကို
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,တဦးတည်းယခုအချိန်တွင်ကိုစစ်ဆေးခြင်း
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,show Tags:
 DocType: DocField,HTML Editor,HTML ကို Editor ကို
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,ငွေတောင်းခံ
 DocType: Email Queue,Not Sent,Sent မဟုတ်
 DocType: Web Form,Actions,* Actions
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,setup ကို&gt; အသုံးပြုသူ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,setup ကို> အသုံးပြုသူ
 DocType: Workflow State,align-justify,တေ့-ကိုအပြစ်လွတ်
 DocType: User,Middle Name (Optional),အလယျပိုငျးအမည် (Optional)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,အခွင့်မရှိကြ
@@ -1398,7 +1398,7 @@ DocType: Contact Us Settings,Email ID,အီးမေးလ် ID ကို
 DocType: Energy Point Rule,Multiplier Field,မြှောက်ကိန်းဖျော်ဖြေမှု
 DocType: Dashboard Chart,Time Interval,အချိန်ကြားကာလ
 DocType: Activity Log,Keep track of all update feeds,အားလုံး update ကို feeds တွေကိုခြေရာခံသိမ်းဆည်းထားပါ
-DocType: OAuth Client,A list of resources which the Client App will have access to after the user allows it.<br> e.g. project,အသုံးပြုသူကခွင့်ပြုပြီးနောက်လိုင်း App ကိုမှဝင်ရောက်ခွင့်ရှိလိမ့်မည်သည့်အရင်းအမြစ်များကိုစာရင်းတစ်ခု။ <br> ဥပမာစီမံကိန်းအတွက်
+DocType: OAuth Client,A list of resources which the Client App will have access to after the user allows it.<br> e.g. project,အသုံးပြုသူကခွင့်ပြုပြီးနောက်လိုင်း App ကိုမှဝင်ရောက်ခွင့်ရှိလိ���့်မည်သည့်အရင်းအမြစ်များကိုစာရင်းတစ်ခု။ <br> ဥပမာစီမံကိန်းအတွက်
 DocType: Translation,Translated Text,ဘာသာပြန်ထားသောစာသား
 DocType: Contact Us Settings,Query Options,query က Options
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,Fetching posts...,ရယူပို့စ်များကို ...
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Standard ဖြစ်ပါသည်
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,ပြည့်သော
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","သူတို့ရည်ရွယ်ချက်ရှိရှိဒီလယ်ကွင်းများတွင်အသုံးပြုနိုင်အဖြစ်, &lt;script&gt; သို့မဟုတ်ပဲဇာတ်ကောင်တူ &lt;သို့မဟုတ်&gt; တူမက HTML encoding က HTML tags များလုပ်ပါ"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","သူတို့ရည်ရွယ်ချက်ရှိရှိဒီလယ်ကွင်းများတွင်အသုံးပြုနိုင်အဖြစ်, &lt;script> သို့မဟုတ်ပဲဇာတ်ကောင်တူ &lt;သို့မဟုတ်> တူမက HTML encoding က HTML tags များလုပ်ပါ"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} {1} အပေါ်ဝေဖန်
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ပွေးသှား
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,footer သာ PDF
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,လာမည့်
 DocType: System Settings,Allow only one session per user,အသုံးပြုသူတစ်ဦးလျှင်တစ်ဦးတည်းသာ session ကို Allow
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,နေအိမ် / မရှိစမ်းသပ်ခြင်း Folder ကို 1 / မရှိစမ်းသပ်ခြင်း Folder ကို 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML ကို
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML ကို
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ကိုရွေးပါသို့မဟုတ်အသစ်တစ်ခုကိုပွဲဖန်တီးရန်အချိန် slot များအနှံ့ဆွဲယူပါ။
 DocType: Contact,Contact Details,ဆက်သွယ်ရန်အသေးစိတ်
 DocType: DocField,In Filter,Filter ကိုအတွက်
@@ -1882,7 +1882,7 @@ DocType: DocField,Int,int
 DocType: Error Log,Title,ဘှဲ့
 apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,"Seems issue with server's razorpay config. Don't worry, in case of failure amount will get refunded to your account.","ပြဿနာဆာဗာ၏ razorpay config ကိုအတူပုံရသည်။ ပျက်ကွက်ပမာဏ၏အမှု၌သင်၏အကောင့်အားပြန်အမ်းရဦးမည်, မစိုးရိမ်ပါနဲ့။"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Customize,Customize
-apps/frappe/frappe/core/doctype/user/user.js,View Permitted Documents,ကြည့်ရန်ခွင့်စာရွက်စာတမ်းများ
+apps/frappe/frappe/core/doctype/user/user.js,View Permitted Documents,ကြည့်ရန်ခ���င့်စာရွက်စာတမ်းများ
 apps/frappe/frappe/utils/print_format.py,You need to install pycups to use this feature!,သင်သည်ဤအင်္ဂါရပ်ကိုအသုံးပြုရန် pycups install လုပ်ရန်လိုအပ်ပါတယ်
 apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Your connection request to Google Calendar was successfully accepted,Google ကပြက္ခဒိန်ရန်သင့်ရဲ့အဆက်အသွယ်လုပ်ဖို့တောင်းဆိုချက်အောင်မြင်စွာလက်ခံခဲ့သည်ခဲ့သည်
 DocType: Tag Link,Tag Link,Tag Link
@@ -2042,7 +2042,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,login ဒီအချိန်မှာခွင့်မပြု
 DocType: Data Migration Run,Current Mapping Action,လက်ရှိမြေပုံလှုပ်ရှားမှု
 DocType: Dashboard Chart Source,Source Name,source အမည်
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,အသုံးပြုသူနှင့်ဆက်စပ်သောအီးမေးလ်အကောင့်မရှိပါ။ ကျေးဇူးပြု၍ User&gt; Email Inbox အောက်တွင်အကောင့်တစ်ခုထည့်ပါ။
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,အသုံးပြုသူနှင့်ဆက်စပ်သောအီးမေးလ်အကောင့်မရှိပါ။ ကျေးဇူးပြု၍ User> Email Inbox အောက်တွင်အကောင့်တစ်ခုထည့်ပါ။
 DocType: Email Account,Email Sync Option,အီးမေးလ်ပို့ရန် Sync ကို Option ကို
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,အဘယ်သူမျှမ Row
 DocType: Async Task,Runtime,runtime
@@ -2057,7 +2057,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ယခု
 DocType: User Email,Enable Outgoing,အထွက် Enable
 DocType: Address,Fax,ဖက်စ်
 apps/frappe/frappe/config/customization.py,Custom Tags,စိတ်တိုင်းကျ Tags:
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,အီးမေးလ်အကောင့်မတည်ဆောက်ပါ ကျေးဇူးပြု၍ Setup&gt; Email&gt; Email Account မှအီးမေးလ်အကောင့်အသစ်ကိုဖွင့်ပါ
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,အီးမေးလ်အကောင့်မတည်ဆောက်ပါ ကျေးဇူးပြု၍ Setup> Email> Email Account မှအီးမေးလ်အကောင့်အသစ်ကိုဖွင့်ပါ
 DocType: Comment,Submitted,Submitted
 DocType: Contact,Pulled from Google Contacts,Google Contacts မှဆွဲထုတ်
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,သက်တမ်းရှိတောင်းဆိုမှုအတွက်
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,06:00 ဥပမာ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",myfield eval: doc.myfield == &#39;&#39; ငါ့အ Value ကို &#39;&#39; eval:&gt; 18 doc.age ဒီနေရာမှာသတ်မှတ်ထားတဲ့ fieldname တန်ဖိုးကိုရှိပါတယ် OR စည်းမျဉ်းစည်းကမ်းတွေကို (ဥပမာ) မှန်သာမှန်လျှင်ဤနယ်ပယ်ပေါ်လာပါလိမ့်မယ်
+eval:doc.age>18",myfield eval: doc.myfield == &#39;&#39; ငါ့အ Value ကို &#39;&#39; eval:> 18 doc.age ဒီနေရာမှာသတ်မှတ်ထားတဲ့ fieldname တန်ဖိုးကိုရှိပါတယ် OR စည်းမျဉ်းစည်းကမ်းတွေကို (ဥပမာ) မှန်သာမှန်လျှင်ဤနယ်ပယ်ပေါ်လာပါလိမ့်မယ်
 DocType: Social Login Key,Office 365,Office 365 ကို
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ယနေ့တွင်
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ယနေ့တွင်
@@ -2146,7 +2146,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ကြီးများပြဿနာ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,custom က HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ဖိုင်တွဲအမည် Enter
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,ပုံမှန်လိပ်စာ template ကိုမတွေ့ပါ။ Setup&gt; ပုံနှိပ်ခြင်းနှင့်ကုန်အမှတ်တံဆိပ်&gt; လိပ်စာပုံစံမှအသစ်တစ်ခုဖန်တီးပါ။
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,ပုံမှန်လိပ်စာ template ကိုမတွေ့ပါ။ Setup> ပုံနှိပ်ခြင်းနှင့်ကုန်အမှတ်တံဆိပ်> လိပ်စာပုံစံမှအသစ်တစ်ခုဖန်တီးပါ။
 apps/frappe/frappe/auth.py,Unknown User,အမည်မသိအသုံးပြုသူ
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,အခန်းက္ပကိုရွေးပါ
 DocType: Comment,Deleted,Deleted
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,လင့်များကြည့်ဖို့မလုံလောက်ခွင့်ပြုချက်
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,လိပ်စာခေါင်းစဉ်မဖြစ်မနေဖြစ်ပါတယ်။
 DocType: Google Contacts,Push to Google Contacts,Google အဆက်အသွယ်မှ Push
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",အဓိကအားဖြင့် Website ကိုစိစစ်အတည်ပြုခြင်းနှင့် SEO ဆိုသည်မှာများအတွက်အသုံးပြုတဲ့ဝဘ်စာမျက်နှာ၏ &lt;head&gt; အပိုင်းအတွက် HTML ကို Added
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",အဓိကအားဖြင့် Website ကိုစိစစ်အတည်ပြုခြင်းနှင့် SEO ဆိုသည်မှာများအတွက်အသုံးပြုတဲ့ဝဘ်စာမျက်နှာ၏ &lt;head> အပိုင်းအတွက် HTML ကို Added
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ပြန်ရောက်သွားတယ်
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,item ၎င်း၏ကိုယ်ပိုင်ဆင်းသက်လာမှဆက်ပြောသည်မရနိုင်ပါ
 DocType: Session Default Settings,Session Defaults,session Defaults ကို
@@ -2346,7 +2346,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,sho
 DocType: Error Snapshot,Relapses,Relapses
 apps/frappe/frappe/public/js/frappe/social/pages/UserList.vue,No user found,အသုံးပြုသူမျှမတွေ့
 DocType: Address,Preferred Shipping Address,ပိုဦးစားပေးသည် Shipping လိပ်စာ
-apps/frappe/frappe/public/js/frappe/form/print.js,With Letter head,ပေးစာဦးခေါင်းနှင့်အတူ
+apps/frappe/frappe/public/js/frappe/form/print.js,With Letter head,ပေးစာဦးခေါ���်းနှင့်အတူ
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} created this {1},{0} {1} ဒီနေသူများကဖန်တီး
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1} in Row {2}. Restricted field: {3},{1} Row {2} အတွက်: {0} များအတွက်ခွင့်မပြု။ ကန့်သတ်သောလယ်: {3}
 DocType: S3 Backup Settings,eu-west-1,EU-အနောက်ဘက်-1
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,သတိပေးခြင်း
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ဒီအမျိုးစုံစာမျက်နှာများပေါ်တွင်ပုံနှိပ်ရစေခြင်းငှါ
 DocType: Data Migration Run,Percent Complete,ရာခိုင်နှုန်းကိုအပြီးအစီး
 DocType: Tag Category,Tag Category,tag ကို Category:
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","နှိုင်းယှဉ်မှုအဘို့,&gt; 5, &lt;10 or = 324 ကိုအသုံးပြုပါ။ အကွာအဝေးများအတွက်, 5:10 (5 &amp; 10 အကြားတန်ဖိုးများအတွက်) ကိုသုံးပါ။"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","နှိုင်းယှဉ်မှုအဘို့,> 5, &lt;10 or = 324 ကိုအသုံးပြုပါ။ အကွာအဝေးများအတွက်, 5:10 (5 &amp; 10 အကြားတန်ဖိုးများအတွက်) ကိုသုံးပါ။"
 DocType: Google Calendar,Pull from Google Calendar,Google ကပြက္ခဒိန်ထဲကနေဆွဲထုတ်
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ကူညီကြပါ
 DocType: User,Login Before,ခင်မှာ Login
@@ -2926,7 +2926,7 @@ DocType: Custom Script,Custom Script,custom Script ကို
 DocType: Address,Address Line 2,လိပ်စာလိုင်း 2
 DocType: Address,Reference,အညွှန်း
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,ရန်တာဝန်ပေး
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,ကျေးဇူးပြု၍ Setup&gt; Email&gt; Email Account မှမူလအီးမေးလ်ကိုသတ်မှတ်ပါ
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,ကျေးဇူးပြု၍ Setup> Email> Email Account မှမူလအီးမေးလ်ကိုသတ်မှတ်ပါ
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ဒေတာကိုရွှေ့ပြောင်းမြေပုံအသေးစိတ်
 DocType: Data Import,Action,action
 DocType: GSuite Settings,Script URL,script URL ကို
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Submit အပေါ် Allow
 DocType: DocField,HTML,HTML ကို
 DocType: Error Snapshot,Exception Type,ခြွင်းချက်ကအမျိုးအစား
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,-Columns Pick
-DocType: Web Page,Add code as &lt;script&gt;,&lt;script&gt; အဖြစ် code ကို Add
+DocType: Web Page,Add code as &lt;script>,&lt;script> အဖြစ် code ကို Add
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Clear ကိုအသုံးပြုသူခွင့်ပြုချက်များ
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,လာမည့်အဖြစ်အပျက်များ
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,ရှယ်ယာ-alt +
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},တန်းစီ {0} ၏တဦးတည်းဖြစ်သင့်တယ်
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> default Template: </h4><p> အသုံးပြုသည် <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templates</a> နှင့် (Custom Field များရှိလျှင်အပါအဝင်) လိပ်စာအပေါင်းတို့သည်လယ်ကွင်းရရှိနိုင်ပါလိမ့်မည် </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> default Template: </h4><p> အသုံးပြုသည် <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templates</a> နှင့် (Custom Field များရှိလျှင်အပါအဝင်) လိပ်စာအပေါင်းတို့သည်လယ်ကွင်းရရှိနိုင်ပါလိမ့်မည် </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Start ကိုနေ့စွဲဖျော်ဖြေမှု
 DocType: Role,Role Name,အခန်းက္ပအမည်
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Desk ရန် Switch

--- a/frappe/translations/my.csv
+++ b/frappe/translations/my.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Standard ဖြစ်ပါသည်
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,ပြည့်သော
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","သူတို့ရည်ရွယ်ချက်ရှိရှိဒီလယ်ကွင်းများတွင်အသုံးပြုနိုင်အဖြစ်, &lt;script> သို့မဟုတ်ပဲဇာတ်ကောင်တူ &lt;သို့မဟုတ်> တူမက HTML encoding က HTML tags များလုပ်ပါ"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","သူတို့ရည်ရွယ်ချက်ရှိရှိဒီလယ်ကွင်းများတွင်အသုံးပြုနိုင်အဖြစ်, <script> သို့မဟုတ်ပဲဇာတ်ကောင်တူ <သို့မဟုတ်> တူမက HTML encoding က HTML tags များလုပ်ပါ"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} {1} အပေါ်ဝေဖန်
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ပွေးသှား
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,footer သာ PDF
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,လာမည့်
 DocType: System Settings,Allow only one session per user,အသုံးပြုသူတစ်ဦးလျှင်တစ်ဦးတည်းသာ session ကို Allow
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,နေအိမ် / မရှိစမ်းသပ်ခြင်း Folder ကို 1 / မရှိစမ်းသပ်ခြင်း Folder ကို 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML ကို
+DocType: Website Settings,<head> HTML,<head> HTML ကို
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ကိုရွေးပါသို့မဟုတ်အသစ်တစ်ခုကိုပွဲဖန်တီးရန်အချိန် slot များအနှံ့ဆွဲယူပါ။
 DocType: Contact,Contact Details,ဆက်သွယ်ရန်အသေးစိတ်
 DocType: DocField,In Filter,Filter ကိုအတွက်
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,လင့်များကြည့်ဖို့မလုံလောက်ခွင့်ပြုချက်
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,လိပ်စာခေါင်းစဉ်မဖြစ်မနေဖြစ်ပါတယ်။
 DocType: Google Contacts,Push to Google Contacts,Google အဆက်အသွယ်မှ Push
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",အဓိကအားဖြင့် Website ကိုစိစစ်အတည်ပြုခြင်းနှင့် SEO ဆိုသည်မှာများအတွက်အသုံးပြုတဲ့ဝဘ်စာမျက်နှာ၏ &lt;head> အပိုင်းအတွက် HTML ကို Added
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",အဓိကအားဖြင့် Website ကိုစိစစ်အတည်ပြုခြင်းနှင့် SEO ဆိုသည်မှာများအတွက်အသုံးပြုတဲ့ဝဘ်စာမျက်နှာ၏ <head> အပိုင်းအတွက် HTML ကို Added
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ပြန်ရောက်သွားတယ်
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,item ၎င်း၏ကိုယ်ပိုင်ဆင်းသက်လာမှဆက်ပြောသည်မရနိုင်ပါ
 DocType: Session Default Settings,Session Defaults,session Defaults ကို
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,သတိပေးခြင်း
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ဒီအမျိုးစုံစာမျက်နှာများပေါ်တွင်ပုံနှိပ်ရစေခြင်းငှါ
 DocType: Data Migration Run,Percent Complete,ရာခိုင်နှုန်းကိုအပြီးအစီး
 DocType: Tag Category,Tag Category,tag ကို Category:
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","နှိုင်းယှဉ်မှုအဘို့,> 5, &lt;10 or = 324 ကိုအသုံးပြုပါ။ အကွာအဝေးများအတွက်, 5:10 (5 &amp; 10 အကြားတန်ဖိုးများအတွက်) ကိုသုံးပါ။"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","နှိုင်းယှဉ်မှုအဘို့,> 5, <10 or = 324 ကိုအသုံးပြုပါ။ အကွာအဝေးများအတွက်, 5:10 (5 &amp; 10 အကြားတန်ဖိုးများအတွက်) ကိုသုံးပါ။"
 DocType: Google Calendar,Pull from Google Calendar,Google ကပြက္ခဒိန်ထဲကနေဆွဲထုတ်
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ကူညီကြပါ
 DocType: User,Login Before,ခင်မှာ Login
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Submit အပေါ် Allow
 DocType: DocField,HTML,HTML ကို
 DocType: Error Snapshot,Exception Type,ခြွင်းချက်ကအမျိုးအစား
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,-Columns Pick
-DocType: Web Page,Add code as &lt;script>,&lt;script> အဖြစ် code ကို Add
+DocType: Web Page,Add code as <script>,<script> အဖြစ် code ကို Add
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Clear ကိုအသုံးပြုသူခွင့်ပြုချက်များ
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,လာမည့်အဖြစ်အပျက်များ
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,ရှယ်ယာ-alt +
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},တန်းစီ {0} ၏တဦးတည်းဖြစ်သင့်တယ်
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> default Template: </h4><p> အသုံးပြုသည် <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templates</a> နှင့် (Custom Field များရှိလျှင်အပါအဝင်) လိပ်စာအပေါင်းတို့သည်လယ်ကွင်းရရှိနိုင်ပါလိမ့်မည် </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> default Template: </h4><p> အသုံးပြုသည် <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templates</a> နှင့် (Custom Field များရှိလျှင်အပါအဝင်) လိပ်စာအပေါင်းတို့သည်လယ်ကွင်းရရှိနိုင်ပါလိမ့်မည် </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Start ကိုနေ့စွဲဖျော်ဖြေမှု
 DocType: Role,Role Name,အခန်းက္ပအမည်
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Desk ရန် Switch

--- a/frappe/translations/my.csv
+++ b/frappe/translations/my.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","enabled လျှင်, စကားဝှက်ကိုတန်ခိုးအစွမ်းသတ္တိဟာနိမ့်ဆုံး Password ကိုရမှတ်တန်ဖိုးကိုအပေါ်အခြေခံပြီးပြဌာန်းပါလိမ့်မည်။ 2 တစ်ဦးကတန်ဖိုးကိုအလတ်စားခိုင်မာတဲ့ဖြစ်ခြင်းနှင့် 4 အလွန်အားကောင်းတဲ့ဖြစ်ခြင်း။"
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","enabled လျှင်, စကားဝှက်ကိုတန်ခိုးအစွမ်းသတ္တိဟာနိမ့်ဆုံး Password ကိုရမှတ်တန်ဖိုးကိုအပေါ်အခြေခံပြီးပြဌာန်းပါလိမ့်မည်။ 2 တစ်ဦးကတန်ဖိုးကိုအလတ်စားခိုင်မာတဲ့ဖြစ်ခြင်းနှင့် 4 အလွန်အားကောင်းတဲ့ဖြစ်ခြင်း။"
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;ရေးအဖွဲ့အဖွဲ့ဝင်များ&quot; သို့မဟုတ် &quot;စီမံခန့်ခွဲမှု&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',လယ်ပြင်၌ရှိသော &#39;&#39; Check &#39;&#39; type ကို &#39;&#39; 0 &#39;သို့မဟုတ်&#39; &#39;1&#39; &#39;တစ်ခုခုရှိရမည်သည် default
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',လယ်ပြင်၌ရှိသော '' Check '' type ကို '' 0 'သို့မဟုတ်' '1' 'တစ်ခုခုရှိရမည်သည် default
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,မနေ့က
 DocType: Contact,Designation,သတ်မှတ်ပေးထားခြင်း
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,အလိုအလျောက်ချိတ်ဆက်ခြင်းတစ်ဦးတည်းသာအီးမေးလ်အကောင့်အတွက် activated နိုင်ပါသည်။
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Disable လု�
 DocType: Translation,Contributed Translation Doctype Name,ဘာသာပြန်ခြင်း DOCTYPE အမည်လှူဒါန်းခဲ့
 DocType: PayPal Settings,Redirect To,ရန် redirect
 DocType: Data Migration Mapping,Pull,ဆွဲပါ
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript ကိုစီစဉ်ဖွဲ့စည်းမှုပုံစံ: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript ကိုစီစဉ်ဖွဲ့စည်းမှုပုံစံ: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,bulk Update ကို
 DocType: Workflow State,chevron-up,Chevron-up က
 DocType: DocType,Allow Guest to View,ဧည့်သည် View မှ Allow
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),ပြီးခဲ့သည့်အပတ်ကရဲ့စွမ်းဆောင်ရည်အပေါ်အခြေခံပြီး stats ({0} ကနေ {1} မှ)
 DocType: LDAP Settings,LDAP Phone Field,LDAP ဖုန်းဖျော်ဖြေမှု
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",Document အမျိုးအစားကို ... ဥပမာဖောက်သည်
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,အဆိုပါအခြေအနေ &#39;&#39; {0} &#39;&#39; မမှန်ကန်
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,အဆိုပါအခြေအနေ '' {0} '' မမှန်ကန်
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Sub-query ကိုသို့မဟုတ် function ကိုအသုံးပြုခြင်းကန့်သတ်တာဖြစ်ပါတယ်
 apps/frappe/frappe/config/customization.py,Add your own translations,သင့်ကိုယ်ပိုင်ဘာသာ Add
@@ -714,7 +714,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL ကို
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,username {0} ရှိနှင့်ပြီးသား
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} အရေးကြီးသောမဟုတ်ပါအဖြစ်တင်သွင်းထားမရပါ
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},သင့်ရဲ့လိပ်စာ Template {0} မှာအမှားရှိပါတယ်
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} &#39;လက်ခံသူများ&#39; &#39;တစ်မမှန်ကန်တဲ့အီးမေးလ်လိပ်စာဖြစ်ပါသည်
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} 'လက်ခံသူများ' 'တစ်မမှန်ကန်တဲ့အီးမေးလ်လိပ်စာဖြစ်ပါသည်
 DocType: Footer Item,"target = ""_blank""",ပစ်မှတ် = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,host က
@@ -756,7 +756,7 @@ DocType: Currency,Currency Name,ငွေကြေးအမည်
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,အဘယ်သူမျှမထားတဲ့အီးမေးလ်
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,link ကို Expired
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;&#39; {1} &#39;အဘို့ {0} မှအရှည်သို့ပြန်သွားခြင်း&#39; &#39;{2}&#39; ၌; {3} အချက်အလက်များ၏ခြင်းကိုဖြစ်ပေါ်စေပါလိမ့်မယ်အဖြစ်အရှည်ချိန်ညှိခြင်း။
+							Setting the length as {3} will cause truncation of data.",'' {1} 'အဘို့ {0} မှအရှည်သို့ပြန်သွားခြင်း' '{2}' ၌; {3} အချက်အလက်များ၏ခြင်းကိုဖြစ်ပေါ်စေပါလိမ့်မယ်အဖြစ်အရှည်ချိန်ညှိခြင်း။
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,File Format ကိုရွေးချယ်ပါ
 DocType: Report,Javascript,Javascript ကို
 DocType: File,Content Hash,content Hash
@@ -772,13 +772,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form",စံ DOCTYPE Customize Form ကိုအသုံးပြု default အနေနဲ့ပုံနှိပ်ပုံစံရှိသည်မဟုတ်နိုင်ပါတယ်
 DocType: Report,Query,မေးခွန်း
 DocType: Customize Form,Sort Order,Sort အမိန့်
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;&#39; List ကိုကြည့်ရန်ခုနှစ်တွင် &#39;&#39; အတန်းအတွက်အမျိုးအစား {0} သည်အခွင့်မပေး {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'' List ကိုကြည့်ရန်ခုနှစ်တွင် '' အတန်းအတွက်အမျိုးအစား {0} သည်အခွင့်မပေး {1}
 DocType: Letter Head,Footer HTML,footer က HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,သင်အသစ်များသည်လယ်ပြင်၌ထည့်သွင်းရန်လိုသည့်နောက်ပိုင်းတံဆိပ်ကိုရွေးချယ်ပါ။
 ,Document Share Report,စာရွက်စာတမ်းဝေမျှမယ်အစီရင်ခံစာ
 DocType: Social Login Key,Base URL,base URL ကို
 DocType: User,Last Login,နောက်ဆုံးဝင်မည်
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},သင် {0} လယ်ကွင်းများအတွက် &#39;&#39; ဘာသာပြန်ချက် &#39;&#39; မသတ်မှတ်နိုင်
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},သင် {0} လယ်ကွင်းများအတွက် '' ဘာသာပြန်ချက် '' မသတ်မှတ်နိုင်
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,ကြောကျတိုငျ
 DocType: Chat Profile,Chat Profile,chat ကိုယ်ရေးဖိုင်
 DocType: Custom Field,Adds a custom field to a DocType,တစ် DOCTYPE မှတစ်စိတ်ကြိုက်ထည့်သွင်း
@@ -787,7 +787,7 @@ DocType: File,Is Home Folder,မူလစာမျက်နှာ Folder ကိ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,နေ့ဗ်ဘားပုံစံ
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ခိုင်လုံသောအီးမေးလ်လိပ်စာမဟုတ်ပါ
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,ပုံနှိပ်ခြင်းအဘို့အ atleast 1 စံချိန်ကို Select လုပ်ပါ
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',အသုံးပြုသူ &#39;&#39; {0} &#39;&#39; ပြီးသားအခန်းကဏ္ဍ &#39;&#39; {1} &#39;&#39; ရှိပါတယ်
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',အသုံးပြုသူ '' {0} '' ပြီးသားအခန်းကဏ္ဍ '' {1} '' ရှိပါတယ်
 DocType: System Settings,Two Factor Authentication method,နှစ်ဦးက factor authentication နည်းလမ်း
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,ပထမဦးစွာနာမကိုမသတ်မှတ်နှင့်စံချိန်သိမ်းဆည်းပါ။
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 မှတ်တမ်း
@@ -1040,7 +1040,7 @@ DocType: Property Setter,Property Setter,အိမ်ခြံမြေ Setter
 DocType: Web Form,Allow Print,ပုံနှိပ်ပါ Allow
 DocType: Communication,Clicked,နှိပ်လိုက်
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,လိုက်အောင်
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},မှ &#39;&#39; {0} {1} မရှိပါခွင့်ပြုချက်
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},မှ '' {0} {1} မရှိပါခွင့်ပြုချက်
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,ပေးပို့ဖို့စီစဉ်ထား
 DocType: DocType,Track Seen,Track မွငျ
 DocType: Dropbox Settings,File Backup,file ကို Backup ကို
@@ -1067,7 +1067,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,စာမျက်နှာက HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,ပို့ကုန် Errored တန်း
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,အဖွဲ့အမည်မှာဗလာမဖြစ်နိုင်ပါ။
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,နောက်ထပ်ဆုံမှတ်များသာ &#39;&#39; Group မှ &#39;&#39; type ကိုဆုံမှတ်များအောက်မှာနေသူများကဖန်တီးနိုင်ပါသည်
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,နောက်ထပ်ဆုံမှတ်များသာ '' Group မှ '' type ကိုဆုံမှတ်များအောက်မှာနေသူများကဖန်တီးနိုင်ပါသည်
 DocType: SMS Parameter,Header,header
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},အမည်မသိစစ်ကြောင်း: {0}
 DocType: Notification Recipient,Email By Role,အခန်းက္ပအားဖြင့်အီးမေးလ်ပို့ရန်
@@ -1253,7 +1253,7 @@ DocType: Workflow State,fast-forward,အစာရှောင်-ရှေ့ဆ
 DocType: Communication,Communication,ဆက်သွယ်ရေး
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,"Check columns to select, drag to set order.","ရွေးဖို့ကော်လံစစ်ဆေး, အမိန့်တင်ထားရန်ဆွဲယူပါ။"
 apps/frappe/frappe/templates/emails/new_message.html,Login and view in Browser,Browser ကိုအတွက်ဝင်မည်နှင့်အမြင်
-apps/frappe/frappe/core/doctype/page/page.js,Go to {0} Page,{0} &#39;s Page ကိုသွားပါ
+apps/frappe/frappe/core/doctype/page/page.js,Go to {0} Page,{0} 's Page ကိုသွားပါ
 DocType: LDAP Settings,Password for Base DN,အခြေစိုက်စခန်း DN ဘို့ Password ကို
 apps/frappe/frappe/core/doctype/version/version_view.html,Table Field,စားပွဲတင်ဖျော်ဖြေမှု
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Columns based on,အပေါ်အခြေခံပြီးကော်လံ
@@ -1458,7 +1458,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,မသင်မနေရလယ်ကွင်း: မဘို့ရာခန့်အခန်းကဏ္ဍ
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} {1} ဝေဖန်
 DocType: Data Migration Mapping,Mapping Name,မြေပုံအမည်
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: က Non-ထူးခြားသောတန်ဖိုးများရှိပါတယ်အဖြစ်ကွင်းဆင်း &#39;&#39; {1} &#39;ထူးခြားသောအဖြစ်သတ်မှတ်ထားမရနိုင်
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: က Non-ထူးခြားသောတန်ဖိုးများရှိပါတယ်အဖြစ်ကွင်းဆင်း '' {1} 'ထူးခြားသောအဖြစ်သတ်မှတ်ထားမရနိုင်
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,down list ကိုသွားလာရန်
 DocType: Currency,A symbol for this currency. For e.g. $,ဒီငွေကြေးများအတွက်သင်္ကေတ။ ဥပမာ $ for
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,အောင်မြင်စွာ updated ဘာသာ
@@ -1915,7 +1915,7 @@ DocType: Notification,Value Change,Value တစ်ခုပြောင်းရ
 DocType: Google Contacts,Authorize Google Contacts Access,Google အဆက်အသွယ် Access ကိုခွင့်ပြုရန်
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,အစီရင်ခံစာထဲကနေမှသာကိန်းဂဏန်းလယ်ကွင်းဖေါ်ပြသည်
 DocType: Data Import Beta,Import Type,သွင်းကုန်အမျိုးအစား
-DocType: Access Log,HTML Page,HTML ကို &#39;s Page
+DocType: Access Log,HTML Page,HTML ကို 's Page
 DocType: Address,Subsidiary,ထောက်ခံသောကုမ္ပဏီ
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting Connection to QZ Tray...,QZ Tray ထဲကမှ Connection ကိုကြိုးစားနေ ...
 DocType: System Settings,In Hours,အလုပ်ချိန်အတွက်
@@ -1980,7 +1980,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,AP-အရှေ့တောင်ဘက်-1
 DocType: DocType,"Must be of type ""Attach Image""",အမျိုးအစားဖြစ်ရမည် &quot;Image ကိုပူးတွဲ&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,အားလုံးရွေးထားမှုဖျက်
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},သငျသညျထားပါကပြန်လည် ပြင်ဆင်. မတတျနိုငျ {0} လယ်ပြင်၌အဘို့ &#39;&#39; သာလျှင် Read &#39;&#39;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},သငျသညျထားပါကပြန်လည် ပြင်ဆင်. မတတျနိုငျ {0} လယ်ပြင်၌အဘို့ '' သာလျှင် Read ''
 DocType: Auto Email Report,Zero means send records updated at anytime,သုညအချိန်မရွေး updated မှတ်တမ်းများပေးပို့ဆိုလိုတယ်
 DocType: Auto Email Report,Zero means send records updated at anytime,သုညအချိန်မရွေး updated မှတ်တမ်းများပေးပို့ဆိုလိုတယ်
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,complete ကို Setup
@@ -2025,7 +2025,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google ကဖောင့်
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","ဤညွှန်ကြားချက်ကိုဘယ်မှာမထောကျအကူပွုလြှငျ, GitHub ကိစ္စများပေါ်တွင်သင့်အကြံပြုချက်များအတွက် add ကိုကျေးဇူးတင်ပါ။"
 DocType: Workflow State,bookmark,bookmark
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Folder ကိုအမည်အား &#39;/&#39; (မျဉ်းစောင်း) မပါဝင်သင့်တယ်
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Folder ကိုအမည်အား '/' (မျဉ်းစောင်း) မပါဝင်သင့်တယ်
 DocType: Note,Note,မှတ်ချက်
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,error အစီရင်ခံစာ
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV ဖိုင် / Excel ကို format နဲ့ပို့ကုန် Data ဖြစ်ပါတယ်။
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,06:00 ဥပမာ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",myfield eval: doc.myfield == &#39;&#39; ငါ့အ Value ကို &#39;&#39; eval:> 18 doc.age ဒီနေရာမှာသတ်မှတ်ထားတဲ့ fieldname တန်ဖိုးကိုရှိပါတယ် OR စည်းမျဉ်းစည်းကမ်းတွေကို (ဥပမာ) မှန်သာမှန်လျှင်ဤနယ်ပယ်ပေါ်လာပါလိမ့်မယ်
+eval:doc.age>18",myfield eval: doc.myfield == '' ငါ့အ Value ကို '' eval:> 18 doc.age ဒီနေရာမှာသတ်မှတ်ထားတဲ့ fieldname တန်ဖိုးကိုရှိပါတယ် OR စည်းမျဉ်းစည်းကမ်းတွေကို (ဥပမာ) မှန်သာမှန်လျှင်ဤနယ်ပယ်ပေါ်လာပါလိမ့်မယ်
 DocType: Social Login Key,Office 365,Office 365 ကို
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ယနေ့တွင်
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ယနေ့တွင်
@@ -2171,7 +2171,7 @@ DocType: Data Migration Connector,Database Name,ဒေတာဘေ့စအမ�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Form တွင် refresh
 DocType: DocField,Select,ကိုရွေးပါ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,View Full Log in ဝင်ရန်
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ရိုးရှင်းသော Python ကိုဖော်ပြမှု, ဥပမာ: status ကို == &#39;&#39; ပွင့်လင်း &#39;နှင့်အမျိုးအစား ==&#39; &#39;ဘာဂ်&#39; &#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","ရိုးရှင်းသော Python ကိုဖော်ပြမှု, ဥပမာ: status ကို == '' ပွင့်လင်း 'နှင့်အမျိုးအစား ==' 'ဘာဂ်' '"
 apps/frappe/frappe/utils/csvutils.py,File not attached,file ကိုပူးတွဲမ
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Connection ကိုဆုံးရှုံးခဲ့ရသည်။ အချို့အင်္ဂါရပ်အလုပ်မဖြစ်ပေလိမ့်မည်။
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;aaa&quot; ကဲ့သို့ပြန်လုပ်ပါခန့်မှန်းရန်မလွယ်ကူများမှာ
@@ -2303,7 +2303,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,သာအမှားများကိုပြရန်
 DocType: Website Settings,Banner HTML,Banner က HTML
 DocType: Workflow,Send Email Alert,အီးမေးလ်သတိပေးချက်ပို့
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ Razorpay &#39;&#39; {0} &#39;&#39; ငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ Razorpay '' {0} '' ငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး
 DocType: Data Import,In Progress,ဆောင်ရွက်ဆဲဖြစ်သည်
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,backup လုပ်ဘို့တန်းစီထားသည်။ ဒါဟာတစ်နာရီမှမိနစ်အနည်းငယ်ကြာနိုင်ပါသည်။
 DocType: Error Snapshot,Pyver,Pyver
@@ -2341,7 +2341,7 @@ DocType: Website Settings,"Added HTML in the <head> section of the web page, pri
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ပြန်ရောက်သွားတယ်
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,item ၎င်း၏ကိုယ်ပိုင်ဆင်းသက်လာမှဆက်ပြောသည်မရနိုင်ပါ
 DocType: Session Default Settings,Session Defaults,session Defaults ကို
-DocType: System Settings,Expiry time of QR Code Image Page,QR Code ကို Image ကို &#39;s Page ၏သက်တမ်းကုန်ဆုံးအချိန်
+DocType: System Settings,Expiry time of QR Code Image Page,QR Code ကို Image ကို 's Page ၏သက်တမ်းကုန်ဆုံးအချိန်
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,show ကိုစုစုပေါင်းမှတ်တမ်း
 DocType: Error Snapshot,Relapses,Relapses
 apps/frappe/frappe/public/js/frappe/social/pages/UserList.vue,No user found,အသုံးပြုသူမျှမတွေ့
@@ -2730,7 +2730,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,ပြင်ဆင်�
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal ကငွေပေးချေမှုတံခါးပေါက် settings ကို
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,ထိပ်တန်း performance
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,custom Fields core ကို DOCTYPE မှဆက်ပြောသည်မရနိုင်ပါ။
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: max ကိုဇာတ်ကောင်ခွင့်ပြုအဖြစ် &#39;&#39; {1} &#39;({3}), လျှော့ချခြင်းကိုရလိမ့်မည်ဖြစ်ပါသည် {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: max ကိုဇာတ်ကောင်ခွင့်ပြုအဖြစ် '' {1} '({3}), လျှော့ချခြင်းကိုရလိမ့်မည်ဖြစ်ပါသည် {2}"
 DocType: OAuth Client,Response Type,တုန့်ပြန်အမျိုးအစား
 DocType: Contact Us Settings,Send enquiries to this email address,ဒီအီးမေးလ်လိပ်စာမေးမြန်းစုံစမ်းလိုသည်များ Send
 DocType: Letter Head,Letter Head Name,ပေးစာအကြီးအကဲအမည်
@@ -2787,7 +2787,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,image ကိုကြည့်ရန်
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","တစ်ခုခုအရောင်းအဝယ်စဉ်အတွင်းမှားသွားဟန်တူပါသည်။ ကျနော်တို့ငွေပေးချေမှုကိုအတည်ပြုကြပြီမဟုတ်ကတည်းက Paypal ကိုအလိုအလျောက်သင်ဤငွေပမာဏကိုပြန်အမ်းမည်ဖြစ်သည်။ ဒါကြောင့်မလျှင်, ညမညသဘောတရား ID ကိုကျွန်တော်တို့ကိုအီးမေးလ်တစ်စောင်ပေးပို့နှင့်ဖော်ပြထားခြင်းကျေးဇူးပြုပြီး: {0} ။"
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","စကားဝှက်အတွက်သင်္ကေတများ, နံပါတ်နှင့်အရင်းအနှီးအက္ခရာများ Include"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","&#39;&#39; {2} &#39;&#39; တံဆိပ်နှင့်အတူ &#39;&#39; {1} &#39;&#39; စိတ်တိုင်းကျဖျော်ဖြေမှုတွင်ဖော်ပြထားသော &#39;&#39; {0} &#39;&#39; လယ်ပြင်ပြီးနောက်ကိုထည့်, မတည်ရှိပါဘူး"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","'' {2} '' တံဆိပ်နှင့်အတူ '' {1} '' စိတ်တိုင်းကျဖျော်ဖြေမှုတွင်ဖော်ပြထားသော '' {0} '' လယ်ပြင်ပြီးနောက်ကိုထည့်, မတည်ရှိပါဘူး"
 DocType: List Filter,List Filter,စာရင်း Filter ကို
 DocType: Workflow State,signal,အလံပြချက်
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,ပူးတွဲပါရှိပြီး
@@ -2797,7 +2797,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,စာရွက်စာတမ်းပြန်
 DocType: Data Export,Data Export,ဒေတာကိုပို့ကုန်
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ဘာသာစကားများကိုရွေးချယ်ပါ ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},သငျသညျကိုလယ်များအတွက် &#39;&#39; Options &#39;ကို {0} သတ်မှတ်ထားလို့မရပါဘူး
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},သငျသညျကိုလယ်များအတွက် '' Options 'ကို {0} သတ်မှတ်ထားလို့မရပါဘူး
 DocType: Help Article,Author,စာရေးသူ
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,ပေးပို့ခြင်းပြန်လည်စတင်
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,ပြန်ဖွင့်
@@ -2811,15 +2811,15 @@ DocType: Web Page,Slideshow,ဆလိုက်ရှိုး
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,default လိပ်စာ Template ဖျက်ပြီးမရနိုင်ပါ
 DocType: Contact,Maintenance Manager,ပြုပြင်ထိန်းသိမ်းမှု Manager က
 DocType: Workflow State,Search,ရှာဖှေ
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ အစင်းငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး &#39;&#39; {0} &#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ အစင်းငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး &#39;&#39; {0} &#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ အစင်းငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး '' {0} '
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ အစင်းငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး '' {0} '
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,အမှိုက်ပုံးထဲရန်ရွှေ့
 DocType: Web Form,Web Form Fields,Web ကို Form တွင် Fields
 DocType: Data Import,Amended From,မှစ. ပြင်ဆင်
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},သတိပေးချက်: {1} နှင့်ဆက်စပ်သောမည်သည့် table ထဲမှာ {0} ရှာတွေ့ဖို့မအောင်မြင်ဘူး
 DocType: S3 Backup Settings,eu-north-1,EU-မြောက်ဘက်-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,ဤစာရွက်စာတမ်းလက်ရှိသေဒဏ်စီရင်ဘို့တန်းစီနေသည်။ ထပ်ကြိုးစားပါ
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,file &#39;{0}&#39; &#39;မတွေ့ရှိ
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,file '{0}' 'မတွေ့ရှိ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,ပုဒ်မ Remove
 DocType: User,Change Password,စကားဝှက်ကိုပြောင်းရန်
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X ကိုဝင်ရိုးတန်းဖျော်ဖြေမှု
@@ -3010,7 +3010,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,သည်ပျေ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,ကလေး Add
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,သွင်းကုန်တိုးတက်ရေးပါတီ
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",အခြေအနေကိုကျေနပ်လျှင်အသုံးပြုသူအချက်များနှင့်အတူဆုခခြဲ့ပါလိမ့်မည်။ ဥပမာ။ doc.status == &#39;&#39; ပိတ် &#39;&#39;
+",အခြေအနေကိုကျေနပ်လျှင်အသုံးပြုသူအချက်များနှင့်အတူဆုခခြဲ့ပါလိမ့်မည်။ ဥပမာ။ doc.status == '' ပိတ် ''
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Submitted Record ဖျက်ပစ်မရနိုင်ပါ။
 DocType: GSuite Templates,Template Name,template အမည်
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,စာရွက်စာတမ်းသစ်အမျိုးအစား
@@ -3113,7 +3113,7 @@ DocType: Web Form,Accept Payment,ငွေပေးချေမှုရမည�
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select list item,စာရင်း item ကို Select လုပ်
 apps/frappe/frappe/config/core.py,A log of request errors,တောင်းဆိုချက်ကိုအမှားများတစ် log က
 DocType: Report,Letter Head,ပေးစာဌာနမှူး
-DocType: DocType,Quick Entry,လျင်မြန်စွာ Entry &#39;
+DocType: DocType,Quick Entry,လျင်မြန်စွာ Entry '
 DocType: Web Form,Button Label,button ကိုတံဆိပ်တပ်ရန်
 apps/frappe/frappe/public/js/frappe/list/list_view.js,{0} items selected,ရှေးခယျြထား {0} ပစ္စည်းများ
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Suspend Sending,ပေးပို့ခြင်းကိုရပ်ဆိုင်း
@@ -3142,7 +3142,7 @@ DocType: Dashboard Chart,Chart Type,ဇယားအမျိုးအစား
 DocType: DocType,Auto Name,မော်တော်ကားအမည်
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,သူတို့ခန့်မှန်းရန်မလွယ်ကူကြောင်း abc သို့မဟုတ် 6543 တူပာရှောင်ကြဉ်ပါ
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,ထပ်ကြိုးစားပါ
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',သို့မဟုတ် &#39;https: //&#39;: URL ကို &#39;&#39; // http &#39;&#39; နှင့်စတင်ရမည်
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',သို့မဟုတ် 'https: //': URL ကို '' // http '' နှင့်စတင်ရမည်
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,option 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Edit ကို
@@ -3382,7 +3382,7 @@ DocType: Notification,Send alert if this field's value changes,ဤနယ်ပ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,theme အရောင်များ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,အသစ်တစ်ခုကို format ကိုအောင်အဖို့ DOCTYPE ကိုရွေးပါ
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,အသုံးပြုသူမတည်ရှိပါဘူး
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;&#39; လက်ခံသူများ &#39;&#39; မသတ်မှတ်ရသေးပါ
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'' လက်ခံသူများ '' မသတ်မှတ်ရသေးပါ
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,အခုလေးတင်
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Apply
 DocType: Footer Item,Policy,ပေါ်လစီ
@@ -3405,7 +3405,7 @@ DocType: DocType,Beta,beta ကို
 DocType: Dashboard Chart,Count,ရေတွက်
 apps/frappe/frappe/templates/includes/comments/comments.py,New Comment on {0}: {1},{0} အပေါ်နယူးမှတ်ချက်: {1}
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,restored {0} as {1},{0} {1} အဖြစ်ပွနျလညျထူထောငျ
-apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are updating, please select ""Overwrite"" else existing rows will not be deleted.","သင်ထားတဲ့ update များကိုနေတယ်ဆိုရင်, လက်ရှိအတန်းဖျက်ပြီးလိမ့်မည်မဟုတ်ပါတခြားအကြောင်း &quot;Overwrite &#39;ကိုရွေးချယ်ပါကျေးဇူးတင်ပါ။"
+apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are updating, please select ""Overwrite"" else existing rows will not be deleted.","သင်ထားတဲ့ update များကိုနေတယ်ဆိုရင်, လက်ရှိအတန်းဖျက်ပြီးလိမ့်မည်မဟုတ်ပါတခြားအကြောင်း &quot;Overwrite 'ကိုရွေးချယ်ပါကျေးဇူးတင်ပါ။"
 DocType: DocField,Translatable,ဘာသာပြန်ချက်
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Syncing {0} of {1},တစ်ပြိုင်တည်းချိန်ကိုက်ခြင်း {0} {1} ၏
 DocType: Letter Head,Letter Head in HTML,HTML မှာပေးစာဌာနမှူး
@@ -3415,9 +3415,9 @@ apps/frappe/frappe/public/js/frappe/form/controls/date.js,Date {0} must be in fo
 DocType: About Us Settings,Org History Heading,org သမိုင်း HEAD
 DocType: Print Settings,Allow Print for Cancelled,ပယ်ဖျက်ဘို့ပရင့်ထုတ်ရန် Allow
 DocType: Communication,Integrations can use this field to set email delivery status,ပေါင်းစည်းမှုရဲ့အီးမေးလ်ပေးအပ်ခြင်းအဆင့်အတန်းသတ်မှတ်ဖို့ဒီလယ်ပြင်ကိုသုံးနိုင်သည်
-DocType: Web Form,Web Page Link Text,Web ကို &#39;s Page Link ကိုစာသား
-DocType: Page,System Page,System ကို &#39;s Page
-DocType: Page,System Page,System ကို &#39;s Page
+DocType: Web Form,Web Page Link Text,Web ကို 's Page Link ကိုစာသား
+DocType: Page,System Page,System ကို 's Page
+DocType: Page,System Page,System ကို 's Page
 apps/frappe/frappe/config/settings.py,"Set default format, page size, print style etc.","Set ကို default format နဲ့, စာမျက်နှာအရွယ်အစား, ပုံနှိပ်စတိုင်စသည်တို့"
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,ESC,ESC
 apps/frappe/frappe/modules/utils.py,Customizations for <b>{0}</b> exported to:<br>{1},တင်ပို့ <b>{0}</b> များအတွက် Custom: <br> {1}
@@ -3431,7 +3431,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,စိတ်တ�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,တိုးတက်ခြင်း
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,အခန်းက္ပအားဖြင့်
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,ပျောက်ဆုံးနေ Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname အတွက်မှားနေသော fieldname &#39;&#39; {0} &#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname အတွက်မှားနေသော fieldname '' {0} '
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,တစ်ဦးစာရွက်စာတမ်းအမျိုးအစားထဲမှာရှာမယ်
 DocType: Custom DocPerm,Role and Level,အခန်းကဏ္ဍနှင့်အဆင့်
 DocType: File,Thumbnail URL,thumbnail URL ကို
@@ -3521,11 +3521,11 @@ DocType: Dashboard Chart,Filters JSON,စိစစ်မှုများ JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,အတည်ပြုရန်ဤနေရာကိုနှိပ်ပါ
 DocType: Email Account,Disable SMTP server authentication,SMTP server ကိုစစ်မှန်ကြောင်းအထောက်အထားပြသခြင်းကို Disable
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,clipboard ထံမှကူးယူပါ။
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,အစား &#39;&#39; တစ် &#39;&#39; သိပ်မကူညီကြဘူး၏ &#39;&#39; @ &#39;&#39; နှင့်တူကိုကြိုတင်ခန့်မှန်းအစားထိုး။
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,အစား '' တစ် '' သိပ်မကူညီကြဘူး၏ '' @ '' နှင့်တူကိုကြိုတင်ခန့်မှန်းအစားထိုး။
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,ငါ့အားဖြင့် Assigned
 apps/frappe/frappe/utils/data.py,Zero,သုည
 DocType: Google Drive,Backup Folder ID,Backup ကို Folder ကို ID ကို
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,မ Developer Mode တွင်! site_config.json အတွက် Set သို့မဟုတ် &#39;&#39; စိတ်တိုင်းကျ &#39;&#39; DOCTYPE စေကြလော့။
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,မ Developer Mode တွင်! site_config.json အတွက် Set သို့မဟုတ် '' စိတ်တိုင်းကျ '' DOCTYPE စေကြလော့။
 DocType: Workflow State,globe,အလုံး
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,ဦးစားပေး
@@ -3575,7 +3575,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,တရားဝင်မိုဘိုင်း nos ရိုက်ထည့်ပေးပါ
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,အဆိုပါအင်္ဂါရပ်များတချို့ကသင့်ရဲ့ browser မှာအလုပ်မဖြစ်ပေလိမ့်မည်။ နောက်ဆုံးပေါ်ဗားရှင်းသင့် browser ကို update ပေးပါ။
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,အဆိုပါအင်္ဂါရပ်များတချို့ကသင့်ရဲ့ browser မှာအလုပ်မဖြစ်ပေလိမ့်မည်။ နောက်ဆုံးပေါ်ဗားရှင်းသင့် browser ကို update ပေးပါ။
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",သိမေးမနေပါနဲ့ &#39;&#39; အကူအညီနဲ့ &#39;&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",သိမေးမနေပါနဲ့ '' အကူအညီနဲ့ ''
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ဤစာရွက်စာတမ်း {0} ဖျက်သိမ်း
 DocType: DocType,Comments and Communications will be associated with this linked document,မှတ်ချက်များနှင့်ဆက်သွယ်ရေးဝန်ကြီးကဒီနှင့်ဆက်စပ်စာရွက်စာတမ်းနှင့်အတူဆက်နွယ်လိမ့်မည်
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,filter ...
@@ -3604,7 +3604,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,subscription ကိုပြင်ဆင်ရေးစဉ် Failed
 DocType: LDAP Settings,LDAP Group Field,LDAP Group မှကွင်းဆင်း
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,တူညီသော
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',လယ်ပြင်၌ရှိသော Options ကို &#39;&#39; Dynamic Link ကို &#39;&#39; type ကို &#39;&#39; DOCTYPE &#39;အဖြစ်ရွေးချယ်စရာနှင့်အတူအခြား Link ကိုကွင်းဆင်းဖို့ထောက်ပြရမယ်
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',လယ်ပြင်၌ရှိသော Options ကို '' Dynamic Link ကို '' type ကို '' DOCTYPE 'အဖြစ်ရွေးချယ်စရာနှင့်အတူအခြား Link ကိုကွင်းဆင်းဖို့ထောက်ပြရမယ်
 DocType: About Us Settings,Team Members Heading,ရေးအဖွဲ့အဖွဲ့ဝင်များဦးတည်
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,မှားနေသော CSV ဖိုင် Format ကို
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ Tray Application ချိတ်ဆက်မှုအမှား ... <br><br> Raw Print အင်္ဂါရပ်ကိုအသုံးပြုရန်သင် QZ Tray application ကို install လုပ်ပြီး run ရမည်။ <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ Tray ကိုဒေါင်းလုတ် လုပ်၍ တပ်ဆင်ရန်ဤနေရာကိုနှိပ်ပါ</a> ။ <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">ကုန်ကြမ်းပုံနှိပ်ခြင်းအကြောင်းပိုမိုလေ့လာသင်ယူရန်ဒီနေရာကိုနှိပ်ပါ</a> ။"
@@ -3734,8 +3734,8 @@ DocType: Web Page,Web Page,ဝက်ဘ်စာမျက်နှာ
 DocType: Workflow Document State,Next Action Email Template,Next ကိုလှုပ်ရှားမှုအီးမေးလ် Template ကို
 DocType: Blog Category,Blogger,ဘလော့ဂါ
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","enabled လျှင်, စာရွက်စာတမ်းမှစသောအပြောင်းအလဲအချိန်ဇယားထဲမှာခြေရာခံများနှင့်ပြသနေကြသည်"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;&#39; ဂလိုဘယ်ရှာရန်ခုနှစ်တွင် &#39;&#39; အတန်းများတွင်အမျိုးအစား {0} အဘို့အခွင့်မပြုထား {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;&#39; ဂလိုဘယ်ရှာရန်ခုနှစ်တွင် &#39;&#39; အတန်းများတွင်အမျိုးအစား {0} အဘို့အခွင့်မပြုထား {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'' ဂလိုဘယ်ရှာရန်ခုနှစ်တွင် '' အတန်းများတွင်အမျိုးအစား {0} အဘို့အခွင့်မပြုထား {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'' ဂလိုဘယ်ရှာရန်ခုနှစ်တွင် '' အတန်းများတွင်အမျိုးအစား {0} အဘို့အခွင့်မပြုထား {1}
 DocType: Energy Point Log,Appreciation,ကြေးဇူးတငျကွောငျး
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,ကြည့်ရန်စာရင်း
 DocType: Workflow,Don't Override Status,Status ကိုဖျက်ရေးရန်မနေပါနဲ့
@@ -3787,7 +3787,7 @@ apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be renamed,အသ�
 apps/frappe/frappe/database/schema.py,Fieldname is limited to 64 characters ({0}),Fieldname 64 ဇာတ်ကောင် ({0}) မှကန့်သတ်သည်
 apps/frappe/frappe/public/js/frappe/form/grid_row.js,Cannot move row,အတန်းမရွှေ့နိုင်သလား
 apps/frappe/frappe/config/desk.py,Email Group List,အီးမေးလ်အုပ်စုစာရင်း
-DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],.ico extenstion နဲ့ icon တစ်ခုဖိုင်။ အသက် 16 &#39;x 16 ဦး px ဖြစ်သင့်သည်။ တစ် favicon မီးစက်ကိုအသုံးပြုပြီးထုတ်လုပ်။ [favicon-generator.org]
+DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],.ico extenstion နဲ့ icon တစ်ခုဖိုင်။ အသက် 16 'x 16 ဦး px ဖြစ်သင့်သည်။ တစ် favicon မီးစက်ကိုအသုံးပြုပြီးထုတ်လုပ်။ [favicon-generator.org]
 DocType: Auto Email Report,Format,format
 DocType: Email Account,Email Addresses,အီးမေးလ်လိပ်စာ
 DocType: Web Form,Allow saving if mandatory fields are not filled,မဖြစ်မနေလယ်ကွင်းပြည့်ဝကြသည်မဟုတ်လျှင်ချွေ Allow
@@ -3883,7 +3883,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,ပျက်ကွက်
 DocType: Translation,Verified,မှန်ကန်ကြောင်းအတည်ပြု
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} ကဆက်ပြောသည်
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&#39;&#39; {0} &#39;ရှာရန်
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}','' {0} 'ရှာရန်
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,ပထမဦးဆုံးအစီရင်ခံစာကိုကိုကယ်တင်ပေးပါ
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,ကဆက်ပြောသည် {0} လစဉ်ကြေး ပေး.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,မခုနှစ်တွင်
@@ -3920,14 +3920,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,ငါ့�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} မမှန်ကန်သောပြည်နယ်
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,အားလုံးစာရွက်စာတမ်းများအမျိုးအစားများမှ Apply
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,စွမ်းအင်ဝန်ကြီးဌာနအမှတ် update ကို
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ PayPal က &#39;&#39; {0} &#39;&#39; ငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',အခြားပေးချေမှုနည်းလမ်းကိုရွေးချယ်ပါ။ PayPal က '' {0} '' ငွေကြေးအရောင်းအထောကျပံ့ပေးမထားဘူး
 DocType: Chat Message,Room Type,အခန်းအမျိုးအစား
 DocType: Data Import Beta,Import Log Preview,သွင်းကုန် Log in ဝင်ရန် Preview ကို
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,ရှာရန်လယ်ကွင်း {0} တရားဝင်မဟုတ်ပါဘူး
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,တင်ထားသောဖိုင်
 DocType: Workflow State,ok-circle,ok-စက်ဝိုင်း
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP အသုံးပြုသူဖန်ဆင်းခြင်းနှင့်ပုံထုတ်ခြင်း
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',သငျသညျ &#39;&#39; ဖောက်သည်အတွက်လိမ္မော်ရောင်ကိုရှာဖွေ &#39;&#39; ကိုတောင်းမှုအရာကိုရှာတွေ့နိုင်ပါသည်
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',သငျသညျ '' ဖောက်သည်အတွက်လိမ္မော်ရောင်ကိုရှာဖွေ '' ကိုတောင်းမှုအရာကိုရှာတွေ့နိုင်ပါသည်
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,စိတ်မကောင်း! အသုံးပြုသူမိမိတို့ကိုယ်ပိုင်စံချိန်မှပြီးပြည့်စုံ access ကိုရှိသင့်သည်။
 ,Usage Info,အသုံးပြုမှုအင်ဖို
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Show ကို Keyboard Shortcuts

--- a/frappe/translations/nl.csv
+++ b/frappe/translations/nl.csv
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistieken gebaseerd op de prestaties van vorige week (van {0} tot {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP-telefoonveld
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","documenttype ..., bijvoorbeeld klant"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,De voorwaarde &#39;{0}&#39; is ongeldig
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,De voorwaarde '{0}' is ongeldig
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Het gebruik van subvragen of functies is beperkt
 apps/frappe/frappe/config/customization.py,Add your own translations,Voeg je eigen vertalingen
@@ -714,7 +714,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook-URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Gebruikersnaam {0} bestaat al
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0} : Kan niet Importeren omdat {1} niet importeerbaar is
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Er is een fout in uw Address Template {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} is een ongeldig e-mailadres in &#39;Ontvangers&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} is een ongeldig e-mailadres in 'Ontvangers'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,gastheer
@@ -756,7 +756,7 @@ DocType: Currency,Currency Name,Valutanaam
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,geen e-mails
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link verlopen
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.","De lengte terugzetten naar {0} voor &#39;{1}&#39; in &#39;{2}&#39;; Als u de lengte instelt op {3}, worden de gegevens afgekapt."
+							Setting the length as {3} will cause truncation of data.","De lengte terugzetten naar {0} voor '{1}' in '{2}'; Als u de lengte instelt op {3}, worden de gegevens afgekapt."
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Selecteer Bestandsformaat
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Content Hash
@@ -777,7 +777,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Document Delen Report
 DocType: Social Login Key,Base URL,Basis-URL
 DocType: User,Last Login,Laatst ingelogd
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},U kunt &#39;Vertaalbaar&#39; niet instellen voor veld {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},U kunt 'Vertaalbaar' niet instellen voor veld {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Kolom
 DocType: Chat Profile,Chat Profile,Chatprofiel
 DocType: Custom Field,Adds a custom field to a DocType,Voegt een aangepast veld toe aan een DocType
@@ -786,7 +786,7 @@ DocType: File,Is Home Folder,Is Thuis Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar-stijl
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} is geen geldig e-mailadres
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Selecteer tenminste 1 record voor het afdrukken
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Gebruiker &#39;{0}&#39; heeft al de rol van &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Gebruiker '{0}' heeft al de rol van '{1}'
 DocType: System Settings,Two Factor Authentication method,Twee Factor Authentication methode
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Stel eerst de naam in en sla de record op.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 records
@@ -1457,7 +1457,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Verplicht veld: set rol voor
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} bekritiseerd {1}
 DocType: Data Migration Mapping,Mapping Name,Naam toewijzen
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Veld &#39;{1}&#39; kan niet als Uniek worden ingesteld omdat het niet-unieke waarden heeft
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Veld '{1}' kan niet als Uniek worden ingesteld omdat het niet-unieke waarden heeft
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navigeer lijst naar beneden
 DocType: Currency,A symbol for this currency. For e.g. $,Een symbool voor deze valuta. Voor bijvoorbeeld $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Succesvol bijgewerkte vertalingen
@@ -1542,8 +1542,8 @@ DocType: Communication,Received,ontvangen
 DocType: Notification,"Trigger on valid methods like ""before_insert"", ""after_update"", etc (will depend on the DocType selected)","Trigger geldige methoden zoals &quot;before_insert&quot;, &quot;after_update&quot;, etc (hangt af van de geselecteerde DocType)"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0} {1},veranderde waarde van {0} {1}
 apps/frappe/frappe/core/doctype/user/user.py,Adding System Manager to this User as there must be atleast one System Manager,System Manager toe te voegen aan deze gebruikershandleiding als er tenminste een System Manager moet zijn
-DocType: Chat Message,URLs,URL&#39;s
-DocType: Data Migration Run,Total Pages,Totaal aantal pagina&#39;s
+DocType: Chat Message,URLs,URL's
+DocType: Data Migration Run,Total Pages,Totaal aantal pagina's
 apps/frappe/frappe/core/doctype/user_permission/user_permission.py,{0} has already assigned default value for {1}.,{0} heeft al een standaardwaarde toegewezen voor {1}.
 DocType: DocField,Attach Image,Bevestig Afbeelding
 DocType: Workflow State,list-alt,list-alt
@@ -2007,7 +2007,7 @@ DocType: Web Form,Show Attachments,Bijlagen weergeven
 DocType: Language,Language,Taal
 apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Browser wordt niet ondersteund
 apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Browser wordt niet ondersteund
-DocType: Social Login Key,Client URLs,Client-URL&#39;s
+DocType: Social Login Key,Client URLs,Client-URL's
 apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Some information is missing,Sommige informatie ontbreekt
 apps/frappe/frappe/public/js/frappe/views/interaction.js,{0} created successfully,{0} is succesvol aangemaakt
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Skipping {0} of {1}, {2}","{0} van {1}, {2} overslaan"
@@ -2016,7 +2016,7 @@ apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Bulk Del
 apps/frappe/frappe/core/doctype/file/file.py,File {0} does not exist,Bestand {0} bestaat niet
 DocType: Dashboard Chart,Dashboard Chart,Dashboardgrafiek
 DocType: Dashboard Chart,Last Quarter,Het laatste kwartier
-apps/frappe/frappe/config/website.py,List of themes for Website.,Lijst van de thema&#39;s voor de website.
+apps/frappe/frappe/config/website.py,List of themes for Website.,Lijst van de thema's voor de website.
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,"Dear User,","Beste gebruiker,"
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Successfully Updated,Succesvol geüpdatet
 DocType: Activity Log,Logout,Afmelden
@@ -2025,7 +2025,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google-lettertype
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Als deze aanwijzingen waar niet behulpzaam , gelieve toe te voegen in uw suggesties op GitHub Issues ."
 DocType: Workflow State,bookmark,bladwijzer
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),De mapnaam mag geen &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),De mapnaam mag geen '/' (slash)
 DocType: Note,Note,Opmerking
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Fout rapport
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Gegevens exporteren in CSV / Excel-indeling.
@@ -2130,7 +2130,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sessie Verval in ur
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Dit veld verschijnt alleen als de veldnaam hier gedefinieerde waarde heeft, of de regels waar zijn (voorbeelden): myfield Eval: doc.myfield == &#39;My Value&#39; eval: doc.age> 18"
+eval:doc.age>18","Dit veld verschijnt alleen als de veldnaam hier gedefinieerde waarde heeft, of de regels waar zijn (voorbeelden): myfield Eval: doc.myfield == 'My Value' eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Vandaag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Zodra je dit hebt ingesteld, hebben de gebruikers uitsluitend toegang tot documenten ( bijv. blog post ) waarvan de link bestaat ( bijv. Blogger ) ."
@@ -2169,7 +2169,7 @@ DocType: Data Migration Connector,Database Name,Database naam
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Vernieuwen Form
 DocType: DocField,Select,Kiezen
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Bekijk volledig logboek
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Eenvoudige Python-expressie, voorbeeld: status == &#39;Open&#39; en type == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Eenvoudige Python-expressie, voorbeeld: status == 'Open' en type == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Bestand niet bijgevoegd
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Verbinding verbroken. Sommige functies werken mogelijk niet.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Herhalingen als &quot;aaa&quot; zijn makkelijk te raden
@@ -2301,7 +2301,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Toon alleen fouten
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Stuur e-mail alert
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Selecteer een andere betaalmethode. Razorpay ondersteunt geen transacties in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Selecteer een andere betaalmethode. Razorpay ondersteunt geen transacties in valuta '{0}'
 DocType: Data Import,In Progress,Bezig
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,De wachtrij voor back-up. Het kan een paar minuten tot een uur.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2452,7 +2452,7 @@ apps/frappe/frappe/core/doctype/data_import/importer.py,Not allowed to Import,Ni
 DocType: Deleted Document,Deleted DocType,verwijderde DocType
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permission Levels,Machtigingsniveaus
 DocType: Workflow State,Warning,Waarschuwing
-apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dit kan op meerdere pagina&#39;s worden afgedrukt
+apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dit kan op meerdere pagina's worden afgedrukt
 DocType: Data Migration Run,Percent Complete,Percentage compleet
 DocType: Tag Category,Tag Category,tag Categorie
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Gebruik voor vergelijking> 5, <10 of = 324. Gebruik 5:10 voor bereiken (voor waarden tussen 5 en 10)."
@@ -2562,7 +2562,7 @@ DocType: Webhook,Request Structure,Verzoekstructuur
 DocType: Personal Data Deletion Request,Pending Verification,wachten op verificatie
 DocType: Website Meta Tag,Website Meta Tag,Website-metatag
 DocType: Email Account,"If non standard port (e.g. 587). If on Google Cloud, try port 2525.",Als niet-standaardpoort (bijvoorbeeld 587). Als u in Google Cloud poort 2525 probeert.
-apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.","Einddatum wissen, omdat dit voor gepubliceerde pagina&#39;s niet in het verleden kan zijn."
+apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.","Einddatum wissen, omdat dit voor gepubliceerde pagina's niet in het verleden kan zijn."
 DocType: User,Send Me A Copy of Outgoing Emails,Stuur me een kopie van uitgaande e-mails
 DocType: System Settings,Scheduler Last Event,Scheduler Laatste Event
 DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Voeg Google Analytics ID toe: bv. UA-89XXX57-1. Zoek hulp bij Google Analytics voor meer informatie.
@@ -2652,7 +2652,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Assign To,Toewijzen aan
 DocType: Workflow State,th-list,th-list
 DocType: Web Page,Enable Comments,Inschakelen Reacties
 apps/frappe/frappe/desk/doctype/note/note_list.js,Notes,Opmerkingen
-DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Beperk de gebruiker van dit IP-adres alleen. Meerdere IP-adressen kunnen worden toegevoegd door het scheiden van met komma&#39;s. Ook aanvaardt gedeeltelijke IP-adres, zoals (111.111.111)"
+DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Beperk de gebruiker van dit IP-adres alleen. Meerdere IP-adressen kunnen worden toegevoegd door het scheiden van met komma's. Ook aanvaardt gedeeltelijke IP-adres, zoals (111.111.111)"
 DocType: Data Import Beta,Import Preview,Voorbeeld importeren
 DocType: Communication,From,Van
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.,Selecteer eerst een groep knooppunt.
@@ -2727,7 +2727,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Wijziging
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal betaling gateway-instellingen
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Toppresteerder
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Aangepaste velden kunnen niet worden toegevoegd aan kern DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} &#39;({3}) zal afgekapt krijgen, als maximum toegestane tekens is {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} '({3}) zal afgekapt krijgen, als maximum toegestane tekens is {2}"
 DocType: OAuth Client,Response Type,response Type
 DocType: Contact Us Settings,Send enquiries to this email address,Stuur uw vragen naar dit e-mailadres
 DocType: Letter Head,Letter Head Name,Brief Hoofd Naam
@@ -2784,7 +2784,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Afbeelding Bekijken
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Het lijkt erop dat er iets mis tijdens de transactie ging. Omdat we niet de betaling bevestigd, zal Paypal automatisch betalen u dit bedrag. Als dit niet gebeurt, stuur ons dan een e-mail met vermelding van Correlation ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Inclusief symbolen, cijfers en hoofdletters in het wachtwoord"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Plaats Na veld &#39;{0}&#39; genoemd in Aangepast veld &#39;{1}&#39;, met label &#39;{2}&#39;, bestaat niet"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Plaats Na veld '{0}' genoemd in Aangepast veld '{1}', met label '{2}', bestaat niet"
 DocType: List Filter,List Filter,Lijst filter
 DocType: Workflow State,signal,signaal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Heeft bijlagen
@@ -2794,7 +2794,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Document hersteld
 DocType: Data Export,Data Export,Gegevens exporteren
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Selecteer taal ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},U kunt &#39;Opties&#39; niet instellen voor veld {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},U kunt 'Opties' niet instellen voor veld {0}
 DocType: Help Article,Author,Auteur
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,doorgaan met het verzenden
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Heropenen
@@ -2808,15 +2808,15 @@ DocType: Web Page,Slideshow,Diashow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Standaard Adres Sjabloon kan niet worden verwijderd
 DocType: Contact,Maintenance Manager,Maintenance Manager
 DocType: Workflow State,Search,Zoek
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecteer een andere betaalmethode. Stripe ondersteunt geen transacties in valuta &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecteer een andere betaalmethode. Stripe ondersteunt geen transacties in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecteer een andere betaalmethode. Stripe ondersteunt geen transacties in valuta '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecteer een andere betaalmethode. Stripe ondersteunt geen transacties in valuta '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Verplaatsen naar prullenbak
 DocType: Web Form,Web Form Fields,Webformulier invulvelden
 DocType: Data Import,Amended From,Gewijzigd Van
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Waarschuwing: Kan niet vinden {0} in een tabel met betrekking tot {1}
 DocType: S3 Backup Settings,eu-north-1,eu-noord-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Dit document is momenteel in de wachtrij voor de uitvoering. Probeer het opnieuw
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Bestand &#39;{0}&#39; niet gevonden
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Bestand '{0}' niet gevonden
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Verwijder Sectie
 DocType: User,Change Password,Verander wachtwoord
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X-as veld
@@ -3007,7 +3007,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Waarde ontbreekt voo
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Onderliggende toevoegen
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Voortgang importeren
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Als aan de voorwaarde is voldaan, wordt de gebruiker beloond met de punten. bv. doc.status == &#39;Gesloten&#39;"
+","Als aan de voorwaarde is voldaan, wordt de gebruiker beloond met de punten. bv. doc.status == 'Gesloten'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Ingediend record kan niet worden verwijderd.
 DocType: GSuite Templates,Template Name,Sjabloonnaam
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nieuw type document
@@ -3140,7 +3140,7 @@ DocType: Dashboard Chart,Chart Type,Diagramtype
 DocType: DocType,Auto Name,Auto Naam
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Vermijd sequenties zoals abc of 6543 zoals ze zijn makkelijk te raden
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Probeer het opnieuw
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL moet beginnen met &#39;http: //&#39; of &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL moet beginnen met 'http: //' of 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Optie 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Bewerken
@@ -3380,7 +3380,7 @@ DocType: Notification,Send alert if this field's value changes,Stuur Alert als d
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Themakleuren
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Selecteer een DocType om een nieuwe indeling te maken
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Gebruiker bestaat niet
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Ontvangers&#39; niet gespecificeerd
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Ontvangers' niet gespecificeerd
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,net nu
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Van toepassing zijn
 DocType: Footer Item,Policy,Beleid
@@ -3392,7 +3392,7 @@ DocType: Chat Profile,Busy,Bezig
 apps/frappe/frappe/core/page/dashboard/dashboard.js,{0} Dashboard,{0} Dashboard
 DocType: Data Migration Plan,Data Migration Plan,Gegevensmigratieplan
 apps/frappe/frappe/core/doctype/communication/communication.js,Reply,Antwoorden
-apps/frappe/frappe/config/core.py,Pages in Desk (place holders),Pagina&#39;s in Bureau (houders plaats)
+apps/frappe/frappe/config/core.py,Pages in Desk (place holders),Pagina's in Bureau (houders plaats)
 DocType: DocField,Collapsible Depends On,Inklapbaar item hangt af van
 DocType: Print Style,Print Style Name,Naam afdrukstijl
 DocType: Print Settings,Allow page break inside tables,Laat pagina-einde in tabellen
@@ -3429,7 +3429,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Aangepaste vertal
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Vooruitgang
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,per rol
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,ontbrekende velden
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ongeldige veldnaam &#39;{0}&#39; in autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ongeldige veldnaam '{0}' in autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Zoek in een documenttype
 DocType: Custom DocPerm,Role and Level,Rol en Niveau
 DocType: File,Thumbnail URL,Miniatuur URL
@@ -3530,7 +3530,7 @@ DocType: Dashboard Chart,Filters JSON,Filters JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Klik hier om te verifiëren
 DocType: Email Account,Disable SMTP server authentication,SMTP-serververificatie uitschakelen
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Gekopieerd naar het klembord.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Voorspelbare vervangingen als &#39;@&#39; in plaats van &#39;a&#39; niet helpen heel veel.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Voorspelbare vervangingen als '@' in plaats van 'a' niet helpen heel veel.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Toegewezen By Me
 apps/frappe/frappe/utils/data.py,Zero,Nul
 DocType: Google Drive,Backup Folder ID,Back-upmap-ID
@@ -3584,7 +3584,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Voer geldige mobiele nummers in
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Sommige van de functies werken mogelijk niet in je browser. Update alstublieft uw browser naar de nieuwste versie.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Sommige van de functies werken mogelijk niet in je browser. Update alstublieft uw browser naar de nieuwste versie.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ik weet het niet, vraag &#39;help&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Ik weet het niet, vraag 'help'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},heeft dit document geannuleerd {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Commentaren en Communicatie zal geassocieerd worden met dit gekoppelde document
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
@@ -3743,8 +3743,8 @@ DocType: Web Page,Web Page,Webpagina
 DocType: Workflow Document State,Next Action Email Template,Volgende actie-e-mailsjabloon
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Indien ingeschakeld, worden wijzigingen in het document bijgehouden en weergegeven in de tijdlijn"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;In Global Search&#39; niet toegestaan voor type {0} in rij {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;In Global Search&#39; niet toegestaan voor type {0} in rij {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'In Global Search' niet toegestaan voor type {0} in rij {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'In Global Search' niet toegestaan voor type {0} in rij {1}
 DocType: Energy Point Log,Appreciation,Waardering
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Lijst weergeven
 DocType: Workflow,Don't Override Status,Niet overschrijven Status
@@ -3853,7 +3853,7 @@ apps/frappe/frappe/public/js/frappe/views/treeview.js,You are not allowed to pri
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions,Gebruikersmachtigingen
 DocType: Workflow State,warning-sign,waarschuwing-teken
 DocType: Prepared Report,Prepared Report,Voorbereid rapport
-apps/frappe/frappe/config/website.py,Add meta tags to your web pages,Voeg metatags toe aan uw webpagina&#39;s
+apps/frappe/frappe/config/website.py,Add meta tags to your web pages,Voeg metatags toe aan uw webpagina's
 DocType: Workflow State,User,Gebruiker
 DocType: Website Settings,"Show title in browser window as ""Prefix - title""",Toon titel in browservenster als &quot;Prefix - titel&quot;
 DocType: Payment Gateway,Gateway Settings,Gateway-instellingen
@@ -3885,14 +3885,14 @@ apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,Assign 
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Section Heading,sectie Koppen
 DocType: Website Settings,Title Prefix,Titel Voorvoegsel
 DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,Kennisgevingen en bulk mails worden verstuurd vanaf deze server voor uitgaande mail.
-DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,"Elke string-gebaseerde printertalen kunnen worden gebruikt. Het schrijven van onbewerkte opdrachten vereist kennis van de moedertaal van de printer, geleverd door de printerfabrikant. Raadpleeg de ontwikkelaarshandleiding van de printerfabrikant over het schrijven van hun eigen opdrachten. Deze commando&#39;s worden aan de serverzijde weergegeven met behulp van de Jinja Templating Language."
+DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,"Elke string-gebaseerde printertalen kunnen worden gebruikt. Het schrijven van onbewerkte opdrachten vereist kennis van de moedertaal van de printer, geleverd door de printerfabrikant. Raadpleeg de ontwikkelaarshandleiding van de printerfabrikant over het schrijven van hun eigen opdrachten. Deze commando's worden aan de serverzijde weergegeven met behulp van de Jinja Templating Language."
 DocType: Workflow State,cog,tandwiel
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Sync on Migrate,Sync op Migrate
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently Viewing,Momenteel wordt bekeken
 DocType: DocField,Default,Standaard
 DocType: Translation,Verified,geverifieerd
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} toegevoegd
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Zoek naar &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Zoek naar '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Sla het rapport eerst
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonnees toegevoegd
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Niet In
@@ -3929,14 +3929,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Me
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} geen geldig Status
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Toepassen op alle soorten documenten
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Update energiepunt
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Selecteer een andere betaalmethode. PayPal biedt geen ondersteuning voor transacties in valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Selecteer een andere betaalmethode. PayPal biedt geen ondersteuning voor transacties in valuta '{0}'
 DocType: Chat Message,Room Type,Kamertype
 DocType: Data Import Beta,Import Log Preview,Voorbeeld van logboek importeren
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Search veld {0} is niet geldig
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,geupload bestand
 DocType: Workflow State,ok-circle,ok-cirkel
 DocType: LDAP Settings,LDAP User Creation and Mapping,Maken en toewijzen van LDAP-gebruikers
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Je kunt dingen vinden door te vragen &#39;vinden oranje in de klanten&#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Je kunt dingen vinden door te vragen 'vinden oranje in de klanten'
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Sorry! Gebruiker dient volledige toegang tot eigen record te hebben.
 ,Usage Info,Gebruiksinfo
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Sneltoetsen weergeven
@@ -3985,7 +3985,7 @@ DocType: Chat Message,Room,Kamer
 apps/frappe/frappe/public/js/frappe/change_log.html,updated to {0},bijgewerkt om {0}
 apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,Achtergrondtaken worden niet uitgevoerd. Neem contact op met de beheerder
 DocType: Portal Settings,Custom Menu Items,Aangepaste menu-items
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,"Alle afbeeldingen die bij de website dia&#39;s zijn gekoppeld, moeten publiek zijn"
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,"Alle afbeeldingen die bij de website dia's zijn gekoppeld, moeten publiek zijn"
 DocType: Workflow State,chevron-right,chevron-rechts
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,"To use Google Drive, enable {0}.",Schakel {0} in om Google Drive te gebruiken.
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be in developer mode to edit a Standard Web Form,U moet ontwikkelaarsmodus inschakelen om een standaard webformulier te kunnen bewerken

--- a/frappe/translations/nl.csv
+++ b/frappe/translations/nl.csv
@@ -1426,7 +1426,7 @@ DocType: Report,Is Standard,Is Standaard
 DocType: Desktop Icon,_report,_rapport
 DocType: Desktop Icon,_report,_rapport
 DocType: Dashboard Chart,Full,vol
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Doe geen HTML coderen HTML-tags zoals &lt;script> of gewoon tekens zoals &lt;en>, omdat ze bewust kunnen worden gebruikt in dit gebied"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Doe geen HTML coderen HTML-tags zoals <script> of gewoon tekens zoals <en>, omdat ze bewust kunnen worden gebruikt in dit gebied"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} bekritiseerd op {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Rennen
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Voettekst wordt a
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,In afwachting van
 DocType: System Settings,Allow only one session per user,Laat slechts één sessie per gebruiker
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folder home / Test 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selecteer of sleep over tijdsloten om een nieuwe gebeurtenis te maken.
 DocType: Contact,Contact Details,Contactgegevens
 DocType: DocField,In Filter,In Filter
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Niet genoeg toestemming om links te zien
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adres titel is verplicht.
 DocType: Google Contacts,Push to Google Contacts,Push naar Google Contacten
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Toegevoegd HTML in de &lt;head> sectie van de webpagina, voornamelijk gebruikt voor de website van verificatie en SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Toegevoegd HTML in de <head> sectie van de webpagina, voornamelijk gebruikt voor de website van verificatie en SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiverend
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Artikel kan niet worden toegevoegd aan zijn eigen onderliggende artikelen.
 DocType: Session Default Settings,Session Defaults,Standaardwaarden sessie
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,Waarschuwing
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dit kan op meerdere pagina&#39;s worden afgedrukt
 DocType: Data Migration Run,Percent Complete,Percentage compleet
 DocType: Tag Category,Tag Category,tag Categorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Gebruik voor vergelijking> 5, &lt;10 of = 324. Gebruik 5:10 voor bereiken (voor waarden tussen 5 en 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Gebruik voor vergelijking> 5, <10 of = 324. Gebruik 5:10 voor bereiken (voor waarden tussen 5 en 10)."
 DocType: Google Calendar,Pull from Google Calendar,Uit Google Agenda halen
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Help
 DocType: User,Login Before,Login Voor
@@ -3102,7 +3102,7 @@ DocType: DocField,Allow on Submit,Laat op Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Uitzondering Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Kies Kolommen
-DocType: Web Page,Add code as &lt;script>,Voe code toe als <script>
+DocType: Web Page,Add code as <script>,Voe code toe als <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Wis gebruikersrechten
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Geplande evenementen
@@ -3479,26 +3479,26 @@ DocType: Workflow State,share-alt,delen-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Wachtrij moet onderdeel uitmaken van {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Standaardsjabloon </ h4> 
  <p> Gebruikt <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> en al de velden van Address ( inclusief aangepaste velden eventuele) zal beschikbaar </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% indien address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} 
- {{city}} & lt; br & gt; 
- {% als state%} {{state}} & lt; br & gt; {% endif -%} 
- {% als pincode%} PIN: {{pincode}} & lt; br & gt; {% endif -%} 
- {{land}} & lt; br & gt; 
- {% wanneer de telefoon%} Telefoon: {{telefoon}} & lt; br & gt; { % endif -%} 
- {% per faxbericht%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% indien email_id%} E-mail: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% indien address_line2%} {{address_line2}} <br> { % endif -%} 
+ {{city}} <br> 
+ {% als state%} {{state}} <br> {% endif -%} 
+ {% als pincode%} PIN: {{pincode}} <br> {% endif -%} 
+ {{land}} <br> 
+ {% wanneer de telefoon%} Telefoon: {{telefoon}} <br> { % endif -%} 
+ {% per faxbericht%} Fax: {{fax}} <br> {% endif -%} 
+ {% indien email_id%} E-mail: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Begindataveld
 DocType: Role,Role Name,Rolnaam

--- a/frappe/translations/nl.csv
+++ b/frappe/translations/nl.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Bestandskop
 DocType: DocField,In Global Search,In Global Search
 DocType: System Settings,Brute Force Security,Brute Force-beveiliging
 DocType: Workflow State,indent-left,inspringing-links
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} jaar geleden
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} jaar geleden
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Het is riskant om dit bestand te verwijderen: {0}. Neem dan contact op met uw systeembeheerder.
 DocType: Currency,Currency Name,Valutanaam
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,geen e-mails
@@ -1048,7 +1048,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Geen {0} gevo
 apps/frappe/frappe/config/customization.py,Add custom forms.,Voeg aangepaste formulieren.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} van {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,dit document ingediend
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Configuratie&gt; Gebruikersrechten
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configuratie> Gebruikersrechten
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Het systeem biedt een groot aantal vooraf gedefinieerde rollen . U kunt nieuwe rollen toevoegen om specifiekere machtigingen in te stellen .
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo-
@@ -1269,7 +1269,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Als de gebruiker een rol gecontroleerd heeft, dan is de gebruiker wordt een &quot;Systeem&quot;. &quot;Systeem&quot; heeft toegang tot de desktop"
 DocType: System Settings,Date and Number Format,Datum en Nummer Formaat
 apps/frappe/frappe/model/document.py,one of,Een van de
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Configuratie&gt; Formulier aanpassen
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Configuratie> Formulier aanpassen
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Het controleren van het ene moment
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Show-tags
 DocType: DocField,HTML Editor,HTML-editor
@@ -1277,7 +1277,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Facturering
 DocType: Email Queue,Not Sent,Niet verzonden
 DocType: Web Form,Actions,Acties
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Stel in&gt; Gebruiker
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Stel in> Gebruiker
 DocType: Workflow State,align-justify,align-justify
 DocType: User,Middle Name (Optional),Tussenvoegsel (optioneel)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Niet toegestaan
@@ -1426,7 +1426,7 @@ DocType: Report,Is Standard,Is Standaard
 DocType: Desktop Icon,_report,_rapport
 DocType: Desktop Icon,_report,_rapport
 DocType: Dashboard Chart,Full,vol
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Doe geen HTML coderen HTML-tags zoals &lt;script&gt; of gewoon tekens zoals &lt;en&gt;, omdat ze bewust kunnen worden gebruikt in dit gebied"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Doe geen HTML coderen HTML-tags zoals &lt;script> of gewoon tekens zoals &lt;en>, omdat ze bewust kunnen worden gebruikt in dit gebied"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} bekritiseerd op {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Rennen
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Voettekst wordt a
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,In afwachting van
 DocType: System Settings,Allow only one session per user,Laat slechts één sessie per gebruiker
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folder home / Test 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selecteer of sleep over tijdsloten om een nieuwe gebeurtenis te maken.
 DocType: Contact,Contact Details,Contactgegevens
 DocType: DocField,In Filter,In Filter
@@ -2042,7 +2042,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Inloggen niet toegestaan op dit moment
 DocType: Data Migration Run,Current Mapping Action,Huidige toewijzingsactie
 DocType: Dashboard Chart Source,Source Name,Bron naam
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Geen e-mailaccount gekoppeld aan de gebruiker. Voeg een account toe onder Gebruiker&gt; E-mailinbox.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Geen e-mailaccount gekoppeld aan de gebruiker. Voeg een account toe onder Gebruiker> E-mailinbox.
 DocType: Email Account,Email Sync Option,E-mail Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rij nr
 DocType: Async Task,Runtime,Runtime
@@ -2057,7 +2057,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Reeds in 
 DocType: User Email,Enable Outgoing,Inschakelen Uitgaand
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Custom Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-mailaccount niet ingesteld. Maak een nieuw e-mailaccount aan via Instellingen&gt; E-mail&gt; E-mailaccount
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-mailaccount niet ingesteld. Maak een nieuw e-mailaccount aan via Instellingen> E-mail> E-mailaccount
 DocType: Comment,Submitted,Ingediend
 DocType: Contact,Pulled from Google Contacts,Getrokken uit Google Contacten
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ongeldig verzoek
@@ -2130,7 +2130,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Sessie Verval in ur
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Dit veld verschijnt alleen als de veldnaam hier gedefinieerde waarde heeft, of de regels waar zijn (voorbeelden): myfield Eval: doc.myfield == &#39;My Value&#39; eval: doc.age&gt; 18"
+eval:doc.age>18","Dit veld verschijnt alleen als de veldnaam hier gedefinieerde waarde heeft, of de regels waar zijn (voorbeelden): myfield Eval: doc.myfield == &#39;My Value&#39; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Vandaag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Zodra je dit hebt ingesteld, hebben de gebruikers uitsluitend toegang tot documenten ( bijv. blog post ) waarvan de link bestaat ( bijv. Blogger ) ."
@@ -2144,7 +2144,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,HOOFDLETTERS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Aangepaste HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Voer mapnaam
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Geen standaard adressjabloon gevonden. Maak een nieuwe aan via Instellingen&gt; Afdrukken en branding&gt; Adressjabloon.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Geen standaard adressjabloon gevonden. Maak een nieuwe aan via Instellingen> Afdrukken en branding> Adressjabloon.
 apps/frappe/frappe/auth.py,Unknown User,Onbekende gebruiker
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Selecteer Rol
 DocType: Comment,Deleted,Verwijderd
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Niet genoeg toestemming om links te zien
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adres titel is verplicht.
 DocType: Google Contacts,Push to Google Contacts,Push naar Google Contacten
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Toegevoegd HTML in de &lt;head&gt; sectie van de webpagina, voornamelijk gebruikt voor de website van verificatie en SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Toegevoegd HTML in de &lt;head> sectie van de webpagina, voornamelijk gebruikt voor de website van verificatie en SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiverend
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Artikel kan niet worden toegevoegd aan zijn eigen onderliggende artikelen.
 DocType: Session Default Settings,Session Defaults,Standaardwaarden sessie
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,Waarschuwing
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dit kan op meerdere pagina&#39;s worden afgedrukt
 DocType: Data Migration Run,Percent Complete,Percentage compleet
 DocType: Tag Category,Tag Category,tag Categorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Gebruik voor vergelijking&gt; 5, &lt;10 of = 324. Gebruik 5:10 voor bereiken (voor waarden tussen 5 en 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Gebruik voor vergelijking> 5, &lt;10 of = 324. Gebruik 5:10 voor bereiken (voor waarden tussen 5 en 10)."
 DocType: Google Calendar,Pull from Google Calendar,Uit Google Agenda halen
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Help
 DocType: User,Login Before,Login Voor
@@ -2923,7 +2923,7 @@ DocType: Custom Script,Custom Script,Aangepaste Script
 DocType: Address,Address Line 2,Adres Lijn 2
 DocType: Address,Reference,Referentie
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Toegewezen Aan
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Stel het standaard e-mailaccount in via Setup&gt; Email&gt; Email Account
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Stel het standaard e-mailaccount in via Setup> Email> Email Account
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Data Migration Mapping Detail
 DocType: Data Import,Action,Actie
 DocType: GSuite Settings,Script URL,Script URL
@@ -3102,7 +3102,7 @@ DocType: DocField,Allow on Submit,Laat op Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Uitzondering Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Kies Kolommen
-DocType: Web Page,Add code as &lt;script&gt;,Voe code toe als <script>
+DocType: Web Page,Add code as &lt;script>,Voe code toe als <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Wis gebruikersrechten
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Geplande evenementen
@@ -3479,15 +3479,15 @@ DocType: Workflow State,share-alt,delen-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Wachtrij moet onderdeel uitmaken van {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Standaardsjabloon </ h4> 
  <p> Gebruikt <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> en al de velden van Address ( inclusief aangepaste velden eventuele) zal beschikbaar </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/no.csv
+++ b/frappe/translations/no.csv
@@ -749,7 +749,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Filbackup e
 DocType: DocField,In Global Search,I Global Søk
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,innrykk-venstre
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} år siden
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} år siden
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Det er risikabelt å slette denne filen: {0}. Ta kontakt med din System Manager.
 DocType: Currency,Currency Name,Valuta Name
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ingen e-post
@@ -1047,7 +1047,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Nei {0} funne
 apps/frappe/frappe/config/customization.py,Add custom forms.,Legg tilpassede skjemaer.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} i {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,innsendt dette dokumentet
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Oppsett&gt; Brukertillatelser
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Oppsett> Brukertillatelser
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Systemet gir mange forhåndsdefinerte roller. Du kan legge til nye roller for å sette finere tillatelser.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1268,7 +1268,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Hvis brukeren har noen rolle sjekket, så brukeren blir en &quot;System Bruker&quot;. &quot;System Bruker&quot; har tilgang til skrivebordet"
 DocType: System Settings,Date and Number Format,Dato og tallformat
 apps/frappe/frappe/model/document.py,one of,en av
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Oppsett&gt; Tilpass skjema
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Oppsett> Tilpass skjema
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kontrollere en stund
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Vis Tags
 DocType: DocField,HTML Editor,HTML Editor
@@ -1276,7 +1276,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Billing
 DocType: Email Queue,Not Sent,Ikke sendt
 DocType: Web Form,Actions,Handlinger
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Oppsett&gt; Bruker
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Oppsett> Bruker
 DocType: Workflow State,align-justify,justere-rettferdig
 DocType: User,Middle Name (Optional),Middle Name (valgfritt)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ikke Tillatt
@@ -1424,7 +1424,7 @@ DocType: User,System User,System User
 DocType: Report,Is Standard,Er Standard
 DocType: Desktop Icon,_report,_rapportere
 DocType: Dashboard Chart,Full,Full
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ikke HTML Encode HTML-tagger som &lt;script&gt; eller bare tegn som &lt;eller&gt;, da de kan bli bevisst brukes i dette feltet"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ikke HTML Encode HTML-tagger som &lt;script> eller bare tegn som &lt;eller>, da de kan bli bevisst brukes i dette feltet"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritisert på {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Løpe
@@ -1806,7 +1806,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Bunntekst vises b
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Avventer
 DocType: System Settings,Allow only one session per user,Tillat bare én økt per bruker
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Hjem / Test mappe 1 / Test mappe 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Velg eller dra på tvers av tidsluker for å opprette en ny hendelse.
 DocType: Contact,Contact Details,Kontaktinformasjon
 DocType: DocField,In Filter,I Filter
@@ -2039,7 +2039,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Logg ikke tillatt på dette tidspunktet
 DocType: Data Migration Run,Current Mapping Action,Aktuell kartleggingshandling
 DocType: Dashboard Chart Source,Source Name,Source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Ingen e-postkonto tilknyttet brukeren. Legg til en konto under Bruker&gt; E-postinnboks.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Ingen e-postkonto tilknyttet brukeren. Legg til en konto under Bruker> E-postinnboks.
 DocType: Email Account,Email Sync Option,E-post Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rad nr
 DocType: Async Task,Runtime,Runtime
@@ -2054,7 +2054,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Allerede 
 DocType: User Email,Enable Outgoing,Aktiver utgående
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Egendefinerte definerte~~POS=HEADCOMP tagger
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-postkonto er ikke konfigurert. Opprett en ny e-postkonto fra Oppsett&gt; E-post&gt; E-postkonto
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-postkonto er ikke konfigurert. Opprett en ny e-postkonto fra Oppsett> E-post> E-postkonto
 DocType: Comment,Submitted,Sendt inn
 DocType: Contact,Pulled from Google Contacts,Trekkes fra Google-kontakter
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,I gyldig forespørsel
@@ -2128,7 +2128,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Session Utløps i Ho
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Dette feltet vises bare hvis feltnavn er definert her har verdi eller reglene er sanne (eksempler): myfield eval: doc.myfield == &#39;Min Value&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Dette feltet vises bare hvis feltnavn er definert her har verdi eller reglene er sanne (eksempler): myfield eval: doc.myfield == &#39;Min Value&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Kontor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,I dag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Når du har satt dette, vil brukerne bare kunne åpne dokumenter (f.eks. Blogginnlegg) der koblingen finnes (f.eks. Blogger)."
@@ -2142,7 +2142,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,STOR BOKSTAV
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Skriv inn mappenavn
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Ingen standard adressemaler funnet. Opprett en ny fra Oppsett&gt; Utskrift og merkevarebygging&gt; Adressemal.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Ingen standard adressemaler funnet. Opprett en ny fra Oppsett> Utskrift og merkevarebygging> Adressemal.
 apps/frappe/frappe/auth.py,Unknown User,Ukjent bruker
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Velg rolle
 DocType: Comment,Deleted,Slettet
@@ -2333,7 +2333,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ikke nok tillatelse til å se koblinger
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresse Tittel er obligatorisk.
 DocType: Google Contacts,Push to Google Contacts,Trykk til Google-kontakter
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Lagt HTML i &lt;head&gt; delen av nettsiden, primært brukes til nettstedet verifikasjon og SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Lagt HTML i &lt;head> delen av nettsiden, primært brukes til nettstedet verifikasjon og SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Residiverende
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Elementet kan ikke legges til sine egne etterkommere
 DocType: Session Default Settings,Session Defaults,Økt mislighold
@@ -2453,7 +2453,7 @@ DocType: Workflow State,Warning,Advarsel
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dette kan skrives ut på flere sider
 DocType: Data Migration Run,Percent Complete,Prosent fullført
 DocType: Tag Category,Tag Category,tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning, bruk&gt; 5, &lt;10 eller = 324. For områder kan du bruke 5:10 (for verdier mellom 5 og 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning, bruk> 5, &lt;10 eller = 324. For områder kan du bruke 5:10 (for verdier mellom 5 og 10)."
 DocType: Google Calendar,Pull from Google Calendar,Trekk fra Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjelp
 DocType: User,Login Before,Login Før
@@ -2921,7 +2921,7 @@ DocType: Custom Script,Custom Script,Custom Script
 DocType: Address,Address Line 2,Adresselinje 2
 DocType: Address,Reference,Referanse
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Tilordnet
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Angi standard e-postkonto fra Oppsett&gt; E-post&gt; E-postkonto
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Angi standard e-postkonto fra Oppsett> E-post> E-postkonto
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Data Migrering Kartlegging Detalj
 DocType: Data Import,Action,Handling
 DocType: GSuite Settings,Script URL,Skript URL
@@ -3099,7 +3099,7 @@ DocType: DocField,Allow on Submit,Tillat på Send
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Unntak Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Plukk kolonner
-DocType: Web Page,Add code as &lt;script&gt;,Legg til kode som &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Legg til kode som &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Fjern brukertillatelser
 DocType: Webhook,Headers,overskrifter
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kommende arrangementer
@@ -3473,16 +3473,16 @@ DocType: Workflow State,share-alt,aksje-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Køen bør være en av {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Standard mal </h4><p> Bruker <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> og alle felt av Adresse (inkludert egendefinerte felt hvis noen) vil være tilgjengelig </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Standard mal </h4><p> Bruker <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> og alle felt av Adresse (inkludert egendefinerte felt hvis noen) vil være tilgjengelig </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Startdatafelt
 DocType: Role,Role Name,Rolle Navn
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Bytt til skrivebord

--- a/frappe/translations/no.csv
+++ b/frappe/translations/no.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Hvis aktivert, vil passordstyrken bli håndhevet basert på verdien Minimumskodepoeng. En verdi på 2 er middels sterk og 4 er veldig sterk."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Hvis aktivert, vil passordstyrken bli håndhevet basert på verdien Minimumskodepoeng. En verdi på 2 er middels sterk og 4 er veldig sterk."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Team medlemmer&quot; eller &quot;Management&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Standard for &#39;Sjekk&#39; type felt må være enten &#39;0&#39; eller &#39;1&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Standard for 'Sjekk' type felt må være enten '0' eller '1'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,I går
 DocType: Contact,Designation,Betegnelse
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Automatisk kobling kan bare aktiveres for en e-postkonto.
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Deaktiver Rappor
 DocType: Translation,Contributed Translation Doctype Name,Bidragt oversettelse Doctype Name
 DocType: PayPal Settings,Redirect To,omdirigere å
 DocType: Data Migration Mapping,Pull,Dra
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Javascript Format: frappe.query_reports [&#39;rapportnavn&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Javascript Format: frappe.query_reports ['rapportnavn'] = {}
 DocType: Bulk Update,Bulk Update,Bulk Update
 DocType: Workflow State,chevron-up,chevron-up
 DocType: DocType,Allow Guest to View,Tillat gjeste til Vis
@@ -755,7 +755,7 @@ DocType: Currency,Currency Name,Valuta Name
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ingen e-post
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link utløpt
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Tilbakestille lengden til {0} for &#39;{1}&#39; i &#39;{2}&#39;; Innstilling av lengden som {3} vil føre til avkorting av data.
+							Setting the length as {3} will cause truncation of data.",Tilbakestille lengden til {0} for '{1}' i '{2}'; Innstilling av lengden som {3} vil føre til avkorting av data.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Velg Filformat
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Content Hash
@@ -771,13 +771,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standard DocType kan ikke ha standard utskriftsformat, bruk Tilpass skjema"
 DocType: Report,Query,Spørring
 DocType: Customize Form,Sort Order,Sorteringsrekkefølge
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;I List View&#39; ikke tillatt for typen {0} i rad {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'I List View' ikke tillatt for typen {0} i rad {1}
 DocType: Letter Head,Footer HTML,Bunntekst HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,Velg etiketten etter som du vil sette inn nytt felt.
 ,Document Share Report,Dokument Del Rapporter
 DocType: Social Login Key,Base URL,Basisadresse
 DocType: User,Last Login,Siste innlogging
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Du kan ikke angi &#39;Oversetterbar&#39; for felt {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Du kan ikke angi 'Oversetterbar' for felt {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Kolonne
 DocType: Chat Profile,Chat Profile,Chat profil
 DocType: Custom Field,Adds a custom field to a DocType,Legger til et egendefinert felt til en DOCTYPE
@@ -1065,7 +1065,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Page HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Eksporter feilede rader
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Gruppens navn kan ikke være tomt.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Ytterligere noder kan bare skapt under &#39;Gruppe&#39; type noder
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Ytterligere noder kan bare skapt under 'Gruppe' type noder
 DocType: SMS Parameter,Header,Header
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Ukjent Kolonne: {0}
 DocType: Notification Recipient,Email By Role,E-post Ved Rolle
@@ -1455,7 +1455,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obligatorisk felt: set rolle for
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritisert {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Felt &#39;{1}&#39; kan ikke settes som unikt ettersom det har ikke-unike verdier
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Felt '{1}' kan ikke settes som unikt ettersom det har ikke-unike verdier
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Naviger listen ned
 DocType: Currency,A symbol for this currency. For e.g. $,Et symbol for denne valuta. For eksempel $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Vellykket oppdaterte oversettelser
@@ -2022,7 +2022,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Hvis disse instruksjonene der ikke nyttig, kan du legge inn dine forslag på GitHub Issues."
 DocType: Workflow State,bookmark,bokmerke
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Mappenavn skal ikke inneholde &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Mappenavn skal ikke inneholde '/' (slash)
 DocType: Note,Note,Notat
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Feilrapport
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Eksporter data i CSV / Excel-format.
@@ -2128,7 +2128,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Session Utløps i Ho
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Dette feltet vises bare hvis feltnavn er definert her har verdi eller reglene er sanne (eksempler): myfield eval: doc.myfield == &#39;Min Value&#39; eval: doc.age> 18
+eval:doc.age>18",Dette feltet vises bare hvis feltnavn er definert her har verdi eller reglene er sanne (eksempler): myfield eval: doc.myfield == 'Min Value' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Kontor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,I dag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Når du har satt dette, vil brukerne bare kunne åpne dokumenter (f.eks. Blogginnlegg) der koblingen finnes (f.eks. Blogger)."
@@ -2167,7 +2167,7 @@ DocType: Data Migration Connector,Database Name,Database navn
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Refresh Form
 DocType: DocField,Select,Velg
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Vis full logg
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Eksempel: status == &#39;Open&#39; og skriv == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Eksempel: status == 'Open' og skriv == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Fil ikke festet
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Forbindelse mistet. Noen funksjoner fungerer kanskje ikke.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Gjentar som &quot;aaa&quot; er lette å gjette
@@ -2299,7 +2299,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Vis bare feil
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Send epostvarsel
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Vennligst velg en annen betalingsmåte. Razorpay støtter ikke transaksjoner i valuta &#39;{0}
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Vennligst velg en annen betalingsmåte. Razorpay støtter ikke transaksjoner i valuta '{0}
 DocType: Data Import,In Progress,I prosess
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,I kø for sikkerhetskopiering. Det kan ta noen minutter til en time.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2783,7 +2783,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Bilde Vis
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Ser ut som noe gikk galt under transaksjonen. Siden vi ikke har bekreftet betalingen, vil Paypal automatisk refundere deg dette beløpet. Hvis den ikke gjør det, kan du sende oss en e-post og nevner Korrelasjon ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Inkluder symboler, tall og hovedbokstaver i passordet"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Sett Etter feltet {0} nevnt i Custom Feltet &#39;{1}&#39;, med etiketten {2}, eksisterer ikke"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Sett Etter feltet {0} nevnt i Custom Feltet '{1}', med etiketten {2}, eksisterer ikke"
 DocType: List Filter,List Filter,Listefilter
 DocType: Workflow State,signal,signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Har Vedlegg
@@ -2793,7 +2793,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokumentgjenoppretting
 DocType: Data Export,Data Export,Data Eksport
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Velg språk...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Du kan ikke angi &#39;Alternativer&#39; for felt {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Du kan ikke angi 'Alternativer' for felt {0}
 DocType: Help Article,Author,Forfatter
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Fortsett Sending
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Gjenåpne
@@ -2807,15 +2807,15 @@ DocType: Web Page,Slideshow,Lysbildefremvisning
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Standard adresse mal kan ikke slettes
 DocType: Contact,Maintenance Manager,Vedlikeholdsbehandling
 DocType: Workflow State,Search,Søk
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vennligst velg en annen betalingsmetode. Stripe støtter ikke transaksjoner i valuta &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vennligst velg en annen betalingsmetode. Stripe støtter ikke transaksjoner i valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vennligst velg en annen betalingsmetode. Stripe støtter ikke transaksjoner i valuta '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vennligst velg en annen betalingsmetode. Stripe støtter ikke transaksjoner i valuta '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Flytt til søppel
 DocType: Web Form,Web Form Fields,Web Form Fields
 DocType: Data Import,Amended From,Endret Fra
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Advarsel: Kan ikke finne {0} i ethvert bord knyttet til {1}
 DocType: S3 Backup Settings,eu-north-1,eu-nord-en
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,"Dette dokumentet er for tiden i kø for gjennomføring. Vær så snill, prøv på nytt"
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Filen &#39;{0}&#39; ikke funnet
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Filen '{0}' ikke funnet
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Fjern Seksjon
 DocType: User,Change Password,Bytt passord
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X aksefelt
@@ -3005,7 +3005,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Verdi mangler for
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Legg Child
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Importer fremdrift
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Hvis betingelsen er tilfreds, vil brukeren bli belønnet med poengene. f.eks. doc.status == &#39;Stengt&#39;"
+","Hvis betingelsen er tilfreds, vil brukeren bli belønnet med poengene. f.eks. doc.status == 'Stengt'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Skrevet Record kan ikke slettes.
 DocType: GSuite Templates,Template Name,Malnavn
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ny type dokument
@@ -3137,7 +3137,7 @@ DocType: Dashboard Chart,Chart Type,Karttype
 DocType: DocType,Auto Name,Auto Name
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Unngå sekvenser som abc eller 6543 som de er enkle å gjette
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,"Vær så snill, prøv på nytt"
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL må starte med &#39;http: //&#39; eller &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL må starte med 'http: //' eller 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Alternativ 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Redigere
@@ -3376,7 +3376,7 @@ DocType: Notification,Send alert if this field's value changes,Send varsel om de
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Temafarger
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Velg en DOCTYPE å lage et nytt format
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Bruker finnes ikke
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Mottakere&#39; ikke spesifisert
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Mottakere' ikke spesifisert
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,akkurat nå
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Søke om
 DocType: Footer Item,Policy,Politikk
@@ -3424,7 +3424,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Custom Oversettel
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Framgang
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,av Rolle
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Manglende felt
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ugyldig feltnavn &#39;{0}&#39; i autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Ugyldig feltnavn '{0}' i autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Søk i en dokumenttype
 DocType: Custom DocPerm,Role and Level,Rolle og nivå
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3513,11 +3513,11 @@ DocType: Dashboard Chart,Filters JSON,Filtre JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Klikk her for å verifisere
 DocType: Email Account,Disable SMTP server authentication,Deaktiver autentisering av SMTP-server
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Kopiert til utklippstavlen.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Forutsigbare erstatninger som &#39;@&#39; i stedet for &#39;a&#39; hjelper ikke veldig mye.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Forutsigbare erstatninger som '@' i stedet for 'a' hjelper ikke veldig mye.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Tildelt By Me
 apps/frappe/frappe/utils/data.py,Zero,Null
 DocType: Google Drive,Backup Folder ID,Mappe-ID for sikkerhetskopi
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ikke i utviklermodus! Sett i site_config.json eller gjøre &#39;Custom&#39; DOCTYPE.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ikke i utviklermodus! Sett i site_config.json eller gjøre 'Custom' DOCTYPE.
 DocType: Workflow State,globe,kloden
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,Prioritet
@@ -3567,7 +3567,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Skriv inn et gyldig mobil nos
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Noen av funksjonene fungerer kanskje ikke i nettleseren din. Vennligst oppdater nettleseren din til den nyeste versjonen.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Noen av funksjonene fungerer kanskje ikke i nettleseren din. Vennligst oppdater nettleseren din til den nyeste versjonen.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Vet ikke, spør &#39;hjelp&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Vet ikke, spør 'hjelp'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},kansellerte dette dokumentet {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Kommentarer og kommunikasjon vil bli assosiert med denne koblet dokument
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
@@ -3596,7 +3596,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Mislyktes mens du endret abonnement
 DocType: LDAP Settings,LDAP Group Field,LDAP-gruppefelt
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Lik
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Alternativer &quot;Dynamic Link &#39;type felt må peke til en annen Link Feltet med alternativer som DOCTYPE
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Alternativer &quot;Dynamic Link 'type felt må peke til en annen Link Feltet med alternativer som DOCTYPE
 DocType: About Us Settings,Team Members Heading,Teammedlemmer Overskrift
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Ugyldig CSV-format
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Feil ved tilkobling til QZ Tray Application ... <br><br> Du må ha QZ Tray-applikasjon installert og kjørt for å bruke Raw Print-funksjonen. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Klikk her for å laste ned og installere QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Klikk her for å lære mer om Raw Printing</a> ."
@@ -3726,8 +3726,8 @@ DocType: Web Page,Web Page,Nettside
 DocType: Workflow Document State,Next Action Email Template,Neste Handling Email Template
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Hvis aktivert, spores endringer i dokumentet og vises på tidslinjen"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;I global søk&#39; ikke tillatt for type {0} i rad {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;I global søk&#39; ikke tillatt for type {0} i rad {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'I global søk' ikke tillatt for type {0} i rad {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'I global søk' ikke tillatt for type {0} i rad {1}
 DocType: Energy Point Log,Appreciation,Verdsettelse
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Vis liste
 DocType: Workflow,Don't Override Status,Ikke overstyr Status
@@ -3875,7 +3875,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Standard
 DocType: Translation,Verified,verifisert
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} lagt
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Søk etter &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Søk etter '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Vennligst lagre rapporten først
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonnenter lagt
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Ikke I
@@ -3912,7 +3912,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Meg
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} er ikke en gyldig State
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Gjelder alle dokumenttyper
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Oppdatering av energipunkt
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Vennligst velg en annen betalingsmåte. PayPal støtter ikke transaksjoner i valuta &#39;{0}
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Vennligst velg en annen betalingsmåte. PayPal støtter ikke transaksjoner i valuta '{0}
 DocType: Chat Message,Room Type,Romtype
 DocType: Data Import Beta,Import Log Preview,Forhåndsvisning av importlogg
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Søkefelt {0} er ikke gyldig

--- a/frappe/translations/no.csv
+++ b/frappe/translations/no.csv
@@ -1424,7 +1424,7 @@ DocType: User,System User,System User
 DocType: Report,Is Standard,Er Standard
 DocType: Desktop Icon,_report,_rapportere
 DocType: Dashboard Chart,Full,Full
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ikke HTML Encode HTML-tagger som &lt;script> eller bare tegn som &lt;eller>, da de kan bli bevisst brukes i dette feltet"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ikke HTML Encode HTML-tagger som <script> eller bare tegn som <eller>, da de kan bli bevisst brukes i dette feltet"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritisert på {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Løpe
@@ -1806,7 +1806,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Bunntekst vises b
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Avventer
 DocType: System Settings,Allow only one session per user,Tillat bare én økt per bruker
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Hjem / Test mappe 1 / Test mappe 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Velg eller dra på tvers av tidsluker for å opprette en ny hendelse.
 DocType: Contact,Contact Details,Kontaktinformasjon
 DocType: DocField,In Filter,I Filter
@@ -2333,7 +2333,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ikke nok tillatelse til å se koblinger
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresse Tittel er obligatorisk.
 DocType: Google Contacts,Push to Google Contacts,Trykk til Google-kontakter
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Lagt HTML i &lt;head> delen av nettsiden, primært brukes til nettstedet verifikasjon og SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Lagt HTML i <head> delen av nettsiden, primært brukes til nettstedet verifikasjon og SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Residiverende
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Elementet kan ikke legges til sine egne etterkommere
 DocType: Session Default Settings,Session Defaults,Økt mislighold
@@ -2453,7 +2453,7 @@ DocType: Workflow State,Warning,Advarsel
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Dette kan skrives ut på flere sider
 DocType: Data Migration Run,Percent Complete,Prosent fullført
 DocType: Tag Category,Tag Category,tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning, bruk> 5, &lt;10 eller = 324. For områder kan du bruke 5:10 (for verdier mellom 5 og 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Til sammenligning, bruk> 5, <10 eller = 324. For områder kan du bruke 5:10 (for verdier mellom 5 og 10)."
 DocType: Google Calendar,Pull from Google Calendar,Trekk fra Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjelp
 DocType: User,Login Before,Login Før
@@ -3099,7 +3099,7 @@ DocType: DocField,Allow on Submit,Tillat på Send
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Unntak Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Plukk kolonner
-DocType: Web Page,Add code as &lt;script>,Legg til kode som &lt;script>
+DocType: Web Page,Add code as <script>,Legg til kode som <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Fjern brukertillatelser
 DocType: Webhook,Headers,overskrifter
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kommende arrangementer
@@ -3473,16 +3473,16 @@ DocType: Workflow State,share-alt,aksje-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Køen bør være en av {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Standard mal </h4><p> Bruker <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> og alle felt av Adresse (inkludert egendefinerte felt hvis noen) vil være tilgjengelig </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Standard mal </h4><p> Bruker <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> og alle felt av Adresse (inkludert egendefinerte felt hvis noen) vil være tilgjengelig </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Startdatafelt
 DocType: Role,Role Name,Rolle Navn
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Bytt til skrivebord

--- a/frappe/translations/pl.csv
+++ b/frappe/translations/pl.csv
@@ -749,7 +749,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Kopie zapas
 DocType: DocField,In Global Search,W Global Search
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} lat temu
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} lat temu
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"To jest ryzykowne, aby usunąć ten plik: {0}. Proszę skontaktować się z System Manager."
 DocType: Currency,Currency Name,Nazwa waluty
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Brak wiadomości e-mail
@@ -1048,7 +1048,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,"Nie znalezio
 apps/frappe/frappe/config/customization.py,Add custom forms.,Dodaj niestandardowe formy.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0} {1} {2} w
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,przedstawiła ten dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Ustawienia&gt; Uprawnienia użytkownika
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Ustawienia> Uprawnienia użytkownika
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,System zapewnia wiele pre-definiowanych ról. Można dodać nowe role do ustawiania uprawnień.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1269,7 +1269,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Jeśli użytkownik ma żadnej roli zaznaczone, użytkownik staje się &quot;systemu użytkownika&quot;. &quot;Użytkownik systemu&quot; ma dostęp do pulpitu"
 DocType: System Settings,Date and Number Format,Format daty i numeru
 apps/frappe/frappe/model/document.py,one of,Jeden z
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Ustawienia&gt; Dostosuj formularz
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Ustawienia> Dostosuj formularz
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Sprawdzanie jednej chwili
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Pokaż tagi
 DocType: DocField,HTML Editor,Edytor HTML
@@ -1277,7 +1277,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Dane do faktury
 DocType: Email Queue,Not Sent,Nie wysłane
 DocType: Web Form,Actions,Działania
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Ustawienia&gt; Użytkownik
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Ustawienia> Użytkownik
 DocType: Workflow State,align-justify,Wyrównaj do lewej i do prawej
 DocType: User,Middle Name (Optional),Drugie imię (opcjonalnie)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Niedozwolone
@@ -1426,7 +1426,7 @@ DocType: Report,Is Standard,Standardowy
 DocType: Desktop Icon,_report,_raport
 DocType: Desktop Icon,_report,_raport
 DocType: Dashboard Chart,Full,Pełny
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Nie znaczniki HTML Kodowanie HTML, takich jak &lt;script&gt; lub po prostu jakby znaków &lt;i&gt;, ponieważ mogą one być celowo stosowana w tej dziedzinie"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nie znaczniki HTML Kodowanie HTML, takich jak &lt;script> lub po prostu jakby znaków &lt;i>, ponieważ mogą one być celowo stosowana w tej dziedzinie"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} krytykowany na {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Biegać
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Stopka będzie wy
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,W toku
 DocType: System Settings,Allow only one session per user,Pozwól tylko na jedną sesję na użytkownika
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Strona główna / Test Folder 1 / folderu Test 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Wybierz albo przeciągnij pomiędzy komórkami czasu aby stworzyć wydarzenie.
 DocType: Contact,Contact Details,Szczegóły kontaktu
 DocType: DocField,In Filter,W Filtrze
@@ -2041,7 +2041,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Login nie jest dostępny w tym czasie
 DocType: Data Migration Run,Current Mapping Action,Bieżąca akcja mapowania
 DocType: Dashboard Chart Source,Source Name,Źródło Nazwa
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Brak konta e-mail powiązanego z użytkownikiem. Dodaj konto w opcji Użytkownik&gt; Skrzynka e-mail.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Brak konta e-mail powiązanego z użytkownikiem. Dodaj konto w opcji Użytkownik> Skrzynka e-mail.
 DocType: Email Account,Email Sync Option,Opcja synchronizacji poczty elektronicznej
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Wiersz nr
 DocType: Async Task,Runtime,Czas pracy
@@ -2056,7 +2056,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,"Jest ju�
 DocType: User Email,Enable Outgoing,Włącz wychodzących
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,Własne tagi
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Konto e-mail nie zostało skonfigurowane. Utwórz nowe konto e-mail w Ustawienia&gt; E-mail&gt; Konto e-mail
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Konto e-mail nie zostało skonfigurowane. Utwórz nowe konto e-mail w Ustawienia> E-mail> Konto e-mail
 DocType: Comment,Submitted,Zgłoszny
 DocType: Contact,Pulled from Google Contacts,Pobrano z kontaktów Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Nieprawidłowe żądanie
@@ -2130,7 +2130,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Długość sesji w g
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","To pole pojawia się tylko wtedy, gdy nazwa pola zdefiniowane tutaj ma wartość lub zasady są prawdziwe (przykłady): myfield eval: doc.myfield == &#39;Moja Wartość&#39; eval: doc.age&gt; 18"
+eval:doc.age>18","To pole pojawia się tylko wtedy, gdy nazwa pola zdefiniowane tutaj ma wartość lub zasady są prawdziwe (przykłady): myfield eval: doc.myfield == &#39;Moja Wartość&#39; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Dzisiaj
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Dzisiaj
@@ -2145,7 +2145,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,DUŻE LITERY
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Niestandardowy HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Wpisz nazwę folderu
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nie znaleziono domyślnego szablonu adresu. Utwórz nowy w Ustawieniach&gt; Drukowanie i znakowanie&gt; Szablon adresu.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nie znaleziono domyślnego szablonu adresu. Utwórz nowy w Ustawieniach> Drukowanie i znakowanie> Szablon adresu.
 apps/frappe/frappe/auth.py,Unknown User,Nieznany użytkownik
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Wybierz rolę
 DocType: Comment,Deleted,Usunięte
@@ -2336,7 +2336,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Brak dostę pu do linków
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Podanie tytułu adresu jest wymagane
 DocType: Google Contacts,Push to Google Contacts,Przekaż do kontaktów Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Dodano HTML w sekcji &lt;head&gt; strony internetowej, używane głównie do weryfikacji stron internetowych i SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML w sekcji &lt;head> strony internetowej, używane głównie do weryfikacji stron internetowych i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nawrót
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,
 DocType: Session Default Settings,Session Defaults,Domyślne ustawienia sesji
@@ -2456,7 +2456,7 @@ DocType: Workflow State,Warning,Ostrzeżenie
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Może to zostać wydrukowane na wielu stronach
 DocType: Data Migration Run,Percent Complete,Procent ukończony
 DocType: Tag Category,Tag Category,Kategoria tagów
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Dla porównania użyj&gt; 5, &lt;10 lub = 324. Dla zakresów użyj 5:10 (dla wartości od 5 do 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Dla porównania użyj> 5, &lt;10 lub = 324. Dla zakresów użyj 5:10 (dla wartości od 5 do 10)."
 DocType: Google Calendar,Pull from Google Calendar,Wyciągnij z Kalendarza Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoc
 DocType: User,Login Before,Logowanie przed godziną
@@ -2925,7 +2925,7 @@ DocType: Custom Script,Custom Script,Własny skrypt
 DocType: Address,Address Line 2,Drugi wiersz adresu
 DocType: Address,Reference,Referencja
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Przypisano do
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Skonfiguruj domyślne konto e-mail w Ustawienia&gt; E-mail&gt; Konto e-mail
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Skonfiguruj domyślne konto e-mail w Ustawienia> E-mail> Konto e-mail
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Szczegóły odwzorowania migracji danych
 DocType: Data Import,Action,Działanie
 DocType: GSuite Settings,Script URL,URL skryptu
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Zezwól na Wysłanie
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Typ wyjątku
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Wybierz kolumny
-DocType: Web Page,Add code as &lt;script&gt;,Dodaj kod jako &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Dodaj kod jako &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Wyczyść uprawnienia użytkownika
 DocType: Webhook,Headers,Nagłówki
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,nadchodzące wydarzenia
@@ -3481,15 +3481,15 @@ DocType: Workflow State,share-alt,
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kolejką powinno być jedno z {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Domyślny szablon </ h4> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja wykorzystuje szablonów </a> i wszystkie pola Adres ( w tym niestandardowe pola jeśli istnieje) będzie dostępny </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/pl.csv
+++ b/frappe/translations/pl.csv
@@ -1426,7 +1426,7 @@ DocType: Report,Is Standard,Standardowy
 DocType: Desktop Icon,_report,_raport
 DocType: Desktop Icon,_report,_raport
 DocType: Dashboard Chart,Full,Pełny
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nie znaczniki HTML Kodowanie HTML, takich jak &lt;script> lub po prostu jakby znaków &lt;i>, ponieważ mogą one być celowo stosowana w tej dziedzinie"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Nie znaczniki HTML Kodowanie HTML, takich jak <script> lub po prostu jakby znaków <i>, ponieważ mogą one być celowo stosowana w tej dziedzinie"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} krytykowany na {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Biegać
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Stopka będzie wy
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,W toku
 DocType: System Settings,Allow only one session per user,Pozwól tylko na jedną sesję na użytkownika
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Strona główna / Test Folder 1 / folderu Test 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Wybierz albo przeciągnij pomiędzy komórkami czasu aby stworzyć wydarzenie.
 DocType: Contact,Contact Details,Szczegóły kontaktu
 DocType: DocField,In Filter,W Filtrze
@@ -2336,7 +2336,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Brak dostę pu do linków
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Podanie tytułu adresu jest wymagane
 DocType: Google Contacts,Push to Google Contacts,Przekaż do kontaktów Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML w sekcji &lt;head> strony internetowej, używane głównie do weryfikacji stron internetowych i SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Dodano HTML w sekcji <head> strony internetowej, używane głównie do weryfikacji stron internetowych i SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nawrót
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,
 DocType: Session Default Settings,Session Defaults,Domyślne ustawienia sesji
@@ -2456,7 +2456,7 @@ DocType: Workflow State,Warning,Ostrzeżenie
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Może to zostać wydrukowane na wielu stronach
 DocType: Data Migration Run,Percent Complete,Procent ukończony
 DocType: Tag Category,Tag Category,Kategoria tagów
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Dla porównania użyj> 5, &lt;10 lub = 324. Dla zakresów użyj 5:10 (dla wartości od 5 do 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Dla porównania użyj> 5, <10 lub = 324. Dla zakresów użyj 5:10 (dla wartości od 5 do 10)."
 DocType: Google Calendar,Pull from Google Calendar,Wyciągnij z Kalendarza Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoc
 DocType: User,Login Before,Logowanie przed godziną
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Zezwól na Wysłanie
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Typ wyjątku
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Wybierz kolumny
-DocType: Web Page,Add code as &lt;script>,Dodaj kod jako &lt;script>
+DocType: Web Page,Add code as <script>,Dodaj kod jako <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Wyczyść uprawnienia użytkownika
 DocType: Webhook,Headers,Nagłówki
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,nadchodzące wydarzenia
@@ -3481,26 +3481,26 @@ DocType: Workflow State,share-alt,
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kolejką powinno być jedno z {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Domyślny szablon </ h4> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja wykorzystuje szablonów </a> i wszystkie pola Adres ( w tym niestandardowe pola jeśli istnieje) będzie dostępny </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% if address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} {{miasto 
-}} & lt; br & gt; 
- {% jeśli państwo%} {{państwo}} & lt; br & gt; {% endif -%} 
- {% if%} kod PIN PIN: {{kod PIN}} & lt; br & gt; {% endif -%} 
- {{państwo}} & lt; br & gt; 
- {% jeśli telefon%} Telefon: {{Telefon}} & lt; br & gt; { % endif -%} 
- {% czy faks%} faks: {{faks}} & lt; br & gt; {% endif -%} 
- {% jeśli email_id%} E-mail: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% if address_line2%} {{address_line2}} <br> { % endif -%} {{miasto 
+}} <br> 
+ {% jeśli państwo%} {{państwo}} <br> {% endif -%} 
+ {% if%} kod PIN PIN: {{kod PIN}} <br> {% endif -%} 
+ {{państwo}} <br> 
+ {% jeśli telefon%} Telefon: {{Telefon}} <br> { % endif -%} 
+ {% czy faks%} faks: {{faks}} <br> {% endif -%} 
+ {% jeśli email_id%} E-mail: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Pole daty rozpoczęcia
 DocType: Role,Role Name,Nazwa roli

--- a/frappe/translations/pl.csv
+++ b/frappe/translations/pl.csv
@@ -563,7 +563,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statystyki oparte na wynikach z ubiegłego tygodnia (od {0} do {1})
 DocType: LDAP Settings,LDAP Phone Field,Pole telefonu LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Typ dokumentu ..., np klienta"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Warunek &#39;{0}&#39; jest nieprawidłowa
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Warunek '{0}' jest nieprawidłowa
 DocType: Workflow State,barcode,kod kreskowy
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Wykorzystanie pod-zapytania lub funkcji jest ograniczone
 apps/frappe/frappe/config/customization.py,Add your own translations,Dodaj własne tłumaczenia
@@ -786,7 +786,7 @@ DocType: File,Is Home Folder,Czy Home Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Styl paska nawigacyjnego
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} jest nieprawidłowym adresem e-mail
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Wybierz conajmniej 1 rekordów do druku
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Użytkownik &#39;{0}&#39; ma już rolę &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Użytkownik '{0}' ma już rolę '{1}'
 DocType: System Settings,Two Factor Authentication method,Metoda uwierzytelniania dwóch czynników
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Najpierw ustaw nazwę i zapisz rekord.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 rekordów
@@ -2130,7 +2130,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Długość sesji w g
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","To pole pojawia się tylko wtedy, gdy nazwa pola zdefiniowane tutaj ma wartość lub zasady są prawdziwe (przykłady): myfield eval: doc.myfield == &#39;Moja Wartość&#39; eval: doc.age> 18"
+eval:doc.age>18","To pole pojawia się tylko wtedy, gdy nazwa pola zdefiniowane tutaj ma wartość lub zasady są prawdziwe (przykłady): myfield eval: doc.myfield == 'Moja Wartość' eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Dzisiaj
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Dzisiaj
@@ -2170,7 +2170,7 @@ DocType: Data Migration Connector,Database Name,Nazwa bazy danych
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Odśwież Formularz
 DocType: DocField,Select,Wybierz
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Wyświetl pełny dziennik
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Przykład: status == &#39;Open&#39; i wpisz == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Przykład: status == 'Open' i wpisz == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Plik nie dołączony
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Utracono połączenie. Niektóre funkcje mogą nie działać.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Powtórzenia typu &quot;AAA&quot; są łatwe do odgadnięcia
@@ -2729,7 +2729,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Zmieniająca
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,Ustawienia bramki płatności PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Najlepszy wykonawca
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Nie można dodawać pól niestandardowych do podstawowych typów DocTyp.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0} {1} &#39;({3}) będzie obcięta, a maksymalna liczba znaków dozwolony jest {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0} {1} '({3}) będzie obcięta, a maksymalna liczba znaków dozwolony jest {2}"
 DocType: OAuth Client,Response Type,Typ odpowiedzi
 DocType: Contact Us Settings,Send enquiries to this email address,Wyślij zapytania na te adresy e-mail
 DocType: Letter Head,Letter Head Name,Nazwa nagłówka
@@ -2786,7 +2786,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Widok obrazka
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Wygląda na to, coś poszło nie tak podczas transakcji. Ponieważ nie potwierdziły płatności Paypal automatycznie zwrócimy Ci tę kwotę. Jeśli nie, prosimy o przesłanie wiadomości e-mail oraz wspomnieć o identyfikator korelacji: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","DołĘ ... cz symbole, cyfry i wielkie litery w hasło"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Włóż Po polu &#39;{0}&#39; o którym mowa w niestandardowym polu &#39;{1}&#39;, z etykietą &quot;{2}&quot; nie istnieje"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Włóż Po polu '{0}' o którym mowa w niestandardowym polu '{1}', z etykietą &quot;{2}&quot; nie istnieje"
 DocType: List Filter,List Filter,Filtr listy
 DocType: Workflow State,signal,sygnał
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ma załączniki
@@ -2810,15 +2810,15 @@ DocType: Web Page,Slideshow,Pokaz slajdów
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Szablon domyślny Adresu nie może być usunięty
 DocType: Contact,Maintenance Manager,Menager Konserwacji
 DocType: Workflow State,Search,Szukaj
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Wybierz inną metodę płatności. Stripe nie obsługuje transakcji w walucie &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Wybierz inną metodę płatności. Stripe nie obsługuje transakcji w walucie &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Wybierz inną metodę płatności. Stripe nie obsługuje transakcji w walucie '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Wybierz inną metodę płatności. Stripe nie obsługuje transakcji w walucie '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Przenieść do kosza
 DocType: Web Form,Web Form Fields,Pola formularza internetowego
 DocType: Data Import,Amended From,Zmodyfikowany od
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Ostrzeżenie: Nie można znaleźć {0} w dowolnej tabeli związanej {1}
 DocType: S3 Backup Settings,eu-north-1,eu-north-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Dokument ten jest obecnie w kolejce do realizacji. Proszę spróbuj ponownie
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Plik &#39;{0}&#39; Nie znaleziono
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Plik '{0}' Nie znaleziono
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Usuń sekcję
 DocType: User,Change Password,Zmień hasło
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Pole Osi X
@@ -3009,7 +3009,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Brakuje wartości dl
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Dodaj pod-element
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Postęp importu
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Jeśli warunek jest spełniony, użytkownik zostanie nagrodzony punktami. na przykład. doc.status == &#39;Zamknięte&#39;"
+","Jeśli warunek jest spełniony, użytkownik zostanie nagrodzony punktami. na przykład. doc.status == 'Zamknięte'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Napisał Record nie mogą być usunięte.
 DocType: GSuite Templates,Template Name,Nazwa szablonu
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nowy typ dokumentu
@@ -3431,7 +3431,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Własne tłumacze
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Postęp
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,brakujące Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Nieprawidłowa nazwa pola &#39;{0}&#39; w autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Nieprawidłowa nazwa pola '{0}' w autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Szukaj w rodzaju dokumentu
 DocType: Custom DocPerm,Role and Level,Rola i Poziom
 DocType: File,Thumbnail URL,Miniatura URL
@@ -3586,7 +3586,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Wprowadź poprawny numer telefonu kom
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Niektóre funkcje mogą nie działać w przeglądarce. Zaktualizuj swoją przeglądarkę do najnowszej wersji.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Niektóre funkcje mogą nie działać w przeglądarce. Zaktualizuj swoją przeglądarkę do najnowszej wersji.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nie wiem, zapytaj &#39;help&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nie wiem, zapytaj 'help'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},anulowałem ten dokument {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Komentarze i komunikacja będą związane z tym połączonego dokumentu
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filtr ...

--- a/frappe/translations/ps.csv
+++ b/frappe/translations/ps.csv
@@ -743,7 +743,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,د دوتن
 DocType: DocField,In Global Search,په نړیوال لټون
 DocType: System Settings,Brute Force Security,د ځواک ځواک امنیت
 DocType: Workflow State,indent-left,indent-کيڼ
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} کاله دمخه
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} کاله دمخه
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,دا خطرناکه چې د دغې دوتنې د ړنګولو: {0}. لطفا د خپل سیستم د مدیر سره اړیکه.
 DocType: Currency,Currency Name,د اسعارو نوم
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,نه برېښناليک
@@ -1041,7 +1041,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,نه {0} وم
 apps/frappe/frappe/config/customization.py,Add custom forms.,د ګمرک د فورمو کړئ.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} د {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,د دې سند ته وسپارل
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,تنظیم&gt; د کارونکي اجازه
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,تنظیم> د کارونکي اجازه
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,دا سیستم د ډیرو مخکې تعریف رول برابروي. تاسو کولای شئ د نوي رول ته اضافه کړی تر میده پرېښلې ټاکل.
 DocType: Communication,CC,CC
 DocType: Country,Geo,د جيو
@@ -1260,7 +1260,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",که د کارونکي لري کوم رول وکتل، نو د کارن د &quot;سیستم کارن&quot; شي. &quot;سيستم کارن&quot; لري د سرپاڼې ته لاسرسی
 DocType: System Settings,Date and Number Format,نېټه او شمېر شکل
 apps/frappe/frappe/model/document.py,one of,یو له
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,تنظیم&gt; فارم دودیز کړئ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,تنظیم> فارم دودیز کړئ
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,يوه شېبه کتل
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,انکړپټه ښودل نښانونه
 DocType: DocField,HTML Editor,ایچ ٹی ایم ایل ایڈیٹر
@@ -1268,7 +1268,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,بلونو
 DocType: Email Queue,Not Sent,نه ته وليږدول شوه
 DocType: Web Form,Actions,کړنې
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,جوړول&gt; کارن
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,جوړول> کارن
 DocType: Workflow State,align-justify,په همغاړیتوب-توجیه
 DocType: User,Middle Name (Optional),د منځني نوم (اختیاری)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,نه اجازه
@@ -1414,7 +1414,7 @@ DocType: Report,Is Standard,آیا د معياري
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,بشپړ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",آيا نه HTML Encode HTML نښانونو په څېر &lt;سکرېپټ&gt; يا د تورو په څېر &lt;یا&gt;، ځکه چې دوی کولای شي په دې برخه کې شي په قصده کارول
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",آيا نه HTML Encode HTML نښانونو په څېر &lt;سکرېپټ> يا د تورو په څېر &lt;یا>، ځکه چې دوی کولای شي په دې برخه کې شي په قصده کارول
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,چلول
 DocType: Blog Post,Content (HTML),مینځپانګه (HTML)
@@ -1787,7 +1787,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,فوټر به ی�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,په تمه
 DocType: System Settings,Allow only one session per user,په سلو کې د کارونکي يوازې يوه غونډه اجازه
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,کور / امتحان پوښی 1 / امتحان پوښی 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;مشر&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;مشر> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,وټاکئ او يا په ټول وخت صنفونه راکاږي د يو نوي پيښه رامنځ ته کړي.
 DocType: Contact,Contact Details,د اړیکو نیولو معلومات
 DocType: DocField,In Filter,په Filter
@@ -2016,7 +2016,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,د ننوت په دې وخت کې اجازه نه لري
 DocType: Data Migration Run,Current Mapping Action,اوسنۍ نقشه ایزه کړنه
 DocType: Dashboard Chart Source,Source Name,سرچینه نوم
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,د کارونکي سره هیڅ کوم بریښنالیک نه دی تړلی. مهرباني وکړئ د کارن&gt; بریښنالیک ان باکس کې لاندې حساب اضافه کړئ.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,د کارونکي سره هیڅ کوم بریښنالیک نه دی تړلی. مهرباني وکړئ د کارن> بریښنالیک ان باکس کې لاندې حساب اضافه کړئ.
 DocType: Email Account,Email Sync Option,برېښناليک پرانیځئ انتخاب
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,قطار
 DocType: Async Task,Runtime,ډول کارېږي،
@@ -2031,7 +2031,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,لا له
 DocType: User Email,Enable Outgoing,فعال باورلیک
 DocType: Address,Fax,فاکس
 apps/frappe/frappe/config/customization.py,Custom Tags,د ګمرکونو نښانونه
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,د بریښنالیک حساب نه دی تنظیم شوی. مهرباني وکړئ له سیټ اپ&gt; بریښنالیک&gt; بریښنالیک حساب څخه نوی بریښنالیک حساب جوړ کړئ
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,د بریښنالیک حساب نه دی تنظیم شوی. مهرباني وکړئ له سیټ اپ> بریښنالیک> بریښنالیک حساب څخه نوی بریښنالیک حساب جوړ کړئ
 DocType: Comment,Submitted,ته وسپارل شول
 DocType: Contact,Pulled from Google Contacts,د ګوګل اړیکو څخه راوتلی
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,په اعتباري غوښتنه
@@ -2104,7 +2104,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,په ساعتونه 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",دې برخه کې به پرانيستل شي يوازې که د fieldname دلته تعریف ارزښت لري، یا د اصولو سمه (مثالونه) دي: myfield eval: doc.myfield == زما ارزښت &#39;eval: doc.age&gt; 18
+eval:doc.age>18",دې برخه کې به پرانيستل شي يوازې که د fieldname دلته تعریف ارزښت لري، یا د اصولو سمه (مثالونه) دي: myfield eval: doc.myfield == زما ارزښت &#39;eval: doc.age> 18
 DocType: Social Login Key,Office 365,دفتر 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,نن
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,نن
@@ -2119,7 +2119,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,د مشرانو د دوسيې د
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,د ګمرکونو د HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,دادوسیه خلاصه نوم ولیکۍ
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,د پتې اصلي ټاپو ټاټوبی ونه موندل شو. مهرباني وکړئ له تنظیم او چاپ کولو او نښه کولو&gt; پته ټیمپلیټ څخه نوی جوړ کړئ.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,د پتې اصلي ټاپو ټاټوبی ونه موندل شو. مهرباني وکړئ له تنظیم او چاپ کولو او نښه کولو> پته ټیمپلیټ څخه نوی جوړ کړئ.
 apps/frappe/frappe/auth.py,Unknown User,نامعلوم ناباوره
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,انتخاب رول
 DocType: Comment,Deleted,ړنګ
@@ -2306,7 +2306,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,نه کافي اجازې ته تړنې وګورئ
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,پته عنوان الزامی دی.
 DocType: Google Contacts,Push to Google Contacts,ګوګل اړیکو ته فشار ورکړئ
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",په &lt;مشر&gt; د ورزیاتولو HTML د ګورت پاڼه د کړی، اصلا د ویب تصدیق او SEO کارول
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",په &lt;مشر> د ورزیاتولو HTML د ګورت پاڼه د کړی، اصلا د ویب تصدیق او SEO کارول
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,وروګرځېد
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,د قالب د خپل descendents زياته نه شي
 DocType: Session Default Settings,Session Defaults,د ناستې ټاکل
@@ -2425,7 +2425,7 @@ DocType: Workflow State,Warning,خبرداری
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,دا ممکن په ډیری پا onو کې چاپ شي
 DocType: Data Migration Run,Percent Complete,فيصده بشپړ شوی
 DocType: Tag Category,Tag Category,Tag کټه ګورۍ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",د پرتله کولو لپاره ،&gt; 5 ، &lt;10 یا = 324 وکاروئ. د حدونو لپاره ، 5:10 وکاروئ (د 5 او 10 ترمنځ ارزښتونو لپاره).
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",د پرتله کولو لپاره ،> 5 ، &lt;10 یا = 324 وکاروئ. د حدونو لپاره ، 5:10 وکاروئ (د 5 او 10 ترمنځ ارزښتونو لپاره).
 DocType: Google Calendar,Pull from Google Calendar,د ګوګل کیلنڈر څخه وباسئ
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,مرسته
 DocType: User,Login Before,ننوتل مخکې
@@ -2882,7 +2882,7 @@ DocType: Custom Script,Custom Script,د ګمرکونو د ښونکی
 DocType: Address,Address Line 2,د ادرس کرښه 2
 DocType: Address,Reference,ماخذ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,ته ګمارل شوي
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,مهرباني وکړئ د ډیفالټ بریښنالیک حساب له سیټ اپ&gt; بریښنالیک&gt; بریښنالیک حساب څخه تنظیم کړئ
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,مهرباني وکړئ د ډیفالټ بریښنالیک حساب له سیټ اپ> بریښنالیک> بریښنالیک حساب څخه تنظیم کړئ
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,د معلوماتو مهاجرت نقشه توضیحات
 DocType: Data Import,Action,کړنه
 DocType: GSuite Settings,Script URL,سکرېپټ د حافظی
@@ -3056,7 +3056,7 @@ DocType: DocField,Allow on Submit,اجازه پر سپارل
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,استثنا ډول
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,یورتان مواده
-DocType: Web Page,Add code as &lt;script&gt;,په توګه &lt;سکرېپټ&gt; کوډ
+DocType: Web Page,Add code as &lt;script>,په توګه &lt;سکرېپټ> کوډ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,د کاروونکي جوازونه پاک کړئ
 DocType: Webhook,Headers,سرلیکونه
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,راتلونکې پېښې
@@ -3425,16 +3425,16 @@ DocType: Workflow State,share-alt,برخه-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},په ليکه کې بايد د يو شي {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4 style=""""> default کينډۍ </h4><p style=""""> کاروي <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> او د پته د ټولو برخو (په شمول د ګمرک فیلډز که چېرې وي) به موجود وي </p><pre style=""""> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4 style=""""> default کينډۍ </h4><p style=""""> کاروي <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> او د پته د ټولو برخو (په شمول د ګمرک فیلډز که چېرې وي) به موجود وي </p><pre style=""""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,د پیل تاریخ نیټه
 DocType: Role,Role Name,رول نوم
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,د ميشتو ونجول

--- a/frappe/translations/ps.csv
+++ b/frappe/translations/ps.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.",که چېرې توانول شوی، د پټنوم د قوت پر بنسټ به د لږ تر لږه پاسورډ نمره ارزښت پلي شي. د 2 ارزښت منځني قوي کېږي او 4 ډېر قوي کېږي.
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.",که چېرې توانول شوی، د پټنوم د قوت پر بنسټ به د لږ تر لږه پاسورډ نمره ارزښت پلي شي. د 2 ارزښت منځني قوي کېږي او 4 ډېر قوي کېږي.
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;د ډلې غړي&quot; یا &quot;د مديريت&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',د ډګر &#39;د وګورئ&#39; ډول لپاره Default بايد يا &#39;0&#39; یا د &#39;1&#39; وي
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',د ډګر 'د وګورئ' ډول لپاره Default بايد يا '0' یا د '1' وي
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,پرون
 DocType: Contact,Designation,ټاکل.
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,اتوماتیک لینک کول یوازې د یو بریښنالیک حساب لپاره فعال کیدی شي.
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,ناتوانې �
 DocType: Translation,Contributed Translation Doctype Name,مرسته شوی د ژباړې لاسوند ډول
 DocType: PayPal Settings,Redirect To,د Redirect
 DocType: Data Migration Mapping,Pull,کشول
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},د جاوا شکل: frappe.query_reports [ &#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},د جاوا شکل: frappe.query_reports [ 'REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,د حجم تازه
 DocType: Workflow State,chevron-up,chevron-up
 DocType: DocType,Allow Guest to View,اجازه ميلمه ته ښکاره کړی
@@ -558,7 +558,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),ارقام د تیرې اونۍ د کړنو پراساس (له {0} څخه تر {1} پورې)
 DocType: LDAP Settings,LDAP Phone Field,د LDAP تلیفون ساحه
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",لاسوند ډول ...، د بيلګې په توګه د پېرېدونکو
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,د حالت &#39;{0}&#39; ناسم دی
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,د حالت '{0}' ناسم دی
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,د فرعي سوال یا کارونې کار محدود دی
 apps/frappe/frappe/config/customization.py,Add your own translations,خپل ژباړې ورزیات کړئ
@@ -749,7 +749,7 @@ DocType: Currency,Currency Name,د اسعارو نوم
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,نه برېښناليک
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,لنک ختم شوی
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",په &#39;{2}&#39; کې د &#39;{1}&#39; لپاره اوږدوالي {0} ته اړول؛ اوږدوالي د {3} په توګه ټاکل به د معلوماتو راکمولو لامل شي.
+							Setting the length as {3} will cause truncation of data.",په '{2}' کې د '{1}' لپاره اوږدوالي {0} ته اړول؛ اوږدوالي د {3} په توګه ټاکل به د معلوماتو راکمولو لامل شي.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,د دوتنې بڼه غوره کړه
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,منځپانګه مخلوط
@@ -765,13 +765,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form",معياري DocType نه شي کولای تلوالیزه چاپي بڼه لري، دتنظيمولو فورمه وکاروي
 DocType: Report,Query,نه خوری
 DocType: Customize Form,Sort Order,سمبالول، منظمول
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;په List View لپاره ډول {0} په قطار نه اجازه {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'په List View لپاره ډول {0} په قطار نه اجازه {1}
 DocType: Letter Head,Footer HTML,فوټر HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,ليبل وروسته چې تاسو غواړئ چې نوي ډګر ورننباسئ وټاکئ.
 ,Document Share Report,سند Share راپور
 DocType: Social Login Key,Base URL,بنسټ بیس URL
 DocType: User,Last Login,تېره ننوتل
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},تاسو د فیلډ لپاره &#39;Translatable&#39; نه ټاکلی شئ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},تاسو د فیلډ لپاره 'Translatable' نه ټاکلی شئ {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,کالم
 DocType: Chat Profile,Chat Profile,د پېژندڅېره
 DocType: Custom Field,Adds a custom field to a DocType,د يو DocType زیاتوي يو دود برخه
@@ -780,7 +780,7 @@ DocType: File,Is Home Folder,ده کور پوښۍ
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,د نوبار ډول
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} یو باوري دبرېښنا ليک پته نه ده
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,تيروخت د چاپولو 1 ریکارډ وټاکئ
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',کارن &#39;{0}&#39; پخوا د رول &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',کارن '{0}' پخوا د رول '{1}'
 DocType: System Settings,Two Factor Authentication method,د دوو فکتور اعتباري طریقه
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,لومړی نوم نومول او ریکارډ خوندي کول.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 ریکارډونه
@@ -1032,7 +1032,7 @@ DocType: Property Setter,Property Setter,ملکیت Setter
 DocType: Web Form,Allow Print,چاپ اجازه
 DocType: Communication,Clicked,چې ټک
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,بې لارې کول
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},ته هيڅ اجازه &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},ته هيڅ اجازه '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,ټاکل شوې واستوي
 DocType: DocType,Track Seen,Track کتل
 DocType: Dropbox Settings,File Backup,د دوتنې شاتړ
@@ -1059,7 +1059,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Page HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,خطا شوې لیکې صادر کړئ
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,د ډلې نوم خالي نه دی.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,لا غوټو يوازې ډله &#39;ډول غوټو لاندې جوړ شي
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,لا غوټو يوازې ډله 'ډول غوټو لاندې جوړ شي
 DocType: SMS Parameter,Header,سرۍ
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},نامعلوم کالم: {0}
 DocType: Notification Recipient,Email By Role,په بريښناليک رول
@@ -1956,7 +1956,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-جنوب ختیځ -1
 DocType: DocType,"Must be of type ""Attach Image""",باید د ډول وي &quot;ضميمه د انځور&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Unselect ټول
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},تاسو کولای unset نه د ساحوي &#39;يوازې ادامه&#39; {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},تاسو کولای unset نه د ساحوي 'يوازې ادامه' {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,صفر مانا ريکارډ تازه په هر وخت ته واستوي
 DocType: Auto Email Report,Zero means send records updated at anytime,صفر مانا ريکارډ تازه په هر وخت ته واستوي
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,بشپړ Setup
@@ -2000,7 +2000,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,ګوګل فونټ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",که چېرې دا د لارښوونو کې چې ګټور نه، مهرباني وکړی په GitHub مسایل د تاسو وړانديزونو اضافه کړي.
 DocType: Workflow State,bookmark,ليکی
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),دادوسیه خلاصه نوم باید شامل نه دي &#39;/&#39; (مخرېوند)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),دادوسیه خلاصه نوم باید شامل نه دي '/' (مخرېوند)
 DocType: Note,Note,یادښت
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,تېروتنه راپور
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,د CSV / Excel بڼه کې د صادراتو ډاټا.
@@ -2104,7 +2104,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,په ساعتونه 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",دې برخه کې به پرانيستل شي يوازې که د fieldname دلته تعریف ارزښت لري، یا د اصولو سمه (مثالونه) دي: myfield eval: doc.myfield == زما ارزښت &#39;eval: doc.age> 18
+eval:doc.age>18",دې برخه کې به پرانيستل شي يوازې که د fieldname دلته تعریف ارزښت لري، یا د اصولو سمه (مثالونه) دي: myfield eval: doc.myfield == زما ارزښت 'eval: doc.age> 18
 DocType: Social Login Key,Office 365,دفتر 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,نن
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,نن
@@ -2144,7 +2144,7 @@ DocType: Data Migration Connector,Database Name,د ډاټا ډاټا
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,تاندول فورمه
 DocType: DocField,Select,وټاکئ
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,بشپړ لاګ وګورئ
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",د ساده پیتون څرګندونې ، مثال: حالت == &#39;خلاص&#39; او ټایپ == &#39;بګ&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",د ساده پیتون څرګندونې ، مثال: حالت == 'خلاص' او ټایپ == 'بګ'
 apps/frappe/frappe/utils/csvutils.py,File not attached,دوتنه نه ضميمه
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,پیوستون ورک شوی. ځینې ځانګړتیاوې ممکن کار ونکړي.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",لکه &quot;aaa&quot; تکرارونه دي اسانه فکر
@@ -2273,7 +2273,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,یوازې غلطی وښایئ
 DocType: Website Settings,Banner HTML,بنر HTML
 DocType: Workflow,Send Email Alert,د بریښنالیک خبرتیا واستوئ
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. Razorpay په اسعارو د راکړې ورکړې ملاتړ نه کوي &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. Razorpay په اسعارو د راکړې ورکړې ملاتړ نه کوي '{0}'
 DocType: Data Import,In Progress,د پرمختګ په حال کې
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,د شاتړ کتار ولاړ. دا ښايي يو څو دقيقو کې د يوه ساعت.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2689,7 +2689,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,د تعديل
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,وی.دا پیسو ليدونکی امستنې
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,غوره لوبغاړی
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,اصلي ډیسک ټایپونو کې دودیز ساحې نشي اضافه کیدلی.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: &#39;{1}&#39; ({3}) به نیمګړې کړې، ځکه max تورو اجازه ده {2}
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: '{1}' ({3}) به نیمګړې کړې، ځکه max تورو اجازه ده {2}
 DocType: OAuth Client,Response Type,غبرګون ډول
 DocType: Contact Us Settings,Send enquiries to this email address,پوښتنو ته دې ایمیل ادرس وليږئ
 DocType: Letter Head,Letter Head Name,لیک د مشر نوم
@@ -2745,7 +2745,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,د انځور ښکاره کړی
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.",ښکاري چې څه د راکړې ورکړې په ترڅ کې رامنځته شو. څرنګه چې موږ د تادیاتو د تاييد نه، وی.دا به په اتوماتيک ډول دغه مبلغ هغوفیس تاسو. که داسې ونه شی، لطفا موږ ته يو بريښناليک ته واستوي او د ارتباط تذکرو یادونه: {0}.
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password",شامل سمبولونه، د شمېر او د مرکز لیکونه په پټنوم
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",ساحه &#39;{0}&#39; ذکر په ګمرک ساحوي وروسته ورننويستل &#39;{1}&#39;، سره ليبل &#39;{2}&#39;، نه شته
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",ساحه '{0}' ذکر په ګمرک ساحوي وروسته ورننويستل '{1}'، سره ليبل '{2}'، نه شته
 DocType: List Filter,List Filter,د لیست فلټر
 DocType: Workflow State,signal,سيګنال
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,ضمیمه لري
@@ -2755,7 +2755,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,سند اعاده
 DocType: Data Export,Data Export,د ډاټا صادرات
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,ژبه غوره کړه ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},تاسو د ساحې {0} لپاره &#39;اختیارونه&#39; نشئ ټاکلی
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},تاسو د ساحې {0} لپاره 'اختیارونه' نشئ ټاکلی
 DocType: Help Article,Author,لیکوال
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Resume لېږل
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,بېرته پرانيستل
@@ -2769,15 +2769,15 @@ DocType: Web Page,Slideshow,سلاید شو
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Default پته کينډۍ نه ړنګ شي
 DocType: Contact,Maintenance Manager,مراقبت مدير
 DocType: Workflow State,Search,د لټون
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. یاتوره په اسعارو د راکړې ورکړې ملاتړ نه کوي &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. یاتوره په اسعارو د راکړې ورکړې ملاتړ نه کوي &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. یاتوره په اسعارو د راکړې ورکړې ملاتړ نه کوي '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. یاتوره په اسعارو د راکړې ورکړې ملاتړ نه کوي '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,د خځلنۍ ته خوځون
 DocType: Web Form,Web Form Fields,ويب فورمه فیلډز
 DocType: Data Import,Amended From,تعدیل له
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},خبرداری: توان نلري پيدا {0} په اړوند د هر میز {1}
 DocType: S3 Backup Settings,eu-north-1,د شمال - 1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,دغه سند د اوس لپاره د اعدام له پيله. لطفا بیا هڅه وکړې
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,د دوتنې &#39;{0}&#39; ونه موندل شو
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,د دوتنې '{0}' ونه موندل شو
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,برخه لرې کړئ
 DocType: User,Change Password,پټ نوم بدل کړی
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,د ایکس ایکس ډګر
@@ -2964,7 +2964,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,ارزښت د ورک
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Add د ماشومانو د
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,پرمختګ واردول
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",که چیرې حالت مطمین وي کارونکي به د ټکو سره انعام ورکړل شي. د مثال په توګه doc.status == &#39;بند&#39;
+",که چیرې حالت مطمین وي کارونکي به د ټکو سره انعام ورکړل شي. د مثال په توګه doc.status == 'بند'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} د {1}: وسپارل دثبت ړنګ نه شي.
 DocType: GSuite Templates,Template Name,کينډۍ نوم
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,د سند د نوي ډول
@@ -3094,7 +3094,7 @@ DocType: Dashboard Chart,Chart Type,د چارټ ډول
 DocType: DocType,Auto Name,د موټرونو نوم
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,لکه ABC يا 6543 سلسلو کې ډډه وشي ځکه چې دوی په اسانه فکر
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,لطفا بیا هڅه وکړې
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL باید د &#39;http: //&#39; یا &#39;https: //&#39; سره پیل شي
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL باید د 'http: //' یا 'https: //' سره پیل شي
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,انتخاب 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,سمول
@@ -3330,7 +3330,7 @@ DocType: Notification,Send alert if this field's value changes,وليږئ که �
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,د موضوع رنګونه
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,يو DocType غوره کړه چې په يوه نوې بڼه کړي
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,کارن شتون نلري
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;اخیستونکي&#39; مشخص شوي ندي
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'اخیستونکي' مشخص شوي ندي
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,همدا اوس
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Apply
 DocType: Footer Item,Policy,د پالیسۍ
@@ -3377,7 +3377,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,د ګمرکونو
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,پرمختګ
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,د رول له خوا
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,ورک فیلډز
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,باطلې fieldname &#39;{0} په autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,باطلې fieldname '{0} په autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,د لټون په يو لاسوند ډول
 DocType: Custom DocPerm,Role and Level,رول او د ليول
 DocType: File,Thumbnail URL,بټنوک URL
@@ -3464,11 +3464,11 @@ DocType: Dashboard Chart,Filters JSON,فلټرونه JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,د تاييدولو لپاره دلته کلیک وکړی
 DocType: Email Account,Disable SMTP server authentication,د SMTP سرور اعتبار ناتوان کړئ
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,کليپ بورډ ته کاپي شوې.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,د وړاندوينې وړ د تعويض په څېر &#39;@&#39; پر ځای د &#39;&#39; a مه ډېره مرسته نه کوي.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,د وړاندوينې وړ د تعويض په څېر '@' پر ځای د '' a مه ډېره مرسته نه کوي.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,ګمارل شوي By ما
 apps/frappe/frappe/utils/data.py,Zero,صفر
 DocType: Google Drive,Backup Folder ID,د بیک اپ فولډر ID
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,نه په پراختیا د په اکر کې! جوړ په site_config.json یا د &#39;ګمرک&#39; DocType کړي.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,نه په پراختیا د په اکر کې! جوړ په site_config.json یا د 'ګمرک' DocType کړي.
 DocType: Workflow State,globe,نړۍ
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,د لومړیتوب
@@ -3518,7 +3518,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,لطفا د اعتبار وړ ګرځنده ترانسفارمرونو د داخل
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,ستاسې په لټونګر کې د ځينې ځانګړنې د کار نه. لطفا د وروستۍ بڼې ته د خپل د کتنمل د اوسمهالولو.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,ستاسې په لټونګر کې د ځينې ځانګړنې د کار نه. لطفا د وروستۍ بڼې ته د خپل د کتنمل د اوسمهالولو.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",نه پوهېږم، پوښتنه د &#39;مرستې&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",نه پوهېږم، پوښتنه د 'مرستې'
 DocType: DocType,Comments and Communications will be associated with this linked document,تبصرې او مخابراتو به له دې سره تړاو لري سند مل وي
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,چاڼ ...
 DocType: Workflow State,bold,ذکر شوي
@@ -3546,7 +3546,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,د ګډون تمدید په وخت کې ناکام شو
 DocType: LDAP Settings,LDAP Group Field,د LDAP ګروپ ډګر
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,مساوی
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',د ډګر اقدام په ډېنامېک لینک &#39;ډول بايد د بل لینک ساحوي سره انتخابونو په توګه&#39; DocType &#39;اشاره
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',د ډګر اقدام په ډېنامېک لینک 'ډول بايد د بل لینک ساحوي سره انتخابونو په توګه' DocType 'اشاره
 DocType: About Us Settings,Team Members Heading,د ډلې غړي د مدعي دی
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,باطلې CSV شکل
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","د QZ ټری کاریال سره په پیوستولو کې تېروتنه ... <br><br> تاسو اړتیا لرئ د QZ ټری غوښتنلیک نصب او چلئ ، د خامو چاپ ب featureه کارولو لپاره. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">د QZ ټری ډاونلوډ او نصبولو لپاره دلته کلیک وکړئ</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">د را چاپولو په اړه د نورو معلوماتو لپاره دلته کلیک وکړئ</a> ."
@@ -3675,8 +3675,8 @@ DocType: Web Page,Web Page,ویب پاڼه
 DocType: Workflow Document State,Next Action Email Template,د بل عمل ای میل سانچہ
 DocType: Blog Category,Blogger,ویبالګ
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline",که چیرې فعال شي ، په سند کې بدلونونه تعقیب شوي او د مهال ویش کې ښودل شوي
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;په Global د لټون لپاره ډول نه اجازه {0} په قطار {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;په Global د لټون لپاره ډول نه اجازه {0} په قطار {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'په Global د لټون لپاره ډول نه اجازه {0} په قطار {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'په Global د لټون لپاره ډول نه اجازه {0} په قطار {1}
 DocType: Energy Point Log,Appreciation,قدرداني
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,محتویات بشپړفهرست
 DocType: Workflow,Don't Override Status,مه حالت نه واوړې
@@ -3822,7 +3822,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,default
 DocType: Translation,Verified,تصدیق شوی
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} زياته کړه
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',لپاره د لټون &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',لپاره د لټون '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,لطفا د دې رپوټ په لومړي سر وژغوري
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ګډون کړه
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,نه په
@@ -3859,14 +3859,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,زه
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} نه یو باوري د بهرنیو چارو
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,د اسنادو ټولو ډولونو باندې تطبیق کړئ
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,د انرژي ټکي تازه
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. وی.دا په اسعارو د راکړې ورکړې ملاتړ نه کوي &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',لطفا بل طریقه ټاکي. وی.دا په اسعارو د راکړې ورکړې ملاتړ نه کوي '{0}'
 DocType: Chat Message,Room Type,د خونې ډول
 DocType: Data Import Beta,Import Log Preview,د خبرونې مخکتنه وارد کړئ
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,د لټون ډګر {0} د اعتبار وړ نه دی
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,پورته شوې دوتنه
 DocType: Workflow State,ok-circle,سمه ده-کړۍ
 DocType: LDAP Settings,LDAP User Creation and Mapping,د LDAP کارن جوړول او نقشه کول
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',تاسو کولای شيان له خوا غوښتنه په مشتريان نارنج پیدا &#39;پیدا
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',تاسو کولای شيان له خوا غوښتنه په مشتريان نارنج پیدا 'پیدا
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,اوبخښه! کارن بايد د خپل ریکارډ بشپړ لاسرسی ولري.
 ,Usage Info,د استفادی پيژندنه
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,د کی بورډ شارټ کټونه وښیه

--- a/frappe/translations/ps.csv
+++ b/frappe/translations/ps.csv
@@ -1414,7 +1414,7 @@ DocType: Report,Is Standard,آیا د معياري
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,بشپړ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",آيا نه HTML Encode HTML نښانونو په څېر &lt;سکرېپټ> يا د تورو په څېر &lt;یا>، ځکه چې دوی کولای شي په دې برخه کې شي په قصده کارول
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",آيا نه HTML Encode HTML نښانونو په څېر <سکرېپټ> يا د تورو په څېر <یا>، ځکه چې دوی کولای شي په دې برخه کې شي په قصده کارول
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,چلول
 DocType: Blog Post,Content (HTML),مینځپانګه (HTML)
@@ -1787,7 +1787,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,فوټر به ی�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,په تمه
 DocType: System Settings,Allow only one session per user,په سلو کې د کارونکي يوازې يوه غونډه اجازه
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,کور / امتحان پوښی 1 / امتحان پوښی 3
-DocType: Website Settings,&lt;head> HTML,&lt;مشر> HTML
+DocType: Website Settings,<head> HTML,<مشر> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,وټاکئ او يا په ټول وخت صنفونه راکاږي د يو نوي پيښه رامنځ ته کړي.
 DocType: Contact,Contact Details,د اړیکو نیولو معلومات
 DocType: DocField,In Filter,په Filter
@@ -2306,7 +2306,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,نه کافي اجازې ته تړنې وګورئ
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,پته عنوان الزامی دی.
 DocType: Google Contacts,Push to Google Contacts,ګوګل اړیکو ته فشار ورکړئ
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",په &lt;مشر> د ورزیاتولو HTML د ګورت پاڼه د کړی، اصلا د ویب تصدیق او SEO کارول
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",په <مشر> د ورزیاتولو HTML د ګورت پاڼه د کړی، اصلا د ویب تصدیق او SEO کارول
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,وروګرځېد
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,د قالب د خپل descendents زياته نه شي
 DocType: Session Default Settings,Session Defaults,د ناستې ټاکل
@@ -2425,7 +2425,7 @@ DocType: Workflow State,Warning,خبرداری
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,دا ممکن په ډیری پا onو کې چاپ شي
 DocType: Data Migration Run,Percent Complete,فيصده بشپړ شوی
 DocType: Tag Category,Tag Category,Tag کټه ګورۍ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",د پرتله کولو لپاره ،> 5 ، &lt;10 یا = 324 وکاروئ. د حدونو لپاره ، 5:10 وکاروئ (د 5 او 10 ترمنځ ارزښتونو لپاره).
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",د پرتله کولو لپاره ،> 5 ، <10 یا = 324 وکاروئ. د حدونو لپاره ، 5:10 وکاروئ (د 5 او 10 ترمنځ ارزښتونو لپاره).
 DocType: Google Calendar,Pull from Google Calendar,د ګوګل کیلنڈر څخه وباسئ
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,مرسته
 DocType: User,Login Before,ننوتل مخکې
@@ -3056,7 +3056,7 @@ DocType: DocField,Allow on Submit,اجازه پر سپارل
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,استثنا ډول
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,یورتان مواده
-DocType: Web Page,Add code as &lt;script>,په توګه &lt;سکرېپټ> کوډ
+DocType: Web Page,Add code as <script>,په توګه <سکرېپټ> کوډ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,د کاروونکي جوازونه پاک کړئ
 DocType: Webhook,Headers,سرلیکونه
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,راتلونکې پېښې
@@ -3425,16 +3425,16 @@ DocType: Workflow State,share-alt,برخه-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},په ليکه کې بايد د يو شي {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4 style=""""> default کينډۍ </h4><p style=""""> کاروي <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> او د پته د ټولو برخو (په شمول د ګمرک فیلډز که چېرې وي) به موجود وي </p><pre style=""""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4 style=""""> default کينډۍ </h4><p style=""""> کاروي <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> او د پته د ټولو برخو (په شمول د ګمرک فیلډز که چېرې وي) به موجود وي </p><pre style=""""> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,د پیل تاریخ نیټه
 DocType: Role,Role Name,رول نوم
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,د ميشتو ونجول

--- a/frappe/translations/pt-BR.csv
+++ b/frappe/translations/pt-BR.csv
@@ -542,7 +542,7 @@ apps/frappe/frappe/config/setup.py +64,Report of all document shares,Relatório 
 apps/frappe/frappe/www/update-password.html +18,New Password,Nova senha
 apps/frappe/frappe/core/doctype/activity_log/activity_log.py +29,Sorry! You cannot delete auto-generated comments,Desculpe! Você não pode excluir comentários gerados automaticamente
 DocType: User,System User,Usuário do Sistema
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como &lt;script&gt; ou apenas caracteres como &lt;ou&gt;, uma vez que poderia ser usado intencionalmente neste campo"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como &lt;script> ou apenas caracteres como &lt;ou>, uma vez que poderia ser usado intencionalmente neste campo"
 DocType: Workflow State,minus-sign,sinal de menos
 apps/frappe/frappe/public/js/frappe/request.js +110,Not Found,Não encontrado
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +92,Export Custom Permissions,Exportar Permissões Personalizadas
@@ -810,7 +810,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Duração da sessã
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Este campo aparecerá apenas se o nome do campo definido está preenchido ou se as regras são verdadeiros (exemplos): meu_campo eval: doc.meu_campo=='Valor' eval: doc.idade&gt;18
+eval:doc.age>18",Este campo aparecerá apenas se o nome do campo definido está preenchido ou se as regras são verdadeiros (exemplos): meu_campo eval: doc.meu_campo=='Valor' eval: doc.idade>18
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +35,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Depois de ter definido isso, os usuários só poderão ser acessar documentos capazes (ex. Blog Post) onde existe a ligação (por exemplo, Blogger ) ."
 DocType: Error Log,Log of Scheduler Errors,Log de Erros Scheduler
 DocType: User,Bio,Bio
@@ -882,7 +882,7 @@ DocType: Workflow State,trash,lixo
 DocType: System Settings,Older backups will be automatically deleted,Os backups mais antigos serão apagados automaticamente
 DocType: Payment Gateway,Gateway,Porta de entrada
 apps/frappe/frappe/contacts/doctype/address/address.py +37,Address Title is mandatory.,Titulo do Endereço é obrigatório.
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML adicionado na seção &lt;head&gt; da página web, principalmente utilizadas para a verificação do site e SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção &lt;head> da página web, principalmente utilizadas para a verificação do site e SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js +9,Relapsed,Reincidente
 apps/frappe/frappe/utils/nestedset.py +183,Item cannot be added to its own descendents,O artigo não pode ser acrescentado para os seus próprios descendentes
 DocType: Error Snapshot,Relapses,Recaídas
@@ -1181,7 +1181,7 @@ DocType: Async Task,Reference Doc,Documento de Referência
 DocType: Communication,Keep a track of all communications,Manter registros de todas as comunicações
 apps/frappe/frappe/desk/form/save.py +34,Did not save,Não salvou
 DocType: Website Slideshow,"Note: For best results, images must be of the same size and width must be greater than height.","Observação: Para melhores resultados, as imagens devem ser do mesmo tamanho, e a largura não deve ser maior do que a altura."
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup &gt; Role Permissions Manager,As permissões podem ser gerenciados através de Configuração &gt; Gestor de Permissões por Função
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup > Role Permissions Manager,As permissões podem ser gerenciados através de Configuração > Gestor de Permissões por Função
 DocType: Contact Us Settings,Pincode,CEP
 apps/frappe/frappe/core/doctype/data_import/importer.py +106,Please make sure that there are no empty columns in the file.,"Por favor, certifique-se de que não existem colunas vazias no arquivo."
 apps/frappe/frappe/utils/oauth.py +184,Please ensure that your profile has an email address,Verifique se o seu perfil tem um endereço de email
@@ -1306,15 +1306,15 @@ DocType: Error Snapshot,Parent Error Snapshot,Pai Snapshot de Erro
 DocType: Workflow State,share-alt,partes-alt
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Usa href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> e todos os campos de Endereço ( incluindo campos personalizados se houver) estará disponível </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/pt-BR.csv
+++ b/frappe/translations/pt-BR.csv
@@ -542,7 +542,7 @@ apps/frappe/frappe/config/setup.py +64,Report of all document shares,Relatório 
 apps/frappe/frappe/www/update-password.html +18,New Password,Nova senha
 apps/frappe/frappe/core/doctype/activity_log/activity_log.py +29,Sorry! You cannot delete auto-generated comments,Desculpe! Você não pode excluir comentários gerados automaticamente
 DocType: User,System User,Usuário do Sistema
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como &lt;script> ou apenas caracteres como &lt;ou>, uma vez que poderia ser usado intencionalmente neste campo"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como <script> ou apenas caracteres como <ou>, uma vez que poderia ser usado intencionalmente neste campo"
 DocType: Workflow State,minus-sign,sinal de menos
 apps/frappe/frappe/public/js/frappe/request.js +110,Not Found,Não encontrado
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +92,Export Custom Permissions,Exportar Permissões Personalizadas
@@ -882,7 +882,7 @@ DocType: Workflow State,trash,lixo
 DocType: System Settings,Older backups will be automatically deleted,Os backups mais antigos serão apagados automaticamente
 DocType: Payment Gateway,Gateway,Porta de entrada
 apps/frappe/frappe/contacts/doctype/address/address.py +37,Address Title is mandatory.,Titulo do Endereço é obrigatório.
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção &lt;head> da página web, principalmente utilizadas para a verificação do site e SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção <head> da página web, principalmente utilizadas para a verificação do site e SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js +9,Relapsed,Reincidente
 apps/frappe/frappe/utils/nestedset.py +183,Item cannot be added to its own descendents,O artigo não pode ser acrescentado para os seus próprios descendentes
 DocType: Error Snapshot,Relapses,Recaídas
@@ -1306,26 +1306,26 @@ DocType: Error Snapshot,Parent Error Snapshot,Pai Snapshot de Erro
 DocType: Workflow State,share-alt,partes-alt
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Usa href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> e todos os campos de Endereço ( incluindo campos personalizados se houver) estará disponível </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% if address_line2%} {{address_line2}} & lt; br & gt; { endif% -%} 
- {{cidade}} & lt; br & gt; 
- {% if estado%} {{estado}} & lt; br & gt; {% endif -%} {% 
- se pincode%} PIN: {{pincode}} & lt; br & gt; {% endif -%} 
- {{país}} & lt; br & gt; 
- {% if telefone%} Telefone: {{telefone}} & lt; br & gt; { % endif -%} 
- {% if fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% if% email_id} Email: {{email_id}} & lt; br & gt ; {endif% -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% if address_line2%} {{address_line2}} <br> { endif% -%} 
+ {{cidade}} <br> 
+ {% if estado%} {{estado}} <br> {% endif -%} {% 
+ se pincode%} PIN: {{pincode}} <br> {% endif -%} 
+ {{país}} <br> 
+ {% if telefone%} Telefone: {{telefone}} <br> { % endif -%} 
+ {% if fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% if% email_id} Email: {{email_id}} <br> {endif% -%} 
  </ code> </ pre>"
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html +23,Switch To Desk,Ir para o Desktop
 DocType: Workflow Document State,Workflow Document State,Status do Documento do Fluxo de Trabalho

--- a/frappe/translations/pt-BR.csv
+++ b/frappe/translations/pt-BR.csv
@@ -560,7 +560,7 @@ DocType: Communication,Phone No.,Nº de Telefone.
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py +23,; not allowed in condition,; não permitido na condição
 DocType: Print Format,Custom HTML Help,Ajuda HTML Personalizado
 apps/frappe/frappe/website/doctype/contact_us_settings/contact_us_settings.js +3,See on Website,Veja no Site
-apps/frappe/frappe/model/db_schema.py +153,Reverting length to {0} for '{1}' in '{2}'; Setting the length as {3} will cause truncation of data.,Revertendo comprimento para {0} para &#39;{1}&#39; em &#39;{2}&#39;; Definir o comprimento como {3} irá causar truncamento de dados.
+apps/frappe/frappe/model/db_schema.py +153,Reverting length to {0} for '{1}' in '{2}'; Setting the length as {3} will cause truncation of data.,Revertendo comprimento para {0} para '{1}' em '{2}'; Definir o comprimento como {3} irá causar truncamento de dados.
 DocType: Print Format,Custom CSS,CSS Personalizado
 apps/frappe/frappe/model/rename_doc.py +429,Ignored: {0} to {1},Ignorados: {0} para {1}
 apps/frappe/frappe/config/setup.py +82,Log of error on automated events (scheduler).,Log de erro sobre eventos automatizados ( programador ) .
@@ -1050,7 +1050,7 @@ apps/frappe/frappe/contacts/doctype/address_template/address_template.py +33,Def
 DocType: Contact,Maintenance Manager,Gerente de Manutenção
 DocType: Website Theme,Top Bar Text Color,Cor do texto da barra superior
 DocType: Auto Repeat,Amended From,Corrigido a partir de
-apps/frappe/frappe/core/doctype/file/file.py +670,File '{0}' not found,Arquivo &#39;{0}&#39; não encontrado
+apps/frappe/frappe/core/doctype/file/file.py +670,File '{0}' not found,Arquivo '{0}' não encontrado
 DocType: User,Change Password,Alterar a senha
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js +398,X Axis Field,Campo do eixo X
 apps/frappe/frappe/public/js/frappe/form/controls/data.js +124,Invalid Email: {0},Email inválido: {0}
@@ -1454,7 +1454,7 @@ DocType: Workflow Action,Workflow Action,Ação do Fluxo de Trabalho
 DocType: Event,Send an email reminder in the morning,Enviar um email lembrete na parte da manhã
 DocType: Blog Post,Published On,Publicado no
 apps/frappe/frappe/website/doctype/web_form/web_form.py +350,Mandatory Information missing:,Informações obrigatórias ausente:
-apps/frappe/frappe/core/doctype/doctype/doctype.py +584,Field '{0}' cannot be set as Unique as it has non-unique values,"O campo &#39;{0}&#39; não pode ser definido como único, pois tem valores não-exclusivos"
+apps/frappe/frappe/core/doctype/doctype/doctype.py +584,Field '{0}' cannot be set as Unique as it has non-unique values,"O campo '{0}' não pode ser definido como único, pois tem valores não-exclusivos"
 apps/frappe/frappe/client.py +160,Only 200 inserts allowed in one request,São permitidas somente 200 inserções por solicitação
 DocType: Event,Repeat On,Repetir em
 DocType: Communication,Marked As Spam,Marcado como spam

--- a/frappe/translations/pt.csv
+++ b/frappe/translations/pt.csv
@@ -562,7 +562,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Estatísticas com base no desempenho da semana passada (de {0} a {1})
 DocType: LDAP Settings,LDAP Phone Field,Campo de telefone LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","tipo de documento..., por ex: cliente"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,A condição &#39;{0}&#39; é inválido
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,A condição '{0}' é inválido
 DocType: Workflow State,barcode,código de barras
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,O uso de subconsulta ou função é restrito
 apps/frappe/frappe/config/customization.py,Add your own translations,Adicione as suas próprias traduções
@@ -711,7 +711,7 @@ DocType: Slack Webhook URL,Webhook URL,URL do Webhook
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Nome de utilizador {0} já existe
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Não é possível definir a importação pois {1} não pode ser importado
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Ocorreu um erro no seu Modelo de Endereços {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} é um endereço de e-mail inválido em &#39;Destinatários&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} é um endereço de e-mail inválido em 'Destinatários'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,Disco Rígido
 DocType: Integration Request,Host,Anfitrião
@@ -753,7 +753,7 @@ DocType: Currency,Currency Name,Nome da Moeda
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,não há e-mails
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link expirado
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Revertendo tamanho para {0} para &#39;{1}&#39; em &#39;{2}&#39;; Definir o comprimento como {3} causará o truncamento de dados.
+							Setting the length as {3} will cause truncation of data.",Revertendo tamanho para {0} para '{1}' em '{2}'; Definir o comprimento como {3} causará o truncamento de dados.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Selecione o formato do arquivo
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash de Conteúdo
@@ -774,7 +774,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Relatório de Partilha de Documento
 DocType: Social Login Key,Base URL,URL Base
 DocType: User,Last Login,Última Sessão
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Você não pode configurar &#39;Traduzível&#39; para o campo {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Você não pode configurar 'Traduzível' para o campo {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Coluna
 DocType: Chat Profile,Chat Profile,Perfil do bate-papo
 DocType: Custom Field,Adds a custom field to a DocType,Adiciona um campo personalizado a um DocType
@@ -783,7 +783,7 @@ DocType: File,Is Home Folder,É o Ficheiro Principal
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Estilo Navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} não é um endereço de email válido
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Selecione pelo menos 1 registro para impressão
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',User &#39;{0}&#39; já tem o papel &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',User '{0}' já tem o papel '{1}'
 DocType: System Settings,Two Factor Authentication method,Método de autenticação de dois fatores
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,"Primeiro, defina o nome e salve o registro."
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 registros
@@ -1452,7 +1452,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Campo obrigatório: definir o papel para
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} criticou {1}
 DocType: Data Migration Mapping,Mapping Name,Mapeando o Nome
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: o campo &#39;{1}&#39; não pode ser definido como Único, pois possui valores não exclusivos"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: o campo '{1}' não pode ser definido como Único, pois possui valores não exclusivos"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navegar pela lista
 DocType: Currency,A symbol for this currency. For e.g. $,Um símbolo para esta moeda. Por ex: $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Traduções atualizadas com êxito
@@ -2020,7 +2020,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Se estas instruções não tiverem sido úteis, por favor, adicione nas suas sugestões nas Incidentes GitHub."
 DocType: Workflow State,bookmark,favorito
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),O nome da pasta não deve incluir &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),O nome da pasta não deve incluir '/' (slash)
 DocType: Note,Note,Nota
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Reportar Erro
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Exportar dados no formato CSV / Excel.
@@ -2126,7 +2126,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Caducidade sessão 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Este campo aparecerá apenas se o nome do campo definido aqui tem valor ou as regras são verdadeiros (exemplos): myfield eval: doc.myfield == &#39;Meu Valor&#39; eval: doc.age> 18
+eval:doc.age>18",Este campo aparecerá apenas se o nome do campo definido aqui tem valor ou as regras são verdadeiros (exemplos): myfield eval: doc.myfield == 'Meu Valor' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hoje
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Depois de ter definido isso, os utilizadores só poderão ser capazes de aceder a documentos (ex: Post de Blog) onde existir a ligação (ex: Blogger)."
@@ -2165,7 +2165,7 @@ DocType: Data Migration Connector,Database Name,Nome do banco de dados
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Recarregar Formulário
 DocType: DocField,Select,Seleção
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Visualizar log completo
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expressão Python Simples, Exemplo: status == &#39;Open&#39; e digite == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Expressão Python Simples, Exemplo: status == 'Open' e digite == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Ficheiro não anexado
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Conexão perdida. Alguns recursos podem não funcionar.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Repetições como ""aaa"" são fáceis de adivinhar"
@@ -2297,7 +2297,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Mostrar apenas erros
 DocType: Website Settings,Banner HTML,Banner de HTML
 DocType: Workflow,Send Email Alert,Enviar alerta de email
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Selecione outra forma de pagamento. não Razorpay não suporta transações em moeda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Selecione outra forma de pagamento. não Razorpay não suporta transações em moeda '{0}'
 DocType: Data Import,In Progress,Em progresso
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Na fila para da cópia de segurança. Pode demorar entre alguns minutos e uma hora.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2789,7 +2789,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Documento restaurado
 DocType: Data Export,Data Export,Exportação de Dados
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Selecione o idioma...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Você não pode configurar &#39;Opções&#39; para o campo {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Você não pode configurar 'Opções' para o campo {0}
 DocType: Help Article,Author,Autor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,retomar o envio
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Reabrir
@@ -2803,8 +2803,8 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,O Modelo de Endereço padrão não pode ser eliminado
 DocType: Contact,Maintenance Manager,Gestor de Manutenção
 DocType: Workflow State,Search,Pesquisar
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecione outro método de pagamento. Stripe não suporta transações em moeda &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecione outro método de pagamento. Stripe não suporta transações em moeda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecione outro método de pagamento. Stripe não suporta transações em moeda '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Selecione outro método de pagamento. Stripe não suporta transações em moeda '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Mover para lixeira
 DocType: Web Form,Web Form Fields,Campos de formulário Web
 DocType: Data Import,Amended From,Alterado De
@@ -3002,7 +3002,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Valor em falta para
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Adicionar Subgrupo
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Progresso da importação
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Se a condição for satisfeita, o usuário será recompensado com os pontos. por exemplo. doc.status == &#39;Closed&#39;"
+","Se a condição for satisfeita, o usuário será recompensado com os pontos. por exemplo. doc.status == 'Closed'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: O Registo Enviado não pode ser eliminado.
 DocType: GSuite Templates,Template Name,Nome do modelo
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,novo tipo de documento
@@ -3374,7 +3374,7 @@ DocType: Notification,Send alert if this field's value changes,Enviar alerta se 
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Cores do Tema
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Selecione um tipo de documento para fazer um novo formato
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Usuário não existe
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Recipientes&#39; não especificados
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Recipientes' não especificados
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,agora mesmo
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Aplique
 DocType: Footer Item,Policy,Política
@@ -3423,7 +3423,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Traduções Perso
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Progresso
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,por Função
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Campos ausentes
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname inválido &#39;{0}&#39; em autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname inválido '{0}' em autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Pesquisar em um tipo de documento
 DocType: Custom DocPerm,Role and Level,Função e Nível
 DocType: File,Thumbnail URL,URL Thumbnail
@@ -3737,8 +3737,8 @@ DocType: Web Page,Web Page,Página Web
 DocType: Workflow Document State,Next Action Email Template,Modelo de email de próxima ação
 DocType: Blog Category,Blogger,Blogueiro
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Se ativado, as alterações no documento são rastreadas e mostradas na linha do tempo"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Na Pesquisa Global&#39; não é permitido para o tipo {0} na linha {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Na Pesquisa Global&#39; não é permitido para o tipo {0} na linha {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Na Pesquisa Global' não é permitido para o tipo {0} na linha {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Na Pesquisa Global' não é permitido para o tipo {0} na linha {1}
 DocType: Energy Point Log,Appreciation,Apreciação
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Ver lista
 DocType: Workflow,Don't Override Status,Não Sobrescrever o Status
@@ -3886,7 +3886,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Padrão
 DocType: Translation,Verified,Verificado
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} adicionado
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Pesquisar por &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Pesquisar por '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Por favor, salve o primeiro relatório"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} assinantes adicionados
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Not Está Em
@@ -3922,14 +3922,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Eu
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} não é um estado válido
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Aplicar a todos os tipos de documentos
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Atualização do ponto de energia
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Selecione outra forma de pagamento. O PayPal não suporta transações em moeda &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Selecione outra forma de pagamento. O PayPal não suporta transações em moeda '{0}'
 DocType: Chat Message,Room Type,Tipo de sala
 DocType: Data Import Beta,Import Log Preview,Visualização do registro de importação
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,campo de pesquisa {0} não é válido
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,arquivo enviado
 DocType: Workflow State,ok-circle,círculo-ok
 DocType: LDAP Settings,LDAP User Creation and Mapping,Criação e Mapeamento de Usuários LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Você pode encontrar as coisas, pedindo &quot;encontrar laranja em clientes &#39;"
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Você pode encontrar as coisas, pedindo &quot;encontrar laranja em clientes '"
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,É proibido compartilhar com o utilizador de website.
 ,Usage Info,Informações de uso
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Mostrar atalhos de teclado

--- a/frappe/translations/pt.csv
+++ b/frappe/translations/pt.csv
@@ -747,7 +747,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,O backup do
 DocType: DocField,In Global Search,Em Global Search
 DocType: System Settings,Brute Force Security,Segurança da força bruta
 DocType: Workflow State,indent-left,travessão-esquerdo
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} ano (s) atrás
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} ano (s) atrás
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"É arriscado eliminar este ficheiro: {0}. Por favor, contate o administrador do sistema."
 DocType: Currency,Currency Name,Nome da Moeda
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,não há e-mails
@@ -1043,7 +1043,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Não foi enco
 apps/frappe/frappe/config/customization.py,Add custom forms.,Adicione formulários personalizados.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} em {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,apresentou este documento
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Configuração&gt; Permissões do Usuário
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configuração> Permissões do Usuário
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,O sistema proporciona várias funções pré - definidas . Você pode adicionar novas funções para definir as permissões mais finos.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1264,7 +1264,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Se o utilizador tiver alguma função selecionada, então o utilizador torna-se um ""Utilizador do Sistema"". Um ""Utilizador do Sistema"" tem acesso à área de trabalho"
 DocType: System Settings,Date and Number Format,Data e Formato de Número
 apps/frappe/frappe/model/document.py,one of,um dos
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Configuração&gt; Personalizar formulário
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Configuração> Personalizar formulário
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Verificando um momento
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Mostrar as tags
 DocType: DocField,HTML Editor,Editor de HTML
@@ -1272,7 +1272,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Faturação
 DocType: Email Queue,Not Sent,Não Enviado
 DocType: Web Form,Actions,Ações
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Configuração&gt; Usuário
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Configuração> Usuário
 DocType: Workflow State,align-justify,alinhar justificado
 DocType: User,Middle Name (Optional),Nome do Meio (Opcional)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Não Permitido
@@ -1421,7 +1421,7 @@ DocType: Report,Is Standard,É Padrão
 DocType: Desktop Icon,_report,_relatório
 DocType: Desktop Icon,_report,_relatório
 DocType: Dashboard Chart,Full,Cheio
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Não Codifique tags de HTML como &lt;script&gt; ou só como caracteres como &lt; or &gt;, pois podem ser utilizados intencionalmente neste campo"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Não Codifique tags de HTML como &lt;script> ou só como caracteres como &lt; or >, pois podem ser utilizados intencionalmente neste campo"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticado em {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Corre
@@ -1803,7 +1803,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Rodapé será exi
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pendente
 DocType: System Settings,Allow only one session per user,Permitir somente uma sessão por utilizador
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Início/Pasta de Teste 1/Pasta de Teste 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selecione ou arraste intervalos de tempo para criar um novo evento.
 DocType: Contact,Contact Details,Dados de Contacto
 DocType: DocField,In Filter,No Filtro
@@ -2037,7 +2037,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Neste momento não é permitido iniciar sessão
 DocType: Data Migration Run,Current Mapping Action,Ação de Mapeamento atual
 DocType: Dashboard Chart Source,Source Name,Nome da Fonte
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Nenhuma conta de email associada ao usuário. Adicione uma conta em Usuário&gt; Caixa de entrada de email.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Nenhuma conta de email associada ao usuário. Adicione uma conta em Usuário> Caixa de entrada de email.
 DocType: Email Account,Email Sync Option,Sincronizar e-mail Opção
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Row No
 DocType: Async Task,Runtime,Tempo de Execução
@@ -2052,7 +2052,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Já está
 DocType: User Email,Enable Outgoing,Ativar Enviar
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Etiquetas personalizadas
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Conta de e-mail não configurada. Crie uma nova conta de email em Configuração&gt; Email&gt; Conta de email
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Conta de e-mail não configurada. Crie uma nova conta de email em Configuração> Email> Conta de email
 DocType: Comment,Submitted,Enviado
 DocType: Contact,Pulled from Google Contacts,Extraído dos Contatos do Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Pedido inválido
@@ -2126,7 +2126,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Caducidade sessão 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Este campo aparecerá apenas se o nome do campo definido aqui tem valor ou as regras são verdadeiros (exemplos): myfield eval: doc.myfield == &#39;Meu Valor&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Este campo aparecerá apenas se o nome do campo definido aqui tem valor ou as regras são verdadeiros (exemplos): myfield eval: doc.myfield == &#39;Meu Valor&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hoje
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Depois de ter definido isso, os utilizadores só poderão ser capazes de aceder a documentos (ex: Post de Blog) onde existir a ligação (ex: Blogger)."
@@ -2140,7 +2140,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,MAIÚSCULAS
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML Personalizada
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Insira o nome da pasta
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nenhum modelo de endereço padrão encontrado. Crie um novo em Configuração&gt; Impressão e identidade visual&gt; Modelo de endereço.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nenhum modelo de endereço padrão encontrado. Crie um novo em Configuração> Impressão e identidade visual> Modelo de endereço.
 apps/frappe/frappe/auth.py,Unknown User,Usuário desconhecido
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Selecione Papel
 DocType: Comment,Deleted,Eliminados
@@ -2331,7 +2331,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Não há permissão suficiente para ver links
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,É obrigatório colocar o Título do Endereço.
 DocType: Google Contacts,Push to Google Contacts,Enviar para os Contatos do Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML adicionado na seção do &lt;livro&gt; da página web, utilizada principalmente para a verificação do website e SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção do &lt;livro> da página web, utilizada principalmente para a verificação do website e SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Reincidência
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,O item não pode ser acrescentado para aos seus próprios subitens
 DocType: Session Default Settings,Session Defaults,Padrões de Sessão
@@ -2450,7 +2450,7 @@ DocType: Workflow State,Warning,Aviso
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Isso pode ser impresso em várias páginas
 DocType: Data Migration Run,Percent Complete,Percentagem completa
 DocType: Tag Category,Tag Category,tag Categoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparação, use&gt; 5, &lt;10 ou = 324. Para intervalos, use 5:10 (para valores entre 5 e 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparação, use> 5, &lt;10 ou = 324. Para intervalos, use 5:10 (para valores entre 5 e 10)."
 DocType: Google Calendar,Pull from Google Calendar,Puxe do Google Agenda
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ajuda
 DocType: User,Login Before,Iniciar Sessão Antes
@@ -2918,7 +2918,7 @@ DocType: Custom Script,Custom Script,Script Personalizado
 DocType: Address,Address Line 2,Endereço Linha 2
 DocType: Address,Reference,Referência
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Atribuído A
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Configure a Conta de email padrão em Configuração&gt; Email&gt; Conta de email
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Configure a Conta de email padrão em Configuração> Email> Conta de email
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detalhes do mapeamento de migração de dados
 DocType: Data Import,Action,Ação
 DocType: GSuite Settings,Script URL,URL do script
@@ -3096,7 +3096,7 @@ DocType: DocField,Allow on Submit,Permitir ao Enviar
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipo de Exceção
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Escolher Colunas
-DocType: Web Page,Add code as &lt;script&gt;,Adicionar código como &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Adicionar código como &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Limpar permissões do usuário
 DocType: Webhook,Headers,Cabeçalhos
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,próximos eventos
@@ -3473,26 +3473,26 @@ DocType: Workflow State,share-alt,partes alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},A fila deve ser uma de {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4>Modelo Padrão</h4>
 <p>Utiliza <a href=""http://jinja.pocoo.org/docs/templates/""> O Modelo Jinja</a> e todos os campos do Endereço (incluindo Campos Personalizados, caso haja) estarão disponíveis</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Telefone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Telefone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>"
 DocType: Calendar View,Start Date Field,Campo de Data de Início
 DocType: Role,Role Name,Nome da Função

--- a/frappe/translations/pt.csv
+++ b/frappe/translations/pt.csv
@@ -1421,7 +1421,7 @@ DocType: Report,Is Standard,É Padrão
 DocType: Desktop Icon,_report,_relatório
 DocType: Desktop Icon,_report,_relatório
 DocType: Dashboard Chart,Full,Cheio
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Não Codifique tags de HTML como &lt;script> ou só como caracteres como &lt; or >, pois podem ser utilizados intencionalmente neste campo"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Não Codifique tags de HTML como <script> ou só como caracteres como < or >, pois podem ser utilizados intencionalmente neste campo"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticado em {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Corre
@@ -1803,7 +1803,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Rodapé será exi
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Pendente
 DocType: System Settings,Allow only one session per user,Permitir somente uma sessão por utilizador
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Início/Pasta de Teste 1/Pasta de Teste 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selecione ou arraste intervalos de tempo para criar um novo evento.
 DocType: Contact,Contact Details,Dados de Contacto
 DocType: DocField,In Filter,No Filtro
@@ -2331,7 +2331,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Não há permissão suficiente para ver links
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,É obrigatório colocar o Título do Endereço.
 DocType: Google Contacts,Push to Google Contacts,Enviar para os Contatos do Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção do &lt;livro> da página web, utilizada principalmente para a verificação do website e SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção do <livro> da página web, utilizada principalmente para a verificação do website e SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Reincidência
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,O item não pode ser acrescentado para aos seus próprios subitens
 DocType: Session Default Settings,Session Defaults,Padrões de Sessão
@@ -2450,7 +2450,7 @@ DocType: Workflow State,Warning,Aviso
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Isso pode ser impresso em várias páginas
 DocType: Data Migration Run,Percent Complete,Percentagem completa
 DocType: Tag Category,Tag Category,tag Categoria
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparação, use> 5, &lt;10 ou = 324. Para intervalos, use 5:10 (para valores entre 5 e 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Para comparação, use> 5, <10 ou = 324. Para intervalos, use 5:10 (para valores entre 5 e 10)."
 DocType: Google Calendar,Pull from Google Calendar,Puxe do Google Agenda
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ajuda
 DocType: User,Login Before,Iniciar Sessão Antes
@@ -3096,7 +3096,7 @@ DocType: DocField,Allow on Submit,Permitir ao Enviar
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Tipo de Exceção
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Escolher Colunas
-DocType: Web Page,Add code as &lt;script>,Adicionar código como &lt;script>
+DocType: Web Page,Add code as <script>,Adicionar código como <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Limpar permissões do usuário
 DocType: Webhook,Headers,Cabeçalhos
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,próximos eventos
@@ -3473,26 +3473,26 @@ DocType: Workflow State,share-alt,partes alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},A fila deve ser uma de {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4>Modelo Padrão</h4>
 <p>Utiliza <a href=""http://jinja.pocoo.org/docs/templates/""> O Modelo Jinja</a> e todos os campos do Endereço (incluindo Campos Personalizados, caso haja) estarão disponíveis</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Telefone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Telefone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>"
 DocType: Calendar View,Start Date Field,Campo de Data de Início
 DocType: Role,Role Name,Nome da Função

--- a/frappe/translations/pt_br.csv
+++ b/frappe/translations/pt_br.csv
@@ -935,7 +935,7 @@ DocType: Bulk Update,Bulk Update,Alteração em Massa
 DocType: Workflow State,zoom-out,diminuir zoom
 DocType: Communication,Email Status,Satus do Email
 apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,Mensagens do chat e outras notificações.
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Arquivo &#39;{0}&#39; não encontrado
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Arquivo '{0}' não encontrado
 DocType: Print Settings,Compact Item Print,Imprimir item no formato compacto
 DocType: DocType,Track Seen,Marcar como visto
 apps/frappe/frappe/model/delete_doc.py,User not allowed to delete {0}: {1},Usuário não tem permissão para excluir {0}: {1}

--- a/frappe/translations/pt_br.csv
+++ b/frappe/translations/pt_br.csv
@@ -85,7 +85,7 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Edit Filter,Edit Filte
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Este campo aparecerá apenas se o nome do campo definido está preenchido ou se as regras são verdadeiros (exemplos): meu_campo eval: doc.meu_campo=='Valor' eval: doc.idade&gt;18
+eval:doc.age>18",Este campo aparecerá apenas se o nome do campo definido está preenchido ou se as regras são verdadeiros (exemplos): meu_campo eval: doc.meu_campo=='Valor' eval: doc.idade>18
 DocType: File,File URL,URL do arquivo
 DocType: Website Settings,Disable Customer Signup link in Login page,Desativar Link de Inscrição na Página de Login
 apps/frappe/frappe/auth.py,Invalid Request,Requisição Inválida
@@ -215,7 +215,7 @@ apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Carregando...
 apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,A senha não pode ter mais de 100 caracteres
 DocType: Portal Settings,Standard Sidebar Menu,Menu Lateral Padrão
 DocType: Help Article,Likes,Likes
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como &lt;script&gt; ou apenas caracteres como &lt;ou&gt;, uma vez que poderia ser usado intencionalmente neste campo"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como &lt;script> ou apenas caracteres como &lt;ou>, uma vez que poderia ser usado intencionalmente neste campo"
 apps/frappe/frappe/core/doctype/data_import/importer.py,Please do not change the rows above {0},"Por favor, não alterar as linhas acima {0}"
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select All,Selecionar Tudo
 apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Adicionar mais
@@ -871,7 +871,7 @@ apps/frappe/frappe/website/doctype/website_settings/website_settings.py,Invalid 
 apps/frappe/frappe/core/doctype/file/file.py,File {0} does not exist,Arquivo {0} não existe
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Não é possível enviar emails neste momento
 DocType: Workflow State,remove-sign,remover-assinar
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML adicionado na seção &lt;head&gt; da página web, principalmente utilizadas para a verificação do site e SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção &lt;head> da página web, principalmente utilizadas para a verificação do site e SEO"
 apps/frappe/frappe/templates/emails/auto_reply.html,"Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail.","Sua consulta foi recebida. Nós responderemos de volta em breve. Se você tiver qualquer informação adicional, por favor responda a este email."
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please duplicate this to make changes,"Por favor, duplicar este para fazer mudanças"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} assinantes acrescentados
@@ -1193,15 +1193,15 @@ DocType: Milestone,Milestone,Marco
 DocType: DocField,In Standard Filter,Em Filtro Padrão
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Usa href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> e todos os campos de Endereço ( incluindo campos personalizados se houver) estará disponível </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/pt_br.csv
+++ b/frappe/translations/pt_br.csv
@@ -215,7 +215,7 @@ apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Carregando...
 apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,A senha não pode ter mais de 100 caracteres
 DocType: Portal Settings,Standard Sidebar Menu,Menu Lateral Padrão
 DocType: Help Article,Likes,Likes
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como &lt;script> ou apenas caracteres como &lt;ou>, uma vez que poderia ser usado intencionalmente neste campo"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Não etiquetas HTML Encode HTML como <script> ou apenas caracteres como <ou>, uma vez que poderia ser usado intencionalmente neste campo"
 apps/frappe/frappe/core/doctype/data_import/importer.py,Please do not change the rows above {0},"Por favor, não alterar as linhas acima {0}"
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select All,Selecionar Tudo
 apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Adicionar mais
@@ -871,7 +871,7 @@ apps/frappe/frappe/website/doctype/website_settings/website_settings.py,Invalid 
 apps/frappe/frappe/core/doctype/file/file.py,File {0} does not exist,Arquivo {0} não existe
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Não é possível enviar emails neste momento
 DocType: Workflow State,remove-sign,remover-assinar
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção &lt;head> da página web, principalmente utilizadas para a verificação do site e SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML adicionado na seção <head> da página web, principalmente utilizadas para a verificação do site e SEO"
 apps/frappe/frappe/templates/emails/auto_reply.html,"Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail.","Sua consulta foi recebida. Nós responderemos de volta em breve. Se você tiver qualquer informação adicional, por favor responda a este email."
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please duplicate this to make changes,"Por favor, duplicar este para fazer mudanças"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} assinantes acrescentados
@@ -1193,26 +1193,26 @@ DocType: Milestone,Milestone,Marco
 DocType: DocField,In Standard Filter,Em Filtro Padrão
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Usa href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> e todos os campos de Endereço ( incluindo campos personalizados se houver) estará disponível </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% if address_line2%} {{address_line2}} & lt; br & gt; { endif% -%} 
- {{cidade}} & lt; br & gt; 
- {% if estado%} {{estado}} & lt; br & gt; {% endif -%} {% 
- se pincode%} PIN: {{pincode}} & lt; br & gt; {% endif -%} 
- {{país}} & lt; br & gt; 
- {% if telefone%} Telefone: {{telefone}} & lt; br & gt; { % endif -%} 
- {% if fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% if% email_id} Email: {{email_id}} & lt; br & gt ; {endif% -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% if address_line2%} {{address_line2}} <br> { endif% -%} 
+ {{cidade}} <br> 
+ {% if estado%} {{estado}} <br> {% endif -%} {% 
+ se pincode%} PIN: {{pincode}} <br> {% endif -%} 
+ {{país}} <br> 
+ {% if telefone%} Telefone: {{telefone}} <br> { % endif -%} 
+ {% if fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% if% email_id} Email: {{email_id}} <br> {endif% -%} 
  </ code> </ pre>"
 DocType: File,Is Private,É privada
 apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,"Outra transação está bloqueando essa. Por favor, tente novamente em alguns segundos."

--- a/frappe/translations/ro.csv
+++ b/frappe/translations/ro.csv
@@ -755,7 +755,7 @@ DocType: Currency,Currency Name,Denumire valută
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Niciun e-mail
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link expirat
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Returnați lungimea la {0} pentru &#39;{1}&#39; în &#39;{2}&#39;; Setarea lungimii ca {3} va determina trunchierea datelor.
+							Setting the length as {3} will cause truncation of data.",Returnați lungimea la {0} pentru '{1}' în '{2}'; Setarea lungimii ca {3} va determina trunchierea datelor.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Selectați Format fișier
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Conținut Hash
@@ -786,7 +786,7 @@ DocType: File,Is Home Folder,Este Acasă Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Style
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} nu este o Adresă de Email validă
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Selectați atleast 1 record pentru imprimare
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Utilizator &#39;{0}&#39; are deja rolul &quot;{1} &#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Utilizator '{0}' are deja rolul &quot;{1} '
 DocType: System Settings,Two Factor Authentication method,Două metode de autentificare a factorilor
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Mai întâi setați numele și salvați înregistrarea.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 înregistrări
@@ -2128,7 +2128,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesiunea de expirare
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Acest câmp va apărea numai în cazul în care numele_campului definit aici are valoare sau regulile sunt adevărate (exemple): myfield eval: doc.myfield == &#39;Valoarea mea&#39; eval: doc.age> 18
+eval:doc.age>18",Acest câmp va apărea numai în cazul în care numele_campului definit aici are valoare sau regulile sunt adevărate (exemple): myfield eval: doc.myfield == 'Valoarea mea' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Biroul 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Astăzi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","După ce ați stabilit acest lucru, utilizatorii vor fi doar documente de acces capabile (ex. Blog post), în cazul în care există link-ul (de exemplu, Blogger)."
@@ -2167,7 +2167,7 @@ DocType: Data Migration Connector,Database Name,Nume Bază de Date
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Actualizează Forma
 DocType: DocField,Select,Selectează
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Vizualizare jurnal complet
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Exprimare simplă Python, Exemplu: status == &#39;Deschis&#39; și tastați == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Exprimare simplă Python, Exemplu: status == 'Deschis' și tastați == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Nu fișier atașat
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Conexiunea a fost pierdută. Este posibil ca unele funcții să nu funcționeze.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Repetări de genul &quot;aaa&quot;, sunt ușor de ghicit"
@@ -2725,7 +2725,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Modificând
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,Setări gateway de plată PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Performant de top
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Câmpurile personalizate nu pot fi adăugate la DocTypes de bază.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) vor primi trunchiate, ca și caractere maxim permis este {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) vor primi trunchiate, ca și caractere maxim permis este {2}"
 DocType: OAuth Client,Response Type,Tip de răspuns
 DocType: Contact Us Settings,Send enquiries to this email address,Trimite întrebări cu privire la această adresă de e-mail
 DocType: Letter Head,Letter Head Name,Nume scrisoare cap
@@ -2782,7 +2782,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Imagine Vizualizare
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Se pare că ceva a mers prost în timpul tranzacției. Din moment ce nu am confirmat plata, Paypal va returna automat această sumă. În caz contrar, vă rugăm să ne trimiteți un e-mail și menționează ID-ul de corespondență: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Includeți simboluri, numere și majuscule în parolă"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","După ce se introduce câmpul &#39;{0}&#39; menționat în Câmpul personalizat &#39;{1}&#39;, cu eticheta &quot;{2} &#39;, nu există"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","După ce se introduce câmpul '{0}' menționat în Câmpul personalizat '{1}', cu eticheta &quot;{2} ', nu există"
 DocType: List Filter,List Filter,Filtrați lista
 DocType: Workflow State,signal,semnal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Are atașamente
@@ -3005,7 +3005,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Valoare lipsă pentr
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Adăugă Copil
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Progresul importului
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Dacă condiția este satisfăcută, utilizatorul va fi recompensat cu punctele. de exemplu. doc.status == &#39;Închis&#39;"
+","Dacă condiția este satisfăcută, utilizatorul va fi recompensat cu punctele. de exemplu. doc.status == 'Închis'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Înregistrarea introdusă nu poate fi ștearsă.
 DocType: GSuite Templates,Template Name,Numele de șablon
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nou tip de document
@@ -3427,7 +3427,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Traduceri persona
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,progres
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,prin normă
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Câmpuri lipsă
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,numele_campului nevalid &#39;{0}&#39; în autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,numele_campului nevalid '{0}' în autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Cauta un tip de document
 DocType: Custom DocPerm,Role and Level,Rol și Nivel
 DocType: File,Thumbnail URL,URL miniatură
@@ -3890,7 +3890,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Implicit
 DocType: Translation,Verified,Verificat
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} adăugat
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Căutați pentru &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Căutați pentru '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Vă rugăm să salvați raportul întâi
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonați adăugați
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Nu în

--- a/frappe/translations/ro.csv
+++ b/frappe/translations/ro.csv
@@ -749,7 +749,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Suportul de
 DocType: DocField,In Global Search,În căutare globală
 DocType: System Settings,Brute Force Security,Siguranța Forței de Securitate
 DocType: Workflow State,indent-left,liniuța-stânga
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} an (i) în urmă
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} an (i) în urmă
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Este riscant să ștergeți acest fișier: {0}. Vă rugăm să contactați Managerul de sistem.
 DocType: Currency,Currency Name,Denumire valută
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Niciun e-mail
@@ -1047,7 +1047,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Nr {0} găsit
 apps/frappe/frappe/config/customization.py,Add custom forms.,Adăugaţi formulare personalizate.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} din {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,a prezentat acest document
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Configurare&gt; Permisii utilizator
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Configurare> Permisii utilizator
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sistemul oferă multe roluri predefinite. Puteți adăuga noi roluri pentru a seta permisiuni fine.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1268,7 +1268,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","În cazul în care utilizatorul are nici un rol verificat, atunci utilizatorul devine un &quot;sistem de utilizatori&quot;. &quot;Utilizator System&quot; are acces la spațiul de lucru"
 DocType: System Settings,Date and Number Format,Format Dată și Număr
 apps/frappe/frappe/model/document.py,one of,unul dintre
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Configurare&gt; Formularizare personalizare
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Configurare> Formularizare personalizare
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Verificarea un moment
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Arată Etichete
 DocType: DocField,HTML Editor,Editor HTML
@@ -1276,7 +1276,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Facturare
 DocType: Email Queue,Not Sent,Nu a fost trimis
 DocType: Web Form,Actions,Acțiuni
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Configurare&gt; Utilizator
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Configurare> Utilizator
 DocType: Workflow State,align-justify,aliniați-justify
 DocType: User,Middle Name (Optional),Al Doilea Nume (Opțional)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nu este permisă
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,Este standard
 DocType: Desktop Icon,_report,_raport
 DocType: Desktop Icon,_report,_raport
 DocType: Dashboard Chart,Full,Deplin
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Nu tag-uri HTML Codare HTML, cum ar fi &lt;script&gt; sau pur si simplu de caractere cum ar fi &lt;sau&gt;, deoarece acestea ar putea fi folosite în mod intenționat în acest domeniu"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nu tag-uri HTML Codare HTML, cum ar fi &lt;script> sau pur si simplu de caractere cum ar fi &lt;sau>, deoarece acestea ar putea fi folosite în mod intenționat în acest domeniu"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticat pentru {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Rulează
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer-ul va fi a
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,În așteptarea
 DocType: System Settings,Allow only one session per user,Permit numai o sesiune pentru fiecare utilizator
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folder Home / Test de 1 / folder de test 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selectați sau glisați peste intervale de timp pentru a crea un nou eveniment.
 DocType: Contact,Contact Details,Detalii Persoana de Contact
 DocType: DocField,In Filter,În Filter
@@ -2039,7 +2039,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Autentificare nu este permis în acest moment
 DocType: Data Migration Run,Current Mapping Action,Acțiune actuală de cartografiere
 DocType: Dashboard Chart Source,Source Name,sursa Nume
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Niciun cont de e-mail asociat cu Utilizatorul. Vă rugăm să adăugați un cont în User&gt; Inbox.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Niciun cont de e-mail asociat cu Utilizatorul. Vă rugăm să adăugați un cont în User> Inbox.
 DocType: Email Account,Email Sync Option,E-mail Opțiunea de sincronizare
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rândul nr
 DocType: Async Task,Runtime,Runtime
@@ -2054,7 +2054,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Există d
 DocType: User Email,Enable Outgoing,Activați ieșire
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Etichete Personalizate
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Contul de e-mail nu este configurat. Vă rugăm să creați un nou cont de e-mail din Configurare&gt; Email&gt; Cont de e-mail
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Contul de e-mail nu este configurat. Vă rugăm să creați un nou cont de e-mail din Configurare> Email> Cont de e-mail
 DocType: Comment,Submitted,Inscrisa
 DocType: Contact,Pulled from Google Contacts,Extras din Contacte Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Cerere invalida
@@ -2128,7 +2128,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesiunea de expirare
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Acest câmp va apărea numai în cazul în care numele_campului definit aici are valoare sau regulile sunt adevărate (exemple): myfield eval: doc.myfield == &#39;Valoarea mea&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Acest câmp va apărea numai în cazul în care numele_campului definit aici are valoare sau regulile sunt adevărate (exemple): myfield eval: doc.myfield == &#39;Valoarea mea&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Biroul 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Astăzi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","După ce ați stabilit acest lucru, utilizatorii vor fi doar documente de acces capabile (ex. Blog post), în cazul în care există link-ul (de exemplu, Blogger)."
@@ -2142,7 +2142,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,MAJUSCULE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Personalizat HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Introduceți numele folderului
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nu a fost găsit un șablon de adresă implicit. Vă rugăm să creați unul nou din Setare&gt; Tipărire și Branding&gt; Model de adrese.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nu a fost găsit un șablon de adresă implicit. Vă rugăm să creați unul nou din Setare> Tipărire și Branding> Model de adrese.
 apps/frappe/frappe/auth.py,Unknown User,Utilizator necunoscut
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Selectați Rolul
 DocType: Comment,Deleted,Șters
@@ -2333,7 +2333,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nu este suficientă permisiune pentru a vedea legături
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Titlul adresei este obligatoriu.
 DocType: Google Contacts,Push to Google Contacts,Apăsați către Contacte Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","HTML adăugat în secțiunea  a paginii web, folosit în principal pentru verificarea site-ului și SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adăugat în secțiunea  a paginii web, folosit în principal pentru verificarea site-ului și SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidivat
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Articol nu poate fi adăugat la propriile descendenți
 DocType: Session Default Settings,Session Defaults,Valorile implicite ale sesiunii
@@ -2453,7 +2453,7 @@ DocType: Workflow State,Warning,Avertisment
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Aceasta poate fi tipărită pe mai multe pagini
 DocType: Data Migration Run,Percent Complete,Procentul complet
 DocType: Tag Category,Tag Category,Etichetă Categorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pentru comparație, utilizați&gt; 5, &lt;10 sau = 324. Pentru intervale, utilizați 5:10 (pentru valori cuprinse între 5 și 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pentru comparație, utilizați> 5, &lt;10 sau = 324. Pentru intervale, utilizați 5:10 (pentru valori cuprinse între 5 și 10)."
 DocType: Google Calendar,Pull from Google Calendar,Trageți din Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ajutor
 DocType: User,Login Before,Înainte de conectare
@@ -2921,7 +2921,7 @@ DocType: Custom Script,Custom Script,Script personalizat
 DocType: Address,Address Line 2,Adresă Linie 2
 DocType: Address,Reference,Referință
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Atribuit pentru
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Vă rugăm să configurați contul de e-mail implicit din Configurare&gt; Email&gt; Cont de e-mail
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Vă rugăm să configurați contul de e-mail implicit din Configurare> Email> Cont de e-mail
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detalii de Mapare a Migrării Datelor
 DocType: Data Import,Action,Acțiune:
 DocType: GSuite Settings,Script URL,Script URL
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Permiteţi după introducere
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Excepție de tip
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Alege Coloane
-DocType: Web Page,Add code as &lt;script&gt;,Adăugă cod ca și &lt;script&gt;&lt;/script&gt;
+DocType: Web Page,Add code as &lt;script>,Adăugă cod ca și &lt;script>&lt;/script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Ștergeți Permisiunile utilizatorului
 DocType: Webhook,Headers,Cap
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,evenimente viitoare
@@ -3477,15 +3477,15 @@ DocType: Workflow State,share-alt,cota-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Coada ar trebui să fie una dintre {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Implicit Model </ h4> 
  <p> <a Utilizeaza href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> și toate domeniile de Adresă ( inclusiv personalizat Domenii dacă există) va fi disponibil </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/ro.csv
+++ b/frappe/translations/ro.csv
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,Este standard
 DocType: Desktop Icon,_report,_raport
 DocType: Desktop Icon,_report,_raport
 DocType: Dashboard Chart,Full,Deplin
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nu tag-uri HTML Codare HTML, cum ar fi &lt;script> sau pur si simplu de caractere cum ar fi &lt;sau>, deoarece acestea ar putea fi folosite în mod intenționat în acest domeniu"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Nu tag-uri HTML Codare HTML, cum ar fi <script> sau pur si simplu de caractere cum ar fi <sau>, deoarece acestea ar putea fi folosite în mod intenționat în acest domeniu"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} criticat pentru {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Rulează
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer-ul va fi a
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,În așteptarea
 DocType: System Settings,Allow only one session per user,Permit numai o sesiune pentru fiecare utilizator
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folder Home / Test de 1 / folder de test 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Selectați sau glisați peste intervale de timp pentru a crea un nou eveniment.
 DocType: Contact,Contact Details,Detalii Persoana de Contact
 DocType: DocField,In Filter,În Filter
@@ -2333,7 +2333,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nu este suficientă permisiune pentru a vedea legături
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Titlul adresei este obligatoriu.
 DocType: Google Contacts,Push to Google Contacts,Apăsați către Contacte Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","HTML adăugat în secțiunea  a paginii web, folosit în principal pentru verificarea site-ului și SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","HTML adăugat în secțiunea  a paginii web, folosit în principal pentru verificarea site-ului și SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidivat
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Articol nu poate fi adăugat la propriile descendenți
 DocType: Session Default Settings,Session Defaults,Valorile implicite ale sesiunii
@@ -2453,7 +2453,7 @@ DocType: Workflow State,Warning,Avertisment
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Aceasta poate fi tipărită pe mai multe pagini
 DocType: Data Migration Run,Percent Complete,Procentul complet
 DocType: Tag Category,Tag Category,Etichetă Categorie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pentru comparație, utilizați> 5, &lt;10 sau = 324. Pentru intervale, utilizați 5:10 (pentru valori cuprinse între 5 și 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Pentru comparație, utilizați> 5, <10 sau = 324. Pentru intervale, utilizați 5:10 (pentru valori cuprinse între 5 și 10)."
 DocType: Google Calendar,Pull from Google Calendar,Trageți din Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ajutor
 DocType: User,Login Before,Înainte de conectare
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Permiteţi după introducere
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Excepție de tip
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Alege Coloane
-DocType: Web Page,Add code as &lt;script>,Adăugă cod ca și &lt;script>&lt;/script>
+DocType: Web Page,Add code as <script>,Adăugă cod ca și <script></script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Ștergeți Permisiunile utilizatorului
 DocType: Webhook,Headers,Cap
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,evenimente viitoare
@@ -3477,26 +3477,26 @@ DocType: Workflow State,share-alt,cota-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Coada ar trebui să fie una dintre {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Implicit Model </ h4> 
  <p> <a Utilizeaza href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> și toate domeniile de Adresă ( inclusiv personalizat Domenii dacă există) va fi disponibil </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% dacă address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} 
- {{oraș}} & lt; br & gt; 
- {% dacă starea%} {{stat}} & lt; br & gt; {% endif -%} 
- {% dacă parola așa%} PIN: {{parola așa}} & lt; br & gt; {% endif -%} 
- {{țară}} & lt; br & gt; 
- {% dacă telefonul%} telefon: {{telefon}} & lt; br & gt; { % endif -%} 
- {% dacă fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% dacă email_id%} Email: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% dacă address_line2%} {{address_line2}} <br> { % endif -%} 
+ {{oraș}} <br> 
+ {% dacă starea%} {{stat}} <br> {% endif -%} 
+ {% dacă parola așa%} PIN: {{parola așa}} <br> {% endif -%} 
+ {{țară}} <br> 
+ {% dacă telefonul%} telefon: {{telefon}} <br> { % endif -%} 
+ {% dacă fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% dacă email_id%} Email: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Câmp cu data de începere
 DocType: Role,Role Name,Rol Nume

--- a/frappe/translations/ru.csv
+++ b/frappe/translations/ru.csv
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,Стандартный отчёт
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Полный
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не HTML Кодировать HTML-теги, такие как &lt;скрипт> или просто символы, такие как &lt;или>, так как они могут быть преднамеренно использованы в этой области"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Не HTML Кодировать HTML-теги, такие как <скрипт> или просто символы, такие как <или>, так как они могут быть преднамеренно использованы в этой области"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} подвергнут критике {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Бег
@@ -1806,7 +1806,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Нижний ко
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,В ожидании
 DocType: System Settings,Allow only one session per user,Разрешить только один сеанс для каждого пользователя
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Главная/Тестовая Папка 1/ Тестовая Папка 3
-DocType: Website Settings,&lt;head> HTML,HTML
+DocType: Website Settings,<head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Выберите или перетащите через временные интервалы, чтобы создать новое событие."
 DocType: Contact,Contact Details,Контактная информация
 DocType: DocField,In Filter,В фильтрe
@@ -2334,7 +2334,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Недостаточно прав для просмотра ссылок
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Название адреса является обязательным.
 DocType: Google Contacts,Push to Google Contacts,Нажмите на контакты Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Добавлена HTML в &lt;HEAD> часть веб-страницы, в основном используется для проверки веб-сайтов и SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Добавлена HTML в <HEAD> часть веб-страницы, в основном используется для проверки веб-сайтов и SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Рецидив
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Продукт не может быть добавлен к своим подпродуктам
 DocType: Session Default Settings,Session Defaults,Сеансы по умолчанию
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Предупреждение
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Это может быть напечатано на нескольких страницах
 DocType: Data Migration Run,Percent Complete,Процент завершен
 DocType: Tag Category,Tag Category,Тэг Категория
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для сравнения используйте> 5, &lt;10 или = 324. Для диапазонов используйте 5:10 (для значений от 5 до 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для сравнения используйте> 5, <10 или = 324. Для диапазонов используйте 5:10 (для значений от 5 до 10)."
 DocType: Google Calendar,Pull from Google Calendar,Вытащить из календаря Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помощь
 DocType: User,Login Before,Входить до
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Разрешить проведение
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Тип исключения
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Выберите столбцы
-DocType: Web Page,Add code as &lt;script>,Добавить код как <скрипт>
+DocType: Web Page,Add code as <script>,Добавить код как <скрипт>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Очистить разрешения пользователя
 DocType: Webhook,Headers,Заголовки
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Предстоящие События
@@ -3477,15 +3477,15 @@ DocType: Workflow State,share-alt,Доля-альт
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Очередь должна быть одной из {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Шаблон по умолчанию </ h4> 
  <р> Использование <a href=""http://jinja.pocoo.org/docs/templates/""> дзиндзя Templating </a> и все поля адрес ( в том числе Пользовательские поля если таковые имеются) будут доступны </ P> 
  <PRE> <код> {{address_line1}} & LT; BR & GT; 

--- a/frappe/translations/ru.csv
+++ b/frappe/translations/ru.csv
@@ -749,7 +749,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Готов�
 DocType: DocField,In Global Search,В глобальном поиске
 DocType: System Settings,Brute Force Security,Защита от Брутфорса
 DocType: Workflow State,indent-left,отступ левого
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} год (лет) назад
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} год (лет) назад
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Это рискованно, чтобы удалить этот файл: {0}. Пожалуйста, обратитесь к менеджеру системы."
 DocType: Currency,Currency Name,Название валюты
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Нет сообщений электронной почты
@@ -1047,7 +1047,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} не на
 apps/frappe/frappe/config/customization.py,Add custom forms.,Добавить пользовательские формы.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} в {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,представил этот документ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Настройка&gt; Полномочия пользователя
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Настройка> Полномочия пользователя
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,"Система предоставляет множество заранее определенных ролей. Вы можете добавить новые роли, чтобы установить более тонкие разрешения."
 DocType: Communication,CC,CC
 DocType: Country,Geo,Гео
@@ -1268,7 +1268,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Если пользователь имеет какую-либо роль, то он становится «Пользователем системы». Пользователем системы имеет доступ к рабочему столу"
 DocType: System Settings,Date and Number Format,Настройки времени и валюты
 apps/frappe/frappe/model/document.py,one of,Один из
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Настройка&gt; Настройка формы
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Настройка> Настройка формы
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Проверка одного момента
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Показать метки
 DocType: DocField,HTML Editor,Редактор HTML
@@ -1276,7 +1276,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Выставление счетов
 DocType: Email Queue,Not Sent,Не Отправлено
 DocType: Web Form,Actions,Действия
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Настройка&gt; Пользователь
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Настройка> Пользователь
 DocType: Workflow State,align-justify,выровнять-оправдать
 DocType: User,Middle Name (Optional),Отчество (необязательно)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Не Допустимая
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,Стандартный отчёт
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Полный
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Не HTML Кодировать HTML-теги, такие как &lt;скрипт&gt; или просто символы, такие как &lt;или&gt;, так как они могут быть преднамеренно использованы в этой области"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не HTML Кодировать HTML-теги, такие как &lt;скрипт> или просто символы, такие как &lt;или>, так как они могут быть преднамеренно использованы в этой области"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} подвергнут критике {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Бег
@@ -1806,7 +1806,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Нижний ко
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,В ожидании
 DocType: System Settings,Allow only one session per user,Разрешить только один сеанс для каждого пользователя
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Главная/Тестовая Папка 1/ Тестовая Папка 3
-DocType: Website Settings,&lt;head&gt; HTML,HTML
+DocType: Website Settings,&lt;head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Выберите или перетащите через временные интервалы, чтобы создать новое событие."
 DocType: Contact,Contact Details,Контактная информация
 DocType: DocField,In Filter,В фильтрe
@@ -2040,7 +2040,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Войти не допускается в это время
 DocType: Data Migration Run,Current Mapping Action,Текущие действия по составлению карт
 DocType: Dashboard Chart Source,Source Name,Имя источника
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,"Нет учетной записи электронной почты, связанной с пользователем. Пожалуйста, добавьте учетную запись под User&gt; Email Inbox."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Нет учетной записи электронной почты, связанной с пользователем. Пожалуйста, добавьте учетную запись под User> Email Inbox."
 DocType: Email Account,Email Sync Option,Опция синхронизации электронной почты
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Строка Нет
 DocType: Async Task,Runtime,Продолжительность
@@ -2055,7 +2055,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Уже в
 DocType: User Email,Enable Outgoing,Включить исходящие
 DocType: Address,Fax,Факс
 apps/frappe/frappe/config/customization.py,Custom Tags,Пользовательские теги
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,"Учетная запись электронной почты не настроена. Пожалуйста, создайте новую учетную запись электронной почты в меню «Настройка»&gt; «Электронная почта»&gt; «Учетная запись электронной почты»."
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,"Учетная запись электронной почты не настроена. Пожалуйста, создайте новую учетную запись электронной почты в меню «Настройка»> «Электронная почта»> «Учетная запись электронной почты»."
 DocType: Comment,Submitted,Проведенный
 DocType: Contact,Pulled from Google Contacts,Вытащено из контактов Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Неверный запрос
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Время сесс
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Это поле появляется только в случае, если имя_поля определено здесь имеет значение или правила являются истинными (примеры): MyField Eval: doc.myfield == &#39;My Value&#39; Eval: doc.age&gt; 18"
+eval:doc.age>18","Это поле появляется только в случае, если имя_поля определено здесь имеет значение или правила являются истинными (примеры): MyField Eval: doc.myfield == &#39;My Value&#39; Eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Офис 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Cегодня
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","После такой установки, пользователи получат доступ только к документам (например, сообщениям в блоге), связанным с этими разрешениями пользователя (например, блоггера)."
@@ -2143,7 +2143,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ВЕРХНИЙ РЕГИСТР
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Особый HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Введите имя папки
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,"Шаблон адреса по умолчанию не найден. Создайте новый, выбрав «Настройка»&gt; «Печать и брендинг»&gt; «Шаблон адреса»."
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"Шаблон адреса по умолчанию не найден. Создайте новый, выбрав «Настройка»> «Печать и брендинг»> «Шаблон адреса»."
 apps/frappe/frappe/auth.py,Unknown User,Неизвестный пользователь
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Выберите Роль
 DocType: Comment,Deleted,Удаленный
@@ -2334,7 +2334,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Недостаточно прав для просмотра ссылок
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Название адреса является обязательным.
 DocType: Google Contacts,Push to Google Contacts,Нажмите на контакты Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Добавлена HTML в &lt;HEAD&gt; часть веб-страницы, в основном используется для проверки веб-сайтов и SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Добавлена HTML в &lt;HEAD> часть веб-страницы, в основном используется для проверки веб-сайтов и SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Рецидив
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Продукт не может быть добавлен к своим подпродуктам
 DocType: Session Default Settings,Session Defaults,Сеансы по умолчанию
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Предупреждение
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Это может быть напечатано на нескольких страницах
 DocType: Data Migration Run,Percent Complete,Процент завершен
 DocType: Tag Category,Tag Category,Тэг Категория
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для сравнения используйте&gt; 5, &lt;10 или = 324. Для диапазонов используйте 5:10 (для значений от 5 до 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для сравнения используйте> 5, &lt;10 или = 324. Для диапазонов используйте 5:10 (для значений от 5 до 10)."
 DocType: Google Calendar,Pull from Google Calendar,Вытащить из календаря Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помощь
 DocType: User,Login Before,Входить до
@@ -2783,7 +2783,7 @@ apps/frappe/frappe/desk/form/save.py,{0} {1} already exists,{0} {1} уже су�
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be one of {0},Добавить к может быть одним из {0}
 DocType: Customize Form,Image View,Просмотр изображения
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Похоже, что-то пошло не так во время транзакции. Поскольку мы не подтвердили платеж, Paypal автоматически вернет вам эту сумму. Если это не так, отправьте нам электронное письмо и укажите идентификатор корреляции: {0}."
-apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Включить символы, цифры и заглавные буквы в пароле"
+apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Включить символы, цифры и ��аглавные буквы в пароле"
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","После того, как вставить поле &#39;{0}&#39;, упомянутой в настраиваемое поле &#39;{1}&#39;, с меткой &#39;{2}&#39;, не существует"
 DocType: List Filter,List Filter,Фильтр списка
 DocType: Workflow State,signal,сигнал
@@ -2921,7 +2921,7 @@ DocType: Custom Script,Custom Script,Специального сценария
 DocType: Address,Address Line 2,Адрес (2-я строка)
 DocType: Address,Reference,Справка
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Назначено
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Настройте учетную запись электронной почты по умолчанию в меню «Настройка»&gt; «Электронная почта»&gt; «Учетная запись электронной почты».
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Настройте учетную запись электронной почты по умолчанию в меню «Настройка»> «Электронная почта»> «Учетная запись электронной почты».
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Подробное описание миграции данных
 DocType: Data Import,Action,Действие
 DocType: GSuite Settings,Script URL,URL-адрес сценария
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Разрешить проведение
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Тип исключения
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Выберите столбцы
-DocType: Web Page,Add code as &lt;script&gt;,Добавить код как <скрипт>
+DocType: Web Page,Add code as &lt;script>,Добавить код как <скрипт>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Очистить разрешения пользователя
 DocType: Webhook,Headers,Заголовки
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Предстоящие События
@@ -3477,15 +3477,15 @@ DocType: Workflow State,share-alt,Доля-альт
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Очередь должна быть одной из {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Шаблон по умолчанию </ h4> 
  <р> Использование <a href=""http://jinja.pocoo.org/docs/templates/""> дзиндзя Templating </a> и все поля адрес ( в том числе Пользовательские поля если таковые имеются) будут доступны </ P> 
  <PRE> <код> {{address_line1}} & LT; BR & GT; 

--- a/frappe/translations/ru.csv
+++ b/frappe/translations/ru.csv
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Статистика на основе результатов прошлой недели (от {0} до {1})
 DocType: LDAP Settings,LDAP Phone Field,Поле телефона LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","тип документа ..., например, клиент"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Условие &#39;{0}&#39; является недействительным
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Условие '{0}' является недействительным
 DocType: Workflow State,barcode,Штрих-код
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Использование подзапроса или функции ограничено
 apps/frappe/frappe/config/customization.py,Add your own translations,Добавить свои собственные переводы
@@ -755,7 +755,7 @@ DocType: Currency,Currency Name,Название валюты
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Нет сообщений электронной почты
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Срок действия ссылки
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Возвращаем длину до {0} для &#39;{1}&#39; в &#39;{2}&#39;; Установка длины как {3} приведет к усечению данных.
+							Setting the length as {3} will cause truncation of data.",Возвращаем длину до {0} для '{1}' в '{2}'; Установка длины как {3} приведет к усечению данных.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Выберите формат файла
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Содержимое Hash
@@ -786,7 +786,7 @@ DocType: File,Is Home Folder,Является Главная Папка
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Стиль Навбар
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} — недопустимый адрес электронной почты
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Выберите по крайней мере 1 запись для печати
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Пользователь &#39;{0}&#39; уже играет роль &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Пользователь '{0}' уже играет роль '{1}'
 DocType: System Settings,Two Factor Authentication method,Двухфакторный метод проверки подлинности
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Сначала задайте имя и сохраните запись.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 записей
@@ -1456,7 +1456,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Обязательное поле: установить роль для
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} раскритиковано {1}
 DocType: Data Migration Mapping,Mapping Name,Название карты
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: поле &#39;{1}&#39; нельзя установить как уникальное, поскольку оно имеет неуникальные значения"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: поле '{1}' нельзя установить как уникальное, поскольку оно имеет неуникальные значения"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Переместиться вниз по списку
 DocType: Currency,A symbol for this currency. For e.g. $,"Символ этой валюты. Например, ₽"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Успешно обновленные переводы
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Время сесс
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Это поле появляется только в случае, если имя_поля определено здесь имеет значение или правила являются истинными (примеры): MyField Eval: doc.myfield == &#39;My Value&#39; Eval: doc.age> 18"
+eval:doc.age>18","Это поле появляется только в случае, если имя_поля определено здесь имеет значение или правила являются истинными (примеры): MyField Eval: doc.myfield == 'My Value' Eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Офис 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Cегодня
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","После такой установки, пользователи получат доступ только к документам (например, сообщениям в блоге), связанным с этими разрешениями пользователя (например, блоггера)."
@@ -2168,7 +2168,7 @@ DocType: Data Migration Connector,Database Name,Имя базы данных
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Обновить Форма
 DocType: DocField,Select,Выбрать
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Посмотреть полный журнал
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Простое выражение Python, пример: status == &#39;Open&#39; и тип == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Простое выражение Python, пример: status == 'Open' и тип == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Файл не прикреплен
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Соединение потеряно. Некоторые функции могут не работать.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Повторы, как &quot;ааа&quot; легко догадаться,"
@@ -2784,7 +2784,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Просмотр изображения
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Похоже, что-то пошло не так во время транзакции. Поскольку мы не подтвердили платеж, Paypal автоматически вернет вам эту сумму. Если это не так, отправьте нам электронное письмо и укажите идентификатор корреляции: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Включить символы, цифры и ��аглавные буквы в пароле"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","После того, как вставить поле &#39;{0}&#39;, упомянутой в настраиваемое поле &#39;{1}&#39;, с меткой &#39;{2}&#39;, не существует"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","После того, как вставить поле '{0}', упомянутой в настраиваемое поле '{1}', с меткой '{2}', не существует"
 DocType: List Filter,List Filter,Фильтр списка
 DocType: Workflow State,signal,сигнал
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Имеет приложения
@@ -2808,15 +2808,15 @@ DocType: Web Page,Slideshow,Слайд-шоу
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Адрес по умолчанию шаблона не может быть удален
 DocType: Contact,Maintenance Manager,Менеджер обслуживания
 DocType: Workflow State,Search,Поиск
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Выберите другой способ оплаты. Полоса не поддерживает транзакции в валюте &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Выберите другой способ оплаты. Полоса не поддерживает транзакции в валюте &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Выберите другой способ оплаты. Полоса не поддерживает транзакции в валюте '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Выберите другой способ оплаты. Полоса не поддерживает транзакции в валюте '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Переместить в корзину
 DocType: Web Form,Web Form Fields,Web Form Поля
 DocType: Data Import,Amended From,Измененный С
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},"Предупреждение: Не удалось найти {0} в любой таблице, связанной с {1}"
 DocType: S3 Backup Settings,eu-north-1,ес-северо-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,"Этот документ в настоящее время в очередь на выполнение. Пожалуйста, попробуйте еще раз"
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Файл &#39;{0}&#39; не найден
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Файл '{0}' не найден
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Удалить раздел
 DocType: User,Change Password,Изменить пароль
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Поле оси X
@@ -3005,7 +3005,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Нет значен�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Добавить потомка
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Импорт прогресса
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Если условие выполнено, пользователь будет вознагражден баллами. например. doc.status == &#39;Закрыто&#39;"
+","Если условие выполнено, пользователь будет вознагражден баллами. например. doc.status == 'Закрыто'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Проведенная Запись не может быть удалена.
 DocType: GSuite Templates,Template Name,Имя Шаблона
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,новый тип документа
@@ -3427,7 +3427,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Пользова�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Готовность
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,по Роли
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Отсутствующие поля
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Invalid имя_поля &#39;{0}&#39; в autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Invalid имя_поля '{0}' в autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Поиск в тип документа
 DocType: Custom DocPerm,Role and Level,Роль и уровень
 DocType: File,Thumbnail URL,Миниатюра URL
@@ -3528,7 +3528,7 @@ DocType: Dashboard Chart,Filters JSON,Фильтры JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,"Нажмите здесь, чтобы проверить,"
 DocType: Email Account,Disable SMTP server authentication,Отключить аутентификацию SMTP-сервера
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Скопировано в буфер обмена.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Предсказуемость замены как &#39;@&#39; вместо &#39;а&#39; не очень поможет.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Предсказуемость замены как '@' вместо 'а' не очень поможет.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Назначенные мной
 apps/frappe/frappe/utils/data.py,Zero,Ноль
 DocType: Google Drive,Backup Folder ID,Идентификатор резервной папки
@@ -3582,7 +3582,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Введите действительные мобильных NOS
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Некоторые из функций могут не работать в вашем браузере. Обновите браузер до последней версии.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Некоторые из функций могут не работать в вашем браузере. Обновите браузер до последней версии.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Не знаю, спросите &#39;помощь&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Не знаю, спросите 'помощь'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},отменил этот документ {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Комментарии и коммуникации будут связаны с этой связанного документа
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Фильтр ...
@@ -3890,7 +3890,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,По умолчанию
 DocType: Translation,Verified,проверенный
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} добавлено
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Поиск &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Поиск '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Пожалуйста, сохраните отчет первой"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} подписчики добавлены
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Не в

--- a/frappe/translations/si.csv
+++ b/frappe/translations/si.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","මෙම පහසුකම සක්රීය කළ විට, මුර පදය ශක්තිය අවම මුරපදය ලකුණු අගය මත පදනම් ක්රියාත්මක කරනු ඇත. 2 ක වටිනාකමින් මධ්ය ශක්තිමත් වීම සහ 4 ඉතා ශක්තිමත් වීම."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","මෙම පහසුකම සක්රීය කළ විට, මුර පදය ශක්තිය අවම මුරපදය ලකුණු අගය මත පදනම් ක්රියාත්මක කරනු ඇත. 2 ක වටිනාකමින් මධ්ය ශක්තිමත් වීම සහ 4 ඉතා ශක්තිමත් වීම."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;කණ්ඩායම මන්ත්රීවරුන්&quot; හෝ &quot;කළමනාකරණය&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',ක්ෂේත්රයේ &#39;පරීක්ෂා කරන්න&#39; &#39;වර්ගය විය යුතුයි&#39; 0 &#39;හෝ&#39; 1 &#39;එක්කෝ සඳහා පෙරනිමි
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',ක්ෂේත්රයේ 'පරීක්ෂා කරන්න' 'වර්ගය විය යුතුයි' 0 'හෝ' 1 'එක්කෝ සඳහා පෙරනිමි
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,ඊයේ
 DocType: Contact,Designation,තනතුර
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,ස්වයංක්‍රීය සම්බන්ධතා සක්‍රිය කළ හැක්කේ එක් විද්‍යුත් තැපැල් ගිණුමක් සඳහා පමණි.
@@ -251,7 +251,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,ආබාධි�
 DocType: Translation,Contributed Translation Doctype Name,දායක වූ පරිවර්තන ඩොක්ටයිප් නම
 DocType: PayPal Settings,Redirect To,වෙත යළි යොමු
 DocType: Data Migration Mapping,Pull,අදින්න
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},ජාවාස්ක්රිප්ට් ආකෘතිය: frappe.query_reports [ &#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},ජාවාස්ක්රිප්ට් ආකෘතිය: frappe.query_reports [ 'REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,තොග යාවත්කාලීන
 DocType: Workflow State,chevron-up,Chevron-අප්
 DocType: DocType,Allow Guest to View,අමුත්තා බලන්න ඉඩ දෙන්න
@@ -553,7 +553,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,උඩුගත කිරීම අසාර්ථක විය
 DocType: LDAP Settings,LDAP Phone Field,LDAP දුරකථන ක්ෂේත්‍රය
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","ලිපි වර්ගය ..., උදා: පාරිභෝගික"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,මෙම තත්වය &#39;{0}&#39; වලංගු නොවන
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,මෙම තත්වය '{0}' වලංගු නොවන
 DocType: Workflow State,barcode,පච්චයක්
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,උප-විමසුම හෝ ක්රියාකාරිත්වය භාවිතය සීමා කරනු ලැබේ
 apps/frappe/frappe/config/customization.py,Add your own translations,ඔබේ ම පරිවර්තනය එකතු කරන්න
@@ -700,7 +700,7 @@ DocType: Slack Webhook URL,Webhook URL,වෙබ්ක්රමය URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,පරිශීලක නාමය {0} දැනටමත් පවතී
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: ආනයන සිටුවම් කල නොහැක ලෙස {1} importable නොවේ
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},ඔබගේ ලිපිනය සැකිල්ල {0} දෝෂයක් වේ
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',&#39;ලබන්නන්&#39; තුළ {0} වලංගු නොවන ඊ-තැපැල් ලිපිනයකි.
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients','ලබන්නන්' තුළ {0} වලංගු නොවන ඊ-තැපැල් ලිපිනයකි.
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,සත්කාරක රට
@@ -742,7 +742,7 @@ DocType: Currency,Currency Name,ව්යවහාර මුදල් නම
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,කිසිදු විද්යුත් තැපැල් පණිවුඩ
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Link කල් ඉකුත් විය
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; හි {1} සඳහා {0} ට දිග හැරීම; {3} ලෙස සකසාගත හැක.
+							Setting the length as {3} will cause truncation of data.",'{2}' හි {1} සඳහා {0} ට දිග හැරීම; {3} ලෙස සකසාගත හැක.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,ගොනු ආකෘතිය තෝරන්න
 DocType: Report,Javascript,කරුණාකර Javascript
 DocType: File,Content Hash,අන්තර්ගත නිහඬයි
@@ -758,7 +758,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","සම්මත DocType, පෙරනිමි මුද්රිත ආකෘතිය නොහැකි Customize ආකෘති පත්රය භාවිතා කරන්න"
 DocType: Report,Query,විමසුම්
 DocType: Customize Form,Sort Order,වර්ග නියමය
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;ලැයිස්තුව දැක්වීම&#39; පේළිය වර්ගය {0} සඳහා අවසර නැත {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'ලැයිස්තුව දැක්වීම' පේළිය වර්ගය {0} සඳහා අවසර නැත {1}
 DocType: Letter Head,Footer HTML,පාදක HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,ඔබට නව ක්ෂේත්ර ඇතුළු කිරීමට අවශ්ය කළ පසු ලේබලය තෝරන්න.
 ,Document Share Report,ලේඛන මෙම දැන්වීම වාර්තා කරන්න
@@ -773,7 +773,7 @@ DocType: File,Is Home Folder,මුල් පිටුව ෆෝල්ඩරය 
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,නවබාර් විලාසිතාව
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} වලංගු විද්යුත් තැපැල් ලිපිනය නොවේ
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,මුද්රණය සඳහා ආයෝජිත මුදලක් 1 වාර්තා තෝරන්න
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',පරිශීලක &#39;{0}&#39; දැනටමත් භූමිකාව &#39;{1}&#39; ඇත
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',පරිශීලක '{0}' දැනටමත් භූමිකාව '{1}' ඇත
 DocType: System Settings,Two Factor Authentication method,සාධක සහතික කිරීමේ ක්රම දෙකක්
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,"පළමුවෙන්ම නම තබන්න, වාර්තාව තබා ගන්න."
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 වාර්තා
@@ -1021,7 +1021,7 @@ DocType: Property Setter,Property Setter,ඉඩකඩම් පන්දු ඔ�
 DocType: Web Form,Allow Print,මුද්රණය ඉඩ දෙන්න
 DocType: Communication,Clicked,මත ක්ලික්
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,අනුගමනය නොකරන්න
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},අවසර නැත කිරීමට &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},අවසර නැත කිරීමට '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,යැවීමට නියමිත
 DocType: DocType,Track Seen,ධාවන දැක
 DocType: Dropbox Settings,File Backup,ගොනු බැකප්
@@ -1048,7 +1048,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,පිටුව HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,දෝෂ සහිත පේළි අපනයනය කරන්න
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,කණ්ඩායම් නාම හිස් විය නොහැක.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,තවදුරටත් මංසල පමණි &#39;සමූහය වර්ගය මංසල යටතේ නිර්මාණය කිරීම ද කළ හැක
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,තවදුරටත් මංසල පමණි 'සමූහය වර්ගය මංසල යටතේ නිර්මාණය කිරීම ද කළ හැක
 DocType: SMS Parameter,Header,ශීර්ෂකය
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},නොදන්නා තීරුව: {0}
 DocType: Notification Recipient,Email By Role,ඊ-තැපැල් කාර්යභාරය වන විට
@@ -1428,7 +1428,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,අනිවාර්ය ක්ෂේත්ර: තැබූ භූමිකාව
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} විවේචනය කරන ලදි {1}
 DocType: Data Migration Mapping,Mapping Name,සිතියම නම
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: &#39;{1}&#39; ක්ෂේත්‍රය අද්විතීය නොවන අගයන් ඇති බැවින් එය අද්විතීය ලෙස සැකසිය නොහැක
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: '{1}' ක්ෂේත්‍රය අද්විතීය නොවන අගයන් ඇති බැවින් එය අද්විතීය ලෙස සැකසිය නොහැක
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,ලැයිස්තුව පහළට සංචාලනය කරන්න
 DocType: Currency,A symbol for this currency. For e.g. $,මෙම මුදල් සඳහා සංකේතය. උදා: $ සඳහා
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,සාර්ථක ලෙස යාවත්කාලීන කරන ලද පරිවර්තන
@@ -1935,7 +1935,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-ගිනිකොන -1
 DocType: DocType,"Must be of type ""Attach Image""",වර්ගයේ විය යුතුය &quot;රූප අමුණන්න&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,එන්ක්රිප්ට් සියලු
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ඔබ ශූන්යය කළ නොහැකි &#39;පමණක් කියවන්න&#39; ක්ෂේත්රය සඳහා {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},ඔබ ශූන්යය කළ නොහැකි 'පමණක් කියවන්න' ක්ෂේත්රය සඳහා {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,ශුන්ය ඕනෑම වේලාවක දී යාවත්කාලීන වාර්තා යැවීමට අදහස්
 DocType: Auto Email Report,Zero means send records updated at anytime,ශුන්ය ඕනෑම වේලාවක දී යාවත්කාලීන වාර්තා යැවීමට අදහස්
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,සම්පූර්ණ කරන සැකසුම
@@ -1979,7 +1979,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,ගූගල් ෆොන්ට්
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","මෙම උපදෙස් නැති ජීවිතේ එහිදී නම්, කරුණාකර GitHub ඇතිවූ ගැටලු පිළිබඳ ඔබගේ අදහස් ගැන එක් කරන්න."
 DocType: Workflow State,bookmark,පිටු සලකුණු කිරීම
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ෆෝල්ඩරයක් &#39;/&#39; (ඇල ඉර) ඇතුලත් නොවේ
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ෆෝල්ඩරයක් '/' (ඇල ඉර) ඇතුලත් නොවේ
 DocType: Note,Note,සටහන
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,දෝෂ වාර්තාව
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel ආකෘතියේ අපනයන දත්ත.
@@ -2084,7 +2084,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,06:00 උදා: ප
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",myfield eval: doc.myfield == &#39;&#39; මාගේ අගය &#39;eval: doc.age> 18 මෙතන අර්ථ fieldname වටිනාකමක් නම් පමණක් හෝ නීති රීති (උදාහරණ) සැබෑ මෙම ක්ෂේත්රය දිස් වනු ඇත
+eval:doc.age>18",myfield eval: doc.myfield == '' මාගේ අගය 'eval: doc.age> 18 මෙතන අර්ථ fieldname වටිනාකමක් නම් පමණක් හෝ නීති රීති (උදාහරණ) සැබෑ මෙම ක්ෂේත්රය දිස් වනු ඇත
 DocType: Social Login Key,Office 365,කාර්යාලය 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,අද
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,අද
@@ -2124,7 +2124,7 @@ DocType: Data Migration Connector,Database Name,දත්ත සමුදාය 
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,ආකෘතිය refresh කරන්න
 DocType: DocField,Select,තෝරන්න
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,සම්පූර්ණ ලොගය බලන්න
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","සරල පයිතන් ප්‍රකාශනය, උදාහරණය: තත්වය == &#39;විවෘත&#39; සහ == &#39;දෝෂය&#39; ටයිප් කරන්න"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","සරල පයිතන් ප්‍රකාශනය, උදාහරණය: තත්වය == 'විවෘත' සහ == 'දෝෂය' ටයිප් කරන්න"
 apps/frappe/frappe/utils/csvutils.py,File not attached,ගොනුව සම්බන්ධ නැති
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,සම්බන්ධතාවය අහිමි විය. සමහර ලක්ෂණ වැඩ නොකරයි.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; වැනි දරුවා අනුමාන කිරීමට පහසුය
@@ -2253,7 +2253,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,දෝෂ පමණක් පෙන්වන්න
 DocType: Website Settings,Banner HTML,බැනරය HTML
 DocType: Workflow,Send Email Alert,Email Alert යවන්න
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. Razorpay මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. Razorpay මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත '{0}'
 DocType: Data Import,In Progress,ප්රගතියේ
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,උපස්ථ සදහා පෙළ ගැසෙනු. එය පැය කිරීම සඳහා විනාඩි කිහිපයක් ගත විය හැකිය.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2668,7 +2668,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,මහසභාවේ
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal ගෙවීම් සැකසුම්
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,ඉහළම කාර්ය සාධනය
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,අභිරුචි ක්ෂේත්‍ර මූලික ඩොක්ටයිපයට එක් කළ නොහැක.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: උපරිම අක්ෂර සඳහා අවසර ලෙස &#39;{1}&#39; ({3}), සීමාව අකුරු ලැබෙනු ඇත {2} වේ"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: උපරිම අක්ෂර සඳහා අවසර ලෙස '{1}' ({3}), සීමාව අකුරු ලැබෙනු ඇත {2} වේ"
 DocType: OAuth Client,Response Type,ප්රතිචාර වර්ගය
 DocType: Contact Us Settings,Send enquiries to this email address,මෙම ඊ-තැපැල් ලිපිනය විමසා යවන්න
 DocType: Letter Head,Letter Head Name,ලිපි ශීර්ෂයක නම
@@ -2723,7 +2723,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,රූප දැක්ම
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","යමක් දී ගණුදෙනුවේ වැරදි ගොස් වගේ. අපි ගෙවීම තහවුරු කර ඇති අතර, Paypal ස්වයංක්රීයව ඔබ මෙම මුදල ආපසු ගෙවන ඇත. එය එහි නොමැති නම්, අප වෙත ඊමේල් මෙම සහසම්බන්ධ හැඳුනුම්පත යැවීම හා සඳහන් කරන්න: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","රහස් වචනය තුළ සංකේත, ඉලක්කම් සහ ප්රාග්ධන ලිපි ඇතුළත්"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ලේබලය සහිත රේගු ක්ෂේත්ර සඳහන් ක්ෂේත්ර පසු ඇතුල් කරන්න &#39;{0}&#39; &#39;{1}&#39;, &#39;{2}&#39;, නොපවතියි"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","ලේබලය සහිත රේගු ක්ෂේත්ර සඳහන් ක්ෂේත්ර පසු ඇතුල් කරන්න '{0}' '{1}', '{2}', නොපවතියි"
 DocType: List Filter,List Filter,ලැයිස්තු පෙරහන
 DocType: Workflow State,signal,සංඥා
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,ඇමිණුම් ඇත
@@ -2733,7 +2733,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,ලේඛන යළි පිහිටුවයි
 DocType: Data Export,Data Export,දත්ත අපනයනය
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,භාෂාව තෝරන්න...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},ක්ෂේත්රය සඳහා &#39;විකල්පයන්&#39; {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},ක්ෂේත්රය සඳහා 'විකල්පයන්' {0}
 DocType: Help Article,Author,කර්තෘ
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,යැවීම ආරම්භ
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,යළි විවෘත
@@ -2747,15 +2747,15 @@ DocType: Web Page,Slideshow,විනිවිදක දර්ශනය
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,පෙරනිමි ලිපිනය සැකිල්ල මකා දැමිය නොහැක
 DocType: Contact,Maintenance Manager,නඩත්තු කළමනාකරු
 DocType: Workflow State,Search,සෙවීම
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. Stripe මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. Stripe මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. Stripe මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. Stripe මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,කුණු කූඩයට දැමීමට ගෙන යන්න
 DocType: Web Form,Web Form Fields,වෙබ් ආකෘති පත්රය ෆීල්ඩ්ස්
 DocType: Data Import,Amended From,සංශෝධිත වන සිට
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},අවවාදයයි: {1} අදාළ ඕනෑම වගුවේ {0} සොයාගත නොහැකි විය
 DocType: S3 Backup Settings,eu-north-1,eu-north-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,මෙම ලේඛනය දැනට ක්රියාත්මක කිරීම සඳහා පෙළ ගැසෙනු ඇත. කරුණාකර නැවත උත්සාහ කරන්න
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ගොනුව &#39;{0}&#39; සොයා ගැනීමට නොහැකි
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ගොනුව '{0}' සොයා ගැනීමට නොහැකි
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,වගන්තිය ඉවත් කරන්න
 DocType: User,Change Password,මුරපදය වෙනස් කරන්න
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,එක්ස් ඇක්සිස් ෆීල්ඩ්
@@ -2939,7 +2939,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,අගය සඳහ�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,ළමා එකතු කරන්න
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,ආනයන ප්‍රගතිය
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",කොන්දේසිය සෑහීමකට පත්වේ නම් පරිශීලකයාට ලකුණු සමඟ ත්‍යාග ලැබේ. උදා. doc.status == &#39;වසා ඇත&#39;
+",කොන්දේසිය සෑහීමකට පත්වේ නම් පරිශීලකයාට ලකුණු සමඟ ත්‍යාග ලැබේ. උදා. doc.status == 'වසා ඇත'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: ඉදිරිපත් වාර්තා ඉවත් කල නොහැක.
 DocType: GSuite Templates,Template Name,සැකිල්ල නම
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ලියවිල්ල නව වර්ගයේ
@@ -3069,7 +3069,7 @@ DocType: Dashboard Chart,Chart Type,වගුව වර්ගය
 DocType: DocType,Auto Name,වාහන නම
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,ඔවුන් අනුමාන කිරීමට පහසුය ලෙස ඒබීසී හෝ 6543 වැනි අනුපිළිවෙලවල් වළකින්න
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,කරුණාකර නැවත උත්සාහ කරන්න
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; හෝ &#39;https: //&#39; සමඟ ආරම්භ විය යුතුය.
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' හෝ 'https: //' සමඟ ආරම්භ විය යුතුය.
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,x විකල්ප 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,සංස්කරණය කරන්න
@@ -3302,7 +3302,7 @@ DocType: Notification,Send alert if this field's value changes,නම් මෙ�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,තේමා වර්ණ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,නව ආකෘතිය ගැනීම සඳහා DocType තෝරන්න
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,පරිශීලකයා නොපවතී
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;ලබන්නන්&#39; නිශ්චිතව දක්වා නැත
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'ලබන්නන්' නිශ්චිතව දක්වා නැත
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,මේ දැන්
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,අදාළ
 DocType: Footer Item,Policy,ප්රතිපත්ති
@@ -3349,7 +3349,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,රේගු ප�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,ප්රගතිය
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,කාර්යභාරය විසින්
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,අතුරුදහන් ෆීල්ඩ්ස්
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname වලංගු නොවන fieldname &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname වලංගු නොවන fieldname '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ලියවිල්ලක් වර්ගය සෝදිසි
 DocType: Custom DocPerm,Role and Level,කාර්යභාරය සහ පෙළ
 DocType: File,Thumbnail URL,සිඟිති-රූපය URL එක
@@ -3436,11 +3436,11 @@ DocType: Dashboard Chart,Filters JSON,පෙරහන් JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,තහවුරු කිරීමට මෙතන ක්ලික් කරන්න
 DocType: Email Account,Disable SMTP server authentication,SMTP සේවාදායක සත්‍යාපනය අක්‍රීය කරන්න
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,ක්ලිප් පුවරුවට පිටපත් කරන ලදි.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,&#39;ඒ&#39; ඉතා උදව් කරන්නේ නැහැ වෙනුවට &#39;@&#39; වැනි අනාවැකි කිව හැකි ආෙද්ශක.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,'ඒ' ඉතා උදව් කරන්නේ නැහැ වෙනුවට '@' වැනි අනාවැකි කිව හැකි ආෙද්ශක.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,මා විසින් පවරා
 apps/frappe/frappe/utils/data.py,Zero,ශුන්ය
 DocType: Google Drive,Backup Folder ID,උපස්ථ ෆෝල්ඩර හැඳුනුම්පත
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,නෑ සංවර්ධක ප්රකාරය! site_config.json දී සකස් කිරීම හෝ &#39;අභිරුචි&#39; DocType කරන්න.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,නෑ සංවර්ධක ප්රකාරය! site_config.json දී සකස් කිරීම හෝ 'අභිරුචි' DocType කරන්න.
 DocType: Workflow State,globe,ලොව
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,ප්රමුඛ
@@ -3488,7 +3488,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,වලංගු ජංගම දුරකථන අංක ඇතුලත් කරන්න
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,විශේෂාංග සමහර ඔබගේ බ්රවුසරයේ වැඩ නොහැකි විය. නවතම අනුවාදය කිරීමට ඔබට ඔබේ බ්රව්සරයේ යාවත්කාලීන කරන්න.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,විශේෂාංග සමහර ඔබගේ බ්රවුසරයේ වැඩ නොහැකි විය. නවතම අනුවාදය කිරීමට ඔබට ඔබේ බ්රව්සරයේ යාවත්කාලීන කරන්න.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","දන්නේ නැහැ, අහන්න &#39;උදව්&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","දන්නේ නැහැ, අහන්න 'උදව්'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},මෙම ලේඛනය අවලංගු කරන ලදි {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,අදහස් හා සන්නිවේදන මෙම සම්බන්ධ ලේඛනය සමග සංෙයෝජිත ෙකෙර්
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,පෙරහන...
@@ -3517,7 +3517,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,දායක මුදල් සංශෝධනය කිරීමේදී අසමත් විය
 DocType: LDAP Settings,LDAP Group Field,LDAP සමූහ ක්ෂේත්‍රය
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,සමාන
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ක්ෂේත්රයේ විකල්ප &#39;ඩයිනමික් ලින්ක් වර්ගය&#39; DocType &#39;ලෙස විකල්ප සමග තවත් ලින්ක් ක්ෂේත්ර පෙන්වා දිය යුතුය
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',ක්ෂේත්රයේ විකල්ප 'ඩයිනමික් ලින්ක් වර්ගය' DocType 'ලෙස විකල්ප සමග තවත් ලින්ක් ක්ෂේත්ර පෙන්වා දිය යුතුය
 DocType: About Us Settings,Team Members Heading,කණ්ඩායම මන්ත්රීවරුන් ශීර්ෂය
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,වලංගු නොවන CSV ආකෘතිය
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ තැටි යෙදුමට සම්බන්ධ වීමේ දෝෂයකි ... <br><br> අමු මුද්‍රණ විශේෂාංගය භාවිතා කිරීම සඳහා ඔබට QZ තැටි යෙදුම ස්ථාපනය කර ක්‍රියාත්මක කළ යුතුය. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ තැටි බාගත කර ස්ථාපනය කිරීමට මෙතැන ක්ලික් කරන්න</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">අමු මුද්‍රණය පිළිබඳ වැඩිදුර දැන ගැනීමට මෙහි ක්ලික් කරන්න</a> ."
@@ -3643,8 +3643,8 @@ DocType: Web Page,Web Page,වෙබ් පිටුව
 DocType: Workflow Document State,Next Action Email Template,ඊළඟ ක්රියාකාරී ඊමේල් සැකිල්ල
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","සක්‍රිය කර ඇත්නම්, ලේඛනයේ වෙනස්කම් නිරීක්ෂණය කර කාලරාමුවෙහි පෙන්වනු ලැබේ"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ගෝලීය සොයන්න දී&#39; පේළිය වර්ගය {0} සඳහා අවසර නැත {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;ගෝලීය සොයන්න දී&#39; පේළිය වර්ගය {0} සඳහා අවසර නැත {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ගෝලීය සොයන්න දී' පේළිය වර්ගය {0} සඳහා අවසර නැත {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'ගෝලීය සොයන්න දී' පේළිය වර්ගය {0} සඳහා අවසර නැත {1}
 DocType: Energy Point Log,Appreciation,අගය කිරීම
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,දැක්ම ලැයිස්තුව
 DocType: Workflow,Don't Override Status,තත්ත්වය ඉක්මවා යන්න එපා
@@ -3787,7 +3787,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,පෙරනිමි
 DocType: Translation,Verified,සත්‍යාපනය
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} එකතු
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&#39;{0}&#39; සඳහා සොයන්න
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}','{0}' සඳහා සොයන්න
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,පළමු වාර්තාව කරුනාකර
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ග්රාහකයන් එකතු
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,වී නැත
@@ -3824,14 +3824,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,මට
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} වලංගු රාජ්ය නොවේ
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,සියලුම ලේඛන වර්ග වලට අයදුම් කරන්න
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,ශක්ති ලක්ෂ්‍ය යාවත්කාලීන කිරීම
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. පේපෑල් මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',කරුණාකර වෙනත් ගෙවීමේ ක්රමයක් තෝරාගන්න. පේපෑල් මුදල් ගනුදෙනු සඳහා පහසුකම් සපයන්නේ නැත '{0}'
 DocType: Chat Message,Room Type,කාමර වර්ගය
 DocType: Data Import Beta,Import Log Preview,ලොග් පෙරදසුන ආයාත කරන්න
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,සොයන්න ක්ෂේත්ර {0} වලංගු නොවේ
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,උඩුගත කරන ලද ගොනුව
 DocType: Workflow State,ok-circle,හරි-රවුම
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP පරිශීලක නිර්මාණය සහ සිතියම්කරණය
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',ඔබ &#39;පාරිභෝගිකයින් තැඹිලි සොයා&#39; අසමින් දේවල් සොයා ගත හැකි
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',ඔබ 'පාරිභෝගිකයින් තැඹිලි සොයා' අසමින් දේවල් සොයා ගත හැකි
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,සමාවන්න! පරිශීලක සිය වාර්තාවම වෙත ප්රවේශ විය යුතුය.
 ,Usage Info,භාවිතය තොරතුරු
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,යතුරුපුවරු කෙටිමං පෙන්වන්න
@@ -3902,7 +3902,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Select Filters
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export Report: {0},අපනයන වාර්තාව: {0}
 DocType: Auto Email Report,Filter Meta,මෙටා පෙරහන්
 DocType: Web Page,Set Meta Tags,මෙටා ටැග් සකසන්න
-DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,පෙළ මෙම ආකෘති පත්රය වෙබ් පිටුවක් තිබේ නම් වෙබ් පිටු සබැඳිය සඳහා ප්රදර්ශනය කළ යුතුය. &#39;&#39; Page_name` හා &#39;parent_website_route` මත පදනම් ලින්ක් මාර්ගයේ ස්වයංක්රීයව නිර්මානය වනු ඇත
+DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,පෙළ මෙම ආකෘති පත්රය වෙබ් පිටුවක් තිබේ නම් වෙබ් පිටු සබැඳිය සඳහා ප්රදර්ශනය කළ යුතුය. '' Page_name` හා 'parent_website_route` මත පදනම් ලින්ක් මාර්ගයේ ස්වයංක්රීයව නිර්මානය වනු ඇත
 DocType: S3 Backup Settings,Backup Limit,බැකප් සීමාව
 DocType: Dashboard Chart,Line,රේඛාව
 DocType: Unhandled Email,Message-id,පණිවුඩය-id

--- a/frappe/translations/si.csv
+++ b/frappe/translations/si.csv
@@ -505,7 +505,7 @@ DocType: Dashboard Chart,Time Series Based On,කාල ශ්‍රේණි �
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0},{0} හි වෙනස් අගය
 DocType: Report,JSON,JSON
 apps/frappe/frappe/core/doctype/user/user.py,Please check your email for verification,සත්යාපනය සඳහා ඔබගේ ඊ-තැපැල් ලිපිනය පරික්ෂා කර බලන්න
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold can not be at the end of the form,ගුණයකින් ස්වරූපයෙන් අවසානයේ විය නොහැකි
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold can not be at the end of the form,ගුණයකින් ස්���රූපයෙන් අවසානයේ විය නොහැකි
 DocType: Communication,Bounced,ගගනගාමියකු
 DocType: Deleted Document,Deleted Name,මකා දමන ලදී නම
 apps/frappe/frappe/config/users_and_permissions.py,System and Website Users,පද්ධතිය සහ වෙබ් අඩවිය භාවිතා කරන්නන්ට
@@ -736,7 +736,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ගොන�
 DocType: DocField,In Global Search,ගෝලීය සොයන්න දී
 DocType: System Settings,Brute Force Security,බලවත් හමුදා ආරක්ෂාව
 DocType: Workflow State,indent-left,ඉන්ඩෙන්ට් වාම
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} වසර (න්) පෙර
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} වසර (න්) පෙර
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,{0}: මෙම ගොනුව මකා දමන්න කිරීම අවදානම් හගත. ඔබේ පද්ධතිය කළමනාකරු හා සම්බන්ධ වන්න.
 DocType: Currency,Currency Name,ව්යවහාර මුදල් නම
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,කිසිදු විද්යුත් තැපැල් පණිවුඩ
@@ -1030,7 +1030,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0} සොය
 apps/frappe/frappe/config/customization.py,Add custom forms.,අභිරුචි ආකාර එකතු කරන්න.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} තුළ {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,මෙම ලියවිල්ල ඉදිරිපත්
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,සැකසුම&gt; පරිශීලක අවසර
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,සැකසුම> පරිශීලක අවසර
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,මෙම පද්ධතිය බොහෝ පෙර අර්ථ චරිත සපයයි. ඔබට ඇත්තේ හොඳ අවසර ඇති කිරීමට නව කාර්යභාරයන් එක් කළ හැකිය.
 DocType: Communication,CC,CC
 DocType: Country,Geo,භූ
@@ -1245,7 +1245,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","පරිශීලක පරීක්ෂා ඕනෑම කාර්යභාරයක් නම්, පරිශීලකයා &quot;පද්ධති පරිශීලක&quot; බවට පත් වෙයි. &quot;පද්ධති පරිශීලක&quot; ඩෙස්ක්ටොප් ප්රවේශය ඇත"
 DocType: System Settings,Date and Number Format,දිනය හා අංකය ආකෘතිය
 apps/frappe/frappe/model/document.py,one of,එක්
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,සැකසුම&gt; පෝරමය අභිරුචිකරණය කරන්න
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,සැකසුම> පෝරමය අභිරුචිකරණය කරන්න
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,එක් මොහොතක පරීක්ෂා
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,ඇමිණුම් පෙන්වන්න
 DocType: DocField,HTML Editor,HTML සංස්කාරකය
@@ -1253,7 +1253,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,බිල්පත්
 DocType: Email Queue,Not Sent,යවා නැත
 DocType: Web Form,Actions,ක්රියා
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,සැකසුම&gt; පරිශීලකයා
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,සැකසුම> පරිශීලකයා
 DocType: Workflow State,align-justify,සන්ධානගත-සාධාරණීකරණය
 DocType: User,Middle Name (Optional),මැද නම (විකල්ප)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,අවසර නැත
@@ -1399,7 +1399,7 @@ DocType: Report,Is Standard,සම්මත වේ
 DocType: Desktop Icon,_report,_වාර්තාව
 DocType: Desktop Icon,_report,_වාර්තාව
 DocType: Dashboard Chart,Full,පූර්ණ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","ඔවුන් හිතාමතාම මෙම ක්ෂේත්රය තුළ භාවිත කළ හැකි ලෙස, &lt;තිර රචනය&gt; හෝ හුදෙක් චරිත වගේ &lt;හෝ&gt; වගේ HTML කේතාංකනය HTML නොවන ටැග් කරන්න"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ඔවුන් හිතාමතාම මෙම ක්ෂේත්රය තුළ භාවිත කළ හැකි ලෙස, &lt;තිර රචනය> හෝ හුදෙක් චරිත වගේ &lt;හෝ> වගේ HTML කේතාංකනය HTML නොවන ටැග් කරන්න"
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,දුවන්න
 DocType: Blog Post,Content (HTML),අන්තර්ගතය (HTML)
@@ -1562,7 +1562,7 @@ apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} reco
 DocType: Custom Role,Custom Role,අභිරුචි කාර්යභාරය
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 2,මුල් පිටුව / ටෙස්ට් ෆෝල්ඩරය 2
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter your password,ඔබගේ මුර පදය ඇතුලත් කරන්න
-DocType: Dropbox Settings,Dropbox Access Secret,නාමාවලි එකක් ප්රවේශ රහස්
+DocType: Dropbox Settings,Dropbox Access Secret,���ාමාවලි එකක් ප්රවේශ රහස්
 DocType: Tag Link,Document Title,ලේඛන මාතෘකාව
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,(Mandatory),(අනිවාර්ය)
 DocType: Social Login Key,Social Login Provider,සමාජ ආරක්ෂණ සැපයුම්කරු
@@ -1767,7 +1767,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,පාදකය �
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,විභාග
 DocType: System Settings,Allow only one session per user,පරිශීලකයෙකුට එක් සැසි ඉඩ දෙන්න
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,මුල් පිටුව / ටෙස්ට් ෆෝල්ඩරය 1 / ටෙස්ට් ෆෝල්ඩරය 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;Head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,තෝරා ගැනීමට හෝ නව අවස්ථාවට නිර්මාණය කිරීමට මඳබව පුරා ඇදගෙන යන්න.
 DocType: Contact,Contact Details,ඇමතුම් විස්තර
 DocType: DocField,In Filter,පෙරහන් දී
@@ -1996,7 +1996,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,ලොගින් වන්න මෙම කාලයේ දී අවසර නැත
 DocType: Data Migration Run,Current Mapping Action,වත්මන් සිතියම් ක්රියාවලිය
 DocType: Dashboard Chart Source,Source Name,මූලාශ්රය නම
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,පරිශීලකයා හා සම්බන්ධ ඊමේල් ගිණුමක් නොමැත. කරුණාකර පරිශීලක&gt; විද්‍යුත් තැපැල් එන ලිපි යටතේ ගිණුමක් එක් කරන්න.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,පරිශීලකයා හා සම්බන්ධ ඊමේල් ගිණුමක් නොමැත. කරුණාකර පරිශීලක> විද්‍යුත් තැපැල් එන ලිපි යටතේ ගිණුමක් එක් කරන්න.
 DocType: Email Account,Email Sync Option,ඊ-තැපැල් සමමුහුර්ත කරන්න ඔප්ෂන්
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,පේළි අංක
 DocType: Async Task,Runtime,runtime
@@ -2011,7 +2011,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,දැන
 DocType: User Email,Enable Outgoing,ඇමතුම් සක්රිය කරන්න
 DocType: Address,Fax,ෆැක්ස්
 apps/frappe/frappe/config/customization.py,Custom Tags,රේගු ඇමිණුම්
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,විද්‍යුත් තැපැල් ගිණුම සැකසෙන්නේ නැත. සැකසුම&gt; විද්‍යුත් තැපෑල&gt; විද්‍යුත් තැපැල් ගිණුමෙන් කරුණාකර නව විද්‍යුත් තැපැල් ගිණුමක් සාදන්න
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,විද්‍යුත් තැපැල් ගිණුම සැකසෙන්නේ නැත. සැකසුම> විද්‍යුත් තැපෑල> විද්‍යුත් තැපැල් ගිණුමෙන් කරුණාකර නව විද්‍යුත් තැපැල් ගිණුමක් සාදන්න
 DocType: Comment,Submitted,ඉදිරිපත්
 DocType: Contact,Pulled from Google Contacts,ගූගල් සම්බන්ධතා වලින් අදින ලදි
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,වලංගු ඉල්ලීම් වලදී
@@ -2050,7 +2050,7 @@ DocType: Report,Report Builder,වාර්තාව Builder
 DocType: Async Task,Task Name,කාර්ය සාධක නම
 DocType: Website Route Meta,Meta Tags,මෙටා ටැග්
 apps/frappe/frappe/app.py,"Your session has expired, please login again to continue.","ඔබගේ සැසිය කල් ඉකුත් වී ඇති අතර, ඉදිරියට ද නැවත කරුණාකර ලොගින් වන්න."
-apps/frappe/frappe/app.py,"Your session has expired, please login again to continue.","ඔබගේ සැසිය කල් ඉකුත් වී ඇති අතර, ඉදිරියට ද නැවත කරුණාකර ලොගින් වන්න."
+apps/frappe/frappe/app.py,"Your session has expired, please login again to continue.","ඔබගේ සැසිය කල් ඉ���ුත් වී ඇති අතර, ඉදිරියට ද නැවත කරුණාකර ලොගින් වන්න."
 apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Invalid Subscription,වලංගු නොවන දායකත්වය
 DocType: Comment,Workflow,කාර්ය ප්රවාහ
 DocType: Website Settings,Welcome Message,පිළිගැනීමේ පණිවිඩය
@@ -2084,7 +2084,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,06:00 උදා: ප
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",myfield eval: doc.myfield == &#39;&#39; මාගේ අගය &#39;eval: doc.age&gt; 18 මෙතන අර්ථ fieldname වටිනාකමක් නම් පමණක් හෝ නීති රීති (උදාහරණ) සැබෑ මෙම ක්ෂේත්රය දිස් වනු ඇත
+eval:doc.age>18",myfield eval: doc.myfield == &#39;&#39; මාගේ අගය &#39;eval: doc.age> 18 මෙතන අර්ථ fieldname වටිනාකමක් නම් පමණක් හෝ නීති රීති (උදාහරණ) සැබෑ මෙම ක්ෂේත්රය දිස් වනු ඇත
 DocType: Social Login Key,Office 365,කාර්යාලය 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,අද
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,අද
@@ -2099,7 +2099,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ඉෙළ CASE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,රේගු HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ෆෝල්ඩරය නම ඇතුලත් කරන්න
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,පෙරනිමි ලිපින සැකිල්ලක් හමු නොවීය. සැකසුම&gt; මුද්‍රණය සහ වෙළඳ නාම&gt; ලිපින සැකිල්ලෙන් කරුණාකර නව එකක් සාදන්න.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,පෙරනිමි ලිපින සැකිල්ලක් හමු නොවීය. සැකසුම> මුද්‍රණය සහ වෙළඳ නාම> ලිපින සැකිල්ලෙන් කරුණාකර නව එකක් සාදන්න.
 apps/frappe/frappe/auth.py,Unknown User,නොදන්නා පරිශීලක
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,කාර්යභාරය තෝරන්න
 DocType: Comment,Deleted,මකා දමන ලදී
@@ -2285,7 +2285,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,සබැඳි බලන්න තරම් අවසර නෑ
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ලිපිනය හිමිකම් අනිවාර්ය වේ.
 DocType: Google Contacts,Push to Google Contacts,ගූගල් සම්බන්ධතා වෙත තල්ලු කරන්න
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",මූලික වශයෙන් වෙබ් අඩවිය සත්යාපනය හා SEO සඳහා භාවිතා කරන වෙබ් පිටුවේ &lt;head&gt; කොටස තුල එකතු HTML
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",මූලික වශයෙන් වෙබ් අඩවිය සත්යාපනය හා SEO සඳහා භාවිතා කරන වෙබ් පිටුවේ &lt;head> කොටස තුල එකතු HTML
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ප්රතික්ෂේප වූ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,අයිතමය තමන්ගේ ම පැවත එන්නන් එකතු කළ නොහැකි
 DocType: Session Default Settings,Session Defaults,සැසි පෙරනිමි
@@ -2402,7 +2402,7 @@ DocType: Workflow State,Warning,අවවාදයයි
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,මෙය පිටු කිහිපයක මුද්‍රණය වීමට ඉඩ ඇත
 DocType: Data Migration Run,Percent Complete,සම්පූර්ණයි
 DocType: Tag Category,Tag Category,ටැග ප්රවර්ගය
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","සංසන්දනය සඳහා,&gt; 5, &lt;10 හෝ = 324 භාවිතා කරන්න. පරාසයන් සඳහා, 5:10 භාවිතා කරන්න (5 සහ 10 අතර අගයන් සඳහා)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","සංසන්දනය සඳහා,> 5, &lt;10 හෝ = 324 භාවිතා කරන්න. පරාසයන් සඳහා, 5:10 භාවිතා කරන්න (5 සහ 10 අතර අගයන් සඳහා)."
 DocType: Google Calendar,Pull from Google Calendar,ගූගල් දින දර්ශනයෙන් අදින්න
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,උදව්
 DocType: User,Login Before,පෙර ලොගින් වන්න
@@ -2858,7 +2858,7 @@ DocType: Custom Script,Custom Script,රේගු කේත රචනය
 DocType: Address,Address Line 2,ලිපින පේළිය 2
 DocType: Address,Reference,විමර්ශන
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,කිරීම සඳහා පවරා
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,කරුණාකර පෙරනිමි ඊමේල් ගිණුම සැකසුම&gt; විද්‍යුත් තැපෑල&gt; විද්‍යුත් තැපැල් ගිණුමෙන් සකසන්න
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,කරුණාකර පෙරනිමි ඊමේල් ගිණුම සැකසුම> විද්‍යුත් තැපෑල> විද්‍යුත් තැපැල් ගිණුමෙන් සකසන්න
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,දත්ත සංක්රමණ සිත සටහන් කිරීම
 DocType: Data Import,Action,කටයුතු
 DocType: GSuite Settings,Script URL,තිර රචනය URL එක
@@ -3031,7 +3031,7 @@ DocType: DocField,Allow on Submit,ඉදිරිපත් මත ඉඩ දෙ�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,ව්යතිරේක වර්ගය
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,තීරු තෝරන්න
-DocType: Web Page,Add code as &lt;script&gt;,&lt;තිර රචනය&gt; ලෙස කේතය එකතු කරන්න
+DocType: Web Page,Add code as &lt;script>,&lt;තිර රචනය> ලෙස කේතය එකතු කරන්න
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,පරිශීලක අවසර හිස් කරන්න
 DocType: Webhook,Headers,ශීර්ෂක
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ඉදිරියට එන සිද්ධීන්
@@ -3397,16 +3397,16 @@ DocType: Workflow State,share-alt,කොටස්-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},පෝලිමේ {0} එක් විය යුතු
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> පෙරනිමි සැකිල්ල </h4><p> භාවිතා <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> සහ ලිපිනය (රේගු ෆීල්ඩ්ස් නම් ඇතුළුව) සියලුම ක්ෂේත්ර ලබා ගත හැකි වනු ඇත </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> පෙරනිමි සැකිල්ල </h4><p> භාවිතා <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> සහ ලිපිනය (රේගු ෆීල්ඩ්ස් නම් ඇතුළුව) සියලුම ක්ෂේත්ර ලබා ගත හැකි වනු ඇත </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ආරම්භක දිනය ක්ෂේත්රය
 DocType: Role,Role Name,කාර්යභාරය නම
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,අංශය සඳහා මාරු

--- a/frappe/translations/si.csv
+++ b/frappe/translations/si.csv
@@ -1399,7 +1399,7 @@ DocType: Report,Is Standard,සම්මත වේ
 DocType: Desktop Icon,_report,_වාර්තාව
 DocType: Desktop Icon,_report,_වාර්තාව
 DocType: Dashboard Chart,Full,පූර්ණ
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","ඔවුන් හිතාමතාම මෙම ක්ෂේත්රය තුළ භාවිත කළ හැකි ලෙස, &lt;තිර රචනය> හෝ හුදෙක් චරිත වගේ &lt;හෝ> වගේ HTML කේතාංකනය HTML නොවන ටැග් කරන්න"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","ඔවුන් හිතාමතාම මෙම ක්ෂේත්රය තුළ භාවිත කළ හැකි ලෙස, <තිර රචනය> හෝ හුදෙක් චරිත වගේ <හෝ> වගේ HTML කේතාංකනය HTML නොවන ටැග් කරන්න"
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,දුවන්න
 DocType: Blog Post,Content (HTML),අන්තර්ගතය (HTML)
@@ -1767,7 +1767,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,පාදකය �
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,විභාග
 DocType: System Settings,Allow only one session per user,පරිශීලකයෙකුට එක් සැසි ඉඩ දෙන්න
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,මුල් පිටුව / ටෙස්ට් ෆෝල්ඩරය 1 / ටෙස්ට් ෆෝල්ඩරය 3
-DocType: Website Settings,&lt;head> HTML,&lt;Head> HTML
+DocType: Website Settings,<head> HTML,<Head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,තෝරා ගැනීමට හෝ නව අවස්ථාවට නිර්මාණය කිරීමට මඳබව පුරා ඇදගෙන යන්න.
 DocType: Contact,Contact Details,ඇමතුම් විස්තර
 DocType: DocField,In Filter,පෙරහන් දී
@@ -2285,7 +2285,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,සබැඳි බලන්න තරම් අවසර නෑ
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ලිපිනය හිමිකම් අනිවාර්ය වේ.
 DocType: Google Contacts,Push to Google Contacts,ගූගල් සම්බන්ධතා වෙත තල්ලු කරන්න
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",මූලික වශයෙන් වෙබ් අඩවිය සත්යාපනය හා SEO සඳහා භාවිතා කරන වෙබ් පිටුවේ &lt;head> කොටස තුල එකතු HTML
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",මූලික වශයෙන් වෙබ් අඩවිය සත්යාපනය හා SEO සඳහා භාවිතා කරන වෙබ් පිටුවේ <head> කොටස තුල එකතු HTML
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,ප්රතික්ෂේප වූ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,අයිතමය තමන්ගේ ම පැවත එන්නන් එකතු කළ නොහැකි
 DocType: Session Default Settings,Session Defaults,සැසි පෙරනිමි
@@ -2402,7 +2402,7 @@ DocType: Workflow State,Warning,අවවාදයයි
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,මෙය පිටු කිහිපයක මුද්‍රණය වීමට ඉඩ ඇත
 DocType: Data Migration Run,Percent Complete,සම්පූර්ණයි
 DocType: Tag Category,Tag Category,ටැග ප්රවර්ගය
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","සංසන්දනය සඳහා,> 5, &lt;10 හෝ = 324 භාවිතා කරන්න. පරාසයන් සඳහා, 5:10 භාවිතා කරන්න (5 සහ 10 අතර අගයන් සඳහා)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","සංසන්දනය සඳහා,> 5, <10 හෝ = 324 භාවිතා කරන්න. පරාසයන් සඳහා, 5:10 භාවිතා කරන්න (5 සහ 10 අතර අගයන් සඳහා)."
 DocType: Google Calendar,Pull from Google Calendar,ගූගල් දින දර්ශනයෙන් අදින්න
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,උදව්
 DocType: User,Login Before,පෙර ලොගින් වන්න
@@ -3031,7 +3031,7 @@ DocType: DocField,Allow on Submit,ඉදිරිපත් මත ඉඩ දෙ�
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,ව්යතිරේක වර්ගය
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,තීරු තෝරන්න
-DocType: Web Page,Add code as &lt;script>,&lt;තිර රචනය> ලෙස කේතය එකතු කරන්න
+DocType: Web Page,Add code as <script>,<තිර රචනය> ලෙස කේතය එකතු කරන්න
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,පරිශීලක අවසර හිස් කරන්න
 DocType: Webhook,Headers,ශීර්ෂක
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,ඉදිරියට එන සිද්ධීන්
@@ -3397,16 +3397,16 @@ DocType: Workflow State,share-alt,කොටස්-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},පෝලිමේ {0} එක් විය යුතු
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> පෙරනිමි සැකිල්ල </h4><p> භාවිතා <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> සහ ලිපිනය (රේගු ෆීල්ඩ්ස් නම් ඇතුළුව) සියලුම ක්ෂේත්ර ලබා ගත හැකි වනු ඇත </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> පෙරනිමි සැකිල්ල </h4><p> භාවිතා <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> සහ ලිපිනය (රේගු ෆීල්ඩ්ස් නම් ඇතුළුව) සියලුම ක්ෂේත්ර ලබා ගත හැකි වනු ඇත </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ආරම්භක දිනය ක්ෂේත්රය
 DocType: Role,Role Name,කාර්යභාරය නම
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,අංශය සඳහා මාරු

--- a/frappe/translations/sk.csv
+++ b/frappe/translations/sk.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Je standardní
 DocType: Desktop Icon,_report,_správa
 DocType: Desktop Icon,_report,_správa
 DocType: Dashboard Chart,Full,plne
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nenechajte HTML Kódovanie HTML tagy ako &lt;script> alebo len znaky ako &lt;alebo>, pretože by mohli byť zámerne použité v tomto odbore"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Nenechajte HTML Kódovanie HTML tagy ako <script> alebo len znaky ako <alebo>, pretože by mohli byť zámerne použité v tomto odbore"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritizovaný dňa {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,beh
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Päta sa zobrazí
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Čakajúce
 DocType: System Settings,Allow only one session per user,Umožňujú len jednu reláciu na jedného používateľa
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Nová událost: Zvolte nebo táhněte skrz Časová pole.
 DocType: Contact,Contact Details,Kontaktné údaje
 DocType: DocField,In Filter,Ve filtru
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nedostatok povolenia na zobrazenie odkazov
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Názov adresy je povinný.
 DocType: Google Contacts,Push to Google Contacts,Push to Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Pridané HTML do sekcie &lt;head> webovej stránky, používané najmä pre overovanie webových stránok a SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Pridané HTML do sekcie <head> webovej stránky, používané najmä pre overovanie webových stránok a SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsujúcou
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Položka nemůže být přidána jako svůj vlastní podřízený potomek
 DocType: Session Default Settings,Session Defaults,Predvolené hodnoty relácie
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,Upozornění
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Môže sa to vytlačiť na viacerých stranách
 DocType: Data Migration Run,Percent Complete,Percento dokončené
 DocType: Tag Category,Tag Category,tag Kategórie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Na porovnanie použite> 5, &lt;10 alebo = 324. Pre rozsahy použite 5:10 (pre hodnoty medzi 5 a 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Na porovnanie použite> 5, <10 alebo = 324. Pre rozsahy použite 5:10 (pre hodnoty medzi 5 a 10)."
 DocType: Google Calendar,Pull from Google Calendar,Vytiahnite z Kalendára Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Nápoveda
 DocType: User,Login Before,Přihlášení před
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Povolit při Odeslání
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Typ výnimky
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vybrat sloupce
-DocType: Web Page,Add code as &lt;script>,Pridať kód ako &lt;script>&lt;/script>
+DocType: Web Page,Add code as <script>,Pridať kód ako <script></script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Vymazať oprávnenie používateľa
 DocType: Webhook,Headers,hlavičky
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Pripravované akcie
@@ -3477,26 +3477,26 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Fronta by mala byť jedna z {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Používá href=""http://jinja.pocoo.org/docs/templates/""> Jinja šablon </a> a všechna pole Adresa ( včetně Custom Fields-li nějaké) budou k dispozici </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {%, pokud address_line2%} {{address_line2}} & lt; br & gt; { % endif -%} {
- {}} city & lt; br & gt; 
- {%, pokud stav%} {{}} state & lt; br & gt; {% endif -%} {
-% v případě, PSC%} PIN: {{PSC}} & lt; br & gt; {% endif -%} 
- {{country}} & lt; br & gt; 
- {%, pokud telefon%} Telefon: {{tel}} & lt; br & gt; { % endif -%} 
- {% v případě, fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {%, pokud email_id%} E-mail: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {%, pokud address_line2%} {{address_line2}} <br> { % endif -%} {
+ {}} city <br> 
+ {%, pokud stav%} {{}} state <br> {% endif -%} {
+% v případě, PSC%} PIN: {{PSC}} <br> {% endif -%} 
+ {{country}} <br> 
+ {%, pokud telefon%} Telefon: {{tel}} <br> { % endif -%} 
+ {% v případě, fax%} Fax: {{fax}} <br> {% endif -%} 
+ {%, pokud email_id%} E-mail: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Pole Dátum začiatku
 DocType: Role,Role Name,Názov role

--- a/frappe/translations/sk.csv
+++ b/frappe/translations/sk.csv
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Štatistiky založené na výkonnosti minulého týždňa (od {0} do {1})
 DocType: LDAP Settings,LDAP Phone Field,Pole telefónu LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","typ dokumentu ..., napr zákazník"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Stavom &#39;{0}&#39; je neplatná
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Stavom '{0}' je neplatná
 DocType: Workflow State,barcode,Barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Použitie vedľajšieho dopytu alebo funkcie je obmedzené
 apps/frappe/frappe/config/customization.py,Add your own translations,Pridajte svoj vlastný preklady
@@ -756,7 +756,7 @@ DocType: Currency,Currency Name,Názov meny
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,žiadne e-maily
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Platnosť odkazu uplynula
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Obnovenie dĺžky na {0} pre &#39;{1}&#39; v &#39;{2}&#39;; Nastavenie dĺžky ako {3} spôsobí skrátenie údajov.
+							Setting the length as {3} will cause truncation of data.",Obnovenie dĺžky na {0} pre '{1}' v '{2}'; Nastavenie dĺžky ako {3} spôsobí skrátenie údajov.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Vyberte formát súboru
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Otisk obsahu (hash)
@@ -787,7 +787,7 @@ DocType: File,Is Home Folder,Je Domovská zložka
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Štýl navigačného panela
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} nie je platná e-mailová adresa
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Zvoľte aspoň 1 záznamov pre tlač
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Užívateľ &#39;{0}&#39; už má za úlohu &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Užívateľ '{0}' už má za úlohu '{1}'
 DocType: System Settings,Two Factor Authentication method,Metóda overovania dvoch faktorov
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Najprv nastavte názov a uložte záznam.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 záznamov
@@ -1458,7 +1458,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Povinné polia: nastavený role
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritizovaný {1}
 DocType: Data Migration Mapping,Mapping Name,Mapovanie názvu
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Pole &#39;{1}&#39; nie je možné nastaviť ako jedinečné, pretože má nejedinečné hodnoty"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Pole '{1}' nie je možné nastaviť ako jedinečné, pretože má nejedinečné hodnoty"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Prejdite zoznam dole
 DocType: Currency,A symbol for this currency. For e.g. $,"Symbol této měny,  např. $"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Úspešne aktualizované preklady
@@ -2024,7 +2024,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Písmo Google
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Pakliže tyto instrukce nebyly nápomocné, prosím přidejte Vaše doporučení na GitHub Issues."
 DocType: Workflow State,bookmark,záložka
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Názov priečinka by nemal obsahovať &#39;/&#39; (lomka)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Názov priečinka by nemal obsahovať '/' (lomka)
 DocType: Note,Note,Poznámka
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Error Report
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Exportovať údaje vo formáte CSV / Excel.
@@ -2130,7 +2130,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Vypršanie platnosti
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Toto pole sa objaví len v prípade, že fieldname tu definované má hodnotu OR pravidlá sú pravými (príklady): myfield eval: doc.myfield == &quot;Môj Value &#39;eval: doc.age> 18"
+eval:doc.age>18","Toto pole sa objaví len v prípade, že fieldname tu definované má hodnotu OR pravidlá sú pravými (príklady): myfield eval: doc.myfield == &quot;Môj Value 'eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,dnes
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Pakliže toto nastavíte, uživatelé budou moci přistoupit pouze na dokumenty (např.: příspěvky blogu), kam existují odkazy (např.: blogger)."
@@ -2169,7 +2169,7 @@ DocType: Data Migration Connector,Database Name,Názov databázy
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Obnoviť formulár
 DocType: DocField,Select,Vybrať
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Zobraziť celý denník
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednoduchý výraz Python, príklad: status == &#39;Open&#39; a napíšte == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Jednoduchý výraz Python, príklad: status == 'Open' a napíšte == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Soubor není příložen
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Prerušené spojenie. Niektoré funkcie nemusia fungovať.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Opakuje typu &quot;AAA&quot;, možno ľahko uhádnuť"
@@ -2301,7 +2301,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Zobraziť len chyby
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Odoslať upozornenie e-mailom
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',"Prosím, vyberte iný spôsob platby. Razorpay nepodporuje transakcií s obeživom, {0} &#39;"
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',"Prosím, vyberte iný spôsob platby. Razorpay nepodporuje transakcií s obeživom, {0} '"
 DocType: Data Import,In Progress,Pokrok
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Vo fronte pre zálohovanie. To môže trvať niekoľko minút až hodinu.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2727,7 +2727,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Ktorým sa mení
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal nastavenie platobná brána
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Najlepšie účinkujúci
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Vlastné polia nemožno pridať k základným typom DocTypes.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) dostane skrátený, pretože max povolenej znaky je {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) dostane skrátený, pretože max povolenej znaky je {2}"
 DocType: OAuth Client,Response Type,typ Response
 DocType: Contact Us Settings,Send enquiries to this email address,Odeslat dotazy na tuto emailovou adresu
 DocType: Letter Head,Letter Head Name,Názov hlavičky listu
@@ -2784,7 +2784,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Image View
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Vyzerá to, že sa niečo počas transakcie zle. Pretože sme nepotvrdili platbu Paypal bude vám automaticky túto čiastku. Ak sa tak nestane, pošlite nám e-mail a uveďte ID korelácia: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Zahrňte do hesla symboly, čísla a veľké písmená"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Vložte Po poľa &#39;{0}&#39; uvedenú vo vlastnom poli &#39;{1}&#39;, so štítkom &#39;{2}&#39; neexistuje"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Vložte Po poľa '{0}' uvedenú vo vlastnom poli '{1}', so štítkom '{2}' neexistuje"
 DocType: List Filter,List Filter,Zoznam filtra
 DocType: Workflow State,signal,signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Má prílohy
@@ -2794,7 +2794,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Obnovený dokument
 DocType: Data Export,Data Export,Export údajov
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Zvoľ jazyk...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Nemôžete nastaviť &#39;Možnosti&#39; pre pole {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Nemôžete nastaviť 'Možnosti' pre pole {0}
 DocType: Help Article,Author,autor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,obnoví odosielanie
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Znovu otvoriť
@@ -2816,7 +2816,7 @@ DocType: Data Import,Amended From,Platném znění
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Varovanie: Nedá sa nájsť {0} v tabuľke vzťahujúcej sa k {1}
 DocType: S3 Backup Settings,eu-north-1,eu-sever-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Tento dokument je v súčasnosti zaradený do fronty na vykonanie. Prosím skúste znova
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Súbor &#39;{0}&#39; nebol nájdený
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Súbor '{0}' nebol nájdený
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Odstranit oddíl
 DocType: User,Change Password,Zmeniť heslo
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Pole osi X
@@ -3005,7 +3005,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Chybí hodnota pro
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Pridať potomka
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Priebeh importu
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Ak je podmienka splnená, užívateľ bude odmenený bodmi. eg. doc.status == &#39;Uzavreté&#39;"
+","Ak je podmienka splnená, užívateľ bude odmenený bodmi. eg. doc.status == 'Uzavreté'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Odoslaný záznam nemôže byť vymazaný.
 DocType: GSuite Templates,Template Name,Názov šablóny
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Nový typ dokumentu
@@ -3427,7 +3427,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,vlastné Preklady
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,pokrok
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,Rolou
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,chýbajúce Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neplatný fieldname &#39;{0}&#39; v autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neplatný fieldname '{0}' v autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Hľadať v type dokumentu
 DocType: Custom DocPerm,Role and Level,Role a úroveň
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3528,7 +3528,7 @@ DocType: Dashboard Chart,Filters JSON,Filtre JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Kliknite tu pre overenie
 DocType: Email Account,Disable SMTP server authentication,Zakázať overenie servera SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Skopírované do schránky.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Predvídateľné substitúcia ako &#39;@&#39; miesto &#39;a&#39; nepomôžu moc.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Predvídateľné substitúcia ako '@' miesto 'a' nepomôžu moc.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Pridelené mnou
 apps/frappe/frappe/utils/data.py,Zero,nula
 DocType: Google Drive,Backup Folder ID,ID záložnej zložky
@@ -3582,7 +3582,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Zadejte platné mobilní nos
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Niektoré funkcie nemusia fungovať vo vašom prehliadači. Aktualizujte svoj prehliadač na najnovšiu verziu.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Niektoré funkcie nemusia fungovať vo vašom prehliadači. Aktualizujte svoj prehliadač na najnovšiu verziu.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Neviem, spýtajte sa &#39;help&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Neviem, spýtajte sa 'help'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},zrušil tento dokument {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Komentáre a komunikácia bude spojená s týmto prepojeným dokumentom
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filtr ...
@@ -3890,7 +3890,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Východzie
 DocType: Translation,Verified,overená
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0}: pridané
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Vyhľadať &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Vyhľadať '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Prosím, uložte zostavu ako prvý"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} odberateľov pridaných
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Nie V
@@ -3927,14 +3927,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,ma
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} nie je platný stav
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Použiť na všetky typy dokumentov
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Aktualizácia bodu energie
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',"Prosím, vyberte iný spôsob platby. PayPal nepodporuje transakcií s obeživom, {0} &#39;"
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',"Prosím, vyberte iný spôsob platby. PayPal nepodporuje transakcií s obeživom, {0} '"
 DocType: Chat Message,Room Type,Typ izby
 DocType: Data Import Beta,Import Log Preview,Import protokolu ukážok
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Vyhľadávacie pole {0} nie je platný
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,nahraný súbor
 DocType: Workflow State,ok-circle,ok-circle
 DocType: LDAP Settings,LDAP User Creation and Mapping,Vytvorenie a mapovanie používateľov LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Môžete nájsť veci tým, že žiada &quot;nájsť oranžovú zákazníkov &#39;"
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Môžete nájsť veci tým, že žiada &quot;nájsť oranžovú zákazníkov '"
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Je nám líto! Uživatel by měl mít kompletní přístup k vlastnímu záznamu.
 ,Usage Info,využitie Info
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Zobraziť klávesové skratky

--- a/frappe/translations/sk.csv
+++ b/frappe/translations/sk.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Zálohovani
 DocType: DocField,In Global Search,V globálnom vyhľadávaní
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,indent-left
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; Pred {0} rokmi
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> Pred {0} rokmi
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Je to riskantné zmazať tento súbor: {0}. Prosím, obráťte sa na správcu systému."
 DocType: Currency,Currency Name,Názov meny
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,žiadne e-maily
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,{0}: nenájde
 apps/frappe/frappe/config/customization.py,Add custom forms.,Pridať vlastné formuláre.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} na {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,predložený tento dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Nastavenie&gt; Používateľské oprávnenia
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Nastavenie> Používateľské oprávnenia
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Systém poskytuje mnoho preddefinovaných rolí. Môžete pridať vlastné nové role pre detailnejšie nastavenie oprávnení.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","V prípade, že používateľ nemá žiadnu úlohu skontrolovať, užívateľ sa stáva &quot;System User&quot;. &quot;System User&quot; má prístup k ploche"
 DocType: System Settings,Date and Number Format,Formát čísel a dátumu
 apps/frappe/frappe/model/document.py,one of,jeden z
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Nastavenie&gt; Prispôsobiť formulár
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Nastavenie> Prispôsobiť formulár
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kontrola jeden okamih
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Zobrazit štítky
 DocType: DocField,HTML Editor,Editor HTML
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Fakturácia
 DocType: Email Queue,Not Sent,Neodoslané
 DocType: Web Form,Actions,Akcie
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Nastavenie&gt; Používateľ
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Nastavenie> Používateľ
 DocType: Workflow State,align-justify,zarovnat-vyplnit
 DocType: User,Middle Name (Optional),Druhé meno (voliteľné)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nepovolené
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,Je standardní
 DocType: Desktop Icon,_report,_správa
 DocType: Desktop Icon,_report,_správa
 DocType: Dashboard Chart,Full,plne
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Nenechajte HTML Kódovanie HTML tagy ako &lt;script&gt; alebo len znaky ako &lt;alebo&gt;, pretože by mohli byť zámerne použité v tomto odbore"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Nenechajte HTML Kódovanie HTML tagy ako &lt;script> alebo len znaky ako &lt;alebo>, pretože by mohli byť zámerne použité v tomto odbore"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritizovaný dňa {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,beh
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Päta sa zobrazí
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Čakajúce
 DocType: System Settings,Allow only one session per user,Umožňujú len jednu reláciu na jedného používateľa
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Home / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Nová událost: Zvolte nebo táhněte skrz Časová pole.
 DocType: Contact,Contact Details,Kontaktné údaje
 DocType: DocField,In Filter,Ve filtru
@@ -2041,7 +2041,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Přihlášení není povoleno v tuto dobu
 DocType: Data Migration Run,Current Mapping Action,Aktuálna mapová akcia
 DocType: Dashboard Chart Source,Source Name,Názov zdroja
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,S používateľom nie je spojený žiadny e-mailový účet. Pridajte účet do sekcie Používateľ&gt; Doručená pošta.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,S používateľom nie je spojený žiadny e-mailový účet. Pridajte účet do sekcie Používateľ> Doručená pošta.
 DocType: Email Account,Email Sync Option,E-mail Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Riadok č
 DocType: Async Task,Runtime,Runtime
@@ -2056,7 +2056,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Je již v
 DocType: User Email,Enable Outgoing,Povolit odchozí
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,vlastné Tagy
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-mailový účet nie je nastavený. Vytvorte nový e-mailový účet z časti Nastavenia&gt; E-mail&gt; E-mailový účet
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-mailový účet nie je nastavený. Vytvorte nový e-mailový účet z časti Nastavenia> E-mail> E-mailový účet
 DocType: Comment,Submitted,Potvrdené
 DocType: Contact,Pulled from Google Contacts,Spúšťané z Kontaktov Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Neplatná požiadavka
@@ -2130,7 +2130,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Vypršanie platnosti
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Toto pole sa objaví len v prípade, že fieldname tu definované má hodnotu OR pravidlá sú pravými (príklady): myfield eval: doc.myfield == &quot;Môj Value &#39;eval: doc.age&gt; 18"
+eval:doc.age>18","Toto pole sa objaví len v prípade, že fieldname tu definované má hodnotu OR pravidlá sú pravými (príklady): myfield eval: doc.myfield == &quot;Môj Value &#39;eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,dnes
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Pakliže toto nastavíte, uživatelé budou moci přistoupit pouze na dokumenty (např.: příspěvky blogu), kam existují odkazy (např.: blogger)."
@@ -2144,7 +2144,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,VEĽKÉ PÍSMENÁ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Vlastné HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Zadajte názov zložky
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Nenašla sa žiadna predvolená šablóna adresy. Vytvorte nový z ponuky Nastavenia&gt; Tlač a branding&gt; Šablóna adresy.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Nenašla sa žiadna predvolená šablóna adresy. Vytvorte nový z ponuky Nastavenia> Tlač a branding> Šablóna adresy.
 apps/frappe/frappe/auth.py,Unknown User,Neznámy používateľ
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Vyberte rolu
 DocType: Comment,Deleted,Vymazané
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Nedostatok povolenia na zobrazenie odkazov
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Názov adresy je povinný.
 DocType: Google Contacts,Push to Google Contacts,Push to Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Pridané HTML do sekcie &lt;head&gt; webovej stránky, používané najmä pre overovanie webových stránok a SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Pridané HTML do sekcie &lt;head> webovej stránky, používané najmä pre overovanie webových stránok a SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsujúcou
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Položka nemůže být přidána jako svůj vlastní podřízený potomek
 DocType: Session Default Settings,Session Defaults,Predvolené hodnoty relácie
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,Upozornění
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Môže sa to vytlačiť na viacerých stranách
 DocType: Data Migration Run,Percent Complete,Percento dokončené
 DocType: Tag Category,Tag Category,tag Kategórie
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Na porovnanie použite&gt; 5, &lt;10 alebo = 324. Pre rozsahy použite 5:10 (pre hodnoty medzi 5 a 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Na porovnanie použite> 5, &lt;10 alebo = 324. Pre rozsahy použite 5:10 (pre hodnoty medzi 5 a 10)."
 DocType: Google Calendar,Pull from Google Calendar,Vytiahnite z Kalendára Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Nápoveda
 DocType: User,Login Before,Přihlášení před
@@ -2922,7 +2922,7 @@ DocType: Custom Script,Custom Script,Přizpůsobený skript
 DocType: Address,Address Line 2,Riadok adresy 2
 DocType: Address,Reference,Referencia
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Priradené (komu)
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Nastavte predvolený e-mailový účet z časti Nastavenie&gt; E-mail&gt; E-mailový účet
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Nastavte predvolený e-mailový účet z časti Nastavenie> E-mail> E-mailový účet
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detail mapovania migrácie údajov
 DocType: Data Import,Action,Akce
 DocType: GSuite Settings,Script URL,Adresa URL skriptu
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Povolit při Odeslání
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Typ výnimky
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Vybrat sloupce
-DocType: Web Page,Add code as &lt;script&gt;,Pridať kód ako &lt;script&gt;&lt;/script&gt;
+DocType: Web Page,Add code as &lt;script>,Pridať kód ako &lt;script>&lt;/script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Vymazať oprávnenie používateľa
 DocType: Webhook,Headers,hlavičky
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Pripravované akcie
@@ -3477,15 +3477,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Fronta by mala byť jedna z {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> <a Používá href=""http://jinja.pocoo.org/docs/templates/""> Jinja šablon </a> a všechna pole Adresa ( včetně Custom Fields-li nějaké) budou k dispozici </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/sl.csv
+++ b/frappe/translations/sl.csv
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Onemogoči Poro�
 DocType: Translation,Contributed Translation Doctype Name,Ime prispevanega prevodnega dotipa
 DocType: PayPal Settings,Redirect To,Preusmeritev Da
 DocType: Data Migration Mapping,Pull,Potegni
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript obliko: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript obliko: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Bulk Update
 DocType: Workflow State,chevron-up,Chevron-up
 DocType: DocType,Allow Guest to View,Dovoli Gost Ogled
@@ -563,7 +563,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),"Statistika, ki temelji na uspešnosti prejšnjega tedna (od {0} do {1})"
 DocType: LDAP Settings,LDAP Phone Field,Telefonsko polje LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Vrsta dokumenta ..., na primer stranke"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Pogojem &#39;{0}&#39; je neveljavna
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Pogojem '{0}' je neveljavna
 DocType: Workflow State,barcode,črtna koda
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Uporaba podizvajalske funkcije ali funkcije je omejena
 apps/frappe/frappe/config/customization.py,Add your own translations,Dodajte svoje prevode
@@ -754,7 +754,7 @@ DocType: Currency,Currency Name,Valuta Ime
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ni e-poštna sporočila
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Povezava je potekla
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.","Povlecite dolžino na {0} za &#39;{1}&#39; v &#39;{2}&#39;; Nastavitev dolžine, kot je {3}, bo povzročilo ukinitev podatkov."
+							Setting the length as {3} will cause truncation of data.","Povlecite dolžino na {0} za '{1}' v '{2}'; Nastavitev dolžine, kot je {3}, bo povzročilo ukinitev podatkov."
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Izberite File Format
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Vsebina Hash
@@ -776,7 +776,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokument Share Report
 DocType: Social Login Key,Base URL,Osnovni URL
 DocType: User,Last Login,Zadnja prijava
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Za polje {0} ni mogoče nastaviti &#39;Translatable&#39;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Za polje {0} ni mogoče nastaviti 'Translatable'
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Stolpec
 DocType: Chat Profile,Chat Profile,Profil klepeta
 DocType: Custom Field,Adds a custom field to a DocType,Doda polje po meri za parameter DocType
@@ -1037,7 +1037,7 @@ DocType: Property Setter,Property Setter,Nepremičnine Setter
 DocType: Web Form,Allow Print,Dovoli Natisni
 DocType: Communication,Clicked,Kliknil
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Brez spremljanja
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},"Ne dovolite, da &#39;{0}&#39; {1}"
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},"Ne dovolite, da '{0}' {1}"
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Načrtovano za pošiljanje
 DocType: DocType,Track Seen,Track Seen
 DocType: Dropbox Settings,File Backup,Varnostno kopiranje datotek
@@ -1453,7 +1453,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obvezno polje: določiti vlogo
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritiziran {1}
 DocType: Data Migration Mapping,Mapping Name,Ime mapiranja
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Polja &#39;{1}&#39; ni mogoče nastaviti kot edinstveno, saj ima edinstvene vrednosti"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Polja '{1}' ni mogoče nastaviti kot edinstveno, saj ima edinstvene vrednosti"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Pomikanje po seznamu navzdol
 DocType: Currency,A symbol for this currency. For e.g. $,Simbol za to valuto. Na primer $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Uspešno posodobljeni prevodi
@@ -2166,7 +2166,7 @@ DocType: Data Migration Connector,Database Name,Ime baze podatkov
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Osveži Form
 DocType: DocField,Select,Izberite
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Ogled celotnega dnevnika
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Preprosta Python Expression, Primer: status == &#39;Open&#39; in vnesite == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Preprosta Python Expression, Primer: status == 'Open' in vnesite == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Datoteka ni priložena
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Povezava izgubljena. Nekatere funkcije morda ne bodo delovale.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Ponavlja kot &quot;aaa&quot;, je lahko uganiti"
@@ -2781,7 +2781,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Image View
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Izgleda, da je šlo nekaj narobe v času transakcije. Ker nismo potrdili plačila, bo Paypal vam samodejno povrne ta znesek. Če se ne, nam pošljite e-pošto in omenil korelacija ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Vključujejo simbole, številke in velike črke v geslom"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Vstavite Po področju &quot;{0}&quot;, naveden v polju po meri &#39;{1}&#39;, z oznako &#39;{2}&#39;, ne obstaja"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Vstavite Po področju &quot;{0}&quot;, naveden v polju po meri '{1}', z oznako '{2}', ne obstaja"
 DocType: List Filter,List Filter,Seznam filtrov
 DocType: Workflow State,signal,Signal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ima priloge
@@ -2791,7 +2791,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Obnovljeni dokument
 DocType: Data Export,Data Export,Izvoz podatkov
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Izberi jezik...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Za polje {0} ni mogoče nastaviti &#39;Možnosti&#39;
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Za polje {0} ni mogoče nastaviti 'Možnosti'
 DocType: Help Article,Author,Avtor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Nadaljevanje pošiljanja
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Ponovno odpre
@@ -3003,7 +3003,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Vrednost manjka za
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Dodaj Child
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Uvozi napredek
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Če je pogoj izpolnjen, bo uporabnik nagrajen s točkami. npr. doc.status == &#39;Zaprto&#39;"
+","Če je pogoj izpolnjen, bo uporabnik nagrajen s točkami. npr. doc.status == 'Zaprto'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Objavljenl zapis ni mogoče izbrisati.
 DocType: GSuite Templates,Template Name,Predloga Ime
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Nova vrsta dokumenta
@@ -3422,7 +3422,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,meri Prevodi
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,napredek
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,po vlogi
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,manjkajoče Polja
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neveljavna fieldname &#39;{0}&#39; v autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Neveljavna fieldname '{0}' v autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Iskanje v vrsti dokumenta
 DocType: Custom DocPerm,Role and Level,Vloga in stopnja
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3516,7 +3516,7 @@ apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@'
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Namenski By Me
 apps/frappe/frappe/utils/data.py,Zero,nič
 DocType: Google Drive,Backup Folder ID,ID za varnostno kopijo mape
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ni v načinu za razvijalce! Postavljena je v site_config.json ali pa &#39;po meri&#39; DOCTYPE.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Ni v načinu za razvijalce! Postavljena je v site_config.json ali pa 'po meri' DOCTYPE.
 DocType: Workflow State,globe,globus
 DocType: System Settings,dd.mm.yyyy,dd.mm.llll
 DocType: Assignment Rule,Priority,Prednost
@@ -3595,7 +3595,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Med spreminjanjem naročnine ni uspelo
 DocType: LDAP Settings,LDAP Group Field,LDAP Group Field
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Enako
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',"Možnosti &#39;Dynamic Link &quot;tip polja mora kazati na drugo Link Polje z možnostmi, kot so&quot; parameter DocType &quot;"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',"Možnosti 'Dynamic Link &quot;tip polja mora kazati na drugo Link Polje z možnostmi, kot so&quot; parameter DocType &quot;"
 DocType: About Us Settings,Team Members Heading,Člani ekipe Postavka
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Neveljavna oblika CSV
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Napaka pri povezovanju z aplikacijo QZ Tray ... <br><br> Za uporabo funkcije Raw Print morate imeti nameščeno in zagnano aplikacijo QZ Tray. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Kliknite tukaj, če želite prenesti in namestiti QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Kliknite tukaj, če želite izvedeti več o surovem tisku</a> ."
@@ -3874,7 +3874,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Privzeto
 DocType: Translation,Verified,Preverjeno
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} dodano
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Iskanje &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Iskanje '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Shranite poročilo najprej
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} naročnikov dodanih
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Ne v

--- a/frappe/translations/sl.csv
+++ b/frappe/translations/sl.csv
@@ -748,7 +748,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Varnostno k
 DocType: DocField,In Global Search,Globalno iskanje
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,alinea-levo
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} leto nazaj
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} leto nazaj
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,To je tvegano izbrisati to datoteko: {0}. Obrnite se na upravitelja sistema.
 DocType: Currency,Currency Name,Valuta Ime
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ni e-poštna sporočila
@@ -1046,7 +1046,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,"Ni {0} za pr
 apps/frappe/frappe/config/customization.py,Add custom forms.,Dodaj oblike po meri.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} v {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,predložen ta dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Nastavitev&gt; Uporabniška dovoljenja
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Nastavitev> Uporabniška dovoljenja
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sistem ponuja veliko vnaprej določeno vlogo. Dodate lahko nove vloge za nastavitev plemenitejše dovoljenja.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1265,7 +1265,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Če ima uporabnik nobene vloge preveri, nato pa uporabnik postane &quot;System User&quot;. &quot;System User&quot; ima dostop do namizja"
 DocType: System Settings,Date and Number Format,Datum in številka Format
 apps/frappe/frappe/model/document.py,one of,eden od
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Nastavitev&gt; Prilagodite obrazec
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Nastavitev> Prilagodite obrazec
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Preverjanje en trenutek
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Prikaži oznake
 DocType: DocField,HTML Editor,HTML Editor
@@ -1273,7 +1273,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Zaračunavanje
 DocType: Email Queue,Not Sent,Ni Poslano
 DocType: Web Form,Actions,Dejanja
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Nastavitev&gt; Uporabnik
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Nastavitev> Uporabnik
 DocType: Workflow State,align-justify,"poravnati, upravičujejo"
 DocType: User,Middle Name (Optional),Middle Name (po želji)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ni dovoljeno
@@ -1422,7 +1422,7 @@ DocType: Report,Is Standard,Je Standard
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Poln
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Ne oznake HTML Encode HTML, kot so &lt;script&gt; ali pa samo znaki, kot so &lt;ali&gt;, saj bi se lahko namenoma uporabljajo na tem področju"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne oznake HTML Encode HTML, kot so &lt;script> ali pa samo znaki, kot so &lt;ali>, saj bi se lahko namenoma uporabljajo na tem področju"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiziran {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Run
@@ -1804,7 +1804,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Podnožje se prik
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,V teku
 DocType: System Settings,Allow only one session per user,Dovoli samo eno sejo na uporabnika
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Domov/Testna mapa 1/Testna mapa 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Izberite ali povlecite čez termine ustvariti nov dogodek.
 DocType: Contact,Contact Details,Kontaktni podatki
 DocType: DocField,In Filter,V Filter
@@ -2037,7 +2037,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Prijava ni dovoljeno v tem času
 DocType: Data Migration Run,Current Mapping Action,Trenutna kartografska akcija
 DocType: Dashboard Chart Source,Source Name,Source Name
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Z uporabnikom ni nobenega e-poštnega računa. Dodajte račun pod Uporabnik&gt; Prejeto po e-pošti.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Z uporabnikom ni nobenega e-poštnega računa. Dodajte račun pod Uporabnik> Prejeto po e-pošti.
 DocType: Email Account,Email Sync Option,E-pošta Sync Možnost
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Vrstica št
 DocType: Async Task,Runtime,Runtime
@@ -2052,7 +2052,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Že v upo
 DocType: User Email,Enable Outgoing,Omogoči Odhodni
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Oznake po meri
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-poštnega računa ni nastavljeno. Ustvarite nov e-poštni račun iz programa Setup&gt; Email&gt; Email Account
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-poštnega računa ni nastavljeno. Ustvarite nov e-poštni račun iz programa Setup> Email> Email Account
 DocType: Comment,Submitted,Predložen
 DocType: Contact,Pulled from Google Contacts,Potegnjeno iz Google Stikov
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Neveljavna Zahteva
@@ -2126,7 +2126,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Potek seje v urah, 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","To polje se pojavi le, če ima fieldname tu opredeljena vrednost ALI pravila so prave (primeri): myfield eval: doc.myfield == &quot;Moja vrednost&quot; eval: doc.age&gt; 18"
+eval:doc.age>18","To polje se pojavi le, če ima fieldname tu opredeljena vrednost ALI pravila so prave (primeri): myfield eval: doc.myfield == &quot;Moja vrednost&quot; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,danes
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,danes
@@ -2141,7 +2141,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ZGORNJI CASE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Vnesite ime mape
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Predloga privzetega naslova ni bila najdena. Ustvarite novega iz nastavitve&gt; Tiskanje in trženje blagovne znamke&gt; Predloga naslova.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Predloga privzetega naslova ni bila najdena. Ustvarite novega iz nastavitve> Tiskanje in trženje blagovne znamke> Predloga naslova.
 apps/frappe/frappe/auth.py,Unknown User,Neznan uporabnik
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Izberite Role
 DocType: Comment,Deleted,Izbrisan
@@ -2332,7 +2332,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ni dovolj dovoljenja za ogled povezav
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Naslov Naslov je obvezen.
 DocType: Google Contacts,Push to Google Contacts,Odprite Google Stike
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Dodano HTML v &lt;head&gt; del spletne strani, uporablja predvsem za preverjanje spletnih strani in SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML v &lt;head> del spletne strani, uporablja predvsem za preverjanje spletnih strani in SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiviral
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Postavka ni mogoče dodati na svoje potomce
 DocType: Session Default Settings,Session Defaults,Privzete seje
@@ -2452,7 +2452,7 @@ DocType: Workflow State,Warning,Opozorilo
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,To se lahko natisne na več straneh
 DocType: Data Migration Run,Percent Complete,Percent Complete
 DocType: Tag Category,Tag Category,tag Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za primerjavo uporabite&gt; 5, &lt;10 ali = 324. Za obsege uporabite 5:10 (za vrednosti med 5 in 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za primerjavo uporabite> 5, &lt;10 ali = 324. Za obsege uporabite 5:10 (za vrednosti med 5 in 10)."
 DocType: Google Calendar,Pull from Google Calendar,Potegnite iz Google Koledarja
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoč
 DocType: User,Login Before,Prijava Pred
@@ -2919,7 +2919,7 @@ DocType: Custom Script,Custom Script,Meri Script
 DocType: Address,Address Line 2,Naslov Line 2
 DocType: Address,Reference,Sklicevanje
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Dodeljeno
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Nastavite privzeti račun e-pošte iz programa Setup&gt; Email&gt; Email account
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Nastavite privzeti račun e-pošte iz programa Setup> Email> Email account
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Podatki o preseljevanju podatkov
 DocType: Data Import,Action,Dejanje
 DocType: GSuite Settings,Script URL,URL skripta
@@ -3097,7 +3097,7 @@ DocType: DocField,Allow on Submit,Dovoli na Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Izjema Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick stolpce
-DocType: Web Page,Add code as &lt;script&gt;,Dodaj oznako kot &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Dodaj oznako kot &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Počistite uporabniška dovoljenja
 DocType: Webhook,Headers,Glave
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Prihajajoči dogodki
@@ -3472,16 +3472,16 @@ DocType: Workflow State,share-alt,Delež-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Čakalna vrsta mora biti eden od {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Privzeto Predloga </h4><p> Uporablja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> in vsa področja naslov (vključno s po meri Fields če sploh) bo na voljo </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Privzeto Predloga </h4><p> Uporablja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> in vsa področja naslov (vključno s po meri Fields če sploh) bo na voljo </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Polje za začetno datum
 DocType: Role,Role Name,Vloga Name
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Stikalo Za Desk

--- a/frappe/translations/sl.csv
+++ b/frappe/translations/sl.csv
@@ -1422,7 +1422,7 @@ DocType: Report,Is Standard,Je Standard
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Poln
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Ne oznake HTML Encode HTML, kot so &lt;script> ali pa samo znaki, kot so &lt;ali>, saj bi se lahko namenoma uporabljajo na tem področju"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Ne oznake HTML Encode HTML, kot so <script> ali pa samo znaki, kot so <ali>, saj bi se lahko namenoma uporabljajo na tem področju"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiziran {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Run
@@ -1804,7 +1804,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Podnožje se prik
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,V teku
 DocType: System Settings,Allow only one session per user,Dovoli samo eno sejo na uporabnika
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Domov/Testna mapa 1/Testna mapa 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Izberite ali povlecite čez termine ustvariti nov dogodek.
 DocType: Contact,Contact Details,Kontaktni podatki
 DocType: DocField,In Filter,V Filter
@@ -2332,7 +2332,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ni dovolj dovoljenja za ogled povezav
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Naslov Naslov je obvezen.
 DocType: Google Contacts,Push to Google Contacts,Odprite Google Stike
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Dodano HTML v &lt;head> del spletne strani, uporablja predvsem za preverjanje spletnih strani in SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Dodano HTML v <head> del spletne strani, uporablja predvsem za preverjanje spletnih strani in SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiviral
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Postavka ni mogoče dodati na svoje potomce
 DocType: Session Default Settings,Session Defaults,Privzete seje
@@ -2452,7 +2452,7 @@ DocType: Workflow State,Warning,Opozorilo
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,To se lahko natisne na več straneh
 DocType: Data Migration Run,Percent Complete,Percent Complete
 DocType: Tag Category,Tag Category,tag Kategorija
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za primerjavo uporabite> 5, &lt;10 ali = 324. Za obsege uporabite 5:10 (za vrednosti med 5 in 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Za primerjavo uporabite> 5, <10 ali = 324. Za obsege uporabite 5:10 (za vrednosti med 5 in 10)."
 DocType: Google Calendar,Pull from Google Calendar,Potegnite iz Google Koledarja
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Pomoč
 DocType: User,Login Before,Prijava Pred
@@ -3097,7 +3097,7 @@ DocType: DocField,Allow on Submit,Dovoli na Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Izjema Type
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick stolpce
-DocType: Web Page,Add code as &lt;script>,Dodaj oznako kot &lt;script>
+DocType: Web Page,Add code as <script>,Dodaj oznako kot <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Počistite uporabniška dovoljenja
 DocType: Webhook,Headers,Glave
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Prihajajoči dogodki
@@ -3472,16 +3472,16 @@ DocType: Workflow State,share-alt,Delež-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Čakalna vrsta mora biti eden od {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Privzeto Predloga </h4><p> Uporablja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> in vsa področja naslov (vključno s po meri Fields če sploh) bo na voljo </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Privzeto Predloga </h4><p> Uporablja <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating</a> in vsa področja naslov (vključno s po meri Fields če sploh) bo na voljo </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Polje za začetno datum
 DocType: Role,Role Name,Vloga Name
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Stikalo Za Desk

--- a/frappe/translations/sq.csv
+++ b/frappe/translations/sq.csv
@@ -1395,7 +1395,7 @@ DocType: Report,Is Standard,Është standard
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,i plotë
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Mos tags HTML Encode HTML si &lt;script> apo vetëm karaktere si &lt;ose>, si ata mund të përdoret qëllimisht në këtë fushë"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Mos tags HTML Encode HTML si <script> apo vetëm karaktere si <ose>, si ata mund të përdoret qëllimisht në këtë fushë"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritikuar në {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,run
@@ -1761,7 +1761,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer do të shf
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Në pritje të
 DocType: System Settings,Allow only one session per user,Lejo vetëm një seancë për përdorues
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Faqja Kryesore / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Zgjidhni ose terhiqe nëpër kohë lojëra elektronike për të krijuar një ngjarje të re.
 DocType: Contact,Contact Details,Detajet Kontakt
 DocType: DocField,In Filter,Në Filter
@@ -2276,7 +2276,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Jo leje të mjaftueshme për të parë lidhjet
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresa Titulli është i detyrueshëm.
 DocType: Google Contacts,Push to Google Contacts,Shtyj te Kontaktet Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Shtuar HTML në &lt;head> seksion i faqes së internetit, e përdorur kryesisht për verifikimin e internetit dhe SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Shtuar HTML në <head> seksion i faqes së internetit, e përdorur kryesisht për verifikimin e internetit dhe SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item nuk mund të shtohet për të pasardhësve të vet
 DocType: Session Default Settings,Session Defaults,Default Seanca
@@ -2395,7 +2395,7 @@ DocType: Workflow State,Warning,Paralajmërim
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Kjo mund të shtypet në shumë faqe
 DocType: Data Migration Run,Percent Complete,Përqindja e plotë
 DocType: Tag Category,Tag Category,tag Category
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Për krahasim, përdorni> 5, &lt;10 ose = 324. Për vargjet, përdorni 5:10 (për vlerat midis 5 dhe 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Për krahasim, përdorni> 5, <10 ose = 324. Për vargjet, përdorni 5:10 (për vlerat midis 5 dhe 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tërhiq nga Kalendari Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ndihmë
 DocType: User,Login Before,Identifikohu Para
@@ -3020,7 +3020,7 @@ DocType: DocField,Allow on Submit,Lejo në Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Exception Lloji
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick Shtylla
-DocType: Web Page,Add code as &lt;script>,Shto kodin si &lt;script>
+DocType: Web Page,Add code as <script>,Shto kodin si <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Pastro Lejet e Përdoruesit
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Ngjarje të ardhshme
@@ -3380,16 +3380,16 @@ DocType: Workflow State,share-alt,pjesa-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Radhë duhet të jetë një {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Gabim Template </h4><p> Përdor <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> dhe të gjitha fushat e Adresa (duke përfshirë Custom Fields nëse ka ndonjë) do të jenë në dispozicion </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Gabim Template </h4><p> Përdor <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> dhe të gjitha fushat e Adresa (duke përfshirë Custom Fields nëse ka ndonjë) do të jenë në dispozicion </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Fillimi Data Field
 DocType: Role,Role Name,Roli Emri
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch në tavolinën

--- a/frappe/translations/sq.csv
+++ b/frappe/translations/sq.csv
@@ -730,7 +730,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Rezervimi i
 DocType: DocField,In Global Search,Global Kërko
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,indent-majtë
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} vit më parë
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} vit më parë
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Kjo është e rrezikshme për të fshirë këtë skedë: {0}. Ju lutemi të kontaktoni Sistemit Soccer tuaj.
 DocType: Currency,Currency Name,Valuta Emri
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Nuk Emails
@@ -1025,7 +1025,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Asnjë {0} gj
 apps/frappe/frappe/config/customization.py,Add custom forms.,Shto forma doganore.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} në {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,dorëzuar këtë dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Setup&gt; Lejet e Përdoruesit
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Setup> Lejet e Përdoruesit
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sistemi ofron shumë para-përcaktuar rolet. Ju mund të shtoni role të reja për të vendosur lejet finer.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1239,7 +1239,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Në qoftë se përdoruesi ka ndonjë rol kontrolluar, atëherë përdoruesi bëhet një &quot;User System&quot;. &quot;User System&quot; ka qasje në desktop"
 DocType: System Settings,Date and Number Format,Data dhe numri Format
 apps/frappe/frappe/model/document.py,one of,një nga
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Setup&gt; Rregulloje formularin
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Setup> Rregulloje formularin
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kontrolluar një moment
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Shfaq Tags
 DocType: DocField,HTML Editor,Editor HTML
@@ -1247,7 +1247,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Faturimi
 DocType: Email Queue,Not Sent,Jo dërguar
 DocType: Web Form,Actions,Veprimet
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Konfigurimi&gt; Përdoruesi
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Konfigurimi> Përdoruesi
 DocType: Workflow State,align-justify,lidhur-justifikojnë
 DocType: User,Middle Name (Optional),Emri e Mesme (Fakultativ)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Nuk lejohet
@@ -1395,7 +1395,7 @@ DocType: Report,Is Standard,Është standard
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,i plotë
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Mos tags HTML Encode HTML si &lt;script&gt; apo vetëm karaktere si &lt;ose&gt;, si ata mund të përdoret qëllimisht në këtë fushë"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Mos tags HTML Encode HTML si &lt;script> apo vetëm karaktere si &lt;ose>, si ata mund të përdoret qëllimisht në këtë fushë"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritikuar në {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,run
@@ -1761,7 +1761,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer do të shf
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Në pritje të
 DocType: System Settings,Allow only one session per user,Lejo vetëm një seancë për përdorues
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Faqja Kryesore / Test Folder 1 / Test Folder 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Zgjidhni ose terhiqe nëpër kohë lojëra elektronike për të krijuar një ngjarje të re.
 DocType: Contact,Contact Details,Detajet Kontakt
 DocType: DocField,In Filter,Në Filter
@@ -1991,7 +1991,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Hyr nuk lejohet në këtë kohë
 DocType: Data Migration Run,Current Mapping Action,Veprimi i Hartave aktuale
 DocType: Dashboard Chart Source,Source Name,burimi Emri
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Asnjë llogari emaili e lidhur me Përdoruesin. Ju lutemi shtoni një llogari nën Përdoruesin&gt; Kutia e postës elektronike.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Asnjë llogari emaili e lidhur me Përdoruesin. Ju lutemi shtoni një llogari nën Përdoruesin> Kutia e postës elektronike.
 DocType: Email Account,Email Sync Option,Email Option Sync
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rreshti Nr
 DocType: Async Task,Runtime,Runtime
@@ -2005,7 +2005,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Tashmë n
 DocType: User Email,Enable Outgoing,Aktivizo largohet
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,Custom Tags
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Llogaria e postës elektronike nuk është konfiguruar. Ju lutemi krijoni një llogari të re Email nga Konfigurimi&gt; Email&gt; Llogaria e postës elektronike
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Llogaria e postës elektronike nuk është konfiguruar. Ju lutemi krijoni një llogari të re Email nga Konfigurimi> Email> Llogaria e postës elektronike
 DocType: Comment,Submitted,Dërguar
 DocType: Contact,Pulled from Google Contacts,Tërhequr nga Kontaktet Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Kërkesë e pavlefshme
@@ -2078,7 +2078,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesioni Expiry në o
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Kjo fushë do të shfaqet vetëm nëse fieldname përcaktuar këtu ka vlerë OR rregullat janë të vërtetë (shembuj): myfield eval: doc.myfield == &#39;Vlera ime &quot;eval: doc.age&gt; 18
+eval:doc.age>18",Kjo fushë do të shfaqet vetëm nëse fieldname përcaktuar këtu ka vlerë OR rregullat janë të vërtetë (shembuj): myfield eval: doc.myfield == &#39;Vlera ime &quot;eval: doc.age> 18
 DocType: Social Login Key,Office 365,Zyra 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,sot
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,sot
@@ -2092,7 +2092,7 @@ apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of th
 DocType: DocType,UPPER CASE,ME SHKRONJA KAPITALE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Custom HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Shkruani emrin dosje
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Asnjë model i adresës së paracaktuar nuk u gjet. Ju lutemi krijoni një të re nga Setup&gt; Printimi dhe Markimi&gt; Modeli i Adresave.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Asnjë model i adresës së paracaktuar nuk u gjet. Ju lutemi krijoni një të re nga Setup> Printimi dhe Markimi> Modeli i Adresave.
 apps/frappe/frappe/auth.py,Unknown User,Përdorues i panjohur
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Zgjidh Roli
 DocType: Comment,Deleted,Deleted
@@ -2276,7 +2276,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Jo leje të mjaftueshme për të parë lidhjet
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adresa Titulli është i detyrueshëm.
 DocType: Google Contacts,Push to Google Contacts,Shtyj te Kontaktet Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Shtuar HTML në &lt;head&gt; seksion i faqes së internetit, e përdorur kryesisht për verifikimin e internetit dhe SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Shtuar HTML në &lt;head> seksion i faqes së internetit, e përdorur kryesisht për verifikimin e internetit dhe SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Item nuk mund të shtohet për të pasardhësve të vet
 DocType: Session Default Settings,Session Defaults,Default Seanca
@@ -2395,7 +2395,7 @@ DocType: Workflow State,Warning,Paralajmërim
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Kjo mund të shtypet në shumë faqe
 DocType: Data Migration Run,Percent Complete,Përqindja e plotë
 DocType: Tag Category,Tag Category,tag Category
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Për krahasim, përdorni&gt; 5, &lt;10 ose = 324. Për vargjet, përdorni 5:10 (për vlerat midis 5 dhe 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Për krahasim, përdorni> 5, &lt;10 ose = 324. Për vargjet, përdorni 5:10 (për vlerat midis 5 dhe 10)."
 DocType: Google Calendar,Pull from Google Calendar,Tërhiq nga Kalendari Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Ndihmë
 DocType: User,Login Before,Identifikohu Para
@@ -2847,7 +2847,7 @@ DocType: Custom Script,Custom Script,Custom Script
 DocType: Address,Address Line 2,Adresa Line 2
 DocType: Address,Reference,Referim
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Caktuar për
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Ju lutemi konfiguroni llogarinë e paracaktuar të postës elektronike nga Konfigurimi&gt; Email&gt; Llogari Email
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Ju lutemi konfiguroni llogarinë e paracaktuar të postës elektronike nga Konfigurimi> Email> Llogari Email
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Detajimi i hartës së migrimit të të dhënave
 DocType: Data Import,Action,Veprim
 DocType: GSuite Settings,Script URL,script URL
@@ -3020,7 +3020,7 @@ DocType: DocField,Allow on Submit,Lejo në Submit
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Exception Lloji
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Pick Shtylla
-DocType: Web Page,Add code as &lt;script&gt;,Shto kodin si &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Shto kodin si &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Pastro Lejet e Përdoruesit
 DocType: Webhook,Headers,headers
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Ngjarje të ardhshme
@@ -3380,16 +3380,16 @@ DocType: Workflow State,share-alt,pjesa-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Radhë duhet të jetë një {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Gabim Template </h4><p> Përdor <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> dhe të gjitha fushat e Adresa (duke përfshirë Custom Fields nëse ka ndonjë) do të jenë në dispozicion </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Gabim Template </h4><p> Përdor <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> dhe të gjitha fushat e Adresa (duke përfshirë Custom Fields nëse ka ndonjë) do të jenë në dispozicion </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Fillimi Data Field
 DocType: Role,Role Name,Roli Emri
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Switch në tavolinën

--- a/frappe/translations/sq.csv
+++ b/frappe/translations/sq.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Prind
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Nëse aktivizohet, forca fjalëkalimi do të zbatohet në bazë të vlerës minimale Password shënuar. Një vlerë e 2 të qenit të mesme të fortë dhe 4 të qenit shumë i fortë."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Nëse aktivizohet, forca fjalëkalimi do të zbatohet në bazë të vlerës minimale Password shënuar. Një vlerë e 2 të qenit të mesme të fortë dhe 4 të qenit shumë i fortë."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Anëtarët e ekipit&quot; ose &quot;Menaxhimi&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Parazgjedhur për &#39;Kontrollo&#39; lloji i fushës duhet të jetë ose &#39;0&#39; ose &#39;1&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Parazgjedhur për 'Kontrollo' lloji i fushës duhet të jetë ose '0' ose '1'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Dje
 DocType: Contact,Designation,Përcaktim
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Lidhja automatike mund të aktivizohet vetëm për një Llogari Email.
@@ -201,7 +201,7 @@ DocType: Website Settings,Select an image of approx width 150px with a transpare
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,No activity,Asnjë veprimtari
 apps/frappe/frappe/www/third_party_apps.html,Third Party Apps,Aplikacionet e palës së tretë
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The first user will become the System Manager (you can change this later).,Përdorues i parë do të bëhet i Sistemit Menaxher (ju mund ta ndryshoni këtë më vonë).
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You cannot give review points to yourself,Ju nuk mund t&#39;i jepni vetes pikat e rishikimit
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You cannot give review points to yourself,Ju nuk mund t'i jepni vetes pikat e rishikimit
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,DocType must be Submittable for the selected Doc Event,DocType duhet të jetë Submittable për Eventin e zgjedhur të Doc
 DocType: Workflow State,circle-arrow-up,rrethi-shigjetë-up
 DocType: Email Domain,Email Domain,Email Domain
@@ -249,7 +249,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Disable Raport
 DocType: Translation,Contributed Translation Doctype Name,Kontribuar Emri Doctype i Përkthimit
 DocType: PayPal Settings,Redirect To,Redirect To
 DocType: Data Migration Mapping,Pull,Tërhiqe
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Formati: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Formati: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Update Bulk
 DocType: Workflow State,chevron-up,Chevron-up
 DocType: DocType,Allow Guest to View,Lejo Guest të Shiko
@@ -547,7 +547,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,Ngarkimi dështoi
 DocType: LDAP Settings,LDAP Phone Field,Fusha telefonike LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Lloji i dokumentit ..., p.sh. konsumatorëve"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Kushti &#39;{0}&#39; është i pavlefshëm
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Kushti '{0}' është i pavlefshëm
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Përdorimi i nën-query ose funksioni është i kufizuar
 apps/frappe/frappe/config/customization.py,Add your own translations,Shto përkthimet tuaj
@@ -694,7 +694,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Emri i përdoruesit {0} tashmë ekziston
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Nuk mund të vënë importin si {1} nuk është i importuar
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Ka një gabim në Stampa tuaj Adresa {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} është një adresë e pavlefshme email në &#39;Përfituesit&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} është një adresë e pavlefshme email në 'Përfituesit'
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,Mikpritës
@@ -736,7 +736,7 @@ DocType: Currency,Currency Name,Valuta Emri
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Nuk Emails
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Lidhja ka skaduar
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Rivendosja e gjatësisë në {0} për &#39;{1}&#39; në &#39;{2}&#39;; Vendosja e gjatësisë si {3} do të shkaktojë shkurtimin e të dhënave.
+							Setting the length as {3} will cause truncation of data.",Rivendosja e gjatësisë në {0} për '{1}' në '{2}'; Vendosja e gjatësisë si {3} do të shkaktojë shkurtimin e të dhënave.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Zgjidh formatin e skedarit
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Përmbajtja Hash
@@ -744,7 +744,7 @@ DocType: User,Stores the JSON of last known versions of various installed apps. 
 DocType: Energy Point Rule,User Field,Fusha e përdoruesit
 DocType: DocType,MyISAM,MyISAM
 DocType: Data Migration Run,Push Delete,Push Delete
-apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed for {1} {2},{0} tashmë c&#39;regjistruar për {1} {2}
+apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed for {1} {2},{0} tashmë c'regjistruar për {1} {2}
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not remove,A nuk heqë
 apps/frappe/frappe/desk/like.py,Liked,Pëlqente
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now,Dërgo Tani
@@ -758,7 +758,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokumenti Shpërndaj Raporto
 DocType: Social Login Key,Base URL,URL bazë
 DocType: User,Last Login,Kycja e fundit
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Ju nuk mund të vendosni &#39;Translatable&#39; për fushën {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Ju nuk mund të vendosni 'Translatable' për fushën {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Kolonë
 DocType: Chat Profile,Chat Profile,Profili i Chat
 DocType: Custom Field,Adds a custom field to a DocType,Shton një fushë me porosi për një DOCTYPE
@@ -767,7 +767,7 @@ DocType: File,Is Home Folder,Është shtëpia Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Stili i navbarit
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} nuk është një email adresë të saktë
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Zgjidhni atleast 1 Të dhënat për printim
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',User &#39;{0}&#39; tashmë e ka rolin &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',User '{0}' tashmë e ka rolin '{1}'
 DocType: System Settings,Two Factor Authentication method,Dy metoda Authentication Factor
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Së pari vendosni emrin dhe ruani të dhënat.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 rekorde
@@ -1016,7 +1016,7 @@ DocType: Property Setter,Property Setter,Pronës Setter
 DocType: Web Form,Allow Print,Lejo Printo
 DocType: Communication,Clicked,Klikuar
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Unfollow
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nuk ka leje për të &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Nuk ka leje për të '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Planifikuar për të dërguar
 DocType: DocType,Track Seen,Track Parë
 DocType: Dropbox Settings,File Backup,Rikthim i dokumentit
@@ -1043,7 +1043,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,Faqe HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Eksportoni rreshtat e gabuar
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Emri i grupit nuk mund të jetë i zbrazët.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Nyjet e mëtejshme mund të krijohet vetëm në nyjet e tipit &#39;Grupit&#39;
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Nyjet e mëtejshme mund të krijohet vetëm në nyjet e tipit 'Grupit'
 DocType: SMS Parameter,Header,Arkitra
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Kolona Panjohur: {0}
 DocType: Notification Recipient,Email By Role,Email nga roli
@@ -1822,7 +1822,7 @@ apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Edit in full page,Edit n
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Open list item,Artikulli i listës së hapur
 DocType: Report,Add Total Row,Shto Total Row
 apps/frappe/frappe/public/js/frappe/form/print.js,No Preview available,Asnjë Pamje në dispozicion
-apps/frappe/frappe/twofactor.py,Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it.,Ju lutemi kontrolloni adresën tuaj të postës elektronike për udhëzime se si të vazhdoni. Mos e mbyllni këtë dritare pasi do t&#39;ju duhet të ktheheni në atë.
+apps/frappe/frappe/twofactor.py,Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it.,Ju lutemi kontrolloni adresën tuaj të postës elektronike për udhëzime se si të vazhdoni. Mos e mbyllni këtë dritare pasi do t'ju duhet të ktheheni në atë.
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Për shembull, nëse ju anuloni dhe të ndryshojë INV004 ajo do të bëhet një INV004-1 ri dokument. Kjo ju ndihmon të mbajnë gjurmët e çdo amendament."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Atleast one field of Parent Document Type is mandatory,Atleast një fushë e llojit të dokumentit prind është i detyrueshëm
 apps/frappe/frappe/config/settings.py,Setup Reports to be emailed at regular intervals,Raportet Setup të jetë me email në intervale të rregullta
@@ -1974,7 +1974,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Font Google
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Nëse këto udhëzime, ku jo të dobishme, ju lutem të shtoni në sugjerimet tuaja mbi Çështjet Github."
 DocType: Workflow State,bookmark,bookmark
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Emri Folder nuk duhet të përfshijë &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Emri Folder nuk duhet të përfshijë '/' (slash)
 DocType: Note,Note,Shënim
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Gabim Raport
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Të dhënat e eksportit në formatin CSV / Excel.
@@ -2078,7 +2078,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Sesioni Expiry në o
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Kjo fushë do të shfaqet vetëm nëse fieldname përcaktuar këtu ka vlerë OR rregullat janë të vërtetë (shembuj): myfield eval: doc.myfield == &#39;Vlera ime &quot;eval: doc.age> 18
+eval:doc.age>18",Kjo fushë do të shfaqet vetëm nëse fieldname përcaktuar këtu ka vlerë OR rregullat janë të vërtetë (shembuj): myfield eval: doc.myfield == 'Vlera ime &quot;eval: doc.age> 18
 DocType: Social Login Key,Office 365,Zyra 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,sot
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,sot
@@ -2117,7 +2117,7 @@ DocType: Data Migration Connector,Database Name,Emri i bazës së të dhënave
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Refresh Form
 DocType: DocField,Select,Përzgjedh
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Shikoni Regjistrin e plotë
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Shprehje e thjeshtë e Pythonit, Shembull: statusi == &#39;Hapni&#39; dhe shkruani == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Shprehje e thjeshtë e Pythonit, Shembull: statusi == 'Hapni' dhe shkruani == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Paraqesë jo bashkangjitur
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Lidhja ka humbur. Disa veçori mund të mos funksionojnë.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Përsërit si &quot;aaa&quot; janë të lehtë me mend
@@ -2244,7 +2244,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Shfaq vetëm gabime
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Dërgo lajmërim me email
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Ju lutem zgjidhni një tjetër metodë e pagesës. Razorpay nuk e mbështet transaksionet në monedhë të &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Ju lutem zgjidhni një tjetër metodë e pagesës. Razorpay nuk e mbështet transaksionet në monedhë të '{0}'
 DocType: Data Import,In Progress,Në progres
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Në radhë për backup. Ajo mund të marrë disa minuta në një orë.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2303,7 +2303,7 @@ apps/frappe/frappe/geo/doctype/currency/currency.js,This Currency is disabled. E
 DocType: Desktop Icon,Blocked,i bllokuar
 DocType: Contact Us Settings,"Default: ""Contact Us""",Gabim: &quot;Na Kontaktoni&quot;
 DocType: Contact,Purchase Manager,Menaxher Blerje
-DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Kur aktivizohet kjo do t&#39;u lejojë mysafirëve të ngarkojnë skedarë në aplikacionin tuaj, Ju mund ta aktivizoni këtë nëse dëshironi të mblidhni skedarë nga përdoruesi pa pasur nevojë që ata të regjistroheni, për shembull në formularin në internet të aplikacioneve të punës."
+DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Kur aktivizohet kjo do t'u lejojë mysafirëve të ngarkojnë skedarë në aplikacionin tuaj, Ju mund ta aktivizoni këtë nëse dëshironi të mblidhni skedarë nga përdoruesi pa pasur nevojë që ata të regjistroheni, për shembull në formularin në internet të aplikacioneve të punës."
 apps/frappe/frappe/public/js/frappe/ui/tags.js,toggle Tag,toggle Tag
 DocType: Custom Script,Sample,Mostër
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,"For performance, only the first 100 rows were processed.","Për performancën, u përpunuan vetëm 100 rreshtat e parë."
@@ -2580,7 +2580,7 @@ DocType: User,User Defaults,Defaults User
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Core DocTypes cannot be customized.,Dokumentet kryesore nuk mund të personalizohen.
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Create New,Krijo ri
 DocType: Workflow State,chevron-down,Chevron-poshtë
-apps/frappe/frappe/public/js/frappe/views/communication.js,Email not sent to {0} (unsubscribed / disabled),Email mos dërguar për {0} (c&#39;regjistruar / aftësi të kufizuara)
+apps/frappe/frappe/public/js/frappe/views/communication.js,Email not sent to {0} (unsubscribed / disabled),Email mos dërguar për {0} (c'regjistruar / aftësi të kufizuara)
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Select fields to export,Zgjidhni fushat për eksport
 DocType: Async Task,Traceback,Gjurmim
 DocType: Currency,Smallest Currency Fraction Value,Vogël Valuta Vlera Fraksion
@@ -2660,7 +2660,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Ndryshimin
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal settings portë e pagesës
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Performuesi më i mirë
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Fushat e personalizuara nuk mund të shtohen në DocTypes thelbësore.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) do të cunguar, si karaktere max lejuara është {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) do të cunguar, si karaktere max lejuara është {2}"
 DocType: OAuth Client,Response Type,Response Lloji
 DocType: Contact Us Settings,Send enquiries to this email address,Dërgoni pyetjet në këtë adresë e-mail
 DocType: Letter Head,Letter Head Name,Emri Letër Shef
@@ -2716,7 +2716,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Image Shiko
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Duket si diçka shkoi keq gjatë transaksionit. Që ne nuk e kanë konfirmuar pagesën, Paypal automatikisht do të kthejë këtë shumë. Në qoftë se jo, ju lutem na dërgoni një email dhe përmend ID Treguesi: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Përfshin simbole, numra dhe shkronja kapitale në fjalëkalimin"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Fut Pas fushë &#39;{0}&#39; të përmendur në Custom Field &#39;{1}&#39;, me etiketën &quot;{2} &#39;, nuk ekziston"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Fut Pas fushë '{0}' të përmendur në Custom Field '{1}', me etiketën &quot;{2} ', nuk ekziston"
 DocType: List Filter,List Filter,Filter Lista
 DocType: Workflow State,signal,sinjal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ka Attachments
@@ -2726,7 +2726,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,dokument Restored
 DocType: Data Export,Data Export,Të dhënat e eksportit
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Zgjidh gjuhen...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Ju nuk mund të vendosni &#39;Options&#39; për fushën {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Ju nuk mund të vendosni 'Options' për fushën {0}
 DocType: Help Article,Author,autor
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Resume Dërgimi
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Rihap
@@ -2740,14 +2740,14 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Default Adresa Template nuk mund të fshihet
 DocType: Contact,Maintenance Manager,Mirëmbajtja Menaxher
 DocType: Workflow State,Search,Kërkim
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Ju lutem zgjidhni një tjetër metodë e pagesës. Stripe nuk e mbështet transaksionet në monedhë të &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Ju lutem zgjidhni një tjetër metodë e pagesës. Stripe nuk e mbështet transaksionet në monedhë të '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Në Shportë
 DocType: Web Form,Web Form Fields,Fushat Forma Web
 DocType: Data Import,Amended From,Ndryshuar Nga
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Warning: Në pamundësi për të gjetur {0} në çdo tavolinë në lidhje me {1}
 DocType: S3 Backup Settings,eu-north-1,eu-veri-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Ky dokument aktualisht në radhë për ekzekutim. Ju lutem provoni përsëri
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File &#39;{0}&#39; nuk u gjet
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File '{0}' nuk u gjet
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Hiq Neni
 DocType: User,Change Password,Ndrysho fjalekalimin
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Fusha X Axis
@@ -2818,7 +2818,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.py,There must
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Get Items,Get Items
 DocType: Contact,Image,Imazh
 DocType: Workflow State,remove-sign,hiqni-shenjë
-apps/frappe/frappe/printing/doctype/print_settings/print_settings.py,Failed to connect to server,Dështoi për t&#39;u lidhur me serverin
+apps/frappe/frappe/printing/doctype/print_settings/print_settings.py,Failed to connect to server,Dështoi për t'u lidhur me serverin
 apps/frappe/frappe/core/doctype/data_export/exporter.py,There is no data to be exported,Nuk ka të dhëna për tu eksportuar
 DocType: Domain Settings,Domains HTML,Fushat HTML
 apps/frappe/frappe/templates/includes/search_template.html,Type something in the search box to search,Lloji diçka në kutinë e kërkimit për të kërkuar
@@ -2927,7 +2927,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Vlera e humbur për
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Shto Fëmija
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Përparimi i importit
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Nëse gjendja është e kënaqur, përdoruesi do të shpërblehet me pikë. psh. doc.status == &#39;Mbyllur&#39;"
+","Nëse gjendja është e kënaqur, përdoruesi do të shpërblehet me pikë. psh. doc.status == 'Mbyllur'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Rekordi i Dërguar nuk mund të fshihet.
 DocType: GSuite Templates,Template Name,Emri template
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,lloj i ri i dokumentit
@@ -3057,7 +3057,7 @@ DocType: Dashboard Chart,Chart Type,Lloji i grafikut
 DocType: DocType,Auto Name,Emri Auto
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Shmangni sekuenca si abc apo 6543 si ata janë të lehtë për të mend
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Ju lutem provoni përsëri
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL-ja duhet të fillojë me &#39;http: //&#39; ose &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL-ja duhet të fillojë me 'http: //' ose 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Opsioni 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,Redaktoj
@@ -3288,7 +3288,7 @@ DocType: Notification,Send alert if this field's value changes,Dërgo vigjilent 
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Ngjyrat e temave
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Zgjidh një DOCTYPE për të bërë një format të ri
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,perdoruesi nuk ekziston
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Përfituesit&#39; nuk janë të specifikuara
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Përfituesit' nuk janë të specifikuara
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,tani
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,aplikoni
 DocType: Footer Item,Policy,Politikë
@@ -3332,7 +3332,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Custom përkthime
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,progres
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,sipas Rolit
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Fushat Pagjetur
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname pavlefshme &#39;{0}&#39; në autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname pavlefshme '{0}' në autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Kërko në një lloj dokument
 DocType: Custom DocPerm,Role and Level,Roli dhe Niveli
 DocType: File,Thumbnail URL,Thumbnail URL
@@ -3419,11 +3419,11 @@ DocType: Dashboard Chart,Filters JSON,Filtrat JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Kliko këtu për të verifikuar
 DocType: Email Account,Disable SMTP server authentication,Disaktivizoni vërtetimin e serverit SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Kopjuar në clipboard.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,zëvendësime parashikueshme si &#39;@&#39; në vend të &#39;a&#39; nuk ndihmojnë shumë.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,zëvendësime parashikueshme si '@' në vend të 'a' nuk ndihmojnë shumë.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Caktuar nga Meje
 apps/frappe/frappe/utils/data.py,Zero,Zero
 DocType: Google Drive,Backup Folder ID,ID e Dosjes së Kopjimit
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Jo në modë Zhvilluesish! Vendosur në site_config.json ose të bëjë DOCTYPE &#39;Doganës&#39;.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Jo në modë Zhvilluesish! Vendosur në site_config.json ose të bëjë DOCTYPE 'Doganës'.
 DocType: Workflow State,globe,botë
 DocType: System Settings,dd.mm.yyyy,DD.MM.VVVV
 DocType: Assignment Rule,Priority,Prioritet
@@ -3471,7 +3471,7 @@ DocType: Notification,Reference Date,Referenca Data
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,Konfigurimi i OTP duke përdorur OTP App nuk u përfundua. Ju lutemi kontaktoni administratorin.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Ju lutemi shkruani nos celular vlefshme
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Disa nga karakteristikat mund të mos punojnë në shfletuesin tuaj. Please update shfletuesit tuaj në versionin e fundit.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nuk e di, pyet &#39;ndihmë&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Nuk e di, pyet 'ndihmë'"
 DocType: DocType,Comments and Communications will be associated with this linked document,Komentet dhe Communications do të jetë i lidhur me këtë dokument lidhur
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filter ...
 DocType: Workflow State,bold,guximtar
@@ -3499,7 +3499,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Dështoi gjatë ndryshimit të pajtimit
 DocType: LDAP Settings,LDAP Group Field,Fusha e grupit LDAP
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Është e barabartë me
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Lloj Options &#39;Dynamic Link&#39; e fushës duhet të vënë në një tjetër terren Link me opsione si &quot;DOCTYPE &#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Lloj Options 'Dynamic Link' e fushës duhet të vënë në një tjetër terren Link me opsione si &quot;DOCTYPE '
 DocType: About Us Settings,Team Members Heading,Anëtarët e ekipit Kreu
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Invalid CSV Format
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Gabim në lidhjen me aplikacionin e tabaka QZ ... <br><br> Duhet të keni të instaluar dhe ekzekutuar aplikacionin QZ Tray, për të përdorur funksionin Raw Print. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Klikoni këtu për të Shkarkuar dhe instaluar QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Klikoni këtu për të mësuar më shumë rreth Printimit të Lartë</a> ."
@@ -3626,8 +3626,8 @@ DocType: Web Page,Web Page,Faqe interneti
 DocType: Workflow Document State,Next Action Email Template,Modeli i ardhshëm i veprimit të veprimit
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Nëse aktivizohet, ndryshimet në dokument ndiqen dhe tregohen në afatin kohor"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&quot;Në Global Kërko &#39;nuk lejohet për llojin {0} në rresht {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&quot;Në Global Kërko &#39;nuk lejohet për llojin {0} në rresht {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&quot;Në Global Kërko 'nuk lejohet për llojin {0} në rresht {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&quot;Në Global Kërko 'nuk lejohet për llojin {0} në rresht {1}
 DocType: Energy Point Log,Appreciation,Vleresim
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Shiko Lista
 DocType: Workflow,Don't Override Status,Mos Refuzim Statusi
@@ -3772,7 +3772,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Mospagim
 DocType: Translation,Verified,verifikuar
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} shtuar
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Zgjeruar per &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Zgjeruar per '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Ju lutemi ruani raportin e parë
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonentë shtuar
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Jo Në
@@ -3808,14 +3808,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,më
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} nuk është një shtet i vlefshëm
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Aplikoni tek të gjitha llojet e dokumenteve
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Përditësimi i pikës së energjisë
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Ju lutem zgjidhni një tjetër metodë e pagesës. PayPal nuk e mbështet transaksionet në monedhë të &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Ju lutem zgjidhni një tjetër metodë e pagesës. PayPal nuk e mbështet transaksionet në monedhë të '{0}'
 DocType: Chat Message,Room Type,Tip dhome
 DocType: Data Import Beta,Import Log Preview,Paraprakisht e Kontrollit të Regjistrit
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Kërko fushë {0} nuk është e vlefshme
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,skedar i ngarkuar
 DocType: Workflow State,ok-circle,ok-rrethi
 DocType: LDAP Settings,LDAP User Creation and Mapping,Krijimi dhe hartëzimi i përdoruesve të LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Ju mund të gjeni gjëra duke pyetur &quot;gjeni portokalli në konsumatorët &#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Ju mund të gjeni gjëra duke pyetur &quot;gjeni portokalli në konsumatorët '
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Na vjen keq! Përdoruesi duhet të kenë qasje të plotë në të dhënat e tyre.
 ,Usage Info,Përdorimi Info
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Shfaqni shkurtoret e tastierës
@@ -3884,7 +3884,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Select Filters
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export Report: {0},Export Raporti: {0}
 DocType: Auto Email Report,Filter Meta,Filter Meta
 DocType: Web Page,Set Meta Tags,Vendosni Etiketat Meta
-DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,"Tekst për t&#39;u shfaqur për Link në web faqe, nëse kjo formë ka një faqe web. Rrugë Link do të jetë e gjeneruar automatikisht bazuar në `page_name` dhe` parent_website_route`"
+DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,"Tekst për t'u shfaqur për Link në web faqe, nëse kjo formë ka një faqe web. Rrugë Link do të jetë e gjeneruar automatikisht bazuar në `page_name` dhe` parent_website_route`"
 DocType: S3 Backup Settings,Backup Limit,Kufiri i rezervës
 DocType: Dashboard Chart,Line,Linjë
 DocType: Unhandled Email,Message-id,Message-id

--- a/frappe/translations/sr.csv
+++ b/frappe/translations/sr.csv
@@ -562,7 +562,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Статистика заснована на учинку прошле недеље (од {0} до {1})
 DocType: LDAP Settings,LDAP Phone Field,ЛДАП телефонско поље
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","Тип документа ..., на пример, купац"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Услов &#39;{0}&#39; је неважећи
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Услов '{0}' је неважећи
 DocType: Workflow State,barcode,баркод
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Употреба под-упита или функције је ограничена
 apps/frappe/frappe/config/customization.py,Add your own translations,Додајте своје преводе
@@ -712,7 +712,7 @@ DocType: Slack Webhook URL,Webhook URL,Вебхоок УРЛ
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Корисничко име {0} већ постоји
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0} : Не удается установить импорт как {1} не является ввозу
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Постоји грешка у вашем Адреса Темплате {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} је неважећа адреса е-поште у &#39;Примаоцима&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} је неважећа адреса е-поште у 'Примаоцима'
 DocType: Footer Item,"target = ""_blank""",таргет = &quot;_бланк&quot;
 DocType: Workflow State,hdd,хдд
 DocType: Integration Request,Host,Домаћин
@@ -754,7 +754,7 @@ DocType: Currency,Currency Name,Валута Име
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Но Емаил
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Линк Истекао
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Враћање дужине на {0} за &#39;{1}&#39; у &#39;{2}&#39;; Подешавање дужине као {3} ће узроковати скраћивање података.
+							Setting the length as {3} will cause truncation of data.",Враћање дужине на {0} за '{1}' у '{2}'; Подешавање дужине као {3} ће узроковати скраћивање података.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Изаберите Филе Формат
 DocType: Report,Javascript,Јавасцрипт
 DocType: File,Content Hash,Содержимое Hash
@@ -776,7 +776,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Документ Подели Пријави
 DocType: Social Login Key,Base URL,База УРЛ
 DocType: User,Last Login,Последњи Улазак
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Не можете поставити &#39;Транслатабле&#39; за поље {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Не можете поставити 'Транслатабле' за поље {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Колона
 DocType: Chat Profile,Chat Profile,Цхат Профил
 DocType: Custom Field,Adds a custom field to a DocType,Додаје прилагођени поље за ДОЦТИПЕ
@@ -785,7 +785,7 @@ DocType: File,Is Home Folder,Ис Хоме Директоријум
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Навбар Стиле
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} није валидна емаил адреса
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Изабери покрвитеља 1 запис за штампање
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Усер &#39;{0}&#39; већ има улогу &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Усер '{0}' већ има улогу '{1}'
 DocType: System Settings,Two Factor Authentication method,Два факторска аутентикацијска метода
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Прво подесите име и сачувајте запис.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Записа
@@ -1456,7 +1456,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Обавезно поље: сет улога
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} критикован {1}
 DocType: Data Migration Mapping,Mapping Name,Име мапирања
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Поље &#39;{1}&#39; се не може поставити као јединствено, јер има јединствене вредности"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Поље '{1}' се не може поставити као јединствено, јер има јединствене вредности"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Навигација по листи доле
 DocType: Currency,A symbol for this currency. For e.g. $,Симбол за ову валуту. За пример $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Успешно ажурирани преводи
@@ -1979,7 +1979,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ап-југоисток-1
 DocType: DocType,"Must be of type ""Attach Image""",Мора бити типа &quot;Аттацх Имаге&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Поништи све
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Не можете унсет &#39;Реад Онли &quot;за област {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Не можете унсет 'Реад Онли &quot;за област {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,Нула значи послати евиденцију ажурира у било ком тренутку
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,завершение установки
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,Ажуриран успешно
@@ -2023,7 +2023,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Гоогле Фонт
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Если эти инструкции , где не помогает, пожалуйста, добавьте в ваши предложения по вопросам GitHub ."
 DocType: Workflow State,bookmark,боокмарк
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Назив фолдера не треба да садржи &#39;/&#39; (Сласх)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Назив фолдера не треба да садржи '/' (Сласх)
 DocType: Note,Note,Приметити
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Грешка Извештај
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Извоз података у ЦСВ / Екцел формату.
@@ -2128,7 +2128,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Седница Ро�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Ово поље ће се појавити само ако фиелднаме овде дефинисана је вредност или правила су прави (примери): мифиелд ЕВАЛ: доц.мифиелд == &#39;Мој Вредност&#39; евал: доц.аге> 18
+eval:doc.age>18",Ово поље ће се појавити само ако фиелднаме овде дефинисана је вредност или правила су прави (примери): мифиелд ЕВАЛ: доц.мифиелд == 'Мој Вредност' евал: доц.аге> 18
 DocType: Social Login Key,Office 365,Оффице 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Данас
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Данас
@@ -2168,7 +2168,7 @@ DocType: Data Migration Connector,Database Name,Име базе података
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Рефресх Образац
 DocType: DocField,Select,Одабрати
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Погледајте цео дневник
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Симпле Питхон Екпрессион, Екампле: статус == &#39;Опен&#39; и откуцајте == &#39;Буг&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Симпле Питхон Екпрессион, Екампле: статус == 'Опен' и откуцајте == 'Буг'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Файл не прилагается
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Конекција изгубљена. Неке функције можда неће радити.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Понавља као &quot;ааа&quot; су лако погодити
@@ -2300,7 +2300,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Покажи само грешке
 DocType: Website Settings,Banner HTML,Банер ХТМЛ
 DocType: Workflow,Send Email Alert,Пошаљи Емаил Алерт
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Разорпаи не подржава трансакције у валути &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Разорпаи не подржава трансакције у валути '{0}'
 DocType: Data Import,In Progress,У току
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Чекању за бацкуп. То може потрајати неколико минута до сат времена.
 DocType: Error Snapshot,Pyver,Пивер
@@ -2727,7 +2727,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Изменама и д
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,ПаиПал Паимент Гатеваи поставке
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Врхунски перформер
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Прилагођена поља се не могу додати у основне ДоцТипес.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} &#39;({3}) би био скраћен, као мак знакова дозвољена је {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: {1} '({3}) би био скраћен, као мак знакова дозвољена је {2}"
 DocType: OAuth Client,Response Type,Тип одговора
 DocType: Contact Us Settings,Send enquiries to this email address,Пошаљите питања на ову емаил адресу
 DocType: Letter Head,Letter Head Name,Писмо Глава Име
@@ -2783,7 +2783,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Слика Погледај
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Изгледа да нешто није у реду током трансакције. Пошто нисмо потврдили плаћање, ПаиПал ће вам аутоматски надокнадити тај износ. Ако се то не деси, пошаљите нам е-маил и споменути корелације ИД: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Укључују симболе, бројеве и велика слова у лозинку"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Убаците Након пољу &#39;{0}&#39; помиње у прилагођеном пољу &#39;{1}&#39;, са ознаком &#39;{2}&#39;, не постоји"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Убаците Након пољу '{0}' помиње у прилагођеном пољу '{1}', са ознаком '{2}', не постоји"
 DocType: List Filter,List Filter,Филтер листе
 DocType: Workflow State,signal,сигнал
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Има прилоге
@@ -2793,7 +2793,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,dokument Ресторед
 DocType: Data Export,Data Export,Извоз података
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Изаберите језик ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Не можете поставити &#39;Опције&#39; за поље {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Не можете поставити 'Опције' за поље {0}
 DocType: Help Article,Author,аутор
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,nastavi слање
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Поново отворити
@@ -2807,15 +2807,15 @@ DocType: Web Page,Slideshow,Слидесхов
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Уобичајено Адреса Шаблон не може бити обрисан
 DocType: Contact,Maintenance Manager,Менаџер Одржавање
 DocType: Workflow State,Search,Претрага
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Трака не подржава трансакције у валути &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Трака не подржава трансакције у валути &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Трака не подржава трансакције у валути '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Трака не подржава трансакције у валути '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Пошаљи У ђубре
 DocType: Web Form,Web Form Fields,Веб Форм Поља
 DocType: Data Import,Amended From,Измењена од
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Упозорење: Није могуће пронаћи {0} у сваком столу у вези са {1}
 DocType: S3 Backup Settings,eu-north-1,еу-север-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,"Овај документ је тренутно чекају на извршење. Молим вас, покушајте поново"
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Фајл &#39;{0}&#39; није пронађен
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Фајл '{0}' није пронађен
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Ремове секцију
 DocType: User,Change Password,Промена лозинке
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Поље Кс оси
@@ -3004,7 +3004,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Вредност н�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Додај Цхилд
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Увези напредак
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Ако је увјет задовољен, корисник ће бити награђен бодовима. на пример. доц.статус == &#39;Затворено&#39;"
+","Ако је увјет задовољен, корисник ће бити награђен бодовима. на пример. доц.статус == 'Затворено'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Поставио Рекорд се не може избрисати.
 DocType: GSuite Templates,Template Name,Име шаблона
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,нови тип документа
@@ -3137,7 +3137,7 @@ DocType: Dashboard Chart,Chart Type,Тип графикона
 DocType: DocType,Auto Name,Ауто Име
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Избегавајте секвенце као што су АБЦ или 6543, јер је лако погодити"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,"Молим вас, покушајте поново"
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',УРЛ адреса мора почети са &#39;хттп: //&#39; или &#39;хттпс: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',УРЛ адреса мора почети са 'хттп: //' или 'хттпс: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Опција 3
 DocType: Communication,uid,? уид
 DocType: Workflow State,Edit,Едит
@@ -3376,7 +3376,7 @@ DocType: Notification,Send alert if this field's value changes,Пошаљи уп
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Боје тема
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Изаберите ДОЦТИПЕ да направи нови формат
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Корисник не постоји
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Примаоци&#39; нису наведени
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Примаоци' нису наведени
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,управо сада
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Применити
 DocType: Footer Item,Policy,политика
@@ -3425,7 +3425,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Цустом Пр
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,напредак
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,по улози
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,миссинг Поља
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Инвалид фиелднаме &#39;{0}&#39; у аутонаме
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Инвалид фиелднаме '{0}' у аутонаме
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Тражи у врсти документа
 DocType: Custom DocPerm,Role and Level,Роль и уровень
 DocType: File,Thumbnail URL,Умањени УРЛ адреса
@@ -3525,7 +3525,7 @@ DocType: Dashboard Chart,Filters JSON,Филтери ЈСОН
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Кликните овде да бисте проверили
 DocType: Email Account,Disable SMTP server authentication,Онемогући провјеру идентитета СМТП сервера
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Копирано у међуспремник.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Предвидљива замене као што су &#39;@&#39; уместо &#39;А&#39; не помажу много.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Предвидљива замене као што су '@' уместо 'А' не помажу много.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Ассигнед Би Ме
 apps/frappe/frappe/utils/data.py,Zero,Нула
 DocType: Google Drive,Backup Folder ID,ИД резервне мапе
@@ -3579,7 +3579,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Введите действительные мобильных NOS
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Неке од функција неће радити у вашем бровсеру. Молимо Вас да ажурирате свој претраживач на најновију верзију.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Неке од функција неће радити у вашем бровсеру. Молимо Вас да ажурирате свој претраживач на најновију верзију.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Не знам, питај &#39;помоћ&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Не знам, питај 'помоћ'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},отказао овај документ {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Коментари и комуникације ће бити повезана са овим везног документа
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Филтер ...
@@ -3738,8 +3738,8 @@ DocType: Web Page,Web Page,Веб страна
 DocType: Workflow Document State,Next Action Email Template,Следећа шаблона за акцију
 DocType: Blog Category,Blogger,Блоггер
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Ако је омогућено, измене у документу се прате и приказују у временској траци"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Глобал Сеарцх &quot;није дозвољено за тип {0} у реду {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Глобал Сеарцх &quot;није дозвољено за тип {0} у реду {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Глобал Сеарцх &quot;није дозвољено за тип {0} у реду {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Глобал Сеарцх &quot;није дозвољено за тип {0} у реду {1}
 DocType: Energy Point Log,Appreciation,Захвалност
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,виев Лист
 DocType: Workflow,Don't Override Status,Не замењују Статус
@@ -3887,7 +3887,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Уобичајено
 DocType: Translation,Verified,Проверено
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} је додао
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Трагање за &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Трагање за '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Сачувајте извештај први
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} је додао претплатници
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Није У
@@ -3924,14 +3924,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Ја
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} није важећидржавни
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Применити на све врсте докумената
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Ажурирање енергетске тачке
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Паипал не подржава трансакције у валути &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Молимо одаберите други начин плаћања. Паипал не подржава трансакције у валути '{0}'
 DocType: Chat Message,Room Type,Врста собе
 DocType: Data Import Beta,Import Log Preview,Увези преглед прегледа
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,поље за претрагу {0} није важећа
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,отпремљена датотека
 DocType: Workflow State,ok-circle,ок-круг
 DocType: LDAP Settings,LDAP User Creation and Mapping,Стварање и мапирање ЛДАП корисника
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Можете наћи ствари тражећи &quot;наћи наранџасто у купце &#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Можете наћи ствари тражећи &quot;наћи наранџасто у купце '
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Извини! Корисник треба да имају потпуни приступ свом запису.
 ,Usage Info,Употреба информације
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Прикажи пречице на тастатури

--- a/frappe/translations/sr.csv
+++ b/frappe/translations/sr.csv
@@ -748,7 +748,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Филе б
 DocType: DocField,In Global Search,У Глобал Сеарцх
 DocType: System Settings,Brute Force Security,Бруте Форце Сецурити
 DocType: Workflow State,indent-left,индент-лево
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} пре годину дана
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} пре годину дана
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,То је ризично да избришете ову датотеку: {0}. Обратите се свом Систем Манагер.
 DocType: Currency,Currency Name,Валута Име
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Но Емаил
@@ -1047,7 +1047,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Не {0} фо
 apps/frappe/frappe/config/customization.py,Add custom forms.,Додај прилагођене облике.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} у {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,доставио овај документ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Подешавање&gt; Дозволе корисника
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Подешавање> Дозволе корисника
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,"Система предоставляет множество заранее определенных ролей. Вы можете добавить новые роли , чтобы установить более тонкие разрешения ."
 DocType: Communication,CC,КЗ
 DocType: Country,Geo,Гео
@@ -1172,7 +1172,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,"Email ID must b
 DocType: Workflow State,retweet,ретвеет
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Customize...,Прилагоди...
 DocType: Print Format,Align Labels to the Right,Поравнајте ознаке на десно
-DocType: Assignment Rule,Disabled,Онеспособљен
+DocType: Assignment Rule,Disabled,Онеспособљ��н
 DocType: File,Uploaded To Dropbox,Преузето са Дропбок-ом
 DocType: Workflow State,eye-close,ока близу
 apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For more information, {0}.","За више информација, {0}."
@@ -1268,7 +1268,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ако корисник има било какву улогу проверити, онда корисник постаје &quot;Системски корисник&quot;. &quot;Системски корисник&quot; има приступ радној површини"
 DocType: System Settings,Date and Number Format,Дата и номер Формат
 apps/frappe/frappe/model/document.py,one of,Један од
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Подешавање&gt; Прилагоди образац
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Подешавање> Прилагоди образац
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Провера један тренутак
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Схов ознаке
 DocType: DocField,HTML Editor,ХТМЛ Едитор
@@ -1276,7 +1276,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Обрачун
 DocType: Email Queue,Not Sent,Није Сент
 DocType: Web Form,Actions,Акције
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Подешавање&gt; Корисник
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Подешавање> Корисник
 DocType: Workflow State,align-justify,алигн оправдава
 DocType: User,Middle Name (Optional),Средње име (опционо)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Није дозвољен
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,Је стандард
 DocType: Desktop Icon,_report,_извештај
 DocType: Desktop Icon,_report,_извештај
 DocType: Dashboard Chart,Full,Пуно
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Не ХТМЛ-Кодирање ХТМЛ ознаке као што су: &lt;сцрипт&gt; или само као ликови &lt;или&gt;, јер може да се намерно користи у овој области"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не ХТМЛ-Кодирање ХТМЛ ознаке као што су: &lt;сцрипт> или само као ликови &lt;или>, јер може да се намерно користи у овој области"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} критикован је {1}
 DocType: Website Settings,FavIcon,Фавицон
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Трцати
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Фоотер ће
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Нерешен
 DocType: System Settings,Allow only one session per user,Дозволите само једну седницу по кориснику
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Почетна / тест Папка 1 / тест Папка 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;хеад&gt; ХТМЛ-
+DocType: Website Settings,&lt;head> HTML,&lt;хеад> ХТМЛ-
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Изаберите или превуците преко терминима да креирате нови догађај.
 DocType: Contact,Contact Details,Контакт Детаљи
 DocType: DocField,In Filter,У филтеру
@@ -2040,7 +2040,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Войти не допускается в это время
 DocType: Data Migration Run,Current Mapping Action,Актуелна акција мапирања
 DocType: Dashboard Chart Source,Source Name,извор Име
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Ниједан налог е-поште није повезан са корисником. Додајте налог у оквиру Корисник&gt; Инбок.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Ниједан налог е-поште није повезан са корисником. Додајте налог у оквиру Корисник> Инбок.
 DocType: Email Account,Email Sync Option,Емаил Синхронизација Опција
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Ред број
 DocType: Async Task,Runtime,Рунтиме
@@ -2055,7 +2055,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Већ к
 DocType: User Email,Enable Outgoing,Омогући Одлазећи
 DocType: Address,Fax,Фак
 apps/frappe/frappe/config/customization.py,Custom Tags,Цустом Ознаке
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Рачун е-поште није подешавање. Креирајте нови рачун е-поште из програма Сетуп&gt; Емаил&gt; Аццоунт Емаил
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Рачун е-поште није подешавање. Креирајте нови рачун е-поште из програма Сетуп> Емаил> Аццоунт Емаил
 DocType: Comment,Submitted,Поднет
 DocType: Contact,Pulled from Google Contacts,Извлачено из Гоогле контаката
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Неважећи Упит
@@ -2128,7 +2128,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Седница Ро�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Ово поље ће се појавити само ако фиелднаме овде дефинисана је вредност или правила су прави (примери): мифиелд ЕВАЛ: доц.мифиелд == &#39;Мој Вредност&#39; евал: доц.аге&gt; 18
+eval:doc.age>18",Ово поље ће се појавити само ако фиелднаме овде дефинисана је вредност или правила су прави (примери): мифиелд ЕВАЛ: доц.мифиелд == &#39;Мој Вредност&#39; евал: доц.аге> 18
 DocType: Social Login Key,Office 365,Оффице 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Данас
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Данас
@@ -2143,7 +2143,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,велика слова
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Цустом ХТМЛ
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Унесите име фасцикле
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Није пронађен ниједан задани предложак адресе. Креирајте нову из Подешавање&gt; Штампање и брендирање&gt; Предложак адреса.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Није пронађен ниједан задани предложак адресе. Креирајте нову из Подешавање> Штампање и брендирање> Предложак адреса.
 apps/frappe/frappe/auth.py,Unknown User,Непознат корисника
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Избор улоге
 DocType: Comment,Deleted,Делетед
@@ -2334,12 +2334,12 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Није довољно дозвола да виде линкове
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Адрес Название является обязательным.
 DocType: Google Contacts,Push to Google Contacts,Притисните на Гоогле контакте
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Додато ХТМЛ-у &lt;хеад&gt; одељак веб странице, првенствено се користи за проверу сајта и СЕО"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Додато ХТМЛ-у &lt;хеад> одељак веб странице, првенствено се користи за проверу сајта и СЕО"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Релапсед
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Продукт не может быть добавлен в своих собственных потомков
 DocType: Session Default Settings,Session Defaults,Задане поставке сесије
 DocType: System Settings,Expiry time of QR Code Image Page,Време истека КР кодне странице
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,Прикажи укупне вредности
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,При��ажи укупне вредности
 DocType: Error Snapshot,Relapses,Рецидива
 apps/frappe/frappe/public/js/frappe/social/pages/UserList.vue,No user found,Није пронађен ниједан корисник
 DocType: Address,Preferred Shipping Address,Жељени Адреса испоруке
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Упозорење
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ово може бити одштампано на више страница
 DocType: Data Migration Run,Percent Complete,Перцент Цомплете
 DocType: Tag Category,Tag Category,таг Категорија
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За поређење користите&gt; 5, &lt;10 или = 324. За опсеге користите 5:10 (за вредности између 5 и 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За поређење користите> 5, &lt;10 или = 324. За опсеге користите 5:10 (за вредности између 5 и 10)."
 DocType: Google Calendar,Pull from Google Calendar,Повуците из Гоогле календара
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помоћ
 DocType: User,Login Before,Пријава Пре
@@ -2903,7 +2903,7 @@ DocType: S3 Backup Settings,Access Key ID,Приступни кључни ИД
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Misc,Остало
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Start new Format,Старт нев Формат
 DocType: Workflow State,font,фонт
-DocType: DocType,Show Preview Popup,Прикажи Превиев Попуп
+DocType: DocType,Show Preview Popup,Прикажи Превиев По��уп
 apps/frappe/frappe/utils/password_strength.py,This is a top-100 common password.,Ово је топ-100 Заједничка лозинка.
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Please enable pop-ups,Молимо омогућите искачуће прозоре
 DocType: Contact,Mobile No,Мобилни Нема
@@ -2921,7 +2921,7 @@ DocType: Custom Script,Custom Script,Цустом Сцрипт
 DocType: Address,Address Line 2,Аддресс Лине 2
 DocType: Address,Reference,Упућивање
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Додељено
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Поставите подразумевани рачун е-поште из програма Сетуп&gt; Емаил&gt; Аццоунт Емаил
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Поставите подразумевани рачун е-поште из програма Сетуп> Емаил> Аццоунт Емаил
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Детаљи мапирања миграције података
 DocType: Data Import,Action,Акција
 DocType: GSuite Settings,Script URL,сцрипт УРЛ адреса
@@ -3099,7 +3099,7 @@ DocType: DocField,Allow on Submit,Дозволи на Субмит
 DocType: DocField,HTML,ХТМЛ-
 DocType: Error Snapshot,Exception Type,Екцептион
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Пицк колоне
-DocType: Web Page,Add code as &lt;script&gt;,Додајте код као &lt;сцрипт&gt;
+DocType: Web Page,Add code as &lt;script>,Додајте код као &lt;сцрипт>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Избриши дозволе корисника
 DocType: Webhook,Headers,Хеадерс
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Предстојећи догађаји
@@ -3474,15 +3474,15 @@ DocType: Workflow State,share-alt,Удео-алт
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Ред треба да буде један од {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<Х4> Стандардно шаблона </ х4> 
  <п> <а Користи хреф=""хттп://јиња.поцоо.орг/доцс/темплатес/""> ЈИЊА Темплатинг </а> и све области Адреса ( укључујући цустом фиелдс ако их има) ће бити доступан </ п> 
  <пре> <цоде> {{аддресс_лине1}} & лт; бр & гт; 
@@ -3503,7 +3503,7 @@ DocType: Contact Phone,Is Primary Mobile,Је примарна мобилна м
 DocType: Workflow Document State,Workflow Document State,Воркфлов Документ држава
 apps/frappe/frappe/public/js/frappe/request.js,File too big,Филе превелика
 apps/frappe/frappe/core/doctype/user/user.py,Email Account added multiple times,Е-маил налог додао више пута
-DocType: Energy Point Settings,Last Point Allocation Date,Последњи датум додељивања тачке
+DocType: Energy Point Settings,Last Point Allocation Date,Последњи д��тум додељивања тачке
 DocType: Payment Gateway,Payment Gateway,Паимент Гатеваи
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} appreciated your work on {1} with {2} point,{0} ценио је ваш рад на {1} са {2} тачком
 DocType: Milestone Tracker,Field to Track,Фиелд то Трацк

--- a/frappe/translations/sr.csv
+++ b/frappe/translations/sr.csv
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,Је стандард
 DocType: Desktop Icon,_report,_извештај
 DocType: Desktop Icon,_report,_извештај
 DocType: Dashboard Chart,Full,Пуно
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Не ХТМЛ-Кодирање ХТМЛ ознаке као што су: &lt;сцрипт> или само као ликови &lt;или>, јер може да се намерно користи у овој области"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Не ХТМЛ-Кодирање ХТМЛ ознаке као што су: <сцрипт> или само као ликови <или>, јер може да се намерно користи у овој области"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} критикован је {1}
 DocType: Website Settings,FavIcon,Фавицон
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Трцати
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Фоотер ће
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Нерешен
 DocType: System Settings,Allow only one session per user,Дозволите само једну седницу по кориснику
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Почетна / тест Папка 1 / тест Папка 3
-DocType: Website Settings,&lt;head> HTML,&lt;хеад> ХТМЛ-
+DocType: Website Settings,<head> HTML,<хеад> ХТМЛ-
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Изаберите или превуците преко терминима да креирате нови догађај.
 DocType: Contact,Contact Details,Контакт Детаљи
 DocType: DocField,In Filter,У филтеру
@@ -2334,7 +2334,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Није довољно дозвола да виде линкове
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Адрес Название является обязательным.
 DocType: Google Contacts,Push to Google Contacts,Притисните на Гоогле контакте
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Додато ХТМЛ-у &lt;хеад> одељак веб странице, првенствено се користи за проверу сајта и СЕО"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Додато ХТМЛ-у <хеад> одељак веб странице, првенствено се користи за проверу сајта и СЕО"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Релапсед
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Продукт не может быть добавлен в своих собственных потомков
 DocType: Session Default Settings,Session Defaults,Задане поставке сесије
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Упозорење
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Ово може бити одштампано на више страница
 DocType: Data Migration Run,Percent Complete,Перцент Цомплете
 DocType: Tag Category,Tag Category,таг Категорија
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За поређење користите> 5, &lt;10 или = 324. За опсеге користите 5:10 (за вредности између 5 и 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","За поређење користите> 5, <10 или = 324. За опсеге користите 5:10 (за вредности између 5 и 10)."
 DocType: Google Calendar,Pull from Google Calendar,Повуците из Гоогле календара
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Помоћ
 DocType: User,Login Before,Пријава Пре
@@ -3099,7 +3099,7 @@ DocType: DocField,Allow on Submit,Дозволи на Субмит
 DocType: DocField,HTML,ХТМЛ-
 DocType: Error Snapshot,Exception Type,Екцептион
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Пицк колоне
-DocType: Web Page,Add code as &lt;script>,Додајте код као &lt;сцрипт>
+DocType: Web Page,Add code as <script>,Додајте код као <сцрипт>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Избриши дозволе корисника
 DocType: Webhook,Headers,Хеадерс
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Предстојећи догађаји
@@ -3474,15 +3474,15 @@ DocType: Workflow State,share-alt,Удео-алт
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Ред треба да буде један од {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<Х4> Стандардно шаблона </ х4> 
  <п> <а Користи хреф=""хттп://јиња.поцоо.орг/доцс/темплатес/""> ЈИЊА Темплатинг </а> и све области Адреса ( укључујући цустом фиелдс ако их има) ће бити доступан </ п> 
  <пре> <цоде> {{аддресс_лине1}} & лт; бр & гт; 

--- a/frappe/translations/sv.csv
+++ b/frappe/translations/sv.csv
@@ -1425,7 +1425,7 @@ DocType: User,System User,Systemanvändare
 DocType: Report,Is Standard,Är Standard
 DocType: Desktop Icon,_report,_rapportera
 DocType: Dashboard Chart,Full,Full
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Inte HTML Koda HTML-taggar som &lt;script> eller bara tecken som &lt;eller>, eftersom de kan användas avsiktligt i detta område"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Inte HTML Koda HTML-taggar som <script> eller bara tecken som <eller>, eftersom de kan användas avsiktligt i detta område"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiserades den {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Springa
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Sidfot visas bara
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Väntar
 DocType: System Settings,Allow only one session per user,Tillåt bara en session per användare
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Hem / Testa mapp 1 / Testa mapp 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Välj eller dra över tidsluckor för att skapa en ny händelse.
 DocType: Contact,Contact Details,Kontaktuppgifter
 DocType: DocField,In Filter,I Filtrera
@@ -2334,7 +2334,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Inte tillräckligt med tillåtelse för att se länkar
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adress titel är obligatorisk.
 DocType: Google Contacts,Push to Google Contacts,Tryck till Google-kontakter
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Inkom HTML i avsnittet &lt;head> på webbsidan, i första hand används för webbplats verifiering och SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Inkom HTML i avsnittet <head> på webbsidan, i första hand används för webbplats verifiering och SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiverande
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Produkt kan inte läggas till sina egna underprodukter
 DocType: Session Default Settings,Session Defaults,Sessioninställningar
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Varning
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Detta kan skrivas ut på flera sidor
 DocType: Data Migration Run,Percent Complete,Procent Slutförd
 DocType: Tag Category,Tag Category,Tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","För jämförelse, använd> 5, &lt;10 eller = 324. För intervall, använd 5:10 (för värden mellan 5 och 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","För jämförelse, använd> 5, <10 eller = 324. För intervall, använd 5:10 (för värden mellan 5 och 10)."
 DocType: Google Calendar,Pull from Google Calendar,Dra från Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjälp
 DocType: User,Login Before,Logga in Innan
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Tillåt på Skicka
 DocType: DocField,HTML,html
 DocType: Error Snapshot,Exception Type,Undantag Typ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Välj Kolumner
-DocType: Web Page,Add code as &lt;script>,Lägg till koden som &lt;script>
+DocType: Web Page,Add code as <script>,Lägg till koden som <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Rensa användarrättigheter
 DocType: Webhook,Headers,rubriker
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,uppkommande händelser
@@ -3477,16 +3477,16 @@ DocType: Workflow State,share-alt,aktie alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kö bör vara en av {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Standardmall </h4><p> Använder <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Mallar</a> och alla områden adress (inklusive anpassade fält om någon) kommer att finnas tillgängligt </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Standardmall </h4><p> Använder <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Mallar</a> och alla områden adress (inklusive anpassade fält om någon) kommer att finnas tillgängligt </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Startdatum Fält
 DocType: Role,Role Name,Rollnamn
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Växla till Desk

--- a/frappe/translations/sv.csv
+++ b/frappe/translations/sv.csv
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Inaktivera rappo
 DocType: Translation,Contributed Translation Doctype Name,Bidragsöversättning Doctype Name
 DocType: PayPal Settings,Redirect To,Omdirigering till
 DocType: Data Migration Mapping,Pull,Dra
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports [&#39;rapportnamn&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Format: frappe.query_reports ['rapportnamn'] = {}
 DocType: Bulk Update,Bulk Update,Bulk Update
 DocType: Workflow State,chevron-up,Chevron-up
 DocType: DocType,Allow Guest to View,Tillåta gäster att Visa
@@ -563,7 +563,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Statistik baserad på förra veckans resultat (från {0} till {1})
 DocType: LDAP Settings,LDAP Phone Field,LDAP-telefonfält
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","dokumentstyp ..., t.ex. kund"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Tillståndet &#39;{0}&#39; är ogiltig
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Tillståndet '{0}' är ogiltig
 DocType: Workflow State,barcode,streckkod
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Användning av underfråga eller funktion är begränsad
 apps/frappe/frappe/config/customization.py,Add your own translations,Lägg till dina egna översättningar
@@ -777,7 +777,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Dokument Dela Rapport
 DocType: Social Login Key,Base URL,Basadress
 DocType: User,Last Login,Senaste inloggning
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Du kan inte ställa in &#39;Translatable&#39; för fält {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Du kan inte ställa in 'Translatable' för fält {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Spalt
 DocType: Chat Profile,Chat Profile,Chat profil
 DocType: Custom Field,Adds a custom field to a DocType,Lägger till ett anpassat fält till en DocType
@@ -786,7 +786,7 @@ DocType: File,Is Home Folder,Är Home Folder
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Style
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} är inte en giltig e-postadress
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Välj minst ett rekord för utskrift
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Användar {0} &quot;har redan rollen &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Användar {0} &quot;har redan rollen '{1}'
 DocType: System Settings,Two Factor Authentication method,Tvåfaktorautentiseringsmetod
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Ange först namnet och spara posten.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 poster
@@ -1456,7 +1456,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Obligatoriskt fält: set roll
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} kritiserade {1}
 DocType: Data Migration Mapping,Mapping Name,Mapping Name
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Fältet &#39;{1}&#39; kan inte ställas in som unikt eftersom det har icke-unika värden
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Fältet '{1}' kan inte ställas in som unikt eftersom det har icke-unika värden
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Navigera listan ner
 DocType: Currency,A symbol for this currency. For e.g. $,En symbol för denna valuta. För t.ex. $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Framgångsrikt uppdaterade översättningar
@@ -2168,7 +2168,7 @@ DocType: Data Migration Connector,Database Name,Databas namn
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Uppdatera Formulär
 DocType: DocField,Select,Välj
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Visa fullständig logg
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Exempel: status == &#39;Open&#39; och typ == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Simple Python Expression, Exempel: status == 'Open' och typ == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Fil inte inlagd
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Anslutning förlorad. Vissa funktioner kanske inte fungerar.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Upprepningar som &quot;AAA&quot; är lätt att gissa
@@ -2300,7 +2300,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Visa bara fel
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,Skicka e-postmeddelande
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Välj en annan betalningsmetod. Razorpay stöder inte transaktioner i valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Välj en annan betalningsmetod. Razorpay stöder inte transaktioner i valuta '{0}'
 DocType: Data Import,In Progress,Pågående
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Kö för säkerhetskopiering. Det kan ta några minuter till en timme.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2794,7 +2794,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Dokumentåterställt
 DocType: Data Export,Data Export,Data Export
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Välj språk...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Du kan inte ställa in &#39;Alternativ&#39; för fält {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Du kan inte ställa in 'Alternativ' för fält {0}
 DocType: Help Article,Author,Författare
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Återuppta uppta~~POS=HEADCOMP Sända
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Öppna igen
@@ -2816,7 +2816,7 @@ DocType: Data Import,Amended From,Ändrat Från
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Varning: Det går inte att hitta {0} i någon tabell relaterad till {1}
 DocType: S3 Backup Settings,eu-north-1,eu-nord-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Detta dokument är för närvarande i kö för exekvering. Var god försök igen
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Arkiv &#39;{0}&#39; hittades inte
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Arkiv '{0}' hittades inte
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Avlägsna Avsnitt
 DocType: User,Change Password,Byt lösenord
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Fält för X-axel
@@ -3006,7 +3006,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Värde saknas för
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Lägg till underval
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Importera framsteg
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",Om villkoret är uppfyllt kommer användaren att belönas med poängen. t.ex. doc.status == &#39;Stängt&#39;
+",Om villkoret är uppfyllt kommer användaren att belönas med poängen. t.ex. doc.status == 'Stängt'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Inskickad information kan inte tas bort.
 DocType: GSuite Templates,Template Name,Mallnamn
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,nytt typ av dokument
@@ -3138,7 +3138,7 @@ DocType: Dashboard Chart,Chart Type,Diagramtyp
 DocType: DocType,Auto Name,Auto Namn
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Undvik sekvenser som abc eller 6543, eftersom de är lätta att gissa"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Var god försök igen
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL måste börja med &#39;http: //&#39; eller &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL måste börja med 'http: //' eller 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Alternativ 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Redigera
@@ -3879,7 +3879,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Standard
 DocType: Translation,Verified,Verifierad
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} tillagd
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Sök efter &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Sök efter '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Spara rapporten först
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} abonnenter tillagda
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Inte I
@@ -3916,7 +3916,7 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Mig
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} inte en giltig stat
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Tillämpa alla dokumenttyper
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Energipunktuppdatering
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Välj en annan betalningsmetod. PayPal stöder inte transaktioner i valuta &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Välj en annan betalningsmetod. PayPal stöder inte transaktioner i valuta '{0}'
 DocType: Chat Message,Room Type,Rumstyp
 DocType: Data Import Beta,Import Log Preview,Förhandsvisning av importlogg
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Sökfält {0} är inte giltigt

--- a/frappe/translations/sv.csv
+++ b/frappe/translations/sv.csv
@@ -749,7 +749,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Filbackup �
 DocType: DocField,In Global Search,I Global Sök
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,indent-vänster
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} år sedan
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} år sedan
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Det är riskabelt att ta bort denna fil: {0}. Kontakta din systemadministratören.
 DocType: Currency,Currency Name,Valuta Namn
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Inga e-post
@@ -1048,7 +1048,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Nr {0} hittad
 apps/frappe/frappe/config/customization.py,Add custom forms.,Lägg till anpassade formulär.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} i {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,lämnat detta dokument
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Inställning&gt; Användarrättigheter
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Inställning> Användarrättigheter
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Systemet erbjuder många fördefinierade roller. Du kan lägga till nya roller för att ställa finare behörigheter.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1269,7 +1269,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",Om användaren har någon roll kontrolleras då användaren blir en &quot;systemanvändare&quot;. &quot;Systemanvändare&quot; har tillgång till skrivbordet
 DocType: System Settings,Date and Number Format,Datum och numeriskt format
 apps/frappe/frappe/model/document.py,one of,en av
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Inställning&gt; Anpassa formulär
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Inställning> Anpassa formulär
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kontroll ett ögonblick
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Visa Taggar
 DocType: DocField,HTML Editor,HTML Editor
@@ -1277,7 +1277,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Fakturering
 DocType: Email Queue,Not Sent,Inte Skickade
 DocType: Web Form,Actions,Åtgärder
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Inställning&gt; Användare
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Inställning> Användare
 DocType: Workflow State,align-justify,rikta-justify
 DocType: User,Middle Name (Optional),Mellannamn (valfritt)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Inte Tillåtna
@@ -1425,7 +1425,7 @@ DocType: User,System User,Systemanvändare
 DocType: Report,Is Standard,Är Standard
 DocType: Desktop Icon,_report,_rapportera
 DocType: Dashboard Chart,Full,Full
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Inte HTML Koda HTML-taggar som &lt;script&gt; eller bara tecken som &lt;eller&gt;, eftersom de kan användas avsiktligt i detta område"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Inte HTML Koda HTML-taggar som &lt;script> eller bara tecken som &lt;eller>, eftersom de kan användas avsiktligt i detta område"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} kritiserades den {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Springa
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Sidfot visas bara
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Väntar
 DocType: System Settings,Allow only one session per user,Tillåt bara en session per användare
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Hem / Testa mapp 1 / Testa mapp 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Välj eller dra över tidsluckor för att skapa en ny händelse.
 DocType: Contact,Contact Details,Kontaktuppgifter
 DocType: DocField,In Filter,I Filtrera
@@ -2040,7 +2040,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Inloggning inte tillåtet vid denna tid
 DocType: Data Migration Run,Current Mapping Action,Aktuell kartläggningsåtgärd
 DocType: Dashboard Chart Source,Source Name,käll~~POS=TRUNC
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Inget e-postkonto kopplat till användaren. Lägg till ett konto under User&gt; Email Inbox.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Inget e-postkonto kopplat till användaren. Lägg till ett konto under User> Email Inbox.
 DocType: Email Account,Email Sync Option,Email Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Rad nr
 DocType: Async Task,Runtime,Runtime
@@ -2055,7 +2055,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Redan i a
 DocType: User Email,Enable Outgoing,Aktivera Utgående
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,anpassade Taggar
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-postkonto är inte inställt. Skapa ett nytt e-postkonto från Inställning&gt; E-post&gt; E-postkonto
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-postkonto är inte inställt. Skapa ett nytt e-postkonto från Inställning> E-post> E-postkonto
 DocType: Comment,Submitted,Avsändare
 DocType: Contact,Pulled from Google Contacts,Dras från Google-kontakter
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Ogiltig Förfrågan
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Session Utgångs i t
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Detta fält visas endast om fältnamn definieras här har värde eller reglerna är sanna (exempel): myfield eval: doc.myfield == &quot;Min värde&quot; eval: doc.age&gt; 18
+eval:doc.age>18",Detta fält visas endast om fältnamn definieras här har värde eller reglerna är sanna (exempel): myfield eval: doc.myfield == &quot;Min värde&quot; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Kontor 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,I dag
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",När du har ställt detta kommer användarna bara att kunna komma åt dokument (t.ex.. Blogginlägg) där länken finns (t.ex.. Blogger).
@@ -2143,7 +2143,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,STORA BOKSTÄVER
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Anpassad HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Ange mappnamn
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Ingen standardadressmall hittades. Skapa en ny från Setup&gt; Print and Branding&gt; Address Mall.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Ingen standardadressmall hittades. Skapa en ny från Setup> Print and Branding> Address Mall.
 apps/frappe/frappe/auth.py,Unknown User,Okänd användare
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Välj roll
 DocType: Comment,Deleted,Raderad
@@ -2334,7 +2334,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Inte tillräckligt med tillåtelse för att se länkar
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adress titel är obligatorisk.
 DocType: Google Contacts,Push to Google Contacts,Tryck till Google-kontakter
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Inkom HTML i avsnittet &lt;head&gt; på webbsidan, i första hand används för webbplats verifiering och SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Inkom HTML i avsnittet &lt;head> på webbsidan, i första hand används för webbplats verifiering och SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Recidiverande
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Produkt kan inte läggas till sina egna underprodukter
 DocType: Session Default Settings,Session Defaults,Sessioninställningar
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Varning
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Detta kan skrivas ut på flera sidor
 DocType: Data Migration Run,Percent Complete,Procent Slutförd
 DocType: Tag Category,Tag Category,Tag Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","För jämförelse, använd&gt; 5, &lt;10 eller = 324. För intervall, använd 5:10 (för värden mellan 5 och 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","För jämförelse, använd> 5, &lt;10 eller = 324. För intervall, använd 5:10 (för värden mellan 5 och 10)."
 DocType: Google Calendar,Pull from Google Calendar,Dra från Google Kalender
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Hjälp
 DocType: User,Login Before,Logga in Innan
@@ -2922,7 +2922,7 @@ DocType: Custom Script,Custom Script,Custom Script
 DocType: Address,Address Line 2,Adress Linje 2
 DocType: Address,Reference,Referens
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Tilldelats
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Ställ in standard e-postkonto från Setup&gt; E-post&gt; E-postkonto
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Ställ in standard e-postkonto från Setup> E-post> E-postkonto
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Data Migration Mapping Detalj
 DocType: Data Import,Action,Åtgärd
 DocType: GSuite Settings,Script URL,Skriptadress
@@ -3100,7 +3100,7 @@ DocType: DocField,Allow on Submit,Tillåt på Skicka
 DocType: DocField,HTML,html
 DocType: Error Snapshot,Exception Type,Undantag Typ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Välj Kolumner
-DocType: Web Page,Add code as &lt;script&gt;,Lägg till koden som &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Lägg till koden som &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Rensa användarrättigheter
 DocType: Webhook,Headers,rubriker
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,uppkommande händelser
@@ -3477,16 +3477,16 @@ DocType: Workflow State,share-alt,aktie alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kö bör vara en av {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Standardmall </h4><p> Använder <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Mallar</a> och alla områden adress (inklusive anpassade fält om någon) kommer att finnas tillgängligt </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Standardmall </h4><p> Använder <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Mallar</a> och alla områden adress (inklusive anpassade fält om någon) kommer att finnas tillgängligt </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Startdatum Fält
 DocType: Role,Role Name,Rollnamn
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Växla till Desk

--- a/frappe/translations/sw.csv
+++ b/frappe/translations/sw.csv
@@ -1033,7 +1033,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Hakuna {0} ku
 apps/frappe/frappe/config/customization.py,Add custom forms.,Ongeza fomu za desturi.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} katika {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,iliwasilisha hati hii
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Sanidi&gt; Ruhusa za Mtumiaji
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Sanidi> Ruhusa za Mtumiaji
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Mfumo hutoa majukumu mengi ya awali. Unaweza kuongeza majukumu mapya ya kuweka vibali vyema.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1250,7 +1250,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Ikiwa mtumiaji ana jukumu lolote la kuchunguza, basi mtumiaji huwa &quot;Mtumiaji wa Mfumo&quot;. &quot;Mtumiaji wa Mfumo&quot; ana upatikanaji wa desktop"
 DocType: System Settings,Date and Number Format,Tarehe na Nambari ya Nambari
 apps/frappe/frappe/model/document.py,one of,moja ya
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Usanidi&gt; Fomu ya Kubinafsisha
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Usanidi> Fomu ya Kubinafsisha
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kuangalia wakati mmoja
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Onyesha Vitambulisho
 DocType: DocField,HTML Editor,Mhariri wa HTML
@@ -1258,7 +1258,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Ulipaji
 DocType: Email Queue,Not Sent,Haikutumwa
 DocType: Web Form,Actions,Vitendo
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Sanidi&gt; Mtumiaji
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Sanidi> Mtumiaji
 DocType: Workflow State,align-justify,onyesha-hakikisha
 DocType: User,Middle Name (Optional),Jina la Kati (Hiari)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Hairuhusiwi
@@ -1405,7 +1405,7 @@ DocType: User,System User,Mtumiaji wa Mfumo
 DocType: Report,Is Standard,Ni Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Kamili
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Usiweke HTML lebo ya vitambulisho vya HTML kama &lt;script&gt; au wahusika tu kama &lt;au&gt;, kama inaweza kutumika kwa makusudi katika uwanja huu"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Usiweke HTML lebo ya vitambulisho vya HTML kama &lt;script> au wahusika tu kama &lt;au>, kama inaweza kutumika kwa makusudi katika uwanja huu"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} alikosolewa kwenye {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Run
@@ -1783,7 +1783,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer itaonyeshw
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Inasubiri
 DocType: System Settings,Allow only one session per user,Ruhusu kikao kimoja tu kwa mtumiaji
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folda ya Nyumbani / Mtihani 1 / Faili ya Mtihani 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;kichwa&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;kichwa> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Chagua au gurudisha wakati unaofaa ili kuunda tukio jipya.
 DocType: Contact,Contact Details,Maelezo ya Mawasiliano
 DocType: DocField,In Filter,Katika Filter
@@ -2014,7 +2014,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Ingia haruhusiwi kwa wakati huu
 DocType: Data Migration Run,Current Mapping Action,Hatua ya Sasa ya Ramani
 DocType: Dashboard Chart Source,Source Name,Jina la Chanzo
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Hakuna akaunti ya barua pepe inayohusiana na Mtumiaji. Tafadhali ongeza akaunti chini ya Mtumiaji&gt; Kikasha cha barua pepe.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Hakuna akaunti ya barua pepe inayohusiana na Mtumiaji. Tafadhali ongeza akaunti chini ya Mtumiaji> Kikasha cha barua pepe.
 DocType: Email Account,Email Sync Option,Option Sync Option
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Row No
 DocType: Async Task,Runtime,Runtime
@@ -2029,7 +2029,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Tayari kw
 DocType: User Email,Enable Outgoing,Wezesha Kuondoka
 DocType: Address,Fax,Faksi
 apps/frappe/frappe/config/customization.py,Custom Tags,Tags Custom
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Akaunti ya barua pepe sio kusanidi. Tafadhali unda Akaunti mpya ya Barua pepe kutoka kwa Kusanidi&gt; Barua pepe&gt; Akaunti ya barua pepe
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Akaunti ya barua pepe sio kusanidi. Tafadhali unda Akaunti mpya ya Barua pepe kutoka kwa Kusanidi> Barua pepe> Akaunti ya barua pepe
 DocType: Comment,Submitted,Iliwasilishwa
 DocType: Contact,Pulled from Google Contacts,Iliyohamishwa kutoka Anwani za Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Katika Ombi Sahihi
@@ -2101,7 +2101,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Mwisho wa Kikao kwa 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Shamba hii itaonekana tu kama jina la uwanja linalotafsiriwa hapa lina thamani OR LA sheria ni za kweli (mifano): myfield eval: doc.myfield == &#39;Thamani yangu&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Shamba hii itaonekana tu kama jina la uwanja linalotafsiriwa hapa lina thamani OR LA sheria ni za kweli (mifano): myfield eval: doc.myfield == &#39;Thamani yangu&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Ofisi 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Leo
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Mara baada ya kuweka hii, watumiaji wataweza kufikia nyaraka (kwa mfano Blog post) ambako kiungo hipo (kwa mfano Blogger)."
@@ -2115,7 +2115,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,JINSI YA UPANDA
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,HTML ya kawaida
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Ingiza jina la folda
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Hakuna Kiolezo cha anwani default kilichopatikana. Tafadhali unda mpya kutoka kwa Kusanidi&gt; Kuchapa na Kuweka alama&gt; Kiolezo cha Anwani.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Hakuna Kiolezo cha anwani default kilichopatikana. Tafadhali unda mpya kutoka kwa Kusanidi> Kuchapa na Kuweka alama> Kiolezo cha Anwani.
 apps/frappe/frappe/auth.py,Unknown User,Mtumiaji asiyejulikana
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Chagua Shauku
 DocType: Comment,Deleted,Imefutwa
@@ -2303,7 +2303,7 @@ DocType: LDAP Settings,Path to Server Certificate,Njia ya Cheti cha Seva
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Si idhini ya kutosha kuona viungo
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Cheti cha anwani ni lazima.
 DocType: Google Contacts,Push to Google Contacts,Sukuma kwa Anwani za Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Aliongeza HTML katika sehemu ya &lt;kichwa&gt; ya ukurasa wa wavuti, hasa kutumika kwa uthibitishaji wa tovuti na SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Aliongeza HTML katika sehemu ya &lt;kichwa> ya ukurasa wa wavuti, hasa kutumika kwa uthibitishaji wa tovuti na SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Ilirudiwa tena
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Kipengee hawezi kuongezwa kwa wazazi wake
 DocType: Session Default Settings,Session Defaults,Defavers ya Kikao
@@ -2422,7 +2422,7 @@ DocType: Workflow State,Warning,Onyo
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Hii inaweza kuchapishwa kwenye kurasa nyingi
 DocType: Data Migration Run,Percent Complete,Asilimia Imekamilika
 DocType: Tag Category,Tag Category,Jamii ya Tag
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Kwa kulinganisha, tumia&gt; 5, &lt;10 au = 324. Kwa safu, tumia 5:10 (kwa maadili kati ya 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Kwa kulinganisha, tumia> 5, &lt;10 au = 324. Kwa safu, tumia 5:10 (kwa maadili kati ya 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Bonyeza kutoka Kalenda ya Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Msaada
 DocType: User,Login Before,Ingia Kabla
@@ -2882,7 +2882,7 @@ DocType: Custom Script,Custom Script,Script Custom
 DocType: Address,Address Line 2,Anwani ya Anwani 2
 DocType: Address,Reference,Kumbukumbu
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Iliyopewa
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Tafadhali weka Akaunti ya barua pepe ya usanidi kutoka kwa Usanidi&gt; Barua pepe&gt; Akaunti ya barua pepe
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Tafadhali weka Akaunti ya barua pepe ya usanidi kutoka kwa Usanidi> Barua pepe> Akaunti ya barua pepe
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Maelezo ya Ramani ya Uhamiaji wa Data
 DocType: Data Import,Action,Hatua
 DocType: GSuite Settings,Script URL,URL ya Hati
@@ -3058,7 +3058,7 @@ DocType: DocField,Allow on Submit,Ruhusu Kuwasilisha
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Aina ya Ufikiaji
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Piga nguzo
-DocType: Web Page,Add code as &lt;script&gt;,Ongeza msimbo kama &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,Ongeza msimbo kama &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Futa ruhusa za Mtumiaji
 DocType: Webhook,Headers,Vichwa
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Matukio ijayo
@@ -3431,16 +3431,16 @@ DocType: Workflow State,share-alt,kushiriki-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Foleni inapaswa kuwa moja ya {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Kigezo cha Kigezo </h4><p> Inatumia <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> na mashamba yote ya Anwani (ikiwa ni pamoja na Mashamba ya Desturi kama ipo) yatapatikana </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Kigezo cha Kigezo </h4><p> Inatumia <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> na mashamba yote ya Anwani (ikiwa ni pamoja na Mashamba ya Desturi kama ipo) yatapatikana </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Shamba ya Tarehe ya Mwanzo
 DocType: Role,Role Name,Jina la majukumu
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Badilisha kwenye dawati

--- a/frappe/translations/sw.csv
+++ b/frappe/translations/sw.csv
@@ -1405,7 +1405,7 @@ DocType: User,System User,Mtumiaji wa Mfumo
 DocType: Report,Is Standard,Ni Standard
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Kamili
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Usiweke HTML lebo ya vitambulisho vya HTML kama &lt;script> au wahusika tu kama &lt;au>, kama inaweza kutumika kwa makusudi katika uwanja huu"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Usiweke HTML lebo ya vitambulisho vya HTML kama <script> au wahusika tu kama <au>, kama inaweza kutumika kwa makusudi katika uwanja huu"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} alikosolewa kwenye {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Run
@@ -1783,7 +1783,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer itaonyeshw
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Inasubiri
 DocType: System Settings,Allow only one session per user,Ruhusu kikao kimoja tu kwa mtumiaji
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Folda ya Nyumbani / Mtihani 1 / Faili ya Mtihani 3
-DocType: Website Settings,&lt;head> HTML,&lt;kichwa> HTML
+DocType: Website Settings,<head> HTML,<kichwa> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Chagua au gurudisha wakati unaofaa ili kuunda tukio jipya.
 DocType: Contact,Contact Details,Maelezo ya Mawasiliano
 DocType: DocField,In Filter,Katika Filter
@@ -2303,7 +2303,7 @@ DocType: LDAP Settings,Path to Server Certificate,Njia ya Cheti cha Seva
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Si idhini ya kutosha kuona viungo
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Cheti cha anwani ni lazima.
 DocType: Google Contacts,Push to Google Contacts,Sukuma kwa Anwani za Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Aliongeza HTML katika sehemu ya &lt;kichwa> ya ukurasa wa wavuti, hasa kutumika kwa uthibitishaji wa tovuti na SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Aliongeza HTML katika sehemu ya <kichwa> ya ukurasa wa wavuti, hasa kutumika kwa uthibitishaji wa tovuti na SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Ilirudiwa tena
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Kipengee hawezi kuongezwa kwa wazazi wake
 DocType: Session Default Settings,Session Defaults,Defavers ya Kikao
@@ -2422,7 +2422,7 @@ DocType: Workflow State,Warning,Onyo
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Hii inaweza kuchapishwa kwenye kurasa nyingi
 DocType: Data Migration Run,Percent Complete,Asilimia Imekamilika
 DocType: Tag Category,Tag Category,Jamii ya Tag
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Kwa kulinganisha, tumia> 5, &lt;10 au = 324. Kwa safu, tumia 5:10 (kwa maadili kati ya 5 &amp; 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Kwa kulinganisha, tumia> 5, <10 au = 324. Kwa safu, tumia 5:10 (kwa maadili kati ya 5 &amp; 10)."
 DocType: Google Calendar,Pull from Google Calendar,Bonyeza kutoka Kalenda ya Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Msaada
 DocType: User,Login Before,Ingia Kabla
@@ -3058,7 +3058,7 @@ DocType: DocField,Allow on Submit,Ruhusu Kuwasilisha
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Aina ya Ufikiaji
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Piga nguzo
-DocType: Web Page,Add code as &lt;script>,Ongeza msimbo kama &lt;script>
+DocType: Web Page,Add code as <script>,Ongeza msimbo kama <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Futa ruhusa za Mtumiaji
 DocType: Webhook,Headers,Vichwa
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Matukio ijayo
@@ -3431,16 +3431,16 @@ DocType: Workflow State,share-alt,kushiriki-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Foleni inapaswa kuwa moja ya {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Kigezo cha Kigezo </h4><p> Inatumia <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> na mashamba yote ya Anwani (ikiwa ni pamoja na Mashamba ya Desturi kama ipo) yatapatikana </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Kigezo cha Kigezo </h4><p> Inatumia <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> na mashamba yote ya Anwani (ikiwa ni pamoja na Mashamba ya Desturi kama ipo) yatapatikana </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Shamba ya Tarehe ya Mwanzo
 DocType: Role,Role Name,Jina la majukumu
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Badilisha kwenye dawati

--- a/frappe/translations/sw.csv
+++ b/frappe/translations/sw.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Mzazi
 apps/frappe/frappe/templates/emails/download_data.html,We have received a request from you to download your {0} data associated with: {1},Tumepokea ombi kutoka kwako kupakua data yako ya {0} inayohusishwa na: {1}
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Ikiwa imewezeshwa, nguvu ya nenosiri itatekelezwa kwa kuzingatia thamani ya chini ya alama ya alama ya nenosiri. Thamani ya 2 kuwa kati ya nguvu na 4 kuwa na nguvu sana."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Wanachama wa Timu&quot; au &quot;Usimamizi&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Kipengee cha &#39;Angalia&#39; aina ya shamba lazima iwe &#39;0&#39; au &#39;1&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Kipengee cha 'Angalia' aina ya shamba lazima iwe '0' au '1'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Jana
 DocType: Contact,Designation,Uteuzi
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Kuunganisha Moja kwa moja kunaweza kuamilishwa kwa Akaunti moja ya barua pepe.
@@ -252,7 +252,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Zima Ripoti
 DocType: Translation,Contributed Translation Doctype Name,Imechangiwa Jina la Doctype Jina
 DocType: PayPal Settings,Redirect To,Rejea Kwa
 DocType: Data Migration Mapping,Pull,Piga
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Jarida la Javascript: vivutio vya usafiri [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},Jarida la Javascript: vivutio vya usafiri ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Mwisho Mwingi
 DocType: Workflow State,chevron-up,chevron-up
 DocType: DocType,Allow Guest to View,Ruhusu Mtazamo Kuangalia
@@ -555,7 +555,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Takwimu kulingana na utendaji wa wiki iliyopita (kutoka {0} hadi {1})
 DocType: LDAP Settings,LDAP Phone Field,Shamba la Simu la LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","aina ya hati ..., kwa mfano mteja"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Hali &#39;{0}&#39; ni batili
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Hali '{0}' ni batili
 DocType: Workflow State,barcode,barcode
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Matumizi ya swala ndogo au kazi ni vikwazo
 apps/frappe/frappe/config/customization.py,Add your own translations,Ongeza tafsiri zako mwenyewe
@@ -704,7 +704,7 @@ DocType: Slack Webhook URL,Webhook URL,URL ya wavuti
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Jina la mtumiaji {0} tayari lipo
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: Haiwezi kuweka kuagiza kama {1} haiwezi kuingizwa
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Kuna hitilafu katika Kiolezo chako cha Anwani {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} ni anwani ya barua pepe batili katika &#39;Wapokeaji&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} ni anwani ya barua pepe batili katika 'Wapokeaji'
 DocType: Footer Item,"target = ""_blank""",lengo = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,Jeshi
@@ -745,7 +745,7 @@ DocType: Currency,Currency Name,Jina la Fedha
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Hakuna Barua pepe
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Kiungo Umemalizika
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Inarudi urefu kwa {0} kwa &#39;{1}&#39; katika &#39;{2}&#39;; Kuweka urefu kama {3} kutasababisha truncation ya data.
+							Setting the length as {3} will cause truncation of data.",Inarudi urefu kwa {0} kwa '{1}' katika '{2}'; Kuweka urefu kama {3} kutasababisha truncation ya data.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Chagua Faili ya Picha
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Hash ya Maudhui
@@ -760,13 +760,13 @@ apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","DocType ya kawaida haiwezi kuwa na muundo wa kuchapisha chaguo-msingi, tumia Customize Form"
 DocType: Report,Query,Swala
 DocType: Customize Form,Sort Order,Panga Utaratibu
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;Katika Orodha ya Orodha&#39; hairuhusiwi kwa aina {0} mfululizo {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'Katika Orodha ya Orodha' hairuhusiwi kwa aina {0} mfululizo {1}
 DocType: Letter Head,Footer HTML,HTML ya HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,Chagua lebo baada ya ambayo unataka kuingiza shamba jipya.
 ,Document Share Report,Ripoti ya Shiriki ya Hati
 DocType: Social Login Key,Base URL,URL ya Msingi
 DocType: User,Last Login,Mwisho Ingia
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Huwezi kuweka &#39;Translatable&#39; kwa shamba {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Huwezi kuweka 'Translatable' kwa shamba {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Safu
 DocType: Chat Profile,Chat Profile,Ongea Profaili
 DocType: Custom Field,Adds a custom field to a DocType,Inaongeza shamba la desturi kwa DocType
@@ -775,7 +775,7 @@ DocType: File,Is Home Folder,Ni Folda ya Nyumbani
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Mtindo wa Navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} sio anwani ya barua pepe halali
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Chagua rekodi 1 ya uchapishaji
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Mtumiaji &#39;{0}&#39; tayari ana jukumu &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Mtumiaji '{0}' tayari ana jukumu '{1}'
 DocType: System Settings,Two Factor Authentication method,Njia mbili za uthibitishaji
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Kwanza kuweka jina na uhifadhi rekodi.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,Rekodi 5
@@ -1024,7 +1024,7 @@ DocType: Property Setter,Property Setter,Setter ya Mali
 DocType: Web Form,Allow Print,Ruhusu Print
 DocType: Communication,Clicked,Imebofya
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Ondoa wazi
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Hakuna kibali cha &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Hakuna kibali cha '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Imepangwa kutuma
 DocType: DocType,Track Seen,Kufuatilia Kuonekana
 DocType: Dropbox Settings,File Backup,Funga Backup
@@ -1051,7 +1051,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,HTML ya ukurasa
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Safari zilizoondolewa nje
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Jina la kikundi hawezi kuwa tupu.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Nodes zaidi zinaweza kuundwa tu chini ya nambari za aina ya &#39;Kikundi&#39;
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Nodes zaidi zinaweza kuundwa tu chini ya nambari za aina ya 'Kikundi'
 DocType: SMS Parameter,Header,Kichwa
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Column isiyojulikana: {0}
 DocType: Notification Recipient,Email By Role,Barua kwa Wajibu
@@ -1436,7 +1436,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Sehemu ya lazima: kuweka jukumu
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} alikosoa {1}
 DocType: Data Migration Mapping,Mapping Name,Jina la Ramani
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: shamba &#39;{1}&#39; haiwezi kuwekwa kipekee kwani ina maadili yasiyo ya kipekee
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: shamba '{1}' haiwezi kuwekwa kipekee kwani ina maadili yasiyo ya kipekee
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Zunguka orodha chini
 DocType: Currency,A symbol for this currency. For e.g. $,Ishara kwa sarafu hii. Kwa mfano $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Mabadiliko yaliyoboreshwa kwa ufanisi
@@ -1954,7 +1954,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-kusini-mashariki-1
 DocType: DocType,"Must be of type ""Attach Image""",Inapaswa kuwa ya aina &quot;Weka picha&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Wachagua Wote
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Huwezi kufuta &#39;Soma Tu&#39; kwa shamba {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},Huwezi kufuta 'Soma Tu' kwa shamba {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,Zero ina maana kutuma rekodi updated wakati wowote
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,Setup kamili
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,Imesasishwa kwa mafanikio
@@ -1997,7 +1997,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Fonti ya Google
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Ikiwa maagizo haya ambapo hayasaidia, tafadhali ongeza maoni yako kwenye Maswala ya GitHub."
 DocType: Workflow State,bookmark,alama
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Jina la folda haipaswi kujumuisha &#39;/&#39; (slash)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Jina la folda haipaswi kujumuisha '/' (slash)
 DocType: Note,Note,Kumbuka
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Ripoti ya Hitilafu
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Tuma Data katika muundo wa CSV / Excel.
@@ -2101,7 +2101,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Mwisho wa Kikao kwa 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Shamba hii itaonekana tu kama jina la uwanja linalotafsiriwa hapa lina thamani OR LA sheria ni za kweli (mifano): myfield eval: doc.myfield == &#39;Thamani yangu&#39; eval: doc.age> 18
+eval:doc.age>18",Shamba hii itaonekana tu kama jina la uwanja linalotafsiriwa hapa lina thamani OR LA sheria ni za kweli (mifano): myfield eval: doc.myfield == 'Thamani yangu' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Ofisi 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Leo
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Mara baada ya kuweka hii, watumiaji wataweza kufikia nyaraka (kwa mfano Blog post) ambako kiungo hipo (kwa mfano Blogger)."
@@ -2140,7 +2140,7 @@ DocType: Data Migration Connector,Database Name,Jina la Database
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Furahisha Fomu
 DocType: DocField,Select,Chagua
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Angalia Ingia Kamili
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Maonyesho rahisi ya Python, Mfano: hali == &#39;Fungua&#39; na chapa == &#39;Mdudu&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Maonyesho rahisi ya Python, Mfano: hali == 'Fungua' na chapa == 'Mdudu'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Faili haijaunganishwa
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Uunganisho ulipotea. Baadhi ya vipengele haviwezi kufanya kazi.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Kurudia kama &quot;aaa&quot; ni rahisi nadhani
@@ -2270,7 +2270,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Onyesha makosa tu
 DocType: Website Settings,Banner HTML,HTML ya banner
 DocType: Workflow,Send Email Alert,Tuma Alert ya Barua pepe
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Tafadhali chagua njia nyingine ya malipo. Razorpay haiunga mkono shughuli za fedha &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Tafadhali chagua njia nyingine ya malipo. Razorpay haiunga mkono shughuli za fedha '{0}'
 DocType: Data Import,In Progress,Inaendelea
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Iliyotokana na uhifadhi. Inaweza kuchukua dakika chache kwa saa.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2692,7 +2692,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Inabadilisha
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,Mipangilio ya njia ya malipo ya PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Utendaji Bora
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Sehemu za Forodha haziwezi kuongezwa kwa Hati za msingi.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) watapata truncated, kama wahusika max kuruhusiwa ni {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) watapata truncated, kama wahusika max kuruhusiwa ni {2}"
 DocType: OAuth Client,Response Type,Aina ya Jibu
 DocType: Contact Us Settings,Send enquiries to this email address,Tuma maswali kwa anwani hii ya barua pepe
 DocType: Letter Head,Letter Head Name,Jina la kichwa cha barua
@@ -2747,7 +2747,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Mtazamo wa Picha
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Inaonekana kama kitu kilichokosea wakati wa shughuli. Kwa kuwa hatukuhakikishia malipo, Paypal itakayorudia kwa kiasi kikubwa kiasi hiki. Ikiwa haifai, tafadhali tutumie barua pepe na tutaja Kitambulisho cha Uwiano: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Weka alama, nambari na barua kuu katika nenosiri"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Ingiza Baada ya shamba &#39;{0}&#39; iliyotajwa katika Custom Field &#39;{1}&#39;, kwa lebo &#39;{2}&#39;, haipo"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Ingiza Baada ya shamba '{0}' iliyotajwa katika Custom Field '{1}', kwa lebo '{2}', haipo"
 DocType: List Filter,List Filter,Futa Filter
 DocType: Workflow State,signal,ishara
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ina Viambatisho
@@ -2757,7 +2757,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Hati imerejeshwa
 DocType: Data Export,Data Export,Export Data
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Chagua Lugha ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Huwezi kuweka &#39;Chaguzi&#39; kwa shamba {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Huwezi kuweka 'Chaguzi' kwa shamba {0}
 DocType: Help Article,Author,Mwandishi
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Tuma tena Kutuma
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Fungua tena
@@ -2771,14 +2771,14 @@ DocType: Web Page,Slideshow,Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Kigezo cha Anwani ya Kichafu haiwezi kufutwa
 DocType: Contact,Maintenance Manager,Meneja wa Matengenezo
 DocType: Workflow State,Search,Tafuta
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Tafadhali chagua njia nyingine ya malipo. Stripe haiunga mkono shughuli za fedha &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Tafadhali chagua njia nyingine ya malipo. Stripe haiunga mkono shughuli za fedha '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Hoja kwa Taka
 DocType: Web Form,Web Form Fields,Mashamba ya Fomu za Mtandao
 DocType: Data Import,Amended From,Imebadilishwa Kutoka
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Onyo: Haiwezi kupata {0} katika meza yoyote kuhusiana na {1}
 DocType: S3 Backup Settings,eu-north-1,eu-kaskazini-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Hati hii sasa imesimamishwa kwa utekelezaji. Tafadhali jaribu tena
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Faili &#39;{0}&#39; haipatikani
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Faili '{0}' haipatikani
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Ondoa Sehemu
 DocType: User,Change Password,Badilisha neno la siri
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Shamba ya Axe ya X
@@ -2965,7 +2965,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Thamani ya kukosa
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Ongeza Mtoto
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Kuendeleza Maendeleo
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",Ikiwa hali imeridhika mtumiaji atalipwa na alama. mfano. doc.status == &#39;Imefungwa&#39;
+",Ikiwa hali imeridhika mtumiaji atalipwa na alama. mfano. doc.status == 'Imefungwa'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Kumbukumbu iliyotumwa haiwezi kufutwa.
 DocType: GSuite Templates,Template Name,Jina la Kigezo
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,aina mpya ya hati
@@ -3096,7 +3096,7 @@ DocType: Dashboard Chart,Chart Type,Aina ya Chati
 DocType: DocType,Auto Name,Jina la Auto
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Epuka maandamano kama abc au 6543 kama ni rahisi nadhani
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Tafadhali jaribu tena
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL lazima ianze na &#39;http: //&#39; au &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL lazima ianze na 'http: //' au 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Chaguo 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Badilisha
@@ -3335,7 +3335,7 @@ DocType: Notification,Send alert if this field's value changes,Tuma macho ikiwa 
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Rangi ya Mada
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Chagua DocType kufanya muundo mpya
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Mtumiaji haipo
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Waliopokea&#39; sio maalum
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Waliopokea' sio maalum
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,sasa hivi
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Tumia
 DocType: Footer Item,Policy,Sera
@@ -3383,7 +3383,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Tafsiri za Destur
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Maendeleo
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,Kwa Jukumu
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Mashamba Yanayopoteza
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Jina la uwanja batili &#39;{0}&#39; katika uhuru
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Jina la uwanja batili '{0}' katika uhuru
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Tafuta katika aina ya hati
 DocType: Custom DocPerm,Role and Level,Wajibu na Ngazi
 DocType: File,Thumbnail URL,URL ya Picha ndogo
@@ -3471,11 +3471,11 @@ DocType: Dashboard Chart,Filters JSON,Vichungi JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Bofya hapa ili kuthibitisha
 DocType: Email Account,Disable SMTP server authentication,Lemaza uthibitishaji wa seva ya SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Imenakiliwa kwa clipboard.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Kubadilishana kutabirika kama &#39;@&#39; badala ya &#39;a&#39; sio kusaidia sana.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Kubadilishana kutabirika kama '@' badala ya 'a' sio kusaidia sana.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Iliyopewa na Mimi
 apps/frappe/frappe/utils/data.py,Zero,Sufuri
 DocType: Google Drive,Backup Folder ID,Kitambulisho cha Hifadhi ya Hifadhi
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Sio katika Mfumo wa Wasanidi programu! Weka kwenye tovuti_config.json au fanya &#39;DocType&#39; ya &#39;Desturi&#39;.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Sio katika Mfumo wa Wasanidi programu! Weka kwenye tovuti_config.json au fanya 'DocType' ya 'Desturi'.
 DocType: Workflow State,globe,globe
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,Kipaumbele
@@ -3524,7 +3524,7 @@ DocType: Notification,Reference Date,Tarehe ya Kumbukumbu
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,Usanidi wa OTP kutumia Programu ya OTP haukukamilishwa. Tafadhali wasiliana na Msimamizi.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,Tafadhali ingiza nambari za simu za halali
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Baadhi ya vipengele haviwezi kufanya kazi katika kivinjari chako. Tafadhali sasisha kivinjari chako kwa toleo la hivi karibuni.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Sijui, uulize &#39;msaada&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Sijui, uulize 'msaada'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ilighairi hati hii {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,Maoni na Mawasiliano zitahusishwa na hati hii iliyounganishwa
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Futa ...
@@ -3553,7 +3553,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Imeshindwa wakati wa kurekebisha usajili
 DocType: LDAP Settings,LDAP Group Field,Shamba la Kikundi cha LDAP
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Sawa
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Aina ya Kiungo cha Dynamic Kiungo lazima ielekeze kwenye Sehemu nyingine ya Kiungo na chaguo kama &#39;DocType&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Aina ya Kiungo cha Dynamic Kiungo lazima ielekeze kwenye Sehemu nyingine ya Kiungo na chaguo kama 'DocType'
 DocType: About Us Settings,Team Members Heading,Wajumbe wa Timu ya kichwa
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Fomu ya CSV isiyo sahihi
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Kosa la unganisho na Matumizi ya Tray ya QZ ... <br><br> Unahitaji kuwa na programu ya QZ Tray iliyosanikishwa na kuendeshwa, ili kutumia kipengee cha Mchapishaji wa Raw. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Bonyeza hapa kupakua na kusanikisha tray ya QZ</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Bonyeza hapa kujifunza zaidi juu ya Uchapishaji wa Raw</a> ."
@@ -3683,7 +3683,7 @@ DocType: Web Page,Web Page,Ukurasa wa wavuti
 DocType: Workflow Document State,Next Action Email Template,Next Action Email Kigezo
 DocType: Blog Category,Blogger,Blogger
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Ikiwashwa, mabadiliko kwenye hati hufuatiliwa na kuonyeshwa kwa muda wa saa"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;Katika Utafutaji wa Global&#39; hakuruhusiwa kwa aina {0} mfululizo {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'Katika Utafutaji wa Global' hakuruhusiwa kwa aina {0} mfululizo {1}
 DocType: Energy Point Log,Appreciation,Kushukuru
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Tazama Orodha
 DocType: Workflow,Don't Override Status,Usivunja Hali
@@ -3828,7 +3828,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Kwa kawaida
 DocType: Translation,Verified,Imethibitishwa
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} aliongeza
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Tafuta &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Tafuta '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Tafadhali salama ripoti ya kwanza
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} wanachama waliongeza
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Sio
@@ -3864,14 +3864,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Mimi
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} si Serikali halali
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Omba kwa Aina zote za Hati
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Sasisha ya uhakika
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Tafadhali chagua njia nyingine ya malipo. PayPal haitoi shughuli katika fedha &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Tafadhali chagua njia nyingine ya malipo. PayPal haitoi shughuli katika fedha '{0}'
 DocType: Chat Message,Room Type,Aina ya Chumba
 DocType: Data Import Beta,Import Log Preview,Hakikisha Ingia hakiki
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Kutafuta uwanja {0} halali
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,faili iliyopakiwa
 DocType: Workflow State,ok-circle,ok-mduara
 DocType: LDAP Settings,LDAP User Creation and Mapping,Uumbaji wa Mtumiaji wa LDAP na Ramani
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Unaweza kupata vitu kwa kuuliza &#39;kupata machungwa kwa wateja&#39;
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Unaweza kupata vitu kwa kuuliza 'kupata machungwa kwa wateja'
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Samahani! Mtumiaji anapaswa kuwa na upatikanaji kamili wa rekodi yao.
 ,Usage Info,Info Usage
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Onyesha njia za mkato za kibodi

--- a/frappe/translations/ta.csv
+++ b/frappe/translations/ta.csv
@@ -1403,7 +1403,7 @@ DocType: Report,Is Standard,ஸ்டாண்டர்ட் உள்ளது
 DocType: Desktop Icon,_report,அறிக்கை
 DocType: Desktop Icon,_report,அறிக்கை
 DocType: Dashboard Chart,Full,முழு
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","வேண்டாம் &lt;ஸ்கிரிப்ட்> அல்லது, அவர்கள் வேண்டுமென்றே இந்த துறையில் பயன்படுத்த முடியும் என போன்ற &lt;அல்லது> எழுத்துக்கள் போன்ற HTML என்கோடு HTML குறிச்சொற்களை"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","வேண்டாம் <ஸ்கிரிப்ட்> அல்லது, அவர்கள் வேண்டுமென்றே இந்த துறையில் பயன்படுத்த முடியும் என போன்ற <அல்லது> எழுத்துக்கள் போன்ற HTML என்கோடு HTML குறிச்சொற்களை"
 DocType: Website Settings,FavIcon,ஃபேவிகான்
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ரன்
 DocType: Blog Post,Content (HTML),உள்ளடக்கம் (HTML)
@@ -1772,7 +1772,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,அடிக்�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,முடிவுபெறாத
 DocType: System Settings,Allow only one session per user,பயனர் ஒன்றுக்கு ஒரே ஒரு அமர்வு அனுமதி
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,முகப்பு / டெஸ்ட் அடைவு 1 / டெஸ்ட் அடைவு 3
-DocType: Website Settings,&lt;head> HTML,"&lt;தலையில்> HTML,"
+DocType: Website Settings,<head> HTML,"<தலையில்> HTML,"
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,தேர்வு அல்லது ஒரு புதிய நிகழ்வை உருவாக்க நேரம் இடங்கள் முழுவதும் இழுக்கவும்.
 DocType: Contact,Contact Details,விபரங்கள்
 DocType: DocField,In Filter,வடிகட்டி உள்ள
@@ -2292,7 +2292,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,இணைப்புகளைப் பார்க்கவும் போதுமான அனுமதி
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,முகவரி தலைப்பு கட்டாயமாகும்.
 DocType: Google Contacts,Push to Google Contacts,Google தொடர்புகளுக்கு தள்ளவும்
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","&lt;Head> சேர்க்கப்பட்டது HTML வலை பக்கம் பிரிவு, முதன்மையாக வலைத்தளத்தில் சரிபார்ப்பு மற்றும் எஸ்சிஓ பயன்படுத்தப்படும்"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","<Head> சேர்க்கப்பட்டது HTML வலை பக்கம் பிரிவு, முதன்மையாக வலைத்தளத்தில் சரிபார்ப்பு மற்றும் எஸ்சிஓ பயன்படுத்தப்படும்"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,மீண்டும் புகைக்க
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,பொருள் அதன் சொந்த ஆதரவாளர்வரை சேர்க்க முடியாது
 DocType: Session Default Settings,Session Defaults,அமர்வு இயல்புநிலைகள்
@@ -2409,7 +2409,7 @@ DocType: Workflow State,Warning,எச்சரிக்கை
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,இது பல பக்கங்களில் அச்சிடப்படலாம்
 DocType: Data Migration Run,Percent Complete,சதவீதம் முடிந்தது
 DocType: Tag Category,Tag Category,டேக் வகை
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ஒப்பிட,> 5, &lt;10 அல்லது = 324 ஐப் பயன்படுத்தவும். வரம்புகளுக்கு, 5:10 ஐப் பயன்படுத்தவும் (5 &amp; 10 க்கு இடையிலான மதிப்புகளுக்கு)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ஒப்பிட,> 5, <10 அல்லது = 324 ஐப் பயன்படுத்தவும். வரம்புகளுக்கு, 5:10 ஐப் பயன்படுத்தவும் (5 &amp; 10 க்கு இடையிலான மதிப்புகளுக்கு)."
 DocType: Google Calendar,Pull from Google Calendar,Google கேலெண்டரிலிருந்து இழுக்கவும்
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,உதவி
 DocType: User,Login Before,உள்நுழைவு முன்
@@ -3045,7 +3045,7 @@ DocType: DocField,Allow on Submit,சமர்ப்பி மீது அன�
 DocType: DocField,HTML,"HTML,"
 DocType: Error Snapshot,Exception Type,விதிவிலக்கு வகை
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,பத்திகள் தேர்வு
-DocType: Web Page,Add code as &lt;script>,&lt;script> என குறியீடு சேர்க்க
+DocType: Web Page,Add code as <script>,<script> என குறியீடு சேர்க்க
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,பயனர் அனுமதிகளை அழி
 DocType: Webhook,Headers,தலைப்புகளிலும்
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,எதிர்வரும் நிகழ்வுகள்
@@ -3416,26 +3416,26 @@ DocType: Workflow State,share-alt,பங்கு-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},கியூ ஒன்றாக இருக்க வேண்டும் {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> இயல்புநிலை டெம்ப்ளேட் </ H4> 
- <p> href=""http://jinja.pocoo.org/docs/templates/""> நிதானத்தில் மாதிரியாக்கம், </a> முகவரி, அனைத்து துறைகளிலும் (பயன்படுத்துகிறது {; br & gt; 
- {% என்றால் address_line2%} {{address_line2}}; & lt; br & gt விருப்ப புலங்கள் ஏதாவது இருந்தால்) </ p> 
+ <p> href=""http://jinja.pocoo.org/docs/templates/""> நிதானத்தில் மாதிரியாக்கம், </a> முகவரி, அனைத்து துறைகளிலும் (பயன்படுத்துகிறது {; br> 
+ {% என்றால் address_line2%} {{address_line2}}; <br & gt விருப்ப புலங்கள் ஏதாவது இருந்தால்) </ p> 
  <pre> <குறியீடு> {{address_line1}} & amp; lt கிடைக்கும் உட்பட % Endif -%} 
- {{நகரம்}}; & lt; br & gt; 
- {% மாநில%} {{மாநில}}; & lt; br & gt; {% Endif -%} 
- {% என்றால் பின்கோடு%} PIN: {{பின்கோடு}}; & lt; br & gt; {% Endif -%} 
- {{நாட்டின்}}; & lt; br & gt; 
- {%, தொலைபேசி%} தொலைபேசி: {{தொலைபேசி}}; & lt; br & gt; { % Endif -%} 
- {% என்றால் தொலைநகல்%} ஃபேக்ஸ்: {{தொலைநகல்}}; & lt; br & gt; {% Endif -%} 
- {% என்றால் email_id%} மின்னஞ்சல்: {{email_id}}; & lt; br & gt {% Endif -%} 
+ {{நகரம்}}; <br> 
+ {% மாநில%} {{மாநில}}; <br> {% Endif -%} 
+ {% என்றால் பின்கோடு%} PIN: {{பின்கோடு}}; <br> {% Endif -%} 
+ {{நாட்டின்}}; <br> 
+ {%, தொலைபேசி%} தொலைபேசி: {{தொலைபேசி}}; <br> { % Endif -%} 
+ {% என்றால் தொலைநகல்%} ஃபேக்ஸ்: {{தொலைநகல்}}; <br> {% Endif -%} 
+ {% என்றால் email_id%} மின்னஞ்சல்: {{email_id}}; <br & gt {% Endif -%} 
  </ குறியீடு> </ pre>"
 DocType: Calendar View,Start Date Field,தொடக்க தேதி புலம்
 DocType: Role,Role Name,பங்கு பெயர்

--- a/frappe/translations/ta.csv
+++ b/frappe/translations/ta.csv
@@ -741,7 +741,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,கோ�
 DocType: DocField,In Global Search,குளோபல் சர்ச்
 DocType: System Settings,Brute Force Security,ப்ரூட் ஃபோர்ஸ் செக்யூரிட்டி
 DocType: Workflow State,indent-left,உள்தள் இடது
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} ஆண்டு (கள்) முன்பு
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} ஆண்டு (கள்) முன்பு
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,இந்த கோப்பு நீக்க ஆபத்தானது: {0}. உங்கள் கணினி மேலாளரைத் தொடர்பு கொள்ளவும்.
 DocType: Currency,Currency Name,நாணயத்தின் பெயர்
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,மின்னஞ்சல்கள் இல்லை
@@ -1033,7 +1033,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,இல்ல�
 apps/frappe/frappe/config/customization.py,Add custom forms.,விருப்ப படிவங்களை சேர்க்கவும்.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} உள்ள {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,இந்த ஆவணம் சமர்ப்பிக்க
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,அமைவு&gt; பயனர் அனுமதிகள்
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,அமைவு> பயனர் அனுமதிகள்
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,அமைப்பு பல முன் வரையறுக்கப்பட்ட கதாபாத்திரங்களில் வழங்குகிறது . நேர்த்தியான அனுமதிகளை அமைக்க புதிய பாத்திரங்கள் சேர்க்க முடியும் .
 DocType: Communication,CC,சிசி
 DocType: Country,Geo,ஜியோ
@@ -1250,7 +1250,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","பயனர் சோதித்ததில் எந்த பங்கு உண்டு என்றால், பயனர் ஒரு &quot;அமைப்பு பயனர்&quot; ஆகிறது. &quot;கணினி பயனர்&quot; டெஸ்க்டாப் அணுகல் உள்ளது"
 DocType: System Settings,Date and Number Format,தேதி மற்றும் எண் அமைப்பு
 apps/frappe/frappe/model/document.py,one of,ஒன்று
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,அமைவு&gt; படிவத்தைத் தனிப்பயனாக்கு
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,அமைவு> படிவத்தைத் தனிப்பயனாக்கு
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,ஒரு கணம் சரிபார்க்கிறது
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,காட்டு குறிச்சொற்களை
 DocType: DocField,HTML Editor,HTML எடிட்டர்
@@ -1258,7 +1258,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,பட்டியலிடல்
 DocType: Email Queue,Not Sent,அனுப்பப்படவில்லை.
 DocType: Web Form,Actions,செயல்கள்
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,அமைப்பு&gt; பயனர்
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,அமைப்பு> பயனர்
 DocType: Workflow State,align-justify,சீரமை-நியாயப்படுத்த
 DocType: User,Middle Name (Optional),நடுத்தர பெயர் (கட்டாயமில்லை)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,அனுமதி இல்லை
@@ -1403,7 +1403,7 @@ DocType: Report,Is Standard,ஸ்டாண்டர்ட் உள்ளது
 DocType: Desktop Icon,_report,அறிக்கை
 DocType: Desktop Icon,_report,அறிக்கை
 DocType: Dashboard Chart,Full,முழு
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","வேண்டாம் &lt;ஸ்கிரிப்ட்&gt; அல்லது, அவர்கள் வேண்டுமென்றே இந்த துறையில் பயன்படுத்த முடியும் என போன்ற &lt;அல்லது&gt; எழுத்துக்கள் போன்ற HTML என்கோடு HTML குறிச்சொற்களை"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","வேண்டாம் &lt;ஸ்கிரிப்ட்> அல்லது, அவர்கள் வேண்டுமென்றே இந்த துறையில் பயன்படுத்த முடியும் என போன்ற &lt;அல்லது> எழுத்துக்கள் போன்ற HTML என்கோடு HTML குறிச்சொற்களை"
 DocType: Website Settings,FavIcon,ஃபேவிகான்
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,ரன்
 DocType: Blog Post,Content (HTML),உள்ளடக்கம் (HTML)
@@ -1772,7 +1772,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,அடிக்�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,முடிவுபெறாத
 DocType: System Settings,Allow only one session per user,பயனர் ஒன்றுக்கு ஒரே ஒரு அமர்வு அனுமதி
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,முகப்பு / டெஸ்ட் அடைவு 1 / டெஸ்ட் அடைவு 3
-DocType: Website Settings,&lt;head&gt; HTML,"&lt;தலையில்&gt; HTML,"
+DocType: Website Settings,&lt;head> HTML,"&lt;தலையில்> HTML,"
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,தேர்வு அல்லது ஒரு புதிய நிகழ்வை உருவாக்க நேரம் இடங்கள் முழுவதும் இழுக்கவும்.
 DocType: Contact,Contact Details,விபரங்கள்
 DocType: DocField,In Filter,வடிகட்டி உள்ள
@@ -2003,7 +2003,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,உள்நுழைய இந்த நேரத்தில் அனுமதி இல்லை
 DocType: Data Migration Run,Current Mapping Action,தற்போதைய வரைபட செயல்
 DocType: Dashboard Chart Source,Source Name,மூல பெயர்
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,பயனருடன் மின்னஞ்சல் கணக்கு எதுவும் இல்லை. பயனர்&gt; மின்னஞ்சல் இன்பாக்ஸின் கீழ் ஒரு கணக்கைச் சேர்க்கவும்.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,பயனருடன் மின்னஞ்சல் கணக்கு எதுவும் இல்லை. பயனர்> மின்னஞ்சல் இன்பாக்ஸின் கீழ் ஒரு கணக்கைச் சேர்க்கவும்.
 DocType: Email Account,Email Sync Option,மின்னஞ்சல் ஒத்திசைவு விருப்பம்
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,வரிசை இல்லை
 DocType: Async Task,Runtime,இயக்க
@@ -2018,7 +2018,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ஏற்
 DocType: User Email,Enable Outgoing,வெளிச்செல்லும் இயக்கு
 DocType: Address,Fax,தொலைநகல்
 apps/frappe/frappe/config/customization.py,Custom Tags,விருப்ப குறிச்சொற்கள்
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,மின்னஞ்சல் கணக்கு அமைக்கப்படவில்லை. அமைவு&gt; மின்னஞ்சல்&gt; மின்னஞ்சல் கணக்கிலிருந்து புதிய மின்னஞ்சல் கணக்கை உருவாக்கவும்
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,மின்னஞ்சல் கணக்கு அமைக்கப்படவில்லை. அமைவு> மின்னஞ்சல்> மின்னஞ்சல் கணக்கிலிருந்து புதிய மின்னஞ்சல் கணக்கை உருவாக்கவும்
 DocType: Comment,Submitted,சமர்ப்பிக்கப்பட்டது
 DocType: Contact,Pulled from Google Contacts,Google தொடர்புகளிலிருந்து இழுக்கப்பட்டது
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,தவறான கோரிக்கை
@@ -2091,7 +2091,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ஹவர்ஸ் �
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",இங்கே வரையறுக்கப்பட்ட FIELDNAME மதிப்பு உள்ளது அல்லது விதிகள் உண்மை (உதாரணங்கள்) இருந்தால் மட்டுமே இந்த துறையில் தோன்றும்: myfield eval: doc.myfield == &#39;என் வேல்யூ&#39; eval: doc.age&gt; 18
+eval:doc.age>18",இங்கே வரையறுக்கப்பட்ட FIELDNAME மதிப்பு உள்ளது அல்லது விதிகள் உண்மை (உதாரணங்கள்) இருந்தால் மட்டுமே இந்த துறையில் தோன்றும்: myfield eval: doc.myfield == &#39;என் வேல்யூ&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,அலுவலகம் 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,இன்று
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,இன்று
@@ -2106,7 +2106,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,மேல் வழக்கு
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,விருப்ப HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,கோப்புறை பெயரை உள்ளிடுக
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,இயல்புநிலை முகவரி வார்ப்புரு இல்லை. அமைவு&gt; அச்சிடுதல் மற்றும் பிராண்டிங்&gt; முகவரி வார்ப்புருவில் இருந்து புதிய ஒன்றை உருவாக்கவும்.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,இயல்புநிலை முகவரி வார்ப்புரு இல்லை. அமைவு> அச்சிடுதல் மற்றும் பிராண்டிங்> முகவரி வார்ப்புருவில் இருந்து புதிய ஒன்றை உருவாக்கவும்.
 apps/frappe/frappe/auth.py,Unknown User,தெரியாத பயனர்
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,பங்கு தேர்வு
 DocType: Comment,Deleted,நீக்கப்பட்ட
@@ -2292,7 +2292,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,இணைப்புகளைப் பார்க்கவும் போதுமான அனுமதி
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,முகவரி தலைப்பு கட்டாயமாகும்.
 DocType: Google Contacts,Push to Google Contacts,Google தொடர்புகளுக்கு தள்ளவும்
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","&lt;Head&gt; சேர்க்கப்பட்டது HTML வலை பக்கம் பிரிவு, முதன்மையாக வலைத்தளத்தில் சரிபார்ப்பு மற்றும் எஸ்சிஓ பயன்படுத்தப்படும்"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","&lt;Head> சேர்க்கப்பட்டது HTML வலை பக்கம் பிரிவு, முதன்மையாக வலைத்தளத்தில் சரிபார்ப்பு மற்றும் எஸ்சிஓ பயன்படுத்தப்படும்"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,மீண்டும் புகைக்க
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,பொருள் அதன் சொந்த ஆதரவாளர்வரை சேர்க்க முடியாது
 DocType: Session Default Settings,Session Defaults,அமர்வு இயல்புநிலைகள்
@@ -2409,7 +2409,7 @@ DocType: Workflow State,Warning,எச்சரிக்கை
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,இது பல பக்கங்களில் அச்சிடப்படலாம்
 DocType: Data Migration Run,Percent Complete,சதவீதம் முடிந்தது
 DocType: Tag Category,Tag Category,டேக் வகை
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ஒப்பிட,&gt; 5, &lt;10 அல்லது = 324 ஐப் பயன்படுத்தவும். வரம்புகளுக்கு, 5:10 ஐப் பயன்படுத்தவும் (5 &amp; 10 க்கு இடையிலான மதிப்புகளுக்கு)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","ஒப்பிட,> 5, &lt;10 அல்லது = 324 ஐப் பயன்படுத்தவும். வரம்புகளுக்கு, 5:10 ஐப் பயன்படுத்தவும் (5 &amp; 10 க்கு இடையிலான மதிப்புகளுக்கு)."
 DocType: Google Calendar,Pull from Google Calendar,Google கேலெண்டரிலிருந்து இழுக்கவும்
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,உதவி
 DocType: User,Login Before,உள்நுழைவு முன்
@@ -2788,7 +2788,7 @@ DocType: User,Interests,ஆர்வம்
 apps/frappe/frappe/core/doctype/user/user.py,Password reset instructions have been sent to your email,கடவுச்சொல் மீட்டமைப்பு வழிமுறைகளை உங்கள் மின்னஞ்சல் அனுப்பப்படும்
 DocType: Energy Point Rule,Allot Points To Assigned Users,ஒதுக்கப்பட்ட பயனர்களுக்கு புள்ளிகள் ஒதுக்குங்கள்
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,"Level 0 is for document level permissions, \
-								higher levels for field level permissions.","நிலை 0 ஆவணம் நிலை அனுமதிகளை, \ துறையில் நிலை அனுமதிகளை அதிக அளவு உள்ளது."
+								higher levels for field level permissions.","நிலை 0 ஆவணம் நிலை அனுமதிகளை, \ துறை���ில் நிலை அனுமதிகளை அதிக அளவு உள்ளது."
 DocType: Contact Email,Is Primary,முதன்மை
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,From Document Type,ஆவண வகையிலிருந்து
 DocType: DocType,Tree structures are implemented using Nested Set,மர கட்டமைப்புகள் நெஸ்டட் செட்டைப் பயன்படுத்தி செயல்படுத்தப்படுகின்றன
@@ -2869,7 +2869,7 @@ DocType: Custom Script,Custom Script,தனிப்பயன் உரை
 DocType: Address,Address Line 2,முகவரி வரி 2
 DocType: Address,Reference,குறிப்பு
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,ஒதுக்கப்படும்
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,அமைவு&gt; மின்னஞ்சல்&gt; மின்னஞ்சல் கணக்கிலிருந்து இயல்புநிலை மின்னஞ்சல் கணக்கை அமைக்கவும்
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,அமைவு> மின்னஞ்சல்> மின்னஞ்சல் கணக்கிலிருந்து இயல்புநிலை மின்னஞ்சல் கணக்கை அமைக்கவும்
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,தரவு இடமாற்றம் மேப்பிங் விரிவாக
 DocType: Data Import,Action,செயல்
 DocType: GSuite Settings,Script URL,ஸ்கிரிப்ட் URL
@@ -3045,7 +3045,7 @@ DocType: DocField,Allow on Submit,சமர்ப்பி மீது அன�
 DocType: DocField,HTML,"HTML,"
 DocType: Error Snapshot,Exception Type,விதிவிலக்கு வகை
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,பத்திகள் தேர்வு
-DocType: Web Page,Add code as &lt;script&gt;,&lt;script&gt; என குறியீடு சேர்க்க
+DocType: Web Page,Add code as &lt;script>,&lt;script> என குறியீடு சேர்க்க
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,பயனர் அனுமதிகளை அழி
 DocType: Webhook,Headers,தலைப்புகளிலும்
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,எதிர்வரும் நிகழ்வுகள்
@@ -3416,15 +3416,15 @@ DocType: Workflow State,share-alt,பங்கு-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},கியூ ஒன்றாக இருக்க வேண்டும் {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> இயல்புநிலை டெம்ப்ளேட் </ H4> 
  <p> href=""http://jinja.pocoo.org/docs/templates/""> நிதானத்தில் மாதிரியாக்கம், </a> முகவரி, அனைத்து துறைகளிலும் (பயன்படுத்துகிறது {; br & gt; 
  {% என்றால் address_line2%} {{address_line2}}; & lt; br & gt விருப்ப புலங்கள் ஏதாவது இருந்தால்) </ p> 
@@ -3754,7 +3754,7 @@ DocType: Event,Private,தனிப்பட்ட
 apps/frappe/frappe/email/doctype/notification/notification.js,No alerts for today,இன்றைக்கு எந்த எச்சரிக்கைகள்
 DocType: Print Settings,Send Email Print Attachments as PDF (Recommended),PDF ஆக மின்னஞ்சல் அச்சிடுக இணைப்புகளை அனுப்ப (பரிந்துரைக்கப்படுகிறது)
 DocType: Web Page,Left,விட்டு
-DocType: Event,All Day,அனைத்து தினம்
+DocType: Event,All Day,அனைத்து ���ினம்
 apps/frappe/frappe/integrations/utils.py,Looks like something is wrong with this site's payment gateway configuration. No payment has been made.,ஏதாவது போல் தெரிகிறது இந்த தளத்தின் கட்டணம் நுழைவாயில் கட்டமைப்பு தவறு உள்ளது. எந்தக் கட்டண செய்யப்பட்டுள்ளன.
 DocType: GCalendar Settings,State,நிலை
 DocType: Workflow Action,Workflow Action,பணியோட்டம் அதிரடி

--- a/frappe/translations/ta.csv
+++ b/frappe/translations/ta.csv
@@ -274,7 +274,7 @@ DocType: Email Group,Total Subscribers,மொத்த சந்தாதா�
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top {0},மேலே {0}
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Row Number,வரிசை எண்
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If a Role does not have access at Level 0, then higher levels are meaningless.","ஒரு பாத்திரத்தில் நிலை 0 அணுகல் இல்லை என்றால் , பின்னர் உயர் மட்டங்களில் பொருளற்றது ."
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Save As,சேமி &#39;
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Save As,சேமி '
 DocType: Comment,Seen,ஸீன்
 apps/frappe/frappe/public/js/frappe/form/layout.js,Show more details,மேலும் விவரங்களுக்கு காட்டு
 DocType: System Settings,Run scheduled jobs only if checked,சோதனை மட்டுமே திட்டமிட்ட வேலைகள் இயக்கவும்
@@ -555,7 +555,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,பதிவேற்றம் தோல்வியுற்றது
 DocType: LDAP Settings,LDAP Phone Field,LDAP தொலைபேசி புலம்
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","ஆவண வகை ..., எ.கா. வாடிக்கையாளர்"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,நிபந்தனைகள் &#39;{0}&#39; செல்லாதது
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,நிபந்தனைகள் '{0}' செல்லாதது
 DocType: Workflow State,barcode,பார்கோடு
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,உப வினவ அல்லது செயல்பாட்டின் பயன்பாடு தடைசெய்யப்பட்டுள்ளது
 apps/frappe/frappe/config/customization.py,Add your own translations,உங்கள் சொந்த மொழிபெயர்ப்பு சேர்
@@ -705,7 +705,7 @@ DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,பயனர் பெயர் {0} ஏற்கனவே உள்ளது
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0} {1} importable அல்ல இறக்குமதி அமைக்க முடியாது
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},உங்கள் முகவரி டெம்ப்ளேட் பிழை உள்ளது {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} என்பது &#39;பெறுநர்கள்&#39; இன் தவறான மின்னஞ்சல் முகவரி.
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} என்பது 'பெறுநர்கள்' இன் தவறான மின்னஞ்சல் முகவரி.
 DocType: Footer Item,"target = ""_blank""",இலக்கு = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,தொகுப்பாளர்
@@ -747,7 +747,7 @@ DocType: Currency,Currency Name,நாணயத்தின் பெயர்
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,மின்னஞ்சல்கள் இல்லை
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,இணைப்பு காலாவதியானது
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; இல் &#39;{2}&#39; க்கான நீளத்தை {0} நீளமாக்குகிறது; {3} என்ற நீளம் அமைப்பது தரவு அழிக்கப்படும்.
+							Setting the length as {3} will cause truncation of data.",'{2}' இல் '{2}' க்கான நீளத்தை {0} நீளமாக்குகிறது; {3} என்ற நீளம் அமைப்பது தரவு அழிக்கப்படும்.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,கோப்பு வடிவமைப்பு தேர்ந்தெடு
 DocType: Report,Javascript,ஜாவா ஸ்கிரிப்ட்
 DocType: File,Content Hash,உள்ளடக்க ஹாஷ்
@@ -768,7 +768,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,ஆவண பகிர் அறிக்கை
 DocType: Social Login Key,Base URL,அடிப்படை URL
 DocType: User,Last Login,கடைசியாக உட்சென்ற தேதி
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},களத்திற்கு {0} &#39;மொழியாக்கம்&#39; அமைக்க முடியாது
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},களத்திற்கு {0} 'மொழியாக்கம்' அமைக்க முடியாது
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,வரிசை
 DocType: Chat Profile,Chat Profile,அரட்டை சுயவிவரம்
 DocType: Custom Field,Adds a custom field to a DocType,ஒரு DOCTYPE ஒரு விருப்ப துறையில் சேர்க்கிறது
@@ -777,7 +777,7 @@ DocType: File,Is Home Folder,முகப்பு அடைவு
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,நவ்பார் நடை
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ஒரு சரியான மின்னஞ்சல் முகவரி அல்ல
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,அச்சிடுவதற்கு குறைந்தது 1 சாதனை தேர்ந்தெடுக்கவும்
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',பயனர் &#39;{0}&#39; ஏற்கனவே பங்கு உள்ளது &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',பயனர் '{0}' ஏற்கனவே பங்கு உள்ளது '{1}'
 DocType: System Settings,Two Factor Authentication method,இரண்டு காரணி அங்கீகார முறை
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,"முதலில் பெயரை அமைக்கவும், பதிவுகளை சேமிக்கவும்."
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 பதிவுகள்
@@ -1432,7 +1432,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,கட்டாய துறையில்: அமைக்க பங்கு
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} விமர்சித்தது {1}
 DocType: Data Migration Mapping,Mapping Name,வரைபடத்தின் பெயர்
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: புலம் &#39;{1}&#39; தனித்துவமற்ற மதிப்புகளைக் கொண்டிருப்பதால் தனித்துவமாக அமைக்க முடியாது
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: புலம் '{1}' தனித்துவமற்ற மதிப்புகளைக் கொண்டிருப்பதால் தனித்துவமாக அமைக்க முடியாது
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,பட்டியலை கீழே செல்லவும்
 DocType: Currency,A symbol for this currency. For e.g. $,இந்த நாணயம் ஒரு குறியீடு. உதாரணமாக $ க்கு
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,மொழிபெயர்ப்புகள் வெற்றிகரமாக புதுப்பிக்கப்பட்டன
@@ -1942,7 +1942,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,AP-தென்கிழக்கு-1
 DocType: DocType,"Must be of type ""Attach Image""",&quot;படத்தை இணைக்கவும்&quot; வகை இருக்க வேண்டும்
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,தேர்வுசெய்ய வேண்டாம்
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},நீங்கள் துறையில் அமைக்காமல் இல்லை &#39;மட்டும் வாசிக்க&#39; கொள்ளலாம் {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},நீங்கள் துறையில் அமைக்காமல் இல்லை 'மட்டும் வாசிக்க' கொள்ளலாம் {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,ஜீரோ எந்த நேரத்திலும் மேம்படுத்தப்பட்டது பதிவுகள் அனுப்ப பொருள்
 DocType: Auto Email Report,Zero means send records updated at anytime,ஜீரோ எந்த நேரத்திலும் மேம்படுத்தப்பட்டது பதிவுகள் அனுப்ப பொருள்
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,அமைவு
@@ -1986,7 +1986,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,கூகிள் எழுத்துரு
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","இந்த வழிமுறைகளை அங்கு பயனுள்ளதாக இல்லை என்றால், மகிழ்ச்சியா சிக்கல்கள் உங்கள் ஆலோசனைகளை சேர்க்க தயவு செய்து ."
 DocType: Workflow State,bookmark,புக்மார்க்
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),அடைவு பெயர் சேர்க்க கூடாது &#39;/&#39; (சாய்வு)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),அடைவு பெயர் சேர்க்க கூடாது '/' (சாய்வு)
 DocType: Note,Note,குறிப்பு
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,பிழை அறிக்கை
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel வடிவத்தில் தரவை ஏற்றுமதி செய்யுங்கள்.
@@ -2091,7 +2091,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,ஹவர்ஸ் �
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",இங்கே வரையறுக்கப்பட்ட FIELDNAME மதிப்பு உள்ளது அல்லது விதிகள் உண்மை (உதாரணங்கள்) இருந்தால் மட்டுமே இந்த துறையில் தோன்றும்: myfield eval: doc.myfield == &#39;என் வேல்யூ&#39; eval: doc.age> 18
+eval:doc.age>18",இங்கே வரையறுக்கப்பட்ட FIELDNAME மதிப்பு உள்ளது அல்லது விதிகள் உண்மை (உதாரணங்கள்) இருந்தால் மட்டுமே இந்த துறையில் தோன்றும்: myfield eval: doc.myfield == 'என் வேல்யூ' eval: doc.age> 18
 DocType: Social Login Key,Office 365,அலுவலகம் 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,இன்று
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,இன்று
@@ -2131,7 +2131,7 @@ DocType: Data Migration Connector,Database Name,தரவுத்தள பெ�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,புதுப்பி படிவம்
 DocType: DocField,Select,தேர்ந்தெடு
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,முழு பதிவையும் காண்க
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","எளிய பைதான் வெளிப்பாடு, எடுத்துக்காட்டு: நிலை == &#39;திற&#39; மற்றும் தட்டச்சு == &#39;பிழை&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","எளிய பைதான் வெளிப்பாடு, எடுத்துக்காட்டு: நிலை == 'திற' மற்றும் தட்டச்சு == 'பிழை'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,கோப்பு இணைக்கப்பட்ட இல்லை
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,தொடர்பு துண்டிக்கப்பட்டது. சில அம்சங்கள் வேலை செய்யாமல் போகலாம்.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; போன்ற மறுநிகழ்வுகள் எளிதாக யூகிக்கலாம்
@@ -2191,7 +2191,7 @@ apps/frappe/frappe/public/js/frappe/desk.js,Version Updated,பதிப்ப�
 DocType: Customize Form Field,Label and Type,லேபிள் மற்றும் வகை
 DocType: Workflow State,forward,முன்
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} edited this {1},{0} திருத்தப்பட்டது இந்த {1}
-DocType: Custom DocPerm,Submit,Submit &#39;
+DocType: Custom DocPerm,Submit,Submit '
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,New Folder,புதிய அடைவு
 DocType: Email Account,Uses the Email Address mentioned in this Account as the Sender for all emails sent using this Account. ,இந்த கணக்கைப் பயன்படுத்தி அனுப்பிய அனைத்து மின்னஞ்சல்கள் அனுப்புநர் இந்த கணக்கு குறிப்பிடப்பட்டுள்ளது மின்னஞ்சல் முகவரி பயன்படுத்துகிறது.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Toggle Charts,விளக்கப்படங்களை மாற்று
@@ -2260,7 +2260,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,பிழைகளை மட்டுமே காண்பி
 DocType: Website Settings,Banner HTML,பதாகை HTML
 DocType: Workflow,Send Email Alert,மின்னஞ்சல் விழிப்பூட்டலை அனுப்பவும்
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். Razorpay நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். Razorpay நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை '{0}'
 DocType: Data Import,In Progress,முன்னேற்றம்
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,காப்பு வரிசைப்படுத்தப்பட்டுள்ளது. அது ஒரு மணி நேரம் ஒரு சில நிமிடங்கள் ஆகலாம்.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2678,7 +2678,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,திருத்த�
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,பேபால் கட்டணம் நுழைவாயில் அமைப்புகளை
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,சிறந்த நடிகர்
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,கோர் டாக் டைப்பில் தனிப்பயன் புலங்களைச் சேர்க்க முடியாது.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) அனுமதி அதிகபட்ச எழுத்துக்கள் என, மட்டுப்படுத்தப்பட்டுள்ளது கிடைக்கும் {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) அனுமதி அதிகபட்ச எழுத்துக்கள் என, மட்டுப்படுத்தப்பட்டுள்ளது கிடைக்கும் {2}"
 DocType: OAuth Client,Response Type,பதில் வகை
 DocType: Contact Us Settings,Send enquiries to this email address,இந்த மின்னஞ்சல் முகவரியை விசாரணைகள் அனுப்பவும்
 DocType: Letter Head,Letter Head Name,கடிதம் தலைமை பெயர்
@@ -2734,7 +2734,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,பட காட்சி
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","ஏதாவது பரிவர்த்தனை தவறு நடந்துவிட்டது போல் தெரிகிறது. நாங்கள் பணம் உறுதி இல்லை என்பதால், பேபால் தானாக இந்த அளவு திரும்ப வேண்டும். அது இல்லை என்றால், எங்களுக்கு ஒரு மின்னஞ்சல் அனுப்ப மற்றும் உறவுடைய ஐடி குறிப்பிட வேண்டும்: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","கடவுச்சொல்லை குறியீடுகள், எண்கள் மற்றும் மூலதன கடிதங்கள் சேர்க்கவும்"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","துறையில் &#39;{0}&#39; விருப்ப துறையில் குறிப்பிடப்பட்டுள்ளது பிறகு நுழைக்க &#39;{1}&#39;, லேபிளை &#39;{2}&#39;, இல்லை"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","துறையில் '{0}' விருப்ப துறையில் குறிப்பிடப்பட்டுள்ளது பிறகு நுழைக்க '{1}', லேபிளை '{2}', இல்லை"
 DocType: List Filter,List Filter,பட்டியல் வடிகட்டி
 DocType: Workflow State,signal,அடையாளம்
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,இணைப்புகள் உள்ளன
@@ -2744,7 +2744,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,ஆவண மீட்டெடுத்தது
 DocType: Data Export,Data Export,தரவு ஏற்றுமதி
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,மொழி தேர்ந்தெடு ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},களத்திற்கு {0} &#39;விருப்பங்களை&#39; அமைக்க முடியாது
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},களத்திற்கு {0} 'விருப்பங்களை' அமைக்க முடியாது
 DocType: Help Article,Author,ஆசிரியர்
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,அனுப்புதல் மீண்டும்
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,மீண்டும் திற
@@ -2758,15 +2758,15 @@ DocType: Web Page,Slideshow,ஸ்லைடுஷோ
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,இயல்புநிலை முகவரி டெம்ப்ளேட் நீக்க முடியாது
 DocType: Contact,Maintenance Manager,பராமரிப்பு மேலாளர்
 DocType: Workflow State,Search,தேடல்
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். கோடுகள் நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். கோடுகள் நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். கோடுகள் நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். கோடுகள் நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,குப்பைக்கு நகர்த்து
 DocType: Web Form,Web Form Fields,வலை படிவம் புலங்கள்
 DocType: Data Import,Amended From,முதல் திருத்தப்பட்ட
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},எச்சரிக்கை: முடியவில்லை கண்டுபிடிக்க {0} தொடர்பான எந்த அட்டவணையில் {1}
 DocType: S3 Backup Settings,eu-north-1,EU-வடக்கு-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,இந்த ஆவணத்தை தற்போது மரணதண்டனை வரிசைப்படுத்தப்பட்டது. தயவு செய்து மீண்டும் முயற்சிக்கவும்
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,கோப்பு &#39;{0}&#39; இல்லை
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,கோப்பு '{0}' இல்லை
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,பிரிவை நீக்க
 DocType: User,Change Password,கடவுச்சொல்லை மாற்று
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,எக்ஸ் அச்சு புலம்
@@ -2951,7 +2951,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,மதிப்ப�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,குழந்தை சேர்
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,இறக்குமதி முன்னேற்றம்
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",நிபந்தனை திருப்தி அடைந்தால் பயனருக்கு புள்ளிகள் வழங்கப்படும். எ.கா.. doc.status == &#39;மூடப்பட்டது&#39;
+",நிபந்தனை திருப்தி அடைந்தால் பயனருக்கு புள்ளிகள் வழங்கப்படும். எ.கா.. doc.status == 'மூடப்பட்டது'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: சமர்ப்பிக்கப்பட்டது பதிவு நீக்க முடியாது.
 DocType: GSuite Templates,Template Name,டெம்பிளேட் பெயர்
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ஆவணத்தின் புதிய வகை
@@ -3083,7 +3083,7 @@ DocType: Dashboard Chart,Chart Type,விளக்கப்படம் வக�
 DocType: DocType,Auto Name,கார் பெயர்
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,அவர்கள் எளிதாக யூகிக்கலாம் என ABC அல்லது 6543 போன்ற காட்சிகளை தவிர்க்க
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,தயவு செய்து மீண்டும் முயற்சிக்கவும்
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; அல்லது &#39;https: //&#39; உடன் தொடங்கப்பட வேண்டும்
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' அல்லது 'https: //' உடன் தொடங்கப்பட வேண்டும்
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,விருப்பம் 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,திருத்த
@@ -3320,7 +3320,7 @@ DocType: Notification,Send alert if this field's value changes,எச்சர�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,தீம் நிறங்கள்
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,ஒரு புதிய வடிவமைப்பில் செய்ய ஒரு DOCTYPE வாய்ப்புகள்
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,பயனர் இல்லை
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;பெறுநர்கள்&#39; குறிப்பிடப்படவில்லை
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'பெறுநர்கள்' குறிப்பிடப்படவில்லை
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,இப்போது
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,விண்ணப்பிக்கவும்
 DocType: Footer Item,Policy,கொள்கை
@@ -3466,7 +3466,7 @@ DocType: Dashboard Chart,Filters JSON,வடிப்பான்கள் JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,சரிபார்க்க இங்கே கிளிக் செய்யவும்
 DocType: Email Account,Disable SMTP server authentication,SMTP சேவையக அங்கீகாரத்தை முடக்கு
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,பதிலாக போன்ற முன்னறிந்துகொள்ள் பதிலீடுகள் &#39;@&#39; &#39;ஒரு&#39; மிகவும் உதவ வேண்டாம்.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,பதிலாக போன்ற முன்னறிந்துகொள்ள் பதிலீடுகள் '@' 'ஒரு' மிகவும் உதவ வேண்டாம்.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,என்னைப் அளிக்கப்பட்ட
 apps/frappe/frappe/utils/data.py,Zero,பூஜ்யம்
 DocType: Google Drive,Backup Folder ID,காப்பு கோப்புறை ஐடி
@@ -3519,7 +3519,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,சரியான மொபைல் இலக்கங்கள் உள்ளிடவும்
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,அம்சங்கள் சில உங்கள் உலாவியில் செயல்படாமல் இருக்கலாம். சமீபத்திய பதிப்புக்கு உங்கள் உலாவி புதுப்பிக்கவும்.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,அம்சங்கள் சில உங்கள் உலாவியில் செயல்படாமல் இருக்கலாம். சமீபத்திய பதிப்புக்கு உங்கள் உலாவி புதுப்பிக்கவும்.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","தெரியாது, கேட்க, &#39;உதவி&#39;"
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","தெரியாது, கேட்க, 'உதவி'"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},இந்த ஆவணத்தை ரத்துசெய்தது {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,கருத்துரைகள் மற்றும் கம்யூனிகேஷன்ஸ் இந்த இணைக்கப்பட்ட ஆவணத்துடன் தொடர்புடைய
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,வடிகட்டி ...
@@ -3818,7 +3818,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,இயல்புநிலை
 DocType: Translation,Verified,சரிபார்க்கப்பட்ட
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} சேர்க்கப்பட்டது
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',தேடல் &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',தேடல் '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,முதல் அறிக்கை காப்பாற்றுங்கள்
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} சந்தாதாரர்கள் சேர்ந்தன
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,இல்லை
@@ -3854,14 +3854,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,என்�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} தவறான நிலை
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,அனைத்து ஆவண வகைகளுக்கும் பொருந்தும்
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,ஆற்றல் புள்ளி புதுப்பிப்பு
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். பேபால் நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',மற்றொரு கட்டண முறையை தேர்ந்தெடுக்கவும். பேபால் நாணய பரிவர்த்தனைகள் ஆதரிக்கவில்லை '{0}'
 DocType: Chat Message,Room Type,அறையின் வகை
 DocType: Data Import Beta,Import Log Preview,பதிவு முன்னோட்டத்தை இறக்குமதி செய்க
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,தேடல் துறையில் {0} தவறானது
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,பதிவேற்றிய கோப்பு
 DocType: Workflow State,ok-circle,"சரி, வட்டம்"
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP பயனர் உருவாக்கம் மற்றும் மேப்பிங்
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',நீங்கள் கேட்டு &#39;வாடிக்கையாளர்கள் ஆரஞ்சு கண்டுபிடிக்க&#39; மூலம் விஷயங்களை கண்டுபிடிக்க முடியும்
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',நீங்கள் கேட்டு 'வாடிக்கையாளர்கள் ஆரஞ்சு கண்டுபிடிக்க' மூலம் விஷயங்களை கண்டுபிடிக்க முடியும்
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,மன்னிக்கவும்! பயனர் தங்களுடைய சொந்த இசைப்பதிவு முழுமையாக அணுக வேண்டும்.
 ,Usage Info,பயன்பாடு தகவல்
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,விசைப்பலகை குறுக்குவழிகளைக் காட்டு

--- a/frappe/translations/te.csv
+++ b/frappe/translations/te.csv
@@ -736,7 +736,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,ఫై�
 DocType: DocField,In Global Search,గ్లోబల్ సెర్చ్
 DocType: System Settings,Brute Force Security,బ్రూట్ ఫోర్స్ సెక్యూరిటీ
 DocType: Workflow State,indent-left,ఇండెంట్ ఎడమకు
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} సంవత్సరం (లు) క్రితం
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} సంవత్సరం (లు) క్రితం
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,ఇది ఈ ఫైల్ను మీరు తొలగించాలని ప్రమాదకర ఉంది: {0}. మీ సిస్టమ్ నిర్వాహకుడిని సంప్రదించండి.
 DocType: Currency,Currency Name,కరెన్సీ పేరు
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ఇమెయిళ్ళు లేవు
@@ -977,7 +977,7 @@ apps/frappe/frappe/share.py,No permission to {0} {1} {2},అనుమతి ల�
 DocType: Address,Permanent,శాశ్వత
 DocType: Address,Permanent,శాశ్వత
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Note: Other permission rules may also apply,గమనిక: ఇతర అనుమతి నియమాలు వర్తించవచ్చు
-DocType: Assignment Rule,Unassign Condition,కేటాయించని పరిస్థితి
+DocType: Assignment Rule,Unassign Condition,కేటాయించని పర���స్థితి
 apps/frappe/frappe/templates/emails/print_link.html,View this in your browser,మీ బ్రౌజర్ లో ఈ వీక్షించండి
 DocType: DocType,Parent Field (Tree),మాతృ క్షేత్రం (చెట్టు)
 DocType: DocType,Search Fields,శోధన ఫీల్డ్స్
@@ -1030,7 +1030,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,ఏ {0} ద�
 apps/frappe/frappe/config/customization.py,Add custom forms.,కస్టమ్ రూపాలు జోడించండి.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} లో {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ఈ పత్రం సమర్పించిన
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,సెటప్&gt; వినియోగదారు అనుమతులు
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,సెటప్> వినియోగదారు అనుమతులు
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,వ్యవస్థ అనేక ముందు నిర్వచించబడిన పాత్రలు అందిస్తుంది. మీరు నాణ్యమైన అనుమతులు సెట్ కొత్త పాత్రలు జోడించవచ్చు.
 DocType: Communication,CC,సిసి
 DocType: Country,Geo,జియో
@@ -1245,7 +1245,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","యూజర్ తనిఖీ ఏ పాత్ర ఉంది, అప్పుడు యూజర్ ఒక &quot;సిస్టమ్ వాడుకరి&quot; అవుతుంది. &quot;సిస్టమ్ వాడుకరి&quot; డెస్క్టాప్ ప్రాప్తి ఉంది"
 DocType: System Settings,Date and Number Format,తేదీ మరియు సంఖ్య ఫార్మాట్
 apps/frappe/frappe/model/document.py,one of,ఒకటి
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,సెటప్&gt; ఫారమ్‌ను అనుకూలీకరించండి
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,సెటప్> ఫారమ్‌ను అనుకూలీకరించండి
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,ఒక క్షణం తనిఖీ చేస్తోంది
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,షో టాగ్లు
 DocType: DocField,HTML Editor,HTML ఎడిటర్
@@ -1253,7 +1253,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,బిల్లింగ్
 DocType: Email Queue,Not Sent,పంపలేదు
 DocType: Web Form,Actions,చర్యలు
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,సెటప్&gt; వినియోగదారు
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,సెటప్> వినియోగదారు
 DocType: Workflow State,align-justify,align సమ్మతం
 DocType: User,Middle Name (Optional),మధ్య పేరు (ఆప్షనల్)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,అనుమతించబడదు
@@ -1399,7 +1399,7 @@ DocType: Report,Is Standard,ప్రమాణం
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,పూర్తి
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",అలా కాదు వంటి &lt;స్క్రిప్ట్&gt; లేదా కేవలం వంటి పాత్రలు &lt;లేదా&gt; వారు కావాలని ఈ రంగంలో వాడబడే వంటి HTML ఎన్కోడ్ HTML టాగ్లు
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",అలా కాదు వంటి &lt;స్క్రిప్ట్> లేదా కేవలం వంటి పాత్రలు &lt;లేదా> వారు కావాలని ఈ రంగంలో వాడబడే వంటి HTML ఎన్కోడ్ HTML టాగ్లు
 DocType: Website Settings,FavIcon,ఇష్టాంశ చిహ్నం
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,రన్
 DocType: Blog Post,Content (HTML),కంటెంట్ (HTML)
@@ -1769,7 +1769,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ఫుటరు P
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,పెండింగ్
 DocType: System Settings,Allow only one session per user,యూజర్ శాతం మాత్రమే ఒక సెషన్ని మాత్రమే అనుమతించు
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,హోం / టెస్ట్ ఫోల్డర్ 1 / టెస్ట్ ఫోల్డర్ 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ఎంచుకోండి లేదా ఒక కొత్త సంఘటన సృష్టించడానికి సమయ విభాగాలు అంతటా లాగండి.
 DocType: Contact,Contact Details,సంప్రదింపు వివరాలు
 DocType: DocField,In Filter,వడపోత లో
@@ -1998,7 +1998,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,ఈ సమయంలో అనుమతి లేదు లాగిన్
 DocType: Data Migration Run,Current Mapping Action,ప్రస్తుత మ్యాపింగ్ చర్య
 DocType: Dashboard Chart Source,Source Name,మూలం పేరు
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,వినియోగదారుతో ఇమెయిల్ ఖాతా లేదు. దయచేసి వినియోగదారు&gt; ఇమెయిల్ ఇన్బాక్స్ క్రింద ఒక ఖాతాను జోడించండి.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,వినియోగదారుతో ఇమెయిల్ ఖాతా లేదు. దయచేసి వినియోగదారు> ఇమెయిల్ ఇన్బాక్స్ క్రింద ఒక ఖాతాను జోడించండి.
 DocType: Email Account,Email Sync Option,ఇమెయిల్ సమకాలీకరణ ఎంపిక
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,వరుస సంఖ్య
 DocType: Async Task,Runtime,రన్టైమ్
@@ -2013,7 +2013,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,ఇప్
 DocType: User Email,Enable Outgoing,అవుట్గోయింగ్ ప్రారంభించు
 DocType: Address,Fax,ఫ్యాక్స్
 apps/frappe/frappe/config/customization.py,Custom Tags,కస్టమ్ టాగ్లు
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ఇమెయిల్ ఖాతా సెటప్ కాదు. దయచేసి సెటప్&gt; ఇమెయిల్&gt; ఇమెయిల్ ఖాతా నుండి క్రొత్త ఇమెయిల్ ఖాతాను సృష్టించండి
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ఇమెయిల్ ఖాతా సెటప్ కాదు. దయచేసి సెటప్> ఇమెయిల్> ఇమెయిల్ ఖాతా నుండి క్రొత్త ఇమెయిల్ ఖాతాను సృష్టించండి
 DocType: Comment,Submitted,Submitted
 DocType: Contact,Pulled from Google Contacts,Google పరిచయాల నుండి తీసివేయబడింది
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,చెల్లుబాటు అయ్యే అభ్యర్ధనలో
@@ -2086,7 +2086,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,గంటలు ఉ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",myfield eval: ఇక్కడ నిర్వచించారు FIELDNAME విలువ ఉంది లేదా నియమాలు నిజమైన (ఉదాహరణలు) ఉన్నాయి మాత్రమే ఈ రంగంలో కనిపిస్తుంది doc.myfield == &#39;నా విలువ&#39; eval: doc.age&gt; 18
+eval:doc.age>18",myfield eval: ఇక్కడ నిర్వచించారు FIELDNAME విలువ ఉంది లేదా నియమాలు నిజమైన (ఉదాహరణలు) ఉన్నాయి మాత్రమే ఈ రంగంలో కనిపిస్తుంది doc.myfield == &#39;నా విలువ&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,ఆఫీస్ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,నేడు
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,నేడు
@@ -2101,7 +2101,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,అప్పర్కేస్
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,కస్టమ్ HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ఫోల్డర్ పేరును నమోదు
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,డిఫాల్ట్ చిరునామా మూస కనుగొనబడలేదు. దయచేసి సెటప్&gt; ప్రింటింగ్ మరియు బ్రాండింగ్&gt; చిరునామా మూస నుండి క్రొత్తదాన్ని సృష్టించండి.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,డిఫాల్ట్ చిరునామా మూస కనుగొనబడలేదు. దయచేసి సెటప్> ప్రింటింగ్ మరియు బ్రాండింగ్> చిరునామా మూస నుండి క్రొత్తదాన్ని సృష్టించండి.
 apps/frappe/frappe/auth.py,Unknown User,తెలియని వాడుకరి
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Select రోల్
 DocType: Comment,Deleted,తొలగించినవి
@@ -2285,7 +2285,7 @@ DocType: LDAP Settings,Path to Server Certificate,సర్వర్ సర్�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,లింకులు చూడటానికి తగినంత అనుమతి
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,చిరునామా శీర్షిక తప్పనిసరి.
 DocType: Google Contacts,Push to Google Contacts,Google పరిచయాలకు నెట్టండి
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",&lt;Head&gt; లో చేర్చబడింది HTML వెబ్ పేజీ యొక్క విభాగం ప్రధానంగా వెబ్సైట్ ధృవీకరణ మరియు SEO కోసం ఉపయోగిస్తారు
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> లో చేర్చబడింది HTML వెబ్ పేజీ యొక్క విభాగం ప్రధానంగా వెబ్సైట్ ధృవీకరణ మరియు SEO కోసం ఉపయోగిస్తారు
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,అంశం దాని సొంత వంశస్థులు జోడించబడింది సాధ్యం కాదు
 DocType: Session Default Settings,Session Defaults,సెషన్ డిఫాల్ట్‌లు
@@ -2401,7 +2401,7 @@ DocType: Workflow State,Warning,హెచ్చరిక
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ఇది బహుళ పేజీలలో ముద్రించబడవచ్చు
 DocType: Data Migration Run,Percent Complete,శాతం పూర్తయింది
 DocType: Tag Category,Tag Category,ట్యాగ్ వర్గం
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","పోలిక కోసం,&gt; 5, &lt;10 లేదా = 324 ఉపయోగించండి. శ్రేణుల కోసం, 5:10 (5 &amp; 10 మధ్య విలువల కోసం) ఉపయోగించండి."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","పోలిక కోసం,> 5, &lt;10 లేదా = 324 ఉపయోగించండి. శ్రేణుల కోసం, 5:10 (5 &amp; 10 మధ్య విలువల కోసం) ఉపయోగించండి."
 DocType: Google Calendar,Pull from Google Calendar,Google క్యాలెండర్ నుండి లాగండి
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,సహాయం
 DocType: User,Login Before,లాగిన్ ముందు
@@ -2465,7 +2465,7 @@ apps/frappe/frappe/public/js/frappe/form/grid.js,The CSV format is case sensitiv
 apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,డెస్క్టాప్ ఐకాన్ ఇప్పటికే ఉంది
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Duplicate,నకిలీ
 DocType: Newsletter,Create and Send Newsletters,సృష్టించు మరియు పంపండి వార్తాలేఖలు
-apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,మీ వ్యాఖ్యకు ధన్యవాదాలు. ఇది ఆమోదం తర్వాత ప్రచురించబడుతుంది
+apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,మీ వ్యాఖ్యకు ధన్యవాదాలు. ఇది ఆమోదం తర్వాత ప్రచురించబడుత���ంది
 DocType: Address,Andaman and Nicobar Islands,అండమాన్ మరియు నికోబార్ దీవులు
 DocType: Google Contacts,Pull from Google Contacts,Google పరిచయాల నుండి లాగండి
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,తనిఖీ తప్పక విలువ రంగంలో రాయండి
@@ -2854,7 +2854,7 @@ DocType: Custom Script,Custom Script,కస్టమ్ స్క్రిప్
 DocType: Address,Address Line 2,చిరునామా లైన్ 2
 DocType: Address,Reference,సూచన
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,కేటాయించిన
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,దయచేసి సెటప్&gt; ఇమెయిల్&gt; ఇమెయిల్ ఖాతా నుండి డిఫాల్ట్ ఇమెయిల్ ఖాతాను సెటప్ చేయండి
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,దయచేసి సెటప్> ఇమెయిల్> ఇమెయిల్ ఖాతా నుండి డిఫాల్ట్ ఇమెయిల్ ఖాతాను సెటప్ చేయండి
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,డేటా మైగ్రేషన్ మ్యాపింగ్ వివరాలు
 DocType: Data Import,Action,యాక్షన్
 DocType: GSuite Settings,Script URL,స్క్రిప్ట్ URL
@@ -3027,7 +3027,7 @@ DocType: DocField,Allow on Submit,సమర్పించండి అనుమ
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,అసాధారణ పరిస్థితి రకాన్ని
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,లు ఎంచుకోండి
-DocType: Web Page,Add code as &lt;script&gt;,&lt;స్క్రిప్ట్&gt; గా కోడ్ జోడించండి
+DocType: Web Page,Add code as &lt;script>,&lt;స్క్రిప్ట్> గా కోడ్ జోడించండి
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,వినియోగదారు అనుమతులను క్లియర్ చేయండి
 DocType: Webhook,Headers,శీర్షికలు
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,రాబోయే ఈవెంట్స్
@@ -3395,16 +3395,16 @@ DocType: Workflow State,share-alt,వాటా-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},క్యూ ఒకటి ఉండాలి {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Default మూస </h4><p> ఉపయోగాలు <a href=""http://jinja.pocoo.org/docs/templates/"">జింజ Templating</a> మరియు అందుబాటులో ఉంటుంది (ఏదైనా ఉంటే కస్టమ్ ఫీల్డ్స్ సహా) అడ్రస్ అన్ని రంగాల్లో </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Default మూస </h4><p> ఉపయోగాలు <a href=""http://jinja.pocoo.org/docs/templates/"">జింజ Templating</a> మరియు అందుబాటులో ఉంటుంది (ఏదైనా ఉంటే కస్టమ్ ఫీల్డ్స్ సహా) అడ్రస్ అన్ని రంగాల్లో </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ప్రారంభ తేదీ ఫీల్డ్
 DocType: Role,Role Name,కారెక్టర్ పేరు
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,డెస్క్ మారండి

--- a/frappe/translations/te.csv
+++ b/frappe/translations/te.csv
@@ -1399,7 +1399,7 @@ DocType: Report,Is Standard,ప్రమాణం
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,పూర్తి
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",అలా కాదు వంటి &lt;స్క్రిప్ట్> లేదా కేవలం వంటి పాత్రలు &lt;లేదా> వారు కావాలని ఈ రంగంలో వాడబడే వంటి HTML ఎన్కోడ్ HTML టాగ్లు
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",అలా కాదు వంటి <స్క్రిప్ట్> లేదా కేవలం వంటి పాత్రలు <లేదా> వారు కావాలని ఈ రంగంలో వాడబడే వంటి HTML ఎన్కోడ్ HTML టాగ్లు
 DocType: Website Settings,FavIcon,ఇష్టాంశ చిహ్నం
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,రన్
 DocType: Blog Post,Content (HTML),కంటెంట్ (HTML)
@@ -1769,7 +1769,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ఫుటరు P
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,పెండింగ్
 DocType: System Settings,Allow only one session per user,యూజర్ శాతం మాత్రమే ఒక సెషన్ని మాత్రమే అనుమతించు
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,హోం / టెస్ట్ ఫోల్డర్ 1 / టెస్ట్ ఫోల్డర్ 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,ఎంచుకోండి లేదా ఒక కొత్త సంఘటన సృష్టించడానికి సమయ విభాగాలు అంతటా లాగండి.
 DocType: Contact,Contact Details,సంప్రదింపు వివరాలు
 DocType: DocField,In Filter,వడపోత లో
@@ -2285,7 +2285,7 @@ DocType: LDAP Settings,Path to Server Certificate,సర్వర్ సర్�
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,లింకులు చూడటానికి తగినంత అనుమతి
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,చిరునామా శీర్షిక తప్పనిసరి.
 DocType: Google Contacts,Push to Google Contacts,Google పరిచయాలకు నెట్టండి
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;Head> లో చేర్చబడింది HTML వెబ్ పేజీ యొక్క విభాగం ప్రధానంగా వెబ్సైట్ ధృవీకరణ మరియు SEO కోసం ఉపయోగిస్తారు
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",<Head> లో చేర్చబడింది HTML వెబ్ పేజీ యొక్క విభాగం ప్రధానంగా వెబ్సైట్ ధృవీకరణ మరియు SEO కోసం ఉపయోగిస్తారు
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,అంశం దాని సొంత వంశస్థులు జోడించబడింది సాధ్యం కాదు
 DocType: Session Default Settings,Session Defaults,సెషన్ డిఫాల్ట్‌లు
@@ -2401,7 +2401,7 @@ DocType: Workflow State,Warning,హెచ్చరిక
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,ఇది బహుళ పేజీలలో ముద్రించబడవచ్చు
 DocType: Data Migration Run,Percent Complete,శాతం పూర్తయింది
 DocType: Tag Category,Tag Category,ట్యాగ్ వర్గం
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","పోలిక కోసం,> 5, &lt;10 లేదా = 324 ఉపయోగించండి. శ్రేణుల కోసం, 5:10 (5 &amp; 10 మధ్య విలువల కోసం) ఉపయోగించండి."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","పోలిక కోసం,> 5, <10 లేదా = 324 ఉపయోగించండి. శ్రేణుల కోసం, 5:10 (5 &amp; 10 మధ్య విలువల కోసం) ఉపయోగించండి."
 DocType: Google Calendar,Pull from Google Calendar,Google క్యాలెండర్ నుండి లాగండి
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,సహాయం
 DocType: User,Login Before,లాగిన్ ముందు
@@ -3027,7 +3027,7 @@ DocType: DocField,Allow on Submit,సమర్పించండి అనుమ
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,అసాధారణ పరిస్థితి రకాన్ని
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,లు ఎంచుకోండి
-DocType: Web Page,Add code as &lt;script>,&lt;స్క్రిప్ట్> గా కోడ్ జోడించండి
+DocType: Web Page,Add code as <script>,<స్క్రిప్ట్> గా కోడ్ జోడించండి
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,వినియోగదారు అనుమతులను క్లియర్ చేయండి
 DocType: Webhook,Headers,శీర్షికలు
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,రాబోయే ఈవెంట్స్
@@ -3395,16 +3395,16 @@ DocType: Workflow State,share-alt,వాటా-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},క్యూ ఒకటి ఉండాలి {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Default మూస </h4><p> ఉపయోగాలు <a href=""http://jinja.pocoo.org/docs/templates/"">జింజ Templating</a> మరియు అందుబాటులో ఉంటుంది (ఏదైనా ఉంటే కస్టమ్ ఫీల్డ్స్ సహా) అడ్రస్ అన్ని రంగాల్లో </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Default మూస </h4><p> ఉపయోగాలు <a href=""http://jinja.pocoo.org/docs/templates/"">జింజ Templating</a> మరియు అందుబాటులో ఉంటుంది (ఏదైనా ఉంటే కస్టమ్ ఫీల్డ్స్ సహా) అడ్రస్ అన్ని రంగాల్లో </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,ప్రారంభ తేదీ ఫీల్డ్
 DocType: Role,Role Name,కారెక్టర్ పేరు
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,డెస్క్ మారండి

--- a/frappe/translations/te.csv
+++ b/frappe/translations/te.csv
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","ప్రారంభించబడితే, పాస్వర్డ్ బలం కనీస పాస్ వర్డ్ స్కోర్ విలువ ఆధారంగా అమలు చేయబడతాయి. 2 యొక్క విలువ మీడియం బలమైన ఉండటం మరియు 4 చాలా బలమైన ఉండటం."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","ప్రారంభించబడితే, పాస్వర్డ్ బలం కనీస పాస్ వర్డ్ స్కోర్ విలువ ఆధారంగా అమలు చేయబడతాయి. 2 యొక్క విలువ మీడియం బలమైన ఉండటం మరియు 4 చాలా బలమైన ఉండటం."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;జట్టు సభ్యులు&quot; లేదా &quot;నిర్వహణ&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',రంగంలో &#39;తనిఖీ&#39; రకం కోసం డిఫాల్ట్ గాని &#39;0&#39; లేదా &#39;1&#39; ఉండాలి
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',రంగంలో 'తనిఖీ' రకం కోసం డిఫాల్ట్ గాని '0' లేదా '1' ఉండాలి
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,నిన్న
 DocType: Contact,Designation,హోదా
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,స్వయంచాలక లింకింగ్ ఒక ఇమెయిల్ ఖాతా కోసం మాత్రమే సక్రియం చేయబడుతుంది.
@@ -251,7 +251,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,ఆపివే�
 DocType: Translation,Contributed Translation Doctype Name,సహకారం అనువాద డాక్టైప్ పేరు
 DocType: PayPal Settings,Redirect To,దారి మార్పు
 DocType: Data Migration Mapping,Pull,పుల్
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},జావాస్క్రిప్ట్ ఫార్మాట్: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},జావాస్క్రిప్ట్ ఫార్మాట్: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,బల్క్ నవీకరణ
 DocType: Workflow State,chevron-up,చెవ్రాన్ అప్
 DocType: DocType,Allow Guest to View,గెస్ట్ చూడండి అనుమతించు
@@ -552,7 +552,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Per
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,అప్లోడ్ విఫలమైంది
 DocType: LDAP Settings,LDAP Phone Field,LDAP ఫోన్ ఫీల్డ్
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",డాక్యుమెంట్ రకము ... ఉదా కస్టమర్
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,కండిషన్ &#39;{0}&#39; చెల్లదు
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,కండిషన్ '{0}' చెల్లదు
 DocType: Workflow State,barcode,బార్కోడ్
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,ఉప ప్రశ్న లేదా చర్య యొక్క ఉపయోగం పరిమితం చేయబడింది
 apps/frappe/frappe/config/customization.py,Add your own translations,మీ సొంత అనువాదాలు జోడించవచ్చు
@@ -700,7 +700,7 @@ DocType: Slack Webhook URL,Webhook URL,వెబ్హూక్ URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,యూజర్ పేరు {0} ఇప్పటికే ఉంది
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} importable కాదు దిగుమతి సెట్ చెయ్యబడదు
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},మీ చిరునామా మూస లోపం ఉంది {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} &#39;గ్రహీతలు&#39; లో చెల్లని ఇమెయిల్ చిరునామా
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} 'గ్రహీతలు' లో చెల్లని ఇమెయిల్ చిరునామా
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,HDD
 DocType: Integration Request,Host,హోస్ట్
@@ -742,7 +742,7 @@ DocType: Currency,Currency Name,కరెన్సీ పేరు
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ఇమెయిళ్ళు లేవు
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,లింక్ గడువు ముగిసింది
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; లో &#39;{1}&#39; కోసం {0} పొడవును తిరిగి మారుస్తుంది; {3} గా పొడవును అమర్చుట వలన డేటా యొక్క కత్తిరింపు అవుతుంది.
+							Setting the length as {3} will cause truncation of data.",'{2}' లో '{1}' కోసం {0} పొడవును తిరిగి మారుస్తుంది; {3} గా పొడవును అమర్చుట వలన డేటా యొక్క కత్తిరింపు అవుతుంది.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,ఫైల్ ఆకృతిని ఎంచుకోండి
 DocType: Report,Javascript,జావాస్క్రిప్ట్
 DocType: File,Content Hash,కంటెంట్ హాష్
@@ -758,13 +758,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","ప్రామాణిక doctype, డిఫాల్ట్ ముద్రణ ఫార్మాట్ ఉండకూడదు అనుకూలపరచండి ఫారంనుండి"
 DocType: Report,Query,ప్రశ్న
 DocType: Customize Form,Sort Order,క్రమబద్ధీకరణ క్రమం
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},&#39;లిస్ట్ వ్యూ&#39; వరుసగా రకం {0} అనుమతించబడలేదు {1}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'లిస్ట్ వ్యూ' వరుసగా రకం {0} అనుమతించబడలేదు {1}
 DocType: Letter Head,Footer HTML,ఫుటరు HTML
 DocType: Custom Field,Select the label after which you want to insert new field.,మీరు కొత్త రంగంలో ఇన్సర్ట్ కోరుకుంటున్న తర్వాత లేబుల్ ఎంచుకోండి.
 ,Document Share Report,డాక్యుమెంట్ Share నివేదిక
 DocType: Social Login Key,Base URL,బేస్ URL
 DocType: User,Last Login,చివరి లాగిన్
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},మీరు ఫీల్డ్ కోసం &#39;కార్యరూపం&#39; చేయకూడదు {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},మీరు ఫీల్డ్ కోసం 'కార్యరూపం' చేయకూడదు {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,కాలమ్
 DocType: Chat Profile,Chat Profile,చాట్ ప్రొఫైల్
 DocType: Custom Field,Adds a custom field to a DocType,ఒక DOCTYPE ఒక కస్టమ్ ఫీల్డ్ జతచేస్తుంది
@@ -773,7 +773,7 @@ DocType: File,Is Home Folder,హోం ఫోల్డర్ని
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,నవ్‌బార్ శైలి
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} చెల్లుబాటు అయ్యే ఇమెయిల్ చిరునామా కాదు
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,ముద్రణా కనీసం 1 రికార్డు ఎంచుకోండి
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',వాడుకరి &#39;{0}&#39; ఇప్పటికే పాత్ర ఉంది &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',వాడుకరి '{0}' ఇప్పటికే పాత్ర ఉంది '{1}'
 DocType: System Settings,Two Factor Authentication method,రెండు ఫాక్టర్ ప్రామాణీకరణ పద్ధతి
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,"మొదట పేరును సెట్ చేసి, రికార్డ్ను సేవ్ చేయండి."
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 రికార్డులు
@@ -1021,7 +1021,7 @@ DocType: Property Setter,Property Setter,ఆస్తి సెట్టర్
 DocType: Web Form,Allow Print,ప్రింట్ అనుమతిస్తుంది
 DocType: Communication,Clicked,క్లిక్
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,అనుసరించవద్దు
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},అనుమతి లేదు &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},అనుమతి లేదు '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,పంపడానికి షెడ్యూల్డ్
 DocType: DocType,Track Seen,ట్రాక్ సీన్
 DocType: Dropbox Settings,File Backup,ఫైల్ బ్యాకప్
@@ -1048,7 +1048,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,పేజ్ HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,తప్పు వరుసలను ఎగుమతి చేయండి
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,సమూహం పేరు ఖాళీగా ఉండకూడదు.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,మరింత నోడ్స్ మాత్రమే &#39;గ్రూప్&#39; రకం నోడ్స్ కింద రూపొందించినవారు చేయవచ్చు
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,మరింత నోడ్స్ మాత్రమే 'గ్రూప్' రకం నోడ్స్ కింద రూపొందించినవారు చేయవచ్చు
 DocType: SMS Parameter,Header,శీర్షిక
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},తెలియని కాలమ్: {0}
 DocType: Notification Recipient,Email By Role,పాత్ర ద్వారా ఇమెయిల్
@@ -1428,7 +1428,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,తప్పనిసరి రంగంలో: సెట్ పాత్ర
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} విమర్శించారు {1}
 DocType: Data Migration Mapping,Mapping Name,మ్యాపింగ్ పేరు
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ఫీల్డ్ &#39;{1}&#39; ప్రత్యేకత లేని విలువలను కలిగి ఉన్నందున దానిని ప్రత్యేకమైనదిగా సెట్ చేయలేరు
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ఫీల్డ్ '{1}' ప్రత్యేకత లేని విలువలను కలిగి ఉన్నందున దానిని ప్రత్యేకమైనదిగా సెట్ చేయలేరు
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,జాబితాను క్రిందికి నావిగేట్ చేయండి
 DocType: Currency,A symbol for this currency. For e.g. $,ఈ కరెన్సీ కోసం ఒక చిహ్నం. ఉదా $ కోసం
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,విజయవంతంగా అనువాదాలు నవీకరించబడ్డాయి
@@ -1937,7 +1937,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-ఆగ్నేయ-1
 DocType: DocType,"Must be of type ""Attach Image""",రకం ఉండాలి &quot;చిత్రం జోడించు&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,దేన్నీ ఎంచుకోవద్దు
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},మీరు రంగంలో కోసం సెట్ చేయకుండా లేదు &#39;మాత్రమే చదవండి&#39; చేయవచ్చు {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},మీరు రంగంలో కోసం సెట్ చేయకుండా లేదు 'మాత్రమే చదవండి' చేయవచ్చు {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,జీరో ఎప్పుడైనా నవీకరించబడింది రికార్డులు పంపడానికి అర్థం
 DocType: Auto Email Report,Zero means send records updated at anytime,జీరో ఎప్పుడైనా నవీకరించబడింది రికార్డులు పంపడానికి అర్థం
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,సెటప్ పూర్తయింది
@@ -1981,7 +1981,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,గూగుల్ ఫాంట్
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","ఉపయోగపడిందా కాదు, GitHub అంశాలపై మీ సూచనలు జోడించడానికి దయచేసి ఇక్కడ ఈ సూచనలను ఉంటే."
 DocType: Workflow State,bookmark,బుక్మార్క్
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ఫోల్డర్ పేరు చేర్చకూడదు &#39;/&#39; (స్లాష్)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ఫోల్డర్ పేరు చేర్చకూడదు '/' (స్లాష్)
 DocType: Note,Note,గమనిక
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,లోపం నివేదిక
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / Excel ఫార్మాట్లో డేటాను ఎగుమతి చేయండి.
@@ -2086,7 +2086,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,గంటలు ఉ�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",myfield eval: ఇక్కడ నిర్వచించారు FIELDNAME విలువ ఉంది లేదా నియమాలు నిజమైన (ఉదాహరణలు) ఉన్నాయి మాత్రమే ఈ రంగంలో కనిపిస్తుంది doc.myfield == &#39;నా విలువ&#39; eval: doc.age> 18
+eval:doc.age>18",myfield eval: ఇక్కడ నిర్వచించారు FIELDNAME విలువ ఉంది లేదా నియమాలు నిజమైన (ఉదాహరణలు) ఉన్నాయి మాత్రమే ఈ రంగంలో కనిపిస్తుంది doc.myfield == 'నా విలువ' eval: doc.age> 18
 DocType: Social Login Key,Office 365,ఆఫీస్ 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,నేడు
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,నేడు
@@ -2126,7 +2126,7 @@ DocType: Data Migration Connector,Database Name,డేటాబేస్ పే�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,రిఫ్రెష్ ఫారం
 DocType: DocField,Select,ఎంచుకోండి
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,పూర్తి లాగ్ చూడండి
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","సాధారణ పైథాన్ వ్యక్తీకరణ, ఉదాహరణ: స్థితి == &#39;ఓపెన్&#39; మరియు == &#39;బగ్&#39; అని టైప్ చేయండి"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","సాధారణ పైథాన్ వ్యక్తీకరణ, ఉదాహరణ: స్థితి == 'ఓపెన్' మరియు == 'బగ్' అని టైప్ చేయండి"
 apps/frappe/frappe/utils/csvutils.py,File not attached,ఫైల్ జత లేదు
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,కనెక్షన్ కోల్పోయింది. కొన్ని లక్షణాలు పనిచేయకపోవచ్చు.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; వంటి పునఃప్రసారాలు ఊహించడం సులభం
@@ -2254,7 +2254,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,లోపాలు మాత్రమే చూపించు
 DocType: Website Settings,Banner HTML,బ్యానర్ HTML
 DocType: Workflow,Send Email Alert,ఇమెయిల్ హెచ్చరికను పంపండి
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. Razorpay ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. Razorpay ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు '{0}'
 DocType: Data Import,In Progress,ప్రోగ్రెస్లో ఉంది
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,బ్యాకప్ కోసం క్యూలో. అది ఒక గంట కొన్ని నిమిషాలు పట్టవచ్చు.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2664,7 +2664,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,సవరణ
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,పేపాల్ చెల్లింపు గేట్వే సెట్టింగులు
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,టాప్ పెర్ఫార్మర్
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,కస్టమ్ ఫీల్డ్‌లను కోర్ డాక్‌టైప్‌లకు జోడించడం సాధ్యం కాదు.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) అనుమతి గరిష్టంగా అక్షరాలు వంటి, కత్తిరించబడింది పొందుతారు {2}"
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) అనుమతి గరిష్టంగా అక్షరాలు వంటి, కత్తిరించబడింది పొందుతారు {2}"
 DocType: OAuth Client,Response Type,ప్రతిస్పందన రకం
 DocType: Contact Us Settings,Send enquiries to this email address,ఈ ఈమెయిల్ చిరునామాకు విచారణ పంపండి
 DocType: Letter Head,Letter Head Name,లెటర్ హెడ్ పేరు
@@ -2720,7 +2720,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,చిత్రం చూడండి
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","ఏదో లావాదేవీల సమయంలో తప్పు జరిగింది కనిపిస్తోంది. మేము చెల్లింపు ధ్రువీకరించారు చేయనందున, పేపాల్ స్వయంచాలకంగా మీరు ఈ మొత్తం తిరిగి చెల్లించు ఉంటుంది. అది కాకపోతే, మాకు ఒక ఇమెయిల్ పంపవచ్చు మరియు సహసంబంధ ID చెప్పలేదు చేయండి: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","పాస్వర్డ్ను చిహ్నాలు, సంఖ్యలు మరియు రాజధాని అక్షరాలు చేర్చండి"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","రంగంలో &#39;{0}&#39; కస్టమ్ ఫీల్డ్ పేర్కొన్నారు తరువాత చొప్పించు &#39;{1}&#39;, లేబుల్ తో &#39;{2}&#39;, లేదు"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","రంగంలో '{0}' కస్టమ్ ఫీల్డ్ పేర్కొన్నారు తరువాత చొప్పించు '{1}', లేబుల్ తో '{2}', లేదు"
 DocType: List Filter,List Filter,జాబితా ఫిల్టర్
 DocType: Workflow State,signal,సిగ్నల్
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,అటాచ్మెంట్లు ఉన్నాయి
@@ -2730,7 +2730,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,డాక్యుమెంట్ పునరుద్ధరించబడిన
 DocType: Data Export,Data Export,డేటా ఎగుమతి
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,భాషను ఎంచుకోండి ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},మీరు రంగంలో {0} కోసం &#39;ఐచ్ఛికాలు&#39; సెట్ చేయలేరు
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},మీరు రంగంలో {0} కోసం 'ఐచ్ఛికాలు' సెట్ చేయలేరు
 DocType: Help Article,Author,రచయిత
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,మళ్ళీ పంపడం
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,మళ్ళీ తెరువు
@@ -2744,15 +2744,15 @@ DocType: Web Page,Slideshow,స్లైడ్
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,డిఫాల్ట్ చిరునామా మూస తొలగించడం సాధ్యం కాదు
 DocType: Contact,Maintenance Manager,మెయింటెనెన్స్ మేనేజర్గా
 DocType: Workflow State,Search,శోధన
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. గీత ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. గీత ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. గీత ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. గీత ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ట్రాష్కు తరలించు
 DocType: Web Form,Web Form Fields,వెబ్ ఫారం ఫీల్డ్స్
 DocType: Data Import,Amended From,సవరించిన
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},హెచ్చరిక: సాధ్యం కాలేదు కనుగొనేందుకు {0} కు సంబంధించి ఏ పట్టికలో {1}
 DocType: S3 Backup Settings,eu-north-1,eu-ఉత్తర-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,ప్రస్తుతం ఈ పత్రం అమలు కోసం క్యూలో ఉంది. దయచేసి మళ్ళీ ప్రయత్నించండి
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ఫైలు &#39;{0}&#39; దొరకలేదు
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,ఫైలు '{0}' దొరకలేదు
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,విభాగం తొలగించు
 DocType: User,Change Password,పాస్వర్డ్ మార్చండి
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X యాక్సిస్ ఫీల్డ్
@@ -2935,7 +2935,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,విలువ త�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,చైల్డ్ జోడించండి
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,దిగుమతి పురోగతి
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",షరతు సంతృప్తి చెందితే వినియోగదారుకు పాయింట్లతో రివార్డ్ చేయబడుతుంది. ఉదా. doc.status == &#39;మూసివేయబడింది&#39;
+",షరతు సంతృప్తి చెందితే వినియోగదారుకు పాయింట్లతో రివార్డ్ చేయబడుతుంది. ఉదా. doc.status == 'మూసివేయబడింది'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: సమర్పించిన రికార్డ్ తొలగించడం సాధ్యం కాదు.
 DocType: GSuite Templates,Template Name,టెంప్లేట్ పేరు
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,పత్రం యొక్క కొత్త రకం
@@ -3064,7 +3064,7 @@ DocType: Dashboard Chart,Chart Type,చార్ట్ రకం
 DocType: DocType,Auto Name,ఆటో పేరు
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,వారు అంచనా సులువుగా గా ABC లేదా 6543 వంటి సన్నివేశాలు మానుకోండి
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,దయచేసి మళ్ళీ ప్రయత్నించండి
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL తప్పనిసరిగా &#39;http: //&#39; లేదా &#39;https: //&#39; తో ప్రారంభించాలి
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL తప్పనిసరిగా 'http: //' లేదా 'https: //' తో ప్రారంభించాలి
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,ఎంపిక 3
 DocType: Communication,uid,యుఐడి
 DocType: Workflow State,Edit,మార్చు
@@ -3300,7 +3300,7 @@ DocType: Notification,Send alert if this field's value changes,ఈ ఫీల్�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,థీమ్ రంగులు
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,ఒక కొత్త ఫార్మాట్ చేయడానికి ఒక DOCTYPE ఎంచుకోండి
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,వినియోగదారు ఉనికిలో లేరు
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;గ్రహీతలు&#39; పేర్కొనబడలేదు
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'గ్రహీతలు' పేర్కొనబడలేదు
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,ఇప్పుడే
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,వర్తించు
 DocType: Footer Item,Policy,విధానం
@@ -3346,7 +3346,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,కస్టమ�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,ప్రోగ్రెస్
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,పాత్ర ద్వారా
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,మిస్సింగ్ ఫీల్డ్స్
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,చెల్లని FIELDNAME &#39;{0}&#39; autoname లో
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,చెల్లని FIELDNAME '{0}' autoname లో
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,డాక్యుమెంట్ టైప్ లో శోధన
 DocType: Custom DocPerm,Role and Level,పాత్ర మరియు లెవెల్
 DocType: File,Thumbnail URL,సూక్ష్మచిత్రం URL
@@ -3434,11 +3434,11 @@ DocType: Dashboard Chart,Filters JSON,ఫిల్టర్లు JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,ధ్రువీకరించడం ఇక్కడ క్లిక్ చేయండి
 DocType: Email Account,Disable SMTP server authentication,SMTP సర్వర్ ప్రామాణీకరణను నిలిపివేయండి
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,క్లిప్‌బోర్డ్‌కు కాపీ చేయబడింది.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,బదులుగా వంటి ఊహాజనిత ప్రత్యామ్నాయాలను &#39;@&#39; &#39;ఒక&#39; చాలా సహాయం లేదు.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,బదులుగా వంటి ఊహాజనిత ప్రత్యామ్నాయాలను '@' 'ఒక' చాలా సహాయం లేదు.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,నా అప్పగించింది
 apps/frappe/frappe/utils/data.py,Zero,జీరో
 DocType: Google Drive,Backup Folder ID,బ్యాకప్ ఫోల్డర్ ID
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,లేదు డెవలపర్ మోడ్లో! Site_config.json సెట్ లేదా &#39;కస్టమ్&#39; DOCTYPE చేస్తాయి.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,లేదు డెవలపర్ మోడ్లో! Site_config.json సెట్ లేదా 'కస్టమ్' DOCTYPE చేస్తాయి.
 DocType: Workflow State,globe,భూగోళం
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,ప్రాధాన్య
@@ -3485,7 +3485,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,చెల్లే మొబైల్ nos నమోదు చేయండి
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,లక్షణాలు కొన్ని మీ బ్రౌజర్లో పని చేయకపోవచ్చు. దయచేసి తాజా వెర్షన్ మీ బ్రౌజర్ అప్డేట్.
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,లక్షణాలు కొన్ని మీ బ్రౌజర్లో పని చేయకపోవచ్చు. దయచేసి తాజా వెర్షన్ మీ బ్రౌజర్ అప్డేట్.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",తెలియదు అడగండి &#39;సహాయం&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",తెలియదు అడగండి 'సహాయం'
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ఈ పత్రాన్ని రద్దు చేసింది {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,వ్యాఖ్యలు మరియు కమ్యూనికేషన్స్ ముడిపెట్టారు పత్రం సంబంధం ఉంటుంది
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,ఫిల్టర్ చెయ్యి ...
@@ -3514,7 +3514,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,సబ్స్క్రిప్షన్ను సవరించేటప్పుడు విఫలమైంది
 DocType: LDAP Settings,LDAP Group Field,LDAP గ్రూప్ ఫీల్డ్
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,సమానం
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',రంగంలో ఐచ్ఛికాలు &#39;డైనమిక్ లింక్&#39; రకం &#39;DOCTYPE&#39; వంటి ఎంపికలు మరొక లింక్ ఫీల్డ్ సూచిస్తుంది ఉండాలి
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',రంగంలో ఐచ్ఛికాలు 'డైనమిక్ లింక్' రకం 'DOCTYPE' వంటి ఎంపికలు మరొక లింక్ ఫీల్డ్ సూచిస్తుంది ఉండాలి
 DocType: About Us Settings,Team Members Heading,శీర్షిక జట్టు సభ్యులు
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,చెల్లని CSV ఫార్మాట్
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ ట్రే అనువర్తనానికి కనెక్ట్ చేయడంలో లోపం ... <br><br> రా ప్రింట్ ఫీచర్‌ను ఉపయోగించడానికి మీరు QZ ట్రే అప్లికేషన్‌ను ఇన్‌స్టాల్ చేసి అమలు చేయాలి. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ ట్రేని డౌన్‌లోడ్ చేసి, ఇన్‌స్టాల్ చేయడానికి ఇక్కడ క్లిక్ చేయండి</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">రా ప్రింటింగ్ గురించి మరింత తెలుసుకోవడానికి ఇక్కడ క్లిక్ చేయండి</a> ."
@@ -3640,8 +3640,8 @@ DocType: Web Page,Web Page,వెబ్ పుట
 DocType: Workflow Document State,Next Action Email Template,తదుపరి యాక్షన్ ఇమెయిల్ మూస
 DocType: Blog Category,Blogger,బ్లాగర్
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","ప్రారంభించబడితే, పత్రంలో మార్పులు ట్రాక్ చేయబడతాయి మరియు కాలక్రమంలో చూపబడతాయి"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;గ్లోబల్ సెర్చ్&#39; రకం కోసం అనుమతి లేదు {0} వరుసగా {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;గ్లోబల్ సెర్చ్&#39; రకం కోసం అనుమతి లేదు {0} వరుసగా {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'గ్లోబల్ సెర్చ్' రకం కోసం అనుమతి లేదు {0} వరుసగా {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'గ్లోబల్ సెర్చ్' రకం కోసం అనుమతి లేదు {0} వరుసగా {1}
 DocType: Energy Point Log,Appreciation,ప్రశంసతో
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,జాబితా వీక్షణ
 DocType: Workflow,Don't Override Status,స్థితి భర్తీ లేదు
@@ -3783,7 +3783,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,డిఫాల్ట్
 DocType: Translation,Verified,నిర్థారించబడింది
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} జోడించారు
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',కోసం శోధన &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',కోసం శోధన '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,మొదటి నివేదిక సేవ్ చేయండి
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} చందాదారులు జోడించారు
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,లో Not
@@ -3819,14 +3819,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,నాక�
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} అనేది సరైన రాష్ట్రం
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,అన్ని పత్రాల రకానికి వర్తించండి
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,ఎనర్జీ పాయింట్ నవీకరణ
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. పేపాల్ ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',దయచేసి మరో చెల్లింపు పద్ధతిని ఎంచుకోండి. పేపాల్ ద్రవ్యంలో లావాదేవీలు మద్దతు లేదు '{0}'
 DocType: Chat Message,Room Type,గది రకం
 DocType: Data Import Beta,Import Log Preview,లాగ్ పరిదృశ్యాన్ని దిగుమతి చేయండి
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,శోధన రంగంలో {0} చెల్లుబాటు కాదు
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,అప్‌లోడ్ చేసిన ఫైల్
 DocType: Workflow State,ok-circle,ok సర్కిల్
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP వినియోగదారు సృష్టి మరియు మ్యాపింగ్
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',మీరు &#39;వినియోగదారులు నారింజ కనుగొనేందుకు&#39; అడగడం ద్వారా విషయాలు తెలుసుకోవచ్చు
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',మీరు 'వినియోగదారులు నారింజ కనుగొనేందుకు' అడగడం ద్వారా విషయాలు తెలుసుకోవచ్చు
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,క్షమించాలి! వాడుకరి వారి సొంత రికార్డు పూర్తి అందుబాటుని కలిగి ఉండాలి.
 ,Usage Info,వాడుక సమాచారం
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,కీబోర్డ్ సత్వరమార్గాలను చూపించు

--- a/frappe/translations/th.csv
+++ b/frappe/translations/th.csv
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),สถิติขึ้นอยู่กับประสิทธิภาพของสัปดาห์ที่ผ่านมา (จาก {0} ถึง {1})
 DocType: LDAP Settings,LDAP Phone Field,ฟิลด์โทรศัพท์ LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",ประเภทของเอกสาร ... ลูกค้าเช่น
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,สภาพ &#39;{0}&#39; ไม่ถูกต้อง
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,สภาพ '{0}' ไม่ถูกต้อง
 DocType: Workflow State,barcode,บาร์โค้ด
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,การใช้ข้อความค้นหาย่อยหรือฟังก์ชันถูก จำกัด ไว้
 apps/frappe/frappe/config/customization.py,Add your own translations,เพิ่มการแปลของคุณเอง
@@ -778,7 +778,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,แบ่งปันเอกสารรายงาน
 DocType: Social Login Key,Base URL,URL พื้นฐาน
 DocType: User,Last Login,เข้าสู่ระบบล่าสุด
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},คุณไม่สามารถตั้งค่า &#39;แปลได้&#39; สำหรับฟิลด์ {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},คุณไม่สามารถตั้งค่า 'แปลได้' สำหรับฟิลด์ {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,คอลัมน์
 DocType: Chat Profile,Chat Profile,โปรไฟล์แชท
 DocType: Custom Field,Adds a custom field to a DocType,เพิ่มฟิลด์ที่กำหนดเองเพื่อ DocType
@@ -787,7 +787,7 @@ DocType: File,Is Home Folder,เป็นโฟลเดอร์แรก
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,สไตล์ Navbar
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ไม่ได้เป็นที่อยู่อีเมลที่ถูกต้อง
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,เลือกอย่างน้อย 1 รายการสำหรับการพิมพ์
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ผู้ใช้ &#39;{0}&#39; แล้วมีบทบาท &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',ผู้ใช้ '{0}' แล้วมีบทบาท '{1}'
 DocType: System Settings,Two Factor Authentication method,วิธีการตรวจสอบความถูกต้องของปัจจัยสองตัว
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,ก่อนตั้งชื่อและบันทึกข้อมูล
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 จำนวน
@@ -1457,7 +1457,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,ฟิลด์บังคับ: กำหนดบทบาท
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} ถูกวิพากษ์วิจารณ์ {1}
 DocType: Data Migration Mapping,Mapping Name,ชื่อการแม็ป
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ฟิลด์ &#39;{1}&#39; ไม่สามารถตั้งค่าเป็นไม่ซ้ำเนื่องจากมีค่าที่ไม่ซ้ำกัน
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: ฟิลด์ '{1}' ไม่สามารถตั้งค่าเป็นไม่ซ้ำเนื่องจากมีค่าที่ไม่ซ้ำกัน
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,นำทางรายการลง
 DocType: Currency,A symbol for this currency. For e.g. $,สัญลักษณ์สำหรับสกุลเงินนี้. ตัวอย่างเช่น $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,อัปเดตการแปลสำเร็จแล้ว
@@ -1980,7 +1980,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,AP-ตะวันออกเฉียงใต้-1
 DocType: DocType,"Must be of type ""Attach Image""",ต้องเป็นชนิด &quot;แนบรูปภาพ&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,ไม่เลือกทั้งหมด
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},คุณไม่สามารถล้าง &#39;อ่านอย่างเดียว&#39; สำหรับเขตข้อมูล {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},คุณไม่สามารถล้าง 'อ่านอย่างเดียว' สำหรับเขตข้อมูล {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,ศูนย์หมายถึงการส่งบันทึกการปรับปรุงตลอดเวลา
 DocType: Auto Email Report,Zero means send records updated at anytime,ศูนย์หมายถึงการส่งบันทึกการปรับปรุงตลอดเวลา
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,การติดตั้ง เสร็จสมบูรณ์
@@ -2025,7 +2025,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",ถ้า คำแนะนำเหล่านี้ ที่ ไม่เป็นประโยชน์ โปรดเพิ่ม ใน คำแนะนำของคุณ เกี่ยวกับ GitHub ปัญหา
 DocType: Workflow State,bookmark,คั่น
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ชื่อโฟลเดอร์ไม่ควรมี &#39;/&#39; (เฉือน)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),ชื่อโฟลเดอร์ไม่ควรมี '/' (เฉือน)
 DocType: Note,Note,หมายเหตุ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,รายงานข้อผิดพลาด
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,ส่งออกข้อมูลในรูปแบบ CSV / Excel
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,หมดอาย�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",ฟิลด์นี้จะปรากฏเฉพาะถ้า fieldname ที่กำหนดไว้ที่นี่มีค่าหรือกฎระเบียบที่เป็นจริง (ตัวอย่าง): myfield EVAL: doc.myfield == &#39;ค่าของฉัน&#39; EVAL: doc.age> 18
+eval:doc.age>18",ฟิลด์นี้จะปรากฏเฉพาะถ้า fieldname ที่กำหนดไว้ที่นี่มีค่าหรือกฎระเบียบที่เป็นจริง (ตัวอย่าง): myfield EVAL: doc.myfield == 'ค่าของฉัน' EVAL: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ในวันนี้
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ในวันนี้
@@ -2171,7 +2171,7 @@ DocType: Data Migration Connector,Database Name,ชื่อฐานข้อ�
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,แบบฟอร์มรีเฟรช
 DocType: DocField,Select,เลือก
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,ดูบันทึกเต็ม
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Python Expression, ตัวอย่าง: status == &#39;Open&#39; และ type == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Python Expression, ตัวอย่าง: status == 'Open' และ type == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,ไฟล์ ที่แนบมา ไม่ได้
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,การเชื่อมต่อสูญหาย คุณลักษณะบางอย่างอาจไม่ทำงาน
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",ซ้ำเช่น &quot;AAA&quot; เป็นเรื่องง่ายที่จะคาดเดา
@@ -2303,7 +2303,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,แสดงเฉพาะข้อผิดพลาด
 DocType: Website Settings,Banner HTML,แบนเนอร์ HTML
 DocType: Workflow,Send Email Alert,ส่งการแจ้งเตือนทางอีเมล
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอีกครั้ง Razorpay ไม่สนับสนุนการทำธุรกรรมในสกุลเงิน &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอีกครั้ง Razorpay ไม่สนับสนุนการทำธุรกรรมในสกุลเงิน '{0}'
 DocType: Data Import,In Progress,กำลังดำเนินการ
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,จัดคิวสำหรับการสำรองข้อมูล มันอาจใช้เวลาไม่กี่นาทีถึงหนึ่งชั่วโมง
 DocType: Error Snapshot,Pyver,Pyver
@@ -2730,7 +2730,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,แก้ไขเพ�
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,การตั้งค่าเกตเวย์การชำระเงิน PayPal
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,นักแสดงยอดนิยม
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,ไม่สามารถเพิ่มฟิลด์ที่กำหนดเองลงใน DocTypes หลัก
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: &quot;{1} &#39;({3}) จะได้รับการตัดเป็นตัวอักษรสูงสุดที่อนุญาตคือ {2}
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: &quot;{1} '({3}) จะได้รับการตัดเป็นตัวอักษรสูงสุดที่อนุญาตคือ {2}
 DocType: OAuth Client,Response Type,พิมพ์คำตอบ
 DocType: Contact Us Settings,Send enquiries to this email address,ส่งคำถาม ไปยังที่อยู่ อีเมลนี้
 DocType: Letter Head,Letter Head Name,ชื่อหัวจดหมาย
@@ -2787,7 +2787,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,ดูภาพ
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.",ดูเหมือนว่าสิ่งที่ผิดพลาดในระหว่างการทำธุรกรรม เนื่องจากเรายังไม่ได้รับการยืนยันการชำระเงินผ่าน Paypal โดยอัตโนมัติจะคืนเงินให้คุณเงินจำนวนนี้ ถ้ามันไม่ได้โปรดส่งอีเมลถึงเราและพูดถึงความสัมพันธ์ ID: {0}
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password",รวมสัญลักษณ์ตัวเลขและตัวพิมพ์ใหญ่ในรหัสผ่าน
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",ใส่หลังจากฟิลด์ &#39;{0}&#39; กล่าวถึงในฟิลด์ที่กำหนดเอง &#39;{1}&#39; ที่มีป้าย &#39;{2}&#39; ไม่ได้อยู่
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",ใส่หลังจากฟิลด์ '{0}' กล่าวถึงในฟิลด์ที่กำหนดเอง '{1}' ที่มีป้าย '{2}' ไม่ได้อยู่
 DocType: List Filter,List Filter,ตัวกรองรายการ
 DocType: Workflow State,signal,สัญญาณ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,มีไฟล์แนบ
@@ -2811,15 +2811,15 @@ DocType: Web Page,Slideshow,สไลด์โชว์
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,แม่แบบเริ่มต้นที่อยู่ไม่สามารถลบได้
 DocType: Contact,Maintenance Manager,ผู้จัดการซ่อมบำรุง
 DocType: Workflow State,Search,ค้นหา
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอื่น แถบไม่รองรับธุรกรรมในสกุลเงิน &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอื่น แถบไม่รองรับธุรกรรมในสกุลเงิน &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอื่น แถบไม่รองรับธุรกรรมในสกุลเงิน '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอื่น แถบไม่รองรับธุรกรรมในสกุลเงิน '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ย้ายไปที่ถังขยะ
 DocType: Web Form,Web Form Fields,ช่องข้อมูลเว็บฟอร์ม
 DocType: Data Import,Amended From,แก้ไขเพิ่มเติมจาก
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},คำเตือน: ไม่พบ {0} ในตารางใด ๆ ที่เกี่ยวข้องกับการ {1}
 DocType: S3 Backup Settings,eu-north-1,EU-เฉียงเหนือ 1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,เอกสารฉบับนี้ถูกจัดคิวสำหรับการดำเนินการในขณะนี้ กรุณาลองอีกครั้ง
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File &#39;{0}&#39; ไม่พบ
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File '{0}' ไม่พบ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,นำมาตรา
 DocType: User,Change Password,เปลี่ยนรหัสผ่าน
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,ฟิลด์ Axis X
@@ -3009,7 +3009,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,ค่าที่�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,เพิ่ม เด็ก
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,นำเข้าความคืบหน้า
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",หากเงื่อนไขเป็นที่พอใจของผู้ใช้จะได้รับการตอบแทนด้วยคะแนน เช่น. doc.status == &#39;ปิด&#39;
+",หากเงื่อนไขเป็นที่พอใจของผู้ใช้จะได้รับการตอบแทนด้วยคะแนน เช่น. doc.status == 'ปิด'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: รายการที่ส่งแล้วไม่สามารถลบได้
 DocType: GSuite Templates,Template Name,ชื่อเทมเพลต
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,ชนิดใหม่ของเอกสาร
@@ -3142,7 +3142,7 @@ DocType: Dashboard Chart,Chart Type,ประเภทแผนภูมิ
 DocType: DocType,Auto Name,ชื่ออัตโนมัติ
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,หลีกเลี่ยงการลำดับเช่น ABC หรือ 6543 ที่พวกเขาเป็นเรื่องง่ายที่จะคาดเดา
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,กรุณาลองอีกครั้ง
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL ต้องเริ่มต้นด้วย &#39;http: //&#39; หรือ &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL ต้องเริ่มต้นด้วย 'http: //' หรือ 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,ตัวเลือกที่ 3
 DocType: Communication,uid,UID
 DocType: Workflow State,Edit,แก้ไข
@@ -3381,7 +3381,7 @@ DocType: Notification,Send alert if this field's value changes,ส่งกา�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,ธีมสี
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,เลือก DocType ที่จะทำให้รูปแบบใหม่
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,ไม่มีผู้ใช้
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;ผู้รับ&#39; ไม่ได้ระบุ
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'ผู้รับ' ไม่ได้ระบุ
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,เมื่อสักครู่
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,ใช้
 DocType: Footer Item,Policy,นโยบาย
@@ -3430,7 +3430,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,คำที่�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,ความคืบหน้า
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,โดยบทบาท
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,ทุ่งนาที่ขาดหายไป
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname ไม่ถูกต้อง &#39;{0}&#39; ใน autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,fieldname ไม่ถูกต้อง '{0}' ใน autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ค้นหาในรูปแบบเอกสาร
 DocType: Custom DocPerm,Role and Level,บทบาท และ ระดับ
 DocType: File,Thumbnail URL,URL รูปขนาดย่อ
@@ -3531,7 +3531,7 @@ DocType: Dashboard Chart,Filters JSON,กรอง JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,คลิกที่นี่เพื่อตรวจสอบ
 DocType: Email Account,Disable SMTP server authentication,ปิดใช้งานการรับรองความถูกต้องเซิร์ฟเวอร์ SMTP
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,คัดลอกไปที่คลิปบอร์ดแล้ว
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,แทนคาดเดาได้เช่น &#39;@&#39; แทน &#39;a&#39; ไม่ได้ช่วยมาก
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,แทนคาดเดาได้เช่น '@' แทน 'a' ไม่ได้ช่วยมาก
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,ได้รับมอบหมายจากฉัน
 apps/frappe/frappe/utils/data.py,Zero,ศูนย์
 DocType: Google Drive,Backup Folder ID,ID โฟลเดอร์สำรอง
@@ -3893,7 +3893,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,ผิดนัด
 DocType: Translation,Verified,ได้รับการยืนยัน
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} เพิ่มแล้ว
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ค้นหา &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',ค้นหา '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,กรุณาบันทึกรายงานครั้งแรก
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} สมาชิกถูกเพิ่มแล้ว
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,ไม่อยู่ใน
@@ -3930,14 +3930,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,ฉัน
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} สถานะไม่ถูกต้อง
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,นำไปใช้กับเอกสารทุกประเภท
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,อัพเดตจุดพลังงาน
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอีกครั้ง PayPal ไม่สนับสนุนการทำธุรกรรมในสกุลเงิน &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',โปรดเลือกวิธีการชำระเงินอีกครั้ง PayPal ไม่สนับสนุนการทำธุรกรรมในสกุลเงิน '{0}'
 DocType: Chat Message,Room Type,ประเภทห้อง
 DocType: Data Import Beta,Import Log Preview,นำเข้าบันทึกตัวอย่าง
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,ช่องค้นหา {0} ไม่ถูกต้อง
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,อัพโหลดไฟล์
 DocType: Workflow State,ok-circle,ok วงกลม
 DocType: LDAP Settings,LDAP User Creation and Mapping,การสร้างและการแมปผู้ใช้ LDAP
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',คุณสามารถค้นหาสิ่งที่โดยขอให้ &#39;พบส้มของลูกค้า
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',คุณสามารถค้นหาสิ่งที่โดยขอให้ 'พบส้มของลูกค้า
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,ขออภัย! ผู้ใช้ควรมีการเข้าถึงที่สมบูรณ์ในการบันทึกของตัวเองของพวกเขา
 ,Usage Info,ข้อมูลการใช้งาน
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,แสดงแป้นพิมพ์ลัด

--- a/frappe/translations/th.csv
+++ b/frappe/translations/th.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,การ�
 DocType: DocField,In Global Search,ในการค้นหาทั่วโลก
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,เยื้องซ้าย
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} ปีที่แล้ว
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} ปีที่แล้ว
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,มันเป็นความเสี่ยงที่จะลบไฟล์นี้: {0} โปรดติดต่อผู้จัดการของระบบ
 DocType: Currency,Currency Name,ชื่อสกุล
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,ไม่มีอีเมล์
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,ไม่ม�
 apps/frappe/frappe/config/customization.py,Add custom forms.,เพิ่มรูปแบบที่กำหนดเอง
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} ใน {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ส่งเอกสารนี้
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,ตั้งค่า&gt; สิทธิ์ผู้ใช้
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,ตั้งค่า> สิทธิ์ผู้ใช้
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,ระบบให้ บทบาท ที่กำหนดไว้ล่วงหน้า หลาย คุณสามารถเพิ่ม บทบาทใหม่ เพื่อกำหนดสิทธิ์ ปลีกย่อย
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",หากผู้ใช้มีบทบาทในการตรวจสอบใด ๆ จากนั้นผู้ใช้จะกลายเป็น &quot;ผู้ใช้ระบบ&quot; &quot;ระบบของผู้ใช้&quot; มีการเข้าถึงเดสก์ทอป
 DocType: System Settings,Date and Number Format,วันที่และ รูปแบบตัวเลข
 apps/frappe/frappe/model/document.py,one of,หนึ่งใน
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,ตั้งค่า&gt; ปรับแต่งฟอร์ม
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,ตั้งค่า> ปรับแต่งฟอร์ม
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,ตรวจสอบช่วงเวลาหนึ่ง
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,แสดงแท็ก
 DocType: DocField,HTML Editor,ตัวแก้ไข HTML
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,การเรียกเก็บเงิน
 DocType: Email Queue,Not Sent,ส่งไม่ได้
 DocType: Web Form,Actions,การดำเนินการ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,ตั้งค่า&gt; ผู้ใช้
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,ตั้งค่า> ผู้ใช้
 DocType: Workflow State,align-justify,จัดแสดงให้เห็นถึง-
 DocType: User,Middle Name (Optional),ชื่อกลาง (ถ้ามี)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,ไม่อนุญาต
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,เป็นมาตรฐาน
 DocType: Desktop Icon,_report,_รายงาน
 DocType: Desktop Icon,_report,_รายงาน
 DocType: Dashboard Chart,Full,เต็ม
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",ไม่ได้แท็ก HTML เข้ารหัส HTML เช่น &lt;script&gt; หรือเพียงแค่ตัวอักษรเช่น &lt;หรือ&gt; ขณะที่พวกเขาสามารถนำมาใช้โดยเจตนาในด้านนี้
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",ไม่ได้แท็ก HTML เข้ารหัส HTML เช่น &lt;script> หรือเพียงแค่ตัวอักษรเช่น &lt;หรือ> ขณะที่พวกเขาสามารถนำมาใช้โดยเจตนาในด้านนี้
 DocType: Website Settings,FavIcon,favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,วิ่ง
 DocType: Blog Post,Content (HTML),เนื้อหา (HTML)
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ส่วนท�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,คาราคาซัง
 DocType: System Settings,Allow only one session per user,อนุญาตให้เพียงหนึ่งในเซสชั่นต่อผู้ใช้
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,หน้าแรก / โฟลเดอร์ทดสอบ 1 / โฟลเดอร์ทดสอบ 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,เลือกหรือลากผ่านช่วงเวลาที่จะสร้างเหตุการณ์ใหม่
 DocType: Contact,Contact Details,รายละเอียดการติดต่อ
 DocType: DocField,In Filter,กรอง
@@ -2042,7 +2042,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,เข้าสู่ระบบ ไม่ได้รับอนุญาต ในเวลานี้
 DocType: Data Migration Run,Current Mapping Action,การทำแผนที่การทำแผนที่ปัจจุบัน
 DocType: Dashboard Chart Source,Source Name,แหล่งที่มาของชื่อ
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,ไม่มีบัญชีอีเมลที่เชื่อมโยงกับผู้ใช้ โปรดเพิ่มบัญชีภายใต้ผู้ใช้&gt; กล่องจดหมายอีเมล
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,ไม่มีบัญชีอีเมลที่เชื่อมโยงกับผู้ใช้ โปรดเพิ่มบัญชีภายใต้ผู้ใช้> กล่องจดหมายอีเมล
 DocType: Email Account,Email Sync Option,อีเมล์ตัวเลือกการซิงค์
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,หมายเลขแถว
 DocType: Async Task,Runtime,Runtime
@@ -2057,7 +2057,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,อยู
 DocType: User Email,Enable Outgoing,เปิดใช้งานขาออก
 DocType: Address,Fax,แฟกซ์
 apps/frappe/frappe/config/customization.py,Custom Tags,แท็กที่กำหนดเอง
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ไม่ได้ตั้งค่าบัญชีอีเมล โปรดสร้างบัญชีอีเมลใหม่จากการตั้งค่า&gt; อีเมล&gt; บัญชีอีเมล
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ไม่ได้ตั้งค่าบัญชีอีเมล โปรดสร้างบัญชีอีเมลใหม่จากการตั้งค่า> อีเมล> บัญชีอีเมล
 DocType: Comment,Submitted,Submitted
 DocType: Contact,Pulled from Google Contacts,ดึงจาก Google Contacts
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,ในคำขอที่ถูกต้อง
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,หมดอาย�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",ฟิลด์นี้จะปรากฏเฉพาะถ้า fieldname ที่กำหนดไว้ที่นี่มีค่าหรือกฎระเบียบที่เป็นจริง (ตัวอย่าง): myfield EVAL: doc.myfield == &#39;ค่าของฉัน&#39; EVAL: doc.age&gt; 18
+eval:doc.age>18",ฟิลด์นี้จะปรากฏเฉพาะถ้า fieldname ที่กำหนดไว้ที่นี่มีค่าหรือกฎระเบียบที่เป็นจริง (ตัวอย่าง): myfield EVAL: doc.myfield == &#39;ค่าของฉัน&#39; EVAL: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ในวันนี้
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,ในวันนี้
@@ -2146,7 +2146,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,UPPER CASE
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,ที่กำหนดเอง HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,ป้อนชื่อโฟลเดอร์
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,ไม่พบเทมเพลตที่อยู่เริ่มต้น โปรดสร้างอันใหม่จากการตั้งค่า&gt; การพิมพ์และการสร้างแบรนด์&gt; เทมเพลตที่อยู่
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,ไม่พบเทมเพลตที่อยู่เริ่มต้น โปรดสร้างอันใหม่จากการตั้งค่า> การพิมพ์และการสร้างแบรนด์> เทมเพลตที่อยู่
 apps/frappe/frappe/auth.py,Unknown User,ผู้ใช้ที่ไม่รู้จัก
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,เลือกบทบาท
 DocType: Comment,Deleted,ที่ถูกลบ
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ไม่ได้รับอนุญาตเพียงพอสำหรับการดูลิงก์
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ที่อยู่ ชื่อเรื่อง มีผลบังคับใช้
 DocType: Google Contacts,Push to Google Contacts,กดไปที่ Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",เพิ่ม HTML ในส่วน &lt;head&gt; ของหน้าเว็บส่วนใหญ่ใช้สำหรับการตรวจสอบเว็บไซต์และ SEO
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",เพิ่ม HTML ในส่วน &lt;head> ของหน้าเว็บส่วนใหญ่ใช้สำหรับการตรวจสอบเว็บไซต์และ SEO
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,อาการกำเริบ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,รายการที่ ไม่สามารถเพิ่ม ไปยัง ลูกหลาน ของตัวเอง
 DocType: Session Default Settings,Session Defaults,ค่าเริ่มต้นของเซสชัน
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,คำเตือน
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,สิ่งนี้อาจถูกพิมพ์บนหลาย ๆ หน้า
 DocType: Data Migration Run,Percent Complete,เปอร์เซ็นต์ที่สมบูรณ์
 DocType: Tag Category,Tag Category,แท็กหมวดหมู่
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","สำหรับการเปรียบเทียบให้ใช้&gt; 5, &lt;10 หรือ = 324 สำหรับช่วงใช้ 5:10 (สำหรับค่าระหว่าง 5 และ 10)"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","สำหรับการเปรียบเทียบให้ใช้> 5, &lt;10 หรือ = 324 สำหรับช่วงใช้ 5:10 (สำหรับค่าระหว่าง 5 และ 10)"
 DocType: Google Calendar,Pull from Google Calendar,ดึงจาก Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ช่วย
 DocType: User,Login Before,เข้าสู่ระบบก่อน
@@ -2925,7 +2925,7 @@ DocType: Custom Script,Custom Script,สคริปต์ที่กำหน�
 DocType: Address,Address Line 2,ที่อยู่บรรทัดที่ 2
 DocType: Address,Reference,การอ้างอิง
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,มอบหมายให้
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,โปรดตั้งค่าบัญชีอีเมลเริ่มต้นจากตั้งค่า&gt; อีเมล&gt; บัญชีอีเมล
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,โปรดตั้งค่าบัญชีอีเมลเริ่มต้นจากตั้งค่า> อีเมล> บัญชีอีเมล
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,การทำแผนที่การโยกย้ายข้อมูลรายละเอียด
 DocType: Data Import,Action,ดำเนินการ
 DocType: GSuite Settings,Script URL,URL ของสคริปต์
@@ -3022,7 +3022,7 @@ DocType: S3 Backup Settings,us-east-1,เราตะวันออก-1
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts by {0},โพสต์โดย {0}
 apps/frappe/frappe/core/doctype/report/report.js,"To format columns, give column labels in the query.",การจัดรูปแบบคอลัมน์ให้ป้ายชื่อคอลัมน์ในแบบสอบถาม
 DocType: Has Domain,Has Domain,มีโดเมน
-DocType: User,Allowed In Mentions,ได้รับอนุญาตในการกล่าวถึง
+DocType: User,Allowed In Mentions,ได้รับอนุญาตในการกล่าวถึ���
 apps/frappe/frappe/www/login.html,Don't have an account? Sign up,ไม่ได้มีบัญชีอยู่แล้ว? ลงชื่อ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Cannot remove ID field,ไม่สามารถลบฟิลด์รหัสได้
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Assign Amend if not Submittable,{0} : ไม่สามารถตั้งค่ากำหนดการแก้ไข ถ้าไม่ Submittable
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,อนุญาตให้ส่ง
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,ประเภทยกเว้น
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,เลือกคอลัมน์
-DocType: Web Page,Add code as &lt;script&gt;,เพิ่มรหัสเป็น &lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,เพิ่มรหัสเป็น &lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ล้างการอนุญาตผู้ใช้
 DocType: Webhook,Headers,ส่วนหัว
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,เหตุการณ์ที่จะเกิดขึ้น
@@ -3480,15 +3480,15 @@ DocType: Workflow State,share-alt,หุ้น Alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},คิวควรเป็นหนึ่งใน {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<h4> แม่แบบเริ่มต้น </ h4> 
  <p> ใช้ <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating a และทุกสาขาของที่อยู่ ( รวมถึงฟิลด์ที่กำหนดเองถ้ามี) จะสามารถใช้ได้ </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/th.csv
+++ b/frappe/translations/th.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,เป็นมาตรฐาน
 DocType: Desktop Icon,_report,_รายงาน
 DocType: Desktop Icon,_report,_รายงาน
 DocType: Dashboard Chart,Full,เต็ม
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",ไม่ได้แท็ก HTML เข้ารหัส HTML เช่น &lt;script> หรือเพียงแค่ตัวอักษรเช่น &lt;หรือ> ขณะที่พวกเขาสามารถนำมาใช้โดยเจตนาในด้านนี้
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",ไม่ได้แท็ก HTML เข้ารหัส HTML เช่น <script> หรือเพียงแค่ตัวอักษรเช่น <หรือ> ขณะที่พวกเขาสามารถนำมาใช้โดยเจตนาในด้านนี้
 DocType: Website Settings,FavIcon,favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,วิ่ง
 DocType: Blog Post,Content (HTML),เนื้อหา (HTML)
@@ -1808,7 +1808,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,ส่วนท�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,คาราคาซัง
 DocType: System Settings,Allow only one session per user,อนุญาตให้เพียงหนึ่งในเซสชั่นต่อผู้ใช้
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,หน้าแรก / โฟลเดอร์ทดสอบ 1 / โฟลเดอร์ทดสอบ 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,เลือกหรือลากผ่านช่วงเวลาที่จะสร้างเหตุการณ์ใหม่
 DocType: Contact,Contact Details,รายละเอียดการติดต่อ
 DocType: DocField,In Filter,กรอง
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,ไม่ได้รับอนุญาตเพียงพอสำหรับการดูลิงก์
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ที่อยู่ ชื่อเรื่อง มีผลบังคับใช้
 DocType: Google Contacts,Push to Google Contacts,กดไปที่ Google Contacts
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",เพิ่ม HTML ในส่วน &lt;head> ของหน้าเว็บส่วนใหญ่ใช้สำหรับการตรวจสอบเว็บไซต์และ SEO
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",เพิ่ม HTML ในส่วน <head> ของหน้าเว็บส่วนใหญ่ใช้สำหรับการตรวจสอบเว็บไซต์และ SEO
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,อาการกำเริบ
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,รายการที่ ไม่สามารถเพิ่ม ไปยัง ลูกหลาน ของตัวเอง
 DocType: Session Default Settings,Session Defaults,ค่าเริ่มต้นของเซสชัน
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,คำเตือน
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,สิ่งนี้อาจถูกพิมพ์บนหลาย ๆ หน้า
 DocType: Data Migration Run,Percent Complete,เปอร์เซ็นต์ที่สมบูรณ์
 DocType: Tag Category,Tag Category,แท็กหมวดหมู่
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","สำหรับการเปรียบเทียบให้ใช้> 5, &lt;10 หรือ = 324 สำหรับช่วงใช้ 5:10 (สำหรับค่าระหว่าง 5 และ 10)"
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","สำหรับการเปรียบเทียบให้ใช้> 5, <10 หรือ = 324 สำหรับช่วงใช้ 5:10 (สำหรับค่าระหว่าง 5 และ 10)"
 DocType: Google Calendar,Pull from Google Calendar,ดึงจาก Google Calendar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,ช่วย
 DocType: User,Login Before,เข้าสู่ระบบก่อน
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,อนุญาตให้ส่ง
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,ประเภทยกเว้น
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,เลือกคอลัมน์
-DocType: Web Page,Add code as &lt;script>,เพิ่มรหัสเป็น &lt;script>
+DocType: Web Page,Add code as <script>,เพิ่มรหัสเป็น <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,ล้างการอนุญาตผู้ใช้
 DocType: Webhook,Headers,ส่วนหัว
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,เหตุการณ์ที่จะเกิดขึ้น
@@ -3480,26 +3480,26 @@ DocType: Workflow State,share-alt,หุ้น Alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},คิวควรเป็นหนึ่งใน {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> แม่แบบเริ่มต้น </ h4> 
  <p> ใช้ <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating a และทุกสาขาของที่อยู่ ( รวมถึงฟิลด์ที่กำหนดเองถ้ามี) จะสามารถใช้ได้ </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% ถ้า address_line2%} {{address_line2}} & lt; br & gt; { endif% -%} 
- {{เมือง}} & lt; br & gt; 
- {% หากรัฐ%} {{รัฐ}} & lt; br & gt; {% endif -%} 
- {% ถ้า Pincode%} PIN: {{Pincode}} & lt; br & gt; {% endif -%} 
- {{ประเทศ}} & lt; br & gt; 
- {% ถ้าโทรศัพท์%} โทรศัพท์: {{โทรศัพท์}} & lt; br & gt; { % endif -%} 
- {% ถ้าโทรสาร%} โทรสาร: {{โทรสาร}} & lt; br & gt; {% endif -%} 
- {% ถ้า email_id%} อีเมล์: {{email_id}} & lt; br & gt ; {% endif -%} 
+ <pre> <code> {{address_line1}} <br> 
+ {% ถ้า address_line2%} {{address_line2}} <br> { endif% -%} 
+ {{เมือง}} <br> 
+ {% หากรัฐ%} {{รัฐ}} <br> {% endif -%} 
+ {% ถ้า Pincode%} PIN: {{Pincode}} <br> {% endif -%} 
+ {{ประเทศ}} <br> 
+ {% ถ้าโทรศัพท์%} โทรศัพท์: {{โทรศัพท์}} <br> { % endif -%} 
+ {% ถ้าโทรสาร%} โทรสาร: {{โทรสาร}} <br> {% endif -%} 
+ {% ถ้า email_id%} อีเมล์: {{email_id}} <br> {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,ฟิลด์วันที่เริ่มต้น
 DocType: Role,Role Name,ชื่อบทบาท

--- a/frappe/translations/tr.csv
+++ b/frappe/translations/tr.csv
@@ -784,7 +784,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Dosya yedek
 DocType: DocField,In Global Search,Küresel Ara
 DocType: System Settings,Brute Force Security,Kaba kuvvet güvenlik
 DocType: Workflow State,indent-left,indent-left
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} yıl önce
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} yıl önce
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Bu dosyayı silmek için riskli: {0}. Sistem Yöneticisi irtibata geçiniz.
 DocType: Currency,Currency Name,Para Birimi Adı
 DocType: Currency,Currency Name,Para Birimi Adı
@@ -1091,7 +1091,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Gösterilecek
 apps/frappe/frappe/config/customization.py,Add custom forms.,Özelleştirilmiş formlar ekle
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} içinde {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,Bu belgeyi ibraz
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Kurulum&gt; Kullanıcı İzinleri
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Kurulum> Kullanıcı İzinleri
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Sistem birçok önceden tanımlı roller sağlar. Sen ince izinlerini ayarlamak için yeni roller ekleyebilir.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1322,7 +1322,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Eğer bir kullanıcı için herhangi bir Rol seçildiyse, kullanıcı ""Sistem Kullanıcısı"" olur. ""Sistem Kullanıcısı"" masaüstüne erişim hakkına sahiptir."
 DocType: System Settings,Date and Number Format,Tarih ve Sayı Biçimi
 apps/frappe/frappe/model/document.py,one of,Bir
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Kurulum&gt; Formu Özelleştir
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Kurulum> Formu Özelleştir
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,bir an denetleniyor
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Etiketleri Göster
 DocType: DocField,HTML Editor,HTML Editör
@@ -1331,7 +1331,7 @@ DocType: Address,Billing,Faturalama
 DocType: Address,Billing,Faturalama
 DocType: Email Queue,Not Sent,Gönderilen Değil
 DocType: Web Form,Actions,Eylemler
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Kurulum&gt; Kullanıcı
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Kurulum> Kullanıcı
 DocType: Workflow State,align-justify,İki Yana Yasla
 DocType: User,Middle Name (Optional),İkinci ad (İsteğe bağlı)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,İzin Değil
@@ -1487,7 +1487,7 @@ DocType: User,System User,Sistem Kullanıcısı
 DocType: Report,Is Standard,Standart mı
 DocType: Desktop Icon,_report,_rapor
 DocType: Dashboard Chart,Full,Tam
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",Do not &lt;script&gt; ya da sadece karakterler kasten bu alanda kullanılan olabilir gibi gibi &lt;veya&gt; gibi HTML Encode HTML etiketleri
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",Do not &lt;script> ya da sadece karakterler kasten bu alanda kullanılan olabilir gibi gibi &lt;veya> gibi HTML Encode HTML etiketleri
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} {1} tarihinde eleştirildi
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,koş
@@ -1884,7 +1884,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Altbilgi yalnızc
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Bekliyor
 DocType: System Settings,Allow only one session per user,Kullanıcı başına yalnızca bir oturuma izin ver
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Ana Sayfa / Test Klasörü 1 / Test Klasör 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;head&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Seçin veya yeni bir etkinlik oluşturmak için zaman dilimleri boyunca sürükleyin.
 DocType: Contact,Contact Details,İletişim Bilgileri
 DocType: DocField,In Filter,Filtre
@@ -2132,7 +2132,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Oturum şu anda izin verilmiyor
 DocType: Data Migration Run,Current Mapping Action,Şu Haritalama İşlemi
 DocType: Dashboard Chart Source,Source Name,kaynak Adı
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Kullanıcı ile ilişkilendirilmiş e-posta hesabı yok. Lütfen Kullanıcı&gt; E-posta Gelen Kutusu altında bir hesap ekleyin.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Kullanıcı ile ilişkilendirilmiş e-posta hesabı yok. Lütfen Kullanıcı> E-posta Gelen Kutusu altında bir hesap ekleyin.
 DocType: Email Account,Email Sync Option,E-posta Eşitleme Seçeneği
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Sıra No
 DocType: Async Task,Runtime,Süre
@@ -2149,7 +2149,7 @@ DocType: User Email,Enable Outgoing,Giden etkinleştirin
 DocType: Address,Fax,Faks
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,özel Etiketler
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,E-posta Hesabı ayarlanmadı. Lütfen Kurulum&gt; E-posta&gt; E-posta Hesabı&#39;ndan yeni bir E-posta Hesabı oluşturun.
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posta Hesabı ayarlanmadı. Lütfen Kurulum> E-posta> E-posta Hesabı&#39;ndan yeni bir E-posta Hesabı oluşturun.
 DocType: Comment,Submitted,Tanzim Edildi
 DocType: Comment,Submitted,Tanzim Edildi
 DocType: Contact,Pulled from Google Contacts,Google Kişilerden Alındı
@@ -2226,7 +2226,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Oturum kapanacak saa
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Burada tanımlanan AlanAdı değeri vardır VEYA kurallar gerçek (örnekler) yalnızca, bu alanı görünür: myField eval: doc.myfield == &#39;Benim Değer&#39; eval: doc.age&gt; 18"
+eval:doc.age>18","Burada tanımlanan AlanAdı değeri vardır VEYA kurallar gerçek (örnekler) yalnızca, bu alanı görünür: myField eval: doc.myfield == &#39;Benim Değer&#39; eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Ofis 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Bugün
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Bugün
@@ -2241,7 +2241,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,BÜYÜK HARF
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Özel HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Klasör adını girin
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Varsayılan Adres Şablonu bulunamadı. Lütfen Kurulum&gt; Yazdırma ve Markalama&gt; Adres Şablonu&#39;ndan yeni bir tane oluşturun.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Varsayılan Adres Şablonu bulunamadı. Lütfen Kurulum> Yazdırma ve Markalama> Adres Şablonu&#39;ndan yeni bir tane oluşturun.
 apps/frappe/frappe/auth.py,Unknown User,Bilinmeyen kullanıcı
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Rol Seçin
 DocType: Comment,Deleted,Silinen
@@ -2434,7 +2434,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Linkleri görmek için yeterli iz yok
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adres Başlığı zorunludur.
 DocType: Google Contacts,Push to Google Contacts,Google Kişileri&#39;ne git
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Web sayfasının  bölümüne, öncelikle web sitesi doğrulaması ve SEO için kullanılan HTML kodları eklendi"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Web sayfasının  bölümüne, öncelikle web sitesi doğrulaması ve SEO için kullanılan HTML kodları eklendi"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nüks
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,"Ürün, kendi soyundan ilave edilemez"
 DocType: Session Default Settings,Session Defaults,Oturum Varsayılanları
@@ -2558,7 +2558,7 @@ DocType: Workflow State,Warning,Uyarı
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Bu birden fazla sayfaya yazdırılabilir
 DocType: Data Migration Run,Percent Complete,Yüzde Tamamlandı
 DocType: Tag Category,Tag Category,Etiket Kategorisi
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Karşılaştırma için,&gt; 5, &lt;10 veya = 324 kullanın. Aralıklar için 5:10 kullanın (5 ve 10 arasındaki değerler için)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Karşılaştırma için,> 5, &lt;10 veya = 324 kullanın. Aralıklar için 5:10 kullanın (5 ve 10 arasındaki değerler için)."
 DocType: Google Calendar,Pull from Google Calendar,Google Takvim’den çekin
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Yardım
 DocType: User,Login Before,Önce Giriş
@@ -3046,7 +3046,7 @@ DocType: Address,Address Line 2,Adres Satırı 2
 DocType: Address,Reference,Referans
 DocType: Address,Reference,Referans
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Atanan
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Lütfen Kurulum&gt; E-posta&gt; E-posta Hesabı&#39;ndan varsayılan E-posta Hesabı&#39;nı ayarlayın.
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Lütfen Kurulum> E-posta> E-posta Hesabı&#39;ndan varsayılan E-posta Hesabı&#39;nı ayarlayın.
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Veri Taşıma Eşleme Ayrıntısı
 DocType: Data Import,Action,Eylem
 DocType: GSuite Settings,Script URL,Komut Dosyası URL&#39;si
@@ -3226,7 +3226,7 @@ DocType: DocField,Allow on Submit,Gönderme Onayı İzni
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,İstisna türü
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Sütunları Seç
-DocType: Web Page,Add code as &lt;script&gt;,Kodu &lt;script&gt; olarak ekle
+DocType: Web Page,Add code as &lt;script>,Kodu &lt;script> olarak ekle
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Kullanıcı İzinlerini Temizle
 DocType: Webhook,Headers,Başlıkları
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Yaklaşan Etkinlikler
@@ -3618,15 +3618,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kuyruk {0} dan biri olmalıdır
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Varsayılan Şablon </ h4> 
  <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja şablonu </a> ve Adres tüm alanları (kullanır {; br & gt;, 
  {% eğer address_line2%} {{address_line2}} & lt; br & gt Özel Alanlar varsa) </ p> 

--- a/frappe/translations/tr.csv
+++ b/frappe/translations/tr.csv
@@ -32,7 +32,7 @@ apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Import Zip,Zip Al
 apps/frappe/frappe/model/base_document.py,Value too big,çok büyük bir değer
 DocType: DocField,DocField,DocField
 DocType: GSuite Settings,Run Script Test,Komut Dosyası Testini Çalıştır
-apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Etkinliğin senkronize edilmesi gereken Google Takvim&#39;i seçin.
+apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Etkinliğin senkronize edilmesi gereken Google Takvim'i seçin.
 DocType: Data Import,Total Rows,Toplam Satır Sayısı
 DocType: Contact,Department,Departman
 DocType: Contact,Department,Departman
@@ -63,8 +63,8 @@ apps/frappe/frappe/model/document.py,Beginning with,ile başlayan
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Veri Alma Şablon
 apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,Oturum Varsayılanları ayarlanırken bir hata oluştu
 apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Ana Kalem
-DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Etkinleştirilirse, şifre kuvveti Minimum Şifre Puanı değerine dayanarak zorlanır. 2&#39;lik bir değer orta derecede güçlü ve 4&#39;ü çok güçlü."
-DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Etkinleştirilirse, şifre kuvveti Minimum Şifre Puanı değerine dayanarak zorlanır. 2&#39;lik bir değer orta derecede güçlü ve 4&#39;ü çok güçlü."
+DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Etkinleştirilirse, şifre kuvveti Minimum Şifre Puanı değerine dayanarak zorlanır. 2'lik bir değer orta derecede güçlü ve 4'ü çok güçlü."
+DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Etkinleştirilirse, şifre kuvveti Minimum Şifre Puanı değerine dayanarak zorlanır. 2'lik bir değer orta derecede güçlü ve 4'ü çok güçlü."
 DocType: About Us Settings,"""Team Members"" or ""Management""","""Takım Üyeleri"" veya ""Yönetim"""
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Alan 'Giriş' türü için varsayılan ya '0' veya '1' olmalı
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Dün
@@ -109,7 +109,7 @@ apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,Portre
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,Ekle
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Google Drive erişim izni
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Select {0},Seçin {0}
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Lütfen Temel URL&#39;yi girin
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,Lütfen Temel URL'yi girin
 DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Etkinleştirilirse, belge, kullanıcı ilk kez açtığında göründüğü gibi işaretlenir"
 DocType: Auto Repeat,Repeat on Day,Günde tekrarlayın
 DocType: DocField,Color,Renk
@@ -165,7 +165,7 @@ apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified aft
 DocType: Address,Himachal Pradesh,Himachal Pradesh
 DocType: System Settings,"If not set, the currency precision will depend on number format","Ayarlanmazsa, para birimi hassaslığı sayı formatına bağlı olacaktır"
 DocType: System Settings,"If not set, the currency precision will depend on number format","Ayarlanmazsa, para birimi hassaslığı sayı formatına bağlı olacaktır"
-apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Awesomebar,Awesomebar&#39;ı açın
+apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Awesomebar,Awesomebar'ı açın
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.","Sunucunun şerit yapılandırmasında bir sorun var gibi görünüyor. Arıza durumunda, tutar hesabınıza iade edilir."
 DocType: Data Import,Import Log,Günlüğü İçe Aktar
 DocType: User Permission,Apply To All Document Types,Tüm Belge Türlerine Uygula
@@ -227,7 +227,7 @@ apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your b
 apps/frappe/frappe/config/desk.py,Event and other calendars.,Olay ve diğer takvimler.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 satır zorunlu)
 apps/frappe/frappe/templates/includes/comments/comments.html,All fields are necessary to submit the comment.,Yorumu göndermek için tüm alanların doldurulması gereklidir.
-DocType: Custom Script,Adds a client custom script to a DocType,Bir DocType&#39;a istemci özel komut dosyası ekler
+DocType: Custom Script,Adds a client custom script to a DocType,Bir DocType'a istemci özel komut dosyası ekler
 DocType: Print Settings,Printer Name,Yazıcı adı
 DocType: Webhook,Form URL-Encoded,Form URL Kodlu
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Genişlikleri px veya% ayarlanabilir.
@@ -302,12 +302,12 @@ DocType: Customize Form Field,"Print Width of the field, if the field is a colum
 DocType: Dropbox Settings,Dropbox Access Key,Dropbox Erişim Anahtarı
 DocType: Dropbox Settings,Dropbox Access Key,Dropbox Erişim Anahtarı
 apps/frappe/frappe/desk/form/utils.py,Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script,Özel komut dosyasının add_fetch yapılandırmasında yanlış alan adı <b>{0}</b>
-apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,Kişinin senkronize edileceği Google Rehber&#39;i seçin.
+apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,Kişinin senkronize edileceği Google Rehber'i seçin.
 DocType: Web Page,Main Section (HTML),Ana Bölüm (HTML)
 DocType: Workflow State,headphones,kulaklık
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Password is required or select Awaiting Password,Şifre gerekli veya Bekleniyor Parola seçmektir
 DocType: Email Account,e.g. replies@yourcomany.com. All replies will come to this inbox.,örneğin replies@yourcomany.com. Tüm yanıtlar bu kutunuza gelecektir.
-DocType: Slack Webhook URL,Slack Webhook URL,Slack Webhook URL&#39;si
+DocType: Slack Webhook URL,Slack Webhook URL,Slack Webhook URL'si
 DocType: Data Migration Run,Current Mapping,Şu Haritalama
 apps/frappe/frappe/templates/includes/login/login.js,Valid email and name required,Gerekli geçerli e-posta ve isim
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Make all attachments private,Tüm ekleri özel yap
@@ -579,14 +579,14 @@ DocType: Dashboard Chart,Half,Yarım
 DocType: Desktop Icon,Link,Bağlantı
 apps/frappe/frappe/utils/file_manager.py,No file attached,Ekli dosya yok
 DocType: Version,Version,Sürüm
-DocType: S3 Backup Settings,Endpoint URL,Bitiş noktası URL&#39;si
+DocType: S3 Backup Settings,Endpoint URL,Bitiş noktası URL'si
 DocType: Dashboard,Charts,Grafikler
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions are automatically applied to Standard Reports and searches.,İzinler standart raporlara ve aramalara otomatik olarak uygulanır.
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,Yükleme başarısız
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Geçen haftaki performansa dayalı istatistikler ({0} - {1} arası)
 DocType: LDAP Settings,LDAP Phone Field,LDAP Telefon Alanı
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",belge türü ... örneğin müşteri
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Durum &#39;{0}&#39; geçersiz
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Durum '{0}' geçersiz
 DocType: Workflow State,barcode,barkod
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Alt sorgu veya işlev kullanımı kısıtlıdır
 apps/frappe/frappe/config/customization.py,Add your own translations,Kendi çevirilerini ekle
@@ -620,7 +620,7 @@ DocType: About Us Settings,Introduce your company to the website visitor.,Web si
 apps/frappe/frappe/utils/password.py,"Encryption key is invalid, Please check site_config.json","Şifreleme anahtarı geçersiz, lütfen site_config.json dosyasını kontrol edin."
 DocType: SMS Settings,Receiver Parameter,Alıcı Parametre
 DocType: SMS Settings,Receiver Parameter,Alıcı Parametre
-apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Toggle Public/Private,Genel / Özel&#39;e Geçiş Yap
+apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Toggle Public/Private,Genel / Özel'e Geçiş Yap
 DocType: Data Migration Mapping Detail,Remote Fieldname,Uzak Alan Adı
 DocType: Communication,To,Şu kişiye
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log_list.js,View Ref,Ref görüntüle
@@ -640,7 +640,7 @@ apps/frappe/frappe/website/doctype/blog_post/blog_post.py,1 comment,1 yorum
 DocType: Website Slideshow,"Note: For best results,  images must be of the same size and width must be greater than height.",Not: En iyi sonucu elde etmek için görüntüler aynı boyutta olmalı ve genişlik yükseklikten büyük olmalıdır.
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,viewed,inceledi
 DocType: Notification,Days Before,Gün Öncesi
-apps/frappe/frappe/desk/doctype/event/event.py,Daily Events should finish on the Same Day.,Günlük Olaylar Aynı Gün&#39;de Bitmelidir.
+apps/frappe/frappe/desk/doctype/event/event.py,Daily Events should finish on the Same Day.,Günlük Olaylar Aynı Gün'de Bitmelidir.
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Edit...,Düzenle...
 DocType: Workflow State,volume-down,volume-down
 apps/frappe/frappe/auth.py,Access not allowed from this IP Address,Bu IP Adresinden erişime izin verilmiyor
@@ -691,7 +691,7 @@ apps/frappe/frappe/utils/jinja.py,Syntax error in template,şablonda sözdizimi 
 DocType: DocField,Width,Genişlik
 apps/frappe/frappe/public/js/frappe/views/communication.js,Message clipped,Mesaj kırpıldı
 DocType: Email Account,Notify if unreplied,Okunmayan eğer bildir
-apps/frappe/frappe/www/qrcode.html,Scan the QR Code and enter the resulting code displayed.,QR Code&#39;u tarayın ve görüntülenen sonuç kodunu girin.
+apps/frappe/frappe/www/qrcode.html,Scan the QR Code and enter the resulting code displayed.,QR Code'u tarayın ve görüntülenen sonuç kodunu girin.
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Enable Gradients,Degradeleri Etkinleştir
 DocType: System Settings,Minimum Password Score,Minimum Şifre Puanı
 DocType: System Settings,Minimum Password Score,Minimum Şifre Puanı
@@ -707,7 +707,7 @@ DocType: Print Format,Default Print Language,Varsayılan Baskı Dili
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Ancestors Of,Ataları
 apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,Kök {0} silinemez
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Henüz yorum yok
-apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings","Lütfen, SMS Ayarları aracılığıyla bir kimlik doğrulama yöntemi olarak ayarlamadan önce SMS&#39;i kurun."
+apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings","Lütfen, SMS Ayarları aracılığıyla bir kimlik doğrulama yöntemi olarak ayarlamadan önce SMS'i kurun."
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,Gerekli Hem DocType ve Adı
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,1-0 docstatus değiştirilemiyor
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,Yeteri kadar puanın yok
@@ -740,11 +740,11 @@ apps/frappe/frappe/twofactor.py,One Time Password (OTP) Registration Code from {
 DocType: DocField,Set Only Once,Sadece bir kez ayarlama
 DocType: Email Queue Recipient,Email Queue Recipient,E-posta Kuyruk Alıcı
 DocType: Address,Nagaland,Nagaland
-DocType: Slack Webhook URL,Webhook URL,Web sayfası URL&#39;si
+DocType: Slack Webhook URL,Webhook URL,Web sayfası URL'si
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Kullanıcı adı {0} zaten mevcut
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: {1} İçeri alınabilir değilse içeri alınabilir işaretlenemez
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Adres Şablon bir hata var {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',"{0}, &#39;Alıcılar&#39; bölümünde geçersiz bir e-posta adresidir"
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',"{0}, 'Alıcılar' bölümünde geçersiz bir e-posta adresidir"
 DocType: Footer Item,"target = ""_blank""","target = ""_blank"""
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,evsahibi
@@ -791,7 +791,7 @@ DocType: Currency,Currency Name,Para Birimi Adı
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,hiçbir e-postalar
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Bağlantı Süresi Doldu
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.","&#39;{1}&#39; içindeki &#39;{2}&#39; için uzunluğu {0} &#39;a geri döndürme; Uzunluğun {3} olarak ayarlanması, verilerin kesilmesine neden olur."
+							Setting the length as {3} will cause truncation of data.","'{1}' içindeki '{2}' için uzunluğu {0} 'a geri döndürme; Uzunluğun {3} olarak ayarlanması, verilerin kesilmesine neden olur."
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Dosya Biçimini Seç
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,İçerik Hash
@@ -804,8 +804,8 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not re
 apps/frappe/frappe/desk/like.py,Liked,Beğendim
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now,Şimdi Gönder
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now,Şimdi Gönder
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standart DocType varsayılan yazdırma biçimine sahip olamaz, Formu Özelleştir&#39;i kullanın"
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standart DocType varsayılan yazdırma biçimine sahip olamaz, Formu Özelleştir&#39;i kullanın"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standart DocType varsayılan yazdırma biçimine sahip olamaz, Formu Özelleştir'i kullanın"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standart DocType varsayılan yazdırma biçimine sahip olamaz, Formu Özelleştir'i kullanın"
 DocType: Report,Query,Sorgu
 DocType: Customize Form,Sort Order,Sıralama
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},'Liste görüntüle' izin türü için {0} üst üste {1}
@@ -814,7 +814,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Belge Paylaş Raporu
 DocType: Social Login Key,Base URL,Temel URL
 DocType: User,Last Login,Son Giriş
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},{0} alanına &#39;Çevrilemez&#39; ayarını yapamazsınız
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},{0} alanına 'Çevrilemez' ayarını yapamazsınız
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Sütun
 DocType: Chat Profile,Chat Profile,Sohbet Profili
 DocType: Custom Field,Adds a custom field to a DocType,Bir DocType için özel bir alan ekler
@@ -823,7 +823,7 @@ DocType: File,Is Home Folder,Home Folder mı
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar Stili
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} geçerli bir e-posta adresi değil
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,baskı için en az 1 kayıt seçin
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Kullanıcı &#39;{0}&#39; zaten bir role sahip &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Kullanıcı '{0}' zaten bir role sahip '{1}'
 DocType: System Settings,Two Factor Authentication method,İki Faktörlü Kimlik Doğrulama Metodu
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,İlk önce ismi ayarlayın ve kaydı kaydedin.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Kayıt
@@ -886,9 +886,9 @@ apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migratio
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Fieldname not set for Custom Field,Fieldname Özel Alan için ayarlı değil
 apps/frappe/frappe/public/js/frappe/model/model.js,Last Updated By,Son Güncelleme tarafından
 apps/frappe/frappe/email/doctype/email_group/email_group.js,View Subscribers,Aboneleri Göster
-apps/frappe/frappe/public/js/frappe/form/print.js,"PDF printing via ""Raw Print"" is not yet supported. Please remove the printer mapping in Printer Settings and try again.",&quot;Raw Print&quot; ile PDF yazdırma henüz desteklenmiyor. Lütfen Yazıcı Ayarlarını Yazıcı Ayarları&#39;ndan kaldırın ve tekrar deneyin.
+apps/frappe/frappe/public/js/frappe/form/print.js,"PDF printing via ""Raw Print"" is not yet supported. Please remove the printer mapping in Printer Settings and try again.",&quot;Raw Print&quot; ile PDF yazdırma henüz desteklenmiyor. Lütfen Yazıcı Ayarlarını Yazıcı Ayarları'ndan kaldırın ve tekrar deneyin.
 DocType: Webhook,after_insert,ekleme_sonrası
-apps/frappe/frappe/core/doctype/file/file.py,Cannot delete file as it belongs to {0} {1} for which you do not have permissions,{0} {1} &#39;e ait olduğu için dosyanın izinleri olmadığı için silinemiyor
+apps/frappe/frappe/core/doctype/file/file.py,Cannot delete file as it belongs to {0} {1} for which you do not have permissions,{0} {1} 'e ait olduğu için dosyanın izinleri olmadığı için silinemiyor
 DocType: Website Theme,Custom JS,Özel JS
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Ms,Bayan
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Ms,Bayan
@@ -901,7 +901,7 @@ DocType: Data Migration Mapping,Mapping,haritalama
 DocType: Web Page,0 is highest,0 en üsttedir
 apps/frappe/frappe/public/js/frappe/microtemplate.js,Please enable pop-ups in your browser,Lütfen tarayıcınızda açılır pencereleri etkinleştir
 apps/frappe/frappe/core/doctype/communication/communication.js,Are you sure you want to relink this communication to {0}?,Eğer {0} bu iletişimi yeniden bağlamak istediğinden emin misin?
-DocType: Print Settings,Server IP,Sunucu IP&#39;si
+DocType: Print Settings,Server IP,Sunucu IP'si
 DocType: Email Queue,Attachments,Eklentiler
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You don't have the permissions to access this document,Bu dokümana erişim izniniz yok
 DocType: Language,Language Name,Dil Adı
@@ -915,7 +915,7 @@ DocType: Contact Phone,Number,Numara
 DocType: Web Form Field,Web Form Field,Web Form Alanı
 apps/frappe/frappe/templates/emails/new_message.html,You have a new message from: ,Yeni bir mesajınız var:
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_field.html,Edit HTML,HTML Düzenle
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Lütfen Yönlendirme URL&#39;sini girin
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,Lütfen Yönlendirme URL'sini girin
 apps/frappe/frappe/core/doctype/language/language.py,"{0} must begin and end with a letter and can only contain letters,
 				hyphen or underscore.","{0} bir harfle başlamalı ve bitmeli ve yalnızca harf, kısa çizgi veya alt çizgi içerebilir."
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Restore Original Permissions,Orijinal izinler Restore
@@ -995,7 +995,7 @@ DocType: Access Log,Show Document,Belgeyi Göster
 DocType: Blogger,User ID of a Blogger,Blogçu için kullanıcı kimliği
 apps/frappe/frappe/core/doctype/user/user.py,There should remain at least one System Manager,En az bir Sistem Yöneticisi orada kalmalıdır
 DocType: GCalendar Account,Authorization Code,Yetki Kodu
-DocType: PayPal Settings,Mention transaction completion page URL,işlem tamamlama sayfası URL&#39;sini Mansiyon
+DocType: PayPal Settings,Mention transaction completion page URL,işlem tamamlama sayfası URL'sini Mansiyon
 DocType: Help Article,Expert,Uzman
 DocType: Workflow State,circle-arrow-right,daire-ok-sağ
 DocType: Role Profile,Role Profile,Rol Profili
@@ -1061,7 +1061,7 @@ apps/frappe/frappe/utils/bot.py,Could not identify {0},{0} tanımlanamadı
 DocType: Address,Address,Adres
 apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,Ödeme başarısız
 DocType: Print Settings,In points. Default is 9.,Puan. Standart 9 olduğunu.
-DocType: OAuth Client,Redirect URIs,URI&#39;ları yönlendir
+DocType: OAuth Client,Redirect URIs,URI'ları yönlendir
 DocType: LDAP Settings,StartTLS,StartTLS
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Submiting {0},{0} gönderiliyor
 DocType: Workflow State,heart,yürek
@@ -1205,7 +1205,7 @@ DocType: Google Drive,Authorize Google Drive Access,Google Drive Erişimine Yetk
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Missing parameter Kanban Board Name,Kanban Board Name eksik parametre
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_stat.html,No records tagged.,Hiç bir kayıt etiketlenmedi.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Field,Field kaldır
-apps/frappe/frappe/public/js/frappe/request.js,You are not connected to Internet. Retry after sometime.,İnternet&#39;e bağlı değilsiniz. Bir ara sonra tekrar deneyin.
+apps/frappe/frappe/public/js/frappe/request.js,You are not connected to Internet. Retry after sometime.,İnternet'e bağlı değilsiniz. Bir ara sonra tekrar deneyin.
 apps/frappe/frappe/public/js/frappe/form/form.js,"Allowing DocType, DocType. Be careful!","Izin DocType, DocType. Dikkat et!"
 apps/frappe/frappe/config/core.py,"Customized Formats for Printing, Email","Baskı, E-posta için Özelleştirilmiş Biçimleri"
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Sum of {0},{0} toplamı
@@ -1223,7 +1223,7 @@ DocType: Workflow State,retweet,retweet
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Customize...,Özelleştirmek...
 DocType: Print Format,Align Labels to the Right,Etiketleri Sağa hizalayın
 DocType: Assignment Rule,Disabled,Devredışı
-DocType: File,Uploaded To Dropbox,Dropbox&#39;a Yüklendi
+DocType: File,Uploaded To Dropbox,Dropbox'a Yüklendi
 DocType: Workflow State,eye-close,eye-close
 apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For more information, {0}.","Daha fazla bilgi için, {0}."
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,Repeats {0},{0} tekrarları
@@ -1354,7 +1354,7 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the do
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Click here to post bugs and suggestions,Hataları ve önerileri yayınlamak için buraya tıklayın.
 DocType: Website Settings,Address and other legal information you may want to put in the footer.,Adres ve diğer yasal bilgileri altbilgi kısmına koyabilirsiniz
 DocType: Website Sidebar Item,Website Sidebar Item,Web sitesi Kenar Çubuğu Öğe
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Click on {0} to generate Refresh Token.,Yenileme Tokenini oluşturmak için {0} &#39;a tıklayın.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Click on {0} to generate Refresh Token.,Yenileme Tokenini oluşturmak için {0} 'a tıklayın.
 apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py,Reference document has been cancelled,Referans doküman iptal edildi
 DocType: PayPal Settings,PayPal Settings,PayPal Ayarları
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Document Type,Belge Türü Seçin
@@ -1383,7 +1383,7 @@ DocType: Web Page,Main Section,Ana Bölüm
 DocType: Page,Icon,ikon
 apps/frappe/frappe/www/update-password.html,"Hint: Include symbols, numbers and capital letters in the password","İpucu: Parolaya semboller, sayılar ve büyük harfler ekleyin"
 apps/frappe/frappe/www/update-password.html,"Hint: Include symbols, numbers and capital letters in the password","İpucu: Parolaya semboller, sayılar ve büyük harfler ekleyin"
-DocType: DocField,Allow in Quick Entry,Hızlı Giriş&#39;e İzin Ver
+DocType: DocField,Allow in Quick Entry,Hızlı Giriş'e İzin Ver
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,PDF,PDF
 DocType: System Settings,dd/mm/yyyy,gg / aa / yyyy
 DocType: System Settings,Backups,Yedekler
@@ -1413,7 +1413,7 @@ apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this docum
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document,Bu döküman iptal edildi
 apps/frappe/frappe/core/doctype/report/report.js,Write a Python file in the same folder where this is saved and return column and result.,Bu kaydedildiği aynı klasörde bir Python dosyası yazın ve sütun ve sonucu döndürür.
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Add to table,Tabloya ekle
-DocType: Website Theme,Theme URL,Tema URL&#39;si
+DocType: Website Theme,Theme URL,Tema URL'si
 DocType: Customize Form,Sort Field,Sıralama Alanı
 DocType: Razorpay Settings,Razorpay Settings,Razorpay Ayarları
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Edit Filter,Düzen Filtre
@@ -1421,7 +1421,7 @@ apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Daha fazla ekle
 DocType: System Settings,Session Expiry Mobile,Oturum Vade Mobil
 apps/frappe/frappe/utils/password.py,Incorrect User or Password,Yanlış Kullanıcı veya Şifre
 apps/frappe/frappe/templates/includes/search_box.html,Search results for,için arama sonuçları
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Lütfen Erişim Simgesi URL&#39;si girin
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Lütfen Erişim Simgesi URL'si girin
 DocType: Notification,Slack,Gevşek
 DocType: Custom DocPerm,If user is the owner,Kullanıcı sahibi ise
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Follow,Takip et
@@ -1522,7 +1522,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Zorunlu alan: için belirlenen rolü
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} eleştirildi {1}
 DocType: Data Migration Mapping,Mapping Name,Eşleme Adı
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: &#39;{1}&#39; alanı benzersiz olmayan değerlere sahip olduğundan Benzersiz olarak ayarlanamaz
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: '{1}' alanı benzersiz olmayan değerlere sahip olduğundan Benzersiz olarak ayarlanamaz
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Listede aşağı git
 DocType: Currency,A symbol for this currency. For e.g. $,Bu para için bir sembol mesela $ için
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Başarıyla güncellenen çeviriler
@@ -1562,7 +1562,7 @@ DocType: Address,Postal,Posta
 DocType: Email Account,Default Incoming,Standart Gelen
 DocType: Workflow State,repeat,tekrarlamak
 DocType: Website Settings,Banner,Banner
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,Value must be one of {0},"Değer, {0} &#39;dan biri olmalı"
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,Value must be one of {0},"Değer, {0} 'dan biri olmalı"
 DocType: Role,"If disabled, this role will be removed from all users.","devre dışı ise, bu rol tüm kullanıcılar kaldırılır."
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Go to {0} List,{0} Listeye Git
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Help on Search,Arama Yardımı
@@ -1587,7 +1587,7 @@ apps/frappe/frappe/config/desk.py,Documents assigned to you and by you.,Size ve 
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,You can also copy-paste this ,Bunu kopyalayıp yapıştırabilirsiniz.
 DocType: User,Email Signature,E-posta İmza
 DocType: Website Settings,Google Analytics ID,Google Analytics Kimliği
-DocType: Web Form,"For help see <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API and Examples</a>","Yardım için bkz. <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">İstemci Komut Dosyası API&#39;sı ve Örnekler</a>"
+DocType: Web Form,"For help see <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API and Examples</a>","Yardım için bkz. <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">İstemci Komut Dosyası API'sı ve Örnekler</a>"
 DocType: Custom DocPerm,Delete,Sil
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New {0},Yeni {0}
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Inbox,Standart Gelen kutusu
@@ -1608,7 +1608,7 @@ DocType: Communication,Received,Alındı
 DocType: Notification,"Trigger on valid methods like ""before_insert"", ""after_update"", etc (will depend on the DocType selected)","&quot;Before_insert&quot;, &quot;after_update&quot;, vb gibi geçerli yöntemler hakkında Tetik (seçilen DocType bağlıdır)"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0} {1},{0} {1} değişmiş değeri
 apps/frappe/frappe/core/doctype/user/user.py,Adding System Manager to this User as there must be atleast one System Manager,"En az bir Sistem Yöneticisi olması gerektiği gibi, bu üyeler için Sistem Yöneticisi ekleme"
-DocType: Chat Message,URLs,URL&#39;ler
+DocType: Chat Message,URLs,URL'ler
 DocType: Data Migration Run,Total Pages,Toplam Sayfa Sayısı
 apps/frappe/frappe/core/doctype/user_permission/user_permission.py,{0} has already assigned default value for {1}.,"{0}, {1} için zaten varsayılan bir değer atadı."
 DocType: DocField,Attach Image,Görüntü Ekleyin
@@ -1684,11 +1684,11 @@ DocType: Address,GST State,GST Durumu
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0}: Gönderilmeden iptal edilemez
 DocType: Website Theme,Theme,Tema
 DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,URI Kimlik Doğrulama Kodu için Bound REDIRECT_PATH
-apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Yardım&#39;ı aç
+apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Yardım'ı aç
 DocType: DocType,Is Submittable,Submittable mi
 apps/frappe/frappe/core/doctype/comment/comment.py,New Mention,Yeni Anma
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,Yeni Google Kişisi senkronize edilmedi.
-DocType: File,Uploaded To Google Drive,Google Drive&#39;a Yüklendi
+DocType: File,Uploaded To Google Drive,Google Drive'a Yüklendi
 apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a check field can be either 0 or 1,"Bir kontrol alanı için değer 0 ya da 1 olabilir, ya da"
 apps/frappe/frappe/model/document.py,Could not find {0},Bulunamıyor {0}
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Filters applied for {0},{0} için uygulanan filtreler
@@ -1764,7 +1764,7 @@ DocType: System Settings,Allow Login using Mobile Number,Mobil Numarayı Kullana
 apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,Bu kaynağa erişmek için yeterli izinlere sahip değilsiniz. erişmek için yöneticinizle bağlantı kurun.
 DocType: Custom Field,Custom,Özel
 DocType: Custom Field,Custom,Özel
-DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Etkinleştirilmişse, Kısıtlı IP Adresi&#39;nden giriş yapan kullanıcılar, İki Faktör Auth için istenmez"
+DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Etkinleştirilmişse, Kısıtlı IP Adresi'nden giriş yapan kullanıcılar, İki Faktör Auth için istenmez"
 DocType: Auto Repeat,Get Contacts,Kişileri Al
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts filed under {0},Filed under Mesajlar {0}
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping Untitled Column,Adsız Sütunu Atla
@@ -1825,7 +1825,7 @@ DocType: File,Is Attachments Folder,Ekler Klasör mı
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Expand All,Hepsini genişlet
 apps/frappe/frappe/public/js/frappe/chat.js,Select a chat to start messaging.,Mesajlaşmayı başlatmak için bir sohbet seçin.
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,Processing,İşleme
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Please select Entity Type first,Lütfen önce Varlık Türü&#39;nü seçin
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Please select Entity Type first,Lütfen önce Varlık Türü'nü seçin
 apps/frappe/frappe/templates/includes/login/login.js,Valid Login id required.,Geçerli oturum kimliği gereklidir.
 apps/frappe/frappe/model/rename_doc.py,Please select a valid csv file with data,Veri içeren geçerli bir csv dosyası seçiniz
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} un-shared this document with {1},{0} belge paylaşımını şu kişiden sildi {1}
@@ -1991,7 +1991,7 @@ DocType: Data Migration Mapping,Remote Primary Key,Uzak Birincil Anahtar
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,In,IN
 DocType: Notification,Value Change,Değer Değiştirme
 DocType: Google Contacts,Authorize Google Contacts Access,Google Kişiler Erişimine Yetki Ver
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Yalnızca Rapor&#39;dan sayısal alanlar gösteriliyor
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Yalnızca Rapor'dan sayısal alanlar gösteriliyor
 DocType: Data Import Beta,Import Type,İthalat türü
 DocType: Access Log,HTML Page,HTML Sayfası
 DocType: Address,Subsidiary,Yardımcı
@@ -1999,7 +1999,7 @@ DocType: Address,Subsidiary,Yardımcı
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting Connection to QZ Tray...,QZ Tepsisine Bağlantı Deneniyor ...
 DocType: System Settings,In Hours,Saatleri
 DocType: System Settings,In Hours,Saatleri
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Google Drive&#39;da klasör bulunamadı - Hata Kodu {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Google Drive'da klasör bulunamadı - Hata Kodu {0}
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,With Letterhead,Antetli ile
 apps/frappe/frappe/email/smtp.py,Invalid Outgoing Mail Server or Port,Geçersiz Giden Posta Sunucusu veya Liman
 DocType: Custom DocPerm,Write,Yazmak
@@ -2095,7 +2095,7 @@ DocType: Language,Language,Dil
 DocType: Language,Language,Dil
 apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Tarayıcı desteklenmiyor
 apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Tarayıcı desteklenmiyor
-DocType: Social Login Key,Client URLs,Müşteri URL&#39;leri
+DocType: Social Login Key,Client URLs,Müşteri URL'leri
 apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Some information is missing,Bazı bilgiler eksik
 apps/frappe/frappe/public/js/frappe/views/interaction.js,{0} created successfully,{0} başarıyla oluşturuldu
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Skipping {0} of {1}, {2}","{1}, {2} öğesinin {0} atlanması"
@@ -2113,7 +2113,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Yazı Tipi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Bu talimatlar burada yararlı değilse, GitHub konular üzerinde önerileri lütfen ekleyin."
 DocType: Workflow State,bookmark,Yerimi
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Klasör adı &#39;/&#39; (eğik çizgi) içermemelidir.
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Klasör adı '/' (eğik çizgi) içermemelidir.
 DocType: Note,Note,Not
 DocType: Note,Note,Not
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Hata raporu
@@ -2149,7 +2149,7 @@ DocType: User Email,Enable Outgoing,Giden etkinleştirin
 DocType: Address,Fax,Faks
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,özel Etiketler
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posta Hesabı ayarlanmadı. Lütfen Kurulum> E-posta> E-posta Hesabı&#39;ndan yeni bir E-posta Hesabı oluşturun.
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,E-posta Hesabı ayarlanmadı. Lütfen Kurulum> E-posta> E-posta Hesabı'ndan yeni bir E-posta Hesabı oluşturun.
 DocType: Comment,Submitted,Tanzim Edildi
 DocType: Comment,Submitted,Tanzim Edildi
 DocType: Contact,Pulled from Google Contacts,Google Kişilerden Alındı
@@ -2226,7 +2226,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Oturum kapanacak saa
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Burada tanımlanan AlanAdı değeri vardır VEYA kurallar gerçek (örnekler) yalnızca, bu alanı görünür: myField eval: doc.myfield == &#39;Benim Değer&#39; eval: doc.age> 18"
+eval:doc.age>18","Burada tanımlanan AlanAdı değeri vardır VEYA kurallar gerçek (örnekler) yalnızca, bu alanı görünür: myField eval: doc.myfield == 'Benim Değer' eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Ofis 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Bugün
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Bugün
@@ -2237,11 +2237,11 @@ DocType: User,Bio,Bio
 DocType: OAuth Client,App Client Secret,Uygulama Müşteri Sırrı
 apps/frappe/frappe/public/js/frappe/form/save.js,Submitting,Tanzim Ediliyor
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of the document to which the data will get added to.,"Ebeveyn, verinin ekleneceği belgenin adıdır."
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Google Drive&#39;da klasör oluşturulamadı - Hata Kodu {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Google Drive'da klasör oluşturulamadı - Hata Kodu {0}
 DocType: DocType,UPPER CASE,BÜYÜK HARF
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Özel HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Klasör adını girin
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Varsayılan Adres Şablonu bulunamadı. Lütfen Kurulum> Yazdırma ve Markalama> Adres Şablonu&#39;ndan yeni bir tane oluşturun.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Varsayılan Adres Şablonu bulunamadı. Lütfen Kurulum> Yazdırma ve Markalama> Adres Şablonu'ndan yeni bir tane oluşturun.
 apps/frappe/frappe/auth.py,Unknown User,Bilinmeyen kullanıcı
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Rol Seçin
 DocType: Comment,Deleted,Silinen
@@ -2266,7 +2266,7 @@ DocType: Data Migration Connector,Database Name,Veri tabanı ismi
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Yenile Formu
 DocType: DocField,Select,Seç
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Tam Günlüğü Görüntüle
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Basit Python İfadesi, Örnek: status == &#39;Aç&#39; ve == &#39;Hata&#39; yazın"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Basit Python İfadesi, Örnek: status == 'Aç' ve == 'Hata' yazın"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Dosya bağlı değil
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Bağlantı koptu. Bazı özellikler çalışmayabilir.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;Aaa&quot; gibi tekrarlar tahmin etmek kolaydır
@@ -2359,7 +2359,7 @@ DocType: Event,Participants,Katılımcılar
 DocType: Integration Request,Reference DocName,Referans docname
 DocType: Web Form,Success Message,Başarı Mesajı
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Export Customizations,ihracat Özelleştirmeler
-apps/frappe/frappe/website/doctype/web_page/web_page.py,End Date cannot be before Start Date!,"Bitiş Tarihi, Başlangıç Tarihi&#39;nden önce olamaz!"
+apps/frappe/frappe/website/doctype/web_page/web_page.py,End Date cannot be before Start Date!,"Bitiş Tarihi, Başlangıç Tarihi'nden önce olamaz!"
 DocType: DocType,User Cannot Search,Kullanıcı aranamıyor
 DocType: Communication Link,Communication Link,İletişim linki
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Invalid Output Format,Geçersiz Çıktı Biçimi
@@ -2371,7 +2371,7 @@ apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.js
 ,Lead Conversion Time,Kurşun Dönüş Süresi
 apps/frappe/frappe/desk/page/activity/activity.js,Build Report,Rapor oluşturmak
 DocType: Note,Notify users with a popup when they log in,oturum açtıklarında bir pop-up ile kullanıcılara bildir
-apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Core Modules {0} cannot be searched in Global Search.,Global Arama&#39;da {0} Çekirdek Modülleri aranamıyor.
+apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Core Modules {0} cannot be searched in Global Search.,Global Arama'da {0} Çekirdek Modülleri aranamıyor.
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Open Chat,Açık sohbet
 apps/frappe/frappe/model/rename_doc.py,"{0} {1} does not exist, select a new target to merge","{0} {1} yok, birleştirmek için yeni bir hedef seçin"
 DocType: Data Migration Connector,Python Module,Python Modülü
@@ -2399,7 +2399,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,Yalnızca hataları göster
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,E-posta Uyarısı Gönder
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',başka bir ödeme yöntemi seçin. Razorpay &#39;{0}&#39; para biriminde yapılan işlemleri desteklemez
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',başka bir ödeme yöntemi seçin. Razorpay '{0}' para biriminde yapılan işlemleri desteklemez
 DocType: Data Import,In Progress,Devam etmekte
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,yedekleme için sıraya. Bir saat için birkaç dakika sürebilir.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2433,7 +2433,7 @@ DocType: LDAP Settings,Path to Server Certificate,Sunucu Sertifikasına Giden Yo
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Linkleri görmek için yeterli iz yok
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Linkleri görmek için yeterli iz yok
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adres Başlığı zorunludur.
-DocType: Google Contacts,Push to Google Contacts,Google Kişileri&#39;ne git
+DocType: Google Contacts,Push to Google Contacts,Google Kişileri'ne git
 DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Web sayfasının  bölümüne, öncelikle web sitesi doğrulaması ve SEO için kullanılan HTML kodları eklendi"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nüks
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,"Ürün, kendi soyundan ilave edilemez"
@@ -2470,7 +2470,7 @@ DocType: Braintree Settings,Private Key,Özel anahtar
 DocType: S3 Backup Settings,ap-northeast-2,ap-kuzeydoğu-2
 DocType: Custom Field,Is Mandatory Field,Zorunlu Alan mi
 DocType: User,Website User,Web Sitesi Kullanım
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,PDF&#39;ye yazdırırken bazı sütunlar kesilebilir. Sütun sayısını 10&#39;un altında tutmaya çalışın.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,PDF'ye yazdırırken bazı sütunlar kesilebilir. Sütun sayısını 10'un altında tutmaya çalışın.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not equals,Eşit değildir
 DocType: Data Import Beta,Don't Send Emails,E-posta Gönderme
 DocType: Integration Request,Integration Request Service,Entegrasyon Talep Hizmet
@@ -2590,7 +2590,7 @@ DocType: DocField,Geolocation,Coğrafi Konum
 DocType: Workflow,Emails will be sent with next possible workflow actions,Bir sonraki olası iş akışı eylemleriyle e-postalar gönderilecek
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Workflow will start after saving.,İş Akışı kaydettikten sonra başlayacaktır.
 DocType: S3 Backup Settings,ap-northeast-1,ap-kuzeydoğu-1
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Jeton üretimi sırasında bir şeyler ters gitti. Yeni bir tane oluşturmak için {0} &#39;a tıklayın.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Jeton üretimi sırasında bir şeyler ters gitti. Yeni bir tane oluşturmak için {0} 'a tıklayın.
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Share,Paylaşılabilir
 apps/frappe/frappe/email/smtp.py,Invalid recipient address,Geçersiz alıcı adresi
 DocType: Workflow State,step-forward,step-forward
@@ -2630,13 +2630,13 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} can
 DocType: Newsletter,Create and Send Newsletters,Oluşturun ve gönderin Haber
 apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,Yorumun için teşekkür ederim. Onaylandıktan sonra yayınlanacaktır
 DocType: Address,Andaman and Nicobar Islands,Andaman ve Nikobar Adaları
-DocType: Google Contacts,Pull from Google Contacts,Google Kişiler&#39;den çekin
+DocType: Google Contacts,Pull from Google Contacts,Google Kişiler'den çekin
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,Değer alanı kontrol edilmesi gerektiği belirtiniz
 DocType: Event,Google Calendar Event ID,Google Takvim Etkinlik Kimliği
 apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added","""Ana"" bu satırın ekleneceği ana tabloyu belirtir"
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,Değerlendirme Noktaları:
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,Paylaşıldı
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,Dosyaları / URL&#39;leri ekleyin ve tabloya ekleyin.
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,Dosyaları / URL'leri ekleyin ve tabloya ekleyin.
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Message not setup,Mesaj ayarlanmıyor
 DocType: Help Category,Help Articles,Yardım Makaleleri
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Type:,Türü:
@@ -2672,7 +2672,7 @@ apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as i
 DocType: User,Send Me A Copy of Outgoing Emails,Bana Giden E-postaların Bir Kopyasını Gönder
 DocType: System Settings,Scheduler Last Event,Programlayıcı Son Olay
 DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Google Analytics ID ekleyin: örn. UA-89XXX57-1. Daha fazla bilgi için Google Analytics yardım arayın.
-apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,Şifre 100&#39;den fazla karakterden uzun olamaz
+apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,Şifre 100'den fazla karakterden uzun olamaz
 DocType: OAuth Client,App Client ID,Uygulama İstemci Kimliği
 DocType: Kanban Board,Kanban Board Name,Kanban Bölüm İsmi
 DocType: Notification Recipient,"Expression, Optional","İfade, Opsiyonel"
@@ -2720,7 +2720,7 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Set,Ayarla
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Set,Ayarla
 apps/frappe/frappe/desk/search.py,This query style is discontinued,Bu sorgu stili durduruldu
 DocType: Notification,Trigger Method,tetik Yöntemi
-apps/frappe/frappe/utils/data.py,Operator must be one of {0},Operatör {0} &#39;dan biri olmalı
+apps/frappe/frappe/utils/data.py,Operator must be one of {0},Operatör {0} 'dan biri olmalı
 DocType: Dropbox Settings,Dropbox Access Token,Bırakma Kutusu Erişim Kartı
 DocType: Workflow State,align-right,sağa-hizala
 DocType: Auto Email Report,Email To,To Email
@@ -2807,7 +2807,7 @@ DocType: Website Slideshow Item,Website Slideshow Item,Web Sitesi Slayt Ürün
 apps/frappe/frappe/model/workflow.py,Self approval is not allowed,Kendi onayına izin verilmez
 DocType: GSuite Templates,Template ID,Şablon Kimliği
 apps/frappe/frappe/integrations/doctype/oauth_client/oauth_client.py,Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed,Hibe Türü ( <code>{0}</code> ) ve Yanıt Türü ( <code>{1}</code> ) kombinasyonu izin verilmez
-apps/frappe/frappe/desk/form/assign_to.py,New Message from {0},{0} &#39;dan gelen yeni mesaj
+apps/frappe/frappe/desk/form/assign_to.py,New Message from {0},{0} 'dan gelen yeni mesaj
 DocType: Portal Settings,Default Role at Time of Signup,Üye Olurken Varsayılan Rol
 DocType: DocType,Title Case,Başlık
 apps/frappe/frappe/templates/emails/download_data.html,Click on the link below to download your data,Verilerinizi indirmek için aşağıdaki linke tıklayın
@@ -2828,7 +2828,7 @@ apps/frappe/frappe/desk/doctype/todo/todo.py,{0} self assigned this task: {1},{0
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Your Country,Ülke
 DocType: Assignment Rule Day,Sunday,Pazar
 DocType: Assignment Rule Day,Sunday,Pazar
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: Alan adı {1} &#39;den biri olamaz
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: Alan adı {1} 'den biri olamaz
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Standings,Sıralamalar
 apps/frappe/frappe/core/doctype/doctype/doctype.js,In Grid View,Grid View
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,No More Activity,Daha Fazla Etkinlik Yok
@@ -2841,8 +2841,8 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/public/js/frappe/form/save.js,Amending,Değiştirilen
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal ödeme ağ geçidi ayarları
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,En İyi Performans
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,"Özel Dokümanlar, çekirdek DocTypes&#39;e eklenemez."
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: izin verilen azami karakter olarak &#39;{1}&#39; ({3}), kesilmiş alacak {2}"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,"Özel Dokümanlar, çekirdek DocTypes'e eklenemez."
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: izin verilen azami karakter olarak '{1}' ({3}), kesilmiş alacak {2}"
 DocType: OAuth Client,Response Type,tepki Türü
 DocType: Contact Us Settings,Send enquiries to this email address,Bu e-posta adresine soruşturma gönder
 DocType: Letter Head,Letter Head Name,Antet Adı
@@ -2861,7 +2861,7 @@ apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping f
 DocType: DocField,Table,Tablo
 DocType: File,File Size,Dosya Boyutu
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You must login to submit this form,Bu formu göndermek için giriş yapmalısınız
-apps/frappe/frappe/email/doctype/notification/notification.py,Cannot set Notification on Document Type {0},Belge Türü&#39;nde Bildirim Ayarlanamıyor {0}
+apps/frappe/frappe/email/doctype/notification/notification.py,Cannot set Notification on Document Type {0},Belge Türü'nde Bildirim Ayarlanamıyor {0}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,"Select your Country, Time Zone and Currency","Ülkenizi,Saat Dilimi ve Para Birimi Seçiniz"
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Mx,mx
 apps/frappe/frappe/templates/emails/energy_points_summary.html,gained {0} points,{0} puan kazandı
@@ -2878,7 +2878,7 @@ DocType: Email Account,no failed attempts,Hiçbir başarısız girişim
 DocType: GSuite Settings,refresh_token,refresh_token
 DocType: Dropbox Settings,App Access Key,Uygulama Erişim Anahtarı
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat failed for {0},{0} için Otomatik Tekrarlama başarısız oldu
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Google Ayarlarında Google API&#39;yi etkinleştirin.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Enable Google API in Google Settings.,Google Ayarlarında Google API'yi etkinleştirin.
 DocType: Session Default,Session Default,Oturum Varsayılanı
 DocType: Chat Room,Last Message,Son Mesaj
 DocType: OAuth Bearer Token,Access Token,Erişim Anahtarı
@@ -2900,7 +2900,7 @@ DocType: Customize Form,Image View,Resim Görüntüle
 DocType: Customize Form,Image View,Resim Görüntüle
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","bir şey işlemi sırasında yanlış gitti gibi görünüyor. Biz ödeme onaylandıktan değil çünkü, Paypal otomatik olarak bu miktarı iade edecektir. Aksi takdirde, bize bir e-posta göndermek ve Korelasyon kimliğini belirtiniz: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Parolaya sembolleri, sayıları ve büyük harfleri ekleyin"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","alan &#39;{0}&#39; Özel Alan belirtilen sonra yerleştirin &#39;{1}&#39; etiketi ile &#39;{2}&#39;, yok"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","alan '{0}' Özel Alan belirtilen sonra yerleştirin '{1}' etiketi ile '{2}', yok"
 DocType: List Filter,List Filter,Liste Filtresi
 DocType: Workflow State,signal,sinyal
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Ekleri Var
@@ -2910,7 +2910,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Doküman Geri Yüklendi
 DocType: Data Export,Data Export,Veri Aktarımı
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Dil Seçin...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},{0} alanına &#39;Seçenekler&#39; ayarlayamazsınız
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},{0} alanına 'Seçenekler' ayarlayamazsınız
 DocType: Help Article,Author,Yazar
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,gönderme Özgeçmiş
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Yeniden açmak
@@ -2924,15 +2924,15 @@ DocType: Web Page,Slideshow,Slayt Gösterisi
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Varsayılan Adres Şablon silinemez
 DocType: Contact,Maintenance Manager,Bakım Müdürü
 DocType: Workflow State,Search,Arama
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lütfen başka bir ödeme yöntemi seçin. Şerit, &#39;{0}&#39; para birimi işlemlerini desteklemez"
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lütfen başka bir ödeme yöntemi seçin. Şerit, &#39;{0}&#39; para birimi işlemlerini desteklemez"
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lütfen başka bir ödeme yöntemi seçin. Şerit, '{0}' para birimi işlemlerini desteklemez"
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',"Lütfen başka bir ödeme yöntemi seçin. Şerit, '{0}' para birimi işlemlerini desteklemez"
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Çöp kutusuna taşıyın
 DocType: Web Form,Web Form Fields,Web Form Alanları
 DocType: Data Import,Amended From,İtibaren değiştirilmiş
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Uyarı: açılamıyor bulmak için {0} ile ilgili herhangi bir tablodaki {1}
 DocType: S3 Backup Settings,eu-north-1,ab-kuzey-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Bu belge şu anda yürütülmesi için sıraya. Lütfen tekrar deneyin
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Dosya &#39;{0}&#39; bulunamadı
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Dosya '{0}' bulunamadı
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Bölüm kaldır
 DocType: User,Change Password,Şifre değiştir
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X Eksen Alanı
@@ -2972,7 +2972,7 @@ DocType: OAuth Bearer Token,Revoked,iptal
 DocType: Web Page,Sidebar and Comments,Kenar çubuğu ve Yorumlar
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Eğer sonra iptal ve bunu kaydetmek Belgeyi Amend zaman, eski sayısının bir versiyonu yeni bir numara almak olacaktır."
 apps/frappe/frappe/email/doctype/notification/notification.py,"Not allowed to attach {0} document,
-				please enable Allow Print For {0} in Print Settings","{0} dokümanı eklemesine izin verilmiyor, lütfen Yazdırma Ayarları&#39;nda {0} için Yazdırmaya İzin Ver&#39;i etkinleştirin"
+				please enable Allow Print For {0} in Print Settings","{0} dokümanı eklemesine izin verilmiyor, lütfen Yazdırma Ayarları'nda {0} için Yazdırmaya İzin Ver'i etkinleştirin"
 apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,See the document at {0},{0} adresindeki dokümana bakın
 DocType: Stripe Settings,Publishable Key,Yayınlanabilir Anahtar
 DocType: Stripe Settings,Publishable Key,Yayınlanabilir Anahtar
@@ -3021,7 +3021,7 @@ apps/frappe/frappe/templates/includes/search_template.html,Type something in the
 apps/frappe/frappe/config/settings.py,Define workflows for forms.,Formlar için iş akışlarını tanımlayın.
 DocType: Address,Other,Diğer
 DocType: Address,Other,Diğer
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,Lütfen URL&#39;yi Yetkilendirin girin
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,Lütfen URL'yi Yetkilendirin girin
 DocType: S3 Backup Settings,Access Key ID,Erişim Tuşu Kimliği
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Misc,Çeşitli
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Start new Format,Yeni Format başlat
@@ -3046,10 +3046,10 @@ DocType: Address,Address Line 2,Adres Satırı 2
 DocType: Address,Reference,Referans
 DocType: Address,Reference,Referans
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Atanan
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Lütfen Kurulum> E-posta> E-posta Hesabı&#39;ndan varsayılan E-posta Hesabı&#39;nı ayarlayın.
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Lütfen Kurulum> E-posta> E-posta Hesabı'ndan varsayılan E-posta Hesabı'nı ayarlayın.
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Veri Taşıma Eşleme Ayrıntısı
 DocType: Data Import,Action,Eylem
-DocType: GSuite Settings,Script URL,Komut Dosyası URL&#39;si
+DocType: GSuite Settings,Script URL,Komut Dosyası URL'si
 apps/frappe/frappe/www/update-password.html,Please enter the password,şifrenizi giriniz
 apps/frappe/frappe/www/printview.py,Not allowed to print cancelled documents,İptal edilmiş dokümanlar yazdırılamaz
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,Sütun oluşturmanıza izin verilmemiştir
@@ -3065,7 +3065,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Saving,Kaydediliyor
 DocType: Print Settings,Print Style Preview,Baskı Önizleme Stil
 apps/frappe/frappe/core/doctype/file/test_file.py,Test_Folder,Test_Folder
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You are not allowed to update this Web Form Document,Bu Web Form Belgesini güncelleme izniniz yok
-apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Lütfen Frappe için Sosyal Oturum Açma Anahtarında Temel URL&#39;yi ayarlayın
+apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,Lütfen Frappe için Sosyal Oturum Açma Anahtarında Temel URL'yi ayarlayın
 DocType: About Us Settings,About Us Settings,Hakkımızda Ayarları
 DocType: Website Settings,Website Theme,Web Sitesi Tema
 DocType: User,Api Access,Api Erişimi
@@ -3084,7 +3084,7 @@ apps/frappe/frappe/core/doctype/data_import/importer_new.py,Invalid Template,Ge�
 apps/frappe/frappe/model/db_query.py,Illegal SQL Query,Geçersiz SQL Sorgusu
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Mandatory:,Zorunlu:
 DocType: Chat Message,Mentions,Mansiyonlar
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,"To use Google Contacts, enable {0}.",Google Kişileri&#39;ni kullanmak için {0} seçeneğini etkinleştirin.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,"To use Google Contacts, enable {0}.",Google Kişileri'ni kullanmak için {0} seçeneğini etkinleştirin.
 apps/frappe/frappe/public/js/frappe/utils/utils.js,{0} Modules,{0} Modüller
 DocType: Chat Room,Chat Room,Sohbet odası
 DocType: Chat Profile,Conversation Tones,Konuşma Sesleri
@@ -3124,13 +3124,13 @@ DocType: GSuite Settings,GSuite Settings,GSuite Ayarları
 DocType: Address,Links,Bağlantılar
 DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,"Bu Hesapta belirtilen E-posta Adresini, bu Hesabı kullanarak gönderilen tüm e-postalar için Gönderenin Adı olarak kullanır."
 DocType: Energy Point Rule,Field To Check,Kontrol Edilecek Alan
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Google Kişileri - {0} Google Kişileri&#39;nde kişi güncellenemedi, hata kodu {1}."
-apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,Lütfen Belge Türü&#39;nü seçin.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Google Kişileri - {0} Google Kişileri'nde kişi güncellenemedi, hata kodu {1}."
+apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,Lütfen Belge Türü'nü seçin.
 apps/frappe/frappe/model/base_document.py,Value missing for,Değer eksik
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Alt öğe ekle
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,İçe Aktarım İlerlemesi
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",Koşul yerine getirilirse kullanıcı puanla ödüllendirilecektir. Örneğin. doc.status == &#39;Kapalı&#39;
+",Koşul yerine getirilirse kullanıcı puanla ödüllendirilecektir. Örneğin. doc.status == 'Kapalı'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Sonlandırılmış bir kayıt silinemez.
 DocType: GSuite Templates,Template Name,Şablon adı
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,Belgenin yeni tip
@@ -3175,9 +3175,9 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with everyone,H
 apps/frappe/frappe/model/base_document.py,Data missing in table,Veri tablosunda eksik
 DocType: Web Form,Success URL,Başarı URL
 DocType: Email Account,Append To,İle ilişkilendir
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Number of DB backups cannot be less than 1,DB yedeklerinin sayısı 1&#39;den az olamaz
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Number of DB backups cannot be less than 1,DB yedeklerinin sayısı 1'den az olamaz
 DocType: Workflow Document State,Only Allow Edit For,Only Allow Edit For
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Backing up to Google Drive.,Google Drive&#39;a yedekleme.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Backing up to Google Drive.,Google Drive'a yedekleme.
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: {0},Zorunlu alan: {0}
 apps/frappe/frappe/templates/includes/comments/comments.html,Your Name,Adınız
 apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Connection Success,Bağlantı Başarı
@@ -3220,7 +3220,7 @@ apps/frappe/frappe/core/doctype/version/version_view.html,Values Changed,Değerl
 DocType: Workflow State,arrow-up,yukarı-yön
 DocType: Dynamic Link,Link Document Type,Bağlantı Doküman Türü
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for {0} table,{0} tablosu için en az bir satır olmalı
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure Auto Repeat, enable ""Allow Auto Repeat"" from {0}.",Otomatik Tekrarı yapılandırmak için {0} &#39;dan &quot;Otomatik Tekrarlamaya İzin Ver&quot; i etkinleştirin.
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure Auto Repeat, enable ""Allow Auto Repeat"" from {0}.",Otomatik Tekrarı yapılandırmak için {0} 'dan &quot;Otomatik Tekrarlamaya İzin Ver&quot; i etkinleştirin.
 DocType: OAuth Bearer Token,Expires In,İçinde sona eriyor
 DocType: DocField,Allow on Submit,Gönderme Onayı İzni
 DocType: DocField,HTML,HTML
@@ -3264,7 +3264,7 @@ DocType: Dashboard Chart,Chart Type,Grafik tipi
 DocType: DocType,Auto Name,Otomatik Ad
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"abc veya 6543 gibi dizileri kullanmayın, tahmin etmesi kolaydır."
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Lütfen tekrar deneyin
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',"URL, &#39;http: //&#39; veya &#39;https: //&#39; ile başlamalıdır."
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',"URL, 'http: //' veya 'https: //' ile başlamalıdır."
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Seçenek 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Düzenle
@@ -3280,7 +3280,7 @@ apps/frappe/frappe/public/js/frappe/model/create_new.js,You have unsaved changes
 DocType: Address,Telangana,Telangana
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for {0} must be an option,{0} bir seçenek olmalıdır için varsayılan
 DocType: Tag Doc Category,Tag Doc Category,Etiket Doc Kategori
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Report with more than 10 columns looks better in Landscape mode.,"Manzara modunda, 10&#39;dan fazla sütunlu rapor daha iyi görünür."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Report with more than 10 columns looks better in Landscape mode.,"Manzara modunda, 10'dan fazla sütunlu rapor daha iyi görünür."
 apps/frappe/frappe/database/database.py,Invalid field name: {0},Geçersiz alan adı: {0}
 DocType: Milestone,Milestone,Aşama
 DocType: User,User Image,Kullanıcı Resmi
@@ -3365,7 +3365,7 @@ DocType: Letter Head,Letter Head Based On,Temelli Mektup Başlığı
 apps/frappe/frappe/utils/oauth.py,Token is missing,Jetonu eksik
 apps/frappe/frappe/www/update-password.html,Set Password,Şifre seç
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records.,{0} kayıtları başarıyla içe aktarıldı.
-apps/frappe/frappe/public/js/frappe/utils/utils.js,Note: Changing the Page Name will break previous URL to this page.,Not: Sayfa Adını değiştirmek önceki URL&#39;yi bu sayfaya ayıracaktır.
+apps/frappe/frappe/public/js/frappe/utils/utils.js,Note: Changing the Page Name will break previous URL to this page.,Not: Sayfa Adını değiştirmek önceki URL'yi bu sayfaya ayıracaktır.
 apps/frappe/frappe/utils/file_manager.py,Removed {0},Kaldırıldı {0}
 DocType: SMS Settings,SMS Settings,SMS Ayarları
 DocType: SMS Settings,SMS Settings,SMS Ayarları
@@ -3409,7 +3409,7 @@ apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator c
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Setting this Address Template as default as there is no other default,"Bu adres şablonunu varsayılan olarak kaydedin, başka varsayılan bulunmamaktadır"
 DocType: Workflow State,Home,Ana Sayfa
 DocType: OAuth Provider Settings,Auto,Otomatik
-DocType: System Settings,User can login using Email id or User Name,Kullanıcı e-posta kimliği veya Kullanıcı Adı&#39;nı kullanarak giriş yapabilir
+DocType: System Settings,User can login using Email id or User Name,Kullanıcı e-posta kimliği veya Kullanıcı Adı'nı kullanarak giriş yapabilir
 DocType: Workflow State,question-sign,question-sign
 apps/frappe/frappe/model/base_document.py,{0} is disabled,{0} devre dışı
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",Web İzleme alanları &quot;rota&quot; zorunlu
@@ -3462,7 +3462,7 @@ apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,Satır D
 DocType: S3 Backup Settings,sa-east-1,sa-doğu-1
 DocType: Workflow Transition,Workflow Transition,İş Akışı Geçiş
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,{0} ay önce
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Özel Alanlar sadece standart bir DocType&#39;a eklenebilir.
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Özel Alanlar sadece standart bir DocType'a eklenebilir.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Created By,Tarafından oluşturulan
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Dropbox Kurulumu
 DocType: Assignment Rule Day,Assignment Rule Day,Atama Kuralı Günü
@@ -3471,7 +3471,7 @@ apps/frappe/frappe/templates/emails/download_data.html,Download Link,İndirme li
 DocType: Chat Message,Content,İçerik
 DocType: Chat Message,Content,İçerik
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} reverted your point on {1},"{0}, {1} tarihinde amacınızı geri aldı"
-DocType: Data Migration Run,Push Insert,Ekle&#39;yi itin
+DocType: Data Migration Run,Push Insert,Ekle'yi itin
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Group Node,Grup Düğüm
 DocType: Auto Repeat,Notification,tebliğ
 DocType: Contact Phone,Contact Phone,İletişim Telefonu
@@ -3479,7 +3479,7 @@ apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} appreciated 
 DocType: Milestone,Document,Belge
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Series {0} already used in {1},Seriler {0} {1} de zaten kullanılmıştır
 apps/frappe/frappe/core/doctype/data_import/importer.py,Unsupported File Format,Desteklenmeyen Dosya Biçimi
-apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray...,QZ Tray&#39;i başlatmaya çalışıyor ...
+apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray...,QZ Tray'i başlatmaya çalışıyor ...
 DocType: Assignment Rule,Example: {{ subject }},Örnek: {{subject}}
 DocType: DocField,Code,Kod
 DocType: DocField,Code,Kod
@@ -3503,13 +3503,13 @@ DocType: Energy Point Log,Criticism,eleştiri
 DocType: Address,Tripura,Tripura
 DocType: About Us Settings,"""Company History""","""Şirket Tarihçesi"""
 apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Bu doküman e-posta gönderildikten sonra değiştirildi.
-DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","İşaretlenirse, bir değer zaten mevcutsa, Get From From&#39;a dayalı olarak bu alanın üzerine yazılmaz."
+DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","İşaretlenirse, bir değer zaten mevcutsa, Get From From'a dayalı olarak bu alanın üzerine yazılmaz."
 DocType: Access Log,Show Report,Raporu göster
 DocType: Address,Tamil Nadu,Tamil Nadu
 DocType: Email Rule,Email Rule,E-posta Kural
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with everyone,{0} herkesle bu belgeyi paylaştı
 apps/frappe/frappe/desk/page/activity/activity_row.html,Commented on {0}: {1},Üzerinde Yorumlananlar {0}: {1}
-apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Looks like someone sent you to an incomplete URL. Please ask them to look into it.,Birisi eksik URL&#39;ye gönderdi benziyor. içine bakmak için isteyin.
+apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Looks like someone sent you to an incomplete URL. Please ask them to look into it.,Birisi eksik URL'ye gönderdi benziyor. içine bakmak için isteyin.
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Your payment has been successfully registered.,Ödemeniz başarıyla kaydedildi.
 DocType: Stripe Settings,Secret Key,Gizli anahtar
 DocType: Stripe Settings,Secret Key,Gizli anahtar
@@ -3518,7 +3518,7 @@ DocType: Notification,Send alert if this field's value changes,Uyarı gönder Bu
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Tema renkleri
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Yeni bir format yapmak için bir DOCTYPE seçin
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Kullanıcı yok
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Alıcılar&#39; belirtilmemiş
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Alıcılar' belirtilmemiş
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,Şu anda
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Uygulamak
 DocType: Footer Item,Policy,Politika
@@ -3567,13 +3567,13 @@ apps/frappe/frappe/config/customization.py,Custom Translations,özel Çeviriler
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,İlerleme
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,Role Göre
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Eksik Alanları
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname geçersiz AlanAdı &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname geçersiz AlanAdı '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Bir belge türü ara
 DocType: Custom DocPerm,Role and Level,Rolü ve Seviye
 DocType: File,Thumbnail URL,Küçük resim URL
 apps/frappe/frappe/desk/moduleview.py,Custom Reports,Özel Raporlar
 DocType: Website Script,Website Script,Website Script
-DocType: GSuite Settings,If you aren't using own publish Google Apps Script webapp you can use the default https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec ,"Kendi yayınlama Google Apps Komut Dosyası web uygulamasını kullanmıyorsanız, varsayılan https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk / exec&#39;i kullanabilirsiniz."
+DocType: GSuite Settings,If you aren't using own publish Google Apps Script webapp you can use the default https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec ,"Kendi yayınlama Google Apps Komut Dosyası web uygulamasını kullanmıyorsanız, varsayılan https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk / exec'i kullanabilirsiniz."
 apps/frappe/frappe/config/settings.py,Customized HTML Templates for printing transactions.,Baskı işlemleri için özel HTML Şablonları.
 apps/frappe/frappe/public/js/frappe/form/print.js,Orientation,Oryantasyon
 DocType: Workflow,Is Active,Aktif
@@ -3583,7 +3583,7 @@ DocType: DocField,Long Text,Uzun Metin
 DocType: Workflow State,Primary,Birincil
 DocType: User,Home Settings,Ev ayarları
 apps/frappe/frappe/core/doctype/data_import/importer.py,Please do not change the rows above {0},Yukarıdaki satırları lütfen değiştirmeyin {0}
-DocType: Web Form,Go to this URL after completing the form (only for Guest users),Formu tamamladıktan sonra bu URL&#39;ye gidin (yalnızca Misafir kullanıcıları için)
+DocType: Web Form,Go to this URL after completing the form (only for Guest users),Formu tamamladıktan sonra bu URL'ye gidin (yalnızca Misafir kullanıcıları için)
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,(Ctrl + G),(Ctrl + G)
 DocType: Contact,More Information,Daha Fazla Bilgi
 DocType: Data Migration Mapping,Field Maps,Alan Haritaları
@@ -3671,7 +3671,7 @@ DocType: Dashboard Chart,Filters JSON,JSON Filtreleri
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Doğrulamak için buraya tıklayın
 DocType: Email Account,Disable SMTP server authentication,SMTP sunucusu kimlik doğrulamasını devre dışı bırak
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Panoya kopyalandı.
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Öngörülebilir gibi değiştirmeler &#39;@&#39; yerine &#39;&#39; çok fazla yardımcı olmamaktadır.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,Öngörülebilir gibi değiştirmeler '@' yerine '' çok fazla yardımcı olmamaktadır.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Bana Atanan
 apps/frappe/frappe/utils/data.py,Zero,Sıfır
 DocType: Google Drive,Backup Folder ID,Yedekleme Klasörü Kimliği
@@ -3700,14 +3700,14 @@ DocType: Module Def,Module Name,Modül Adı
 DocType: S3 Backup Settings,eu-west-3,ab-batı-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},{1} üzerinden {0} yüklüyor
 DocType: DocType,DocType is a Table / Form in the application.,DocType uygulamasında bir tablo / Formu olduğunu.
-DocType: Social Login Key,Authorize URL,URL&#39;yi yetkilendir
+DocType: Social Login Key,Authorize URL,URL'yi yetkilendir
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.",Google Takvim - {0} hata kodu Google Takvim’den etkinlik alınamadı.
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failed,Otomatik Doküman Oluşturma Başarısız Oldu
 DocType: Email Account,GMail,GMail
 DocType: Letter Head,Letter Head Image,Letter Head Görüntüsü
 DocType: Address,Party GSTIN,Parti GSTIN
 apps/frappe/frappe/public/js/frappe/utils/utils.js,{0} Report,{0} Raporu
-DocType: SMS Settings,Use POST,POST&#39;u kullanın
+DocType: SMS Settings,Use POST,POST'u kullanın
 DocType: Communication,SMS,SMS
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Fetch Images,Görüntüleri getir
 DocType: DocType,Web View,Web Görünümü
@@ -3763,7 +3763,7 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Eşittir
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Alan Seçenekler 'Dynamic Link' type 'DocType' gibi seçenekler ile başka Bağlantı alanı işaret etmelidir
 DocType: About Us Settings,Team Members Heading,Ekip Üyeleri Başlığı
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Geçersiz CSV Biçimi
-apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ Tepsi Uygulamasına bağlanırken hata oluştu ... <br><br> Raw Print özelliğini kullanmak için QZ Tray uygulamasının kurulu ve çalışıyor olması gerekir. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ Tray&#39;i indirip kurmak için buraya tıklayın</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Ham Baskı hakkında daha fazla bilgi için buraya tıklayın</a> ."
+apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ Tepsi Uygulamasına bağlanırken hata oluştu ... <br><br> Raw Print özelliğini kullanmak için QZ Tray uygulamasının kurulu ve çalışıyor olması gerekir. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ Tray'i indirip kurmak için buraya tıklayın</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Ham Baskı hakkında daha fazla bilgi için buraya tıklayın</a> ."
 apps/frappe/frappe/desk/page/backups/backups.js,Set Number of Backups,Yedekler Set Sayısı
 DocType: DocField,Do not allow user to change after set the first time,Kullanıcı değiştirmesine izin vermeyin sonra ilk kez ayarlayın
 apps/frappe/frappe/utils/data.py,1 year ago,1 yıl önce
@@ -3778,7 +3778,7 @@ DocType: Blog Post,Content Type,İçerik Türü
 DocType: Blog Post,Content Type,İçerik Türü
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,{0} Calendar,{0} Takvim
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Export Report: ,İhracat Raporu
-DocType: Data Migration Run,Push Update,Güncelleştir&#39;e Bas
+DocType: Data Migration Run,Push Update,Güncelleştir'e Bas
 DocType: Email Account,Port,Port
 DocType: Print Format,Arial,Arial
 apps/frappe/frappe/auth.py,Incomplete login details,Eksik oturum açma bilgileri
@@ -3889,7 +3889,7 @@ DocType: Transaction Log,Transaction Log,İşlem Günlüğü
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last month's performance (from {0} to {1}),Geçen ayın performansına göre istatistikler ({0} - {1} arası)
 DocType: Contact Us Settings,City,İl
 DocType: Contact Us Settings,City,Şehir
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Enable Allow Auto Repeat for the doctype {0} in Customize Form,Özelleştir Formunda {0} doctype için Otomatik Tekrarlamaya İzin Ver&#39;i etkinleştirin
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Enable Allow Auto Repeat for the doctype {0} in Customize Form,Özelleştir Formunda {0} doctype için Otomatik Tekrarlamaya İzin Ver'i etkinleştirin
 DocType: DocField,Perm Level,Seviye Perm
 apps/frappe/frappe/www/confirm_workflow_action.html,View document,Belgeyi görüntüle
 apps/frappe/frappe/desk/doctype/event/event.py,Events In Today's Calendar,Bugünün Takvim'de Olaylar
@@ -3946,8 +3946,8 @@ DocType: Custom DocPerm,Level,Seviye
 DocType: Custom DocPerm,Level,Seviye
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Last 30 days,Son 30 gün
 DocType: Custom DocPerm,Report,Rapor
-apps/frappe/frappe/website/doctype/web_form/web_form.py,Amount must be greater than 0.,Miktar 0&#39;dan büyük olmalıdır.
-apps/frappe/frappe/public/js/frappe/form/print.js,Connected to QZ Tray!,QZ Tray&#39;e bağlı!
+apps/frappe/frappe/website/doctype/web_form/web_form.py,Amount must be greater than 0.,Miktar 0'dan büyük olmalıdır.
+apps/frappe/frappe/public/js/frappe/form/print.js,Connected to QZ Tray!,QZ Tray'e bağlı!
 apps/frappe/frappe/desk/reportview.py,{0} is saved,{0} kaydedilir
 apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be renamed,Kullanıcı {0} adı değiştirilemez
 apps/frappe/frappe/database/schema.py,Fieldname is limited to 64 characters ({0}),AlanAdı 64 karakterle sınırlıdır ({0})
@@ -3964,7 +3964,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Change,Değ
 DocType: Email Domain,domain name,domain adı
 DocType: Contact Email,Contact Email,İletişim E-Posta
 DocType: Kanban Board Column,Order,Sipariş
-apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No results found for {0} in Global Search,Global Arama&#39;da {0} için sonuç bulunamadı
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No results found for {0} in Global Search,Global Arama'da {0} için sonuç bulunamadı
 DocType: Report,Ref DocType,Ref DocType
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client ID before social login is enabled,Sosyal giriş etkinleştirilmeden önce lütfen Müşteri Kimliğini girin
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Amend without Cancel,{0}: Öğesi tanzim edilmeden iptal edilemez
@@ -3996,7 +3996,7 @@ DocType: Contact,Gender,Cinsiyet
 DocType: Contact,Gender,Cinsiyet
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Mandatory Information missing:,Eksik zorunlu bilgiler:
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} reverted your points on {1},{0} puanlarınızı {1} için geri aldı
-apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Check Request URL,İstek URL&#39;sini kontrol et
+apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Check Request URL,İstek URL'sini kontrol et
 apps/frappe/frappe/client.py,Only 200 inserts allowed in one request,Sadece 200 ekler tek isteği izin
 DocType: Footer Item,URL,URL
 apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,Doğrulama ekranına geri dönün ve kimlik doğrulama uygulamanız tarafından görüntülenen kodu girin
@@ -4055,7 +4055,7 @@ DocType: DocField,Default,Varsayılan
 DocType: DocField,Default,Varsayılan
 DocType: Translation,Verified,Doğrulanmış
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} eklendi
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&#39;{0}&#39; için ara
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}','{0}' için ara
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,İlk raporu kaydetmek Lütfen
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} aboneler eklendi
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Değil ise
@@ -4086,7 +4086,7 @@ apps/frappe/frappe/desk/moduleview.py,Standard Reports,Standart Raporlar
 DocType: Dashboard Chart Link,Dashboard Chart Link,Kontrol Paneli Grafik Bağlantısı
 DocType: User,Email Settings,E-posta Ayarları
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop Here,Buraya bırak
-DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Etkinleştirildiğinde, kullanıcı İki Faktör Kimlik Doğrulaması kullanarak herhangi bir IP Adresinden giriş yapabilir, bu, Sistem Ayarları&#39;ndaki tüm kullanıcılar için de ayarlanabilir."
+DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Etkinleştirildiğinde, kullanıcı İki Faktör Kimlik Doğrulaması kullanarak herhangi bir IP Adresinden giriş yapabilir, bu, Sistem Ayarları'ndaki tüm kullanıcılar için de ayarlanabilir."
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Printer Settings...,Yazıcı Ayarları ...
 apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Lütfen Devam Etmek İçin Parolanızı Girin
 apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Lütfen Devam Etmek İçin Parolanızı Girin
@@ -4094,14 +4094,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Ben mi
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} geçerli bir durum değil
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Tüm Belge Türlerine Uygula
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Enerji noktası güncellemesi
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',başka bir ödeme yöntemi seçin. PayPal &#39;{0}&#39; para biriminde yapılan işlemleri desteklemez
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',başka bir ödeme yöntemi seçin. PayPal '{0}' para biriminde yapılan işlemleri desteklemez
 DocType: Chat Message,Room Type,Oda tipi
 DocType: Data Import Beta,Import Log Preview,Günlük Önizlemesini İçe Aktar
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,Arama alanı {0} geçerli değil
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,yüklenen dosya
 DocType: Workflow State,ok-circle,ok-circle
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP Kullanıcı Oluşturma ve Haritalama
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Sen müşterilerin turuncu bulmak &#39;sorarak şeyler bulabilirsiniz
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',Sen müşterilerin turuncu bulmak 'sorarak şeyler bulabilirsiniz
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Maalesef! Kullanıcı kendi kayıtlarına tam erişimi olmalıdır.
 ,Usage Info,kullanım Bilgisi
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Klavye Kısayollarını Göster
@@ -4156,7 +4156,7 @@ apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Ple
 DocType: Portal Settings,Custom Menu Items,Özel Menü Öğeleri
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,Web Sitesi Slayt gösterisine eklenen tüm resimler herkese açık olmalıdır
 DocType: Workflow State,chevron-right,chevron-right
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,"To use Google Drive, enable {0}.",Google Drive&#39;ı kullanmak için {0} seçeneğini etkinleştirin.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,"To use Google Drive, enable {0}.",Google Drive'ı kullanmak için {0} seçeneğini etkinleştirin.
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be in developer mode to edit a Standard Web Form,Bir standart bir Web formu düzenlemek için geliştirici modunda olmanız gerekir
 DocType: Personal Data Deletion Request,Personal Data Deletion Request,Kişisel Veri Silme İsteği
 DocType: Payment Gateway,Gateway Controller,Gateway Denetleyicisi

--- a/frappe/translations/tr.csv
+++ b/frappe/translations/tr.csv
@@ -1487,7 +1487,7 @@ DocType: User,System User,Sistem Kullanıcısı
 DocType: Report,Is Standard,Standart mı
 DocType: Desktop Icon,_report,_rapor
 DocType: Dashboard Chart,Full,Tam
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",Do not &lt;script> ya da sadece karakterler kasten bu alanda kullanılan olabilir gibi gibi &lt;veya> gibi HTML Encode HTML etiketleri
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",Do not <script> ya da sadece karakterler kasten bu alanda kullanılan olabilir gibi gibi <veya> gibi HTML Encode HTML etiketleri
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} {1} tarihinde eleştirildi
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,koş
@@ -1884,7 +1884,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Altbilgi yalnızc
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Bekliyor
 DocType: System Settings,Allow only one session per user,Kullanıcı başına yalnızca bir oturuma izin ver
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Ana Sayfa / Test Klasörü 1 / Test Klasör 3
-DocType: Website Settings,&lt;head> HTML,&lt;head> HTML
+DocType: Website Settings,<head> HTML,<head> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Seçin veya yeni bir etkinlik oluşturmak için zaman dilimleri boyunca sürükleyin.
 DocType: Contact,Contact Details,İletişim Bilgileri
 DocType: DocField,In Filter,Filtre
@@ -2434,7 +2434,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Linkleri görmek için yeterli iz yok
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Adres Başlığı zorunludur.
 DocType: Google Contacts,Push to Google Contacts,Google Kişileri&#39;ne git
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Web sayfasının  bölümüne, öncelikle web sitesi doğrulaması ve SEO için kullanılan HTML kodları eklendi"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Web sayfasının  bölümüne, öncelikle web sitesi doğrulaması ve SEO için kullanılan HTML kodları eklendi"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nüks
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,"Ürün, kendi soyundan ilave edilemez"
 DocType: Session Default Settings,Session Defaults,Oturum Varsayılanları
@@ -2558,7 +2558,7 @@ DocType: Workflow State,Warning,Uyarı
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Bu birden fazla sayfaya yazdırılabilir
 DocType: Data Migration Run,Percent Complete,Yüzde Tamamlandı
 DocType: Tag Category,Tag Category,Etiket Kategorisi
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Karşılaştırma için,> 5, &lt;10 veya = 324 kullanın. Aralıklar için 5:10 kullanın (5 ve 10 arasındaki değerler için)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Karşılaştırma için,> 5, <10 veya = 324 kullanın. Aralıklar için 5:10 kullanın (5 ve 10 arasındaki değerler için)."
 DocType: Google Calendar,Pull from Google Calendar,Google Takvim’den çekin
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Yardım
 DocType: User,Login Before,Önce Giriş
@@ -3226,7 +3226,7 @@ DocType: DocField,Allow on Submit,Gönderme Onayı İzni
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,İstisna türü
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Sütunları Seç
-DocType: Web Page,Add code as &lt;script>,Kodu &lt;script> olarak ekle
+DocType: Web Page,Add code as <script>,Kodu <script> olarak ekle
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Kullanıcı İzinlerini Temizle
 DocType: Webhook,Headers,Başlıkları
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Yaklaşan Etkinlikler
@@ -3618,26 +3618,26 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Kuyruk {0} dan biri olmalıdır
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Varsayılan Şablon </ h4> 
- <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja şablonu </a> ve Adres tüm alanları (kullanır {; br & gt;, 
- {% eğer address_line2%} {{address_line2}} & lt; br & gt Özel Alanlar varsa) </ p> 
+ <p> <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja şablonu </a> ve Adres tüm alanları (kullanır {; br>, 
+ {% eğer address_line2%} {{address_line2}} <br & gt Özel Alanlar varsa) </ p> 
  <pre> <code> {{address_line1}} & lt sunulacak dahil % endif -%} 
- {{şehir}} & lt; br & gt; 
- {% eğer devlet%} {{devlet}} & lt; br & gt; {% endif -%} {% 
- eğer pin kodunu%} PIN: {{pin}} & lt; br & gt; {% endif -%} 
- {{ülke}} & lt; br & gt; 
- {% eğer telefon%} Telefon: {{telefon}} & lt; br & gt; { % endif -%} 
- {% takdirde faks%} Faks: {{faks}} & lt; br & gt; {% endif -%} 
- {% eğer email_id%} E-posta: {{email_id}} & lt; br & gt {% endif -%} 
+ {{şehir}} <br> 
+ {% eğer devlet%} {{devlet}} <br> {% endif -%} {% 
+ eğer pin kodunu%} PIN: {{pin}} <br> {% endif -%} 
+ {{ülke}} <br> 
+ {% eğer telefon%} Telefon: {{telefon}} <br> { % endif -%} 
+ {% takdirde faks%} Faks: {{faks}} <br> {% endif -%} 
+ {% eğer email_id%} E-posta: {{email_id}} <br & gt {% endif -%} 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Başlangıç Tarihi Alanı
 DocType: Role,Role Name,Rol Adı

--- a/frappe/translations/uk.csv
+++ b/frappe/translations/uk.csv
@@ -750,7 +750,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Резер�
 DocType: DocField,In Global Search,У Global Пошук
 DocType: System Settings,Brute Force Security,Брутні сили безпеки
 DocType: Workflow State,indent-left,відступ зліва-
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} рік тому
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} рік тому
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Це ризиковано, щоб видалити цей файл: {0}. Будь ласка, зверніться до менеджера системи."
 DocType: Currency,Currency Name,Назва валюти
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Немає повідомлень електронної пошти
@@ -1049,7 +1049,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,"Немає {
 apps/frappe/frappe/config/customization.py,Add custom forms.,Додати користувача форми.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} в {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,представив цей документ
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Налаштування&gt; Дозволи користувача
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Налаштування> Дозволи користувача
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,"Система забезпечує безліч визначених функцій. Ви можете додати нові ролі, щоб встановити більш тонкі дозволу."
 DocType: Communication,CC,CC
 DocType: Country,Geo,Гео
@@ -1270,7 +1270,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Якщо будь-яку роль користувача позначено, тоді він стає ""Системним користувачем"". ""Системний користувач"" має доступ до стільниці"
 DocType: System Settings,Date and Number Format,Дата і номер Формат
 apps/frappe/frappe/model/document.py,one of,один з
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Налаштування&gt; Налаштувати форму
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Налаштування> Налаштувати форму
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Перевірка одного моменту
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Показати Теги
 DocType: DocField,HTML Editor,Редактор HTML
@@ -1278,7 +1278,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Біллінг
 DocType: Email Queue,Not Sent,Чи не Відправлено
 DocType: Web Form,Actions,Заходи
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Налаштування&gt; Користувач
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Налаштування> Користувач
 DocType: Workflow State,align-justify,вирівняти-виправдання
 DocType: User,Middle Name (Optional),По батькові (необов&#39;язково)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Не дозволено
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,СТАНДАРТ
 DocType: Desktop Icon,_report,_звіт
 DocType: Desktop Icon,_report,_звіт
 DocType: Dashboard Chart,Full,Повний
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Чи не HTML Кодувати HTML-теги, такі як &lt;скрипт&gt; або просто символи, такі як &lt;або&gt;, так як вони можуть бути навмисно використані в цій області"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Чи не HTML Кодувати HTML-теги, такі як &lt;скрипт> або просто символи, такі як &lt;або>, так як вони можуть бути навмисно використані в цій області"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} піддається критиці {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Біжи
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Нижній ко
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,До
 DocType: System Settings,Allow only one session per user,Дозволити лише один сеанс для кожного користувача
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Головна/Тестова Тека 1/Тестова Тека 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;HEAD&gt; HTML-
+DocType: Website Settings,&lt;head> HTML,&lt;HEAD> HTML-
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Виберіть або перетягніть по часових комірках, щоб створити нову подію."
 DocType: Contact,Contact Details,Контактні дані
 DocType: DocField,In Filter,У фільтр
@@ -2042,7 +2042,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Вхід не дозволяється у цей час
 DocType: Data Migration Run,Current Mapping Action,Поточний дію карти
 DocType: Dashboard Chart Source,Source Name,ім&#39;я джерела
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,"Жоден обліковий запис електронної пошти не пов’язаний з Користувачем. Будь ласка, додайте обліковий запис у розділі Користувач&gt; Вхідні адреси електронної пошти."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Жоден обліковий запис електронної пошти не пов’язаний з Користувачем. Будь ласка, додайте обліковий запис у розділі Користувач> Вхідні адреси електронної пошти."
 DocType: Email Account,Email Sync Option,Електронна пошта синхронізації Варіант
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Рядок №
 DocType: Async Task,Runtime,Тривалість
@@ -2057,7 +2057,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Вже у
 DocType: User Email,Enable Outgoing,Включити вихідні
 DocType: Address,Fax,Факс
 apps/frappe/frappe/config/customization.py,Custom Tags,призначені для користувача теги
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Не налаштовано обліковий запис електронної пошти. Створіть новий обліковий запис електронної пошти у меню Налаштування&gt; Електронна пошта&gt; Обліковий запис електронної пошти
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Не налаштовано обліковий запис електронної пошти. Створіть новий обліковий запис електронної пошти у меню Налаштування> Електронна пошта> Обліковий запис електронної пошти
 DocType: Comment,Submitted,Проведено
 DocType: Contact,Pulled from Google Contacts,Знято з контактів Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Невірний запит
@@ -2131,7 +2131,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Час вичерп
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18","Це поле з&#39;являється тільки в разі, якщо ім&#39;я_поля визначено тут має значення чи правила є істинними (приклади): MyField Eval: doc.myfield == &#39;My Value&#39; Eval: doc.age&gt; 18"
+eval:doc.age>18","Це поле з&#39;являється тільки в разі, якщо ім&#39;я_поля визначено тут має значення чи правила є істинними (приклади): MyField Eval: doc.myfield == &#39;My Value&#39; Eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Офіс 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,сьогодні
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,сьогодні
@@ -2146,7 +2146,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,ВЕРХНІЙ РЕГІСТР
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Особливий HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Введіть ім'я теки
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Шаблон адреси за замовчуванням не знайдено. Створіть новий із меню Налаштування&gt; Друк та брендинг&gt; Шаблон адреси.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Шаблон адреси за замовчуванням не знайдено. Створіть новий із меню Налаштування> Друк та брендинг> Шаблон адреси.
 apps/frappe/frappe/auth.py,Unknown User,Невідомий користувач
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Виберіть Роль
 DocType: Comment,Deleted,Віддалений
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,"Бракує дозволів, щоб побачити посилання"
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Назва адреси є обов'язковою.
 DocType: Google Contacts,Push to Google Contacts,Перейдіть до контактів Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Додана HTML в &lt;HEAD&gt; частина веб-сторінки, в основному використовується для перевірки веб-сайтів та SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Додана HTML в &lt;HEAD> частина веб-сторінки, в основному використовується для перевірки веб-сайтів та SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Рецидив
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Товар не може бути доданий у власних нащадків
 DocType: Session Default Settings,Session Defaults,За замовчуванням сесії
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,Попередження
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Це може бути надруковано на кількох сторінках
 DocType: Data Migration Run,Percent Complete,Відсоток завершено
 DocType: Tag Category,Tag Category,Тег Категорія
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для порівняння використовуйте&gt; 5, &lt;10 або = 324. Для діапазонів використовуйте 5:10 (для значень від 5 до 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для порівняння використовуйте> 5, &lt;10 або = 324. Для діапазонів використовуйте 5:10 (для значень від 5 до 10)."
 DocType: Google Calendar,Pull from Google Calendar,Витягніть з Google Календар
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Довідка
 DocType: User,Login Before,Увійти перед
@@ -2926,7 +2926,7 @@ DocType: Custom Script,Custom Script,Сценарій на замовлення
 DocType: Address,Address Line 2,Адресний рядок 2
 DocType: Address,Reference,Посилання
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Призначено
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Установіть обліковий запис електронної пошти за замовчуванням у програмі Налаштування&gt; Електронна пошта&gt; Обліковий запис електронної пошти
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Установіть обліковий запис електронної пошти за замовчуванням у програмі Налаштування> Електронна пошта> Обліковий запис електронної пошти
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Детальний опис картки міграції даних
 DocType: Data Import,Action,Дія
 DocType: GSuite Settings,Script URL,URL Script
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Дозволити на Надіслати
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Тип винятку
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Виберіть стовпці
-DocType: Web Page,Add code as &lt;script&gt;,Додайте код в скрипт &lt;&gt;
+DocType: Web Page,Add code as &lt;script>,Додайте код в скрипт &lt;>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Очистити дозволи користувача
 DocType: Webhook,Headers,Заголовки
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Майбутні події
@@ -3366,7 +3366,7 @@ apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specifi
 DocType: Energy Point Log,Criticism,Критика
 DocType: Address,Tripura,Tripura
 DocType: About Us Settings,"""Company History""",&quot;Історія компанії&quot;
-apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Цей документ був змінений після надсилання електронного листа.
+apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Цей документ був змі��ений після надсилання електронного листа.
 DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","Якщо встановлено прапорець, це поле не буде перезаписано на основі &quot;Витягнути з&quot;, якщо значення вже існує."
 DocType: Access Log,Show Report,Показати звіт
 DocType: Address,Tamil Nadu,Тамілнад
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,Частка Alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Черга повинна бути одним з {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Шаблон за замовчуванням </h4><p> Використовує <a href=""http://jinja.pocoo.org/docs/templates/"">дзіндзя темплатним</a> і всі поля Адреса (включаючи Настроювані поля якщо такі є) будуть доступні </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Шаблон за замовчуванням </h4><p> Використовує <a href=""http://jinja.pocoo.org/docs/templates/"">дзіндзя темплатним</a> і всі поля Адреса (включаючи Настроювані поля якщо такі є) будуть доступні </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Поле Дата початку
 DocType: Role,Role Name,Ім&#39;я ролі
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Перемикання на робочий стіл
@@ -3930,7 +3930,7 @@ DocType: LDAP Settings,LDAP User Creation and Mapping,Створення та к
 apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',"Ви можете знайти речі, запитуючи ""знайти апельсин серед клієнтів"""
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Вибачте! Користувач повинен мати повний доступ до свого запису.
 ,Usage Info,Використання Info
-apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Показати комбінації клавіш
+apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Показати ком��інації клавіш
 apps/frappe/frappe/utils/oauth.py,Invalid Token,Неприпустимий маркер
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not upload backup - Error {0},Google Диск - Не вдалося завантажити резервну копію - Помилка {0}
 DocType: Email Account,Email Server,Сервер електронної пошти

--- a/frappe/translations/uk.csv
+++ b/frappe/translations/uk.csv
@@ -1427,7 +1427,7 @@ DocType: Report,Is Standard,СТАНДАРТ
 DocType: Desktop Icon,_report,_звіт
 DocType: Desktop Icon,_report,_звіт
 DocType: Dashboard Chart,Full,Повний
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Чи не HTML Кодувати HTML-теги, такі як &lt;скрипт> або просто символи, такі як &lt;або>, так як вони можуть бути навмисно використані в цій області"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Чи не HTML Кодувати HTML-теги, такі як <скрипт> або просто символи, такі як <або>, так як вони можуть бути навмисно використані в цій області"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} піддається критиці {1}
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Біжи
@@ -1809,7 +1809,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Нижній ко
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,До
 DocType: System Settings,Allow only one session per user,Дозволити лише один сеанс для кожного користувача
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Головна/Тестова Тека 1/Тестова Тека 3
-DocType: Website Settings,&lt;head> HTML,&lt;HEAD> HTML-
+DocType: Website Settings,<head> HTML,<HEAD> HTML-
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,"Виберіть або перетягніть по часових комірках, щоб створити нову подію."
 DocType: Contact,Contact Details,Контактні дані
 DocType: DocField,In Filter,У фільтр
@@ -2337,7 +2337,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,"Бракує дозволів, щоб побачити посилання"
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Назва адреси є обов'язковою.
 DocType: Google Contacts,Push to Google Contacts,Перейдіть до контактів Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Додана HTML в &lt;HEAD> частина веб-сторінки, в основному використовується для перевірки веб-сайтів та SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Додана HTML в <HEAD> частина веб-сторінки, в основному використовується для перевірки веб-сайтів та SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Рецидив
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Товар не може бути доданий у власних нащадків
 DocType: Session Default Settings,Session Defaults,За замовчуванням сесії
@@ -2457,7 +2457,7 @@ DocType: Workflow State,Warning,Попередження
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Це може бути надруковано на кількох сторінках
 DocType: Data Migration Run,Percent Complete,Відсоток завершено
 DocType: Tag Category,Tag Category,Тег Категорія
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для порівняння використовуйте> 5, &lt;10 або = 324. Для діапазонів використовуйте 5:10 (для значень від 5 до 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Для порівняння використовуйте> 5, <10 або = 324. Для діапазонів використовуйте 5:10 (для значень від 5 до 10)."
 DocType: Google Calendar,Pull from Google Calendar,Витягніть з Google Календар
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Довідка
 DocType: User,Login Before,Увійти перед
@@ -3104,7 +3104,7 @@ DocType: DocField,Allow on Submit,Дозволити на Надіслати
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Тип винятку
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Виберіть стовпці
-DocType: Web Page,Add code as &lt;script>,Додайте код в скрипт &lt;>
+DocType: Web Page,Add code as <script>,Додайте код в скрипт <>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Очистити дозволи користувача
 DocType: Webhook,Headers,Заголовки
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Майбутні події
@@ -3481,16 +3481,16 @@ DocType: Workflow State,share-alt,Частка Alt-
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Черга повинна бути одним з {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Шаблон за замовчуванням </h4><p> Використовує <a href=""http://jinja.pocoo.org/docs/templates/"">дзіндзя темплатним</a> і всі поля Адреса (включаючи Настроювані поля якщо такі є) будуть доступні </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Шаблон за замовчуванням </h4><p> Використовує <a href=""http://jinja.pocoo.org/docs/templates/"">дзіндзя темплатним</a> і всі поля Адреса (включаючи Настроювані поля якщо такі є) будуть доступні </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Поле Дата початку
 DocType: Role,Role Name,Ім&#39;я ролі
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Перемикання на робочий стіл

--- a/frappe/translations/uk.csv
+++ b/frappe/translations/uk.csv
@@ -26,7 +26,7 @@ DocType: Email Queue,Send After,Відправити Після
 apps/frappe/frappe/utils/file_manager.py,Please select a file or url,"Будь ласка, виберіть файл або URL"
 apps/frappe/frappe/public/js/frappe/views/treeview.js,{0} Tree,{0} Дерево
 DocType: User,User Emails,листи користувачів
-DocType: User,Username,Ім&#39;я користувача
+DocType: User,Username,Ім'я користувача
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Import Zip,Імпортувати Zip
 apps/frappe/frappe/model/base_document.py,Value too big,Занадто велике значення
 DocType: DocField,DocField,DocField
@@ -64,7 +64,7 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Якщо включено, то сила пароля буде забезпечуватися на основі мінімального значення пароля Score. Значення 2 є середньої сили і 4 будучи дуже сильним."
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Якщо включено, то сила пароля буде забезпечуватися на основі мінімального значення пароля Score. Значення 2 є середньої сили і 4 будучи дуже сильним."
 DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Члени команди&quot; або &quot;Управління&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',За замовчуванням для &quot;Перевірити&quot; типу поля повинні бути &#39;0&#39; або &#39;1&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',За замовчуванням для &quot;Перевірити&quot; типу поля повинні бути '0' або '1'
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Вчора
 DocType: Contact,Designation,Посада
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Автоматичне посилання може бути активоване лише для одного облікового запису електронної пошти.
@@ -141,7 +141,7 @@ apps/frappe/frappe/utils/password_strength.py,"Repeats like ""abcabcabc"" are on
 DocType: Notification,Channel,Канал
 apps/frappe/frappe/templates/emails/administrator_logged_in.html,"If you think this is unauthorized, please change the Administrator password.","Якщо ви думаєте, що це несанкціоноване, будь ласка, змініть пароль адміністратора."
 DocType: Data Import Beta,Data Import Beta,Бета-імпорт даних
-apps/frappe/frappe/email/doctype/email_account/email_account.py,{0} is mandatory,{0} є обов&#39;язковим
+apps/frappe/frappe/email/doctype/email_account/email_account.py,{0} is mandatory,{0} є обов'язковим
 DocType: Assignment Rule,Assignment Rules,Правила призначення
 DocType: Workflow State,eject,Витяг
 apps/frappe/frappe/public/js/frappe/form/form.js,Field {0} not found.,Поле {0} не найден.
@@ -164,14 +164,14 @@ DocType: User Permission,Apply To All Document Types,Застосувати до
 apps/frappe/frappe/config/website.py,Embed image slideshows in website pages.,Код для вставки слайд-шоу зображень на веб-сторінках в.
 apps/frappe/frappe/email/doctype/newsletter/newsletter.js,Send,Послати
 DocType: Workflow Action Master,Workflow Action Name,Назва дії робочого процесу
-apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can not be merged,DocType не можуть бути об&#39;єднані
+apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can not be merged,DocType не можуть бути об'єднані
 DocType: Web Form Field,Fieldtype,FieldType
 apps/frappe/frappe/core/doctype/file/file.py,Not a zip file,Чи не поштовий файл
 DocType: Global Search DocType,Global Search DocType,Глобальний пошук DocType
 DocType: Auto Repeat,"To add dynamic subject, use jinja tags like
 
 <div><pre><code>New {{ doc.doctype }} #{{ doc.name }}</code></pre></div>","Щоб додати динамічний предмет, використовуйте теги jinja, такі як <div><pre> <code>New {{ doc.doctype }} #{{ doc.name }}</code> </pre> </div>"
-apps/frappe/frappe/public/js/frappe/form/save.js,"Mandatory fields required in table {0}, Row {1}","Обов&#39;язкові поля, необхідні в таблиці {0}, рядок {1}"
+apps/frappe/frappe/public/js/frappe/form/save.js,"Mandatory fields required in table {0}, Row {1}","Обов'язкові поля, необхідні в таблиці {0}, рядок {1}"
 apps/frappe/frappe/utils/password_strength.py,Capitalization doesn't help very much.,Капіталізація не надто допоможе.
 DocType: Error Snapshot,Friendly Title,Дружній Назва
 DocType: Newsletter,Email Sent?,Листа відправлено?
@@ -216,22 +216,22 @@ DocType: SMS Settings,Enter url parameter for message,Введіть URL пар�
 apps/frappe/frappe/public/js/frappe/utils/common.js,Auto Repeat created for this document,"Автоматичне повторення, створене для цього документа"
 apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your browser,Перегляньте звіт у своєму веб-переглядачі
 apps/frappe/frappe/config/desk.py,Event and other calendars.,Подія та інші календарі.
-apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 ряд обов&#39;язковий)
+apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 ряд обов'язковий)
 apps/frappe/frappe/templates/includes/comments/comments.html,All fields are necessary to submit the comment.,Всі поля необхідно надати коментар.
 DocType: Custom Script,Adds a client custom script to a DocType,Додає користувацький сценарій клієнта до DocType
-DocType: Print Settings,Printer Name,Ім&#39;я принтера
+DocType: Print Settings,Printer Name,Ім'я принтера
 DocType: Webhook,Form URL-Encoded,URL-форма форми - закодована
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Ширина може бути у рх або%.
 apps/frappe/frappe/public/js/frappe/form/print.js,Start,Початок
-DocType: Contact,First Name,Ім&#39;я
-DocType: LDAP Settings,LDAP Username Field,LDAP Ім&#39;я користувача Поле
+DocType: Contact,First Name,Ім'я
+DocType: LDAP Settings,LDAP Username Field,LDAP Ім'я користувача Поле
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,LDAP is not enabled.,LDAP не ввімкнено.
 DocType: Portal Settings,Standard Sidebar Menu,Стандартне меню Бічна панель
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failure,Автоматичне повторення відмови створення документа
 apps/frappe/frappe/core/doctype/file/file.py,Cannot delete Home and Attachments folders,"Не вдається видалити теки ""Головна"" та ""Долучення"""
 apps/frappe/frappe/config/desk.py,Files,Файли
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions get applied on Users based on what Roles they are assigned.,"Дозволи бути застосована на користувачів, заснованих на тому, що ролі, які вони призначені."
-apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,"Ви не можете відправляти повідомлення електронної пошти, пов&#39;язані з цим документом"
+apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,"Ви не можете відправляти повідомлення електронної пошти, пов'язані з цим документом"
 apps/frappe/frappe/model/db_query.py,Please select atleast 1 column from {0} to sort/group,"Будь ласка, виберіть принаймні 1 стовпець {0} для сортування / груп"
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1}. Restricted field: {2},Не дозволено для {0}: {1}. Поле з обмеженням: {2}
 DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,"Перевірте це, якщо ви перевіряєте ваш платіж за допомогою API Пісочниця"
@@ -254,7 +254,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Відключи
 DocType: Translation,Contributed Translation Doctype Name,Назва доктрипу перекладу
 DocType: PayPal Settings,Redirect To,перенаправити
 DocType: Data Migration Mapping,Pull,Витягніть
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Формат: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript Формат: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Масове оновлення
 DocType: Workflow State,chevron-up,шеврона до
 DocType: DocType,Allow Guest to View,"Дозволити для гостей, щоб подивитися"
@@ -296,7 +296,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Password is requ
 DocType: Email Account,e.g. replies@yourcomany.com. All replies will come to this inbox.,наприклад replies@yourcomany.com. Всі відповіді будуть приходити до цього поштову скриньку.
 DocType: Slack Webhook URL,Slack Webhook URL,URL-адреса Slack Webhook
 DocType: Data Migration Run,Current Mapping,Поточне відображення
-apps/frappe/frappe/templates/includes/login/login.js,Valid email and name required,Дійсно електронна пошта та ім&#39;я потрібно
+apps/frappe/frappe/templates/includes/login/login.js,Valid email and name required,Дійсно електронна пошта та ім'я потрібно
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Make all attachments private,Зробіть усі вкладення приватними
 DocType: User,Send Notifications for documents followed by me,"Надсилайте сповіщення за документами, за якими я йду"
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add User Permissions,Додати дозволи користувача
@@ -368,7 +368,7 @@ DocType: System Settings,Enable Two Factor Auth,Увімкнути двофак�
 DocType: Post,Liked By,Вподобане
 DocType: DocField,Print Hide If No Value,Друк Приховати Якщо немає значення
 DocType: Kanban Board Column,yellow,жовтий
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Is Published Field must be a valid fieldname,Опубліковано Поле повинно бути дійсним ім&#39;я_поля
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Is Published Field must be a valid fieldname,Опубліковано Поле повинно бути дійсним ім'я_поля
 DocType: Block Module,Block Module,Блок Модуль
 apps/frappe/frappe/core/doctype/version/version_view.html,New Value,нове значення
 apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field,"DocType <b>{0},</b> наданий для поля <b>{1},</b> повинен мати принаймні одне поле Посилання"
@@ -380,13 +380,13 @@ DocType: Notification,Send Alert On,Відправити попередженн�
 DocType: Customize Form,"Customize Label, Print Hide, Default etc.","Налаштувати Label, Друк приховувати, за замовчуванням і т.д."
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Unzipping files...,Розпакування файлів ...
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} appreciated your work on {1} with {2} points,{0} оцінив вашу роботу на {1} з {2} балами
-apps/frappe/frappe/core/doctype/communication/communication.py,Please make sure the Reference Communication Docs are not circularly linked.,"Будь ласка, переконайтеся, що Довідкові документи зв&#39;язку не є циркулярними."
+apps/frappe/frappe/core/doctype/communication/communication.py,Please make sure the Reference Communication Docs are not circularly linked.,"Будь ласка, переконайтеся, що Довідкові документи зв'язку не є циркулярними."
 DocType: Assignment Rule,Assign Condition,Призначте умову
 apps/frappe/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py,Download Your Data,Завантажте свої дані
 DocType: Dashboard Chart,Value Based On,Значення на основі
 DocType: List View Setting,Disable Sidebar Stats,Вимкнути статистику бічної панелі
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Create a New Format,Створити новий формат
-apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Unable to create bucket: {0}. Change it to a more unique name.,Неможливо створити відро: {0}. Змініть його на більш унікальне ім&#39;я.
+apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Unable to create bucket: {0}. Change it to a more unique name.,Неможливо створити відро: {0}. Змініть його на більш унікальне ім'я.
 DocType: Webhook,Request URL,Запит URL
 DocType: Customize Form,Is Table,Чи є таблиця
 DocType: Email Account,Total number of emails to sync in initial sync process ,Загальна кількість повідомлень електронної пошти для синхронізації в процесі початкової синхронізації
@@ -410,14 +410,14 @@ DocType: System Settings,Currency Precision,Валюта Precision
 apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,"Інший угода блокує це. Будь ласка, спробуйте ще раз через кілька секунд."
 apps/frappe/frappe/public/js/frappe/ui/filters/filter_list.js,Clear filters,Очистити фільтри
 DocType: Test Runner,App,додаток
-apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Вкладення не можуть бути правильно пов&#39;язані з новим документом
+apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Вкладення не можуть бути правильно пов'язані з новим документом
 DocType: Chat Message Attachment,Attachment,Долучення
 DocType: Auto Repeat,Yearly,Річний
 DocType: Communication,Message ID,ідентифікатор повідомлення
-DocType: Property Setter,Field Name,Ім&#39;я поля
+DocType: Property Setter,Field Name,Ім'я поля
 DocType: Assignment Rule,Assign To Users,Призначити користувачам
 apps/frappe/frappe/public/js/frappe/utils/utils.js,or,або
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,module name...,Модуль ім&#39;я ...
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,module name...,Модуль ім'я ...
 apps/frappe/frappe/templates/pages/integrations/payment-success.html,Continue,Продовжувати
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,Інтеграція Google відключена.
 DocType: Custom Field,Fieldname,Fieldname
@@ -433,7 +433,7 @@ apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,Панель пр�
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Не вдалося відправити електронну пошту в цей час
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Календар Google - Не вдалося оновити подію {0} в Календарі Google, код помилки {1}."
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Пошук або введіть команду
-DocType: Activity Log,Timeline Name,терміни Ім&#39;я
+DocType: Activity Log,Timeline Name,терміни Ім'я
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,Лише один {0} можна встановити як основний.
 DocType: Email Account,e.g. smtp.gmail.com,наприклад smtp.gmail.com
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add A New Rule,Додати нове правило
@@ -442,7 +442,7 @@ DocType: User Permission,For Value,Для значення
 DocType: Event,Google Calendar ID,Ідентифікатор календаря Google
 apps/frappe/frappe/www/complete_signup.html,One Last Step,Останній крок
 apps/frappe/frappe/config/settings.py,Import Data,Імпортувати дані
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer,"Назва типу документа (DOCTYPE), ви хочете це поле, пов&#39;язані з. наприклад Замовник"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer,"Назва типу документа (DOCTYPE), ви хочете це поле, пов'язані з. наприклад Замовник"
 DocType: Role Profile,Roles Assigned,"Ролі, призначені"
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search Help,Пошук Допомога
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search Help,Пошук Допомога
@@ -452,7 +452,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linkin
 DocType: LDAP Settings,LDAP Middle Name Field,Поле середнього імені LDAP
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Importing {0} of {1},Імпорт {0} з {1}
 DocType: GCalendar Account,Allow GCalendar Access,Дозволити доступ до GCalendar
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} обов&#39;язкове поле
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} обов'язкове поле
 apps/frappe/frappe/templates/includes/login/login.js,Login token required,Треба ввімкнути токен
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Monthly Rank: ,Щомісячний рейтинг:
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select multiple list items,Виберіть кілька елементів списку
@@ -463,7 +463,7 @@ DocType: Google Maps Settings,Google Maps Settings,Налаштування Ка
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Loading...,Завантаження ...
 DocType: DocField,Password,Пароль
 apps/frappe/frappe/utils/response.py,Your system is being updated. Please refresh again after a few moments,"Ваша система оновлюється. Будь ласка, поновіть ще раз за кілька хвилин"
-DocType: Blogger,Will be used in url (usually first name).,Буде використовуватися в URL (зазвичай ім&#39;я).
+DocType: Blogger,Will be used in url (usually first name).,Буде використовуватися в URL (зазвичай ім'я).
 DocType: Comment,Comment Email,Коментувати електронну пошту
 DocType: Auto Email Report,Day of Week,день тижня
 DocType: Note,Expire Notification On,Expire Повідомлення про
@@ -483,7 +483,7 @@ apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Auto assignment failed: {0},Помилка автоматичного призначення: {0}
 apps/frappe/frappe/templates/includes/search_box.html,Search...,Пошук ...
 apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,Please select Company,"Будь ласка, виберіть компанію"
-apps/frappe/frappe/utils/nestedset.py,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,Об&#39;єднання можливе тільки між Група-к-групи або аркуш вузол-вузол листа
+apps/frappe/frappe/utils/nestedset.py,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,Об'єднання можливе тільки між Група-к-групи або аркуш вузол-вузол листа
 apps/frappe/frappe/utils/file_manager.py,Added {0},Додано {0}
 apps/frappe/frappe/templates/includes/search_template.html,No matching records. Search something new,Немає відповідних записів. Пошук щось нове
 DocType: Chat Profile,Away,Далеко
@@ -503,7 +503,7 @@ apps/frappe/frappe/model/base_document.py,{0} must be set first,{0} повине
 apps/frappe/frappe/utils/password_strength.py,"Use a few words, avoid common phrases.","Використовуйте кілька слів, уникати загальних фраз."
 DocType: Workflow State,plane,літак
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Rounded Corners,Закруглені куточки
-apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","Якщо ви завантажуєте нові рекорди &quot;, Неймінг серії&quot; стає обов&#39;язковим, якщо вони присутні."
+apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","Якщо ви завантажуєте нові рекорди &quot;, Неймінг серії&quot; стає обов'язковим, якщо вони присутні."
 apps/frappe/frappe/email/doctype/notification/notification.js,Get Alerts for Today,Віртуальний на сьогоднішній день
 DocType: Contact,Google Contacts Id,Ідентифікатор контактів Google
 apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can only be renamed by Administrator,DocType можуть бути перейменовані тільки адміністратор
@@ -517,7 +517,7 @@ DocType: Report,JSON,JSON
 apps/frappe/frappe/core/doctype/user/user.py,Please check your email for verification,"Будь ласка, перевірте свою електронну пошту для перевірки"
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold can not be at the end of the form,Fold не може бути в кінці вигляді
 DocType: Communication,Bounced,Повернені
-DocType: Deleted Document,Deleted Name,видаляється Ім&#39;я
+DocType: Deleted Document,Deleted Name,видаляється Ім'я
 apps/frappe/frappe/config/users_and_permissions.py,System and Website Users,Системні користувачі і користувачі веб-сайту
 DocType: Workflow Document State,Doc Status,Док Статус
 DocType: Data Migration Run,Pull Update,Потягніть оновлення
@@ -541,7 +541,7 @@ apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Document 
 apps/frappe/frappe/model/document.py,Document Queued,документ Queued
 DocType: GSuite Templates,Destination ID,Ідентифікатор пункту призначення
 DocType: Desktop Icon,List,Список
-DocType: Activity Log,Link Name,посилання Ім&#39;я
+DocType: Activity Log,Link Name,посилання Ім'я
 DocType: System Settings,mm/dd/yyyy,мм / дд / рррр
 apps/frappe/frappe/core/doctype/user/user.py,Invalid Password: ,Неправильний пароль:
 apps/frappe/frappe/core/doctype/user/user.py,Invalid Password: ,Неправильний пароль:
@@ -551,7 +551,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Re:,Re:
 DocType: LDAP Settings,Require Trusted Certificate,Потрібна довірена довідка
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} rows for {1},{0} рядків для {1}
 DocType: Currency,"Sub-currency. For e.g. ""Cent""","Суб-валюта. Наприклад, ""коп."""
-apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.js,Connection Name,Назва з&#39;єднання
+apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.js,Connection Name,Назва з'єднання
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,New Kanban Board,Нова рада канбан
 DocType: Dashboard Chart,Half,Половина
 DocType: Desktop Icon,Link,Посилання
@@ -564,7 +564,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Статистика на основі результативності минулого тижня (від {0} до {1})
 DocType: LDAP Settings,LDAP Phone Field,Телефонне поле LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","тип документа ..., наприклад, клієнт"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Умова &#39;{0}&#39; є недійсним
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Умова '{0}' є недійсним
 DocType: Workflow State,barcode,штрих-код
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Використання суб-запиту або функції обмежено
 apps/frappe/frappe/config/customization.py,Add your own translations,Додати свої власні переклади
@@ -573,10 +573,10 @@ apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Blank Template,
 DocType: About Us Team Member,About Us Team Member,Про нас Команда Член
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions.","Дозволи встановлюються для ролей та типів документів (DocTypes) шляхом встановлення таких прав, як: Читання, Запис, Створення, Видалення, Проведення, Скасування, Відновлення, Звіт, Імпорт, Експорт, Друк, E-mail встановлення дозволів користувачам."
 DocType: Assignment Rule Day,Wednesday,Середа
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Поле Зображення повинно бути допустимим ім&#39;я_поля
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Поле Зображення повинно бути допустимим ім'я_поля
 DocType: Chat Token,Token,знак
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} is restricted,Ім&#39;я поля {0} обмежене
-DocType: Property Setter,ID (name) of the entity whose property is to be set,"ID (ім&#39;я) особи, чия власність повинна бути встановлена"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} is restricted,Ім'я поля {0} обмежене
+DocType: Property Setter,ID (name) of the entity whose property is to be set,"ID (ім'я) особи, чия власність повинна бути встановлена"
 DocType: Website Settings,Website Theme Image Link,Посилання на зображення теми веб-сайту
 DocType: Web Form,Sidebar Items,Sidebar товари
 DocType: Web Form,Show as Grid,Показати як сітку
@@ -633,13 +633,13 @@ DocType: Print Format,Style Settings,налаштування стилю
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Filter By,Фільтрувати за
 apps/frappe/frappe/database/database.py,No conditions provided,Не передбачено жодних умов
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Y Axis Fields
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,Сортування поля {0} повинен бути дійсним ім&#39;я_поля
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,Сортування поля {0} повинен бути дійсним ім'я_поля
 apps/frappe/frappe/public/js/frappe/list/base_list.js,More,Більш
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Create a new record,Створіть новий запис
 DocType: Contact,Sales Manager,Менеджер з продажу
 apps/frappe/frappe/public/js/frappe/model/model.js,Rename,Перейменувати
 DocType: Print Format,Format Data,Формат даних
-DocType: List Filter,Filter Name,Фільтрувати ім&#39;я
+DocType: List Filter,Filter Name,Фільтрувати ім'я
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Like,Схоже на
 DocType: Assignment Rule,Automation,Автоматизація
 DocType: Google Drive,Last Backup On,Остання резервна копія увімкнена
@@ -658,7 +658,7 @@ DocType: Email Account,Enable Auto Reply,Включити Auto Відповіс�
 apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Not Seen,Не бачив
 apps/frappe/frappe/public/js/frappe/form/print.js,Cannot have multiple printers mapped to a single print format.,Неможливо кілька принтерів відображати в одному форматі друку.
 DocType: Workflow State,zoom-in,збільшити
-apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Reference DocType and Reference Name are required,Посилання DocType і Ім&#39;я посилання потрібно
+apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Reference DocType and Reference Name are required,Посилання DocType і Ім'я посилання потрібно
 apps/frappe/frappe/utils/jinja.py,Syntax error in template,Синтаксична помилка в шаблоні
 DocType: DocField,Width,Ширина
 apps/frappe/frappe/public/js/frappe/views/communication.js,Message clipped,Повідомлення вирізано
@@ -680,14 +680,14 @@ apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Ancestors Of,Предк
 apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,Корінь {0} не може бути вилучена
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Коментарів немає
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings","Будь-ласка, настройте SMS, перш ніж встановити його як метод автентифікації, через SMS Settings"
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,Обидва DocType і ім&#39;я потрібно
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,Обидва DocType і ім'я потрібно
 apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,Неможливо змінити docstatus від 1 до 0
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,Вам не вистачає балів
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Take Backup Now,Take Backup Now
 DocType: Contact,Open,Відкрито
 DocType: Workflow Transition,Defines actions on states and the next step and allowed roles.,Визначає дії на держави і наступний крок і дозволили ролі.
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Reviewer,Топ рецензента
-DocType: Data Migration Mapping,Remote Objectname,Віддалений об&#39;єктменю
+DocType: Data Migration Mapping,Remote Objectname,Віддалений об'єктменю
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","У кращої практики, не може привласнити цей набір правило введене в різних ролей. Замість цього, встановити кілька ролей одному користувачеві."
 apps/frappe/frappe/www/confirm_workflow_action.html,Please confirm your action to {0} this document.,"Будь ласка, підтвердьте свою дію на {0} цього документа."
 DocType: Success Action,Next Actions HTML,Наступні дії HTML
@@ -711,7 +711,7 @@ DocType: DocField,Set Only Once,Встановити тільки один ра�
 DocType: Email Queue Recipient,Email Queue Recipient,E-mail одержувача черзі
 DocType: Address,Nagaland,Нагаланд
 DocType: Slack Webhook URL,Webhook URL,URL-адреса веб-вузла
-apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Ім&#39;я користувача {0} вже існує
+apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Ім'я користувача {0} вже існує
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,"{0}: Неможливо встановити імпорт, оскільки {1} не імпортується"
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Існує помилка в адресному шаблоні {0}
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} - це недійсна електронна адреса в &quot;Одержувачі&quot;
@@ -756,7 +756,7 @@ DocType: Currency,Currency Name,Назва валюти
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,Немає повідомлень електронної пошти
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Посилання закінчився
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Повернення довжини до {0} для &#39;{1}&#39; в &#39;{2}&#39;; Встановлення тривалості як {3} призведе до скорочення даних.
+							Setting the length as {3} will cause truncation of data.",Повернення довжини до {0} для '{1}' в '{2}'; Встановлення тривалості як {3} призведе до скорочення даних.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Виберіть формат файлу
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Вміст хеша
@@ -787,13 +787,13 @@ DocType: File,Is Home Folder,"є текою ""Головна"""
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Стиль Навбар
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} не корректна Email адреса
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Виберіть принаймні 1 запис для друку
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Користувач &#39;{0}&#39; вже грає роль &quot;{1} &#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Користувач '{0}' вже грає роль &quot;{1} '
 DocType: System Settings,Two Factor Authentication method,Два методу автентифікації факторів
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Спочатку встановіть ім&#39;я та збережіть запис.
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Спочатку встановіть ім'я та збережіть запис.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 Записи
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with {0},Оприлюднено для {0}
 apps/frappe/frappe/email/queue.py,Unsubscribe,Відмовитися від підписки
-DocType: View Log,Reference Name,Ім&#39;я посилання
+DocType: View Log,Reference Name,Ім'я посилання
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Change User,Змінити користувача
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Update Translations,Оновити переклади
 DocType: Error Snapshot,Exception,Виняток
@@ -801,7 +801,7 @@ DocType: Email Account,Use IMAP,Використання IMAP
 DocType: Activity Log,Activity Log,Журнал активності
 DocType: View Log,Viewed By,Переглянуто за
 DocType: Integration Request,Authorized,уповноважений
-DocType: DocType,Single Types have only one record no tables associated. Values are stored in tabSingles,Неодружений Види не тільки один запис не зв&#39;язані таблиці. Значення зберігаються в tabSingles
+DocType: DocType,Single Types have only one record no tables associated. Values are stored in tabSingles,Неодружений Види не тільки один запис не зв'язані таблиці. Значення зберігаються в tabSingles
 DocType: System Settings,Enable Password Policy,Включення політики паролів
 DocType: System Settings,Enable Password Policy,Включення політики паролів
 DocType: Web Form,"List as [{""label"": _(""Jobs""), ""route"":""jobs""}]","Список як [{ &quot;етикетка&quot;: _ ( &quot;Робота&quot;), &quot;маршрут&quot;: &quot;робота&quot;}]"
@@ -856,7 +856,7 @@ apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Ms,Місс
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Background Color,Колір фону
 apps/frappe/frappe/public/js/frappe/views/communication.js,There were errors while sending email. Please try again.,Були помилки при відправленні електронної пошти. Будь ласка спробуйте ще раз.
 DocType: Portal Settings,Portal Settings,Налаштування порталу
-DocType: Review Level,Level Name,Ім&#39;я рівня
+DocType: Review Level,Level Name,Ім'я рівня
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,Cannot update {0},Не вдається оновити {0}
 DocType: Data Migration Mapping,Mapping,Картографування
 DocType: Web Page,0 is highest,0 є найвищим
@@ -870,7 +870,7 @@ DocType: Email Group Member,Email Group Member,Електронна пошта �
 apps/frappe/frappe/auth.py,Your account has been locked and will resume after {0} seconds,"Ваш обліковий запис заблоковано, і його буде відновлено через {0} секунди"
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions are used to limit users to specific records.,Права користувача використовуються для обмеження доступу користувачів до певних записів.
 DocType: Notification,Value Changed,Значення Змінено
-apps/frappe/frappe/model/base_document.py,Duplicate name {0} {1},Дублювати ім&#39;я {0} {1}
+apps/frappe/frappe/model/base_document.py,Duplicate name {0} {1},Дублювати ім'я {0} {1}
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Retry,Спроба спробувати
 DocType: Contact Phone,Number,Номер
 DocType: Web Form Field,Web Form Field,Поле Веб-форми
@@ -916,12 +916,12 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,{0} cannot be set for Single 
 DocType: Data Import,Data Import,Імпорт даних
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Configure Chart,Налаштувати діаграму
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_viewers.js,{0} are currently viewing this document,{0} в даний час переглядає цей документ
-DocType: ToDo,Assigned By Full Name,Присвоюється Повне ім&#39;я
+DocType: ToDo,Assigned By Full Name,Присвоюється Повне ім'я
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,{0} updated,{0} оновлений
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Report cannot be set for Single types,Звіт не може бути встановлений на окремі типи
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Share URL,Надіслати URL-адресу
 DocType: System Settings,Allow Consecutive Login Attempts ,Дозволити послідовні вхідні спроби
-apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,"Під час здійснення платежу сталася помилка. Будь ласка, зв&#39;яжіться з нами."
+apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,"Під час здійснення платежу сталася помилка. Будь ласка, зв'яжіться з нами."
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} days ago,{0} днів тому
 DocType: Email Account,Awaiting Password,очікування пароля
 DocType: Address,Address Line 1,Адресний рядок 1
@@ -966,7 +966,7 @@ DocType: LDAP Settings,Organizational Unit for Users,Організаційни�
 ,Transaction Log Report,Звіт журналу транзакцій
 DocType: Custom DocPerm,Custom DocPerm,призначені для користувача DocPerm
 DocType: Newsletter,Send Unsubscribe Link,Надіслати посилання Відмовитися
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,There are some linked records which needs to be created before we can import your file. Do you want to create the following missing records automatically?,"Є кілька пов&#39;язаних записів, які потрібно створити, перш ніж ми зможемо імпортувати ваш файл. Ви хочете автоматично створити такі відсутні записи?"
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,There are some linked records which needs to be created before we can import your file. Do you want to create the following missing records automatically?,"Є кілька пов'язаних записів, які потрібно створити, перш ніж ми зможемо імпортувати ваш файл. Ви хочете автоматично створити такі відсутні записи?"
 DocType: Access Log,Method,Метод
 DocType: Report,Script Report,Повідомити сценарію
 DocType: OAuth Authorization Code,Scopes,області застосування
@@ -978,7 +978,7 @@ apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for Us
 apps/frappe/frappe/public/js/frappe/social/components/PostSidebar.vue,Frequently Visited Links,Часто відвідувані посилання
 DocType: Notification,"To add dynamic subject, use jinja tags like
 
-<div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Щоб додати динамічний об&#39;єкт, використовувати теги, як дзіндзя <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
+<div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Щоб додати динамічний об'єкт, використовувати теги, як дзіндзя <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
 apps/frappe/frappe/desk/search.py,Invalid Search Field {0},Неправильне поле пошуку {0}
 DocType: User,Modules HTML,Модулі HTML-
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Дозволити доступ до Google Календар
@@ -1040,7 +1040,7 @@ DocType: Property Setter,Property Setter,Нерухомість сетер
 DocType: Web Form,Allow Print,дозволити друк
 DocType: Communication,Clicked,Натиснув
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Не слідкувати
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Немає доступу для &#39;{0}&#39; {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},Немає доступу для '{0}' {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,планується відправити
 DocType: DocType,Track Seen,трек відвідування
 DocType: Dropbox Settings,File Backup,Файл резервного копіювання
@@ -1066,7 +1066,7 @@ DocType: Kanban Board Column,Blue,Синій
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customizations will be removed. Please confirm.,Всі налаштування будуть видалені. Будь-ласка підтвердіть.
 DocType: Page,Page HTML,Сторінка HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Експорт помилкових рядків
-apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Ім&#39;я групи не може бути порожнім.
+apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Ім'я групи не може бути порожнім.
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Подальші вузли можуть бути створені тільки під вузлами типу &quot;група&quot;
 DocType: SMS Parameter,Header,Тема
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Невідомий Колонка: {0}
@@ -1125,12 +1125,12 @@ DocType: User,Simultaneous Sessions,одночасних сесій
 DocType: Social Login Key,Client Credentials,Облікові дані клієнта
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Open a module or tool,Відкриття модуля або інструменту
 DocType: Communication,Delivery Status,Статус поставки
-DocType: Module Def,App Name,Ім&#39;я програми
+DocType: Module Def,App Name,Ім'я програми
 DocType: Workflow,"Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)","Поле, яке представляє стан робочого процесу для операції (якщо такого поля немає, то буде створено приховане користувацьке поле)"
 DocType: Help Article,Knowledge Base Contributor,База знань Учасник
 DocType: Communication,Sent Read Receipt,направлено прочитання
 DocType: Email Queue,Unsubscribe Method,метод Відмовитися
-DocType: GSuite Templates,Related DocType,пов&#39;язані DocType
+DocType: GSuite Templates,Related DocType,пов'язані DocType
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit to add content,"Редагувати, щоб додати вміст"
 apps/frappe/frappe/public/js/frappe/views/communication.js,Select Languages,Виберіть Мови
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Card Details,Інформація про картку
@@ -1141,7 +1141,7 @@ apps/frappe/frappe/templates/emails/auto_reply.html,Reference: {0} {1},Поси�
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Mrs,пані
 DocType: File,Attached To Name,Долучено до імені
 DocType: Address,Address Type,Тип адреси
-apps/frappe/frappe/email/receive.py,Invalid User Name or Support Password. Please rectify and try again.,"Невірний ім&#39;я користувача або пароль Підтримка. Ласка, виправити і спробувати ще раз."
+apps/frappe/frappe/email/receive.py,Invalid User Name or Support Password. Please rectify and try again.,"Невірний ім'я користувача або пароль Підтримка. Ласка, виправити і спробувати ще раз."
 DocType: Email Account,Yahoo Mail,Yahoo Mail
 apps/frappe/frappe/email/doctype/notification/notification.py,Error in Notification,Помилка сповіщення
 DocType: Access Log,Log Data,Дані журналу
@@ -1181,9 +1181,9 @@ apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For 
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,Repeats {0},Повторення {0}
 DocType: OAuth Provider Settings,OAuth Provider Settings,OAuth провайдера Налаштування
 DocType: Review Level,Review Points,Огляньте бали
-DocType: Workflow Document State,Workflow Action is not created for optional states,Дія робочого процесу не створюється для необов&#39;язкових станів
+DocType: Workflow Document State,Workflow Action is not created for optional states,Дія робочого процесу не створюється для необов'язкових станів
 DocType: Address,City/Town,Місто
-DocType: Data Migration Connector,Connector Name,Назва роз&#39;єму
+DocType: Data Migration Connector,Connector Name,Назва роз'єму
 DocType: Address,Is Your Company Address,Є адресою Вашої компанії
 DocType: Energy Point Log,Social,Соціальний
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Календар Google - не вдалося створити Календар для {0}, код помилки {1}."
@@ -1195,7 +1195,7 @@ DocType: Route History,Route History,Історія маршрутів
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Give Review Points,Дайте оглядові бали
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Календар Google - не вдалося вставити контакт у контакти Google {0}, код помилки {1}."
 apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,OTP-секрет може бути скинутий тільки адміністратором.
-apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,"Уникайте років, які пов&#39;язані з вами."
+apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,"Уникайте років, які пов'язані з вами."
 apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Обмежити користувача для певного документа
 DocType: GSuite Templates,GSuite Templates,GSuite шаблони
 apps/frappe/frappe/utils/goal.py,Goal,Мета
@@ -1235,7 +1235,7 @@ DocType: User,Banner Image,Картинка банера
 DocType: Custom Field,Custom Field,Користувацькі поля
 apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which date field must be checked,"Вкажіть, будь ласка, поля дати, що повинні бути позначені"
 DocType: Custom DocPerm,Set User Permissions,Встановити дозволи користувача
-DocType: Email Account,Email Account Name,E-mail Ім&#39;я рахунки
+DocType: Email Account,Email Account Name,E-mail Ім'я рахунки
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Something went wrong while generating dropbox access token. Please check error log for more details.,"Щось пішло не так при створенні маркерів доступу Dropbox. Будь ласка, перевірте журнал помилок для отримання більш докладної інформації."
 DocType: File,old_parent,old_parent
 apps/frappe/frappe/config/desk.py,"Newsletters to contacts, leads.","Розсилка контактам, Lead-ам."
@@ -1246,11 +1246,11 @@ DocType: Assignment Rule,Description,Опис
 DocType: Print Settings,Repeat Header and Footer in PDF,Повторіть Колонтитули в PDF
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Failure,Невдача
 DocType: Address Template,Is Default,За замовчуванням
-DocType: Data Migration Connector,Connector Type,Тип роз&#39;єму
-apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py,Column Name cannot be empty,Ім&#39;я стовпця не може бути порожнім
+DocType: Data Migration Connector,Connector Type,Тип роз'єму
+apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py,Column Name cannot be empty,Ім'я стовпця не може бути порожнім
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Error while connecting to email account {0},Помилка при підключенні до облікового запису електронної пошти {0}
 DocType: Workflow State,fast-forward,швидко вперед
-DocType: Communication,Communication,Зв&#39;язки
+DocType: Communication,Communication,Зв'язки
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,"Check columns to select, drag to set order.","Перевірте колонки, щоб вибрати, перетягнути, щоб встановити порядок."
 apps/frappe/frappe/templates/emails/new_message.html,Login and view in Browser,Вхід і перегляд у веб-переглядачі
 apps/frappe/frappe/core/doctype/page/page.js,Go to {0} Page,Перейдіть на сторінку {0}
@@ -1280,7 +1280,7 @@ DocType: Email Queue,Not Sent,Чи не Відправлено
 DocType: Web Form,Actions,Заходи
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Налаштування> Користувач
 DocType: Workflow State,align-justify,вирівняти-виправдання
-DocType: User,Middle Name (Optional),По батькові (необов&#39;язково)
+DocType: User,Middle Name (Optional),По батькові (необов'язково)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Не дозволено
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,No Google Calendar Event to sync.,Немає синхронізувати події Google Календар.
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Following fields have missing values:,Ці поля мають пропущені значення:
@@ -1321,7 +1321,7 @@ DocType: Data Migration Run,Fail,Невдалий
 DocType: Workflow State,download-alt,скачати альт-
 DocType: Data Migration Run,Pull Failed,Потягнути не вдалося
 apps/frappe/frappe/public/js/frappe/views/components/Desktop.vue,Show / Hide Cards,Показати / приховати картки
-DocType: Communication,Feedback Request,Зворотній зв&#39;язок Запит
+DocType: Communication,Feedback Request,Зворотній зв'язок Запит
 apps/frappe/frappe/config/settings.py,Import Data from CSV / Excel files.,Імпортувати дані з файлів CSV / Excel.
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Following fields are missing:,Ці поля відсутні:
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Cancelling {0},Скасування {0}
@@ -1369,7 +1369,7 @@ DocType: Notification,Slack,Слабка
 DocType: Custom DocPerm,If user is the owner,Якщо користувач є власником
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Follow,Дотримуйтесь
 ,Activity,Діяльність
-DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Допомога: Для посилання на інший запис в системі, використовуйте &quot;# Форма / Примітка / [Примітка Ім&#39;я]&quot; як URL Link. (не використовуйте &quot;HTTP: //&quot;)"
+DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Допомога: Для посилання на інший запис в системі, використовуйте &quot;# Форма / Примітка / [Примітка Ім'я]&quot; як URL Link. (не використовуйте &quot;HTTP: //&quot;)"
 DocType: User Permission,Allow,Дозволити
 DocType: Data Import Beta,Update Existing Records,Оновити існуючі записи
 apps/frappe/frappe/utils/password_strength.py,Let's avoid repeated words and characters,Давайте уникати повторюваних слів і символів
@@ -1377,7 +1377,7 @@ DocType: Energy Point Rule,Energy Point Rule,Правило енергетичн
 DocType: Communication,Delayed,Затримується
 apps/frappe/frappe/config/settings.py,List of backups available for download,"Список резервних копій, доступних для завантаження"
 apps/frappe/frappe/www/login.html,Sign up,Зареєструватися
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Row {0}: Not allowed to disable Mandatory for standard fields,Рядок {0}: заборонено вимикати Обов&#39;язковий для стандартних полів
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Row {0}: Not allowed to disable Mandatory for standard fields,Рядок {0}: заборонено вимикати Обов'язковий для стандартних полів
 apps/frappe/frappe/config/customization.py,Dashboards,Інформаційні панелі
 DocType: Test Runner,Output,вихід
 DocType: Milestone,Track Field,Бігова доріжка
@@ -1432,7 +1432,7 @@ apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized o
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Біжи
 DocType: Blog Post,Content (HTML),Вміст (HTML)
-DocType: Personal Data Download Request,User Name,Ім&#39;я користувача
+DocType: Personal Data Download Request,User Name,Ім'я користувача
 DocType: Workflow State,minus-sign,мінус знак
 apps/frappe/frappe/public/js/frappe/request.js,Not Found,Не знайдено
 apps/frappe/frappe/www/printview.py,No {0} permission,Немає {0} дозвіл
@@ -1455,9 +1455,9 @@ DocType: ToDo,Medium,Середній
 DocType: Comment,Comment By,Коментар від
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Customize Form,Налаштувати форму
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Тип одиниці
-apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Обов&#39;язкове поле: встановити роль
+apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Обов'язкове поле: встановити роль
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} критикують {1}
-DocType: Data Migration Mapping,Mapping Name,Картографічне ім&#39;я
+DocType: Data Migration Mapping,Mapping Name,Картографічне ім'я
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: Поле &quot;{1}&quot; не можна встановити як унікальне, оскільки воно має унікальні значення"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Переміщення списку вниз
 DocType: Currency,A symbol for this currency. For e.g. $,"Символ цієї валюти. Наприклад, ₴"
@@ -1510,7 +1510,7 @@ apps/frappe/frappe/public/js/frappe/roles_editor.js,Clear all roles,Очисті
 apps/frappe/frappe/model/base_document.py,{0} must be unique,{0} має бути унікальним
 apps/frappe/frappe/model/base_document.py,Row,Ряд
 apps/frappe/frappe/public/js/frappe/views/communication.js,"CC, BCC & Email Template","CC, BCC та шаблон електронної пошти"
-DocType: Data Migration Mapping Detail,Local Fieldname,Локальне поле ім&#39;я
+DocType: Data Migration Mapping Detail,Local Fieldname,Локальне поле ім'я
 DocType: DocType,Track Changes,відстеження змін
 DocType: Workflow State,Check,Перевірити
 DocType: Chat Profile,Offline,Offline
@@ -1553,7 +1553,7 @@ apps/frappe/frappe/www/qrcode.html,Steps to verify your login,Кроки для 
 apps/frappe/frappe/utils/password.py,Password not found,Пароль не знайдений
 DocType: Data Migration Mapping,Page Length,Довжина сторінки
 DocType: Email Queue,Expose Recipients,Expose Одержувачі
-apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To is mandatory for incoming mails,Додати до є обов&#39;язковим для вхідних повідомлень
+apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To is mandatory for incoming mails,Додати до є обов'язковим для вхідних повідомлень
 DocType: Contact,Salutation,Звертання
 DocType: Communication,Rejected,Відхилено
 apps/frappe/frappe/public/js/frappe/ui/tags.js,Remove Tag,Видалити тег
@@ -1614,7 +1614,7 @@ apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found
 DocType: Address,GST State,GST держава
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0}: Неможливо встановити Скасувати без Проведення
 DocType: Website Theme,Theme,Тема
-DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,"Перенаправлення URI, пов&#39;язаного з Auth кодексу"
+DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,"Перенаправлення URI, пов'язаного з Auth кодексу"
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Відкрийте довідку
 DocType: DocType,Is Submittable,Є Submittable
 apps/frappe/frappe/core/doctype/comment/comment.py,New Mention,Нове згадування
@@ -1624,7 +1624,7 @@ apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a
 apps/frappe/frappe/model/document.py,Could not find {0},Не вдалося знайти {0}
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Filters applied for {0},Фільтри застосовано для {0}
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Column Labels:,Колонка Мітки:
-apps/frappe/frappe/model/naming.py,Naming Series mandatory,Іменування серії обов&#39;язковим
+apps/frappe/frappe/model/naming.py,Naming Series mandatory,Іменування серії обов'язковим
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} criticized your work on {1} with {2} points,{0} критикував вашу роботу щодо {1} з пунктами {2}
 DocType: Workflow State,Inbox,Вхідні
 DocType: Kanban Board Column,Red,Червоний
@@ -1659,7 +1659,7 @@ DocType: Address,Haryana,Харьяна
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} appreciation points for {1} {2},{0} оцінку балів за {1} {2}
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Roles can be set for users from their User page.,Ролі можуть бути встановлені для користувачів з їх сторінки користувача.
 apps/frappe/frappe/templates/includes/comments/comments.html,Add Comment,Додати коментар
-DocType: DocField,Mandatory,Обов&#39;язкове
+DocType: DocField,Mandatory,Обов'язкове
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Module to Export,Модуль для експорту
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: No basic permissions set,{0}: Не встановлено базовий набір дозволів
 apps/frappe/frappe/utils/backups.py,Download link for your backup will be emailed on the following email address: {0},Посилання для скачування Вашої резервної копії буде відіслане на цей e-mail: {0}
@@ -1677,14 +1677,14 @@ DocType: Data Import Beta,Template Warnings,Попередження про ша
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Filters saved,фільтри збережені
 DocType: DocField,Percent,Відсотків
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Please set filters,"Будь ласка, встановіть фільтри"
-apps/frappe/frappe/public/js/frappe/form/linked_with.js,Linked With,Пов&#39;язаний з
+apps/frappe/frappe/public/js/frappe/form/linked_with.js,Linked With,Пов'язаний з
 apps/frappe/frappe/templates/emails/auto_email_report.html,Edit Auto Email Report Settings,Редагувати налаштування звіту Auto Email
 DocType: Chat Room,Message Count,Кількість повідомлень
 DocType: Workflow State,book,книга
 DocType: Communication,Read by Recipient,Читає одержувач
 DocType: Website Settings,Landing Page,Цільової сторінки
 apps/frappe/frappe/public/js/frappe/form/script_manager.js,Error in Custom Script,Помилка в призначеній для користувача Script
-apps/frappe/frappe/public/js/frappe/form/quick_entry.js,{0} Name,{0} Ім&#39;я
+apps/frappe/frappe/public/js/frappe/form/quick_entry.js,{0} Name,{0} Ім'я
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,No Permissions set for this criteria.,Дозволи не встановлений для цього критеріїв.
 DocType: Auto Email Report,Auto Email Report,Auto E-mail Повідомити
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Delete comment?,Видалити коментар?
@@ -1721,16 +1721,16 @@ apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Ple
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete this record to allow sending to this email address,"Видалити цей запис, щоб дозволити відправляти на цей e-mail"
 DocType: Email Account,"If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)","Якщо нестандартний порт (наприклад, POP3: 995/110, IMAP: 993/143)"
 apps/frappe/frappe/public/js/frappe/views/components/DeskSection.vue,Customize Shortcuts,Налаштувати ярлики
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,"Лише обов&#39;язкові поля, необхідні для нових записів. Ви можете видалити необов&#39;язкові стовпці, якщо хочете."
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,"Лише обов'язкові поля, необхідні для нових записів. Ви можете видалити необов'язкові стовпці, якщо хочете."
 apps/frappe/frappe/desk/page/user_profile/user_profile.html,Show More Activity,Показати більше активності
 apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,"Введіть код, відображений у додатку OTP."
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Unable to update event,Не вдалося оновити подія
 apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,Код підтвердження був надісланий на вашу зареєстровану електронну адресу.
 apps/frappe/frappe/core/doctype/user/user.py,Throttled,Дросельний
-apps/frappe/frappe/utils/data.py,"Filter must have 4 values (doctype, fieldname, operator, value): {0}","Фільтр повинен мати 4 значення (доктайпів, ім&#39;я_поля, оператор, значення): {0}"
+apps/frappe/frappe/utils/data.py,"Filter must have 4 values (doctype, fieldname, operator, value): {0}","Фільтр повинен мати 4 значення (доктайпів, ім'я_поля, оператор, значення): {0}"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Застосувати правило призначення
 apps/frappe/frappe/utils/bot.py,show,шоу
-apps/frappe/frappe/utils/data.py,Invalid field name {0},Неправильне ім&#39;я поля {0}
+apps/frappe/frappe/utils/data.py,Invalid field name {0},Неправильне ім'я поля {0}
 apps/frappe/frappe/model/document.py,{0} must be after {1},{0} повинен бути після {1}
 DocType: Address Template,Address Template,Шаблон адреси
 DocType: Workflow State,text-height,Текст висоти
@@ -1744,7 +1744,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Sub
 DocType: Event,Repeat this Event,Повторіть цю подію
 DocType: Address,Maintenance User,Користувач Технічного обслуговування
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,"LDAP Search String needs to end with a placeholder, eg sAMAccountName={0}","Пошуковий рядок LDAP повинен закінчуватися заповнювачем, наприклад, sAMAccountName = {0}"
-apps/frappe/frappe/utils/password_strength.py,Avoid dates and years that are associated with you.,"Уникайте дат і років, які пов&#39;язані з вами."
+apps/frappe/frappe/utils/password_strength.py,Avoid dates and years that are associated with you.,"Уникайте дат і років, які пов'язані з вами."
 DocType: Custom DocPerm,Amend,Відновити
 DocType: Data Import,Generated File,Згенерований файл
 DocType: Transaction Log,Previous Hash,Попередній хаш
@@ -1758,7 +1758,7 @@ apps/frappe/frappe/model/rename_doc.py,Please select a valid csv file with data,
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} un-shared this document with {1},{0} не поділився цим документом з {1}
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained {0} point,Ви набрали {0} балів
 DocType: LDAP Settings,SSL/TLS Mode,Режим SSL / TLS
-DocType: DocType,"Make ""name"" searchable in Global Search",Зробити «ім&#39;я» для пошуку в Глобальному Пошуку
+DocType: DocType,"Make ""name"" searchable in Global Search",Зробити «ім'я» для пошуку в Глобальному Пошуку
 apps/frappe/frappe/core/doctype/version/version_view.html,Row # ,Ряд #
 apps/frappe/frappe/templates/emails/auto_reply.html,This is an automatically generated reply,Це автоматична відповідь
 DocType: Help Category,Category Description,Опис категорії
@@ -1774,7 +1774,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Reviews,В�
 DocType: DocType,Route,маршрут
 apps/frappe/frappe/config/integrations.py,Razorpay Payment gateway settings,Налаштування шлюзу оплати Razorpay
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Fetch attached images from document,Завантажте прикріплені зображення з документа
-DocType: Chat Room,Name,Ім&#39;я
+DocType: Chat Room,Name,Ім'я
 DocType: Contact Us Settings,Skype,Skype
 DocType: Chat Profile,Notification Tones,Тональні сповіщення
 DocType: Assignment Rule,Load Balancing,Балансування завантаження
@@ -1799,7 +1799,7 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Ce
 DocType: Newsletter,Test Email Address,Тест E-mail адреса
 DocType: Auto Repeat,Reference Document Type,Посилання Тип документа
 DocType: ToDo,Sender,Відправник
-DocType: Google Drive,Backup Folder Name,Ім&#39;я папки резервного копіювання
+DocType: Google Drive,Backup Folder Name,Ім'я папки резервного копіювання
 apps/frappe/frappe/email/doctype/notification/notification.py,Error while evaluating Notification {0}. Please fix your template.,Помилка при оцінці сповіщення {0}. Виправте свій шаблон.
 DocType: GSuite Settings,Google Apps Script,Google Apps Script
 apps/frappe/frappe/templates/includes/comments/comments.html,Leave a Comment,Залишити коментар
@@ -1815,7 +1815,7 @@ DocType: Contact,Contact Details,Контактні дані
 DocType: DocField,In Filter,У фільтр
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Kanban,Kanban
 DocType: DocType,Show in Module Section,Показати в розділі Модуль
-DocType: Workflow Document State,Is Optional State,Є необов&#39;язковою державою
+DocType: Workflow Document State,Is Optional State,Є необов'язковою державою
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,The {0} is already on auto repeat {1},{0} вже ввімкнено автоматичне повторення {1}
 DocType: Letter Head,Header HTML,HTML заголовка
 apps/frappe/frappe/core/doctype/communication/communication.js,Relink,Перередактіруйте
@@ -1842,7 +1842,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Shared with user {0} with read access,
 DocType: GCalendar Account,Next Sync Token,Далі Синхронізований Токен
 DocType: Energy Point Settings,Energy Point Settings,Налаштування енергетичної точки
 DocType: Async Task,Succeeded,Завершено успішно
-apps/frappe/frappe/public/js/frappe/form/save.js,Mandatory fields required in {0},Обов&#39;язкові поля обов&#39;язкові в {0}
+apps/frappe/frappe/public/js/frappe/form/save.js,Mandatory fields required in {0},Обов'язкові поля обов'язкові в {0}
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Reset Permissions for {0}?,Скидання дозволів для {0}?
 apps/frappe/frappe/config/desktop.py,Users and Permissions,Люди і дозволу
 DocType: S3 Backup Settings,S3 Backup Settings,Налаштування резервної копії S3
@@ -1867,14 +1867,14 @@ DocType: Communication Link,Link Title,лінк титли
 DocType: Workflow State,fast-backward,швидко назад
 DocType: Address,Chandigarh,Чандігарх
 DocType: DocShare,DocShare,DocShare
-DocType: Assignment Rule Day,Friday,П&#39;ятниця
+DocType: Assignment Rule Day,Friday,П'ятниця
 apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Edit in full page,Редагувати в повній сторінці
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Open list item,Відкрити елемент списку
 DocType: Report,Add Total Row,Додати загальний підсумок
 apps/frappe/frappe/public/js/frappe/form/print.js,No Preview available,Попередній перегляд недоступний
 apps/frappe/frappe/twofactor.py,Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it.,"Будь ласка, перевірте свою зареєстровану електронну адресу, щоб дізнатися, як продовжити. Не закривайте це вікно, тому що вам доведеться повернутися до нього."
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Наприклад, якщо ви скасуєте та відновите INV004, він стане новим документом INV004-1. Це допомагає стежити за кожною поправкою."
-apps/frappe/frappe/core/doctype/data_export/data_export.js,Atleast one field of Parent Document Type is mandatory,Принаймні одне поле типу батьківського документа обов&#39;язкове
+apps/frappe/frappe/core/doctype/data_export/data_export.js,Atleast one field of Parent Document Type is mandatory,Принаймні одне поле типу батьківського документа обов'язкове
 apps/frappe/frappe/config/settings.py,Setup Reports to be emailed at regular intervals,"Звіти по установці, щоб отримувати по електронній пошті через регулярні проміжки часу"
 DocType: Workflow Document State,0 - Draft; 1 - Submitted; 2 - Cancelled,0 - Чернетка; 1 - Проведено; 2 - Відмінено
 DocType: File,Attached To DocType,Долучено до ДокТипу
@@ -1903,7 +1903,7 @@ DocType: DocType,Database Engine,Database Engine
 DocType: Customize Form,"Fields separated by comma (,) will be included in the ""Search By"" list of Search dialog box","Поля, розділені комами (,) будуть включені в &quot;Пошук по&quot; списку діалоговому вікні Пошук"
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Please Duplicate this Website Theme to customize.,"Ласка, дублювати цю сторінку Тема для настройки."
 DocType: Address,Meghalaya,Meghalaya
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Неправильне ім&#39;я користувача або пароль
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Неправильне ім'я користувача або пароль
 DocType: DocField,Text Editor,Текстовий редактор
 apps/frappe/frappe/config/website.py,Settings for About Us Page.,"Налаштування для сторінки ""Про нас""."
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit Custom HTML,Редагувати замовлення HTML
@@ -1926,7 +1926,7 @@ DocType: Custom DocPerm,Write,Запис
 apps/frappe/frappe/core/doctype/report/report.py,Only Administrator allowed to create Query / Script Reports,Лише адміністратор дозволив створити Query / Script Звіти
 apps/frappe/frappe/public/js/frappe/form/save.js,Updating,Оновлення
 DocType: Data Import Beta,Preview,Попередній перегляд
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated","Поле &quot;Значення&quot; є обов&#39;язковим. Будь ласка, вкажіть значення для поновлення"
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated","Поле &quot;Значення&quot; є обов'язковим. Будь ласка, вкажіть значення для поновлення"
 DocType: Customize Form,Use this fieldname to generate title,Використовуйте ім'я цього поля щоб генерувати заголовок
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Email From,Імпортувати пошту з
 apps/frappe/frappe/contacts/doctype/contact/contact.js,Invite as User,Запросити стати користувачем
@@ -1948,7 +1948,7 @@ apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Assignment Complet
 DocType: Desktop Icon,Idx,Idx
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Toggle Full Width,Переключення на повну ширину
 DocType: Address,Madhya Pradesh,Мадхья-Прадеш
-DocType: Deleted Document,New Name,Нове ім&#39;я
+DocType: Deleted Document,New Name,Нове ім'я
 DocType: System Settings,Is First Startup,Перший запуск
 DocType: Communication,Email Status,Email Статус
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the document before removing assignment,"Будь ласка, збережіть документ, перш ніж знімати призначення"
@@ -1973,9 +1973,9 @@ DocType: System Settings,Allow Guests to Upload Files,Дозволити гос�
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify,Перевірити
 DocType: Workflow Document State,Update Field,Оновлення поле
 DocType: Chat Profile,Enable Chat,Увімкнути чат
-DocType: LDAP Settings,Base Distinguished Name (DN),Підстава различающееся ім&#39;я (DN)
+DocType: LDAP Settings,Base Distinguished Name (DN),Підстава различающееся ім'я (DN)
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Leave this conversation,Залиште цю розмову
-apps/frappe/frappe/model/base_document.py,Options not set for link field {0},Опції не встановлений галузі зв&#39;язку {0}
+apps/frappe/frappe/model/base_document.py,Options not set for link field {0},Опції не встановлений галузі зв'язку {0}
 apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker,Черга / працівник
 DocType: S3 Backup Settings,ap-southeast-1,ap-південний схід-1
 DocType: DocType,"Must be of type ""Attach Image""",Повинно бути типу &quot;Приєднати зображення&quot;
@@ -1988,11 +1988,11 @@ apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully
 DocType: Workflow State,asterisk,зірочка
 DocType: Data Import,Successful,Успішний
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Please do not change the template headings.,"Будь-ласка, не змінюйте заголовки шаблону."
-DocType: Activity Log,Linked,Зв&#39;язаний
+DocType: Activity Log,Linked,Зв'язаний
 apps/frappe/frappe/config/desk.py,Activity log of all users.,Журнал активність всіх користувачів.
 DocType: Workflow State,shopping-cart,кошик
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Week,тиждень
-DocType: DocType,Open a dialog with mandatory fields to create a new record quickly,Відкрийте діалогове вікно із обов&#39;язковими полями для швидкого створення нової записи
+DocType: DocType,Open a dialog with mandatory fields to create a new record quickly,Відкрийте діалогове вікно із обов'язковими полями для швидкого створення нової записи
 apps/frappe/frappe/templates/includes/login/login.js,Not Allowed: Disabled User,Не дозволено: інвалідований користувач
 DocType: Social Login Key,Google,Google
 DocType: Email Domain,Example Email Address,Приклад E-mail адреса
@@ -2025,15 +2025,15 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Font
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Якщо ці інструкції вам не допомогли, додайте, будь ласка, ваші пропозиції у розділ Issues репозиторію на GitHub"
 DocType: Workflow State,bookmark,закладка
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Ім&#39;я папки не повинно містити «/» (слеш)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Ім'я папки не повинно містити «/» (слеш)
 DocType: Note,Note,Примітка
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Звіт про помилки
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Експортувати дані у форматі CSV / Excel.
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Setting up Global Search documents.,Налаштування документів глобального пошуку.
 apps/frappe/frappe/www/qrcode.html,Authentication Apps you can use are: ,"Програми автентифікації, які ви можете використовувати, є:"
-apps/frappe/frappe/public/js/frappe/form/controls/data.js,{0} already exists. Select another name,{0} вже існує. Виберіть інше ім&#39;я
+apps/frappe/frappe/public/js/frappe/form/controls/data.js,{0} already exists. Select another name,{0} вже існує. Виберіть інше ім'я
 DocType: S3 Backup Settings,None,Ні
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a valid fieldname,Терміни поле повинно бути дійсним ім&#39;я_поля
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a valid fieldname,Терміни поле повинно бути дійсним ім'я_поля
 DocType: Contact,Email Ids,E-mail ідентифікатори
 DocType: GCalendar Account,Session Token,Токен сесії
 DocType: Currency,Symbol,Символ
@@ -2041,7 +2041,7 @@ apps/frappe/frappe/model/base_document.py,Row #{0}:,Ряд # {0}:
 apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,Confirm Deletion of Data,Підтвердити видалення даних
 apps/frappe/frappe/auth.py,Login not allowed at this time,Вхід не дозволяється у цей час
 DocType: Data Migration Run,Current Mapping Action,Поточний дію карти
-DocType: Dashboard Chart Source,Source Name,ім&#39;я джерела
+DocType: Dashboard Chart Source,Source Name,ім'я джерела
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Жоден обліковий запис електронної пошти не пов’язаний з Користувачем. Будь ласка, додайте обліковий запис у розділі Користувач> Вхідні адреси електронної пошти."
 DocType: Email Account,Email Sync Option,Електронна пошта синхронізації Варіант
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Рядок №
@@ -2075,7 +2075,7 @@ DocType: Footer Item,Footer Item,Footer Пункт
 ,Download Backups,Завантажити Резервні копії
 DocType: Energy Point Log,Points,Очки
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1,Головна/Тестова Тека 1
-apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Assign to me,Зв&#39;язати мене
+apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Assign to me,Зв'язати мене
 DocType: DocField,Dynamic Link,Dynamic Link
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Press Alt Key to trigger additional shortcuts in Menu and Sidebar,"Натисніть клавішу Alt, щоб запустити додаткові ярлики в меню та бічній панелі"
 DocType: List View Setting,List View Setting,Налаштування перегляду списку
@@ -2093,7 +2093,7 @@ DocType: Tag Doc Category,Doctype to Assign Tags,Doctype Призначення 
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.js,Show Relapses,Показати Рецидиви
 apps/frappe/frappe/core/doctype/communication/communication.js,Email has been moved to trash,E-mail був переміщений в кошик
 DocType: Report,Report Builder,Конструктор звітів
-DocType: Async Task,Task Name,Ім&#39;я завдання
+DocType: Async Task,Task Name,Ім'я завдання
 DocType: Website Route Meta,Meta Tags,Метатеги
 apps/frappe/frappe/app.py,"Your session has expired, please login again to continue.","Ваша сесія закінчилася, будь ласка, увійдіть знову, щоб продовжити."
 apps/frappe/frappe/app.py,"Your session has expired, please login again to continue.","Ваша сесія закінчилася, будь ласка, увійдіть знову, щоб продовжити."
@@ -2117,7 +2117,7 @@ DocType: Contact Phone,Is Primary Phone,Первинний телефон
 apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,"Надішліть електронний лист на {0}, щоб пов’язати його тут."
 DocType: Auto Email Report,Weekdays,Будні дні
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} records will be exported,{0} записи будуть експортовані
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Назва поля повинно бути дійсним ім&#39;я_поля
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Назва поля повинно бути дійсним ім'я_поля
 DocType: Post Comment,Post Comment,Опублікувати коментар
 apps/frappe/frappe/config/core.py,Documents,Документи
 apps/frappe/frappe/config/users_and_permissions.py,Activity Log by ,Журнал активності
@@ -2131,11 +2131,11 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Час вичерп
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18","Це поле з&#39;являється тільки в разі, якщо ім&#39;я_поля визначено тут має значення чи правила є істинними (приклади): MyField Eval: doc.myfield == &#39;My Value&#39; Eval: doc.age> 18"
+eval:doc.age>18","Це поле з'являється тільки в разі, якщо ім'я_поля визначено тут має значення чи правила є істинними (приклади): MyField Eval: doc.myfield == 'My Value' Eval: doc.age> 18"
 DocType: Social Login Key,Office 365,Офіс 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,сьогодні
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,сьогодні
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Після того як ви встановили це, користувачі зможуть тільки доступ до документів (наприклад ,. Блог Пост), де існує зв&#39;язок (наприклад, Blogger.)."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Після того як ви встановили це, користувачі зможуть тільки доступ до документів (наприклад ,. Блог Пост), де існує зв'язок (наприклад, Blogger.)."
 DocType: Data Import Beta,Submit After Import,Надіслати після імпорту
 DocType: Error Log,Log of Scheduler Errors,Журнал помилок Scheduler
 DocType: User,Bio,Біо
@@ -2167,13 +2167,13 @@ DocType: Notification,Value To Be Set,Значення To Be Set
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Edit {0},Редагувати {0}
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,First Level,Перший рівень
 DocType: Workflow Document State,Represents the states allowed in one document and role assigned to change the state.,"Являє держави дозволило в одному документі і роллю, відведеною для зміни стану."
-DocType: Data Migration Connector,Database Name,Ім&#39;я бази даних
+DocType: Data Migration Connector,Database Name,Ім'я бази даних
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Оновити Форма
 DocType: DocField,Select,Вибрати
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Переглянути повний журнал
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Просте вираження Python, приклад: status == &#39;Open&#39; та введіть == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Просте вираження Python, приклад: status == 'Open' та введіть == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,Файл не долучено
-apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Зв&#39;язок втрачений. Деякі функції можуть не працювати.
+apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Зв'язок втрачений. Деякі функції можуть не працювати.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess","Повтори на кшталт ""ааа"" легко вгадати"
 apps/frappe/frappe/public/js/frappe/chat.js,New Chat,Новий чат
 DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","Якщо ви встановите це, цей предмет прийде в списку, що розкривається під обраної батька."
@@ -2189,7 +2189,7 @@ DocType: Chat Room,Avatar,Аватар
 DocType: Blogger,Posts,Пост-и
 DocType: Social Login Key,Salesforce,Відділ продажів
 DocType: DocType,Has Web View,Має Web View
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"DocType's name should start with a letter and it can only consist of letters, numbers, spaces and underscores","Ім&#39;я DOCTYPE має починатися з літери і може складатися тільки з букв, цифр, пробілів і знаків підкреслення"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"DocType's name should start with a letter and it can only consist of letters, numbers, spaces and underscores","Ім'я DOCTYPE має починатися з літери і може складатися тільки з букв, цифр, пробілів і знаків підкреслення"
 DocType: Dashboard,Dashboard Name,Назва інформаційної панелі
 apps/frappe/frappe/www/update-password.html,The password of your account has expired.,Термін дії вашого пароля закінчився.
 DocType: Communication,Spam,спам
@@ -2198,7 +2198,7 @@ apps/frappe/frappe/public/js/frappe/views/communication.js,Dear,Дорогий
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Add Group,Додати групу
 DocType: Address,Maharashtra,Махараштра
 DocType: Auto Repeat,Accounts User,Облікові записи користувачів
-DocType: Web Page,HTML for header section. Optional,HTML для розділу заголовка. Необов&#39;язковий
+DocType: Web Page,HTML for header section. Optional,HTML для розділу заголовка. Необов'язковий
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,This feature is brand new and still experimental,Ця функція є новою і досі експериментальна
 apps/frappe/frappe/model/rename_doc.py,Maximum {0} rows allowed,Максимум {0} рядків дозволено
 DocType: Dashboard Chart Link,Chart,Діаграма
@@ -2214,7 +2214,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Generate New R
 DocType: Portal Settings,Portal Menu,Меню порталу
 apps/frappe/frappe/database/schema.py,Length of {0} should be between 1 and 1000,Довжина {0} має бути від 1 до 1000
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,Search for anything,Шукати щось
-DocType: Data Migration Connector,Hostname,Ім&#39;я хоста
+DocType: Data Migration Connector,Hostname,Ім'я хоста
 DocType: Data Migration Mapping,Condition Detail,Подробиці умов
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"For currency {0}, the minimum transaction amount should be {1}",Для валюти {0} мінімальна сума транзакції повинна бути {1}
 DocType: DocField,Print Hide,Друк Приховати
@@ -2355,15 +2355,15 @@ apps/frappe/frappe/public/js/frappe/form/workflow.js,Document is only editable b
 apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed by {2}.","Завдання {0}, що ви призначені {1}, був закритий {2}."
 DocType: Print Format,Show Line Breaks after Sections,Показати розриви рядків після розділів
 DocType: Communication,Read by Recipient On,Читає одержувач
-DocType: Blogger,Short Name,Коротке ім&#39;я
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Linked with {0},Зв&#39;язано з {0}
+DocType: Blogger,Short Name,Коротке ім'я
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Linked with {0},Зв'язано з {0}
 apps/frappe/frappe/email/doctype/email_account/email_account.js,"You are selecting Sync Option as ALL, It will resync all \
 				read as well as unread message from server. This may also cause the duplication\
-				of Communication (emails).","Ви вибираєте варіант синхронізації, як все, він буде пересінхронізіроваться все \ читання, а також непрочитаних повідомлень від сервера. Це також може привести до дубльованої \ зв&#39;язку (електронна пошта)."
+				of Communication (emails).","Ви вибираєте варіант синхронізації, як все, він буде пересінхронізіроваться все \ читання, а також непрочитаних повідомлень від сервера. Це також може привести до дубльованої \ зв'язку (електронна пошта)."
 DocType: Workflow State,magnet,магніт
 apps/frappe/frappe/geo/doctype/currency/currency.js,This Currency is disabled. Enable to use in transactions,Ця валюта відключена. Включити для використання в операціях
 DocType: Desktop Icon,Blocked,блокований
-DocType: Contact Us Settings,"Default: ""Contact Us""",За замовчуванням: &quot;Зворотній зв&#39;язок&quot;
+DocType: Contact Us Settings,"Default: ""Contact Us""",За замовчуванням: &quot;Зворотній зв'язок&quot;
 DocType: Contact,Purchase Manager,Менеджер по закупкам
 DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Якщо це ввімкнено, це дозволить гостям завантажувати файли у вашу програму. Ви можете ввімкнути це, якщо ви хочете збирати файли від користувача, не маючи їх входити, наприклад, у веб-форму заявок на роботу."
 apps/frappe/frappe/public/js/frappe/ui/tags.js,toggle Tag,переключити тег
@@ -2371,7 +2371,7 @@ DocType: Custom Script,Sample,Зразок
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,"For performance, only the first 100 rows were processed.",Для виконання було оброблено лише перші 100 рядків.
 DocType: Braintree Settings,Private Key,Приватний ключ
 DocType: S3 Backup Settings,ap-northeast-2,ap-північний схід-2
-DocType: Custom Field,Is Mandatory Field,Є Поле обов&#39;язково для заповнення
+DocType: Custom Field,Is Mandatory Field,Є Поле обов'язково для заповнення
 DocType: User,Website User,Користувач веб-сайту
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,Деякі стовпці можуть бути відрізані під час друку в PDF. Спробуйте зберегти кількість стовпців під 10.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not equals,Не дорівнює
@@ -2384,10 +2384,10 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Assign,Пр
 DocType: Translation,PR sent,PR відправлено
 DocType: Auto Email Report,Only Send Records Updated in Last X Hours,Тільки Send Records Оновлене в останніх X годин
 DocType: Auto Email Report,Only Send Records Updated in Last X Hours,Тільки Send Records Оновлене в останніх X годин
-DocType: Communication,Feedback,Зворотній зв&#39;язок
+DocType: Communication,Feedback,Зворотній зв'язок
 apps/frappe/frappe/public/js/frappe/form/controls/base_control.js,Open Translation,Відкритий переклад
 apps/frappe/frappe/templates/emails/auto_repeat_fail.html,This email is autogenerated,Цей електронний лист створено автоматично
-DocType: Workflow State,Icon will appear on the button,Іконка з&#39;явиться на кнопці
+DocType: Workflow State,Icon will appear on the button,Іконка з'явиться на кнопці
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Click to Set Filters,"Клацніть, щоб встановити фільтри"
 DocType: Energy Point Log,Revert,Повернутись
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Socketio is not connected. Cannot upload,Socketio не підключено. Не вдається завантажити
@@ -2439,12 +2439,12 @@ apps/frappe/frappe/utils/verified_command.py,Invalid Link,Невірне пос�
 DocType: Web Form,Client Script,Клієнтський сценарій
 DocType: Web Page,Show Title,Показати заголовок
 DocType: Chat Message,Direct,Прямий
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname {1} appears multiple times in rows {2},{0}: Ім&#39;я поля {1} відображається кілька разів у рядках {2}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname {1} appears multiple times in rows {2},{0}: Ім'я поля {1} відображається кілька разів у рядках {2}
 DocType: Property Setter,Property Type,Тип нерухомості
 DocType: Workflow State,screenshot,Скріншот
 apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,"Тільки адміністратор може зберегти стандартний звіт. Будь-ласка, перейменуйте та збережіть."
 DocType: System Settings,Background Workers,фонові Робочі
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Fieldname {0} конфліктує з мета об&#39;єкта
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Fieldname {0} конфліктує з мета об'єкта
 DocType: Deleted Document,Data,Дані
 apps/frappe/frappe/public/js/frappe/model/model.js,Document Status,Стан документу
 apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,Approval Required,Потрібне затвердження
@@ -2481,7 +2481,7 @@ DocType: Help Article,Intermediate,проміжний
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} changed {1} to {2},{0} змінив {1} на {2}
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Cancelled Document restored as Draft,Скасований документ відновлений як чернетка
 DocType: Data Migration Run,Start Time,Час початку
-apps/frappe/frappe/model/delete_doc.py,Cannot delete or cancel because {0} {1} is linked with {2} {3} {4},"Неможливо видалити або скасувати, оскільки {0} {1} пов&#39;язано з {2} {3} {4}"
+apps/frappe/frappe/model/delete_doc.py,Cannot delete or cancel because {0} {1} is linked with {2} {3} {4},"Неможливо видалити або скасувати, оскільки {0} {1} пов'язано з {2} {3} {4}"
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Read,Може Читати
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,{0} Chart,{0} Графік
 DocType: Custom Role,Response,Відповідь
@@ -2495,7 +2495,7 @@ apps/frappe/frappe/email/smtp.py,Invalid recipient address,Невірна адр
 DocType: Workflow State,step-forward,крок вперед
 DocType: System Settings,Allow Login After Fail,Дозволити вхід після помилки
 DocType: Role Permission for Page and Report,Set Role For,Встановити роль для
-DocType: GCalendar Account,The name that will appear in Google Calendar,"Назва, яка з&#39;явиться в Календарі Google"
+DocType: GCalendar Account,The name that will appear in Google Calendar,"Назва, яка з'явиться в Календарі Google"
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Direct room with {0} already exists.,Пряма кімната з {0} вже існує.
 apps/frappe/frappe/core/doctype/user/user.js,Refreshing...,Оновлюється…
 DocType: Event,Starts on,Починається на
@@ -2506,7 +2506,7 @@ apps/frappe/frappe/public/js/frappe/desk.js,Session Start Failed,Session Не в
 apps/frappe/frappe/email/queue.py,This email was sent to {0} and copied to {1},Цей лист був відправлений на адресу {0} і скопіювати в {1}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document {0},подав цей документ {0}
 DocType: Workflow State,th,ї
-DocType: Social Login Key,Provider Name,Ім&#39;я провайдера
+DocType: Social Login Key,Provider Name,Ім'я провайдера
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Create a new {0},Створити нову {0}
 DocType: Contact,Google Contacts,Контакти Google
 DocType: GCalendar Account,GCalendar Account,Обліковий запис GCalendar
@@ -2523,7 +2523,7 @@ apps/frappe/frappe/config/settings.py,Deleted Documents,Дистанційні �
 apps/frappe/frappe/public/js/frappe/form/grid.js,The CSV format is case sensitive,Формат CSV з урахуванням регістру
 apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,Desktop Icon вже існує
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Duplicate,Дублювати
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} cannot be hidden and mandatory without default,{0}: Поле {1} у рядку {2} не може бути прихованим і обов&#39;язковим без замовчування
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} cannot be hidden and mandatory without default,{0}: Поле {1} у рядку {2} не може бути прихованим і обов'язковим без замовчування
 DocType: Newsletter,Create and Send Newsletters,Створення і відправлення розсилки
 apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,Дякую за Ваш коментар Він буде опублікований після затвердження
 DocType: Address,Andaman and Nicobar Islands,Андаманські і Нікобарські острови
@@ -2571,12 +2571,12 @@ DocType: System Settings,Scheduler Last Event,Планувальник оста�
 DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,"Додати Google Analytics ID. Наприклад, UA-89XXX57-1. Для отримання додаткової інформації звертайтесь, будь ласка, до розділів довідки Google Analytics."
 apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,Пароль не може бути довшим 100 символів
 DocType: OAuth Client,App Client ID,App ID клієнта
-DocType: Kanban Board,Kanban Board Name,Ім&#39;я канбан Board
+DocType: Kanban Board,Kanban Board Name,Ім'я канбан Board
 DocType: Notification Recipient,"Expression, Optional","Вираз, Додатковий"
 DocType: GSuite Settings,Copy and paste this code into and empty Code.gs in your project at script.google.com,Скопіюйте та вставте цей код в порожній і Code.gs в проекті в script.google.com
 apps/frappe/frappe/email/queue.py,This email was sent to {0},Цей лист був відправлений на адресу {0}
 DocType: System Settings,Hide footer in auto email reports,Приховати нижній колонтитул у звітах про автоматичну електронну пошту
-DocType: DocField,Remember Last Selected Value,Пам&#39;ятайте Останнє вибране значення
+DocType: DocField,Remember Last Selected Value,Пам'ятайте Останнє вибране значення
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,This document cannot be reverted,Цей документ неможливо повернути
 DocType: Email Account,Check this to pull emails from your mailbox,"Перевірте це, щоб витягнути листи з поштової скриньки"
 apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,click here,натисніть тут
@@ -2588,7 +2588,7 @@ DocType: Assignment Rule Day,Monday,Понеділок
 apps/frappe/frappe/utils/password_strength.py,Make use of longer keyboard patterns,Використовуйте довших моделей клавіатури
 apps/frappe/frappe/templates/includes/integrations/stripe_checkout.js,Processing...,Обробка ...
 DocType: Data Import,Don't create new records,Не створюйте нові записи
-apps/frappe/frappe/utils/nestedset.py,Nested set error. Please contact the Administrator.,"Вкладені набір помилок. Будь ласка, зв&#39;яжіться з Адміністратором."
+apps/frappe/frappe/utils/nestedset.py,Nested set error. Please contact the Administrator.,"Вкладені набір помилок. Будь ласка, зв'яжіться з Адміністратором."
 DocType: Workflow State,envelope,конверт
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 2,Варіант 2
 apps/frappe/frappe/utils/print_format.py,Printing failed,Помилка друку
@@ -2662,7 +2662,7 @@ apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Find {0} in {1},Знайти {0} в {1}
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No posts yet,Повідомлень ще немає
 DocType: OAuth Client,Implicit,неявний
-DocType: Email Account,"Append as communication against this DocType (must have fields, ""Status"", ""Subject"")","Додайте в зв&#39;язку з цією DocType (повинен мати поля, &quot;статус&quot;, &quot;Тема&quot;)"
+DocType: Email Account,"Append as communication against this DocType (must have fields, ""Status"", ""Subject"")","Додайте в зв'язку з цією DocType (повинен мати поля, &quot;статус&quot;, &quot;Тема&quot;)"
 DocType: Letter Head,Default Letter Head,Фірмовий заголовок за замовчуванням
 DocType: OAuth Client,"URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.
 <br>e.g. http://hostname//api/method/frappe.www.login.login_via_facebook","Ідентифікатори URI для отримання коду авторизації, як тільки користувач надати їм доступ, а також відповіді недостатність. Як правило, кінцева точка REST піддається Клієнтом App. <br> наприклад, HTTP: //hostname//api/method/frappe.www.login.login_via_facebook"
@@ -2689,7 +2689,7 @@ DocType: Auto Email Report,Filter Data,Фільтр даних
 apps/frappe/frappe/public/js/frappe/form/controls/select.js,Please attach a file first.,"Будь ласка, додайте файл в першу чергу."
 apps/frappe/frappe/templates/emails/download_data.html,Dear {0},Шановний {0}
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 week,1 тиждень
-apps/frappe/frappe/model/naming.py,"There were some errors setting the name, please contact the administrator","Були деякі помилки настройки ім&#39;я, будь ласка, зв&#39;яжіться з адміністратором"
+apps/frappe/frappe/model/naming.py,"There were some errors setting the name, please contact the administrator","Були деякі помилки настройки ім'я, будь ласка, зв'яжіться з адміністратором"
 apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email account not correct,рахунок вхідних повідомлень електронної пошти не правильно
 apps/frappe/frappe/templates/includes/contact.js,"You seem to have written your name instead of your email. \
 				Please enter a valid email address so that we can get back.","Ви, здається, написали своє ім'я, а не адресу електронної пошти. \ Будь ласка, введіть адресу електронної пошти, щоб ми могли отримати назад."
@@ -2717,7 +2717,7 @@ apps/frappe/frappe/templates/emails/administrator_logged_in.html,"Dear System Ma
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} self assigned this task: {1},{0} самостійно призначив це завдання: {1}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Your Country,Ваша країна
 DocType: Assignment Rule Day,Sunday,Неділя
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: Ім&#39;я поля не може бути одним із {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: Ім'я поля не може бути одним із {1}
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Standings,Турнірна таблиця
 apps/frappe/frappe/core/doctype/doctype/doctype.js,In Grid View,У табличному вигляді
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,No More Activity,Більше активності немає
@@ -2787,7 +2787,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Перегляд зображення
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Схоже, щось пішло не так під час операції. Так як ми не підтвердили оплату, Paypal автоматично поверне вам цю суму. Якщо цього не відбулося, будь ласка, надішліть нам по електронній пошті і згадати Кореляція ID: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Увімкніть символи, цифри і великі літери в паролі"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Після того, як вставити поле &#39;{0}&#39;, згаданої в настроюється поле &quot;{1} &#39;, з міткою&#39; {2} &#39;, не існує"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Після того, як вставити поле '{0}', згаданої в настроюється поле &quot;{1} ', з міткою' {2} ', не існує"
 DocType: List Filter,List Filter,Список фільтрів
 DocType: Workflow State,signal,сигнал
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Має вкладення
@@ -2819,7 +2819,7 @@ DocType: Data Import,Amended From,Відновлено з
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},"Попередження: Не вдалося знайти {0} у жодній таблиці, пов'язаній з {1}"
 DocType: S3 Backup Settings,eu-north-1,eu-північ-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Цей документ в даний час в чергу на виконання. Будь ласка спробуйте ще раз
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Файл &#39;{0}&#39; не найден
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,Файл '{0}' не найден
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Видалити розділ
 DocType: User,Change Password,Змінити пароль
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X Осі Поле
@@ -2850,7 +2850,7 @@ apps/frappe/frappe/core/doctype/data_import/data_import.py,Can't save the form a
 DocType: Workflow,States,Штати
 DocType: Notification,Attach Print,Долучити роздрук
 DocType: Assignment Rule,Assignment Rule,Правило призначення
-apps/frappe/frappe/core/doctype/user/user.py,Suggested Username: {0},Схожі Ім&#39;я користувача: {0}
+apps/frappe/frappe/core/doctype/user/user.py,Suggested Username: {0},Схожі Ім'я користувача: {0}
 DocType: Assignment Rule Day,Day,день
 apps/frappe/frappe/public/js/frappe/desk.js,Modules,модулі
 apps/frappe/frappe/templates/pages/integrations/payment-success.html,Payment Success,оплата успіху
@@ -2868,15 +2868,15 @@ apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Type,Т�
 DocType: Workflow State,circle-arrow-left,Круг-стрілка-вліво
 DocType: System Settings,Force User to Reset Password,Змусити користувача скинути пароль
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"To get the updated report, click on {0}.","Щоб отримати оновлений звіт, натисніть {0}."
-apps/frappe/frappe/sessions.py,Redis cache server not running. Please contact Administrator / Tech support,Кеш-сервер Redis не працює. Зв&#39;яжіться з нами Administrator / технічна підтримка
+apps/frappe/frappe/sessions.py,Redis cache server not running. Please contact Administrator / Tech support,Кеш-сервер Redis не працює. Зв'яжіться з нами Administrator / технічна підтримка
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_header.html,Searching,пошук
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_header.html,Searching,пошук
 DocType: Currency,Fraction,Частка
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Event Synced with Google Calendar.,Подія синхронізована з Календарем Google.
-DocType: LDAP Settings,LDAP First Name Field,LDAP Ім&#39;я поля
+DocType: LDAP Settings,LDAP First Name Field,LDAP Ім'я поля
 DocType: Contact,Middle Name,батькові
 DocType: Custom Field,Field Description,Поле Опис
-apps/frappe/frappe/model/naming.py,Name not set via Prompt,Ім&#39;я не встановлено за допомогою Підкажіть
+apps/frappe/frappe/model/naming.py,Name not set via Prompt,Ім'я не встановлено за допомогою Підкажіть
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Email Inbox,Email Вхідні
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Updating {0} of {1}, {2}","Оновлення {0} з {1}, {2}"
 DocType: Auto Email Report,Filters Display,фільтри Показати
@@ -2955,14 +2955,14 @@ apps/frappe/frappe/email/smtp.py,Invalid login or password,Невірне ім�
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Download Template,Звантажити шаблон
 apps/frappe/frappe/config/customization.py,Add custom javascript to forms.,Додати замовлення Javascript для форм.
 ,Role Permissions Manager,Дозволи ролі менеджера
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Name of the new Print Format,Ім&#39;я нового формату друку
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Name of the new Print Format,Ім'я нового формату друку
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Toggle Sidebar,Переключити бічну панель
 DocType: Data Migration Run,Pull Insert,Витягніть вставку
 DocType: Energy Point Rule,"Maximum points allowed after multiplying points with the multiplier value
 (Note: For no limit leave this field empty or set 0)","Максимум балів, допущених після множення балів зі значенням множника (Примітка. Для жодного обмеження не залишайте це поле порожнім або встановіть 0)"
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Invalid Template,Недійсний шаблон
 apps/frappe/frappe/model/db_query.py,Illegal SQL Query,Незаконний запит SQL
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Mandatory:,Обов&#39;язково:
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Mandatory:,Обов'язково:
 DocType: Chat Message,Mentions,Згадує
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,"To use Google Contacts, enable {0}.","Щоб використовувати контакти Google, увімкніть {0}."
 apps/frappe/frappe/public/js/frappe/utils/utils.js,{0} Modules,{0} Модулі
@@ -3001,8 +3001,8 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,{{{0}}} is not a valid fieldn
 DocType: Custom Role,Permission Rules,Введено Правила
 DocType: Braintree Settings,Public Key,Відкритий ключ
 DocType: GSuite Settings,GSuite Settings,налаштування GSuite
-DocType: Address,Links,Зв&#39;язки
-DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,"Використовується назва електронної адреси, зазначена в цьому обліковому записі, як Ім&#39;я відправника для всіх електронних листів, надісланих за допомогою цього облікового запису."
+DocType: Address,Links,Зв'язки
+DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,"Використовується назва електронної адреси, зазначена в цьому обліковому записі, як Ім'я відправника для всіх електронних листів, надісланих за допомогою цього облікового запису."
 DocType: Energy Point Rule,Field To Check,Поле для перевірки
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Контакти Google - не вдалося оновити контакт у контактах Google {0}, код помилки {1}."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,"Будь ласка, виберіть тип документа."
@@ -3010,9 +3010,9 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Значення б�
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Додати підлеглий елемент
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Імпорт прогресу
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Якщо умову буде виконано, користувач буде нагороджений балами. напр. doc.status == &#39;Закрито&#39;"
+","Якщо умову буде виконано, користувач буде нагороджений балами. напр. doc.status == 'Закрито'"
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: Проведений Запис не може бути видалено.
-DocType: GSuite Templates,Template Name,ім&#39;я шаблону
+DocType: GSuite Templates,Template Name,ім'я шаблону
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,новий тип документа
 DocType: Communication,Read,Прочитати
 DocType: Address,Chhattisgarh,Чхаттісгарх
@@ -3033,11 +3033,11 @@ DocType: Report,Reference Report,Довідковий звіт
 DocType: Activity Log,Link DocType,посилання DocType
 apps/frappe/frappe/public/js/frappe/chat.js,You don't have any messages yet.,У вас ще немає повідомлень.
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Remove all customizations?,Видалити всі налаштування?
-DocType: Website Slideshow,Slideshow Name,Ім&#39;я Слайд-шоу
+DocType: Website Slideshow,Slideshow Name,Ім'я Слайд-шоу
 DocType: Address,Andhra Pradesh,Андхра-Прадеш
 apps/frappe/frappe/public/js/frappe/form/save.js,Cancelling,Скасування
 DocType: DocType,Allow Rename,Дозволити Перейменувати
-DocType: Activity Log,Full Name,Повне ім&#39;я
+DocType: Activity Log,Full Name,Повне ім'я
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,Назва дубліката фільтра
 DocType: Chat Room User,Chat Room User,Користувач чату
 apps/frappe/frappe/model/workflow.py,Workflow State not set,Стан робочого процесу не встановлено
@@ -3045,7 +3045,7 @@ DocType: Google Calendar,Authorize Google Calendar Access,Авторизуйте
 apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,"Сторінка, яку ви шукаєте, відсутня. Можливо, вона була переміщена або у посиланні є помилка."
 apps/frappe/frappe/www/404.html,Error Code: {0},Код помилки: {0}
 DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Опис для перерахування сторінку, у вигляді звичайного тексту, тільки пару рядків. (макс 140 знаків)"
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} are mandatory fields,{0} - обов&#39;язкові поля
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} are mandatory fields,{0} - обов'язкові поля
 DocType: Workflow,Allow Self Approval,Дозволити самоврядування
 DocType: Event,Event Category,Категорія події
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,John Doe,Джон Доу
@@ -3057,7 +3057,7 @@ DocType: Email Account,Append To,Додати до
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Number of DB backups cannot be less than 1,Кількість резервних копій БД не може бути менше 1
 DocType: Workflow Document State,Only Allow Edit For,Тільки Дозволити редагування для
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Backing up to Google Drive.,Резервне копіювання на Диск Google.
-apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: {0},Обов&#39;язкове поле: {0}
+apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: {0},Обов'язкове поле: {0}
 apps/frappe/frappe/templates/includes/comments/comments.html,Your Name,Ваше ім'я
 apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Connection Success,Успіх підключення
 DocType: DocType,InnoDB,InnoDB
@@ -3122,7 +3122,7 @@ apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Drag elements from the sidebar to add. Drag them back to trash.,"Перетягніть елементи з бічної панелі, щоб додати. Перетягніть їх назад у відро для сміття."
 DocType: Workflow State,resize-small,розмір-мала
 DocType: Address,Postal Code,Поштовий індекс
-apps/frappe/frappe/core/doctype/communication/communication.js,Relink Communication,Relink зв&#39;язку
+apps/frappe/frappe/core/doctype/communication/communication.js,Relink Communication,Relink зв'язку
 DocType: Translation,Contributed,Внесли свій внесок
 apps/frappe/frappe/config/customization.py,Form Customization,Налаштування форми
 apps/frappe/frappe/www/third_party_apps.html,No Active Sessions,Немає активних сеансів
@@ -3139,7 +3139,7 @@ DocType: Property Setter,Property,Властивість
 DocType: Email Account,Yandex.Mail,Яндекс.Пошта
 DocType: Dashboard Chart,Chart Name,Назва діаграми
 DocType: Dashboard Chart,Chart Type,Тип діаграми
-DocType: DocType,Auto Name,Авто Ім&#39;я
+DocType: DocType,Auto Name,Авто Ім'я
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Уникайте послідовностей на кшталт абвгд або 6543, оскільки їх легко вгадати"
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Будь ласка спробуйте ще раз
 apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL-адреса повинна починатися з &quot;http: //&quot; або &quot;https: //&quot;
@@ -3176,9 +3176,9 @@ DocType: Assignment Rule Day,Thursday,Четвер
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough review points,Не вистачає точок огляду
 apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Ви не маєте дозволу на доступ до цього файлу
 apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,Зберегти таємне API:
-apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},Не можете зв&#39;язати документ скасований: {0}
+apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},Не можете зв'язати документ скасований: {0}
 apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,"Неможливо змінити стандартний звіт. Будь ласка, дублювати і створити новий звіт"
-apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Компанія є обов&#39;язковим, так як це ваша компанія адреса"
+apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address","Компанія є обов'язковим, так як це ваша компанія адреса"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,"For example: If you want to include the document ID, use {0}","Наприклад: Якщо ви хочете, щоб включити ідентифікатор документа, використовуйте {0}"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Table Columns for {0},Вибрати стовпчики Таблиця для {0}
 DocType: Custom Field,Options Help,Довідка з опцій
@@ -3203,7 +3203,7 @@ apps/frappe/frappe/twofactor.py,Verfication Code,Верфікований код
 DocType: Webhook,Webhook Request,Запит на Webhook
 apps/frappe/frappe/model/rename_doc.py,** Failed: {0} to {1}: {2},** Не вдалося: {0} до {1}: {2}
 DocType: Data Migration Mapping,Mapping Type,Тип карти
-apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Select Mandatory,Виберіть Обов&#39;язковий
+apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Select Mandatory,Виберіть Обов'язковий
 apps/frappe/frappe/public/js/frappe/ui/upload.html,Browse,Переглянути
 apps/frappe/frappe/utils/password_strength.py,"No need for symbols, digits, or uppercase letters.","Немає необхідності для символів, цифр або букв у верхньому регістрі."
 DocType: DocField,Currency,Валюта
@@ -3245,7 +3245,7 @@ DocType: OAuth Provider Settings,Force,сила
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Last synced {0},Востаннє синхронізовано {0}
 DocType: DocField,Fold,Скласти
 apps/frappe/frappe/printing/doctype/print_format/print_format.py,Standard Print Format cannot be updated,Стандартний формат для друку не може бути оновлений
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} of type {2} cannot be mandatory,{0}: Поле {1} типу {2} не може бути обов&#39;язковим
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} of type {2} cannot be mandatory,{0}: Поле {1} типу {2} не може бути обов'язковим
 DocType: System Settings,In Days,У Дні
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Miss,Міс
 apps/frappe/frappe/public/js/frappe/model/model.js,Please specify,Будь ласка уточніть
@@ -3271,15 +3271,15 @@ DocType: Email Account,uidnext,uidnext
 DocType: User,Redirect URL,перенаправлення URL
 DocType: SMS Settings,Enter url parameter for receiver nos,Enter url parameter for receiver nos
 DocType: Chat Profile,Online,Online
-DocType: Email Account,Always use Account's Name as Sender's Name,Завжди використовуйте ім&#39;я облікового запису як ім&#39;я відправника
+DocType: Email Account,Always use Account's Name as Sender's Name,Завжди використовуйте ім'я облікового запису як ім'я відправника
 apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,Тільки адміністратор може видалити черзі по електронній пошті
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Setting this Address Template as default as there is no other default,"Встановлення цього шаблону адреси за замовчуванням, оскільки немає ніякого іншого за замовчуванням"
 DocType: Workflow State,Home,Головна
 DocType: OAuth Provider Settings,Auto,автоматичний
-DocType: System Settings,User can login using Email id or User Name,"Користувач може ввійти, використовуючи ідентифікатор електронної пошти або ім&#39;я користувача"
+DocType: System Settings,User can login using Email id or User Name,"Користувач може ввійти, використовуючи ідентифікатор електронної пошти або ім'я користувача"
 DocType: Workflow State,question-sign,Питання-знак
 apps/frappe/frappe/model/base_document.py,{0} is disabled,{0} вимкнено
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",Поле &quot;route&quot; є обов&#39;язковим для Web Views
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"Field ""route"" is mandatory for Web Views",Поле &quot;route&quot; є обов'язковим для Web Views
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Insert Column Before {0},Вставити колонку до {0}
 DocType: Energy Point Rule,The user from this field will be rewarded points,Користувач з цього поля отримає бали
 DocType: Assignment Rule,Close Condition,Умови закриття
@@ -3348,7 +3348,7 @@ apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray..
 DocType: Assignment Rule,Example: {{ subject }},Приклад: {{предмет}}
 DocType: DocField,Code,Код
 DocType: Workflow,"All possible Workflow States and roles of the workflow. Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Всі можливі стани і ролі в робочому процесі. Варіанти станів документу: 0 ""Збережені"", 1 ""Проведені"" і 2 ""Скасовані"""
-apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} are required,{0} обов&#39;язкові
+apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} are required,{0} обов'язкові
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Last Modified On,Остання зміна
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document.","Дозволи на рівні 0 це дозволу на рівні документа, тобто вони є первинними для доступу до документа."
 DocType: Auto Repeat,Print Format,Формат друку
@@ -3431,7 +3431,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,призначе�
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,прогрес
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,за ролями
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,відсутні поля
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Invalid ім&#39;я_поля &#39;{0}&#39; в autoname
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Invalid ім'я_поля '{0}' в autoname
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Пошук в документі типу
 DocType: Custom DocPerm,Role and Level,Роль і рівень
 DocType: File,Thumbnail URL,Мініатюра URL
@@ -3492,7 +3492,7 @@ DocType: Address Template,"<h4>Default Template</h4>
 {% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<h4> Шаблон за замовчуванням </h4><p> Використовує <a href=""http://jinja.pocoo.org/docs/templates/"">дзіндзя темплатним</a> і всі поля Адреса (включаючи Настроювані поля якщо такі є) будуть доступні </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Поле Дата початку
-DocType: Role,Role Name,Ім&#39;я ролі
+DocType: Role,Role Name,Ім'я ролі
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Перемикання на робочий стіл
 apps/frappe/frappe/config/core.py,Script or Query reports,Сценарій або Запит повідомляє
 DocType: Contact Phone,Is Primary Mobile,Первинний мобільний
@@ -3544,7 +3544,7 @@ apps/frappe/frappe/www/update-password.html,Invalid Password,неправиль�
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record out of {1}.,Запис {0} імпортовано з {1}.
 DocType: Contact,Purchase Master Manager,Купівля Майстер-менеджер
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the lock icon to toggle public/private,"Клацніть на піктограму блокування, щоб переключити приватне / приватне"
-DocType: Module Def,Module Name,Ім&#39;я модуля
+DocType: Module Def,Module Name,Ім'я модуля
 DocType: S3 Backup Settings,eu-west-3,eu-захід-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},Завантаження {0} з {1}
 DocType: DocType,DocType is a Table / Form in the application.,DocType є Таблиця / Форма у додатку.
@@ -3577,7 +3577,7 @@ apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work 
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,"Деякі з функцій можуть не працювати у вашому браузері. Будь ласка, поновіть свій браузер до останньої версії."
 apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Не знаю, зверніться до ""Довідки"""
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},скасував цей документ {0}
-DocType: DocType,Comments and Communications will be associated with this linked document,Коментарі та комунікації будуть пов&#39;язані з цією пов&#39;язаного документа
+DocType: DocType,Comments and Communications will be associated with this linked document,Коментарі та комунікації будуть пов'язані з цією пов'язаного документа
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Фільтри ...
 DocType: Workflow State,bold,сміливий
 DocType: Auto Repeat,Status,Стан
@@ -3604,7 +3604,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Помилка під час зміни підписки
 DocType: LDAP Settings,LDAP Group Field,Групове поле LDAP
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Дорівнює
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',"Options &#39;&#39; Dynamic Link тип поля повинен вказувати на інший Link поле з опціями, як &#39;&#39; DocType"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',"Options '' Dynamic Link тип поля повинен вказувати на інший Link поле з опціями, як '' DocType"
 DocType: About Us Settings,Team Members Heading,Члени команди Очолювати
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Невірний формат CSV
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Помилка підключення до програми QZ Tray ... <br><br> Для використання функції Raw Print вам потрібно встановити та запустити додаток QZ Tray. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Натисніть тут, щоб завантажити та встановити QZ Tray</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Клацніть тут, щоб дізнатися більше про сирий друк</a> ."
@@ -3646,15 +3646,15 @@ DocType: Workflow,DocType on which this Workflow is applicable.,"Тип доку
 DocType: User,Enabled,Включено
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,Не вдалося виконати налаштування
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,New {0}: {1},Нові {0}: {1}
-DocType: Tag Category,Category Name,Категорія Ім&#39;я
-apps/frappe/frappe/model/db_query.py,Parent is required to get child table data,Батько зобов&#39;язаний отримати дані дочірньої таблиці
+DocType: Tag Category,Category Name,Категорія Ім'я
+apps/frappe/frappe/model/db_query.py,Parent is required to get child table data,Батько зобов'язаний отримати дані дочірньої таблиці
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Subscribers,Імпорт передплатників
 DocType: Print Settings,PDF Settings,Параметри PDF
-DocType: Kanban Board Column,Column Name,Ім&#39;я стовпця
+DocType: Kanban Board Column,Column Name,Ім'я стовпця
 DocType: Language,Based On,Грунтуючись на
 DocType: Email Account,"For more information, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">click here</a>.","Для отримання додаткової інформації <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">натисніть тут</a> ."
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Number of columns does not match with data,Кількість стовпців не збігається з даними
-apps/frappe/frappe/printing/doctype/print_format/print_format.js,Make Default,Чи не з&#39;являтися до суду
+apps/frappe/frappe/printing/doctype/print_format/print_format.js,Make Default,Чи не з'являтися до суду
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Execution Time: {0} sec,Час виконання: {0} сек
 apps/frappe/frappe/model/utils/__init__.py,Invalid include path,Недійсний шлях включення
 DocType: Communication,Email Account,E-mail аккаунт
@@ -3682,7 +3682,7 @@ apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,No
 DocType: Workflow State,Calendar,Календар
 apps/frappe/frappe/client.py,No document found for given filters,Чи не знайдено документів для заданих фільтрів
 apps/frappe/frappe/config/website.py,A user who posts blogs.,"Користувач, який публікує блоги."
-apps/frappe/frappe/model/rename_doc.py,"Another {0} with name {1} exists, select another name","Ще {0} з ім&#39;ям {1} існує, виберіть інше ім&#39;я"
+apps/frappe/frappe/model/rename_doc.py,"Another {0} with name {1} exists, select another name","Ще {0} з ім'ям {1} існує, виберіть інше ім'я"
 DocType: DocType,Custom?,Користувальницькі?
 DocType: Website Settings,Website Theme Image,Зображення теми веб-сайту
 DocType: Workflow State,road,дорога
@@ -3721,7 +3721,7 @@ apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.html,Select Group By...
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,e.g. (55 + 434) / 4 or =Math.sin(Math.PI/2)...,"наприклад, (55 + 434) / 4 = або Math.sin (Math.PI / 2) ..."
 apps/frappe/frappe/utils/csvutils.py,{0} is required,{0} обов’язковий
 DocType: Integration Request,Integration Type,Тип інтеграції
-DocType: Newsletter,Send Attachements,Надіслати від&#39;єднуються
+DocType: Newsletter,Send Attachements,Надіслати від'єднуються
 apps/frappe/frappe/config/integrations.py,Google Contacts Integration.,Інтеграція контактів Google.
 DocType: Transaction Log,Transaction Log,Журнал транзакцій
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last month's performance (from {0} to {1}),Статистика на основі результатів минулого місяця (від {0} до {1})
@@ -3763,7 +3763,7 @@ DocType: Report,Disable Prepared Report,Вимкнути підготовлен�
 apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,Користувач {0} подав запит на видалення даних
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,Нелегальна Токен доступу. Будь ласка спробуйте ще раз
 apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","Додаток був оновлений до нової версії, будь ласка, поновіть цю сторінку"
-DocType: Notification,Optional: The alert will be sent if this expression is true,"Буде відправлено попередження, якщо цей вираз істинно: Необов&#39;язково"
+DocType: Notification,Optional: The alert will be sent if this expression is true,"Буде відправлено попередження, якщо цей вираз істинно: Необов'язково"
 DocType: Data Migration Plan,Plan Name,Назва плану
 DocType: Print Settings,Print with letterhead,Друк за допомогою фірмових бланків
 apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,Attach a web link,Приєднайте веб-посилання
@@ -3790,12 +3790,12 @@ apps/frappe/frappe/config/desk.py,Email Group List,Список груп Еле�
 DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],Значок файлу з розширенням .ico розширенням. Повинно бути 16 х 16 пікселів. Генерується з використанням генератора FavIcon. [favicon-generator.org]
 DocType: Auto Email Report,Format,формат
 DocType: Email Account,Email Addresses,Адреси електронної пошти
-DocType: Web Form,Allow saving if mandatory fields are not filled,"Надати дозвіл на, якщо обов&#39;язкові поля не заповнено"
+DocType: Web Form,Allow saving if mandatory fields are not filled,"Надати дозвіл на, якщо обов'язкові поля не заповнено"
 DocType: S3 Backup Settings,us-west-2,нас-захід-2
 apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Select Child Table,Виберіть дочірню таблицю
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Trigger Primary Action,Первинна дія тригера
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Change,Зміна
-DocType: Email Domain,domain name,Доменне ім&#39;я
+DocType: Email Domain,domain name,Доменне ім'я
 DocType: Contact Email,Contact Email,Контактний Email
 DocType: Kanban Board Column,Order,замовлення
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No results found for {0} in Global Search,У глобальному пошуку не знайдено результатів для {0}
@@ -3826,14 +3826,14 @@ apps/frappe/frappe/utils/bot.py,I found these: ,Я знайшов це:
 DocType: Event,Send an email reminder in the morning,Надіслати електронною поштою нагадування вранці
 DocType: Blog Post,Published On,Опубліковано на
 DocType: Contact,Gender,Стать
-apps/frappe/frappe/website/doctype/web_form/web_form.py,Mandatory Information missing:,Обов&#39;язкова інформація відсутня:
+apps/frappe/frappe/website/doctype/web_form/web_form.py,Mandatory Information missing:,Обов'язкова інформація відсутня:
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} reverted your points on {1},{0} повернув свої бали на {1}
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Check Request URL,Перевірити URL-адресу запиту
 apps/frappe/frappe/client.py,Only 200 inserts allowed in one request,Тільки 200 вставок допускається в одному запиті
 DocType: Footer Item,URL,URL
 apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,"Поверніться на екран підтвердження та введіть код, який відображається за допомогою вашої програми автентифікації"
 DocType: ToDo,Reference Type,Тип посилання
-apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Please enable developer mode to create new connection,Увімкніть режим розробника для створення нового з&#39;єднання
+apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Please enable developer mode to create new connection,Увімкніть режим розробника для створення нового з'єднання
 DocType: Event,Repeat On,Повторіть На
 DocType: SMS Parameter,SMS Parameter,SMS Параметр
 DocType: Auto Email Report,Half Yearly,Півроку
@@ -3855,8 +3855,8 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,More...,Детальн�
 DocType: System Settings,User can login using Email id or Mobile number,"Користувач може увійти в систему, використовуючи ІД епошти або мобільний номер"
 DocType: Bulk Update,Update Value,Оновлення Значення
 apps/frappe/frappe/core/doctype/communication/communication.js,Mark as {0},Повідомити про {0}
-apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,"Будь ласка, виберіть нове ім&#39;я для перейменування"
-apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,"Будь ласка, виберіть нове ім&#39;я для перейменування"
+apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,"Будь ласка, виберіть нове ім'я для перейменування"
+apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,"Будь ласка, виберіть нове ім'я для перейменування"
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Invalid column,Недійсний стовпець
 DocType: Data Migration Connector,Data Migration,Переміщення даних
 DocType: User,API Key cannot be  regenerated,API-ключ не може бути регенерований
@@ -3868,7 +3868,7 @@ DocType: Event,Event Participants,Учасники події
 DocType: Auto Repeat,Frequency,частота
 DocType: Custom Field,Insert After,Вставити після
 DocType: Event,Sync with Google Calendar,Синхронізуйте з Календарем Google
-DocType: Access Log,Report Name,Ім&#39;я звіту
+DocType: Access Log,Report Name,Ім'я звіту
 DocType: Desktop Icon,Reverse Icon Color,Зворотний колір значка
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Save,Зберегти
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat_schedule.html,Next Scheduled Date,Наступна запланована дата
@@ -3883,7 +3883,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,За замовчуванням
 DocType: Translation,Verified,Перевірено
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} додано
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Пошук &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Пошук '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Будь ласка, збережіть звіт першої"
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} додано абонентів
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Не в
@@ -3936,10 +3936,10 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: Email Account,Email Server,Сервер електронної пошти
 DocType: Assignment Rule,Document Type,Тип документу
 DocType: Address,Tax Category,Податкова категорія
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Label is mandatory,Етикетка є обов&#39;язковим
-DocType: PayPal Settings,API Username,API Ім&#39;я користувача
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Label is mandatory,Етикетка є обов'язковим
+DocType: PayPal Settings,API Username,API Ім'я користувача
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Half Day,Півдня
-DocType: Communication,Communication Type,Тип зв&#39;язку
+DocType: Communication,Communication Type,Тип зв'язку
 DocType: DocField,Unique,Унікальний
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} appreciated on {1},{0} оцінено {1}
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Partial Success,Частковий успіх
@@ -3964,8 +3964,8 @@ apps/frappe/frappe/model/document.py,Insufficient Permission for {0},Недос�
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Report was not saved (there were errors),Повідомити не був збережений (були помилки)
 apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,Неможливо змінити вміст заголовка
 DocType: Print Settings,Print Style,Друк Стиль
-apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not Linked to any record,Чи не пов&#39;язаний із записом
-apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not Linked to any record,Чи не пов&#39;язаний із записом
+apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not Linked to any record,Чи не пов'язаний із записом
+apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not Linked to any record,Чи не пов'язаний із записом
 DocType: Custom DocPerm,Import,Імпорт
 DocType: User,Social Logins,Соціальні логіни
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Row {0}: Not allowed to enable Allow on Submit for standard fields,Ряд {0}: Чи не дозволяється включити Дозволити на Надіслати на стандартних полів
@@ -4015,7 +4015,7 @@ DocType: System Settings,Bypass Two Factor Auth for users who login from restric
 DocType: Event,Google Calendar,Календар Google
 apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,"{0}, щоб більше не отримувати електронні листи цього типу"
 apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Відкрийте додаток для автентифікації на своєму мобільному телефоні.
-apps/frappe/frappe/model/rename_doc.py,merged {0} into {1},об&#39;єднані {0} в {1}
+apps/frappe/frappe/model/rename_doc.py,merged {0} into {1},об'єднані {0} в {1}
 DocType: System Settings,mm-dd-yyyy,мм-дд-рррр
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.js,New Connection,Нове підключення
 apps/frappe/frappe/chat/__init__.py,"Sorry, you're not authorized.","Вибачте, ви не авторизовані."

--- a/frappe/translations/ur.csv
+++ b/frappe/translations/ur.csv
@@ -63,7 +63,7 @@ apps/frappe/frappe/public/js/frappe/model/model.js,Parent,والدین
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.",فعال ہونے پر، پاس ورڈ کی طاقت کم از کم پاس ورڈ اسکور قیمت کی بنیاد پر نافذ کیا جائے گا. درمیانے درجے کے مضبوط ہونے کی وجہ سے 2 کے ایک قدر اور 4 بہت مضبوط ہے.
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.",فعال ہونے پر، پاس ورڈ کی طاقت کم از کم پاس ورڈ اسکور قیمت کی بنیاد پر نافذ کیا جائے گا. درمیانے درجے کے مضبوط ہونے کی وجہ سے 2 کے ایک قدر اور 4 بہت مضبوط ہے.
 DocType: About Us Settings,"""Team Members"" or ""Management""","""جماعت کے ارکان"" یا ""انتظام"""
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',میدان کے چیک &#39;قسم کے لئے پہلے سے طے شدہ یا تو&#39; 0 &#39;یا&#39; 1 &#39;ہونا ضروری ہے
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',میدان کے چیک 'قسم کے لئے پہلے سے طے شدہ یا تو' 0 'یا' 1 'ہونا ضروری ہے
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,کل
 DocType: Contact,Designation,عہدہ
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,خودکار لنکنگ صرف ایک ای میل اکاؤنٹ کے لئے چالو کی جاسکتی ہے۔
@@ -250,7 +250,7 @@ apps/frappe/frappe/core/doctype/report/report.js,Disable Report,غیر فعال 
 DocType: Translation,Contributed Translation Doctype Name,تعاون یافتہ ترجمہ دستاویز نام۔
 DocType: PayPal Settings,Redirect To,پر ری ڈائریکٹ
 DocType: Data Migration Mapping,Pull,ھیںچو
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},جاوا کی شکل: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},جاوا کی شکل: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,بلک اپ ڈیٹ
 DocType: Workflow State,chevron-up,شیوران اپ
 DocType: DocType,Allow Guest to View,مہمان دیکھنے کے لئے اجازت
@@ -555,7 +555,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),پچھلے ہفتے کی کارکردگی پر مبنی اعدادوشمار ({0} سے {1} تک)
 DocType: LDAP Settings,LDAP Phone Field,ایل ڈی اے پی فون فیلڈ۔
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer",دستاویز کی قسم ...، مثال کے طور پر گاہک
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,حالت &#39;{0}&#39; غلط ہے
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,حالت '{0}' غلط ہے
 DocType: Workflow State,barcode,بارکوڈ
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,ذیلی سوال یا فنکشن کا استعمال محدود ہے
 apps/frappe/frappe/config/customization.py,Add your own translations,اپنا خود کا ترجمہ شامل کریں
@@ -746,7 +746,7 @@ DocType: Currency,Currency Name,کرنسی نام
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,کوئی ای میلز
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,لنک ختم ہو گیا
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{1}&#39; کے لئے &#39;{2}&#39; کے لئے {0} کی لمبائی کو آگے بڑھانا؛ لمبائی کی ترتیب کے طور پر {3} ڈیٹا کا ٹکنانا کرنا ہوگا.
+							Setting the length as {3} will cause truncation of data.",'{1}' کے لئے '{2}' کے لئے {0} کی لمبائی کو آگے بڑھانا؛ لمبائی کی ترتیب کے طور پر {3} ڈیٹا کا ٹکنانا کرنا ہوگا.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,فائل کی شکل منتخب کریں
 DocType: Report,Javascript,جاوا سکرپٹ
 DocType: File,Content Hash,مواد ہیش
@@ -768,7 +768,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,دستاویز کا اشتراک رپورٹ
 DocType: Social Login Key,Base URL,بیس یو آر ایل
 DocType: User,Last Login,آخری لاگ ان
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},آپ فیلڈ کے لئے &#39;Translatable&#39; سیٹ نہیں کر سکتے ہیں {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},آپ فیلڈ کے لئے 'Translatable' سیٹ نہیں کر سکتے ہیں {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,کالم
 DocType: Chat Profile,Chat Profile,چیٹ پروفائل
 DocType: Custom Field,Adds a custom field to a DocType,ایک DOCTYPE کرنے کے لئے ایک اپنی مرضی کے میدان کا اضافہ کر دیتی
@@ -777,7 +777,7 @@ DocType: File,Is Home Folder,ہوم فولڈر ہے
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,نوبار اسٹائل
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} ایک درست ای میل پتہ نہیں ہے
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,پرنٹنگ کے لئے کم سے کم 1 ریکارڈ کریں
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',صارف &#39;{0}&#39; پہلے ہی کردار ہے &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',صارف '{0}' پہلے ہی کردار ہے '{1}'
 DocType: System Settings,Two Factor Authentication method,دو فیکٹر کی توثیق کا طریقہ
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,سب سے پہلے نام قائم اور ریکارڈ کو بچانے کے.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 ریکارڈ
@@ -1027,7 +1027,7 @@ DocType: Property Setter,Property Setter,پراپرٹی سیٹر
 DocType: Web Form,Allow Print,پرنٹ اجازت دیں
 DocType: Communication,Clicked,کلک
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,غیر مسدود کریں
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},کرنے کی اجازت نہیں &#39;{0} {1}
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},کرنے کی اجازت نہیں '{0} {1}
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,بھیجنے کے لئے تخسوچت
 DocType: DocType,Track Seen,ٹریک دیکھا
 DocType: Dropbox Settings,File Backup,فائل بیک اپ
@@ -1054,7 +1054,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,صفحے کے HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,غلط خطوط برآمد کریں۔
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,گروپ کا نام خالی نہیں ہوسکتا ہے.
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,مزید نوڈس صرف &#39;گروپ&#39; قسم نوڈس کے تحت پیدا کیا جا سکتا
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,مزید نوڈس صرف 'گروپ' قسم نوڈس کے تحت پیدا کیا جا سکتا
 DocType: SMS Parameter,Header,ہیڈر
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},نامعلوم کالم: {0}
 DocType: Notification Recipient,Email By Role,کردار کی طرف سے ای میل
@@ -1943,7 +1943,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,ap-جنوب مشرقی -1۔
 DocType: DocType,"Must be of type ""Attach Image""",قسم کا ہونا ضروری ہے &quot;تصویر منسلک&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,غیر منتخب تمام
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},آپ کو میدان کے لئے ناسیٹ نہیں &#39;صرف پڑھیں&#39; کر سکتے ہیں {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},آپ کو میدان کے لئے ناسیٹ نہیں 'صرف پڑھیں' کر سکتے ہیں {0}
 DocType: Auto Email Report,Zero means send records updated at anytime,زیرو ریکارڈز کسی بھی وقت اپ ڈیٹ بھیجنے کا مطلب
 DocType: Auto Email Report,Zero means send records updated at anytime,زیرو ریکارڈز کسی بھی وقت اپ ڈیٹ بھیجنے کا مطلب
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,مکمل سیٹ
@@ -1987,7 +1987,7 @@ DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, use
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,گوگل فونٹ
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.",مددگار نہیں، GitHub کے مسائل پر آپ کی تجاویز میں شامل کریں جہاں ان ہدایات پر تو.
 DocType: Workflow State,bookmark,بک مارک
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),فولڈر کا نام شامل نہیں کرنا چاہئے &#39;/&#39; (سلیش)
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),فولڈر کا نام شامل نہیں کرنا چاہئے '/' (سلیش)
 DocType: Note,Note,نوٹ
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,غلطی کی رپورٹ
 apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,CSV / ایکسل فارمیٹ میں برآمد ڈیٹا.
@@ -2091,7 +2091,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,گھنٹے مثال 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",یہ فیلڈ دکھایا جائے گا FIELDNAME یہاں بیان کیا قیمت ہے یا قوانین سچے (مثالیں) ہیں صرف اس صورت: myfield سے Eval: doc.myfield == &#39;میری قدر&#39; سے Eval: doc.age> 18
+eval:doc.age>18",یہ فیلڈ دکھایا جائے گا FIELDNAME یہاں بیان کیا قیمت ہے یا قوانین سچے (مثالیں) ہیں صرف اس صورت: myfield سے Eval: doc.myfield == 'میری قدر' سے Eval: doc.age> 18
 DocType: Social Login Key,Office 365,آفس 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,آج
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,آج
@@ -2131,7 +2131,7 @@ DocType: Data Migration Connector,Database Name,ڈیٹا بیس کا نام
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,تازہ کاری فارم
 DocType: DocField,Select,منتخب کریں
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,مکمل لاگ دیکھیں۔
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",سادہ ازگر اظہار ، مثال: حیثیت == &#39;کھولیں&#39; اور ٹائپ کریں == &#39;بگ&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",سادہ ازگر اظہار ، مثال: حیثیت == 'کھولیں' اور ٹائپ کریں == 'بگ'
 apps/frappe/frappe/utils/csvutils.py,File not attached,فائل منسلک نہیں
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,کنکشن کھو دیا. کچھ خصوصیات کام نہیں کر سکتے ہیں.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",جیسے &quot;AAA&quot; دوہراتا اندازہ لگانا آسان ہے
@@ -2259,7 +2259,7 @@ apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} alre
 DocType: Data Import,Show only errors,صرف غلطیاں دکھائیں
 DocType: Website Settings,Banner HTML,بینر ایچ ٹی ایم ایل
 DocType: Workflow,Send Email Alert,ای میل انتباہ بھیجیں
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. Razorpay کرنسی میں لین دین کی حمایت نہیں کرتا &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. Razorpay کرنسی میں لین دین کی حمایت نہیں کرتا '{0}'
 DocType: Data Import,In Progress,کام جاری ہے
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,بیک اپ کے لیے قطار. اس ایک گھنٹے کے لئے چند منٹ لگ سکتے ہیں.
 DocType: Error Snapshot,Pyver,Pyver
@@ -2673,7 +2673,7 @@ apps/frappe/frappe/public/js/frappe/form/save.js,Amending,ترمیم
 apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,تعمیل پے پال کی ادائیگی کے گیٹ وے ترتیبات
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,ٹاپ پرفارمر
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,بنیادی دستاویزات میں کسٹم فیلڈز شامل نہیں کیے جاسکتے ہیں۔
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: &#39;{1}&#39; ({3}) ٹونٹ ہو جائے گا، کیونکہ زیادہ سے زیادہ حروف کی اجازت دی گئی ہے {2}
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}",{0}: '{1}' ({3}) ٹونٹ ہو جائے گا، کیونکہ زیادہ سے زیادہ حروف کی اجازت دی گئی ہے {2}
 DocType: OAuth Client,Response Type,رسپانس قسم
 DocType: Contact Us Settings,Send enquiries to this email address,یہ ای میل پتہ پوچھ گچھ بھیج
 DocType: Letter Head,Letter Head Name,خط ہیڈ نام
@@ -2729,7 +2729,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,تصویر دیکھیں
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.",ایسا لگتا ہے کہ کچھ کی طرح لین دین کے دوران غلط ہو گیا. ہم ادائیگی کی تصدیق نہیں کی چونکہ، پے پال خود کار طریقے سے آپ کو اس رقم واپس کر دیں گے. اگر ایسا نہیں ہوتا، ہمیں ایک ای میل بھیج اور لزوم ID ذکر کیجیے: {0}.
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password",پاس ورڈ علامات، اعداد اور بڑے حروف شامل ہیں
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",میدان &#39;{0}&#39; کسٹم فیلڈ میں ذکر کے بعد داخل کریں &#39;{1}&#39;، لیبل کے ساتھ &#39;{2}&#39;، موجود نہیں ہے
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",میدان '{0}' کسٹم فیلڈ میں ذکر کے بعد داخل کریں '{1}'، لیبل کے ساتھ '{2}'، موجود نہیں ہے
 DocType: List Filter,List Filter,فہرست فلٹر
 DocType: Workflow State,signal,سگنل
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,منسلک ہے
@@ -2739,7 +2739,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,دستاویز بحال
 DocType: Data Export,Data Export,ڈیٹا برآمد
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,زبان منتخب کریں ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},آپ فیلڈ کے لئے &#39;اختیارات&#39; مقرر نہیں کرسکتے ہیں {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},آپ فیلڈ کے لئے 'اختیارات' مقرر نہیں کرسکتے ہیں {0}
 DocType: Help Article,Author,مصنف
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,بھیجنے دوبارہ شروع
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,دوبارہ کھولنے
@@ -2753,15 +2753,15 @@ DocType: Web Page,Slideshow,سلائیڈ شو
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,پہلے سے طے شدہ ایڈریس سانچہ خارج نہیں کیا جا سکتا
 DocType: Contact,Maintenance Manager,بحالی مینیجر
 DocType: Workflow State,Search,تلاش کریں
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. پٹی کرنسی میں لین دین کی حمایت نہیں کرتا &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. پٹی کرنسی میں لین دین کی حمایت نہیں کرتا &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. پٹی کرنسی میں لین دین کی حمایت نہیں کرتا '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. پٹی کرنسی میں لین دین کی حمایت نہیں کرتا '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,ردی میں ڈالیں
 DocType: Web Form,Web Form Fields,ویب فارم قطعے
 DocType: Data Import,Amended From,سے ترمیم شدہ
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},انتباہ: {0} سے متعلق کسی بھی میز میں {0} تلاش کرنے میں ناکام
 DocType: S3 Backup Settings,eu-north-1,یورو شمال۔
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,یہ دستاویز فی الحال عملدرآمد کے لئے قطار بند ہے. دوبارہ کوشش کریں
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,فائل &#39;{0}&#39; نہیں ملا
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,فائل '{0}' نہیں ملا
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,سیکشن ہٹائیں
 DocType: User,Change Password,پاس ورڈ بدلو
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,ایکس ایکسس فیلڈ
@@ -2944,7 +2944,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,قیمت کے لئے
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,چائلڈ شامل
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,درآمد کی پیشرفت۔
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",اگر شرط مطمئن ہے تو صارف کو پوائنٹس سے نوازا جائے گا۔ جیسے doc.status == &#39;بند&#39;
+",اگر شرط مطمئن ہے تو صارف کو پوائنٹس سے نوازا جائے گا۔ جیسے doc.status == 'بند'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: پیش ریکارڈ خارج نہیں کیا جا سکتا.
 DocType: GSuite Templates,Template Name,سانچہ نام
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,دستاویز کی نئی قسم
@@ -3072,7 +3072,7 @@ DocType: Dashboard Chart,Chart Type,چارٹ کی قسم
 DocType: DocType,Auto Name,آٹو نام
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,وہ اندازہ لگانا آسان ہے کے طور پر اے بی سی یا 6543 کی طرح کے انداز سے بچیں
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,دوبارہ کوشش کریں
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL کا آغاز &#39;http: //&#39; یا &#39;https: //&#39; سے ہونا چاہئے
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL کا آغاز 'http: //' یا 'https: //' سے ہونا چاہئے
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,آپشن 3
 DocType: Communication,uid,یو آئی ڈی
 DocType: Workflow State,Edit,میں ترمیم کریں
@@ -3306,7 +3306,7 @@ DocType: Notification,Send alert if this field's value changes,اس میدان �
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,تھیم رنگ
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,ایک نئی شکل بنانے کے لئے ایک DOCTYPE کریں
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,صارف موجود نہیں
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;وصول کنندگان&#39; متعین نہیں ہیں
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'وصول کنندگان' متعین نہیں ہیں
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,ابھی ابھی
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,کا اطلاق کریں
 DocType: Footer Item,Policy,پالیسی
@@ -3352,7 +3352,7 @@ apps/frappe/frappe/config/customization.py,Custom Translations,اپنی مرضی
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,پیش رفت
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,کردار کی طرف سے
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,لاپتہ قطعات
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname میں غلط FIELDNAME &#39;{0}&#39;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,autoname میں غلط FIELDNAME '{0}'
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,ایک دستاویز کی قسم میں تلاش کریں
 DocType: Custom DocPerm,Role and Level,کردار اور لیول
 DocType: File,Thumbnail URL,اظفورہ یو آر ایل
@@ -3439,11 +3439,11 @@ DocType: Dashboard Chart,Filters JSON,JSON کو فلٹرز کریں۔
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,توثیق کرنے کے لئے یہاں کلک کریں
 DocType: Email Account,Disable SMTP server authentication,SMTP سرور کی توثیق کو غیر فعال کریں۔
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,کلپ بورڈ میں کاپی۔
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,بجائے اس طرح پیشین گوئی کے قابل بدل &#39;@&#39; &#39;ایک&#39; بہت زیادہ مدد نہیں کرتے.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,بجائے اس طرح پیشین گوئی کے قابل بدل '@' 'ایک' بہت زیادہ مدد نہیں کرتے.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,مجھے طرف سے تفویض کردہ
 apps/frappe/frappe/utils/data.py,Zero,زیرو
 DocType: Google Drive,Backup Folder ID,بیک اپ فولڈر ID۔
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,نہیں ڈیولپر موڈ میں! site_config.json میں سیٹ یا &#39;مرضی&#39; DOCTYPE بنانے.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,نہیں ڈیولپر موڈ میں! site_config.json میں سیٹ یا 'مرضی' DOCTYPE بنانے.
 DocType: Workflow State,globe,دنیا
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
 DocType: Assignment Rule,Priority,ترجیح
@@ -3491,7 +3491,7 @@ DocType: Notification,Reference Date,حوالہ تاریخ
 apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP ایپ کا استعمال کرتے ہوئے OTP سیٹ اپ مکمل نہیں ہوا تھا۔ برائے مہربانی ایڈمنسٹریٹر سے رابطہ کریں۔
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,درست موبائل نمبر درج کریں
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,خصوصیات میں سے کچھ آپ کے براؤزر میں کام نہیں کر سکتے. تازہ ترین ورژن کے لئے اپنے براؤزر کو اپ ڈیٹ کریں.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",، معلوم نہیں پوچھیں &#39;مدد&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",، معلوم نہیں پوچھیں 'مدد'
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},اس دستاویز کو منسوخ کردیا {0}
 DocType: DocType,Comments and Communications will be associated with this linked document,تبصرے اور کموینیکیشن اس منسلک دستاویز کے ساتھ منسلک کیا جائے گا
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,فلٹر ...
@@ -3520,7 +3520,7 @@ apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid 
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,رکنیت میں ترمیم کے دوران ناکامی
 DocType: LDAP Settings,LDAP Group Field,ایل ڈی اے پی گروپ فیلڈ۔
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,برابر
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',میدان کے اختیارات &#39;متحرک لنک&#39; قسم &#39;DOCTYPE&#39; کے طور پر اختیارات کے ساتھ ایک لنک فیلڈ کی طرف اشارہ کرنا ضروری ہے
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',میدان کے اختیارات 'متحرک لنک' قسم 'DOCTYPE' کے طور پر اختیارات کے ساتھ ایک لنک فیلڈ کی طرف اشارہ کرنا ضروری ہے
 DocType: About Us Settings,Team Members Heading,سرخی ٹیم کے ارکان
 apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,غلط CSV شکل
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","کیو زیڈ ٹرے ایپلیکیشن سے رابطہ کرنے میں خرابی… <br><br> آپ کو را پرنٹ کی خصوصیت استعمال کرنے کے ل Q ، QZ ٹرے ایپلی کیشن انسٹال اور چلانے کی ضرورت ہے۔ <br><br> <a href=""https://qz.io/download/"" target=""_blank"">کیو زیڈ ٹرے کو ڈاؤن لوڈ اور انسٹال کرنے کے لئے یہاں کلک کریں</a> ۔ <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">را پرنٹنگ کے بارے میں مزید معلومات کے لئے یہاں کلک کریں</a> ۔"
@@ -3647,8 +3647,8 @@ DocType: Web Page,Web Page,ویب صفحہ
 DocType: Workflow Document State,Next Action Email Template,اگلا ایکشن ای میل سانچہ
 DocType: Blog Category,Blogger,بلاگر
 DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline",اگر چالو ہوتا ہے تو ، دستاویز میں ہونے والی تبدیلیوں کو ٹریک کیا جاتا ہے اور ٹائم لائن میں دکھایا جاتا ہے۔
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;گلوبل تلاش میں&#39; قسم کے لئے کی اجازت نہیں {0} قطار میں {1}
-apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},&#39;گلوبل تلاش میں&#39; قسم کے لئے کی اجازت نہیں {0} قطار میں {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'گلوبل تلاش میں' قسم کے لئے کی اجازت نہیں {0} قطار میں {1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},'گلوبل تلاش میں' قسم کے لئے کی اجازت نہیں {0} قطار میں {1}
 DocType: Energy Point Log,Appreciation,تعریف
 apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,لنک کی فہرست
 DocType: Workflow,Don't Override Status,سٹیٹس کی جگہ لے لے نہیں چھوڑیں
@@ -3790,7 +3790,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,پہلے سے طے شدہ
 DocType: Translation,Verified,تصدیق شدہ۔
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} شامل
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',کے لئے تلاش &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',کے لئے تلاش '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,پہلی رپورٹ بچا لو
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} صارفین شامل
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,اندر نہیں
@@ -3826,14 +3826,14 @@ apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,میں
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} ایک درست ریاست
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,تمام دستاویزات کی قسموں پر لگائیں۔
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,انرجی پوائنٹ کی تازہ کاری۔
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. تعمیل پے پال کرنسی میں لین دین کی حمایت نہیں کرتا &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',ایک اور طریقہ ادائیگی کا انتخاب کریں. تعمیل پے پال کرنسی میں لین دین کی حمایت نہیں کرتا '{0}'
 DocType: Chat Message,Room Type,کمرہ کی قسم
 DocType: Data Import Beta,Import Log Preview,لاگ کا مشاہدہ درآمد کریں۔
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,تلاش فیلڈ {0} درست نہیں ہے
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,اپ لوڈ فائل
 DocType: Workflow State,ok-circle,ٹھیک دائرے
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP صارف تخلیق اور تعریفیں۔
-apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',آپ کے صارفین میں سنتری مل &#39;پوچھ کر چیزوں کو تلاش کر سکتے ہیں
+apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',آپ کے صارفین میں سنتری مل 'پوچھ کر چیزوں کو تلاش کر سکتے ہیں
 apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,معاف کیجئے گا! صارف کو ان کے اپنے ریکارڈ کو مکمل رسائی حاصل کرنا چاہئے.
 ,Usage Info,استعمال معلومات
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,کی بورڈ شارٹ کٹس دکھائیں۔

--- a/frappe/translations/ur.csv
+++ b/frappe/translations/ur.csv
@@ -1406,7 +1406,7 @@ DocType: Report,Is Standard,معیاری ہے
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,مکمل
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",مت &lt;سکرپٹ> یا صرف کرداروں وہ جان بوجھ کر اس میدان میں استعمال کیا جا سکتا ہے کے طور طرح &lt;یا>، جیسے HTML ضابطہ کاری HTML ٹیگ
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",مت <سکرپٹ> یا صرف کرداروں وہ جان بوجھ کر اس میدان میں استعمال کیا جا سکتا ہے کے طور طرح <یا>، جیسے HTML ضابطہ کاری HTML ٹیگ
 DocType: Website Settings,FavIcon,ویب شبیہ
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,رن
 DocType: Blog Post,Content (HTML),مواد (HTML)
@@ -1774,7 +1774,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,فوٹر صرف �
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,زیر غور
 DocType: System Settings,Allow only one session per user,فی صارف صرف ایک سیشن کی اجازت دیں
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ہوم / ٹیسٹ کے فولڈر 1 / ٹیسٹ کے فولڈر 3
-DocType: Website Settings,&lt;head> HTML,&lt;سر> ایچ ٹی ایم ایل
+DocType: Website Settings,<head> HTML,<سر> ایچ ٹی ایم ایل
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,کو منتخب کریں یا ایک نیا ایونٹ بنانے کے لئے وقت سلاٹ بھر ھیںچیں.
 DocType: Contact,Contact Details,رابطہ کی تفصیلات
 DocType: DocField,In Filter,فلٹر میں
@@ -2291,7 +2291,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,لنکس دیکھنا نہیں کافی اجازت
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ایڈریس عنوان لازمی ہے.
 DocType: Google Contacts,Push to Google Contacts,گوگل رابطوں پر دبائیں۔
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;سر> میں شامل HTML ویب کے صفحے کے سیکشن، بنیادی طور پر ویب سائٹ کی توثیق کی اور SEO کے لئے استعمال کیا جاتا ہے
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",<سر> میں شامل HTML ویب کے صفحے کے سیکشن، بنیادی طور پر ویب سائٹ کی توثیق کی اور SEO کے لئے استعمال کیا جاتا ہے
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,آئٹم کو اس کی اپنی اولاد میں شامل نہیں کیا جا سکتا
 DocType: Session Default Settings,Session Defaults,سیشن ڈیفالٹس
@@ -2408,7 +2408,7 @@ DocType: Workflow State,Warning,انتباہ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,یہ متعدد صفحات پر چھاپ سکتا ہے۔
 DocType: Data Migration Run,Percent Complete,فی صد مکمل
 DocType: Tag Category,Tag Category,ٹیگ زمرہ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",موازنہ کے لئے ،> 5 ، &lt;10 یا = 324 استعمال کریں۔ حدود کے ل 5 ، 5:10 (5 اور 10 کے درمیان اقدار کے لئے) استعمال کریں۔
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",موازنہ کے لئے ،> 5 ، <10 یا = 324 استعمال کریں۔ حدود کے ل 5 ، 5:10 (5 اور 10 کے درمیان اقدار کے لئے) استعمال کریں۔
 DocType: Google Calendar,Pull from Google Calendar,گوگل کی��نڈر سے کھینچیں۔
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,مدد
 DocType: User,Login Before,لاگ ان سے پہلے
@@ -3035,7 +3035,7 @@ DocType: DocField,Allow on Submit,جمع کرانے پر کی اجازت دیں
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,رعایت کی قسم
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,کالم اٹھاو
-DocType: Web Page,Add code as &lt;script>,&lt;سکرپٹ> کے طور پر کوڈ شامل کریں
+DocType: Web Page,Add code as <script>,<سکرپٹ> کے طور پر کوڈ شامل کریں
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,صارف کی اجازتیں صاف کریں۔
 DocType: Webhook,Headers,ہیڈر
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,انے والی تقریبات
@@ -3400,16 +3400,16 @@ DocType: Workflow State,share-alt,حصہ ALT
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},قطار {0} میں سے ایک ہونا چاہئے
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4 style="";text-align:right;direction:rtl""> پہلے سے طے شدہ سانچہ </h4><p style="";text-align:right;direction:rtl""> کا استعمال کرتا ہے <a href=""http://jinja.pocoo.org/docs/templates/"">میں Jinja templating کے</a> اور دستیاب ہو جائے گا (اگر کوئی اپنی مرضی کے شعبوں سمیت) ایڈریس کے تمام شعبوں </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4 style="";text-align:right;direction:rtl""> پہلے سے طے شدہ سانچہ </h4><p style="";text-align:right;direction:rtl""> کا استعمال کرتا ہے <a href=""http://jinja.pocoo.org/docs/templates/"">میں Jinja templating کے</a> اور دستیاب ہو جائے گا (اگر کوئی اپنی مرضی کے شعبوں سمیت) ایڈریس کے تمام شعبوں </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,تاریخ کی تاریخ شروع کریں
 DocType: Role,Role Name,رول نام
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ڈیسک سے جوڑئیے

--- a/frappe/translations/ur.csv
+++ b/frappe/translations/ur.csv
@@ -740,7 +740,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,فائل ب
 DocType: DocField,In Global Search,گلوبل تلاش میں
 DocType: System Settings,Brute Force Security,برٹ فورس سیکورٹی
 DocType: Workflow State,indent-left,پوٹ بائیں
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} سال (سال پہلے)
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} سال (سال پہلے)
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,اس فائل کو حذف کرنا خطرناک ہے: {0}. آپ کے سسٹم مینیجر سے رابطہ کریں.
 DocType: Currency,Currency Name,کرنسی نام
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,کوئی ای میلز
@@ -1036,7 +1036,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,کوئی {0} 
 apps/frappe/frappe/config/customization.py,Add custom forms.,اپنی مرضی کے مطابق فارم شامل.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} میں {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,اس دستاویز جمع کرائی
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,سیٹ اپ&gt; صارف کی اجازت
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,سیٹ اپ> صارف کی اجازت
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,نظام بہت پہلے سے مقرر کردار فراہم کرتا ہے. آپ finer کی اجازت مقرر کرنے کے لئے نئے کردار شامل کر سکتے ہیں.
 DocType: Communication,CC,CC
 DocType: Country,Geo,جیو
@@ -1202,7 +1202,7 @@ apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} reco
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"tag name..., e.g. #tag",ٹیگ کا نام ... ، جیسے # ٹیگ
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Keyboard Shortcuts,کی بورڈ شارٹ کٹس
 DocType: Post,Comments,تبصرے
-apps/frappe/frappe/public/js/frappe/dom.js,Confirm,کی توثیق
+apps/frappe/frappe/public/js/frappe/dom.js,Confirm,کی ت��ثیق
 apps/frappe/frappe/public/js/frappe/desk.js,Authenticating...,تصدیق کر رہا ہے…
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Collapse All,تمام مختصر کریں
 apps/frappe/frappe/www/login.html,Forgot Password?,پاسورڈ بھول گے؟
@@ -1254,7 +1254,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",صارف کی جانچ پڑتال کوئی کردار نہیں ہیں تب صارف ایک &quot;سسٹم یوزر&quot; بن جاتا ہے. &quot;سسٹم یوزر کے&quot; ڈیسک ٹاپ تک رسائی حاصل ہے
 DocType: System Settings,Date and Number Format,تاریخ اور نمبر کی شکل
 apps/frappe/frappe/model/document.py,one of,اس میں سے ایک
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,سیٹ اپ&gt; فارم کو کسٹمائز کریں
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,سیٹ اپ> فارم کو کسٹمائز کریں
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,ایک لمحے پڑتال کر رہا ہے
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,دکھائیں ٹیگز
 DocType: DocField,HTML Editor,ایچ ٹی ایم ایل ایڈیٹر
@@ -1262,7 +1262,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,بلنگ
 DocType: Email Queue,Not Sent,نہیں بھیجا
 DocType: Web Form,Actions,عوامل
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,سیٹ اپ&gt; صارف
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,سیٹ اپ> صارف
 DocType: Workflow State,align-justify,سیدھ-جواز
 DocType: User,Middle Name (Optional),مشرق نام (اختیاری)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,اجازت نہیں
@@ -1406,7 +1406,7 @@ DocType: Report,Is Standard,معیاری ہے
 DocType: Desktop Icon,_report,_report
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,مکمل
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",مت &lt;سکرپٹ&gt; یا صرف کرداروں وہ جان بوجھ کر اس میدان میں استعمال کیا جا سکتا ہے کے طور طرح &lt;یا&gt;، جیسے HTML ضابطہ کاری HTML ٹیگ
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",مت &lt;سکرپٹ> یا صرف کرداروں وہ جان بوجھ کر اس میدان میں استعمال کیا جا سکتا ہے کے طور طرح &lt;یا>، جیسے HTML ضابطہ کاری HTML ٹیگ
 DocType: Website Settings,FavIcon,ویب شبیہ
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,رن
 DocType: Blog Post,Content (HTML),مواد (HTML)
@@ -1774,7 +1774,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,فوٹر صرف �
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,زیر غور
 DocType: System Settings,Allow only one session per user,فی صارف صرف ایک سیشن کی اجازت دیں
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,ہوم / ٹیسٹ کے فولڈر 1 / ٹیسٹ کے فولڈر 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;سر&gt; ایچ ٹی ایم ایل
+DocType: Website Settings,&lt;head> HTML,&lt;سر> ایچ ٹی ایم ایل
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,کو منتخب کریں یا ایک نیا ایونٹ بنانے کے لئے وقت سلاٹ بھر ھیںچیں.
 DocType: Contact,Contact Details,رابطہ کی تفصیلات
 DocType: DocField,In Filter,فلٹر میں
@@ -1821,7 +1821,7 @@ DocType: System Settings,Show Full Error and Allow Reporting of Issues to the De
 apps/frappe/frappe/www/third_party_apps.html,Active Sessions,فعال سیشن
 DocType: DocType,ASC,ASC
 apps/frappe/frappe/public/js/frappe/form/print.js,New Print Format Name,نیا پرنٹ فارمیٹ نام۔
-apps/frappe/frappe/templates/emails/data_deletion_approval.html,Click on the link below to approve the request,درخواست کو منظور کرنے کے لئے نیچے دیئے گئے لنک پر کلک کریں۔
+apps/frappe/frappe/templates/emails/data_deletion_approval.html,Click on the link below to approve the request,درخواست کو منظور کرنے کے لئے نیچے دیئے گئے لنک پر کلک ک��یں۔
 DocType: Workflow State,align-left,سیدھ بائیں
 DocType: User,Defaults,ڈیفالٹس
 DocType: Energy Point Log,Revert Of,واپس لوٹائیں۔
@@ -2004,7 +2004,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,اس وقت کی اجازت نہیں لاگ ان
 DocType: Data Migration Run,Current Mapping Action,موجودہ تعریفیں ایکشن
 DocType: Dashboard Chart Source,Source Name,ماخذ نام
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,صارف کے ساتھ کوئی ای میل اکاؤنٹ وابستہ نہیں ہے۔ براہ کرم صارف&gt; ای میل ان باکس کے تحت ایک اکاؤنٹ شامل کریں۔
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,صارف کے ساتھ کوئی ای میل اکاؤنٹ وابستہ نہیں ہے۔ براہ کرم صارف> ای میل ان باکس کے تحت ایک اکاؤنٹ شامل کریں۔
 DocType: Email Account,Email Sync Option,ای میل کی مطابقت پذیری اختیار
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,صف نمبر
 DocType: Async Task,Runtime,رن ٹائم
@@ -2019,7 +2019,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,پہلے 
 DocType: User Email,Enable Outgoing,سبکدوش ہونے والے فعال
 DocType: Address,Fax,فیکس
 apps/frappe/frappe/config/customization.py,Custom Tags,اپنی مرضی کے ٹیگز
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,ای میل اکاؤنٹ سیٹ اپ نہیں ہے۔ براہ کرم سیٹ اپ&gt; ای میل&gt; ای میل اکاؤنٹ سے نیا ای میل اکاؤنٹ بنائیں
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,ای میل اکاؤنٹ سیٹ اپ نہیں ہے۔ براہ کرم سیٹ اپ> ای میل> ای میل اکاؤنٹ سے نیا ای میل اکاؤنٹ بنائیں
 DocType: Comment,Submitted,پیش
 DocType: Contact,Pulled from Google Contacts,گوگل رابطوں سے کھینچ لیا گیا۔
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,جائز درخواست میں
@@ -2091,7 +2091,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,گھنٹے مثال 
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",یہ فیلڈ دکھایا جائے گا FIELDNAME یہاں بیان کیا قیمت ہے یا قوانین سچے (مثالیں) ہیں صرف اس صورت: myfield سے Eval: doc.myfield == &#39;میری قدر&#39; سے Eval: doc.age&gt; 18
+eval:doc.age>18",یہ فیلڈ دکھایا جائے گا FIELDNAME یہاں بیان کیا قیمت ہے یا قوانین سچے (مثالیں) ہیں صرف اس صورت: myfield سے Eval: doc.myfield == &#39;میری قدر&#39; سے Eval: doc.age> 18
 DocType: Social Login Key,Office 365,آفس 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,آج
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,آج
@@ -2106,7 +2106,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,اوپری کیس
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,اپنی مرضی کے مطابق ایچ ٹی ایم ایل
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,فولڈر کا نام درج کریں
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,پتہ کا کوئی طے شدہ سانچہ نہیں ملا۔ براہ کرم سیٹ اپ&gt; پرنٹنگ اور برانڈنگ&gt; ایڈریس ٹیمپلیٹ سے ایک نیا بنائیں۔
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,پتہ کا کوئی طے شدہ سانچہ نہیں ملا۔ براہ کرم سیٹ اپ> پرنٹنگ اور برانڈنگ> ایڈریس ٹیمپلیٹ سے ایک نیا بنائیں۔
 apps/frappe/frappe/auth.py,Unknown User,نامعلوم صارف
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,منتخب کردار
 DocType: Comment,Deleted,خارج کر دیا گیا
@@ -2291,7 +2291,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,لنکس دیکھنا نہیں کافی اجازت
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,ایڈریس عنوان لازمی ہے.
 DocType: Google Contacts,Push to Google Contacts,گوگل رابطوں پر دبائیں۔
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",&lt;سر&gt; میں شامل HTML ویب کے صفحے کے سیکشن، بنیادی طور پر ویب سائٹ کی توثیق کی اور SEO کے لئے استعمال کیا جاتا ہے
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",&lt;سر> میں شامل HTML ویب کے صفحے کے سیکشن، بنیادی طور پر ویب سائٹ کی توثیق کی اور SEO کے لئے استعمال کیا جاتا ہے
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Relapsed
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,آئٹم کو اس کی اپنی اولاد میں شامل نہیں کیا جا سکتا
 DocType: Session Default Settings,Session Defaults,سیشن ڈیفالٹس
@@ -2408,8 +2408,8 @@ DocType: Workflow State,Warning,انتباہ
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,یہ متعدد صفحات پر چھاپ سکتا ہے۔
 DocType: Data Migration Run,Percent Complete,فی صد مکمل
 DocType: Tag Category,Tag Category,ٹیگ زمرہ
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",موازنہ کے لئے ،&gt; 5 ، &lt;10 یا = 324 استعمال کریں۔ حدود کے ل 5 ، 5:10 (5 اور 10 کے درمیان اقدار کے لئے) استعمال کریں۔
-DocType: Google Calendar,Pull from Google Calendar,گوگل کیلنڈر سے کھینچیں۔
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",موازنہ کے لئے ،> 5 ، &lt;10 یا = 324 استعمال کریں۔ حدود کے ل 5 ، 5:10 (5 اور 10 کے درمیان اقدار کے لئے) استعمال کریں۔
+DocType: Google Calendar,Pull from Google Calendar,گوگل کی��نڈر سے کھینچیں۔
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,مدد
 DocType: User,Login Before,لاگ ان سے پہلے
 DocType: Web Page,Insert Style,داخل انداز
@@ -2864,7 +2864,7 @@ DocType: Custom Script,Custom Script,اپنی مرضی کے سکرپٹ
 DocType: Address,Address Line 2,پتہ لائن 2
 DocType: Address,Reference,حوالہ
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,مقرر کیا، مقرر کرنا
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,براہ کرم سیٹ اپ&gt; ای میل&gt; ای میل اکاؤنٹ سے پہلے سے طے شدہ ای میل اکاؤنٹ مرتب کریں
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,براہ کرم سیٹ اپ> ای میل> ای میل اکاؤنٹ سے پہلے سے طے شدہ ای میل اکاؤنٹ مرتب کریں
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,ڈیٹا منتقلی کی تعریفیں کی تفصیل
 DocType: Data Import,Action,ایکشن
 DocType: GSuite Settings,Script URL,اسکرپٹ URL
@@ -3035,7 +3035,7 @@ DocType: DocField,Allow on Submit,جمع کرانے پر کی اجازت دیں
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,رعایت کی قسم
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,کالم اٹھاو
-DocType: Web Page,Add code as &lt;script&gt;,&lt;سکرپٹ&gt; کے طور پر کوڈ شامل کریں
+DocType: Web Page,Add code as &lt;script>,&lt;سکرپٹ> کے طور پر کوڈ شامل کریں
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,صارف کی اجازتیں صاف کریں۔
 DocType: Webhook,Headers,ہیڈر
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,انے والی تقریبات
@@ -3400,16 +3400,16 @@ DocType: Workflow State,share-alt,حصہ ALT
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},قطار {0} میں سے ایک ہونا چاہئے
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4 style="";text-align:right;direction:rtl""> پہلے سے طے شدہ سانچہ </h4><p style="";text-align:right;direction:rtl""> کا استعمال کرتا ہے <a href=""http://jinja.pocoo.org/docs/templates/"">میں Jinja templating کے</a> اور دستیاب ہو جائے گا (اگر کوئی اپنی مرضی کے شعبوں سمیت) ایڈریس کے تمام شعبوں </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4 style="";text-align:right;direction:rtl""> پہلے سے طے شدہ سانچہ </h4><p style="";text-align:right;direction:rtl""> کا استعمال کرتا ہے <a href=""http://jinja.pocoo.org/docs/templates/"">میں Jinja templating کے</a> اور دستیاب ہو جائے گا (اگر کوئی اپنی مرضی کے شعبوں سمیت) ایڈریس کے تمام شعبوں </p><pre style="";text-align:right;direction:rtl""> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,تاریخ کی تاریخ شروع کریں
 DocType: Role,Role Name,رول نام
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,ڈیسک سے جوڑئیے

--- a/frappe/translations/uz.csv
+++ b/frappe/translations/uz.csv
@@ -1,28 +1,28 @@
 apps/frappe/frappe/utils/change_log.py,New {} releases for the following apps are available,Quyidagi ilovalar uchun yangi {} versiyalar mavjud
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Please select a Amount Field.,Miqdor maydoni tanlang.
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Loading import file...,Import qilingan fayl yuklanmoqda ...
-DocType: Assignment Rule,Last User,So&#39;nggi foydalanuvchi
+DocType: Assignment Rule,Last User,So'nggi foydalanuvchi
 apps/frappe/frappe/desk/form/assign_to.py,"A new task, {0}, has been assigned to you by {1}. {2}",{1} tomonidan sizga yangi vazifa ({0}) tayinlangan. {2}
 apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,Session Defaults Saved,Seans birlamchi sozlamalari saqlandi
 apps/frappe/frappe/public/js/frappe/form/controls/attach.js,Reload File,Faylni qayta yuklash
 DocType: Email Queue,Email Queue records.,Email Queue qaydlari.
 DocType: Post,Post,Post
 DocType: Address,Punjab,Punjab
-apps/frappe/frappe/config/settings.py,Rename many items by uploading a .csv file.,.csv faylini yuklash orqali ko&#39;p narsalarni qayta nomlash.
-DocType: Workflow State,pause,to&#39;xtatib turish
-apps/frappe/frappe/public/js/frappe/web_form/webform_script.js,You are not permitted to access this page.,Ushbu sahifaga kirishga ruxsat yo&#39;q.
+apps/frappe/frappe/config/settings.py,Rename many items by uploading a .csv file.,.csv faylini yuklash orqali ko'p narsalarni qayta nomlash.
+DocType: Workflow State,pause,to'xtatib turish
+apps/frappe/frappe/public/js/frappe/web_form/webform_script.js,You are not permitted to access this page.,Ushbu sahifaga kirishga ruxsat yo'q.
 DocType: About Us Settings,Website,Veb-sayt
-apps/frappe/frappe/www/third_party_apps.py,You need to be logged in to access this page,Ushbu sahifaga kirish uchun siz tizimga kirgan bo&#39;lishingiz kerak
+apps/frappe/frappe/www/third_party_apps.py,You need to be logged in to access this page,Ushbu sahifaga kirish uchun siz tizimga kirgan bo'lishingiz kerak
 DocType: System Settings,Note: Multiple sessions will be allowed in case of mobile device,Izoh: Mobil qurilmada bir nechta sessiyalarga ruxsat beriladi
 DocType: DocType,Form Settings,Form sozlamalari
-apps/frappe/frappe/templates/emails/download_data.html,Download Data,Ma&#39;lumotni yuklab oling
+apps/frappe/frappe/templates/emails/download_data.html,Download Data,Ma'lumotni yuklab oling
 apps/frappe/frappe/public/js/frappe/form/form.js,Permanently Submit {0}?,Doimiy ravishda {0} yuborilsinmi?
 apps/frappe/frappe/desk/page/backups/backups.js,Download Files Backup,Faylni zaxiralashni yuklash
 DocType: Address,County,Tuman
-DocType: Workflow,If Checked workflow status will not override status in list view,Belgilangan biznes rivoji holati ro&#39;yxat ko&#39;rinishida holatni bekor qilmaydi
-apps/frappe/frappe/client.py,Invalid file path: {0},Noto&#39;g&#39;ri fayl yo&#39;li: {0}
-DocType: Workflow State,eye-open,ko&#39;zni oching
-DocType: Email Queue,Send After,Keyin jo&#39;nating
+DocType: Workflow,If Checked workflow status will not override status in list view,Belgilangan biznes rivoji holati ro'yxat ko'rinishida holatni bekor qilmaydi
+apps/frappe/frappe/client.py,Invalid file path: {0},Noto'g'ri fayl yo'li: {0}
+DocType: Workflow State,eye-open,ko'zni oching
+DocType: Email Queue,Send After,Keyin jo'nating
 apps/frappe/frappe/utils/file_manager.py,Please select a file or url,"Iltimos, faylni yoki urlni tanlang"
 apps/frappe/frappe/public/js/frappe/views/treeview.js,{0} Tree,{0} daraxt
 DocType: User,User Emails,Foydalanuvchi e-pochtalari
@@ -31,11 +31,11 @@ apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Import Zip,Zipni imp
 apps/frappe/frappe/model/base_document.py,Value too big,Juda katta qiymat
 DocType: DocField,DocField,DocField
 DocType: GSuite Settings,Run Script Test,Sinov skriptini ishga tushirish
-apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Qaysi voqea sinxronlanishi kerak bo&#39;lgan Google Taqvim-ni tanlang.
+apps/frappe/frappe/desk/doctype/event/event.py,Select Google Calendar to which event should be synced.,Qaysi voqea sinxronlanishi kerak bo'lgan Google Taqvim-ni tanlang.
 DocType: Data Import,Total Rows,Umumiy satrlar
-DocType: Contact,Department,Bo&#39;lim
+DocType: Contact,Department,Bo'lim
 DocType: DocField,Options,Tanlovlar
-apps/frappe/frappe/client.py,Cannot edit standard fields,Standart maydonlarni tahrirlab bo&#39;lmadi
+apps/frappe/frappe/client.py,Cannot edit standard fields,Standart maydonlarni tahrirlab bo'lmadi
 DocType: Print Format,Print Format Builder,Format formatlash usuli
 DocType: GCalendar Account,Calendar Name,Taqvim nomi
 DocType: Report,Report Manager,Hisobot menejeri
@@ -44,11 +44,11 @@ apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! I could not find wh
 DocType: Data Migration Run,Logs,Yozuvlar
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,There was an error saving filters,Filtrlarni saqlashda xatolik yuz berdi
 DocType: Custom DocPerm,This role update User Permissions for a user,Ushbu rol foydalanuvchi uchun foydalanuvchi ruxsatlarini yangilaydi
-apps/frappe/frappe/public/js/frappe/model/model.js,Rename {0},{0} nomini o&#39;zgartirish
+apps/frappe/frappe/public/js/frappe/model/model.js,Rename {0},{0} nomini o'zgartirish
 DocType: Workflow State,zoom-out,yiriklashtirish
 DocType: Data Import Beta,Import Options,Import parametrlari
-apps/frappe/frappe/public/js/frappe/form/form.js,Cannot open {0} when its instance is open,Uning namunasi ochiq bo&#39;lganida {0} ochilmaydi
-apps/frappe/frappe/model/document.py,Table {0} cannot be empty,{0} jadvali bo&#39;sh bo&#39;lishi mumkin emas
+apps/frappe/frappe/public/js/frappe/form/form.js,Cannot open {0} when its instance is open,Uning namunasi ochiq bo'lganida {0} ochilmaydi
+apps/frappe/frappe/model/document.py,Table {0} cannot be empty,{0} jadvali bo'sh bo'lishi mumkin emas
 DocType: SMS Parameter,Parameter,Parametr
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Images,Rasmlar
 DocType: Activity Log,Reference Owner,Malumot egasi
@@ -57,12 +57,12 @@ DocType: Social Login Key,GitHub,GitHub
 apps/frappe/frappe/model/base_document.py,"{0}, Row {1}","{0}, satr {1}"
 DocType: DocField,Markdown Editor,Markdown muharriri
 apps/frappe/frappe/model/document.py,Beginning with,Boshida
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Ma&#39;lumotlar import qilish jadvali
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Data Import Template,Ma'lumotlar import qilish jadvali
 apps/frappe/frappe/public/js/frappe/ui/toolbar/toolbar.js,An error occurred while setting Session Defaults,Sessiya standart parametrlarini belgilashda xatolik yuz berdi
 apps/frappe/frappe/public/js/frappe/model/model.js,Parent,Ota-onalar
-DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Agar yoqilsa, parol kuchi minimal parolni baholash qiymatiga asoslanadi. O&#39;rtacha kuchli 2, 4 esa juda kuchli."
-DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Jamoa a&#39;zolari&quot; yoki &quot;Menejment&quot;
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',&quot;Nazorat&quot; maydonining turi uchun &quot;0&quot; yoki &quot;1&quot; bo&#39;lishi kerak
+DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Agar yoqilsa, parol kuchi minimal parolni baholash qiymatiga asoslanadi. O'rtacha kuchli 2, 4 esa juda kuchli."
+DocType: About Us Settings,"""Team Members"" or ""Management""",&quot;Jamoa a'zolari&quot; yoki &quot;Menejment&quot;
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',&quot;Nazorat&quot; maydonining turi uchun &quot;0&quot; yoki &quot;1&quot; bo'lishi kerak
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Kecha
 DocType: Contact,Designation,Belgilar
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Avtomatik ulanish faqat bitta elektron pochta hisob qaydnomasi uchun faollashtirilishi mumkin.
@@ -73,60 +73,60 @@ DocType: Email Account,Enable Incoming,Kirishni yoqish
 apps/frappe/frappe/core/doctype/version/version_view.html,Danger,Xavf
 DocType: Address,Email Address,Elektron pochta manzili
 DocType: Workflow State,th-large,juda katta
-DocType: Communication,Unread Notification Sent,O&#39;qilmagan xabarnoma yuborildi
+DocType: Communication,Unread Notification Sent,O'qilmagan xabarnoma yuborildi
 apps/frappe/frappe/public/js/frappe/utils/tools.js,Export not allowed. You need {0} role to export.,Eksportga ruxsat berilmaydi. Eksport qilish uchun sizga {0} rol kerak.
 DocType: Assignment Rule,Automatically Assign Documents to Users,Hujjatlarni avtomatik ravishda foydalanuvchilarga topshirish
 apps/frappe/frappe/public/js/frappe/social/components/Post.vue,Unpin,Yechib oling
 DocType: System Settings,In seconds,Soniyada
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Cancel {0} documents?,{0} hujjatlarni bekor qilmoqchimisiz?
-DocType: DocType,Is Published Field,Maydon e&#39;lon qilinadi
+DocType: DocType,Is Published Field,Maydon e'lon qilinadi
 DocType: GCalendar Settings,GCalendar Settings,GCalendar sozlamalari
 DocType: Email Group,Email Group,E-pochta guruhi
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Calendar - {0} hodisasini Google Taqvimidan o&#39;chirib bo&#39;lmadi, xato kodi {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}.","Google Calendar - {0} hodisasini Google Taqvimidan o'chirib bo'lmadi, xato kodi {1}."
 DocType: Event,Pulled from Google Calendar,Google Taqvimidan tortib olindi
-DocType: Note,Seen By,Ko&#39;rilgan
-apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Bir nechta qo&#39;shish
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,Siz bir nechta energiya nuqtalarini qo&#39;lga kiritdingiz
+DocType: Note,Seen By,Ko'rilgan
+apps/frappe/frappe/public/js/frappe/form/grid.js,Add Multiple,Bir nechta qo'shish
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained some energy points,Siz bir nechta energiya nuqtalarini qo'lga kiritdingiz
 apps/frappe/frappe/core/doctype/user/user.py,Not a valid User Image.,Foydalanuvchi Foydalanuvchi Foydalanuvchi emas.
 DocType: Energy Point Log,Reverted,Qaytdi
 DocType: Success Action,First Success Message,Birinchi muvaffaqiyatli xabar
-apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Not Like,Yo&#39;q
-apps/frappe/frappe/model/document.py,Incorrect value: {0} must be {1} {2},Noto&#39;g&#39;ri qiymat: {0} {1} {2}
-apps/frappe/frappe/config/customization.py,"Change field properties (hide, readonly, permission etc.)","Joylar xususiyatlarini o&#39;zgartirish (yashirish, o&#39;qish, ruxsatnoma va h.k.)"
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Not Like,Yo'q
+apps/frappe/frappe/model/document.py,Incorrect value: {0} must be {1} {2},Noto'g'ri qiymat: {0} {1} {2}
+apps/frappe/frappe/config/customization.py,"Change field properties (hide, readonly, permission etc.)","Joylar xususiyatlarini o'zgartirish (yashirish, o'qish, ruxsatnoma va h.k.)"
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Appreciate,Qadrlang
 DocType: Workflow State,lock,qulflang
-apps/frappe/frappe/config/website.py,Settings for Contact Us Page.,Biz bilan bog&#39;lanish uchun sozlamalar.
+apps/frappe/frappe/config/website.py,Settings for Contact Us Page.,Biz bilan bog'lanish uchun sozlamalar.
 apps/frappe/frappe/core/doctype/user/user.py,Administrator Logged In,Administrator hisobga kiritildi
-DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","&quot;Savollar so&#39;rovi, qo&#39;llab-quvvatlash so&#39;rovi&quot; va hokazo. Kabi yangi variantni tanlang yoki vergul bilan ajrating."
-apps/frappe/frappe/public/js/frappe/ui/tag_editor.js,Add a tag ...,Teg qo&#39;shish ...
+DocType: Contact Us Settings,"Contact options, like ""Sales Query, Support Query"" etc each on a new line or separated by commas.","&quot;Savollar so'rovi, qo'llab-quvvatlash so'rovi&quot; va hokazo. Kabi yangi variantni tanlang yoki vergul bilan ajrating."
+apps/frappe/frappe/public/js/frappe/ui/tag_editor.js,Add a tag ...,Teg qo'shish ...
 apps/frappe/frappe/public/js/frappe/form/print.js,Portrait,Portret
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,Qo&#39;shish
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Insert,Qo'shish
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Allow Google Drive Access,Google Drive kirishiga ruxsat bering
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Select {0},{0} ni tanlang
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Base URL,"Iltimos, asosiy URL manzilini kiriting"
-DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Agar yoqilgan bo&#39;lsa, foydalanuvchi birinchi marta ochganda hujjat ko&#39;rinadigan deb belgilanadi"
+DocType: DocType,"If enabled, the document is marked as seen, the first time a user opens it","Agar yoqilgan bo'lsa, foydalanuvchi birinchi marta ochganda hujjat ko'rinadigan deb belgilanadi"
 DocType: Auto Repeat,Repeat on Day,Kunni takrorlang
 DocType: DocField,Color,Rang
 DocType: Data Migration Run,Log,Kundalik
-DocType: Workflow State,indent-right,indent-o&#39;ng
+DocType: Workflow State,indent-right,indent-o'ng
 DocType: Has Role,Has Role,Rolu bor
 DocType: System Settings,Time in seconds to retain QR code image on server. Min:<strong>240</strong>,Serverda QR kodini saqlab qolish uchun sekundlarda. Min: <strong>240</strong>
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}:Fieldtype {1} for {2} cannot be indexed,{0}: {2} uchun {1} maydon turini indekslab bo&#39;lmaydi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}:Fieldtype {1} for {2} cannot be indexed,{0}: {2} uchun {1} maydon turini indekslab bo'lmaydi
 DocType: Dashboard Chart,Timespan,Timespan
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Web Link,Veb bog&#39;lanish
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Web Link,Veb bog'lanish
 DocType: Deleted Document,Restored,Qayta tiklandi
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 minute ago,1 daqiqa oldin
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type.","Tizim boshqaruvchisidan tashqari, Foydalanuvchi ruxsati bilan o&#39;rnatilgan rollar o&#39;ng Hujjat turi uchun boshqa foydalanuvchilar uchun ruxsatlarni o&#39;rnatishi mumkin."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type.","Tizim boshqaruvchisidan tashqari, Foydalanuvchi ruxsati bilan o'rnatilgan rollar o'ng Hujjat turi uchun boshqa foydalanuvchilar uchun ruxsatlarni o'rnatishi mumkin."
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Configure Theme,Mavzuni sozlash
 DocType: Company History,Company History,Kompaniya tarixi
-apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.js,Reset,Nolga o&#39;rnatish
+apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.js,Reset,Nolga o'rnatish
 DocType: Workflow State,volume-up,ovoz balandligi
-apps/frappe/frappe/config/integrations.py,Webhooks calling API requests into web apps,Veb-ilovalar API so&#39;rovlarini veb-ilovalarga chaqiradi
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Show Traceback,Kuzatish rejimini ko&#39;rsatish
+apps/frappe/frappe/config/integrations.py,Webhooks calling API requests into web apps,Veb-ilovalar API so'rovlarini veb-ilovalarga chaqiradi
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Show Traceback,Kuzatish rejimini ko'rsatish
 DocType: DocType,Default Print Format,Standart nashr formati
 DocType: Workflow State,Tags,Teglar
 apps/frappe/frappe/public/js/frappe/form/workflow.js,None: End of Workflow,Hech kim: Ish xarining oxiri
-apps/frappe/frappe/database/mariadb/schema.py,"{0} field cannot be set as unique in {1}, as there are non-unique existing values",{0} maydonini yagona noyob mavjud qiymatlar bo&#39;lgani uchun {1} da noyob deb belgilash mumkin emas
+apps/frappe/frappe/database/mariadb/schema.py,"{0} field cannot be set as unique in {1}, as there are non-unique existing values",{0} maydonini yagona noyob mavjud qiymatlar bo'lgani uchun {1} da noyob deb belgilash mumkin emas
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Document Types,Hujjat turlari
 DocType: Address,Jammu and Kashmir,Jammu va Kashmir
 DocType: Workflow,Workflow State Field,Ish jarayoni holati maydoni
@@ -134,10 +134,10 @@ DocType: Language,Guest,Mehmon
 DocType: DocType,Title Field,Sarlavha maydoni
 DocType: Error Log,Error Log,Xato jurnali
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Invalid URL,Noto‘g‘ri URL
-apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Last 7 days,So&#39;nggi 7 kun
+apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Last 7 days,So'nggi 7 kun
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""abcabcabc"" are only slightly harder to guess than ""abc""",&quot;Abcabcabc&quot; kabi takrorlash faqat &quot;abc&quot; ga qaraganda ancha qiynaladi
 DocType: Notification,Channel,Kanal
-apps/frappe/frappe/templates/emails/administrator_logged_in.html,"If you think this is unauthorized, please change the Administrator password.","Agar bu ruxsatsiz deb hisoblasangiz, ma&#39;mur parolini o&#39;zgartiring."
+apps/frappe/frappe/templates/emails/administrator_logged_in.html,"If you think this is unauthorized, please change the Administrator password.","Agar bu ruxsatsiz deb hisoblasangiz, ma'mur parolini o'zgartiring."
 DocType: Data Import Beta,Data Import Beta,Beta-ma’lumotlarni import qilish
 apps/frappe/frappe/email/doctype/email_account/email_account.py,{0} is mandatory,{0} majburiydir
 DocType: Assignment Rule,Assignment Rules,Topshirish qoidalari
@@ -151,13 +151,13 @@ DocType: Translation,Translation,Tarjima
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Mr,Janob
 DocType: OAuth Authorization Code,Client,Mijoz
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Select Column,Ustunni tanlang
-apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified after you have loaded it,Ushbu forma siz yuklaganingizdan so&#39;ng o&#39;zgartirildi
+apps/frappe/frappe/public/js/frappe/form/form.js,This form has been modified after you have loaded it,Ushbu forma siz yuklaganingizdan so'ng o'zgartirildi
 DocType: Address,Himachal Pradesh,Himachal Pradesh
-DocType: System Settings,"If not set, the currency precision will depend on number format","Agar belgilanmasa, valyuta aniqligi raqam formatiga bog&#39;liq bo&#39;ladi"
+DocType: System Settings,"If not set, the currency precision will depend on number format","Agar belgilanmasa, valyuta aniqligi raqam formatiga bog'liq bo'ladi"
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Awesomebar,Awesomebar-ni oching
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.",Serverning chiziqli konfiguratsiyasi bilan bog&#39;liq muammo mavjud. Muvaffaqiyatsiz bo&#39;lgan taqdirda sizning hisobingizga mablag &#39;qaytariladi.
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,"It seems that there is an issue with the server's stripe configuration. In case of failure, the amount will get refunded to your account.",Serverning chiziqli konfiguratsiyasi bilan bog'liq muammo mavjud. Muvaffaqiyatsiz bo'lgan taqdirda sizning hisobingizga mablag 'qaytariladi.
 DocType: Data Import,Import Log,Import jurnali
-DocType: User Permission,Apply To All Document Types,Barcha hujjatlar turlariga qo&#39;llang
+DocType: User Permission,Apply To All Document Types,Barcha hujjatlar turlariga qo'llang
 apps/frappe/frappe/config/website.py,Embed image slideshows in website pages.,Veb-sayt sahifalarida rasm slayd-ruxsatlarini joylashtiring.
 apps/frappe/frappe/email/doctype/newsletter/newsletter.js,Send,Yuborish
 DocType: Workflow Action Master,Workflow Action Name,Ish oqimining nomi
@@ -169,17 +169,17 @@ DocType: Auto Repeat,"To add dynamic subject, use jinja tags like
 
 <div><pre><code>New {{ doc.doctype }} #{{ doc.name }}</code></pre></div>","Dinamik mavzuni qo'shish uchun, kabi jinja teglaridan foydalaning <div><pre> <code>New {{ doc.doctype }} #{{ doc.name }}</code> </pre> </div>"
 apps/frappe/frappe/public/js/frappe/form/save.js,"Mandatory fields required in table {0}, Row {1}","Majburiy maydonlar {0} da, qatorda {1}"
-apps/frappe/frappe/utils/password_strength.py,Capitalization doesn't help very much.,Kapitallashtirish juda ko&#39;p yordam bermaydi.
-DocType: Error Snapshot,Friendly Title,Do&#39;stlik sarlavhasi
+apps/frappe/frappe/utils/password_strength.py,Capitalization doesn't help very much.,Kapitallashtirish juda ko'p yordam bermaydi.
+DocType: Error Snapshot,Friendly Title,Do'stlik sarlavhasi
 DocType: Newsletter,Email Sent?,E-pochta yuborildi?
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Toggle Chart,Grafikni almashtirish
 apps/frappe/frappe/desk/form/save.py,Did not cancel,Bekor qilmadim
-DocType: Social Login Key,Client Information,Mijoz haqida ma&#39;lumot
+DocType: Social Login Key,Client Information,Mijoz haqida ma'lumot
 DocType: Workflow State,plus,ortiqcha
-apps/frappe/frappe/integrations/oauth2.py,Logged in as Guest or Administrator,Mehmon yoki ma&#39;mur sifatida tizimga kiritildi
+apps/frappe/frappe/integrations/oauth2.py,Logged in as Guest or Administrator,Mehmon yoki ma'mur sifatida tizimga kiritildi
 DocType: Email Account,UNSEEN,UNSEEN
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,File Manager,Fayl menejeri
-DocType: Website Settings,"HTML Header, Robots and Redirects","HTML sarlavhasi, robotlar va qayta yo&#39;naltirishlar"
+DocType: Website Settings,"HTML Header, Robots and Redirects","HTML sarlavhasi, robotlar va qayta yo'naltirishlar"
 DocType: GCalendar Account,Refresh Token,Qayta tiklash
 DocType: Address,Goa,Goa
 apps/frappe/frappe/core/page/background_jobs/background_jobs.html,No pending or current jobs for this site,Ushbu sayt uchun kutilayotgan yoki joriy ishlar mavjud emas
@@ -189,7 +189,7 @@ DocType: Braintree Settings,Braintree Settings,Braintree Sozlamalari
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Created {0} records successfully.,{0} yozuvlar muvaffaqiyatli yaratildi.
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Save Filter,Filtrni saqlang
 DocType: Print Format,Helvetica,Helvetica
-apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Cannot delete {0},{0} o&#39;chirib bo&#39;lmadi
+apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Cannot delete {0},{0} o'chirib bo'lmadi
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,Verification Link,Tekshirish havolasi
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Ancestors Of,Ota-bobolari emas
 DocType: Address,Jharkhand,Jarxand
@@ -199,133 +199,133 @@ DocType: Communication,BCC,BCC
 DocType: Unhandled Email,Reason,Sabab
 DocType: Email Unsubscribe,Email Unsubscribe,E - mail obunani bekor qilish
 DocType: Website Settings,Select an image of approx width 150px with a transparent background for best results.,Eng yaxshi natijalarni olish uchun shaffof fon bilan taxminan 150px kenglikdagi tasvirni tanlang.
-apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,No activity,Harakat yo&#39;q
+apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,No activity,Harakat yo'q
 apps/frappe/frappe/www/third_party_apps.html,Third Party Apps,Uchinchi tomon ilovalari
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The first user will become the System Manager (you can change this later).,Birinchi foydalanuvchi tizim boshqaruvchisiga aylanadi (uni keyinroq o&#39;zgartirishingiz mumkin).
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You cannot give review points to yourself,Siz o&#39;zingizga sharh ochib berolmaysiz
-apps/frappe/frappe/integrations/doctype/webhook/webhook.py,DocType must be Submittable for the selected Doc Event,DocType tanlangan Doc hodisasi uchun Submittable bo&#39;lishi kerak
-DocType: Workflow State,circle-arrow-up,aylana-o&#39;q-up
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The first user will become the System Manager (you can change this later).,Birinchi foydalanuvchi tizim boshqaruvchisiga aylanadi (uni keyinroq o'zgartirishingiz mumkin).
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You cannot give review points to yourself,Siz o'zingizga sharh ochib berolmaysiz
+apps/frappe/frappe/integrations/doctype/webhook/webhook.py,DocType must be Submittable for the selected Doc Event,DocType tanlangan Doc hodisasi uchun Submittable bo'lishi kerak
+DocType: Workflow State,circle-arrow-up,aylana-o'q-up
 DocType: Email Domain,Email Domain,E-pochta domeni
 DocType: Workflow State,italic,kursiv
 DocType: LDAP Group Mapping,ERPNext Role,ERPNext roli
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Import without Create,{0}: Yaratishsiz Importni o&#39;rnatib bo&#39;lmadi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Import without Create,{0}: Yaratishsiz Importni o'rnatib bo'lmadi
 DocType: SMS Settings,Enter url parameter for message,Xabar uchun url parametrini kiriting
 apps/frappe/frappe/public/js/frappe/utils/common.js,Auto Repeat created for this document,Avtomatik takrorlash ushbu hujjat uchun yaratilgan
-apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your browser,Hisobotni brauzeringizda ko&#39;rish
+apps/frappe/frappe/templates/emails/auto_email_report.html,View report in your browser,Hisobotni brauzeringizda ko'rish
 apps/frappe/frappe/config/desk.py,Event and other calendars.,Voqealar va boshqa kalendarlar.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} (1 row mandatory),{0} (1 qator majburiy)
 apps/frappe/frappe/templates/includes/comments/comments.html,All fields are necessary to submit the comment.,Fikrlarni yuborish uchun barcha joylar kerak.
-DocType: Custom Script,Adds a client custom script to a DocType,DocType-ga mijozning maxsus skriptini qo&#39;shadi
+DocType: Custom Script,Adds a client custom script to a DocType,DocType-ga mijozning maxsus skriptini qo'shadi
 DocType: Print Settings,Printer Name,Printer nomi
 DocType: Webhook,Form URL-Encoded,Forma URL-kodlangan
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Kengliklari px yoki% sifatida o&#39;rnatilishi mumkin.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Widths can be set in px or %.,Kengliklari px yoki% sifatida o'rnatilishi mumkin.
 apps/frappe/frappe/public/js/frappe/form/print.js,Start,Boshlang
 DocType: Contact,First Name,Ism
 DocType: LDAP Settings,LDAP Username Field,LDAP foydalanuvchi nomi maydon
 apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,LDAP is not enabled.,LDAP yoqilmagan.
 DocType: Portal Settings,Standard Sidebar Menu,Foydalanuvchi shkafi menyusi
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failure,Avtomatik takrorlash Hujjatlarni yaratish xatosi
-apps/frappe/frappe/core/doctype/file/file.py,Cannot delete Home and Attachments folders,Uy va biriktirilgan papkalarni o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/core/doctype/file/file.py,Cannot delete Home and Attachments folders,Uy va biriktirilgan papkalarni o'chirib bo'lmaydi
 apps/frappe/frappe/config/desk.py,Files,Fayllar
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions get applied on Users based on what Roles they are assigned.,Ruxsatlar foydalanuvchilarga ular qanday rollarda tayinlanganligiga qarab tatbiq etiladi.
-apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,Siz ushbu hujjatga tegishli elektron pochta xabarlarini yuborishga ruxsat yo&#39;q
+apps/frappe/frappe/public/js/frappe/views/communication.js,You are not allowed to send emails related to this document,Siz ushbu hujjatga tegishli elektron pochta xabarlarini yuborishga ruxsat yo'q
 apps/frappe/frappe/model/db_query.py,Please select atleast 1 column from {0} to sort/group,"Iltimos, tartibida / guruhi uchun {0} dan atleast 1 ustunini tanlang"
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1}. Restricted field: {2},{0}: {1} uchun ruxsat berilmagan. Cheklangan maydon: {2}
-DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Sandbox API yordamida to&#39;lovingizni sinovdan o&#39;tkazsangiz buni tekshirib ko&#39;ring
-apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,Siz standart veb-sayt mavzusini o&#39;chirishingiz mumkin emas
+DocType: PayPal Settings,Check this if you are testing your payment using the Sandbox API,Sandbox API yordamida to'lovingizni sinovdan o'tkazsangiz buni tekshirib ko'ring
+apps/frappe/frappe/website/doctype/website_theme/website_theme.py,You are not allowed to delete a standard Website Theme,Siz standart veb-sayt mavzusini o'chirishingiz mumkin emas
 DocType: Data Import,Log Details,Tafsilotlar
 DocType: Workflow Transition,Example,Misol
 DocType: Webhook Header,Webhook Header,Webhook Header
-DocType: Access Log,Report Information,Hisobot haqida ma&#39;lumot
+DocType: Access Log,Report Information,Hisobot haqida ma'lumot
 DocType: Print Settings,Print Server,Chop etish serverlari
-DocType: Workflow State,gift,sovg&#39;a
+DocType: Workflow State,gift,sovg'a
 DocType: Communication,Timeline Links,Yilnoma havolalari
 DocType: Workflow Action,Completed By,Tugallangan
-apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Unable to find attachment {0},{0} ilovasini topib bo&#39;lmadi.
-apps/frappe/frappe/core/page/permission_manager/permission_manager.py,Cannot Remove,O&#39;chirish mumkin emas
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Unable to find attachment {0},{0} ilovasini topib bo'lmadi.
+apps/frappe/frappe/core/page/permission_manager/permission_manager.py,Cannot Remove,O'chirish mumkin emas
 apps/frappe/frappe/public/js/frappe/request.js,The resource you are looking for is not available,Siz izlayotgan resurs mavjud emas
 DocType: Chat Profile,Chat Background,Chat fon
-apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Read,O&#39;qilgan deb belgilash
+apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Read,O'qilgan deb belgilash
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Updating {0},{0} yangilanmoqda
-apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Hisobotni o&#39;chirib qo&#39;yish
+apps/frappe/frappe/core/doctype/report/report.js,Disable Report,Hisobotni o'chirib qo'yish
 DocType: Translation,Contributed Translation Doctype Name,Hisoblangan tarjima hujjati nomi
 DocType: PayPal Settings,Redirect To,Qaytish
 DocType: Data Migration Mapping,Pull,Torting
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript formati: frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript formati: frappe.query_reports ['REPORTNAME'] = {}
 DocType: Bulk Update,Bulk Update,Ommaviy yangilanish
 DocType: Workflow State,chevron-up,chevron-up
-DocType: DocType,Allow Guest to View,Mehmonni ko&#39;rishga ruxsat berish
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} should not be same as {1},{0} {1} bilan bir xil bo&#39;lmasligi kerak
+DocType: DocType,Allow Guest to View,Mehmonni ko'rishga ruxsat berish
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} should not be same as {1},{0} {1} bilan bir xil bo'lmasligi kerak
 DocType: Webhook,on_change,on_change
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Delete {0} items permanently?,{0} mahsulotni doimiy o&#39;chirib tashlash kerakmi?
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Delete {0} items permanently?,{0} mahsulotni doimiy o'chirib tashlash kerakmi?
 apps/frappe/frappe/utils/oauth.py,Not Allowed,Ruxsat berilmagan
 DocType: DocShare,Internal record of document shares,Hujjat aktsiyalarining ichki qayd
-DocType: Energy Point Settings,Review Levels,Darajalarni ko&#39;rib chiqish
+DocType: Energy Point Settings,Review Levels,Darajalarni ko'rib chiqish
 DocType: Workflow State,Comment,Fikr
 DocType: Data Migration Plan,Postprocess Method,Postpesess usuli
 apps/frappe/frappe/public/js/frappe/ui/capture.js,Take Photo,Rasmga olmoq
 DocType: Assignment Rule,Round Robin,Dumaloq Robin
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"You can change Submitted documents by cancelling them and then, amending them.","Yuborilgan hujjatlarni bekor qilib, keyin ularni o&#39;zgartirish orqali o&#39;zgartirishingiz mumkin."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"You can change Submitted documents by cancelling them and then, amending them.","Yuborilgan hujjatlarni bekor qilib, keyin ularni o'zgartirish orqali o'zgartirishingiz mumkin."
 DocType: Data Import,Update records,Yozuvlarni yangilang
-apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Invalid module path,Moduli yo&#39;li noto&#39;g&#39;ri
-DocType: DocField,Display,Ko&#39;rish
+apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Invalid module path,Moduli yo'li noto'g'ri
+DocType: DocField,Display,Ko'rish
 DocType: Email Group,Total Subscribers,Jami abonentlar
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top {0},Top {0}
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Row Number,Qator raqami
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If a Role does not have access at Level 0, then higher levels are meaningless.","Agar rolda 0 darajasida kirish imkoni bo&#39;lmasa, unda yuqori darajalar mazmunsiz bo&#39;ladi."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If a Role does not have access at Level 0, then higher levels are meaningless.","Agar rolda 0 darajasida kirish imkoni bo'lmasa, unda yuqori darajalar mazmunsiz bo'ladi."
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Save As,Turli Saqlash
-DocType: Comment,Seen,Ko&#39;rinadi
-apps/frappe/frappe/public/js/frappe/form/layout.js,Show more details,Qo&#39;shimcha ma&#39;lumotni ko&#39;rsatish
-DocType: System Settings,Run scheduled jobs only if checked,Belgilangan bo&#39;lsa faqat rejalashtirilgan ishlarni bajaring
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Will only be shown if section headings are enabled,"Bo&#39;lim sarlavhalari yoqilgan bo&#39;lsa, faqat ko&#39;rsatiladi"
+DocType: Comment,Seen,Ko'rinadi
+apps/frappe/frappe/public/js/frappe/form/layout.js,Show more details,Qo'shimcha ma'lumotni ko'rsatish
+DocType: System Settings,Run scheduled jobs only if checked,Belgilangan bo'lsa faqat rejalashtirilgan ishlarni bajaring
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Will only be shown if section headings are enabled,"Bo'lim sarlavhalari yoqilgan bo'lsa, faqat ko'rsatiladi"
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Archive,Arxiv
 apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload,Fayl yuklash
-DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","Standart qiymat maydonlarini (tugmachalarini) va qiymatlarini kiriting. Biror maydon uchun bir nechta qiymat qo&#39;shsangiz, unda birinchisi tanlanadi. Ushbu standartlarni &quot;hamjihat&quot; ruxsat berish qoidalarini o&#39;rnatish uchun ham ishlatiladi. Maydonlarning ro&#39;yxatini ko&#39;rish uchun &quot;Formani moslashtiring&quot; bo&#39;limiga o&#39;ting."
+DocType: User,"Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set ""match"" permission rules. To see list of fields, go to ""Customize Form"".","Standart qiymat maydonlarini (tugmachalarini) va qiymatlarini kiriting. Biror maydon uchun bir nechta qiymat qo'shsangiz, unda birinchisi tanlanadi. Ushbu standartlarni &quot;hamjihat&quot; ruxsat berish qoidalarini o'rnatish uchun ham ishlatiladi. Maydonlarning ro'yxatini ko'rish uchun &quot;Formani moslashtiring&quot; bo'limiga o'ting."
 DocType: Auto Repeat,Message,Xabar
 DocType: Communication,Rating,Reyting
-DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Chiziqning maydoni kengligi, agar maydon jadvaldagi ustun bo&#39;lsa"
+DocType: Customize Form Field,"Print Width of the field, if the field is a column in a table","Chiziqning maydoni kengligi, agar maydon jadvaldagi ustun bo'lsa"
 DocType: Dropbox Settings,Dropbox Access Key,Dropbox kirish uchun kalit
 apps/frappe/frappe/desk/form/utils.py,Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script,Maxsus skriptning add_fetch konfiguratsiyasida <b>{0}</b> noto'g'ri maydon nomi
-apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,Kontakt sinxronlashtirilishi kerak bo&#39;lgan Google Contacts-ni tanlang.
-DocType: Web Page,Main Section (HTML),Asosiy bo&#39;lim (HTML)
+apps/frappe/frappe/contacts/doctype/contact/contact.py,Select Google Contacts to which contact should be synced.,Kontakt sinxronlashtirilishi kerak bo'lgan Google Contacts-ni tanlang.
+DocType: Web Page,Main Section (HTML),Asosiy bo'lim (HTML)
 DocType: Workflow State,headphones,minigarnituralar
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Password is required or select Awaiting Password,Parolni kiritish yoki Parolni kutish-ni tanlang
 DocType: Email Account,e.g. replies@yourcomany.com. All replies will come to this inbox.,"masalan, replies@yourcomany.com. Barcha javoblar ushbu kiruvchi qutiga keladi."
-DocType: Slack Webhook URL,Slack Webhook URL,Veb-brauzer URL-ni bo&#39;shating
+DocType: Slack Webhook URL,Slack Webhook URL,Veb-brauzer URL-ni bo'shating
 DocType: Data Migration Run,Current Mapping,Joriy xaritalash
 apps/frappe/frappe/templates/includes/login/login.js,Valid email and name required,Kerakli elektron pochta va ism kerak
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Make all attachments private,Barcha biriktirmalarni shaxsiy qilib qo&#39;ying
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Make all attachments private,Barcha biriktirmalarni shaxsiy qilib qo'ying
 DocType: User,Send Notifications for documents followed by me,Men bilan kelgan hujjatlar uchun bildirishnomalarni yuboring
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add User Permissions,Foydalanuvchi ruxsatlarini qo&#39;shish
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add User Permissions,Foydalanuvchi ruxsatlarini qo'shish
 DocType: Session Default Settings,Session Default Settings,Sessiya standart sozlamalari
 DocType: Address,Current,Joriy
 apps/frappe/frappe/config/core.py,Groups of DocTypes,DocTypes guruhlari
 DocType: Auto Email Report,XLSX,XLSX
 apps/frappe/frappe/templates/emails/password_reset.html,Reset your password,Parolni tiklash
-apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Show Weekends,Dam olish kunlari ko&#39;rsatish
+apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Show Weekends,Dam olish kunlari ko'rsatish
 DocType: Workflow State,remove-circle,olib tashlash
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,My Profile,Mening profilim
 DocType: Help Article,Beginner,Boshlovchi
 DocType: Contact,Is Primary Contact,Birlamchi aloqa
-apps/frappe/frappe/config/website.py,Javascript to append to the head section of the page.,Sahifaning bosh qismiga qo&#39;shiladigan Javascript.
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add / Update,Qo&#39;shish / Yangilash
+apps/frappe/frappe/config/website.py,Javascript to append to the head section of the page.,Sahifaning bosh qismiga qo'shiladigan Javascript.
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Add / Update,Qo'shish / Yangilash
 apps/frappe/frappe/www/printview.py,Not allowed to print draft documents,Loyihaviy hujjatlarni chop etishga ruxsat berilmaydi
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Reset to defaults,Standartlarga asl holatini tiklash
-DocType: Workflow,Transition Rules,O&#39;tish qoidalari
+DocType: Workflow,Transition Rules,O'tish qoidalari
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Showing only first {0} rows in preview,Oldindan ko‘rishda faqat birinchi {0} qator ko‘rsatilmoqda
 apps/frappe/frappe/core/doctype/report/report.js,Example:,Misol:
 DocType: Workflow,Defines workflow states and rules for a document.,Hujjat uchun ish oqimining qoidalarini va qoidalarini belgilaydi.
 DocType: Workflow State,Filter,Filtrni tanlang
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Check the Error Log for more information: {0},Qo&#39;shimcha ma&#39;lumot olish uchun Xato jurnalini tekshiring: {0}
-apps/frappe/frappe/database/schema.py,Fieldname {0} cannot have special characters like {1},{0} domen nomi {1} kabi maxsus belgilarga ega bo&#39;lmasligi mumkin
-apps/frappe/frappe/model/workflow.py,Applying: {0},Qo&#39;llanilmoqda: {0}
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Check the Error Log for more information: {0},Qo'shimcha ma'lumot olish uchun Xato jurnalini tekshiring: {0}
+apps/frappe/frappe/database/schema.py,Fieldname {0} cannot have special characters like {1},{0} domen nomi {1} kabi maxsus belgilarga ega bo'lmasligi mumkin
+apps/frappe/frappe/model/workflow.py,Applying: {0},Qo'llanilmoqda: {0}
 apps/frappe/frappe/public/js/frappe/request.js,Internal Server Error,Serverdagi ichki xatolik
-apps/frappe/frappe/config/settings.py,Update many values at one time.,Bir vaqtning o&#39;zida bir nechta qiymatlarni yangilang.
-apps/frappe/frappe/model/document.py,Error: Document has been modified after you have opened it,Xato: Siz uni ochganingizdan so&#39;ng hujjat o&#39;zgartirildi
+apps/frappe/frappe/config/settings.py,Update many values at one time.,Bir vaqtning o'zida bir nechta qiymatlarni yangilang.
+apps/frappe/frappe/model/document.py,Error: Document has been modified after you have opened it,Xato: Siz uni ochganingizdan so'ng hujjat o'zgartirildi
 apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Job,Ish
 apps/frappe/frappe/core/doctype/activity_log/feed.py,{0} logged out: {1},{0} tizimdan chiqdi: {1}
-DocType: Address,West Bengal,G&#39;arbiy Bengal
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Assign Submit if not Submittable,"{0}: Submittable emas, agar Assign Assign ni o&#39;rnatib bo&#39;lmadi"
+DocType: Address,West Bengal,G'arbiy Bengal
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Assign Submit if not Submittable,"{0}: Submittable emas, agar Assign Assign ni o'rnatib bo'lmadi"
 DocType: Transaction Log,Row Index,Row indeks
 DocType: Social Login Key,Facebook,Facebook
 apps/frappe/frappe/www/list.py,"Filtered by ""{0}""",&quot;{0}&quot; tomonidan filtrlangan
@@ -333,78 +333,78 @@ DocType: Salutation,Administrator,Administrator
 DocType: LDAP Group Mapping,LDAP Group,LDAP guruhi
 DocType: Activity Log,Closed,Yopiq
 DocType: Blog Settings,Blog Title,Blog sarlavhasi
-apps/frappe/frappe/core/doctype/role/role.py,Standard roles cannot be disabled,Standart rollarni o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/core/doctype/role/role.py,Standard roles cannot be disabled,Standart rollarni o'chirib bo'lmaydi
 apps/frappe/frappe/public/js/frappe/chat.js,Chat Type,Chat turi
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Map Columns,Xaritadagi ustunlar
 DocType: Address,Mizoram,Mizoram
 DocType: Newsletter,Newsletter,Xabarnoma
-apps/frappe/frappe/model/db_query.py,Cannot use sub-query in order by,Pastki so&#39;rovlarni tartibda ishlatish mumkin emas
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options must be a valid DocType for field {1} in row {2},{0}: Tanlovlar {2} qatoridagi {1} maydoni uchun to&#39;g&#39;ri DocType bo&#39;lishi kerak.
+apps/frappe/frappe/model/db_query.py,Cannot use sub-query in order by,Pastki so'rovlarni tartibda ishlatish mumkin emas
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options must be a valid DocType for field {1} in row {2},{0}: Tanlovlar {2} qatoridagi {1} maydoni uchun to'g'ri DocType bo'lishi kerak.
 DocType: Web Form,Button Help,Tugma yordami
 DocType: Kanban Board Column,purple,binafsha rang
-DocType: About Us Settings,Team Members,Jamoa a&#39;zolari
+DocType: About Us Settings,Team Members,Jamoa a'zolari
 DocType: Assignment Rule,System Manager,Tizim menejeri
 DocType: Custom DocPerm,Permissions,Ruxsatnomalar
 apps/frappe/frappe/config/integrations.py,Slack Webhooks for internal integration,Ichki integratsiya uchun Webhooks-ni tozalang
 DocType: Dropbox Settings,Allow Dropbox Access,Dropboxga ruxsat berish
 DocType: Print Format,Raw Commands,Xom buyruqlar
-apps/frappe/frappe/core/doctype/deleted_document/deleted_document.js,Restore,Orqaga o&#39;rnatish
+apps/frappe/frappe/core/doctype/deleted_document/deleted_document.js,Restore,Orqaga o'rnatish
 DocType: Auto Repeat,Auto Repeat,Avto-takrorlash
 DocType: Auto Email Report,To Date Field,Sana maydoniga
 DocType: Bulk Update,"SQL Conditions. Example: status=""Open""",SQL shartlari. Misol: status = &quot;Ochish&quot;
 DocType: User,Get your globally recognized avatar from Gravatar.com,Gravatar.com dan butun dunyoga tanilgan avatarni oling
 DocType: Workflow State,plus-sign,ortiqcha belgisi
-apps/frappe/frappe/__init__.py,App {0} is not installed,Ilova {0} o&#39;rnatilmagan
+apps/frappe/frappe/__init__.py,App {0} is not installed,Ilova {0} o'rnatilmagan
 DocType: Data Migration Plan,Mappings,Taqqoslash
 DocType: Notification Recipient,Notification Recipient,Xabarnoma qabul qiluvchisi
 DocType: Workflow State,Refresh,Yangilash
 DocType: Event,Public,Ommaviy
-apps/frappe/frappe/public/js/frappe/list/base_list.js,Nothing to show,Ko&#39;rsatadigan hech narsa yo&#39;q
+apps/frappe/frappe/public/js/frappe/list/base_list.js,Nothing to show,Ko'rsatadigan hech narsa yo'q
 DocType: System Settings,Enable Two Factor Auth,Ikkala omilni tasdiqlashni yoqish
 DocType: Post,Liked By,Yoqdi
-DocType: DocField,Print Hide If No Value,Qiymat bo&#39;lmasa Berkitish bekitsin
+DocType: DocField,Print Hide If No Value,Qiymat bo'lmasa Berkitish bekitsin
 DocType: Kanban Board Column,yellow,sariq rangda
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Is Published Field must be a valid fieldname,Chop etilgan joy tegishli maydon nomi bo&#39;lishi kerak
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Is Published Field must be a valid fieldname,Chop etilgan joy tegishli maydon nomi bo'lishi kerak
 DocType: Block Module,Block Module,Blokni blokirovkalash
 apps/frappe/frappe/core/doctype/version/version_view.html,New Value,Yangi qiymat
-apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field,<b>{1}</b> maydoni uchun berilgan <b>{0}</b> DocType bitta bog&#39;lanish maydonidan kamida bitta bo&#39;lishi kerak
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html,Add a column,Ustun qo&#39;shing
+apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field,<b>{1}</b> maydoni uchun berilgan <b>{0}</b> DocType bitta bog'lanish maydonidan kamida bitta bo'lishi kerak
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.html,Add a column,Ustun qo'shing
 apps/frappe/frappe/www/contact.html,Your email address,Sizning e-pochta manzilingiz
 DocType: Desktop Icon,Module,Modul
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} records out of {1}.,{1} dan {0} yozuvi muvaffaqiyatli yangilandi.
 DocType: Notification,Send Alert On,Ogohlantirish yoqilsin
 DocType: Customize Form,"Customize Label, Print Hide, Default etc.","Yorliqni moslash, bosib chiqarishni yashirish, asl qiymati va h.k."
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Unzipping files...,Fayllar ochilmoqda ...
-apps/frappe/frappe/core/doctype/communication/communication.py,Please make sure the Reference Communication Docs are not circularly linked.,"Iltimos, ma&#39;lumotnoma aloqa docs aylana bilan bog&#39;liq emasligiga ishonch hosil qiling."
+apps/frappe/frappe/core/doctype/communication/communication.py,Please make sure the Reference Communication Docs are not circularly linked.,"Iltimos, ma'lumotnoma aloqa docs aylana bilan bog'liq emasligiga ishonch hosil qiling."
 DocType: Assignment Rule,Assign Condition,Shartni tayinlang
-apps/frappe/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py,Download Your Data,Ma&#39;lumotlaringizni yuklab oling
+apps/frappe/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py,Download Your Data,Ma'lumotlaringizni yuklab oling
 DocType: Dashboard Chart,Value Based On,Asoslangan qiymat
-DocType: List View Setting,Disable Sidebar Stats,Yon panel statistikasini o&#39;chirish
+DocType: List View Setting,Disable Sidebar Stats,Yon panel statistikasini o'chirish
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Create a New Format,Yangi format yaratish
-apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Unable to create bucket: {0}. Change it to a more unique name.,Paqir yaratilmadi: {0}. Uni yanada noyob nomga o&#39;zgartiring.
-DocType: Webhook,Request URL,URL so&#39;rash
+apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Unable to create bucket: {0}. Change it to a more unique name.,Paqir yaratilmadi: {0}. Uni yanada noyob nomga o'zgartiring.
+DocType: Webhook,Request URL,URL so'rash
 DocType: Customize Form,Is Table,Jadval bormi?
 DocType: Email Account,Total number of emails to sync in initial sync process ,Dastlabki sinxronlash jarayonida sinxronlanadigan elektron pochtalarning umumiy soni
-DocType: Website Settings,Set Banner from Image,Rasmdan bannerni o&#39;rnating
+DocType: Website Settings,Set Banner from Image,Rasmdan bannerni o'rnating
 DocType: Email Account,SparkPost,SparkPost
 apps/frappe/frappe/templates/emails/new_user.html,A new account has been created for you at {0},{0} da siz uchun yangi hisob yaratildi
-apps/frappe/frappe/templates/includes/login/login.js,Instructions Emailed,Ko&#39;rsatmalar elektron pochta orqali yuborildi
+apps/frappe/frappe/templates/includes/login/login.js,Instructions Emailed,Ko'rsatmalar elektron pochta orqali yuborildi
 apps/frappe/frappe/public/js/frappe/views/communication.js,Enter Email Recipient(s),Elektron pochta manzilini kiriting
 DocType: Print Format,Verdana,Verdana
 apps/frappe/frappe/core/doctype/success_action/success_action.js,Select atleast 2 actions,Atleast 2 harakatini tanlang
 apps/frappe/frappe/public/js/frappe/barcode_scanner/quagga.js,Scan Barcode,Shtrix-kodni skanerlash
-DocType: Email Flag Queue,Email Flag Queue,E-pochtaning bayrog&#39;i
+DocType: Email Flag Queue,Email Flag Queue,E-pochtaning bayrog'i
 DocType: Access Log,Columns / Fields,Ustunlar / maydonlar
 apps/frappe/frappe/config/settings.py,Stylesheets for Print Formats,Bosib chiqarish formatlari uchun uslub sahifalar
-apps/frappe/frappe/utils/bot.py,Can't identify open {0}. Try something else.,{0} ochiqligini aniqlab bo&#39;lmaydi. Boshqa bir narsani ko&#39;ring.
-apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Your information has been submitted,Sizning ma&#39;lumotlaringiz yuborildi
-apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be deleted,{0} foydalanuvchisini o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/utils/bot.py,Can't identify open {0}. Try something else.,{0} ochiqligini aniqlab bo'lmaydi. Boshqa bir narsani ko'ring.
+apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Your information has been submitted,Sizning ma'lumotlaringiz yuborildi
+apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be deleted,{0} foydalanuvchisini o'chirib bo'lmaydi
 DocType: System Settings,Currency Precision,Valyutalar aniqligi
-apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,"Yana bir bitim buni blokirovka qiladi. Iltimos, bir necha soniyadan so&#39;ng qayta urinib ko&#39;ring."
+apps/frappe/frappe/public/js/frappe/request.js,Another transaction is blocking this one. Please try again in a few seconds.,"Yana bir bitim buni blokirovka qiladi. Iltimos, bir necha soniyadan so'ng qayta urinib ko'ring."
 apps/frappe/frappe/public/js/frappe/ui/filters/filter_list.js,Clear filters,Filtrlarni tozalang
 DocType: Test Runner,App,Ilova
-apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Qo&#39;shimchalar yangi hujjatga to&#39;g&#39;ri bog&#39;langan bo&#39;lishi mumkin emas
-DocType: Chat Message Attachment,Attachment,Qo&#39;shimcha
+apps/frappe/frappe/public/js/frappe/views/interaction.js,The attachments could not be correctly linked to the new document,Qo'shimchalar yangi hujjatga to'g'ri bog'langan bo'lishi mumkin emas
+DocType: Chat Message Attachment,Attachment,Qo'shimcha
 DocType: Auto Repeat,Yearly,Har yili
 DocType: Communication,Message ID,Xabar identifikatori
 DocType: Property Setter,Field Name,Joy nomi
@@ -412,42 +412,42 @@ DocType: Assignment Rule,Assign To Users,Foydalanuvchilarga tayinlang
 apps/frappe/frappe/public/js/frappe/utils/utils.js,or,yoki
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,module name...,modul nomi ...
 apps/frappe/frappe/templates/pages/integrations/payment-success.html,Continue,Davom etish
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,Google Integration o&#39;chirilgan.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Integration is disabled.,Google Integration o'chirilgan.
 DocType: Custom Field,Fieldname,Joy nom
 DocType: Workflow State,certificate,sertifikat
 apps/frappe/frappe/templates/includes/login/login.js,Verifying...,Tasdiqlanmoqda ...
-apps/frappe/frappe/core/doctype/data_export/exporter.py,First data column must be blank.,Birinchi ma&#39;lumotlar ustuni bo&#39;sh bo&#39;lishi kerak.
-apps/frappe/frappe/core/doctype/version/version.js,Show all Versions,Barcha versiyalarni ko&#39;rsatish
-apps/frappe/frappe/templates/includes/comments/comments.py,View Comment,Sharhni ko&#39;rish
+apps/frappe/frappe/core/doctype/data_export/exporter.py,First data column must be blank.,Birinchi ma'lumotlar ustuni bo'sh bo'lishi kerak.
+apps/frappe/frappe/core/doctype/version/version.js,Show all Versions,Barcha versiyalarni ko'rsatish
+apps/frappe/frappe/templates/includes/comments/comments.py,View Comment,Sharhni ko'rish
 DocType: Workflow State,Print,Chop etish
 DocType: Energy Point Log,Review,Sharh
 DocType: User,Restrict IP,IPni cheklash
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Dashboard,Dashboard
 apps/frappe/frappe/email/smtp.py,Unable to send emails at this time,Hozirgi vaqtda elektron pochta xabarlari yuborilmadi
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Taqvimi - Google Taqvimda {0} hodisasini yangilab bo&#39;lmadi, xato kodi {1}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not update Event {0} in Google Calendar, error code {1}.","Google Taqvimi - Google Taqvimda {0} hodisasini yangilab bo'lmadi, xato kodi {1}."
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Search or type a command,Buyruqni tering yoki yozing
 DocType: Activity Log,Timeline Name,Vaqt jadvalining nomi
-apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,Faqat bitta {0} asosiy sifatida o&#39;rnatilishi mumkin.
+apps/frappe/frappe/contacts/doctype/contact/contact.py,Only one {0} can be set as primary.,Faqat bitta {0} asosiy sifatida o'rnatilishi mumkin.
 DocType: Email Account,e.g. smtp.gmail.com,"masalan, smtp.gmail.com"
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add A New Rule,Yangi qoidani qo&#39;shing
-DocType: Contact,Sales Master Manager,Sotuvlar bo&#39;yicha menejer
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add A New Rule,Yangi qoidani qo'shing
+DocType: Contact,Sales Master Manager,Sotuvlar bo'yicha menejer
 DocType: User Permission,For Value,Qiymat uchun
 DocType: Event,Google Calendar ID,Google Taqvim ID raqami
-apps/frappe/frappe/www/complete_signup.html,One Last Step,So&#39;nggi qadam
-apps/frappe/frappe/config/settings.py,Import Data,Ma&#39;lumotlarni import qilish
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer,"Ushbu maydonning bog&#39;lanishini xohlagan hujjatning nomi (DocType). Masalan, mijoz"
+apps/frappe/frappe/www/complete_signup.html,One Last Step,So'nggi qadam
+apps/frappe/frappe/config/settings.py,Import Data,Ma'lumotlarni import qilish
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer,"Ushbu maydonning bog'lanishini xohlagan hujjatning nomi (DocType). Masalan, mijoz"
 DocType: Role Profile,Roles Assigned,Tayin qilingan rollar
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search Help,Qidiruv yordami
-DocType: Top Bar Item,Parent Label,Ota-ona yorlig&#39;i
-apps/frappe/frappe/templates/emails/auto_reply.html,"Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail.","So&#39;rovingiz qabul qilindi. Biz qisqa vaqt ichida javob qaytaramiz. Qo&#39;shimcha ma&#39;lumotingiz bo&#39;lsa, iltimos, ushbu pochta manziliga javob bering."
-apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only if Incoming is enabled.,Avtomatik ulanishni faqat kiruvchi kirish yoqilgan bo&#39;lsa yoqish mumkin.
+DocType: Top Bar Item,Parent Label,Ota-ona yorlig'i
+apps/frappe/frappe/templates/emails/auto_reply.html,"Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail.","So'rovingiz qabul qilindi. Biz qisqa vaqt ichida javob qaytaramiz. Qo'shimcha ma'lumotingiz bo'lsa, iltimos, ushbu pochta manziliga javob bering."
+apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only if Incoming is enabled.,Avtomatik ulanishni faqat kiruvchi kirish yoqilgan bo'lsa yoqish mumkin.
 DocType: LDAP Settings,LDAP Middle Name Field,LDAP-familiya maydoni
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Importing {0} of {1},{1} dan {0} ni import qilish
 DocType: GCalendar Account,Allow GCalendar Access,GCalendarga ruxsat berish
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} is a mandatory field,{0} - majburiy maydon
 apps/frappe/frappe/templates/includes/login/login.js,Login token required,Kirish tokenlari talab qilinadi
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Monthly Rank: ,Oylik reyting:
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Select multiple list items,Bir nechta ro&#39;yxat elementlarini tanlang
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Select multiple list items,Bir nechta ro'yxat elementlarini tanlang
 DocType: Event,Repeat Till,Till-i takrorlang
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New,Yangi
 apps/frappe/frappe/public/js/frappe/views/components/ModuleLinkItem.vue,You need to create these first: ,Avval bularni yaratishingiz kerak:
@@ -459,26 +459,26 @@ DocType: Blogger,Will be used in url (usually first name).,Urla (odatda birinchi
 DocType: Comment,Comment Email,Elektron pochta sharhlari
 DocType: Auto Email Report,Day of Week,Haftaning kuni
 DocType: Note,Expire Notification On,Bildirishni yoqing
-apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Ctrl+Enter to add comment,Fikr qo&#39;shish uchun Ctrl + Enter ni bosing
+apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Ctrl+Enter to add comment,Fikr qo'shish uchun Ctrl + Enter ni bosing
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Set as Default Theme,Odatiy mavzu sifatida o‘rnatish
-apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload in Progress. Please try again in a few moments.,"Fayl yuklanmoqda. Iltimos, birozdan keyin qayta urinib ko&#39;ring."
+apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload in Progress. Please try again in a few moments.,"Fayl yuklanmoqda. Iltimos, birozdan keyin qayta urinib ko'ring."
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Edit Heading,Sarlavhani tahrirlash
 DocType: File,File URL,URL manzili
 DocType: Version,Table HTML,Jadval HTML
-apps/frappe/frappe/email/doctype/email_group/email_group.js,Add Subscribers,Abonentlarni qo&#39;shish
+apps/frappe/frappe/email/doctype/email_group/email_group.js,Add Subscribers,Abonentlarni qo'shish
 apps/frappe/frappe/desk/doctype/event/event.py,Upcoming Events for Today,Bugungi tadbirlar
 DocType: Google Calendar,Push to Google Calendar,Google Taqvim-ga bosing
 DocType: Notification Recipient,Email By Document Field,Hujjat sohasiga elektron pochta
 DocType: Domain Settings,Domain Settings,Domen sozlamalari
 apps/frappe/frappe/email/receive.py,Cannot connect: {0},Ulanmayapti: {0}
-apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.,O&#39;z so&#39;zini o&#39;zi taxmin qilish oson.
+apps/frappe/frappe/utils/password_strength.py,A word by itself is easy to guess.,O'z so'zini o'zi taxmin qilish oson.
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Auto assignment failed: {0},Avtomatik tayinlash amalga oshmadi: {0}
 apps/frappe/frappe/templates/includes/search_box.html,Search...,Qidirmoq...
 apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,Please select Company,"Iltimos, Kompaniya-ni tanlang"
-apps/frappe/frappe/utils/nestedset.py,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,Birlashish faqatgina Guruh-guruh yoki barg tugunlaridan to-bargli tugungacha bo&#39;lishi mumkin
-apps/frappe/frappe/utils/file_manager.py,Added {0},Qo&#39;shilgan {0}
-apps/frappe/frappe/templates/includes/search_template.html,No matching records. Search something new,Hech qanday mos yozuvlar yo&#39;q. Yangi narsalarni qidirish
-DocType: Chat Profile,Away,Yo&#39;q
+apps/frappe/frappe/utils/nestedset.py,Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node,Birlashish faqatgina Guruh-guruh yoki barg tugunlaridan to-bargli tugungacha bo'lishi mumkin
+apps/frappe/frappe/utils/file_manager.py,Added {0},Qo'shilgan {0}
+apps/frappe/frappe/templates/includes/search_template.html,No matching records. Search something new,Hech qanday mos yozuvlar yo'q. Yangi narsalarni qidirish
+DocType: Chat Profile,Away,Yo'q
 DocType: Currency,Fraction Units,Fraktsiya qitish
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} from {1} to {2},{1} dan {2} gacha {0}
 apps/frappe/frappe/public/js/frappe/ui/toolbar/user_progress_dialog.js,Mark as Done,Bajarildi deb belgilang
@@ -492,53 +492,53 @@ DocType: DocField,Hidden,Yashirin
 DocType: Web Form,Allow Incomplete Forms,Tugatilmagan shakllarga ruxsat berish
 apps/frappe/frappe/utils/print_format.py,PDF generation failed,PDF ishlab chiqarish muvaffaqiyatsiz tugadi
 apps/frappe/frappe/model/base_document.py,{0} must be set first,Avval {0} belgilanishi kerak
-apps/frappe/frappe/utils/password_strength.py,"Use a few words, avoid common phrases.","Bir necha so&#39;zdan foydalaning, umumiy so&#39;zlardan qoching."
+apps/frappe/frappe/utils/password_strength.py,"Use a few words, avoid common phrases.","Bir necha so'zdan foydalaning, umumiy so'zlardan qoching."
 DocType: Workflow State,plane,samolyot
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Rounded Corners,Dumaloq burchaklar
-apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","Agar siz yangi yozuvlarni yuklamoqchi bo&#39;lsangiz, &quot;nomlash seriyasi&quot; majburiy bo&#39;lib qoladi."
+apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, ""Naming Series"" becomes mandatory, if present.","Agar siz yangi yozuvlarni yuklamoqchi bo'lsangiz, &quot;nomlash seriyasi&quot; majburiy bo'lib qoladi."
 apps/frappe/frappe/email/doctype/notification/notification.js,Get Alerts for Today,Bugungi kunda ogohlantirishlarni oling
 DocType: Contact,Google Contacts Id,Google Kontaktlar identifikatori
-apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can only be renamed by Administrator,DocType faqat Administrator tomonidan o&#39;zgartirilishi mumkin
+apps/frappe/frappe/core/doctype/doctype/doctype.py,DocType can only be renamed by Administrator,DocType faqat Administrator tomonidan o'zgartirilishi mumkin
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,6 months,6 oy
-apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Please attach an image file to set HTML,HTML-ni o&#39;rnatish uchun rasm faylini ilova qiling
+apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Please attach an image file to set HTML,HTML-ni o'rnatish uchun rasm faylini ilova qiling
 DocType: Chat Message,Chat Message,Tezkor xabar
 apps/frappe/frappe/utils/oauth.py,Email not verified with {0},Email {0} bilan tasdiqlanmagan
 DocType: Dashboard Chart,Time Series Based On,Vaqt seriyasiga asoslangan
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0},{0} o&#39;zgaruvchan qiymati
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0},{0} o'zgaruvchan qiymati
 DocType: Report,JSON,JSON
 apps/frappe/frappe/core/doctype/user/user.py,Please check your email for verification,Tasdiqlash uchun elektron pochta manzilingizni tekshiring
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold can not be at the end of the form,Katak shakl oxirida bo&#39;lishi mumkin emas
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold can not be at the end of the form,Katak shakl oxirida bo'lishi mumkin emas
 DocType: Communication,Bounced,Qaytarildi
-DocType: Deleted Document,Deleted Name,O&#39;chirilgan ism
+DocType: Deleted Document,Deleted Name,O'chirilgan ism
 apps/frappe/frappe/config/users_and_permissions.py,System and Website Users,Tizim va veb-sayt foydalanuvchilari
 DocType: Workflow Document State,Doc Status,Doc maqomi
 DocType: Data Migration Run,Pull Update,Yangilang
 DocType: Auto Email Report,No of Rows (Max 500),Satrlar soni (maksimum 500)
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.html,Select Field...,Maydonni tanlang ...
 DocType: Language,Language Code,Til kodi
-DocType: Dropbox Settings,Note: By default emails for failed backups are sent.,Eslatma: Sukut bo&#39;yicha zaxira nusxalari uchun elektron pochta xabarlari yuboriladi.
-apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Add Filter,Filtrni qo&#39;shish
+DocType: Dropbox Settings,Note: By default emails for failed backups are sent.,Eslatma: Sukut bo'yicha zaxira nusxalari uchun elektron pochta xabarlari yuboriladi.
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Add Filter,Filtrni qo'shish
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,SMS sent to following numbers: {0},Quyidagi raqamlarga yuborilgan SMS: {0}
 apps/frappe/frappe/utils/data.py,{0} and {1},{0} va {1}
 apps/frappe/frappe/public/js/frappe/chat.js,Start a conversation.,Suhbatni boshlang.
-DocType: Print Settings,"Always add ""Draft"" Heading for printing draft documents",Loyiha hujjatlarini chop etish uchun har doim &quot;Taslak&quot; qo&#39;shing
+DocType: Print Settings,"Always add ""Draft"" Heading for printing draft documents",Loyiha hujjatlarini chop etish uchun har doim &quot;Taslak&quot; qo'shing
 apps/frappe/frappe/email/doctype/notification/notification.py,Error in Notification: {},Bildirishnomada xato: {}
 DocType: Data Migration Run,Current Mapping Start,Joriy xaritalash boshlang
 apps/frappe/frappe/core/doctype/communication/communication.js,Email has been marked as spam,E-pochta spam sifatida belgilandi
 DocType: Comment,Website Manager,Veb-sayt boshqaruvchisi
-apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload Disconnected. Please try again.,"Faylni yuklash uzilib qoldi. Iltimos, yana bir bor urinib ko&#39;ring."
+apps/frappe/frappe/public/js/frappe/socketio_client.js,File Upload Disconnected. Please try again.,"Faylni yuklash uzilib qoldi. Iltimos, yana bir bor urinib ko'ring."
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translations,Tarjimalar
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,You selected Draft or Cancelled documents,Taslak yoki Bekor qilingan hujjatlarni tanladingiz
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Document {0} has been set to state {1} by {2},"{0} hujjati {1} tomonidan {2} tomonidan belgilanadi,"
 apps/frappe/frappe/model/document.py,Document Queued,Document Queued
 DocType: GSuite Templates,Destination ID,Nishon identifikatori
-DocType: Desktop Icon,List,Ro&#39;yxat
+DocType: Desktop Icon,List,Ro'yxat
 DocType: Activity Log,Link Name,Ulanish nomi
 DocType: System Settings,mm/dd/yyyy,mm / dd / yyyy
-apps/frappe/frappe/core/doctype/user/user.py,Invalid Password: ,Parol noto&#39;g&#39;ri:
+apps/frappe/frappe/core/doctype/user/user.py,Invalid Password: ,Parol noto'g'ri:
 DocType: Print Settings,Send document web view link in email,Hujjat veb-versiyasini havolani elektron pochta orqali yuboring
 apps/frappe/frappe/public/js/frappe/ui/slides.js,Previous,Avvalgi
-apps/frappe/frappe/email/doctype/email_account/email_account.py,Re:,O&#39;tilganlik sanasi:
+apps/frappe/frappe/email/doctype/email_account/email_account.py,Re:,O'tilganlik sanasi:
 DocType: LDAP Settings,Require Trusted Certificate,Ishonchli sertifikatni talab qilish
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} rows for {1},{1} uchun {0} satr
 DocType: Currency,"Sub-currency. For e.g. ""Cent""","Sub-valyutada. Masalan, &quot;Cent&quot;"
@@ -550,37 +550,37 @@ apps/frappe/frappe/utils/file_manager.py,No file attached,Hech qanday fayl birik
 DocType: Version,Version,Versiya
 DocType: S3 Backup Settings,Endpoint URL,Endpoint URL
 DocType: Dashboard,Charts,Grafikalar
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions are automatically applied to Standard Reports and searches.,Ruxsatnomalar standart hisobotlar va qidiruvlarga avtomatik ravishda qo&#39;llaniladi.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions are automatically applied to Standard Reports and searches.,Ruxsatnomalar standart hisobotlar va qidiruvlarga avtomatik ravishda qo'llaniladi.
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,Yuklash amalga oshmadi
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),O&#39;tgan haftadagi natijalarga asoslangan statistika ({0} dan {1} gacha)
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),O'tgan haftadagi natijalarga asoslangan statistika ({0} dan {1} gacha)
 DocType: LDAP Settings,LDAP Phone Field,LDAP telefon maydoni
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","hujjat turi ..., masalan, mijozlar"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,&#39;{0}&#39; sharti bekor
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,'{0}' sharti bekor
 DocType: Workflow State,barcode,shtrix kodi
-apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Sub-so&#39;rov yoki funktsiyadan foydalanish cheklangan
-apps/frappe/frappe/config/customization.py,Add your own translations,O&#39;zingizning tarjimalaringizni qo&#39;shing
+apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Sub-so'rov yoki funktsiyadan foydalanish cheklangan
+apps/frappe/frappe/config/customization.py,Add your own translations,O'zingizning tarjimalaringizni qo'shing
 DocType: Country,Country Name,Davlat nomi
-apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Blank Template,Bo&#39;sh shablon
-DocType: About Us Team Member,About Us Team Member,Biz haqimizda jamoa a&#39;zosi
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions.","Ruxlar va Hujjat turlari (DocTypes deb nomlanadi) O&#39;qish, Yozish, Yaratish, O&#39;chirish, Yuborish, Bekor qilish, O&#39;chirish, Hisobot berish, Import qilish, eksport qilish, Chop etish, E-pochtani o&#39;rnatish va Foydalanish Ruxsati kabi huquqlarni o&#39;rnatish orqali belgilanadi."
+apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Blank Template,Bo'sh shablon
+DocType: About Us Team Member,About Us Team Member,Biz haqimizda jamoa a'zosi
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions.","Ruxlar va Hujjat turlari (DocTypes deb nomlanadi) O'qish, Yozish, Yaratish, O'chirish, Yuborish, Bekor qilish, O'chirish, Hisobot berish, Import qilish, eksport qilish, Chop etish, E-pochtani o'rnatish va Foydalanish Ruxsati kabi huquqlarni o'rnatish orqali belgilanadi."
 DocType: Assignment Rule Day,Wednesday,Chorshanba
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Rasm maydoni tegishli maydon nomi bo&#39;lishi kerak
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be a valid fieldname,Rasm maydoni tegishli maydon nomi bo'lishi kerak
 DocType: Chat Token,Token,Token
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} is restricted,{0} maydon nomi cheklangan
 DocType: Property Setter,ID (name) of the entity whose property is to be set,Mol-mulki belgilanadigan shaxsning identifikatori (nomi)
 DocType: Website Settings,Website Theme Image Link,Veb-sayt mavzusi rasmiga havola
 DocType: Web Form,Sidebar Items,Yonaloq buyumlari
-DocType: Web Form,Show as Grid,Grid sifatida ko&#39;rsatish
-apps/frappe/frappe/installer.py,App {0} already installed,{0} ilovasi allaqachon o&#39;rnatilgan
-DocType: Energy Point Rule,Users assigned to the reference document will get points.,Ma&#39;lumotnoma hujjatiga tayinlangan foydalanuvchilar ball oladi.
-apps/frappe/frappe/printing/doctype/print_settings/print_settings.js,No Preview,Ko&#39;rib chiqish yo&#39;q
+DocType: Web Form,Show as Grid,Grid sifatida ko'rsatish
+apps/frappe/frappe/installer.py,App {0} already installed,{0} ilovasi allaqachon o'rnatilgan
+DocType: Energy Point Rule,Users assigned to the reference document will get points.,Ma'lumotnoma hujjatiga tayinlangan foydalanuvchilar ball oladi.
+apps/frappe/frappe/printing/doctype/print_settings/print_settings.js,No Preview,Ko'rib chiqish yo'q
 DocType: Workflow State,exclamation-sign,ishora belgisi
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Unzipped {0} files,Ajratilgan {0} fayl
-apps/frappe/frappe/public/js/frappe/form/controls/link.js,empty,bo&#39;sh
-apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js,Show Permissions,Ruxsatlarni ko&#39;rsatish
-DocType: Data Import,New data will be inserted.,Yangi ma&#39;lumotlar qo&#39;shiladi.
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a Link or Dynamic Link,Vaqt jadvalining maydoni bog&#39;lanish yoki dinamik bog&#39;lanish bo&#39;lishi kerak
-apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Date Range,Sana oralig&#39;i
+apps/frappe/frappe/public/js/frappe/form/controls/link.js,empty,bo'sh
+apps/frappe/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js,Show Permissions,Ruxsatlarni ko'rsatish
+DocType: Data Import,New data will be inserted.,Yangi ma'lumotlar qo'shiladi.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a Link or Dynamic Link,Vaqt jadvalining maydoni bog'lanish yoki dinamik bog'lanish bo'lishi kerak
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Date Range,Sana oralig'i
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Gantt,Gantt
 apps/frappe/frappe/public/js/frappe/views/reports/print_tree.html,Page {0} of {1},{1} sahifaning {0} sahifasi
 DocType: About Us Settings,Introduce your company to the website visitor.,Sizning kompaniyangizni veb-saytingizga tashrif buyuring.
@@ -589,27 +589,27 @@ DocType: SMS Settings,Receiver Parameter,Qabul qiluvchining parametrlari
 apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Toggle Public/Private,Umumiy / shaxsiy rejimida almashtirish
 DocType: Data Migration Mapping Detail,Remote Fieldname,Uzoq manzili
 DocType: Communication,To,To
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log_list.js,View Ref,Ko&#39;rish
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log_list.js,View Ref,Ko'rish
 apps/frappe/frappe/public/js/frappe/desk.js,Places,Joylar
 DocType: Kanban Board Column,darkgrey,Darkgrey
 apps/frappe/frappe/model/rename_doc.py,Successful: {0} to {1},Muvaffaqiyatli: {0} - {1}
-apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,"Demo-da foydalanuvchi ma&#39;lumotlarini o&#39;zgartirib bo&#39;lmaydi. Iltimos, https://erpnext.com manzili bo&#39;yicha yangi hisob uchun ro&#39;yxatdan o&#39;ting"
+apps/frappe/frappe/core/doctype/user/user.py,Cannot change user details in demo. Please signup for a new account at https://erpnext.com,"Demo-da foydalanuvchi ma'lumotlarini o'zgartirib bo'lmaydi. Iltimos, https://erpnext.com manzili bo'yicha yangi hisob uchun ro'yxatdan o'ting"
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop,Damla
-apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please duplicate this to make changes,O&#39;zgarishlarni amalga oshirish uchun buni takrorlang
+apps/frappe/frappe/printing/doctype/print_format/print_format.js,Please duplicate this to make changes,O'zgarishlarni amalga oshirish uchun buni takrorlang
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Press Enter to save,Saqlash uchun Enter ni bosing
 apps/frappe/frappe/utils/pdf.py,PDF generation failed because of broken image links,PDF-fayllar buzilgan rasm havolalari tufayli amalga oshmadi
-DocType: Print Settings,Font Size,Shrift o&#39;lchami
-DocType: System Settings,Disable Standard Email Footer,Standart elektron pochta tagligini o&#39;chirish
+DocType: Print Settings,Font Size,Shrift o'lchami
+DocType: System Settings,Disable Standard Email Footer,Standart elektron pochta tagligini o'chirish
 DocType: Workflow State,facetime-video,facetime-video
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,1 comment,1 ta sharh
-DocType: Website Slideshow,"Note: For best results,  images must be of the same size and width must be greater than height.",Eslatma: Yaxshi natijaga erishish uchun rasmlar bir xil o&#39;lchamda va kengligi balandlikdan kattaroq bo&#39;lishi kerak.
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,viewed,ko&#39;rsatildi
+DocType: Website Slideshow,"Note: For best results,  images must be of the same size and width must be greater than height.",Eslatma: Yaxshi natijaga erishish uchun rasmlar bir xil o'lchamda va kengligi balandlikdan kattaroq bo'lishi kerak.
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,viewed,ko'rsatildi
 DocType: Notification,Days Before,Avvalgi kunlar
 apps/frappe/frappe/desk/doctype/event/event.py,Daily Events should finish on the Same Day.,Kundalik tadbirlar xuddi shu kuni tugashi kerak.
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Edit...,Tahrirlash ...
 DocType: Workflow State,volume-down,ovoz balandligi pastga
 apps/frappe/frappe/auth.py,Access not allowed from this IP Address,Ushbu IP-manzildan kirish taqiqlangan
-apps/frappe/frappe/desk/reportview.py,No Tags,Teglar yo&#39;q
+apps/frappe/frappe/desk/reportview.py,No Tags,Teglar yo'q
 DocType: Email Account,Send Notification to,Bildirishnoma yuborish
 DocType: DocField,Collapsible,Katlanabilir
 DocType: Translation,Saved,Saqlangan
@@ -617,28 +617,28 @@ apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Options for selec
 apps/frappe/frappe/public/js/frappe/form/form.js,Permanently Cancel {0}?,{0} butunlay bekor qilinsinmi?
 DocType: Workflow State,music,musiqa
 apps/frappe/frappe/www/qrcode.html,QR Code,QR kodi
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,No records deleted,Hech qanday yozuv o&#39;chirilmadi
-apps/frappe/frappe/email/doctype/notification/notification.js,Last Modified Date,So&#39;nggi o&#39;zgartirish sanasi
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,No records deleted,Hech qanday yozuv o'chirilmadi
+apps/frappe/frappe/email/doctype/notification/notification.js,Last Modified Date,So'nggi o'zgartirish sanasi
 DocType: Chat Profile,Settings,Sozlamalar
 DocType: Print Format,Style Settings,Uslub sozlamalari
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Filter By,Tomonidan filtrlash
-apps/frappe/frappe/database/database.py,No conditions provided,Hech qanday sharoit ta&#39;minlanmagan
+apps/frappe/frappe/database/database.py,No conditions provided,Hech qanday sharoit ta'minlanmagan
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Y Axis Fields,Y eksa maydonchalari
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,{0} bo&#39;yicha tartiblash maydonida joriy maydon nomi bo&#39;lishi kerak
-apps/frappe/frappe/public/js/frappe/list/base_list.js,More,Ko&#39;proq
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Sort field {0} must be a valid fieldname,{0} bo'yicha tartiblash maydonida joriy maydon nomi bo'lishi kerak
+apps/frappe/frappe/public/js/frappe/list/base_list.js,More,Ko'proq
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Create a new record,Yangi yozuv yarating
 DocType: Contact,Sales Manager,Savdo menedjeri
-apps/frappe/frappe/public/js/frappe/model/model.js,Rename,Nomni o&#39;zgartiring
-DocType: Print Format,Format Data,Ma&#39;lumotlarni formatlash
+apps/frappe/frappe/public/js/frappe/model/model.js,Rename,Nomni o'zgartiring
+DocType: Print Format,Format Data,Ma'lumotlarni formatlash
 DocType: List Filter,Filter Name,Filtrni nomi
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Like,Xuddi shunday
 DocType: Assignment Rule,Automation,Avtomatlashtirish
-DocType: Google Drive,Last Backup On,So&#39;nggi zaxira yoqilgan
+DocType: Google Drive,Last Backup On,So'nggi zaxira yoqilgan
 DocType: Customize Form Field,Customize Form Field,Shakl maydonini moslash
 DocType: Energy Point Rule,For Document Event,Hujjat hodisasi uchun
 DocType: Website Settings,Chat Room Name,Chat xonasining nomi
 DocType: OAuth Client,Grant Type,Grant turi
-apps/frappe/frappe/config/users_and_permissions.py,Check which Documents are readable by a User,Hujjatlarni foydalanuvchi tomonidan o&#39;qilishi mumkinligini tekshiring
+apps/frappe/frappe/config/users_and_permissions.py,Check which Documents are readable by a User,Hujjatlarni foydalanuvchi tomonidan o'qilishi mumkinligini tekshiring
 DocType: Deleted Document,Hub Sync ID,Uyadagi sinxronlash identifikatori
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,use % as wildcard,% joker belgilar sifatida foydalaning
 DocType: Auto Repeat,Quarterly,Har chorakda
@@ -646,15 +646,15 @@ apps/frappe/frappe/email/doctype/email_account/email_account.js,"Email Domain no
 DocType: User,Reset Password Key,Parol kalitini qayta tiklash
 apps/frappe/frappe/model/workflow.py,Illegal Document Status for {0},{0} uchun noqonuniy hujjat holati
 DocType: Email Account,Enable Auto Reply,Avtomatik javob berish funksiyasini yoqish
-apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Not Seen,Ko&#39;rilmagan
-apps/frappe/frappe/public/js/frappe/form/print.js,Cannot have multiple printers mapped to a single print format.,Bitta bosib chiqarish formatiga bir nechta printer ulanib bo&#39;lmadi.
+apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Not Seen,Ko'rilmagan
+apps/frappe/frappe/public/js/frappe/form/print.js,Cannot have multiple printers mapped to a single print format.,Bitta bosib chiqarish formatiga bir nechta printer ulanib bo'lmadi.
 DocType: Workflow State,zoom-in,yaqinlashtirish
-apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Reference DocType and Reference Name are required,Yo&#39;naltirilgan DocType va Reference Name talab qilinadi
+apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Reference DocType and Reference Name are required,Yo'naltirilgan DocType va Reference Name talab qilinadi
 apps/frappe/frappe/utils/jinja.py,Syntax error in template,Shablondagi sintaksik xato
 DocType: DocField,Width,Kengligi
 apps/frappe/frappe/public/js/frappe/views/communication.js,Message clipped,Xabar qisildi
-DocType: Email Account,Notify if unreplied,Unreplied yoki yo&#39;qligini bildirish
-apps/frappe/frappe/www/qrcode.html,Scan the QR Code and enter the resulting code displayed.,QR kodini skanerlang va natijada ko&#39;rsatilgan kodni kiriting.
+DocType: Email Account,Notify if unreplied,Unreplied yoki yo'qligini bildirish
+apps/frappe/frappe/www/qrcode.html,Scan the QR Code and enter the resulting code displayed.,QR kodini skanerlang va natijada ko'rsatilgan kodni kiriting.
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Enable Gradients,Gradients-ni yoqish
 DocType: System Settings,Minimum Password Score,Minimal parol
 DocType: DocType,Fields,Maydonlar
@@ -663,48 +663,48 @@ apps/frappe/frappe/core/doctype/data_import/importer.py,Parent Table,Ota-jadval
 apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js,S3 Backup complete!,S3 Zaxiralash tugadi!
 apps/frappe/frappe/config/desktop.py,Developer,Dasturchi
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Created,Yaratildi
-apps/frappe/frappe/website/doctype/website_settings/website_settings.py,{0} in row {1} cannot have both URL and child items,{1} qatoridagi {0} URL va parollar ham bo&#39;lishi mumkin emas
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for the following tables: {0},Quyidagi jadvallar uchun bitta qator atleast bo&#39;lishi kerak: {0}
+apps/frappe/frappe/website/doctype/website_settings/website_settings.py,{0} in row {1} cannot have both URL and child items,{1} qatoridagi {0} URL va parollar ham bo'lishi mumkin emas
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for the following tables: {0},Quyidagi jadvallar uchun bitta qator atleast bo'lishi kerak: {0}
 DocType: Print Format,Default Print Language,Standart bosib chiqarish tili
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Ancestors Of,Otalari
-apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,Ildiz {0} o&#39;chirib bo&#39;lmaydi
-apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Hech qanday izoh yo&#39;q
+apps/frappe/frappe/utils/nestedset.py,Root {0} cannot be deleted,Ildiz {0} o'chirib bo'lmaydi
+apps/frappe/frappe/website/doctype/blog_post/blog_post.py,No comments yet,Hech qanday izoh yo'q
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py,"Please setup SMS before setting it as an authentication method, via SMS Settings",SMS sozlamalari orqali autentifikatsiya usuli sifatida sozlashdan oldin SMS-xabarlarni sozlang
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Both DocType and Name required,DocType va Name ham talab qilinadi
-apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,Docstatusni 1dan 0gacha o&#39;zgartirib bo&#39;lmaydi
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,Sizda etarlicha ochkolar yo&#39;q
+apps/frappe/frappe/model/document.py,Cannot change docstatus from 1 to 0,Docstatusni 1dan 0gacha o'zgartirib bo'lmaydi
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough points,Sizda etarlicha ochkolar yo'q
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Take Backup Now,Endi zahira nusxasini oling
 DocType: Contact,Open,Ochish
 DocType: Workflow Transition,Defines actions on states and the next step and allowed roles.,Shtatlardagi harakatlar va keyingi qadamlarni aniqlaydi va rollarga ruxsat beradi.
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Reviewer,Eng yaxshi sharhlovchi
-DocType: Data Migration Mapping,Remote Objectname,Masofadagi ob&#39;ekt nomi
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","Eng yaxshi amaliyot sifatida, turli xil rollarda bir xil ruxsat to&#39;plamini tayinlamang. Buning o&#39;rniga, bitta foydalanuvchiga bir nechta rolni o&#39;rnating."
+DocType: Data Migration Mapping,Remote Objectname,Masofadagi ob'ekt nomi
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User.","Eng yaxshi amaliyot sifatida, turli xil rollarda bir xil ruxsat to'plamini tayinlamang. Buning o'rniga, bitta foydalanuvchiga bir nechta rolni o'rnating."
 apps/frappe/frappe/www/confirm_workflow_action.html,Please confirm your action to {0} this document.,"Iltimos, ushbu hujjatni {0} uchun tasdiqlang."
 DocType: Success Action,Next Actions HTML,Keyingi amallar HTML
 apps/frappe/frappe/public/js/frappe/social/social_home.js,Create Post,Post yaratish
-apps/frappe/frappe/desk/doctype/event/event.js,Add Participants,Ishtirokchilarni qo&#39;shish
-DocType: Web Page,Main Section (Markdown),Asosiy bo&#39;lim (Markdown)
+apps/frappe/frappe/desk/doctype/event/event.js,Add Participants,Ishtirokchilarni qo'shish
+DocType: Web Page,Main Section (Markdown),Asosiy bo'lim (Markdown)
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Only {0} emailed reports are allowed per user,Bitta foydalanuvchi uchun faqatgina {0} elektron pochta hisoboti mavjud
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldtype {1} for {2} cannot be unique,{0}: {2} uchun {1} maydon turi noyob bo&#39;lolmaydi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldtype {1} for {2} cannot be unique,{0}: {2} uchun {1} maydon turi noyob bo'lolmaydi
 DocType: Address,Address Title,Manzil sarlavhasi
-DocType: Website Settings,Footer Items,Olingan ma&#39;lumotlar
+DocType: Website Settings,Footer Items,Olingan ma'lumotlar
 apps/frappe/frappe/public/js/frappe/ui/page.html,Menu,Menyu
 DocType: DefaultValue,DefaultValue,DefaultValue
 DocType: Auto Repeat,Daily,Kundalik
 apps/frappe/frappe/config/users_and_permissions.py,User Roles,Foydalanuvchi roli
 DocType: Property Setter,Property Setter overrides a standard DocType or Field property,Property Setter standart DocType yoki Field xususiyatini bekor qiladi
-apps/frappe/frappe/core/doctype/user/user.py,Cannot Update: Incorrect / Expired Link.,Yangiladimi: noto&#39;g&#39;ri / muddati tugagan havola.
-apps/frappe/frappe/utils/password_strength.py,Better add a few more letters or another word,Yana bir necha harf yoki boshqa so&#39;z qo&#39;shing
+apps/frappe/frappe/core/doctype/user/user.py,Cannot Update: Incorrect / Expired Link.,Yangiladimi: noto'g'ri / muddati tugagan havola.
+apps/frappe/frappe/utils/password_strength.py,Better add a few more letters or another word,Yana bir necha harf yoki boshqa so'z qo'shing
 DocType: Auto Repeat,Repeat on Last Day of the Month,Oyning oxirgi kunida takrorlash
-apps/frappe/frappe/twofactor.py,One Time Password (OTP) Registration Code from {},{} Dan bir marta parol (OTP) ro&#39;yxatdan o&#39;tish kodi
-DocType: DocField,Set Only Once,Faqat bir marta o&#39;rnating
+apps/frappe/frappe/twofactor.py,One Time Password (OTP) Registration Code from {},{} Dan bir marta parol (OTP) ro'yxatdan o'tish kodi
+DocType: DocField,Set Only Once,Faqat bir marta o'rnating
 DocType: Email Queue Recipient,Email Queue Recipient,Email Queue Recipient
 DocType: Address,Nagaland,Nagaland
 DocType: Slack Webhook URL,Webhook URL,Webhook URL
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,{0} ismli foydalanuvchi allaqachon mavjud
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,{0}: import sifatida sozlanmagan {1} import qilinmaydi
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Sizning manzilingiz shablonida {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} - &quot;Qabul qiluvchilar&quot; bo&#39;limida noto&#39;g&#39;ri e-pochta manzili
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} - &quot;Qabul qiluvchilar&quot; bo'limida noto'g'ri e-pochta manzili
 DocType: Footer Item,"target = ""_blank""",target = &quot;_blank&quot;
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,Xost
@@ -714,23 +714,23 @@ DocType: ToDo,High,Oliy
 apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,New Event,Yangi hodisa
 DocType: S3 Backup Settings,Secret Access Key,Yashirin maxfiy kalit
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Male,Erkak
-apps/frappe/frappe/core/doctype/user/user.py,OTP Secret has been reset. Re-registration will be required on next login.,OTP Secret qayta tiklandi. Keyingi kirish uchun qayta ro&#39;yxatdan o&#39;tkazish talab qilinadi.
-DocType: Communication,From Full Name,To&#39;liq ismdan
-apps/frappe/frappe/desk/query_report.py,You don't have access to Report: {0},Hisobingizga kirish imkoni yo&#39;q: {0}
+apps/frappe/frappe/core/doctype/user/user.py,OTP Secret has been reset. Re-registration will be required on next login.,OTP Secret qayta tiklandi. Keyingi kirish uchun qayta ro'yxatdan o'tkazish talab qilinadi.
+DocType: Communication,From Full Name,To'liq ismdan
+apps/frappe/frappe/desk/query_report.py,You don't have access to Report: {0},Hisobingizga kirish imkoni yo'q: {0}
 DocType: User,Send Welcome Email,Xush kelibsiz Email yuboring
 DocType: Assignment Rule User,Assignment Rule User,Tayinlash qoidasi foydalanuvchi
-apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Remove Filter,Filtrni o&#39;chirish
-DocType: Web Form Field,Show in filter,Filtrda ko&#39;rsatish
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Remove Filter,Filtrni o'chirish
+DocType: Web Form Field,Show in filter,Filtrda ko'rsatish
 DocType: Address,Daman and Diu,Daman va Diu
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Project,Loyiha
 DocType: Address,Personal,Shaxsiy
 DocType: S3 Backup Settings,See https://docs.aws.amazon.com/de_de/general/latest/gr/rande.html#s3_region for details.,Tafsilotlar uchun https://docs.aws.amazon.com/de_de/general/latest/gr/rande.html#s3_region-ga qarang.
 apps/frappe/frappe/config/settings.py,Bulk Rename,Ommaviy qayta nomlash
-DocType: Email Queue,Show as cc,Cc sifatida ko&#39;rsatish
+DocType: Email Queue,Show as cc,Cc sifatida ko'rsatish
 DocType: DocField,Heading,Sarlavha
 DocType: Workflow State,resize-vertical,resize-vertikal
 apps/frappe/frappe/public/js/frappe/ui/capture.js,Take Video,Videoni oling
-DocType: Contact Us Settings,Introductory information for the Contact Us Page,Biz bilan bog&#39;lanish sahifasiga kirish haqida ma&#39;lumot
+DocType: Contact Us Settings,Introductory information for the Contact Us Page,Biz bilan bog'lanish sahifasiga kirish haqida ma'lumot
 DocType: Print Style,CSS,CSS
 DocType: Workflow State,thumbs-down,barmoqlarni pastga tushirish
 DocType: User,Send Notifications for Email threads,Elektron pochta xabarlari uchun bildirishnomalarni yuboring
@@ -741,173 +741,173 @@ DocType: DocField,In Global Search,Global izlovchilarda
 DocType: System Settings,Brute Force Security,Brute Force Xavfsizlik
 DocType: Workflow State,indent-left,indent-chap
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} yil oldin
-apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Ushbu faylni o&#39;chirish xavfli: {0}. Iltimos, tizim boshqaruvchisiga murojaat qiling."
+apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Ushbu faylni o'chirish xavfli: {0}. Iltimos, tizim boshqaruvchisiga murojaat qiling."
 DocType: Currency,Currency Name,Valyuta nomi
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,E-pochtalar yo&#39;q
-apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Bog&#39;langan vaqti tugadi
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,E-pochtalar yo'q
+apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Bog'langan vaqti tugadi
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",&#39;{2}&#39; &#39;{1}&#39; uchun {0} uzunligini qaytarish; Uzoqlikni {3} qilib belgilash ma&#39;lumotlarning uzilishiga sabab bo&#39;ladi.
+							Setting the length as {3} will cause truncation of data.",'{2}' '{1}' uchun {0} uzunligini qaytarish; Uzoqlikni {3} qilib belgilash ma'lumotlarning uzilishiga sabab bo'ladi.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Fayl formatini tanlang
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Content Hash
-DocType: User,Stores the JSON of last known versions of various installed apps. It is used to show release notes.,JSON-ga turli xil o&#39;rnatilgan ilovalarning oxirgi ma&#39;lum versiyalarini joylashtiradi. U versiyalarni ko&#39;rsatish uchun ishlatiladi.
+DocType: User,Stores the JSON of last known versions of various installed apps. It is used to show release notes.,JSON-ga turli xil o'rnatilgan ilovalarning oxirgi ma'lum versiyalarini joylashtiradi. U versiyalarni ko'rsatish uchun ishlatiladi.
 DocType: Energy Point Rule,User Field,Foydalanuvchi maydoni
 DocType: DocType,MyISAM,MyISAM
-DocType: Data Migration Run,Push Delete,Yo&#39;q qilish tugmachasini bosing
+DocType: Data Migration Run,Push Delete,Yo'q qilish tugmachasini bosing
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed for {1} {2},{0} uchun {1} {2}
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not remove,O&#39;chirmadi
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not remove,O'chirmadi
 apps/frappe/frappe/desk/like.py,Liked,Yoqdi
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Send Now,Hozir yuboring
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"Standard DocType cannot have default print format, use Customize Form","Standart DocType formati asl nusxa formatiga ega bo`lmaydi, Shaklni moslashtiring"
-DocType: Report,Query,So&#39;rov
+DocType: Report,Query,So'rov
 DocType: Customize Form,Sort Order,Tartiblash tartibi
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,'In List View' not allowed for type {0} in row {1},{1} qatorida {0} uchun &quot;List View&quot; da ruxsat berilmagan
 DocType: Letter Head,Footer HTML,Quyi HTML HTML
-DocType: Custom Field,Select the label after which you want to insert new field.,Yangi maydon qo&#39;shish kerakli yorliqni tanlang.
-,Document Share Report,Hujjat bo&#39;yicha hisobot
+DocType: Custom Field,Select the label after which you want to insert new field.,Yangi maydon qo'shish kerakli yorliqni tanlang.
+,Document Share Report,Hujjat bo'yicha hisobot
 DocType: Social Login Key,Base URL,Asosiy URL
-DocType: User,Last Login,So&#39;nggi kirish
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Siz {0} uchun &quot;Translatable&quot; funksiyasini o&#39;rnatishingiz mumkin emas
+DocType: User,Last Login,So'nggi kirish
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Siz {0} uchun &quot;Translatable&quot; funksiyasini o'rnatishingiz mumkin emas
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Ustun
 DocType: Chat Profile,Chat Profile,Chat profili
-DocType: Custom Field,Adds a custom field to a DocType,DocType-ga maxsus maydon qo&#39;shiladi
+DocType: Custom Field,Adds a custom field to a DocType,DocType-ga maxsus maydon qo'shiladi
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,Click on the link below to verify your request,So‘rovingizni tasdiqlash uchun quyidagi havolani bosing
 DocType: File,Is Home Folder,Uy papkasi
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Navbar uslubi
-apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} - bu to&#39;g&#39;ri elektron pochta manzili emas
+apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} - bu to'g'ri elektron pochta manzili emas
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Bosib chiqarish uchun atleast 1 yozuvini tanlang
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',&#39;{0}&#39; foydalanuvchi allaqachon &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}','{0}' foydalanuvchi allaqachon '{1}'
 DocType: System Settings,Two Factor Authentication method,Ikki omil autentifikatsiya usuli
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Avval nomni o&#39;rnating va yozib oling.
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Avval nomni o'rnating va yozib oling.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 yozuvlar
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with {0},{0} bilan ulashilgan
 apps/frappe/frappe/email/queue.py,Unsubscribe,Obunani bekor qilish
 DocType: View Log,Reference Name,Malumot nomi
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,Change User,Foydalanuvchini o&#39;zgartirish
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,Change User,Foydalanuvchini o'zgartirish
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Update Translations,Tarjimalarni yangilang
 DocType: Error Snapshot,Exception,Istisno
 DocType: Email Account,Use IMAP,IMAP-dan foydalaning
 DocType: Activity Log,Activity Log,Faoliyat jurnali
-DocType: View Log,Viewed By,Ko&#39;rilgan
+DocType: View Log,Viewed By,Ko'rilgan
 DocType: Integration Request,Authorized,Vakolatli
-DocType: DocType,Single Types have only one record no tables associated. Values are stored in tabSingles,Faqatgina turlari faqatgina bitta qayd bilan bog&#39;liq. Qiymatlar tabSingle ichida saqlanadi
+DocType: DocType,Single Types have only one record no tables associated. Values are stored in tabSingles,Faqatgina turlari faqatgina bitta qayd bilan bog'liq. Qiymatlar tabSingle ichida saqlanadi
 DocType: System Settings,Enable Password Policy,Parol siyosatini yoqish
-DocType: Web Form,"List as [{""label"": _(""Jobs""), ""route"":""jobs""}]","[{&quot;Label&quot;: _ (&quot;Jobs&quot;), &quot;marshrut&quot;: &quot;ish&quot;) sifatida ro&#39;yxatlang []]"
-apps/frappe/frappe/custom/doctype/property_setter/property_setter.py,Field type cannot be changed for {0},{0} uchun maydon turi o&#39;zgartirib bo&#39;lmaydi
-DocType: Workflow,Rules defining transition of state in the workflow.,Ish oqimiga davlatning o&#39;tishini belgilovchi qoidalar.
+DocType: Web Form,"List as [{""label"": _(""Jobs""), ""route"":""jobs""}]","[{&quot;Label&quot;: _ (&quot;Jobs&quot;), &quot;marshrut&quot;: &quot;ish&quot;) sifatida ro'yxatlang []]"
+apps/frappe/frappe/custom/doctype/property_setter/property_setter.py,Field type cannot be changed for {0},{0} uchun maydon turi o'zgartirib bo'lmaydi
+DocType: Workflow,Rules defining transition of state in the workflow.,Ish oqimiga davlatning o'tishini belgilovchi qoidalar.
 DocType: File,Folder,Folder
 DocType: Website Route Meta,Website Route Meta,Route Meta veb-sayti
 DocType: DocField,Index,Indeks
 DocType: Email Group,Newsletter Manager,BB direktori
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 1,1-variant
 apps/frappe/frappe/public/js/frappe/form/formatters.js,{0} to {1},{0} - {1} ga
-apps/frappe/frappe/config/settings.py,Log of error during requests.,So&#39;rovlar paytida xatolikni yozish.
-apps/frappe/frappe/email/doctype/newsletter/newsletter.py,{0} has been successfully added to the Email Group.,{0} elektron pochta guruhiga muvaffaqiyatli qo&#39;shildi.
+apps/frappe/frappe/config/settings.py,Log of error during requests.,So'rovlar paytida xatolikni yozish.
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,{0} has been successfully added to the Email Group.,{0} elektron pochta guruhiga muvaffaqiyatli qo'shildi.
 apps/frappe/frappe/public/js/frappe/form/grid.js,Do not edit headers which are preset in the template,Shablondagi oldindan belgilangan sarlavhalarni tahrir qilmang
 apps/frappe/frappe/twofactor.py,Login Verification Code from {},Kirish kodini tasdiqlash kodi {}
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained {0} points,Siz {0} ball to&#39;pladingiz
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained {0} points,Siz {0} ball to'pladingiz
 DocType: Address,Uttar Pradesh,Uttar Pradesh
 apps/frappe/frappe/www/confirm_workflow_action.html,Note:,Eslatma:
 DocType: Address,Pondicherry,Pondicherry
 DocType: Data Import,Import Status,Import holati
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Scheduled to send to {0},{0} ga yuborish rejalashtirilgan
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Page Shortcuts,Sahifa yorliqlari
-DocType: Kanban Board Column,Indicator,Ko&#39;rsatkich
+DocType: Kanban Board Column,Indicator,Ko'rsatkich
 DocType: DocShare,Everyone,Har kim
 DocType: Workflow State,backward,orqaga qarab
 apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Only one rule allowed with the same Role, Level and {1}","{0}: Faqat bitta qoida bir xil roli, darajasi va {1}"
-DocType: Email Queue,Add Unsubscribe Link,Obunani bekor qilish havolasini qo&#39;shish
-apps/frappe/frappe/templates/includes/comments/comments.html,No comments yet. Start a new discussion.,Hech qanday izoh yo&#39;q. Yangi suhbatni boshlang.
+DocType: Email Queue,Add Unsubscribe Link,Obunani bekor qilish havolasini qo'shish
+apps/frappe/frappe/templates/includes/comments/comments.html,No comments yet. Start a new discussion.,Hech qanday izoh yo'q. Yangi suhbatni boshlang.
 DocType: Workflow State,share,ulush
-apps/frappe/frappe/config/settings.py,Set numbering series for transactions.,Jurnallarni raqamlash seriyasini o&#39;rnatish.
+apps/frappe/frappe/config/settings.py,Set numbering series for transactions.,Jurnallarni raqamlash seriyasini o'rnatish.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Configure Charts,Grafiklarni sozlash
 DocType: User,Last IP,Oxirgi IP
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please add a subject to your email,"Iltimos, e-pochtangizga mavzu qo&#39;shing"
-apps/frappe/frappe/share.py,A new document {0} has been shared by with you {1}.,{0} yangi hujjat siz bilan {1} baham ko&#39;rdi.
-DocType: Data Migration Connector,Data Migration Connector,Ma&#39;lumotlarni uzatish ulagichi
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please add a subject to your email,"Iltimos, e-pochtangizga mavzu qo'shing"
+apps/frappe/frappe/share.py,A new document {0} has been shared by with you {1}.,{0} yangi hujjat siz bilan {1} baham ko'rdi.
+DocType: Data Migration Connector,Data Migration Connector,Ma'lumotlarni uzatish ulagichi
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} reverted {1},{0} qaytarildi {1}
 DocType: Email Account,Track Email Status,Elektron pochta holatini kuzating
 DocType: Note,Notify Users On Every Login,Foydalanuvchilarni har bir kirishda xabardor qiling
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,Cannot match column {0} with any field,{0} ustunini biron bir maydon bilan moslab bo&#39;lmadi
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,Cannot match column {0} with any field,{0} ustunini biron bir maydon bilan moslab bo'lmadi
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} records.,{0} yozuvlari muvaffaqiyatli yangilandi.
 DocType: PayPal Settings,API Password,API Password
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Enter python module or select connector type,Python modulini kiriting yoki ulagichning turini tanlang
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Fieldname not set for Custom Field,Fieldname maxsus maydonchaga o&#39;rnatilmagan
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Fieldname not set for Custom Field,Fieldname maxsus maydonchaga o'rnatilmagan
 apps/frappe/frappe/public/js/frappe/model/model.js,Last Updated By,Yangilandi
-apps/frappe/frappe/email/doctype/email_group/email_group.js,View Subscribers,Abonentlarni ko&#39;rish
-apps/frappe/frappe/public/js/frappe/form/print.js,"PDF printing via ""Raw Print"" is not yet supported. Please remove the printer mapping in Printer Settings and try again.",&quot;Raw Print&quot; orqali PDF bosib chiqarish hali qo&#39;llab-quvvatlanmaydi. Printer sozlamalarida printerlar xaritasini olib tashlang va qaytadan urining.
+apps/frappe/frappe/email/doctype/email_group/email_group.js,View Subscribers,Abonentlarni ko'rish
+apps/frappe/frappe/public/js/frappe/form/print.js,"PDF printing via ""Raw Print"" is not yet supported. Please remove the printer mapping in Printer Settings and try again.",&quot;Raw Print&quot; orqali PDF bosib chiqarish hali qo'llab-quvvatlanmaydi. Printer sozlamalarida printerlar xaritasini olib tashlang va qaytadan urining.
 DocType: Webhook,after_insert,after_insert
-apps/frappe/frappe/core/doctype/file/file.py,Cannot delete file as it belongs to {0} {1} for which you do not have permissions,"Faylni o&#39;chirib bo&#39;lmaydi, chunki u sizga ruxsat yo&#39;q {0} {1} ga tegishli"
+apps/frappe/frappe/core/doctype/file/file.py,Cannot delete file as it belongs to {0} {1} for which you do not have permissions,"Faylni o'chirib bo'lmaydi, chunki u sizga ruxsat yo'q {0} {1} ga tegishli"
 DocType: Website Theme,Custom JS,Custom JS
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Ms,Xonim
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Background Color,Fon rangi
-apps/frappe/frappe/public/js/frappe/views/communication.js,There were errors while sending email. Please try again.,"E-pochtani yuborishda xatolik yuz berdi. Iltimos, yana bir bor urinib ko&#39;ring."
+apps/frappe/frappe/public/js/frappe/views/communication.js,There were errors while sending email. Please try again.,"E-pochtani yuborishda xatolik yuz berdi. Iltimos, yana bir bor urinib ko'ring."
 DocType: Portal Settings,Portal Settings,Portal sozlamalari
 DocType: Review Level,Level Name,Daraja nomi
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,Cannot update {0},{0} yangilanib bo&#39;lmadi
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,Cannot update {0},{0} yangilanib bo'lmadi
 DocType: Data Migration Mapping,Mapping,Mapping
 DocType: Web Page,0 is highest,0 eng yuqori
 apps/frappe/frappe/public/js/frappe/microtemplate.js,Please enable pop-ups in your browser,"Iltimos, brauzeringizda qalqib chiquvchi oynalarni yoqing"
 apps/frappe/frappe/core/doctype/communication/communication.js,Are you sure you want to relink this communication to {0}?,Ushbu muloqotni {0} ga qayta tiklashni xohlaysizmi?
 DocType: Print Settings,Server IP,Server IPsi
-DocType: Email Queue,Attachments,Qo&#39;shimchalar
-apps/frappe/frappe/website/doctype/web_form/web_form.py,You don't have the permissions to access this document,Ushbu hujjatga kirish uchun sizda ruxsat yo&#39;q
+DocType: Email Queue,Attachments,Qo'shimchalar
+apps/frappe/frappe/website/doctype/web_form/web_form.py,You don't have the permissions to access this document,Ushbu hujjatga kirish uchun sizda ruxsat yo'q
 DocType: Language,Language Name,Til nomi
-DocType: Email Group Member,Email Group Member,E-pochta guruhi a&#39;zosi
-apps/frappe/frappe/auth.py,Your account has been locked and will resume after {0} seconds,Hisobingiz qulflangan va {0} sekunddan so&#39;ng davom etadi
+DocType: Email Group Member,Email Group Member,E-pochta guruhi a'zosi
+apps/frappe/frappe/auth.py,Your account has been locked and will resume after {0} seconds,Hisobingiz qulflangan va {0} sekunddan so'ng davom etadi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions are used to limit users to specific records.,Foydalanuvchi ruxsati foydalanuvchilarni muayyan yozuvlarga cheklash uchun ishlatiladi.
-DocType: Notification,Value Changed,Qiymati o&#39;zgargan
+DocType: Notification,Value Changed,Qiymati o'zgargan
 apps/frappe/frappe/model/base_document.py,Duplicate name {0} {1},Duplicate name {0} {1}
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Retry,Qayta urin
 DocType: Contact Phone,Number,Raqam
 DocType: Web Form Field,Web Form Field,Veb formasi maydoni
 apps/frappe/frappe/templates/emails/new_message.html,You have a new message from: ,Sizda yangi xabaringiz bor:
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_field.html,Edit HTML,HTMLni tahrirlash
-apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,"Iltimos, yo&#39;naltirish URL manzilini kiriting"
+apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Redirect URL,"Iltimos, yo'naltirish URL manzilini kiriting"
 apps/frappe/frappe/core/doctype/language/language.py,"{0} must begin and end with a letter and can only contain letters,
-				hyphen or underscore.","{0} harf bilan boshlanib, tugashi kerak va faqat harflar, defis yoki pastki chiziqlardan iborat bo&#39;lishi mumkin."
+				hyphen or underscore.","{0} harf bilan boshlanib, tugashi kerak va faqat harflar, defis yoki pastki chiziqlardan iborat bo'lishi mumkin."
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Restore Original Permissions,Asl ruxsatlarni tiklash
-DocType: Address,Shop,Do&#39;kon
+DocType: Address,Shop,Do'kon
 DocType: DocField,Button,Tugma
 apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} is now default print format for {1} doctype,{0} endi {1} doctype uchun odatiy chop formati
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,Archived Columns,Arxivlangan ustunlar
 DocType: Email Account,Default Outgoing,Standart Chiqish
-DocType: Workflow State,play,o&#39;ynash
-apps/frappe/frappe/templates/emails/new_user.html,Click on the link below to complete your registration and set a new password,Ro&#39;yxatdan o&#39;tishni yakunlash va yangi parolni o&#39;rnatish uchun quyidagi linkni bosing
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not add,Qo&#39;shilmadi
+DocType: Workflow State,play,o'ynash
+apps/frappe/frappe/templates/emails/new_user.html,Click on the link below to complete your registration and set a new password,Ro'yxatdan o'tishni yakunlash va yangi parolni o'rnatish uchun quyidagi linkni bosing
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Did not add,Qo'shilmadi
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Email Accounts Assigned,E-pochta hisoblari tayinlangan emas
-DocType: S3 Backup Settings,eu-west-2,eu-g&#39;arbiy-2
-DocType: Contact Us Settings,Contact Us Settings,Biz bilan bog&#39;laning
+DocType: S3 Backup Settings,eu-west-2,eu-g'arbiy-2
+DocType: Contact Us Settings,Contact Us Settings,Biz bilan bog'laning
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,Searching ...,Qidirilmoqda ...
 DocType: Workflow State,text-width,matn kengligi
-apps/frappe/frappe/public/js/frappe/form/form.js,Maximum Attachment Limit for this record reached.,Ushbu yozuv uchun maksimal qo&#39;shimcha cheklovga yetdi.
-apps/frappe/frappe/public/js/frappe/file_uploader/FileBrowser.vue,Search by filename or extension,Fayl nomi yoki kengaytmasi bo&#39;yicha qidirish
-DocType: Notification,View Properties (via Customize Form),Xususiyatlarni ko&#39;rish (moslashuv shakli orqali)
+apps/frappe/frappe/public/js/frappe/form/form.js,Maximum Attachment Limit for this record reached.,Ushbu yozuv uchun maksimal qo'shimcha cheklovga yetdi.
+apps/frappe/frappe/public/js/frappe/file_uploader/FileBrowser.vue,Search by filename or extension,Fayl nomi yoki kengaytmasi bo'yicha qidirish
+DocType: Notification,View Properties (via Customize Form),Xususiyatlarni ko'rish (moslashuv shakli orqali)
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on a file to select it.,Faylni tanlash uchun uni bosing.
 DocType: Note Seen By,Note Seen By,Eslatmalar
-apps/frappe/frappe/utils/password_strength.py,Try to use a longer keyboard pattern with more turns,Ko&#39;proq navbatlar bilan ko&#39;proq klaviatura naqshidan foydalanishga harakat qiling
+apps/frappe/frappe/utils/password_strength.py,Try to use a longer keyboard pattern with more turns,Ko'proq navbatlar bilan ko'proq klaviatura naqshidan foydalanishga harakat qiling
 ,LeaderBoard,LeaderBoard
 DocType: DocType,Default Sort Order,Odatiy tartiblash tartibi
 DocType: Address,Rajasthan,Rajasthan
 DocType: Email Template,Email Reply Help,Elektron pochta orqali javob berish yordami
-apps/frappe/frappe/core/doctype/report/report.js,Report Builder reports are managed directly by the report builder. Nothing to do.,Report Builder hisobotlari to&#39;g&#39;ridan-to&#39;g&#39;ri hisobot yaratuvchisi tomonidan boshqariladi. Qiladigan ish yo&#39;q.
+apps/frappe/frappe/core/doctype/report/report.js,Report Builder reports are managed directly by the report builder. Nothing to do.,Report Builder hisobotlari to'g'ridan-to'g'ri hisobot yaratuvchisi tomonidan boshqariladi. Qiladigan ish yo'q.
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Please verify your Email Address,E-pochta manzilingizni tasdiqlang
 apps/frappe/frappe/model/document.py,none of,hech kim
-apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Add Fields,Maydonlarni qo&#39;shish
+apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Add Fields,Maydonlarni qo'shish
 apps/frappe/frappe/public/js/frappe/views/communication.js,Send Me A Copy,Menga nusxa yuborish
 DocType: Dropbox Settings,App Secret Key,Ilova maxfiy kalit
 DocType: Webhook,on_submit,on_submit
 apps/frappe/frappe/config/website.py,Web Site,Veb-sayt
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0} cannot be set for Single types,{0} bir nechta turlari uchun sozlanmaydi
-DocType: Data Import,Data Import,Ma&#39;lumotlarni import qilish
+DocType: Data Import,Data Import,Ma'lumotlarni import qilish
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Configure Chart,Grafikni sozlash
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_viewers.js,{0} are currently viewing this document,{0} hozirda ushbu hujjatni tomosha qilmoqda
-DocType: ToDo,Assigned By Full Name,To&#39;liq nomi bilan tayinlangan
+DocType: ToDo,Assigned By Full Name,To'liq nomi bilan tayinlangan
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,{0} updated,{0} yangilandi
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Report cannot be set for Single types,Bir nechta turlari uchun hisobotni sozlab bo&#39;lmaydi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Report cannot be set for Single types,Bir nechta turlari uchun hisobotni sozlab bo'lmaydi
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Share URL,URLni ulash
 DocType: System Settings,Allow Consecutive Login Attempts ,Harakatlarga kirishga ruxsat berish
-apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,"To&#39;lov jarayonida xatolik yuz berdi. Iltimos, biz bilan bog&#39;laning."
+apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,"To'lov jarayonida xatolik yuz berdi. Iltimos, biz bilan bog'laning."
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} days ago,{0} kun oldin
 DocType: Email Account,Awaiting Password,Parolni kutish
 DocType: Address,Address Line 1,Manzil uchun 1-chi qator
@@ -919,70 +919,70 @@ apps/frappe/frappe/templates/emails/delete_data_confirmation.html, to your brows
 apps/frappe/frappe/utils/data.py,Cent,Cent
 ,Recorder,Yozuvchi
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Compose Email,E-pochtani tuzing
-apps/frappe/frappe/config/settings.py,"States for workflow (e.g. Draft, Approved, Cancelled).","Ish yuritish uchun davlatlar (masalan, loyiha, ma&#39;qullangan, bekor qilingan)."
+apps/frappe/frappe/config/settings.py,"States for workflow (e.g. Draft, Approved, Cancelled).","Ish yuritish uchun davlatlar (masalan, loyiha, ma'qullangan, bekor qilingan)."
 DocType: Print Settings,Allow Print for Draft,Taslak uchun chop etishga ruxsat berish
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Set Quantity,Miqdori belgilang
 apps/frappe/frappe/public/js/frappe/form/form.js,Submit this document to confirm,Tasdiqlash uchun ushbu hujjatni yuboring
 DocType: Contact,Unsubscribed,Obunani bekor qilish
-apps/frappe/frappe/config/users_and_permissions.py,Set custom roles for page and report,Sahifa va hisobot uchun maxsus rollarni o&#39;rnating
+apps/frappe/frappe/config/users_and_permissions.py,Set custom roles for page and report,Sahifa va hisobot uchun maxsus rollarni o'rnating
 DocType: Braintree Settings,Merchant ID,Savdo identifikatori
 apps/frappe/frappe/public/js/frappe/utils/rating_icons.html,Rating: ,Baholash:
 DocType: Address,Dadra and Nagar Haveli,Dadra va Nagar Xavel
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Attach Your Picture,Rasmingizni biriktiring
-apps/frappe/frappe/core/doctype/version/version_view.html,Row Values Changed,Satr qiymatlari o&#39;zgartirildi
-DocType: Workflow State,Stop,To&#39;xta
-DocType: Footer Item,Link to the page you want to open. Leave blank if you want to make it a group parent.,"Ochish kerakli sahifaga havola. Agar guruh ota-onasi bo&#39;lmoqchi bo&#39;lsangiz, bo&#39;sh qoldiring."
+apps/frappe/frappe/core/doctype/version/version_view.html,Row Values Changed,Satr qiymatlari o'zgartirildi
+DocType: Workflow State,Stop,To'xta
+DocType: Footer Item,Link to the page you want to open. Leave blank if you want to make it a group parent.,"Ochish kerakli sahifaga havola. Agar guruh ota-onasi bo'lmoqchi bo'lsangiz, bo'sh qoldiring."
 DocType: DocType,Is Single,Yagona
-apps/frappe/frappe/core/doctype/user/user.py,Sign Up is disabled,Ro&#39;yxatdan o&#39;tish o&#39;chirilgan
+apps/frappe/frappe/core/doctype/user/user.py,Sign Up is disabled,Ro'yxatdan o'tish o'chirilgan
 apps/frappe/frappe/email/queue.py,{0} has left the conversation in {1} {2},{0} suhbatni {1} {2}
-DocType: Access Log,Show Document,Hujjatni ko&#39;rsatish
+DocType: Access Log,Show Document,Hujjatni ko'rsatish
 DocType: Blogger,User ID of a Blogger,Bloggerning foydalanuvchi identifikatori
 apps/frappe/frappe/core/doctype/user/user.py,There should remain at least one System Manager,Eng kamida bitta tizim menejeri qolishi kerak
 DocType: GCalendar Account,Authorization Code,Avtorizatsiya kodi
 DocType: PayPal Settings,Mention transaction completion page URL,Jarayonni yakunlash sahifasining URL manzilini eslang
 DocType: Help Article,Expert,Mutaxassis
-DocType: Workflow State,circle-arrow-right,aylana-o&#39;q-o&#39;ng
+DocType: Workflow State,circle-arrow-right,aylana-o'q-o'ng
 DocType: Role Profile,Role Profile,Rolik profili
 apps/frappe/frappe/permissions.py,Document Type is not importable,Hujjat turini import qilib bo‘lmaydi
 DocType: LDAP Settings,LDAP Server Url,LDAP Server URL
-apps/frappe/frappe/public/js/frappe/form/form.js,Cannot open instance when its {0} is open,"{0} ochiq bo&#39;lsa, misolni ochib bo&#39;lmadi"
-apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Header HTML set from attachment {0},HTML sarlavhasi {0} qo&#39;shimchasidan olingan
+apps/frappe/frappe/public/js/frappe/form/form.js,Cannot open instance when its {0} is open,"{0} ochiq bo'lsa, misolni ochib bo'lmadi"
+apps/frappe/frappe/printing/doctype/letter_head/letter_head.py,Header HTML set from attachment {0},HTML sarlavhasi {0} qo'shimchasidan olingan
 apps/frappe/frappe/config/desktop.py,Customization,Shaxsiylashtirish
-DocType: LDAP Settings,Organizational Unit for Users,Foydalanuvchilar uchun tashkiliy bo&#39;lim
+DocType: LDAP Settings,Organizational Unit for Users,Foydalanuvchilar uchun tashkiliy bo'lim
 ,Transaction Log Report,Jurnal hisoboti hisoboti
 DocType: Custom DocPerm,Custom DocPerm,Maxsus DocPerm
 DocType: Newsletter,Send Unsubscribe Link,Obunani bekor qilish havolasini yuboring
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,There are some linked records which needs to be created before we can import your file. Do you want to create the following missing records automatically?,Faylingizni import qilishdan oldin yaratilishi kerak bo&#39;lgan ba&#39;zi bir-biriga bog&#39;langan yozuvlar mavjud. Quyidagi yo&#39;qolgan yozuvlarni avtomatik ravishda yaratmoqchimisiz?
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,There are some linked records which needs to be created before we can import your file. Do you want to create the following missing records automatically?,Faylingizni import qilishdan oldin yaratilishi kerak bo'lgan ba'zi bir-biriga bog'langan yozuvlar mavjud. Quyidagi yo'qolgan yozuvlarni avtomatik ravishda yaratmoqchimisiz?
 DocType: Access Log,Method,Boshqaruv
 DocType: Report,Script Report,Skript haqida hisobot
 DocType: OAuth Authorization Code,Scopes,Maydonlar
 DocType: About Us Settings,Company Introduction,Kompaniya Kirish
-DocType: User,Last Password Reset Date,So&#39;nggi parolni tiklash sanasi
+DocType: User,Last Password Reset Date,So'nggi parolni tiklash sanasi
 DocType: DocField,Length,Uzunligi
-apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Hujjatni tiklash yoki butunlay o&#39;chirib tashlash.
+apps/frappe/frappe/config/settings.py,Restore or permanently delete a document.,Hujjatni tiklash yoki butunlay o'chirib tashlash.
 apps/frappe/frappe/chat/doctype/chat_profile/chat_profile.py,Chat Profile for User {0} exists.,Foydalanuvchi uchun {0} chat profili mavjud.
 apps/frappe/frappe/public/js/frappe/social/components/PostSidebar.vue,Frequently Visited Links,Tez-tez tashrif buyuriladigan havolalar
 DocType: Notification,"To add dynamic subject, use jinja tags like
 
 <div><pre><code>{{ doc.name }} Delivered</code></pre></div>","Dinamik mavzuni qo'shish uchun, kabi jinja teglaridan foydalaning <div><pre> <code>{{ doc.name }} Delivered</code> </pre> </div>"
-apps/frappe/frappe/desk/search.py,Invalid Search Field {0},Qidiruv joyi {0} noto&#39;g&#39;ri
+apps/frappe/frappe/desk/search.py,Invalid Search Field {0},Qidiruv joyi {0} noto'g'ri
 DocType: User,Modules HTML,HTML modullari
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Allow Google Calendar Access,Google taqvimiga kirishga ruxsat bering
-DocType: Assignment Rule,Higher priority rule will be applied first,Avvaliga ustuvorlikning yuqoriroq qoidasi qo&#39;llaniladi
+DocType: Assignment Rule,Higher priority rule will be applied first,Avvaliga ustuvorlikning yuqoriroq qoidasi qo'llaniladi
 DocType: Email Account,"Track if your email has been opened by the recipient.
 <br>
-Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","E-pochtangiz qabul qiluvchi tomonidan ochilgan bo&#39;lsa, uni kuzatib boring. <br> Eslatma: Agar bir nechta alıcıya yuborgan bo&#39;lsangiz, 1 qabul qiluvchi elektron pochtani o&#39;qiysa ham, &quot;Ochilgan&quot;"
+Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered ""Opened""","E-pochtangiz qabul qiluvchi tomonidan ochilgan bo'lsa, uni kuzatib boring. <br> Eslatma: Agar bir nechta alıcıya yuborgan bo'lsangiz, 1 qabul qiluvchi elektron pochtani o'qiysa ham, &quot;Ochilgan&quot;"
 apps/frappe/frappe/public/js/frappe/ui/field_group.js,Missing Values Required,Missing qiymatlar kerak
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Allow Google Contacts Access,Google Kontaktlarga kirishga ruxsat bering
 DocType: Data Migration Connector,Frappe,Frappe
-apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Unread,O&#39;qilmagan deb belgilash
+apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Unread,O'qilmagan deb belgilash
 DocType: Activity Log,Operation,Operatsiya
-DocType: Customize Form,Change Label (via Custom Translation),Yorliqni o&#39;zgartirish (maxsus tarjima orqali)
-apps/frappe/frappe/share.py,No permission to {0} {1} {2},{0} {1} {2} uchun ruxsat yo&#39;q
+DocType: Customize Form,Change Label (via Custom Translation),Yorliqni o'zgartirish (maxsus tarjima orqali)
+apps/frappe/frappe/share.py,No permission to {0} {1} {2},{0} {1} {2} uchun ruxsat yo'q
 DocType: Address,Permanent,Doimiy
-apps/frappe/frappe/public/js/frappe/form/workflow.js,Note: Other permission rules may also apply,Eslatma: Boshqa ruxsat berish qoidalari ham qo&#39;llanilishi mumkin
+apps/frappe/frappe/public/js/frappe/form/workflow.js,Note: Other permission rules may also apply,Eslatma: Boshqa ruxsat berish qoidalari ham qo'llanilishi mumkin
 DocType: Assignment Rule,Unassign Condition,Vaziyatni belgilash
-apps/frappe/frappe/templates/emails/print_link.html,View this in your browser,Buni brauzeringizda ko&#39;ring
+apps/frappe/frappe/templates/emails/print_link.html,View this in your browser,Buni brauzeringizda ko'ring
 DocType: DocType,Parent Field (Tree),Ota-ona maydoni (daraxti)
 DocType: DocType,Search Fields,Maydonlarni qidirish
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,Sync Contacts,Kontaktlarni sinxronlash
@@ -996,15 +996,15 @@ DocType: Social Login Key,Enable Social Login,Ijtimoiy kirishni yoqish
 DocType: Data Import Beta,Warnings,Ogohlantirishlar
 DocType: Communication,Event,Voqealar
 apps/frappe/frappe/public/js/frappe/views/communication.js,"On {0}, {1} wrote:","{0} da, {1} da shunday deb yozgan edi:"
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Cannot delete standard field. You can hide it if you want,"Standart maydonni o&#39;chirib bo&#39;lmaydi. Agar xohlasangiz, uni yashirishingiz mumkin"
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Cannot delete standard field. You can hide it if you want,"Standart maydonni o'chirib bo'lmaydi. Agar xohlasangiz, uni yashirishingiz mumkin"
 DocType: Top Bar Item,For top bar,Yuqori satr uchun
 DocType: Social Login Key,Auth URL Data,URL raqamini aniqlang
-apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,Zaxira uchun navbatga qo&#39;yildi. Yuklab olish havolasiga ega bo&#39;lgan elektron maktub olasiz
-apps/frappe/frappe/utils/bot.py,Could not identify {0},{0} ni aniqlab bo&#39;lmadi
+apps/frappe/frappe/desk/page/backups/backups.py,Queued for backup. You will receive an email with the download link,Zaxira uchun navbatga qo'yildi. Yuklab olish havolasiga ega bo'lgan elektron maktub olasiz
+apps/frappe/frappe/utils/bot.py,Could not identify {0},{0} ni aniqlab bo'lmadi
 DocType: Address,Address,Manzil
-apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,To&#39;lov amalga oshmadi
+apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Payment Failed,To'lov amalga oshmadi
 DocType: Print Settings,In points. Default is 9.,Ballarda. Odatiy 9.
-DocType: OAuth Client,Redirect URIs,URI&#39;larni qayta yo&#39;naltirish
+DocType: OAuth Client,Redirect URIs,URI'larni qayta yo'naltirish
 DocType: LDAP Settings,StartTLS,StartTLS
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Submiting {0},{0}
 DocType: Workflow State,heart,yurak
@@ -1015,33 +1015,33 @@ DocType: S3 Backup Settings,Bucket,Kepçe
 apps/frappe/frappe/public/js/frappe/ui/capture.js,Unable to load camera.,Kamera yuklanmadi.
 apps/frappe/frappe/core/doctype/user/user.py,Welcome email sent,Xush kelibsiz elektron pochta
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Let's prepare the system for first use.,Dastlabki ishlatish uchun tizimni tayyorlaylik.
-apps/frappe/frappe/core/doctype/user/user.py,Already Registered,Siz allaqachon ro&#39;yxatdan o&#39;tgansiz
+apps/frappe/frappe/core/doctype/user/user.py,Already Registered,Siz allaqachon ro'yxatdan o'tgansiz
 DocType: System Settings,Float Precision,Float Precision
 DocType: Notification,Sender Email,Yuboruvchi Email
-apps/frappe/frappe/core/doctype/page/page.py,Only Administrator can edit,Faqat ma&#39;mur tahrir qilishi mumkin
+apps/frappe/frappe/core/doctype/page/page.py,Only Administrator can edit,Faqat ma'mur tahrir qilishi mumkin
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Please select applicable Doctypes,"Iltimos, tegishli hujjatlarni tanlang"
-DocType: DocType,Editable Grid,O&#39;zgartirishlar paneli
+DocType: DocType,Editable Grid,O'zgartirishlar paneli
 DocType: Property Setter,Property Setter,Xususiyat sozlagichi
 DocType: Web Form,Allow Print,Bosib chiqarishga ruxsat berish
 DocType: Communication,Clicked,Tugatgan
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Unfollow,Bekor qilish
-apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},&#39;{0}&#39; {1} uchun ruxsat yo&#39;q
-apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Jo&#39;natish rejalashtirilmoqda
+apps/frappe/frappe/public/js/frappe/form/form.js,No permission to '{0}' {1},'{0}' {1} uchun ruxsat yo'q
+apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Scheduled to send,Jo'natish rejalashtirilmoqda
 DocType: DocType,Track Seen,Kuzatib boring
 DocType: Dropbox Settings,File Backup,Faylni zaxiralash
 DocType: Kanban Board Column,orange,apelsin
 apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Hech qanday {0} topilmadi
-apps/frappe/frappe/config/customization.py,Add custom forms.,Maxsus shakllar qo&#39;shing.
+apps/frappe/frappe/config/customization.py,Add custom forms.,Maxsus shakllar qo'shing.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {2} da {1}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ushbu hujjatni taqdim etdi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Sozlash> Foydalanuvchi ruxsati
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Tizim oldindan belgilangan ko&#39;plab rollarni ta&#39;minlaydi. Yaxshiroq ruxsatlarni o&#39;rnatish uchun yangi rollarni qo&#39;shishingiz mumkin.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Tizim oldindan belgilangan ko'plab rollarni ta'minlaydi. Yaxshiroq ruxsatlarni o'rnatish uchun yangi rollarni qo'shishingiz mumkin.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
 DocType: Data Migration Run,Trigger Name,Tetik nomi
 apps/frappe/frappe/public/js/frappe/desk.js,Domains,Domenlar
 DocType: Blog Category,Blog Category,Mazkur foydalanuvchiga yozish kategoriyasi
-apps/frappe/frappe/model/mapper.py,Cannot map because following condition fails: ,"Quyidagi shart bajarilmasa, xaritani topib bo&#39;lmaydi:"
+apps/frappe/frappe/model/mapper.py,Cannot map because following condition fails: ,"Quyidagi shart bajarilmasa, xaritani topib bo'lmaydi:"
 DocType: Role Permission for Page and Report,Roles HTML,HTML rollari
 apps/frappe/frappe/website/doctype/website_settings/website_settings.js,Select a Brand Image first.,Avval Tovar tasvirini tanlang.
 DocType: Dashboard Chart Source,Dashboard Chart Source,Dashboard jadvalining manbasi
@@ -1051,84 +1051,84 @@ DocType: Kanban Board Column,Blue,Moviy
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customizations will be removed. Please confirm.,"Barcha sozlashlar olib tashlanadi. Iltimos, tasdiqlang."
 DocType: Page,Page HTML,HTML-sahifa
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,Xato qatorlarni eksport qilish
-apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Guruh nomi bo&#39;sh bo&#39;lishi mumkin emas.
+apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,Guruh nomi bo'sh bo'lishi mumkin emas.
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,Boshqa tugunlarni faqat &quot;Guruh&quot; tipidagi tugunlar ostida yaratish mumkin
 DocType: SMS Parameter,Header,Sarlavha
-apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Noma&#39;lum ustun: {0}
-DocType: Notification Recipient,Email By Role,Xatga ko&#39;ra elektron pochta
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Nothing to update,Yangilanadigan narsa yo&#39;q
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Users with role {0}:,{0} roli bo&#39;lgan foydalanuvchilar:
+apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},Noma'lum ustun: {0}
+DocType: Notification Recipient,Email By Role,Xatga ko'ra elektron pochta
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Nothing to update,Yangilanadigan narsa yo'q
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Users with role {0}:,{0} roli bo'lgan foydalanuvchilar:
 DocType: Print Format,Custom Format,Maxsus format
 DocType: Workflow State,random,tasodifiy
 DocType: Newsletter Email Group,Newsletter Email Group,Elektron pochta guruhi
 DocType: Braintree Settings,Integrations,Integratsiya
-DocType: DocField,Section Break,Bo&#39;limni ajratish
+DocType: DocField,Section Break,Bo'limni ajratish
 DocType: Address,Warehouse,QXI
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Font Styles,Shrift uslublari
 DocType: Address,Other Territory,Boshqa hudud
 ,Messages,Xabarlar
 apps/frappe/frappe/config/website.py,Portal,Portal
 DocType: Email Account,Use Different Email Login ID,Turli E-pochtada kirish identifikatoridan foydalaning
-apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,Ishlash uchun so&#39;rovni ko&#39;rsatish kerak
-apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Server braintree konfiguratsiyasi bilan bog&#39;liq muammodir. Xavotir olmang, mag&#39;lubiyatsiz bo&#39;lsa, hisobingiz hisobingizga qaytariladi."
+apps/frappe/frappe/desk/query_report.py,Must specify a Query to run,Ishlash uchun so'rovni ko'rsatish kerak
+apps/frappe/frappe/integrations/doctype/braintree_settings/braintree_settings.py,"There seems to be an issue with the server's braintree configuration. Don't worry, in case of failure, the amount will get refunded to your account.","Server braintree konfiguratsiyasi bilan bog'liq muammodir. Xavotir olmang, mag'lubiyatsiz bo'lsa, hisobingiz hisobingizga qaytariladi."
 apps/frappe/frappe/www/me.html,Manage Third Party Apps,Uchinchi tomon dasturlarini boshqarish
-DocType: Website Settings,Route Redirects,Yo&#39;nalishni yo&#39;naltirish
+DocType: Website Settings,Route Redirects,Yo'nalishni yo'naltirish
 apps/frappe/frappe/config/settings.py,"Language, Date and Time settings","Til, Sana va Vaqt sozlamalari"
 DocType: User Email,User Email,Foydalanuvchi e-pochtasi
 DocType: Assignment Rule Day,Saturday,Shanba
 DocType: User,Represents a User in the system.,Tizimda foydalanuvchilarni bildiradi.
-DocType: List View Setting,Disable Auto Refresh,Avtomatik yangilashni o&#39;chiring
+DocType: List View Setting,Disable Auto Refresh,Avtomatik yangilashni o'chiring
 DocType: Comment,Label,Yorliq
 apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed.",{1} ga tayinlangan {0} vazifasi yopildi.
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please close this window,"Iltimos, ushbu oynani yoping"
 DocType: Print Format,Print Format Type,Chop etish formati turi
-DocType: Newsletter,A Lead with this Email Address should exist,Ushbu elektron pochta manzili bilan qo&#39;rg&#39;oshin mavjud bo&#39;lishi kerak
+DocType: Newsletter,A Lead with this Email Address should exist,Ushbu elektron pochta manzili bilan qo'rg'oshin mavjud bo'lishi kerak
 apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Open Source Applications for the Web,Internet uchun ommaviy dasturiy ilovalar
-DocType: Event,Call,Qo&#39;ng&#39;iroq qiling
-apps/frappe/frappe/website/doctype/website_theme/website_theme.js,"Add the name of a ""Google Web Font"" e.g. ""Open Sans""","&quot;Google Veb Shrift&quot; nomini qo&#39;shing, masalan &quot;Ochiq Sans&quot;"
+DocType: Event,Call,Qo'ng'iroq qiling
+apps/frappe/frappe/website/doctype/website_theme/website_theme.js,"Add the name of a ""Google Web Font"" e.g. ""Open Sans""","&quot;Google Veb Shrift&quot; nomini qo'shing, masalan &quot;Ochiq Sans&quot;"
 apps/frappe/frappe/public/js/frappe/request.js,Request Timed Out,Vaqtni talab qilish muddati
-apps/frappe/frappe/config/settings.py,Enable / Disable Domains,Domendlarni yoqish / o&#39;chirish
+apps/frappe/frappe/config/settings.py,Enable / Disable Domains,Domendlarni yoqish / o'chirish
 DocType: Role Permission for Page and Report,Allow Roles,Rollarga ruxsat berish
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records out of {1}.,{1} dan {0} yozuvlar muvaffaqiyatli import qilindi.
-DocType: Assignment Rule,"Simple Python Expression, Example: Status in (""Invalid"")","Oddiy Python iborasi, misol: in (&quot;Noto&#39;g&#39;ri&quot;) holati"
-DocType: User,Last Active,So&#39;nggi Foydalanuvchi bilan
+DocType: Assignment Rule,"Simple Python Expression, Example: Status in (""Invalid"")","Oddiy Python iborasi, misol: in (&quot;Noto'g'ri&quot;) holati"
+DocType: User,Last Active,So'nggi Foydalanuvchi bilan
 DocType: Email Account,SMTP Settings for outgoing emails,Chiqish e-pochta xabarlari uchun SMTP sozlamalari
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,choose an,tanlang
-DocType: Data Export,Filter List,Filtr ro&#39;yxati
+DocType: Data Export,Filter List,Filtr ro'yxati
 DocType: Data Export,Excel,Excel
 DocType: Email Account,Auto Reply Message,Avtomatik javob yozish
 DocType: Data Migration Mapping,Condition,Vaziyat
 apps/frappe/frappe/utils/data.py,{0} hours ago,{0} soat oldin
 apps/frappe/frappe/utils/data.py,1 month ago,1 oy oldin
-apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Not Specified,Ko&#39;rsatilmagan
+apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Not Specified,Ko'rsatilmagan
 DocType: Contact,User ID,foydalanuvchi IDsi
 DocType: Communication,Sent,Yuborildi
 DocType: Address,Kerala,Kerala
-apps/frappe/frappe/public/js/frappe/desk.js,Administration,Ma&#39;muriyat
+apps/frappe/frappe/public/js/frappe/desk.js,Administration,Ma'muriyat
 DocType: User,Simultaneous Sessions,Sinxron sessiyalar
-DocType: Social Login Key,Client Credentials,Mijozning hisobga olish ma&#39;lumotlari
+DocType: Social Login Key,Client Credentials,Mijozning hisobga olish ma'lumotlari
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Open a module or tool,Moduli yoki vositani oching
 DocType: Communication,Delivery Status,Etkazib berish holati
 DocType: Module Def,App Name,Ilova nomi
-DocType: Workflow,"Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)","Jarayonning ishchi oqim holatini ifodalovchi maydon (maydon mavjud bo&#39;lmasa, yangi maxfiy maxsus maydon yaratiladi)"
-DocType: Help Article,Knowledge Base Contributor,Ma&#39;lumotlar bazasi ishtirokchisi
-DocType: Communication,Sent Read Receipt,Qabulnoma o&#39;qildi
+DocType: Workflow,"Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)","Jarayonning ishchi oqim holatini ifodalovchi maydon (maydon mavjud bo'lmasa, yangi maxfiy maxsus maydon yaratiladi)"
+DocType: Help Article,Knowledge Base Contributor,Ma'lumotlar bazasi ishtirokchisi
+DocType: Communication,Sent Read Receipt,Qabulnoma o'qildi
 DocType: Email Queue,Unsubscribe Method,Obunani bekor qilish usuli
-DocType: GSuite Templates,Related DocType,Bilan bog&#39;liq DocType
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit to add content,Kontent qo&#39;shish uchun tahrirlash
+DocType: GSuite Templates,Related DocType,Bilan bog'liq DocType
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit to add content,Kontent qo'shish uchun tahrirlash
 apps/frappe/frappe/public/js/frappe/views/communication.js,Select Languages,Tillarni tanlang
-apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Card Details,Karta ma&#39;lumotlari
-apps/frappe/frappe/__init__.py,No permission for {0},{0} uchun ruxsat yo&#39;q
+apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Card Details,Karta ma'lumotlari
+apps/frappe/frappe/__init__.py,No permission for {0},{0} uchun ruxsat yo'q
 DocType: DocType,Advanced,Murakkab
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Seems API Key or API Secret is wrong !!!,API kaliti yoki API maxfiyligi noto&#39;g&#39;ri deb o&#39;ylaydi !!!
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Seems API Key or API Secret is wrong !!!,API kaliti yoki API maxfiyligi noto'g'ri deb o'ylaydi !!!
 apps/frappe/frappe/templates/emails/auto_reply.html,Reference: {0} {1},Malumot: {0} {1}
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Mrs,Honim
 DocType: File,Attached To Name,Ismga biriktirilgan
 DocType: Address,Address Type,Manzil turi
-apps/frappe/frappe/email/receive.py,Invalid User Name or Support Password. Please rectify and try again.,"Foydalanuvchi nomi yoki qo&#39;llab-quvvatlash paroli noto&#39;g&#39;ri. Iltimos, tuzatish va qayta urinib ko&#39;ring."
+apps/frappe/frappe/email/receive.py,Invalid User Name or Support Password. Please rectify and try again.,"Foydalanuvchi nomi yoki qo'llab-quvvatlash paroli noto'g'ri. Iltimos, tuzatish va qayta urinib ko'ring."
 DocType: Email Account,Yahoo Mail,Yahoo pochtasi
 apps/frappe/frappe/email/doctype/notification/notification.py,Error in Notification,Bildirishnomada xato
-DocType: Access Log,Log Data,Ma&#39;lumotlar jurnali
+DocType: Access Log,Log Data,Ma'lumotlar jurnali
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Madam,Madam
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Criticize,Tanqid qiling
 apps/frappe/frappe/desk/page/activity/activity_row.html,Updated {0}: {1},Yangilangan {0}: {1}
@@ -1138,66 +1138,66 @@ apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox access is approved!,Dropboxga ruxsat tasdiqlandi!
 DocType: Customize Form,Enter Form Type,Shakli turini kiriting
 DocType: Google Drive,Authorize Google Drive Access,Google Drive kirishiga ruxsat bering
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Missing parameter Kanban Board Name,Yo&#39;qotilgan parametr Kanban Kengashi nomi
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Missing parameter Kanban Board Name,Yo'qotilgan parametr Kanban Kengashi nomi
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_stat.html,No records tagged.,Hech qanday yozuv yozilmagan.
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Field,Joyni o&#39;chirish
-apps/frappe/frappe/public/js/frappe/request.js,You are not connected to Internet. Retry after sometime.,Siz Internetga ulanmagansiz. Birozdan so&#39;ng qayta urinib ko&#39;ring.
-apps/frappe/frappe/public/js/frappe/form/form.js,"Allowing DocType, DocType. Be careful!","DocType, DocType ruxsat berish. Ehtiyot bo&#39;ling!"
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Field,Joyni o'chirish
+apps/frappe/frappe/public/js/frappe/request.js,You are not connected to Internet. Retry after sometime.,Siz Internetga ulanmagansiz. Birozdan so'ng qayta urinib ko'ring.
+apps/frappe/frappe/public/js/frappe/form/form.js,"Allowing DocType, DocType. Be careful!","DocType, DocType ruxsat berish. Ehtiyot bo'ling!"
 apps/frappe/frappe/config/core.py,"Customized Formats for Printing, Email","Chop etish uchun maxsus formatlar, elektron pochta"
 apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Sum of {0},Jami {0}
 apps/frappe/frappe/public/js/frappe/desk.js,Updated To New Version,Yangi versiyaga yangilandi
-DocType: Custom Field,Depends On,Ga bog&#39;liq
+DocType: Custom Field,Depends On,Ga bog'liq
 DocType: Kanban Board Column,Green,Yashil rangda
-DocType: Custom DocPerm,Additional Permissions,Qo&#39;shimcha ruxsatlar
+DocType: Custom DocPerm,Additional Permissions,Qo'shimcha ruxsatlar
 DocType: Email Account,Always use Account's Email Address as Sender,Yuboruvchi sifatida doimo Hisob Email manzilidan foydalaning
 apps/frappe/frappe/templates/includes/comments/comments.html,Login to comment,Fikr bildirish uchun kirish
-apps/frappe/frappe/core/doctype/data_import/importer.py,Start entering data below this line,Ushbu satrning ostidagi ma&#39;lumotlarni kiritishni boshlang
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed values for {0},{0} uchun o&#39;zgargan qiymatlar
+apps/frappe/frappe/core/doctype/data_import/importer.py,Start entering data below this line,Ushbu satrning ostidagi ma'lumotlarni kiritishni boshlang
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed values for {0},{0} uchun o'zgargan qiymatlar
 apps/frappe/frappe/email/doctype/email_account/email_account.py,"Email ID must be unique, Email Account already exists \
-				for {0}","Email identifikatori noyob bo&#39;lishi kerak, Email qaydnomasi allaqachon mavjud \ {0} uchun"
+				for {0}","Email identifikatori noyob bo'lishi kerak, Email qaydnomasi allaqachon mavjud \ {0} uchun"
 DocType: Workflow State,retweet,retweet
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Customize...,Moslash ...
-DocType: Print Format,Align Labels to the Right,Yorliqlarni o&#39;ngga tekislang
-DocType: Assignment Rule,Disabled,O&#39;chirib qo&#39;yildi
+DocType: Print Format,Align Labels to the Right,Yorliqlarni o'ngga tekislang
+DocType: Assignment Rule,Disabled,O'chirib qo'yildi
 DocType: File,Uploaded To Dropbox,Dropboxga yuklangan
-DocType: Workflow State,eye-close,ko&#39;zni yopish
-apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For more information, {0}.",Qo&#39;shimcha ma&#39;lumot uchun {0}.
+DocType: Workflow State,eye-close,ko'zni yopish
+apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,"For more information, {0}.",Qo'shimcha ma'lumot uchun {0}.
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,Repeats {0},{0} takrorlaydi
 DocType: OAuth Provider Settings,OAuth Provider Settings,OAuth Provider sozlamalari
-DocType: Review Level,Review Points,Ko&#39;rib chiqish nuqtalari
+DocType: Review Level,Review Points,Ko'rib chiqish nuqtalari
 DocType: Workflow Document State,Workflow Action is not created for optional states,Ish oqimi harakati ixtiyoriy holatlar uchun yaratilmagan
 DocType: Address,City/Town,Shahar / shahar
 DocType: Data Migration Connector,Connector Name,Ulagichi nomi
 DocType: Address,Is Your Company Address,Sizning kompaniyangiz manzili
 DocType: Energy Point Log,Social,Ijtimoiy
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google Calendar - {0}, xato kodi {1} uchun taqvim yaratib bo&#39;lmadi."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not create Calendar for {0}, error code {1}.","Google Calendar - {0}, xato kodi {1} uchun taqvim yaratib bo'lmadi."
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Editing Row,Satrni tahrirlash
-DocType: Workflow Action Master,Workflow Action Master,Ish xarlari bo&#39;yicha master
+DocType: Workflow Action Master,Workflow Action Master,Ish xarlari bo'yicha master
 DocType: Custom Field,Field Type,Er turi
 apps/frappe/frappe/utils/data.py,only.,faqatgina.
 DocType: Route History,Route History,Marshrut tarixi
 apps/frappe/frappe/social/doctype/energy_point_settings/energy_point_settings.js,Give Review Points,Sharh ochkolarini bering
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}.","Google Taqvimi - Google kontaktlariga {0}, xato kodi {1} joylashtirilmadi."
-apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,OTP maxfiyligi faqat ma&#39;mur tomonidan tiklanadi.
-apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,Siz bilan bog&#39;langan yillardan qoching.
+apps/frappe/frappe/core/doctype/user/user.py,OTP secret can only be reset by the Administrator.,OTP maxfiyligi faqat ma'mur tomonidan tiklanadi.
+apps/frappe/frappe/utils/password_strength.py,Avoid years that are associated with you.,Siz bilan bog'langan yillardan qoching.
 apps/frappe/frappe/config/users_and_permissions.py,Restrict user for specific document,Muayyan hujjat uchun foydalanuvchini cheklash
 DocType: GSuite Templates,GSuite Templates,GSuite Shablonlar
 apps/frappe/frappe/utils/goal.py,Goal,Maqsad
-apps/frappe/frappe/email/receive.py,Invalid Mail Server. Please rectify and try again.,"Pochta serveri noto&#39;g&#39;ri. Iltimos, tuzatish va qayta urinib ko&#39;ring."
+apps/frappe/frappe/email/receive.py,Invalid Mail Server. Please rectify and try again.,"Pochta serveri noto'g'ri. Iltimos, tuzatish va qayta urinib ko'ring."
 DocType: DocField,"For Links, enter the DocType as range.
-For Select, enter list of Options, each on a new line.",Linklar uchun DocType ni oralig&#39;i sifatida kiriting. Tanlash uchun Options ni har bir yangi satrda kiriting.
+For Select, enter list of Options, each on a new line.",Linklar uchun DocType ni oralig'i sifatida kiriting. Tanlash uchun Options ni har bir yangi satrda kiriting.
 DocType: Workflow State,film,film
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Sync Calendar,Taqvimni sinxronlash
-apps/frappe/frappe/model/db_query.py,No permission to read {0},{0} ni o&#39;qish uchun ruxsat yo&#39;q
+apps/frappe/frappe/model/db_query.py,No permission to read {0},{0} ni o'qish uchun ruxsat yo'q
 apps/frappe/frappe/config/desktop.py,Tools,Asboblar
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Include indentation,Shriftni qo&#39;shing
-apps/frappe/frappe/utils/password_strength.py,Avoid recent years.,So&#39;nggi yillardan qoching.
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Include indentation,Shriftni qo'shing
+apps/frappe/frappe/utils/password_strength.py,Avoid recent years.,So'nggi yillardan qoching.
 apps/frappe/frappe/templates/includes/login/login.js,Verification,Tasdiqlash
-apps/frappe/frappe/utils/nestedset.py,Multiple root nodes not allowed.,Ko&#39;p ildizli tugunlarga ruxsat berilmaydi.
-DocType: Note,"If enabled, users will be notified every time they login. If not enabled, users will only be notified once.","Agar yoqilgan bo&#39;lsa, foydalanuvchilar har safar kirganlarida ularga xabar qilinadi. Agar yoqilmagan bo&#39;lsa, foydalanuvchilarga faqat bir marta xabar qilinadi."
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid {0} condition,{0} sharti noto&#39;g&#39;ri
-DocType: OAuth Client,"If checked, users will not see the Confirm Access dialog.","Agar belgilansa, foydalanuvchilar kirishni tasdiqlash dialogini ko&#39;rmaydilar."
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} record deleted,{0} yozuv o&#39;chirildi
+apps/frappe/frappe/utils/nestedset.py,Multiple root nodes not allowed.,Ko'p ildizli tugunlarga ruxsat berilmaydi.
+DocType: Note,"If enabled, users will be notified every time they login. If not enabled, users will only be notified once.","Agar yoqilgan bo'lsa, foydalanuvchilar har safar kirganlarida ularga xabar qilinadi. Agar yoqilmagan bo'lsa, foydalanuvchilarga faqat bir marta xabar qilinadi."
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid {0} condition,{0} sharti noto'g'ri
+DocType: OAuth Client,"If checked, users will not see the Confirm Access dialog.","Agar belgilansa, foydalanuvchilar kirishni tasdiqlash dialogini ko'rmaydilar."
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} record deleted,{0} yozuv o'chirildi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"tag name..., e.g. #tag","yorliq nomi ..., masalan #tag"
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Keyboard Shortcuts,Klaviatura yorliqlari
 DocType: Post,Comments,Sharhlar
@@ -1208,35 +1208,35 @@ apps/frappe/frappe/www/login.html,Forgot Password?,Parolni unutdingizmi?
 DocType: System Settings,yyyy-mm-dd,yyyy-mm-dd
 apps/frappe/frappe/desk/report/todo/todo.py,ID,ID
 apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Server Error,Serverda xato
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,See all past reports.,O&#39;tgan barcha hisobotlarni ko&#39;rib chiqing.
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,See all past reports.,O'tgan barcha hisobotlarni ko'rib chiqing.
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Login Id is required,Kirish identifikatori talab qilinadi
 DocType: Website Slideshow,Website Slideshow,Sayt Slaydshou
-apps/frappe/frappe/core/page/dashboard/dashboard.js,No Data,Ma&#39;lumot yo&#39;q
+apps/frappe/frappe/core/page/dashboard/dashboard.js,No Data,Ma'lumot yo'q
 DocType: Website Settings,"Link that is the website home page. Standard Links (index, login, products, blog, about, contact)","Ushbu veb-saytning asosiy sahifasi. Foydalanuvchi bilan aloqa (katalog, kirish, mahsulotlar, blog, haqida, aloqa)"
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Authentication failed while receiving emails from Email Account {0}. Message from server: {1},{0} e-pochta qayd yozuvidan e-pochtalarni olishda autentifikatsiya amalga oshmadi. Serverdan xabar: {1}
 DocType: User,Banner Image,Banner Image
 DocType: Custom Field,Custom Field,Maxsus maydon
-apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which date field must be checked,Iltimos qaysi sana maydonini tekshirish kerakligini ko&#39;rsating
-DocType: Custom DocPerm,Set User Permissions,Foydalanuvchi ruxsatlarini o&#39;rnatish
+apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which date field must be checked,Iltimos qaysi sana maydonini tekshirish kerakligini ko'rsating
+DocType: Custom DocPerm,Set User Permissions,Foydalanuvchi ruxsatlarini o'rnatish
 DocType: Email Account,Email Account Name,E-pochta hisobi nomi
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Something went wrong while generating dropbox access token. Please check error log for more details.,Dropbox kirish belgisini yaratishda muammo yuz berdi. Batafsil ma&#39;lumot uchun xato jurnalini tekshiring.
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Something went wrong while generating dropbox access token. Please check error log for more details.,Dropbox kirish belgisini yaratishda muammo yuz berdi. Batafsil ma'lumot uchun xato jurnalini tekshiring.
 DocType: File,old_parent,old_parent
 apps/frappe/frappe/config/desk.py,"Newsletters to contacts, leads.","Kontaktlar axborotnomasi, olib boradi."
 DocType: Email Account,"e.g. ""Support"", ""Sales"", ""Jerry Yang""","&quot;Yordam&quot;, &quot;Sotuv&quot;, &quot;Jerri Yang&quot;"
-apps/frappe/frappe/twofactor.py,Incorrect Verification code,Noto&#39;g&#39;ri tasdiqlash kodi
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,Google Contacts Integration o&#39;chirilgan.
-DocType: Assignment Rule,Description,Ta&#39;rif
+apps/frappe/frappe/twofactor.py,Incorrect Verification code,Noto'g'ri tasdiqlash kodi
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts Integration is disabled.,Google Contacts Integration o'chirilgan.
+DocType: Assignment Rule,Description,Ta'rif
 DocType: Print Settings,Repeat Header and Footer in PDF,PDF-da bosh va pastki tugmani takrorlang
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Failure,Muvaffaqiyatsiz
 DocType: Address Template,Is Default,Standart
 DocType: Data Migration Connector,Connector Type,Ulagich turi
-apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py,Column Name cannot be empty,Ustun nomi bo&#39;sh bo&#39;lishi mumkin emas
+apps/frappe/frappe/desk/doctype/kanban_board/kanban_board.py,Column Name cannot be empty,Ustun nomi bo'sh bo'lishi mumkin emas
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Error while connecting to email account {0},{0} elektron pochta hisobiga ulanishda xatolik yuz berdi
 DocType: Workflow State,fast-forward,tez oldinga
 DocType: Communication,Communication,Aloqa
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,"Check columns to select, drag to set order.","Tanlash uchun ustunlarni tekshiring, tartibni o&#39;rnatish uchun harakatlantiring."
-apps/frappe/frappe/templates/emails/new_message.html,Login and view in Browser,Brauzerda kirish va ko&#39;rish
-apps/frappe/frappe/core/doctype/page/page.js,Go to {0} Page,{0} sahifasiga o&#39;ting
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,"Check columns to select, drag to set order.","Tanlash uchun ustunlarni tekshiring, tartibni o'rnatish uchun harakatlantiring."
+apps/frappe/frappe/templates/emails/new_message.html,Login and view in Browser,Brauzerda kirish va ko'rish
+apps/frappe/frappe/core/doctype/page/page.js,Go to {0} Page,{0} sahifasiga o'ting
 DocType: LDAP Settings,Password for Base DN,Base DN uchun parol
 apps/frappe/frappe/core/doctype/version/version_view.html,Table Field,Jadval maydoni
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Columns based on,Asoslangan ustunlar
@@ -1244,54 +1244,54 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Importing 
 DocType: Workflow State,move,harakatlaning
 apps/frappe/frappe/model/document.py,Action Failed,Amal bajarilmadi
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,For User,Foydalanuvchi uchun
-DocType: View Log,View log,Jurnalni ko&#39;rish
+DocType: View Log,View log,Jurnalni ko'rish
 DocType: Address,Assam,Assam
 apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,← Back to upload files,Upload Fayllarni yuklashga qaytish
-apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Outgoing email account not correct,Chiquvchi elektron pochta hisoboti to&#39;g&#39;ri emas
+apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Outgoing email account not correct,Chiquvchi elektron pochta hisoboti to'g'ri emas
 DocType: Transaction Log,Chaining Hash,Chaqiriladigan xash
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,E-pochta manzilingizni belgilang
-DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Agar foydalanuvchining roli tekshirilsa, foydalanuvchi &quot;tizim foydalanuvchisi&quot; bo&#39;ladi. &quot;Tizim foydalanuvchisi&quot; stolga kirish huquqiga ega"
+DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Agar foydalanuvchining roli tekshirilsa, foydalanuvchi &quot;tizim foydalanuvchisi&quot; bo'ladi. &quot;Tizim foydalanuvchisi&quot; stolga kirish huquqiga ega"
 DocType: System Settings,Date and Number Format,Sana va raqam formati
 apps/frappe/frappe/model/document.py,one of,bittasi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Sozlash> Formani sozlash
-apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Bir onni tekshirib ko&#39;rish
-apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Teglarni ko&#39;rsatish
+apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Bir onni tekshirib ko'rish
+apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Teglarni ko'rsatish
 DocType: DocField,HTML Editor,HTML tahrirlovchisi
-DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Agar qattiq foydalanuvchi ruxsatini qo&#39;llash va foydalanuvchining ruxsatnomasi foydalanuvchi uchun DocType uchun belgilansa, u holda bog&#39;ning qiymati bo&#39;sh bo&#39;lgan barcha hujjatlar ushbu foydalanuvchi uchun ko&#39;rsatilmaydi."
+DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User","Agar qattiq foydalanuvchi ruxsatini qo'llash va foydalanuvchining ruxsatnomasi foydalanuvchi uchun DocType uchun belgilansa, u holda bog'ning qiymati bo'sh bo'lgan barcha hujjatlar ushbu foydalanuvchi uchun ko'rsatilmaydi."
 DocType: Address,Billing,Billing
 DocType: Email Queue,Not Sent,Yuborilmadi
 DocType: Web Form,Actions,Amallar
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Sozlash> Foydalanuvchi
 DocType: Workflow State,align-justify,tekislang
-DocType: User,Middle Name (Optional),O&#39;rtacha nomi (majburiy emas)
+DocType: User,Middle Name (Optional),O'rtacha nomi (majburiy emas)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ruxsat berilmadi
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,No Google Calendar Event to sync.,Sinxronlanadigan Google Taqvim hodisasi yo&#39;q.
-apps/frappe/frappe/public/js/frappe/ui/field_group.js,Following fields have missing values:,Quyidagi maydonlar bo&#39;yicha kam qiymatlar mavjud:
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,No Google Calendar Event to sync.,Sinxronlanadigan Google Taqvim hodisasi yo'q.
+apps/frappe/frappe/public/js/frappe/ui/field_group.js,Following fields have missing values:,Quyidagi maydonlar bo'yicha kam qiymatlar mavjud:
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,via automatic rule {0} on {1},{1} saytidagi {0} avtomatik qoida orqali
 apps/frappe/frappe/core/report/transaction_log_report/transaction_log_report.py,First Transaction,Birinchi jurnali
-apps/frappe/frappe/app.py,You do not have enough permissions to complete the action,Amalni bajarish uchun sizda yetarli huquqlar yo&#39;q
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Single DocTypes cannot be customized.,Bitta hujjatlar turini sozlab bo&#39;lmaydi.
+apps/frappe/frappe/app.py,You do not have enough permissions to complete the action,Amalni bajarish uchun sizda yetarli huquqlar yo'q
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Single DocTypes cannot be customized.,Bitta hujjatlar turini sozlab bo'lmaydi.
 DocType: User,Document Follow,Hujjatga amal qilish
-apps/frappe/frappe/public/js/frappe/form/link_selector.js,No Results,Natija yo&#39;q
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,No Results,Natija yo'q
 DocType: System Settings,Security,Xavfsizlik
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Scheduled to send to {0} recipients,{0} qabul qiluvchilarni yuborish rejalashtirilmoqda
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Cut,Kesish
-apps/frappe/frappe/model/rename_doc.py,renamed from {0} to {1},{0} dan {1} ga o&#39;zgartirilgan
+apps/frappe/frappe/model/rename_doc.py,renamed from {0} to {1},{0} dan {1} ga o'zgartirilgan
 apps/frappe/frappe/public/js/frappe/list/list_view.js,{0} of {1} ({2} rows with children),{1} ({2} qatorli bolalar bilan) {0}
 DocType: Currency,**Currency** Master,** Valyuta ** Magistr
-DocType: Email Account,No of emails remaining to be synced,Sinxronlanadigan e-pochta xabari yo&#39;q
+DocType: Email Account,No of emails remaining to be synced,Sinxronlanadigan e-pochta xabari yo'q
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the document before assignment,"Iltimos, hujjatni topshirishdan oldin saqlang"
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Click here to post bugs and suggestions,Xatolar va takliflarni yuborish uchun shu yerga bosing
-DocType: Website Settings,Address and other legal information you may want to put in the footer.,Unvon va boshqa huquqiy ma&#39;lumotlar quyida joylashgan formani qo&#39;yish mumkin.
+DocType: Website Settings,Address and other legal information you may want to put in the footer.,Unvon va boshqa huquqiy ma'lumotlar quyida joylashgan formani qo'yish mumkin.
 DocType: Website Sidebar Item,Website Sidebar Item,Veb-sayt shtab-elementi
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Click on {0} to generate Refresh Token.,Tokeni yangilash uchun {0} tugmachasini bosing.
-apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py,Reference document has been cancelled,Yo&#39;naltiruvchi hujjat bekor qilindi
+apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py,Reference document has been cancelled,Yo'naltiruvchi hujjat bekor qilindi
 DocType: PayPal Settings,PayPal Settings,PayPal sozlamalari
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Document Type,Hujjat turi-ni tanlang
-apps/frappe/frappe/utils/nestedset.py,Cannot delete {0} as it has child nodes,Bolalar tugunlari bo&#39;lgani uchun {0} ni o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/utils/nestedset.py,Cannot delete {0} as it has child nodes,Bolalar tugunlari bo'lgani uchun {0} ni o'chirib bo'lmaydi
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} minutes ago,{0} daqiqa oldin
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Assignment Day {0} has been repeated.,Topshirish kuni {0} takrorlandi.
-DocType: Kanban Board Column,lightblue,yorug&#39;lik
+DocType: Kanban Board Column,lightblue,yorug'lik
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Same Field is entered more than once,Xuddi shu maydon bir necha marta kiritiladi
 DocType: Print Settings,Enable Raw Printing,Xom chop etishni yoqish
 DocType: Contact,Contact Numbers,Aloqa raqamlari
@@ -1303,70 +1303,70 @@ DocType: Communication,User Tags,Foydalanuvchi teglari
 DocType: Data Migration Run,Fail,Muvaffaqiyatsiz
 DocType: Workflow State,download-alt,download-alt
 DocType: Data Migration Run,Pull Failed,Muvaffaqiyatsiz tortish
-apps/frappe/frappe/public/js/frappe/views/components/Desktop.vue,Show / Hide Cards,Kartalarni ko&#39;rsatish / yashirish
-DocType: Communication,Feedback Request,Fikr-mulohaza so&#39;rovi
-apps/frappe/frappe/config/settings.py,Import Data from CSV / Excel files.,Ma&#39;lumotlarni CSV / Excel fayllaridan import qilish.
+apps/frappe/frappe/public/js/frappe/views/components/Desktop.vue,Show / Hide Cards,Kartalarni ko'rsatish / yashirish
+DocType: Communication,Feedback Request,Fikr-mulohaza so'rovi
+apps/frappe/frappe/config/settings.py,Import Data from CSV / Excel files.,Ma'lumotlarni CSV / Excel fayllaridan import qilish.
 apps/frappe/frappe/website/doctype/web_form/web_form.py,Following fields are missing:,Quyidagi joylar etishmayapti:
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,Cancelling {0},{0} bekor qilinmoqda
-DocType: Web Page,Main Section,Asosiy bo&#39;lim
+DocType: Web Page,Main Section,Asosiy bo'lim
 DocType: Page,Icon,Belgini
 apps/frappe/frappe/www/update-password.html,"Hint: Include symbols, numbers and capital letters in the password","Maslahat: Parolga simvollar, raqamlar va bosh harflarni kiriting"
 DocType: DocField,Allow in Quick Entry,Tez kirishga ruxsat berish
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,PDF,PDF
 DocType: System Settings,dd/mm/yyyy,dd / mm / yyyy
 DocType: System Settings,Backups,Zaxiralashlar
-apps/frappe/frappe/core/doctype/communication/communication.js,Add Contact,Kontaktni qo&#39;shish
+apps/frappe/frappe/core/doctype/communication/communication.js,Add Contact,Kontaktni qo'shish
 DocType: Notification Recipient,Optional: Always send to these ids. Each Email Address on a new row,Majburiy emas: Har doim bu idlarga yuboring. Har bir elektron pochta manzili yangi qatorda
 apps/frappe/frappe/public/js/frappe/form/layout.js,Hide Details,Tafsilotlarni yashirish
 apps/frappe/frappe/www/qrcode.py,Page has expired!,Sahifa muddati tugadi!
-DocType: LDAP Settings,Path to private Key File,Shaxsiy kalit fayliga o&#39;tish
+DocType: LDAP Settings,Path to private Key File,Shaxsiy kalit fayliga o'tish
 DocType: Workflow State,Tasks,Vazifalar
 DocType: Assignment Rule Day,Tuesday,Seshanba
 DocType: Blog Settings,Blog Settings,Blog sozlamalari
-apps/frappe/frappe/templates/emails/new_user.html,You can also copy-paste this link in your browser,Bundan tashqari siz bu havolani brauzeringizdan nusxa ko&#39;chirishingiz mumkin
+apps/frappe/frappe/templates/emails/new_user.html,You can also copy-paste this link in your browser,Bundan tashqari siz bu havolani brauzeringizdan nusxa ko'chirishingiz mumkin
 DocType: Workflow State,bullhorn,bullhorn
 apps/frappe/frappe/model/workflow.py,Not a valid Workflow Action,Haqiqiy ishbuzarlik harakati emas
 DocType: Footer Item,Target,Maqsad
 DocType: System Settings,Number of Backups,Zaxiralashlar soni
-DocType: Dashboard Chart,Last Year,O&#39;tgan yili
+DocType: Dashboard Chart,Last Year,O'tgan yili
 DocType: Website Settings,Copyright,Mualliflik huquqi
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Go,Boring
-DocType: OAuth Authorization Code,Invalid,Noto&#39;g&#39;ri
+DocType: OAuth Authorization Code,Invalid,Noto'g'ri
 DocType: ToDo,Due Date,Muddati
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Quarter Day,Chorak kuni
 DocType: Website Settings,Hide Footer Signup,Footer Signupni yashirish
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document,ushbu hujjatni bekor qildi
-apps/frappe/frappe/core/doctype/report/report.js,Write a Python file in the same folder where this is saved and return column and result.,Bu saqlangan va ustun va natija beradigan o&#39;sha papkada Python faylini yozing.
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Add to table,Jadvalga qo&#39;shish
+apps/frappe/frappe/core/doctype/report/report.js,Write a Python file in the same folder where this is saved and return column and result.,Bu saqlangan va ustun va natija beradigan o'sha papkada Python faylini yozing.
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Add to table,Jadvalga qo'shish
 DocType: Website Theme,Theme URL,Mavzu URL manzili
 DocType: Customize Form,Sort Field,Joyni saralash
 DocType: Razorpay Settings,Razorpay Settings,Razorpay sozlamalari
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Edit Filter,Filtrni tahrirlash
-apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Qo&#39;shimcha qo&#39;shish
+apps/frappe/frappe/public/js/frappe/ui/slides.js,Add More,Qo'shimcha qo'shish
 DocType: System Settings,Session Expiry Mobile,Kirish muddati mobaynida mobil
-apps/frappe/frappe/utils/password.py,Incorrect User or Password,Noto&#39;g&#39;ri foydalanuvchi yoki parol
+apps/frappe/frappe/utils/password.py,Incorrect User or Password,Noto'g'ri foydalanuvchi yoki parol
 apps/frappe/frappe/templates/includes/search_box.html,Search results for,Uchun qidiruv natijalari
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Access Token URL,Kirish nishoni URL manzilini kiriting
 DocType: Notification,Slack,Tiklanish
-DocType: Custom DocPerm,If user is the owner,Agar foydalanuvchi foydalanuvchi bo&#39;lsa
+DocType: Custom DocPerm,If user is the owner,Agar foydalanuvchi foydalanuvchi bo'lsa
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Follow,Kuzatib boring
 ,Activity,Faoliyat
-DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Yordam: Tizimda yana bir yozuvni bog&#39;lash uchun, &quot;# Form / Note / [Note Name]&quot; dan foydalaning. (&quot;http: //&quot; foydalanmang)"
+DocType: Note,"Help: To link to another record in the system, use ""#Form/Note/[Note Name]"" as the Link URL. (don't use ""http://"")","Yordam: Tizimda yana bir yozuvni bog'lash uchun, &quot;# Form / Note / [Note Name]&quot; dan foydalaning. (&quot;http: //&quot; foydalanmang)"
 DocType: User Permission,Allow,Ruxsat ber
 DocType: Data Import Beta,Update Existing Records,Mavjud yozuvlarni yangilang
-apps/frappe/frappe/utils/password_strength.py,Let's avoid repeated words and characters,"Keling, takrorlanadigan so&#39;zlar va belgilardan qochamiz"
+apps/frappe/frappe/utils/password_strength.py,Let's avoid repeated words and characters,"Keling, takrorlanadigan so'zlar va belgilardan qochamiz"
 DocType: Energy Point Rule,Energy Point Rule,Energiya nuqtasi qoidasi
 DocType: Communication,Delayed,Geciktirildi
-apps/frappe/frappe/config/settings.py,List of backups available for download,Yuklash uchun mavjud zaxiralar ro&#39;yxati
-apps/frappe/frappe/www/login.html,Sign up,Ro&#39;yxatdan o&#39;tish
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Row {0}: Not allowed to disable Mandatory for standard fields,Row {0}: standart maydonlarni to&#39;ldirish majburiy emas
+apps/frappe/frappe/config/settings.py,List of backups available for download,Yuklash uchun mavjud zaxiralar ro'yxati
+apps/frappe/frappe/www/login.html,Sign up,Ro'yxatdan o'tish
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Row {0}: Not allowed to disable Mandatory for standard fields,Row {0}: standart maydonlarni to'ldirish majburiy emas
 apps/frappe/frappe/config/customization.py,Dashboards,Asboblar paneli
 DocType: Test Runner,Output,Chiqish
 DocType: Milestone,Track Field,Trek maydoni
 DocType: Notification,Set Property After Alert,Alertdan keyin obyektni sozlash
-apps/frappe/frappe/config/customization.py,Add fields to forms.,Formalarga joy qo&#39;shing.
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Looks like something is wrong with this site's Paypal configuration.,Ushbu saytning PayPal konfiguratsiyasida biror narsa noto&#39;g&#39;ri.
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Add Review,Sharh qo&#39;shish
+apps/frappe/frappe/config/customization.py,Add fields to forms.,Formalarga joy qo'shing.
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Looks like something is wrong with this site's Paypal configuration.,Ushbu saytning PayPal konfiguratsiyasida biror narsa noto'g'ri.
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Add Review,Sharh qo'shish
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Font Size (px),Shrift hajmi (px)
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Only standard DocTypes are allowed to be customized from Customize Form.,Faqat Custom DocTypes-ni Customize Form-dan moslashtirish mumkin.
 DocType: Email Account,Sendgrid,Sendgrid
@@ -1375,39 +1375,39 @@ DocType: S3 Backup Settings,cn-north-1,cn-shimol-1
 apps/frappe/frappe/templates/includes/login/login.js,Verification Code,Tasdiq kodi
 DocType: Workflow State,leaf,barg
 DocType: Portal Menu Item,Portal Menu Item,Portal Menyu elementi
-apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Set Filters,Filtrlarni o&#39;rnating
+apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Set Filters,Filtrlarni o'rnating
 DocType: Contact Us Settings,Email ID,Email identifikatori
 DocType: Energy Point Rule,Multiplier Field,Multiplier maydoni
-DocType: Dashboard Chart,Time Interval,Vaqt oralig&#39;i
+DocType: Dashboard Chart,Time Interval,Vaqt oralig'i
 DocType: Activity Log,Keep track of all update feeds,Barcha yangilash yangiliklarini kuzatib boring
 DocType: OAuth Client,A list of resources which the Client App will have access to after the user allows it.<br> e.g. project,"Mijozlar ilovasi foydalanuvchi ruxsat berganidan keyin unga kirish imkoniyatiga ega bo'lgan resurslar ro'yxati. <br> masalan, loyiha"
 DocType: Translation,Translated Text,Tarjima qilingan matn
-DocType: Contact Us Settings,Query Options,So&#39;rov parametrlari
+DocType: Contact Us Settings,Query Options,So'rov parametrlari
 apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,Fetching posts...,Xabarlar olinmoqda ...
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Contact Synced with Google Contacts.,Google Kontaktlari bilan sinxronlangan kontakt.
 DocType: Access Log,Timestamp,Vaqt belgilari
 DocType: Patch Log,Patch Log,Patch log
 DocType: Data Migration Mapping,Local Primary Key,Mahalliy asosiy kalit
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options required for Link or Table type field {1} in row {2},{0}: {2} qatorda {1} bog&#39;lanish yoki jadval turi turi uchun zarur bo&#39;lgan tanlovlar.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options required for Link or Table type field {1} in row {2},{0}: {2} qatorda {1} bog'lanish yoki jadval turi turi uchun zarur bo'lgan tanlovlar.
 apps/frappe/frappe/utils/bot.py,Hello {0},Salom {0}
 apps/frappe/frappe/core/doctype/user/user.py,Welcome to {0},{0} ga xush kelibsiz!
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Add,Qo&#39;shish
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_column.html,Add,Qo'shish
 DocType: Communication,Sent or Received,Yuborilgan yoki qabul qilingan
 DocType: Auto Repeat,Reference Document,Malumot hujjati
 DocType: DefaultValue,Key,Kalit
 DocType: Address,Contacts,Kontaktlar
-DocType: System Settings,Setup Complete,O&#39;rnatish tugallandi
+DocType: System Settings,Setup Complete,O'rnatish tugallandi
 apps/frappe/frappe/config/users_and_permissions.py,Report of all document shares,Hujjatning barcha aktsiyalari haqida hisobot
 apps/frappe/frappe/www/update-password.html,New Password,Yangi Parol
-apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Filter {0} missing,Filtr {0} yo&#39;q
-apps/frappe/frappe/core/doctype/activity_log/activity_log.py,Sorry! You cannot delete auto-generated comments,Kechirasiz! Avtomatik yaratilgan fikrlarni o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Filter {0} missing,Filtr {0} yo'q
+apps/frappe/frappe/core/doctype/activity_log/activity_log.py,Sorry! You cannot delete auto-generated comments,Kechirasiz! Avtomatik yaratilgan fikrlarni o'chirib bo'lmaydi
 DocType: Google Settings,Used For Google Maps Integration.,Google Maps integratsiyasi uchun ishlatiladi.
-apps/frappe/frappe/core/doctype/communication/communication.js,Reference DocType,Yo&#39;naltirilgan DocType
+apps/frappe/frappe/core/doctype/communication/communication.js,Reference DocType,Yo'naltirilgan DocType
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,No records will be exported,Hech qanday yozuvlar eksport qilinmaydi
 DocType: User,System User,Tizim foydalanuvchisi
 DocType: Report,Is Standard,Standart
 DocType: Desktop Icon,_report,_report
-DocType: Dashboard Chart,Full,To&#39;liq
+DocType: Dashboard Chart,Full,To'liq
 DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","HTML <skript> kabi HTML teglar bilan kodlash yoki <yoki> kabi oddiy belgilarni kiritmang, chunki ular ushbu sohada qasddan ishlatilishi mumkin"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} {1} da tanqid qilingan
 DocType: Website Settings,FavIcon,FavIcon
@@ -1416,12 +1416,12 @@ DocType: Blog Post,Content (HTML),Tarkib (HTML)
 DocType: Personal Data Download Request,User Name,Foydalanuvchi ismi
 DocType: Workflow State,minus-sign,manfiy belgisi
 apps/frappe/frappe/public/js/frappe/request.js,Not Found,Topilmadi
-apps/frappe/frappe/www/printview.py,No {0} permission,{0} ruxsat yo&#39;q
+apps/frappe/frappe/www/printview.py,No {0} permission,{0} ruxsat yo'q
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Export Custom Permissions,Maxsus ruxsatnomalarni eksport qilish
 apps/frappe/frappe/desk/page/leaderboard/leaderboard.js,No items found.,Hech qanday mahsulot topilmadi.
 DocType: Data Export,Fields Multicheck,Maydonlar Multicheck
 DocType: Activity Log,Login,Kirish
-DocType: Web Form,Payments,To&#39;lovlar
+DocType: Web Form,Payments,To'lovlar
 apps/frappe/frappe/www/qrcode.html,Hi {0},Salom {0}
 apps/frappe/frappe/config/integrations.py,Google Drive Integration.,Google Drive integratsiyasi.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,{0} reverted your points on {1} {2},{0} {1} {2} ga ochkoingizni qaytarib berdi.
@@ -1432,14 +1432,14 @@ apps/frappe/frappe/www/message.html,Status: {0},Holat: {0}
 DocType: Blog Post,Markdown,Markdown
 DocType: DocShare,Document Name,Hujjat nomi
 apps/frappe/frappe/core/doctype/communication/communication.js,Mark as Spam,Spam sifatida belgilang
-DocType: ToDo,Medium,O&#39;rtacha
+DocType: ToDo,Medium,O'rtacha
 DocType: Comment,Comment By,Izoh muallifi
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Customize Form,Formani xususiylashtirish
-apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Ob&#39;ekt turi
+apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Type,Ob'ekt turi
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,Majburiy maydon: uchun rolni belgilang
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} tanqid qilingan {1}
 DocType: Data Migration Mapping,Mapping Name,Xaritaning nomi
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: &#39;{1}&#39; maydonini noyob deb belgilash mumkin emas, chunki u o&#39;ziga xos bo&#39;lmagan qiymatlarga ega"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,"{0}: '{1}' maydonini noyob deb belgilash mumkin emas, chunki u o'ziga xos bo'lmagan qiymatlarga ega"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Ro‘yxatni pastga siljiting
 DocType: Currency,A symbol for this currency. For e.g. $,"Ushbu valyutaning ramzi. Masalan, $"
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Tarjima muvaffaqiyatli yangilandi
@@ -1447,12 +1447,12 @@ apps/frappe/frappe/public/js/frappe/ui/toolbar/about.js,Frappe Framework,Frappe 
 DocType: S3 Backup Settings,Enable Automatic Backup,Avtomatik zaxiralashni yoqish
 apps/frappe/frappe/config/settings.py,Email Templates for common queries.,Umumiy savollar uchun E-mail shablonni.
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Permission Error,Ruxsat usuli
-apps/frappe/frappe/model/naming.py,Name of {0} cannot be {1},{0} nomi {1} bo&#39;lishi mumkin emas
-DocType: User Permission,Applicable For,Qo&#39;llaniladigan
+apps/frappe/frappe/model/naming.py,Name of {0} cannot be {1},{0} nomi {1} bo'lishi mumkin emas
+DocType: User Permission,Applicable For,Qo'llaniladigan
 apps/frappe/frappe/core/doctype/version/version_view.html,Success,Muvaffaqiyat
 apps/frappe/frappe/public/js/frappe/desk.js,Session Expired,Seans muddati tugadi
 DocType: Kanban Board Column,Kanban Board Column,Kanban boshqaruv ustuni
-apps/frappe/frappe/utils/password_strength.py,Straight rows of keys are easy to guess,To&#39;g&#39;ri qatorli tugmachalarni taxmin qilish oson
+apps/frappe/frappe/utils/password_strength.py,Straight rows of keys are easy to guess,To'g'ri qatorli tugmachalarni taxmin qilish oson
 DocType: Communication,Phone No.,Telefon raqami
 DocType: Personal Data Deletion Request,Pending Approval,Tasdiqni kutish
 DocType: Workflow State,fire,olov
@@ -1460,7 +1460,7 @@ apps/frappe/frappe/www/update-password.html,Success! You are good to go 👍,Muv
 apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.py,; not allowed in condition,; holatda ruxsat berilmaydi
 DocType: Async Task,Async Task,Async vazifasi
 DocType: Workflow State,picture,rasm
-apps/frappe/frappe/www/complete_signup.html,Complete,To&#39;ldiring
+apps/frappe/frappe/www/complete_signup.html,Complete,To'ldiring
 DocType: DocType,Image Field,Rasm maydoni
 DocType: Print Format,Custom HTML Help,Maxsus HTML yordami
 DocType: LDAP Settings,Default Role on Creation,Yaratilishdagi odatiy rol
@@ -1468,9 +1468,9 @@ apps/frappe/frappe/website/doctype/contact_us_settings/contact_us_settings.js,Se
 DocType: Workflow Transition,Next State,Keyingi davlat
 DocType: User,Block Modules,Bloklarni bloklash
 DocType: Print Format,Custom CSS,Maxsus CSS
-apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Add a comment,Fikr qo&#39;shish
+apps/frappe/frappe/public/js/frappe/form/controls/comment.js,Add a comment,Fikr qo'shish
 DocType: Webhook,on_update,on_update
-apps/frappe/frappe/model/rename_doc.py,Ignored: {0} to {1},E&#39;tibor berilmadi: {0} dan {1} ga
+apps/frappe/frappe/model/rename_doc.py,Ignored: {0} to {1},E'tibor berilmadi: {0} dan {1} ga
 DocType: Address,Gujarat,Gujarat
 apps/frappe/frappe/config/settings.py,Log of error on automated events (scheduler).,Avtomatlashtirilgan hodisalarda (scheduler) xato qayd.
 apps/frappe/frappe/utils/csvutils.py,Not a valid Comma Separated Value (CSV File),Vergul bilan ajratilgan qiymat emas (CSV fayli)
@@ -1479,35 +1479,35 @@ DocType: Email Account,Default Incoming,Standart kirish
 DocType: Workflow State,repeat,takrorlang
 DocType: Website Settings,Banner,Banner
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Value must be one of {0},Qiymat {0} dan biri bo‘lishi kerak
-DocType: Role,"If disabled, this role will be removed from all users.","Agar o&#39;chirib qo&#39;yilgan bo&#39;lsa, unda barcha foydalanuvchilar o&#39;chiriladi."
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Go to {0} List,{0} ro&#39;yxatiga o&#39;ting
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Help on Search,Qidiruv bo&#39;yicha yordam
+DocType: Role,"If disabled, this role will be removed from all users.","Agar o'chirib qo'yilgan bo'lsa, unda barcha foydalanuvchilar o'chiriladi."
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Go to {0} List,{0} ro'yxatiga o'ting
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Help on Search,Qidiruv bo'yicha yordam
 DocType: Milestone,Milestone Tracker,Milestone Tracker
-apps/frappe/frappe/core/doctype/user/user.py,Registered but disabled,"Ro&#39;yxatdan o&#39;tgan, lekin o&#39;chirilgan"
-apps/frappe/frappe/templates/emails/auto_repeat_fail.html,The Auto Repeat for this document has been disabled.,Ushbu hujjat uchun Avtomatik takrorlash o&#39;chirilgan.
+apps/frappe/frappe/core/doctype/user/user.py,Registered but disabled,"Ro'yxatdan o'tgan, lekin o'chirilgan"
+apps/frappe/frappe/templates/emails/auto_repeat_fail.html,The Auto Repeat for this document has been disabled.,Ushbu hujjat uchun Avtomatik takrorlash o'chirilgan.
 DocType: DocType,Hide Copy,Nusxani yashirish
 apps/frappe/frappe/public/js/frappe/roles_editor.js,Clear all roles,Barcha rollarni tozalang
-apps/frappe/frappe/model/base_document.py,{0} must be unique,{0} noyob bo&#39;lishi kerak
+apps/frappe/frappe/model/base_document.py,{0} must be unique,{0} noyob bo'lishi kerak
 apps/frappe/frappe/model/base_document.py,Row,Roy
 apps/frappe/frappe/public/js/frappe/views/communication.js,"CC, BCC & Email Template","CC, BCC va Email shablonini"
 DocType: Data Migration Mapping Detail,Local Fieldname,Mahalliy nom
-DocType: DocType,Track Changes,O&#39;zgarishlarni kuzatib boring
+DocType: DocType,Track Changes,O'zgarishlarni kuzatib boring
 DocType: Workflow State,Check,Tekshiring
 DocType: Chat Profile,Offline,Oflayn
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0},{0} muvaffaqiyatli import qilindi
 DocType: User,API Key,API kaliti
 DocType: Email Account,Send unsubscribe message in email,E-pochtaga obunani bekor qilish xabarini yuboring
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Edit Title,Sarlavha tahrir
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Fieldname which will be the DocType for this link field.,Domen nomi bu bog&#39;lanish uchun DocType bo&#39;ladi.
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Fieldname which will be the DocType for this link field.,Domen nomi bu bog'lanish uchun DocType bo'ladi.
 apps/frappe/frappe/config/desk.py,Documents assigned to you and by you.,Sizga va siz tomoningizdan tayinlangan hujjatlar.
-apps/frappe/frappe/templates/emails/delete_data_confirmation.html,You can also copy-paste this ,"Bundan tashqari, siz nusxa ko&#39;chirishingiz mumkin"
+apps/frappe/frappe/templates/emails/delete_data_confirmation.html,You can also copy-paste this ,"Bundan tashqari, siz nusxa ko'chirishingiz mumkin"
 DocType: User,Email Signature,Emailga imzo
 DocType: Website Settings,Google Analytics ID,Google Analytics ID
 DocType: Web Form,"For help see <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API and Examples</a>","Yordam uchun <a href=""https://frappe.io/docs/user/en/guides/portal-development/web-forms"" target=""_blank"">Client Script API va Examples-</a> ga qarang"
-DocType: Custom DocPerm,Delete,O&#39;chir
+DocType: Custom DocPerm,Delete,O'chir
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,New {0},Yangi {0}
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Inbox,Standart kirish qutisi
-DocType: Review Level,Review Level,Ko&#39;rib chiqish darajasi
+DocType: Review Level,Review Level,Ko'rib chiqish darajasi
 DocType: Print Settings,PDF Page Size,PDF sahifa hajmi
 DocType: Energy Point Rule,Rule Name,Qoida nomi
 DocType: Data Import,Attach file for Import,Import uchun faylni biriktiring
@@ -1517,19 +1517,19 @@ apps/frappe/frappe/core/doctype/data_export/exporter.py,"For updating, you can u
 DocType: Chat Token,Country,Davlat
 apps/frappe/frappe/contacts/doctype/address/address.py,Addresses,Manzillar
 DocType: Comment,Shared,Birgalikda
-apps/frappe/frappe/public/js/frappe/views/communication.js,Attach Document Print,Hujjat chop etish qo&#39;shish
-DocType: Bulk Update,Field,Yo&#39;l
+apps/frappe/frappe/public/js/frappe/views/communication.js,Attach Document Print,Hujjat chop etish qo'shish
+DocType: Bulk Update,Field,Yo'l
 DocType: Communication,Received,Qabul qilingan
-DocType: Notification,"Trigger on valid methods like ""before_insert"", ""after_update"", etc (will depend on the DocType selected)","&quot;Before_insert&quot;, &quot;after_update&quot; va hokazo (tanlangan DocTypega bog&#39;liq) kabi joriy usullarni ishga tushirish"
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0} {1},{0} {1} qiymatining o&#39;zgarishi
-apps/frappe/frappe/core/doctype/user/user.py,Adding System Manager to this User as there must be atleast one System Manager,Tizim menejerini ushbu foydalanuvchiga qo&#39;shish
+DocType: Notification,"Trigger on valid methods like ""before_insert"", ""after_update"", etc (will depend on the DocType selected)","&quot;Before_insert&quot;, &quot;after_update&quot; va hokazo (tanlangan DocTypega bog'liq) kabi joriy usullarni ishga tushirish"
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed value of {0} {1},{0} {1} qiymatining o'zgarishi
+apps/frappe/frappe/core/doctype/user/user.py,Adding System Manager to this User as there must be atleast one System Manager,Tizim menejerini ushbu foydalanuvchiga qo'shish
 DocType: Chat Message,URLs,URL manzillari
 DocType: Data Migration Run,Total Pages,Jami sahifalar
 apps/frappe/frappe/core/doctype/user_permission/user_permission.py,{0} has already assigned default value for {1}.,{0} allaqachon {1} uchun asl qiymatni tayinlagan.
-DocType: DocField,Attach Image,Rasm qo&#39;shish
-DocType: Workflow State,list-alt,ro&#39;yxat-alt
+DocType: DocField,Attach Image,Rasm qo'shish
+DocType: Workflow State,list-alt,ro'yxat-alt
 apps/frappe/frappe/www/update-password.html,Password Updated,Parol yangilandi
-apps/frappe/frappe/www/qrcode.html,Steps to verify your login,Kirishingizni tasdiqlash bo&#39;yicha qadamlar
+apps/frappe/frappe/www/qrcode.html,Steps to verify your login,Kirishingizni tasdiqlash bo'yicha qadamlar
 apps/frappe/frappe/utils/password.py,Password not found,Parol topilmadi
 DocType: Data Migration Mapping,Page Length,Sahifa uzunligi
 DocType: Email Queue,Expose Recipients,Qabul qiluvchilarni namoyish qiling
@@ -1540,27 +1540,27 @@ apps/frappe/frappe/public/js/frappe/ui/tags.js,Remove Tag,Yorliqni olib tashlang
 DocType: Chat Room User,Admin,Admin
 DocType: Website Settings,Brand,Tovar
 apps/frappe/frappe/config/integrations.py,Google API Settings.,Google API sozlamalari.
-DocType: Report,Query Report,So&#39;rov haqida hisobot
-DocType: User,Set New Password,Yangi parolni o&#39;rnating
+DocType: Report,Query Report,So'rov haqida hisobot
+DocType: User,Set New Password,Yangi parolni o'rnating
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1},{0}: {1} uchun ruxsat berilmagan
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,"%s is not a valid report format. Report format should \
-				one of the following %s",% s joriy hisobot formati emas. Hisobot formati quyidagi% slaridan biri bo&#39;lishi kerak
+				one of the following %s",% s joriy hisobot formati emas. Hisobot formati quyidagi% slaridan biri bo'lishi kerak
 DocType: Chat Message,Chat,Chat
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No documents found tagged with {0},{0} bilan belgilangan hujjatlar topilmadi
 DocType: LDAP Group Mapping,LDAP Group Mapping,LDAP guruhini xaritalash
 DocType: Dashboard Chart,Chart Options,Grafik parametrlari
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Untitled Column,Nomsiz ustun
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} from {1} to {2} in row #{3},# {3} qatoridagi {1} dan {2} gacha bo&#39;lgan {0}
-DocType: Communication,Expired,Muddati o&#39;tgan
-apps/frappe/frappe/templates/pages/integrations/razorpay_checkout.py,Seems token you are using is invalid!,Siz foydalanayotgan parol noto&#39;g&#39;ri!
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} from {1} to {2} in row #{3},# {3} qatoridagi {1} dan {2} gacha bo'lgan {0}
+DocType: Communication,Expired,Muddati o'tgan
+apps/frappe/frappe/templates/pages/integrations/razorpay_checkout.py,Seems token you are using is invalid!,Siz foydalanayotgan parol noto'g'ri!
 DocType: DocType,Is Tree,Daraxt
-DocType: Customize Form Field,Number of columns for a field in a Grid (Total Columns in a grid should be less than 11),Griddagi maydon uchun ustunlar soni (griddagi umumiy ustunlar 11 dan kam bo&#39;lishi kerak)
+DocType: Customize Form Field,Number of columns for a field in a Grid (Total Columns in a grid should be less than 11),Griddagi maydon uchun ustunlar soni (griddagi umumiy ustunlar 11 dan kam bo'lishi kerak)
 DocType: DocType,System,Tizim
-DocType: Web Form,Max Attachment Size (in MB),Maksimal qo&#39;shish kattaligi (MB da)
+DocType: Web Form,Max Attachment Size (in MB),Maksimal qo'shish kattaligi (MB da)
 apps/frappe/frappe/www/login.html,Have an account? Login,Hisob bormi? Kirish
 DocType: Workflow State,arrow-down,pastga-pastga
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Row {0},{0} qator
-apps/frappe/frappe/model/delete_doc.py,User not allowed to delete {0}: {1},Foydalanuvchining {0} o&#39;chirib tashlashga ruxsat berilmagan: {1}
+apps/frappe/frappe/model/delete_doc.py,User not allowed to delete {0}: {1},Foydalanuvchining {0} o'chirib tashlashga ruxsat berilmagan: {1}
 apps/frappe/frappe/public/js/frappe/list/list_view.js,{0} of {1},{1} dan {0}
 apps/frappe/frappe/public/js/frappe/model/model.js,Last Updated On,Oxirgi yangilangan
 DocType: SMS Settings,Message Parameter,Xabar parametrlari
@@ -1569,9 +1569,9 @@ apps/frappe/frappe/public/js/frappe/form/toolbar.js,Select Field,Maydonni tanlan
 DocType: Website Settings,Top Bar,Top Bar
 DocType: GSuite Settings,Script Code,Skript kodi
 apps/frappe/frappe/core/doctype/user/user.js,Create User Email,Foydalanuvchi e-pochtasini yaratish
-apps/frappe/frappe/core/doctype/doctype/doctype.py,No Permissions Specified,Hech qanday ruxsat yo&#39;q
+apps/frappe/frappe/core/doctype/doctype/doctype.py,No Permissions Specified,Hech qanday ruxsat yo'q
 apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,{0} not found,{0} topilmadi
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} records deleted,{0} yozuvlar o&#39;chirildi
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,{0} records deleted,{0} yozuvlar o'chirildi
 DocType: Custom Role,Custom Role,Maxsus rol
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 2,Bosh sahifa / Sinovlarni tekshirish 2
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter your password,Parolingizni kiriting
@@ -1579,103 +1579,103 @@ DocType: Dropbox Settings,Dropbox Access Secret,Dropboxga kirish maxfiyligi
 DocType: Tag Link,Document Title,Hujjat nomi
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,(Mandatory),(Majburiy)
 DocType: Social Login Key,Social Login Provider,Ijtimoiy kirish provayder
-apps/frappe/frappe/templates/includes/comments/comments.html,Add Another Comment,Boshqa izoh qo&#39;shing
-apps/frappe/frappe/core/doctype/data_import/importer.py,No data found in the file. Please reattach the new file with data.,Faylda hech qanday ma&#39;lumot topilmadi. Yangi faylni ma&#39;lumotlar bilan qayta joylang.
+apps/frappe/frappe/templates/includes/comments/comments.html,Add Another Comment,Boshqa izoh qo'shing
+apps/frappe/frappe/core/doctype/data_import/importer.py,No data found in the file. Please reattach the new file with data.,Faylda hech qanday ma'lumot topilmadi. Yangi faylni ma'lumotlar bilan qayta joylang.
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Edit DocType,DocType-ni tahrirlash
-apps/frappe/frappe/templates/emails/data_deletion_approval.html,Confirm Request,So&#39;rovni tasdiqlang
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Kattalashish Bo&#39;limning oldidan chiqish kerak
+apps/frappe/frappe/templates/emails/data_deletion_approval.html,Confirm Request,So'rovni tasdiqlang
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fold must come before a Section Break,Kattalashish Bo'limning oldidan chiqish kerak
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Under Development,Rivojlanish ostida
-apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Go to the document,Hujjatga o&#39;ting
-apps/frappe/frappe/public/js/frappe/model/meta.js,Last Modified By,Oxirgi o&#39;zgartirilgan
+apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Go to the document,Hujjatga o'ting
+apps/frappe/frappe/public/js/frappe/model/meta.js,Last Modified By,Oxirgi o'zgartirilgan
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Customizations Reset,Moslashtirishni tiklash
-DocType: Workflow State,hand-down,qo&#39;lni pastga tushirish
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type ""Select"".",Kanban ustuni sifatida ishlatilishi mumkin bo&#39;lgan maydonlar topilmadi. &quot;Tanlash&quot; turidagi maxsus maydonni qo&#39;shish uchun Customize Formasidan foydalaning.
+DocType: Workflow State,hand-down,qo'lni pastga tushirish
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,"No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type ""Select"".",Kanban ustuni sifatida ishlatilishi mumkin bo'lgan maydonlar topilmadi. &quot;Tanlash&quot; turidagi maxsus maydonni qo'shish uchun Customize Formasidan foydalaning.
 DocType: Address,GST State,GST davlati
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0}: Yuborilmasdan Bekor qilishni o&#39;rnatib bo&#39;lmadi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Cancel without Submit,{0}: Yuborilmasdan Bekor qilishni o'rnatib bo'lmadi
 DocType: Website Theme,Theme,Mavzu
-DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,URI kodini tekshirish uchun yo&#39;naltirish
+DocType: OAuth Authorization Code,Redirect URI Bound To Auth Code,URI kodini tekshirish uchun yo'naltirish
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Help,Yordamni oching
 DocType: DocType,Is Submittable,Submittable mavjud
 apps/frappe/frappe/core/doctype/comment/comment.py,New Mention,Yangi marosim
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,No new Google Contacts synced.,Yangi Google Kontaktlar sinxronlanmadi.
 DocType: File,Uploaded To Google Drive,Google Drive-ga yuklandi
-apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a check field can be either 0 or 1,Tekshirish maydonining qiymati 0 yoki 1 bo&#39;lishi mumkin
+apps/frappe/frappe/custom/doctype/property_setter/property_setter.js,Value for a check field can be either 0 or 1,Tekshirish maydonining qiymati 0 yoki 1 bo'lishi mumkin
 apps/frappe/frappe/model/document.py,Could not find {0},{0} topilmadi
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Filters applied for {0},{0} uchun ishlatiladigan filtrlar
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Column Labels:,Ustunlar yorlig&#39;i:
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Column Labels:,Ustunlar yorlig'i:
 apps/frappe/frappe/model/naming.py,Naming Series mandatory,Namunali seriya majburiy
 DocType: Workflow State,Inbox,Kirish qutisi
 DocType: Kanban Board Column,Red,Qizil rangli
 DocType: Workflow State,Tag,Yorliq
 DocType: Custom Script,Script,Skript
-apps/frappe/frappe/core/doctype/data_import/log_details.html,Document can't saved.,Hujjat saqlab bo&#39;lmaydigan.
+apps/frappe/frappe/core/doctype/data_import/log_details.html,Document can't saved.,Hujjat saqlab bo'lmaydigan.
 DocType: Energy Point Rule,Maximum Points,Maksimal ball
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,My Settings,Mening sozlamalarim
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Text Color,Matn rangi
-apps/frappe/frappe/desk/page/backups/backups.py,Backup job is already queued. You will receive an email with the download link,Zahiralash ishi allaqachon navbatga qo&#39;yildi. Yuklab olish havolasiga ega bo&#39;lgan elektron maktub olasiz
+apps/frappe/frappe/desk/page/backups/backups.py,Backup job is already queued. You will receive an email with the download link,Zahiralash ishi allaqachon navbatga qo'yildi. Yuklab olish havolasiga ega bo'lgan elektron maktub olasiz
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,1 Google Calendar Event synced.,1 Google Calendar Event sinxronlandi.
 DocType: Desktop Icon,Force Show,Kuch namoyishi
-apps/frappe/frappe/auth.py,Invalid Request,Noto&#39;g&#39;ri so&#39;rov
-apps/frappe/frappe/public/js/frappe/form/layout.js,This form does not have any input,Ushbu formaning hech qanday usuli yo&#39;q
-apps/frappe/frappe/core/doctype/system_settings/system_settings.py,Session Expiry must be in format {0},Seans amal qilish muddati {0} formatida bo&#39;lishi kerak
+apps/frappe/frappe/auth.py,Invalid Request,Noto'g'ri so'rov
+apps/frappe/frappe/public/js/frappe/form/layout.js,This form does not have any input,Ushbu formaning hech qanday usuli yo'q
+apps/frappe/frappe/core/doctype/system_settings/system_settings.py,Session Expiry must be in format {0},Seans amal qilish muddati {0} formatida bo'lishi kerak
 DocType: Chat Message,Group,Guruh
 DocType: Footer Item,"Select target = ""_blank"" to open in a new page.",Yangi sahifada ochish uchun maqsadni = &quot;_blank&quot; ni tanlang.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 year,1 yil
-apps/frappe/frappe/public/js/frappe/model/model.js,Permanently delete {0}?,{0} butunlay o&#39;chirib tashlansinmi?
-apps/frappe/frappe/core/doctype/file/file.py,Same file has already been attached to the record,Xuddi shu fayl allaqachon qaydga qo&#39;shilgan
-apps/frappe/frappe/model/workflow.py,{0} is not a valid Workflow State. Please update your Workflow and try again.,"{0} joriy ish oqimi holati emas. Iltimos, ishchi oqimni yangilang va qaytadan urinib ko&#39;ring."
+apps/frappe/frappe/public/js/frappe/model/model.js,Permanently delete {0}?,{0} butunlay o'chirib tashlansinmi?
+apps/frappe/frappe/core/doctype/file/file.py,Same file has already been attached to the record,Xuddi shu fayl allaqachon qaydga qo'shilgan
+apps/frappe/frappe/model/workflow.py,{0} is not a valid Workflow State. Please update your Workflow and try again.,"{0} joriy ish oqimi holati emas. Iltimos, ishchi oqimni yangilang va qaytadan urinib ko'ring."
 apps/frappe/frappe/templates/emails/energy_points_summary.html,gave {0} points,{0} ball berdi
 DocType: Workflow State,wrench,kaliti
-apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Set,O&#39;rnatilmagan
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Set,O'rnatilmagan
 DocType: Deleted Document,GitHub Sync ID,GitHub Sync ID
 DocType: Activity Log,Date,Sana
-apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No more posts,Boshqa xabarlar yo&#39;q
-DocType: Access Log,RAW Information Log,RAW ma&#39;lumot jurnali
-DocType: Website Settings,Disable Signup,Ro&#39;yxatga olishni o&#39;chirib qo&#39;yish
+apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No more posts,Boshqa xabarlar yo'q
+DocType: Access Log,RAW Information Log,RAW ma'lumot jurnali
+DocType: Website Settings,Disable Signup,Ro'yxatga olishni o'chirib qo'yish
 DocType: Email Queue,Email Queue,Email Queue
 DocType: Address,Haryana,Haryana
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} appreciation points for {1} {2},{0} {1} {2} uchun ballar
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Roles can be set for users from their User page.,Foydalanuvchilar uchun foydalanuvchi sahifalari roli belgilanishi mumkin.
-apps/frappe/frappe/templates/includes/comments/comments.html,Add Comment,Izoh qo&#39;shish
+apps/frappe/frappe/templates/includes/comments/comments.html,Add Comment,Izoh qo'shish
 DocType: DocField,Mandatory,Majburiy
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Module to Export,Moduli eksport qilish
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: No basic permissions set,{0}: Asosiy ruxsatnomalar o&#39;rnatilmagan
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: No basic permissions set,{0}: Asosiy ruxsatnomalar o'rnatilmagan
 apps/frappe/frappe/utils/backups.py,Download link for your backup will be emailed on the following email address: {0},Zaxirangiz uchun yuklab olish uchun link quyidagi elektron pochta manziliga yuboriladi: {0}
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Meaning of Submit, Cancel, Amend","Yuborishning ma&#39;nosi, Bekor qilish, o&#39;zgartirish"
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Meaning of Submit, Cancel, Amend","Yuborishning ma'nosi, Bekor qilish, o'zgartirish"
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,To Do,Qilmoq
-DocType: Test Runner,Module Path,Moduli yo&#39;li
+DocType: Test Runner,Module Path,Moduli yo'li
 DocType: Milestone Tracker,Track milestones for any document,Har qanday hujjat uchun bosqichlarni kuzatib boring
-DocType: Social Login Key,Identity Details,Identifikatsiya ma&#39;lumotlari
-apps/frappe/frappe/model/workflow.py,Workflow State transition not allowed from {0} to {1},{0} dan {1} ga ish oqimi holatiga o&#39;tish mumkin emas
-apps/frappe/frappe/desk/doctype/dashboard/dashboard.js,Show Dashboard,Asboblar panelini ko&#39;rsatish
+DocType: Social Login Key,Identity Details,Identifikatsiya ma'lumotlari
+apps/frappe/frappe/model/workflow.py,Workflow State transition not allowed from {0} to {1},{0} dan {1} ga ish oqimi holatiga o'tish mumkin emas
+apps/frappe/frappe/desk/doctype/dashboard/dashboard.js,Show Dashboard,Asboblar panelini ko'rsatish
 apps/frappe/frappe/desk/form/assign_to.py,New Message,Yangi xabar
-DocType: File,Preview HTML,HTMLni oldindan ko&#39;rish
-DocType: Desktop Icon,query-report,so&#39;rov-hisobot
+DocType: File,Preview HTML,HTMLni oldindan ko'rish
+DocType: Desktop Icon,query-report,so'rov-hisobot
 DocType: Data Import Beta,Template Warnings,Andoza ogohlantirishlari
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Filters saved,Filtrlar saqlandi
 DocType: DocField,Percent,Foiz
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Please set filters,Filtrni o&#39;rnating
-apps/frappe/frappe/public/js/frappe/form/linked_with.js,Linked With,Bilan bog&#39;langan
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Please set filters,Filtrni o'rnating
+apps/frappe/frappe/public/js/frappe/form/linked_with.js,Linked With,Bilan bog'langan
 apps/frappe/frappe/templates/emails/auto_email_report.html,Edit Auto Email Report Settings,Avtomatik E-pochta hisoboti sozlamalarini tahrirlash
 DocType: Chat Room,Message Count,Xabarlar soni
 DocType: Workflow State,book,kitob
-DocType: Communication,Read by Recipient,Qabul qiluvchi tomonidan o&#39;qildi
+DocType: Communication,Read by Recipient,Qabul qiluvchi tomonidan o'qildi
 DocType: Website Settings,Landing Page,Ochilish sahifasi
 apps/frappe/frappe/public/js/frappe/form/script_manager.js,Error in Custom Script,Maxsus skriptda xato
 apps/frappe/frappe/public/js/frappe/form/quick_entry.js,{0} Name,{0} Ism
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,No Permissions set for this criteria.,Ushbu mezon uchun ruxsat yo&#39;q.
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,No Permissions set for this criteria.,Ushbu mezon uchun ruxsat yo'q.
 DocType: Auto Email Report,Auto Email Report,Avtomatik e-pochta hisoboti
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Delete comment?,Fikr o&#39;chirib tashlansinmi?
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Delete comment?,Fikr o'chirib tashlansinmi?
 DocType: Address Template,This format is used if country specific format is not found,"Ushbu format, mamlakatga xos formati topilmasa ishlatiladi"
 DocType: System Settings,Allow Login using Mobile Number,Mobil raqamdan foydalanib kirishga ruxsat berish
-apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,Ushbu resursga kirish uchun sizda yetarli huquqlar yo&#39;q. Kirish uchun menejerga murojaat qiling.
+apps/frappe/frappe/public/js/frappe/request.js,You do not have enough permissions to access this resource. Please contact your manager to get access.,Ushbu resursga kirish uchun sizda yetarli huquqlar yo'q. Kirish uchun menejerga murojaat qiling.
 DocType: Custom Field,Custom,Maxsus
-DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Agar yoqilgan bo&#39;lsa, cheklangan IP-manzildan kirgan foydalanuvchilar ikkita Factor Auth uchun so&#39;ralmaydi"
+DocType: System Settings,"If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth","Agar yoqilgan bo'lsa, cheklangan IP-manzildan kirgan foydalanuvchilar ikkita Factor Auth uchun so'ralmaydi"
 DocType: Auto Repeat,Get Contacts,Kontaktlarni oling
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts filed under {0},{0} da berilgan xabarlar
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping Untitled Column,Nomsiz ustunni o&#39;tkazib yuborish
-DocType: Notification,Send alert if date matches this field's value,"Agar sana ushbu maydonning qiymatiga mos bo&#39;lsa, ogohlantirish yuboring"
-DocType: Workflow,Transitions,O&#39;tish
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping Untitled Column,Nomsiz ustunni o'tkazib yuborish
+DocType: Notification,Send alert if date matches this field's value,"Agar sana ushbu maydonning qiymatiga mos bo'lsa, ogohlantirish yuboring"
+DocType: Workflow,Transitions,O'tish
 apps/frappe/frappe/desk/page/activity/activity_row.html,{0} {1} to {2},{0} {1} dan {2} gacha
 DocType: User,Login After,Keyin kirish
 DocType: Print Format,Monospace,Monospace
@@ -1683,7 +1683,7 @@ DocType: Letter Head,Printing,Bosib chiqarish
 DocType: Workflow State,thumbs-up,Barakalla
 DocType: DocPerm,DocPerm,DocPerm
 DocType: Print Settings,Fonts,Shriftlar
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Precision should be between 1 and 6,Precision 1 va 6 orasida bo&#39;lishi kerak
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Precision should be between 1 and 6,Precision 1 va 6 orasida bo'lishi kerak
 apps/frappe/frappe/core/doctype/communication/communication.js,Fw: {0},Fw: {0}
 apps/frappe/frappe/public/js/frappe/utils/utils.js,and,va
 apps/frappe/frappe/templates/emails/auto_email_report.html,This report was generated on {0},Ushbu hisobot {0} da ishlab chiqarilgan
@@ -1695,24 +1695,24 @@ DocType: Auto Email Report,Report Filters,Hisobotlarni filtrlash
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,now,hozir
 DocType: Workflow State,step-backward,qadam orqaga
 apps/frappe/frappe/utils/boilerplate.py,{app_title},{app_title}
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please set Dropbox access keys in your site config,"Iltimos, saytingiz konfiguratsiyasidagi Dropbox kirish kalitlarini o&#39;rnating"
-apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete this record to allow sending to this email address,Ushbu e-pochta manziliga yuborishga ruxsat berish uchun ushbu yozuvni o&#39;chirib tashlang
-DocType: Email Account,"If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)","Agar nostandart port bo&#39;lsa (masalan, POP3: 995/110, IMAP: 993/143)"
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please set Dropbox access keys in your site config,"Iltimos, saytingiz konfiguratsiyasidagi Dropbox kirish kalitlarini o'rnating"
+apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Delete this record to allow sending to this email address,Ushbu e-pochta manziliga yuborishga ruxsat berish uchun ushbu yozuvni o'chirib tashlang
+DocType: Email Account,"If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)","Agar nostandart port bo'lsa (masalan, POP3: 995/110, IMAP: 993/143)"
 apps/frappe/frappe/public/js/frappe/views/components/DeskSection.vue,Customize Shortcuts,Yorliqlarni sozlang
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,Yangi yozuvlar uchun majburiy joylar kerak. Siz xohlamagan ustunlarni o&#39;chirishingiz mumkin.
-apps/frappe/frappe/desk/page/user_profile/user_profile.html,Show More Activity,Ko&#39;proq faollikni ko&#39;rsatish
-apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,OTP ilovasida ko&#39;rsatilgan kodni kiriting.
-apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Unable to update event,Voqeani yangilab bo&#39;lmadi
-apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,Tasdiqlangan kod sizning ro&#39;yxatdan o&#39;tgan elektron pochta manzilingizga yuborildi.
-apps/frappe/frappe/core/doctype/user/user.py,Throttled,To&#39;satdan
-apps/frappe/frappe/utils/data.py,"Filter must have 4 values (doctype, fieldname, operator, value): {0}","Filtrda 4 ta qiymat bo&#39;lishi kerak (doctype, fieldname, operator, value): {0}"
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Topshiriq qoidasini qo&#39;llang
-apps/frappe/frappe/utils/bot.py,show,ko&#39;rsatish
-apps/frappe/frappe/utils/data.py,Invalid field name {0},Joy nomeri {0} noto&#39;g&#39;ri
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish.,Yangi yozuvlar uchun majburiy joylar kerak. Siz xohlamagan ustunlarni o'chirishingiz mumkin.
+apps/frappe/frappe/desk/page/user_profile/user_profile.html,Show More Activity,Ko'proq faollikni ko'rsatish
+apps/frappe/frappe/templates/includes/login/login.js,Enter Code displayed in OTP App.,OTP ilovasida ko'rsatilgan kodni kiriting.
+apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Unable to update event,Voqeani yangilab bo'lmadi
+apps/frappe/frappe/twofactor.py,Verification code has been sent to your registered email address.,Tasdiqlangan kod sizning ro'yxatdan o'tgan elektron pochta manzilingizga yuborildi.
+apps/frappe/frappe/core/doctype/user/user.py,Throttled,To'satdan
+apps/frappe/frappe/utils/data.py,"Filter must have 4 values (doctype, fieldname, operator, value): {0}","Filtrda 4 ta qiymat bo'lishi kerak (doctype, fieldname, operator, value): {0}"
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Apply Assignment Rule,Topshiriq qoidasini qo'llang
+apps/frappe/frappe/utils/bot.py,show,ko'rsatish
+apps/frappe/frappe/utils/data.py,Invalid field name {0},Joy nomeri {0} noto'g'ri
 apps/frappe/frappe/model/document.py,{0} must be after {1},{0} {1} dan keyin bo‘lishi kerak
 DocType: Address Template,Address Template,Manzil shablonni
 DocType: Workflow State,text-height,matn balandligi
-DocType: Data Migration Plan Mapping,Data Migration Plan Mapping,Ma&#39;lumotlarni ko&#39;chirish rejasini xaritalash
+DocType: Data Migration Plan Mapping,Data Migration Plan Mapping,Ma'lumotlarni ko'chirish rejasini xaritalash
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Starting Frappé ...,Frappe boshlanmoqda ...
 DocType: Web Form Field,Max Length,Maksimal uzunligi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,For {0} {1},{0} {1} uchun
@@ -1721,20 +1721,20 @@ DocType: Workflow State,map-marker,xarita belgisi
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Submit an Issue,Muammo berish
 DocType: Event,Repeat this Event,Ushbu tadbirni takrorlang
 DocType: Address,Maintenance User,Xizmat foydalanuvchisi
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,"LDAP Search String needs to end with a placeholder, eg sAMAccountName={0}","LDAP qidirish satrini to&#39;ldirish bilan yakunlash kerak, masalan sAMAccountName = {0}"
-apps/frappe/frappe/utils/password_strength.py,Avoid dates and years that are associated with you.,Siz bilan bog&#39;liq bo&#39;lgan sana va yillardan qoching.
-DocType: Custom DocPerm,Amend,O&#39;zgartiring
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,"LDAP Search String needs to end with a placeholder, eg sAMAccountName={0}","LDAP qidirish satrini to'ldirish bilan yakunlash kerak, masalan sAMAccountName = {0}"
+apps/frappe/frappe/utils/password_strength.py,Avoid dates and years that are associated with you.,Siz bilan bog'liq bo'lgan sana va yillardan qoching.
+DocType: Custom DocPerm,Amend,O'zgartiring
 DocType: Data Import,Generated File,Yaratilgan fayl
 DocType: Transaction Log,Previous Hash,Oldingi hash
-DocType: File,Is Attachments Folder,Qo&#39;shilgan fayllar
+DocType: File,Is Attachments Folder,Qo'shilgan fayllar
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Expand All,Hammasini kengaytirish
 apps/frappe/frappe/public/js/frappe/chat.js,Select a chat to start messaging.,Xabar yozishni boshlash uchun suhbatni tanlang.
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,Processing,Ishlov berish
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Please select Entity Type first,Avval tijorat turi tanlang
 apps/frappe/frappe/templates/includes/login/login.js,Valid Login id required.,Kerakli kirish identifikatori talab qilinadi.
-apps/frappe/frappe/model/rename_doc.py,Please select a valid csv file with data,Ma&#39;lumotlar bilan joriy CSV faylini tanlang
+apps/frappe/frappe/model/rename_doc.py,Please select a valid csv file with data,Ma'lumotlar bilan joriy CSV faylini tanlang
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} un-shared this document with {1},{0} ushbu hujjatni {1}
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained {0} point,Siz {0} ball to&#39;pladingiz
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You gained {0} point,Siz {0} ball to'pladingiz
 DocType: LDAP Settings,SSL/TLS Mode,SSL / TLS rejimi
 DocType: DocType,"Make ""name"" searchable in Global Search",&quot;Global Search&quot; da &quot;nom&quot; izlash mumkin
 apps/frappe/frappe/core/doctype/version/version_view.html,Row # ,Qator #
@@ -1742,28 +1742,28 @@ apps/frappe/frappe/templates/emails/auto_reply.html,This is an automatically gen
 DocType: Help Category,Category Description,Turkum tavsifi
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Default Theme,Odatiy mavzu
 apps/frappe/frappe/model/document.py,Record does not exist,Yozuv mavjud emas
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,The process for deletion of {0} data associated with {1} has been initiated.,{1} bilan bog&#39;liq {0} ma&#39;lumotlarni yo&#39;q qilish jarayoni boshlandi.
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,The process for deletion of {0} data associated with {1} has been initiated.,{1} bilan bog'liq {0} ma'lumotlarni yo'q qilish jarayoni boshlandi.
 apps/frappe/frappe/core/doctype/version/version_view.html,Original Value,Asl qiymati
 DocType: Help Category,Help Category,Yordam kategoriyasi
-apps/frappe/frappe/utils/oauth.py,User {0} is disabled,{0} foydalanuvchisi o&#39;chirib qo&#39;yilgan
+apps/frappe/frappe/utils/oauth.py,User {0} is disabled,{0} foydalanuvchisi o'chirib qo'yilgan
 DocType: Dashboard Chart,Last Month,O `tgan oy
-apps/frappe/frappe/www/404.html,Page missing or moved,Sahifa etishmayotgan yoki ko&#39;chirilgan
+apps/frappe/frappe/www/404.html,Page missing or moved,Sahifa etishmayotgan yoki ko'chirilgan
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Reviews,Sharhlar
-DocType: DocType,Route,Yo&#39;nalish
-apps/frappe/frappe/config/integrations.py,Razorpay Payment gateway settings,Razorpay To&#39;lov shlyuzi sozlamalari
+DocType: DocType,Route,Yo'nalish
+apps/frappe/frappe/config/integrations.py,Razorpay Payment gateway settings,Razorpay To'lov shlyuzi sozlamalari
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Fetch attached images from document,Belgilangan rasmlarni hujjat bilan qabul qiling
 DocType: Chat Room,Name,Ism
 DocType: Contact Us Settings,Skype,Skype
 DocType: Chat Profile,Notification Tones,Xabarnoma tovushlari
 DocType: Assignment Rule,Load Balancing,Yuklarni muvozanatlash
-DocType: OAuth Authorization Code,Valid,To&#39;g&#39;ri
+DocType: OAuth Authorization Code,Valid,To'g'ri
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Open Link,Linkni oching
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Your Language,Tilingiz
-DocType: Dashboard Chart,Average,O&#39;rtacha
-apps/frappe/frappe/public/js/frappe/form/grid.js,Add Row,Roy qo&#39;shish
+DocType: Dashboard Chart,Average,O'rtacha
+apps/frappe/frappe/public/js/frappe/form/grid.js,Add Row,Roy qo'shish
 DocType: Tag Category,Doctypes,Doctypes
 apps/frappe/frappe/public/js/frappe/form/print.js,Printer,Printer
-apps/frappe/frappe/desk/query_report.py,Query must be a SELECT,So&#39;rov SELECT bo&#39;lishi kerak
+apps/frappe/frappe/desk/query_report.py,Query must be a SELECT,So'rov SELECT bo'lishi kerak
 DocType: Auto Repeat,Completed,Tugallandi
 DocType: File,Is Private,Xususiy
 DocType: Data Export,Select DocType,DocType-ni tanlang
@@ -1773,7 +1773,7 @@ DocType: Workflow State,align-center,Hizala-markaz
 DocType: Address,Lakshadweep Islands,Lakshadveyt orollari
 DocType: DocType,Allow events in timeline,Vaqt jadvalidagi voqealarga ruxsat berish
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Write,Yozishi mumkin
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit.",Billing kabi ba&#39;zi bir hujjatlar oxirgi marta o&#39;zgartirilmasligi kerak. Bunday hujjatlar uchun oxirgi holat &quot;Taklif&quot; deb ataladi. Siz topshirishi mumkin bo&#39;lgan rollarni cheklashingiz mumkin.
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit.",Billing kabi ba'zi bir hujjatlar oxirgi marta o'zgartirilmasligi kerak. Bunday hujjatlar uchun oxirgi holat &quot;Taklif&quot; deb ataladi. Siz topshirishi mumkin bo'lgan rollarni cheklashingiz mumkin.
 DocType: Newsletter,Test Email Address,E-pochta manzilini tekshiring
 DocType: Auto Repeat,Reference Document Type,Hujjatning turi
 DocType: ToDo,Sender,Yuboruvchi
@@ -1782,8 +1782,8 @@ apps/frappe/frappe/email/doctype/notification/notification.py,Error while evalua
 DocType: GSuite Settings,Google Apps Script,Google Apps skripti
 apps/frappe/frappe/templates/includes/comments/comments.html,Leave a Comment,Fikr qoldiring
 apps/frappe/frappe/website/doctype/help_article/templates/help_article.html,More articles on {0},{0} da boshqa maqolalar
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,No contacts linked to document,Hujjatga bog&#39;langan kontaktlar yo&#39;q
-DocType: Letter Head,Footer will display correctly only in PDF,Taglik faqat PDF formatida to&#39;g&#39;ri ko&#39;rsatiladi
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,No contacts linked to document,Hujjatga bog'langan kontaktlar yo'q
+DocType: Letter Head,Footer will display correctly only in PDF,Taglik faqat PDF formatida to'g'ri ko'rsatiladi
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Kutilmoqda
 DocType: System Settings,Allow only one session per user,Bir foydalanuvchi uchun bitta seansga ruxsat berish
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Bosh sahifa / Sinovlarni tekshirish 1 / Tasvirni tekshirish 3
@@ -1792,16 +1792,16 @@ apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag ac
 DocType: Contact,Contact Details,Aloqa tafsilotlari
 DocType: DocField,In Filter,Filtrda
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Kanban,Kanban
-DocType: DocType,Show in Module Section,Module bo&#39;limida ko&#39;rsatish
+DocType: DocType,Show in Module Section,Module bo'limida ko'rsatish
 DocType: Workflow Document State,Is Optional State,Ixtiyoriy holat
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,The {0} is already on auto repeat {1},{1} {1} avtomatik takrorlashda
 DocType: Letter Head,Header HTML,HTML sarlavhasi
 apps/frappe/frappe/core/doctype/communication/communication.js,Relink,Qaytib chiqing
-apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,SMS yuborilmadi. Ma&#39;mur bilan bog&#39;laning.
+apps/frappe/frappe/templates/includes/login/login.js,SMS was not sent. Please contact Administrator.,SMS yuborilmadi. Ma'mur bilan bog'laning.
 DocType: Web Page,"Page to show on the website
-",Veb-saytda ko&#39;rsatiladigan sahifa
+",Veb-saytda ko'rsatiladigan sahifa
 apps/frappe/frappe/config/settings.py,Create and manage newsletter,Axborot byulletenlarini yaratish va boshqarish
-DocType: Note,Seen By Table,Jadvalda ko&#39;rib chiqildi
+DocType: Note,Seen By Table,Jadvalda ko'rib chiqildi
 apps/frappe/frappe/www/third_party_apps.html,Logged in,Kiritilgan
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Sending and Inbox,Standart yuborish va Kirish qutisi
 DocType: System Settings,OTP App,OTP ilovasi
@@ -1811,15 +1811,15 @@ apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.py,Scheduler i
 DocType: Print Settings,Letter,Maktub
 DocType: DocType,"Naming Options:
 <ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>
-<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Nomlanishi parametrlari: <ol><li> <b>maydon: [maydonning nomi]</b> - <b>sohaga qarab</b> </li><li> <b>naming_series:</b> - Naming Series (noming_series deb nomlangan maydon bo&#39;lishi kerak </li><li> <b>Buyruq</b> - Bir ism uchun tez-tez foydalanuvchi </li><li> <b>[ketma-ket]</b> - <b>ketma-ketlik bilan ketma-ketlik</b> (nuqta bilan ajratilgan); Masalan, PRE ##### </li><li> <b>formati: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - barcha tarjima qilingan so&#39;zlarni ( <b>maydon nomlari</b> , sana so&#39;zlari (DD, MM, YY), seriyalar) qiymatlari bilan almashtiring. Tashqari belgilar, har qanday belgi ishlatilishi mumkin. </li></ol>"
-apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,"Hujjatni yaratishda xatolik yuz berdi. Iltimos, yana bir bor urinib ko&#39;ring."
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,Rasm maydoni turi bo&#39;lishi kerak
+<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>","Nomlanishi parametrlari: <ol><li> <b>maydon: [maydonning nomi]</b> - <b>sohaga qarab</b> </li><li> <b>naming_series:</b> - Naming Series (noming_series deb nomlangan maydon bo'lishi kerak </li><li> <b>Buyruq</b> - Bir ism uchun tez-tez foydalanuvchi </li><li> <b>[ketma-ket]</b> - <b>ketma-ketlik bilan ketma-ketlik</b> (nuqta bilan ajratilgan); Masalan, PRE ##### </li><li> <b>formati: EXAMPLE- {MM} morewords {fieldname1} - {fieldname2} - {#####}</b> - barcha tarjima qilingan so'zlarni ( <b>maydon nomlari</b> , sana so'zlari (DD, MM, YY), seriyalar) qiymatlari bilan almashtiring. Tashqari belgilar, har qanday belgi ishlatilishi mumkin. </li></ol>"
+apps/frappe/frappe/public/js/frappe/views/interaction.js,There were errors while creating the document. Please try again.,"Hujjatni yaratishda xatolik yuz berdi. Iltimos, yana bir bor urinib ko'ring."
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Image field must be of type Attach Image,Rasm maydoni turi bo'lishi kerak
 apps/frappe/frappe/permissions.py,You are not allowed to export {} doctype,Siz {} dokument turini eksport qila olmaysiz
 DocType: DocField,Columns,Ustunlar
 apps/frappe/frappe/desk/form/assign_to.py,Shared with user {0} with read access,Foydalanuvchi bilan {0} foydalanuvchi bilan ulashilgan
 DocType: GCalendar Account,Next Sync Token,Keyingi Sync Token
 DocType: Energy Point Settings,Energy Point Settings,Energiya nuqtasini sozlash
-DocType: Async Task,Succeeded,Muvaffaqiyatli bo&#39;ldi
+DocType: Async Task,Succeeded,Muvaffaqiyatli bo'ldi
 apps/frappe/frappe/public/js/frappe/form/save.js,Mandatory fields required in {0},{0} da majburiy maydonlar kerak
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Reset Permissions for {0}?,{0} uchun ruxsatni qayta tiklash?
 apps/frappe/frappe/config/desktop.py,Users and Permissions,Foydalanuvchilar va ruxsatnomalar
@@ -1827,61 +1827,61 @@ DocType: S3 Backup Settings,S3 Backup Settings,S3 Zahiralash sozlamalari
 apps/frappe/frappe/core/doctype/version/version_view.html,Rows Removed,Qatorlar olib tashlandi
 apps/frappe/frappe/permissions.py,{0} {1} not found,{0} {1} topilmadi
 apps/frappe/frappe/www/login.py,Mobile Number,Mobil telefon raqami
-DocType: Comment,Attachment Removed,Qo&#39;shilgan fayl o&#39;chirildi
-apps/frappe/frappe/utils/password_strength.py,Recent years are easy to guess.,So&#39;nggi yillarda taxmin qilish oson.
+DocType: Comment,Attachment Removed,Qo'shilgan fayl o'chirildi
+apps/frappe/frappe/utils/password_strength.py,Recent years are easy to guess.,So'nggi yillarda taxmin qilish oson.
 DocType: Calendar View,Subject Field,Mavzu maydoni
 apps/frappe/frappe/public/js/frappe/views/interaction.js,The document has been assigned to {0},Hujjat {0} ga tayinlangan
-DocType: System Settings,Show Full Error and Allow Reporting of Issues to the Developer,To&#39;liq xatoni ko&#39;rsating va muammoni hisobotchilarga bildiring
+DocType: System Settings,Show Full Error and Allow Reporting of Issues to the Developer,To'liq xatoni ko'rsating va muammoni hisobotchilarga bildiring
 apps/frappe/frappe/www/third_party_apps.html,Active Sessions,Faol sessiyalar
 DocType: DocType,ASC,ASC
 apps/frappe/frappe/public/js/frappe/form/print.js,New Print Format Name,Chop etish formatining yangi nomi
-apps/frappe/frappe/templates/emails/data_deletion_approval.html,Click on the link below to approve the request,So&#39;rovni tasdiqlash uchun quyidagi havolani bosing
+apps/frappe/frappe/templates/emails/data_deletion_approval.html,Click on the link below to approve the request,So'rovni tasdiqlash uchun quyidagi havolani bosing
 DocType: Workflow State,align-left,align-left
 DocType: User,Defaults,Standartlar
 DocType: Energy Point Log,Revert Of,Qaytarish
 apps/frappe/frappe/public/js/frappe/model/model.js,Merge with existing,Mavjud bilan birlashtirilsin
-DocType: User,Birth Date,Tug&#39;ilgan sana
-DocType: Communication Link,Link Title,Bog&#39;lanish nomi
+DocType: User,Birth Date,Tug'ilgan sana
+DocType: Communication Link,Link Title,Bog'lanish nomi
 DocType: Workflow State,fast-backward,tez orqaga
 DocType: Address,Chandigarh,Chandigarh
 DocType: DocShare,DocShare,DocShare
 DocType: Assignment Rule Day,Friday,Juma kuni
-apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Edit in full page,To&#39;liq sahifada tahrir qiling
-apps/frappe/frappe/public/js/frappe/list/list_view.js,Open list item,Ochiladigan ro&#39;yxat elementi
-DocType: Report,Add Total Row,Umumiy satr qo&#39;shish
-apps/frappe/frappe/public/js/frappe/form/print.js,No Preview available,Ko&#39;rib chiqish yo&#39;q
-apps/frappe/frappe/twofactor.py,Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it.,"Qanday qilib davom ettirish bo&#39;yicha ko&#39;rsatmalar uchun ro&#39;yxatdan o&#39;tgan elektron pochta manzilingizni tekshiring. Bu oynani yopib qo&#39;ymang, chunki siz unga qaytib kelishingiz kerak."
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Masalan, agar siz INV004ni bekor qilsangiz va o&#39;zgartirsangiz, u INV004-1 yangi hujjat bo&#39;ladi. Bu har bir o&#39;zgarishlarni kuzatib borishga yordam beradi."
+apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Edit in full page,To'liq sahifada tahrir qiling
+apps/frappe/frappe/public/js/frappe/list/list_view.js,Open list item,Ochiladigan ro'yxat elementi
+DocType: Report,Add Total Row,Umumiy satr qo'shish
+apps/frappe/frappe/public/js/frappe/form/print.js,No Preview available,Ko'rib chiqish yo'q
+apps/frappe/frappe/twofactor.py,Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it.,"Qanday qilib davom ettirish bo'yicha ko'rsatmalar uchun ro'yxatdan o'tgan elektron pochta manzilingizni tekshiring. Bu oynani yopib qo'ymang, chunki siz unga qaytib kelishingiz kerak."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment.,"Masalan, agar siz INV004ni bekor qilsangiz va o'zgartirsangiz, u INV004-1 yangi hujjat bo'ladi. Bu har bir o'zgarishlarni kuzatib borishga yordam beradi."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Atleast one field of Parent Document Type is mandatory,Asosiy hujjat turining eng kamida bitta maydoni majburiydir
 apps/frappe/frappe/config/settings.py,Setup Reports to be emailed at regular intervals,Hisobotlar muntazam ravishda elektron pochta orqali yuboriladi
 DocType: Workflow Document State,0 - Draft; 1 - Submitted; 2 - Cancelled,0 - loyiha; 1 - taqdim etilgan; 2 - Bekor qilindi
-DocType: File,Attached To DocType,DocType-ga qo&#39;shildi
+DocType: File,Attached To DocType,DocType-ga qo'shildi
 DocType: DocField,Int,Int
 DocType: Error Log,Title,Sarlavha
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,"Seems issue with server's razorpay config. Don't worry, in case of failure amount will get refunded to your account.","Serverning razorpay konfiguratsiyasi bilan o&#39;xshab qoladi. Xavotir olmang, chunki qobiliyatsiz to&#39;lov miqdori hisobingizga qaytariladi."
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,"Seems issue with server's razorpay config. Don't worry, in case of failure amount will get refunded to your account.","Serverning razorpay konfiguratsiyasi bilan o'xshab qoladi. Xavotir olmang, chunki qobiliyatsiz to'lov miqdori hisobingizga qaytariladi."
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Customize,Moslashtiring
-apps/frappe/frappe/core/doctype/user/user.js,View Permitted Documents,Ruxsat etilgan hujjatlarni ko&#39;rish
-apps/frappe/frappe/utils/print_format.py,You need to install pycups to use this feature!,Ushbu xususiyatdan foydalanish uchun siz pikuplarni o&#39;rnatishingiz kerak!
-apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Your connection request to Google Calendar was successfully accepted,Google Taqvimga ulanish so&#39;rovi muvaffaqiyatli qabul qilindi
+apps/frappe/frappe/core/doctype/user/user.js,View Permitted Documents,Ruxsat etilgan hujjatlarni ko'rish
+apps/frappe/frappe/utils/print_format.py,You need to install pycups to use this feature!,Ushbu xususiyatdan foydalanish uchun siz pikuplarni o'rnatishingiz kerak!
+apps/frappe/frappe/templates/pages/integrations/gcalendar-success.html,Your connection request to Google Calendar was successfully accepted,Google Taqvimga ulanish so'rovi muvaffaqiyatli qabul qilindi
 DocType: Tag Link,Tag Link,Tag link
 apps/frappe/frappe/core/report/transaction_log_report/transaction_log_report.py,Chain Integrity,Zanjirning yaxlitligi
 DocType: Data Export,CSV,CSV
 DocType: Currency,"1 Currency = [?] Fraction
 For e.g. 1 USD = 100 Cent","1 Valyuta = [?] Fraktsiya Masalan, 1 AQSh dollari = 100 Cent"
 DocType: Data Import,Partially Successful,Qisman muvaffaqiyatli
-apps/frappe/frappe/core/doctype/user/user.py,"Too many users signed up recently, so the registration is disabled. Please try back in an hour","So&#39;nggi paytlarda juda ko&#39;p foydalanuvchi ro&#39;yxatga olindi, shuning uchun ro&#39;yxatga olish o&#39;chirib qo&#39;yildi. Bir soatdan keyin urinib ko&#39;ring"
-apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add New Permission Rule,Yangi ruxsatnoma qoidasini qo&#39;shing
+apps/frappe/frappe/core/doctype/user/user.py,"Too many users signed up recently, so the registration is disabled. Please try back in an hour","So'nggi paytlarda juda ko'p foydalanuvchi ro'yxatga olindi, shuning uchun ro'yxatga olish o'chirib qo'yildi. Bir soatdan keyin urinib ko'ring"
+apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Add New Permission Rule,Yangi ruxsatnoma qoidasini qo'shing
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,You can use wildcard %,Joker belgidan%
 DocType: LDAP Settings,LDAP Group Mappings,LDAP guruh xaritalari
 DocType: Chat Message Attachment,Chat Message Attachment,Tezkor xabar birikmasi
-DocType: LDAP Settings,Path to CA Certs File,CA Certs fayliga yo&#39;l
+DocType: LDAP Settings,Path to CA Certs File,CA Certs fayliga yo'l
 DocType: Address,Manipur,Manipur
-DocType: Web Form Field,Allow Read On All Link Options,Barcha bog&#39;lanish parametrlarini o&#39;qishga ruxsat berish
-DocType: DocType,Database Engine,Ma&#39;lumotlar bazasi tizimi
-DocType: Customize Form,"Fields separated by comma (,) will be included in the ""Search By"" list of Search dialog box","Vergul (,) bilan ajratilgan maydonlar &quot;Qidiruvni&quot; qidirish ro&#39;yxatiga kiritiladi"
+DocType: Web Form Field,Allow Read On All Link Options,Barcha bog'lanish parametrlarini o'qishga ruxsat berish
+DocType: DocType,Database Engine,Ma'lumotlar bazasi tizimi
+DocType: Customize Form,"Fields separated by comma (,) will be included in the ""Search By"" list of Search dialog box","Vergul (,) bilan ajratilgan maydonlar &quot;Qidiruvni&quot; qidirish ro'yxatiga kiritiladi"
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Please Duplicate this Website Theme to customize.,"Iltimos, sozlash uchun ushbu veb-sayt mavzusini takrorlang."
 DocType: Address,Meghalaya,Meghalaya
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Foydalanuvchi nomi yoki parol noto&#39;g&#39;ri
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Invalid username or password,Foydalanuvchi nomi yoki parol noto'g'ri
 DocType: DocField,Text Editor,Matn tahrirlovchisi
 apps/frappe/frappe/config/website.py,Settings for About Us Page.,Biz haqimizda.
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit Custom HTML,Maxsus HTMLni tahrirlash
@@ -1889,60 +1889,60 @@ DocType: Error Snapshot,Error Snapshot,Xato ekrani
 DocType: S3 Backup Settings,ap-northeast-3,shimoli-sharqiy-3
 DocType: Data Migration Mapping,Remote Primary Key,Masofadagi asosiy kalit
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,In,In
-DocType: Notification,Value Change,Qiymat o&#39;zgarishi
+DocType: Notification,Value Change,Qiymat o'zgarishi
 DocType: Google Contacts,Authorize Google Contacts Access,Google Kontaktlarga kirishga ruxsat bering
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Hisobotdagi faqat raqamli maydonlarni ko&#39;rsatish
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Showing only Numeric fields from Report,Hisobotdagi faqat raqamli maydonlarni ko'rsatish
 DocType: Data Import Beta,Import Type,Import turi
 DocType: Access Log,HTML Page,HTML sahifasi
-DocType: Address,Subsidiary,Sho&#39;ba korxonasi
+DocType: Address,Subsidiary,Sho'ba korxonasi
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting Connection to QZ Tray...,QZ trayiga ulanishga urinilmoqda ...
 DocType: System Settings,In Hours,Soatlarda
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Google Drive-da papkani topib bo&#39;lmadi - Xato kodi {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not find folder in Google Drive - Error Code {0},Google Drive - Google Drive-da papkani topib bo'lmadi - Xato kodi {0}
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,With Letterhead,Antetli harflar bilan
-apps/frappe/frappe/email/smtp.py,Invalid Outgoing Mail Server or Port,Chiquvchi pochta-server yoki port noto&#39;g&#39;ri
+apps/frappe/frappe/email/smtp.py,Invalid Outgoing Mail Server or Port,Chiquvchi pochta-server yoki port noto'g'ri
 DocType: Custom DocPerm,Write,Yozing
-apps/frappe/frappe/core/doctype/report/report.py,Only Administrator allowed to create Query / Script Reports,Faqat Administrator so&#39;rovlar / skriptlar hisobotlarini yaratishga ruxsat berildi
+apps/frappe/frappe/core/doctype/report/report.py,Only Administrator allowed to create Query / Script Reports,Faqat Administrator so'rovlar / skriptlar hisobotlarini yaratishga ruxsat berildi
 apps/frappe/frappe/public/js/frappe/form/save.js,Updating,Yangilanmoqda
-DocType: Data Import Beta,Preview,Ko&#39;rib chiqish
-apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated",Maydoni &quot;qiymat&quot; majburiydir. Yangilanadigan qiymatni ko&#39;rsating
+DocType: Data Import Beta,Preview,Ko'rib chiqish
+apps/frappe/frappe/desk/doctype/bulk_update/bulk_update.js,"Field ""value"" is mandatory. Please specify value to be updated",Maydoni &quot;qiymat&quot; majburiydir. Yangilanadigan qiymatni ko'rsating
 DocType: Customize Form,Use this fieldname to generate title,Sarlavha yaratish uchun ushbu maydon nomidan foydalaning
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Email From,Elektron pochtadan import
 apps/frappe/frappe/contacts/doctype/contact/contact.js,Invite as User,Foydalanuvchi sifatida taklif qiling
 DocType: Data Migration Run,Started,Boshlandi
 apps/frappe/frappe/permissions.py,User {0} does not have access to this document,{0} foydalanuvchisi ushbu hujjatga kirish huquqiga ega emas
 DocType: Data Migration Run,End Time,Tugash vaqti
-apps/frappe/frappe/public/js/frappe/views/interaction.js,Select Attachments,Qo&#39;shilganlar-ni tanlang
+apps/frappe/frappe/public/js/frappe/views/interaction.js,Select Attachments,Qo'shilganlar-ni tanlang
 apps/frappe/frappe/model/naming.py, for {0},{0} uchun
-apps/frappe/frappe/public/js/frappe/form/print.js,You are not allowed to print this document,Ushbu hujjatni chop etishga ruxsat yo&#39;q
+apps/frappe/frappe/public/js/frappe/form/print.js,You are not allowed to print this document,Ushbu hujjatni chop etishga ruxsat yo'q
 apps/frappe/frappe/data_migration/doctype/data_migration_run/data_migration_run.js,Currently updating {0},Siz {0} yangilanmoqda
 apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Please set filters value in Report Filter table.,Filteringiz jadvalidagi filtr qiymatini belgilang.
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export All {0} rows?,Barcha {0} qatorlarni eksport qilinsinmi?
 DocType: Page,Standard,Standart
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Attach File,Faylni biriktiring
 DocType: Data Migration Plan,Preprocess Method,Tayyorlash usuli
-apps/frappe/frappe/desk/form/document_follow.py,Document Follow Notification,Hujjatni kuzatib borish to&#39;g&#39;risida bildirishnoma
+apps/frappe/frappe/desk/form/document_follow.py,Document Follow Notification,Hujjatni kuzatib borish to'g'risida bildirishnoma
 apps/frappe/frappe/desk/page/backups/backups.html,Size,Hajmi
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Assignment Complete,Topshirish tugadi
 DocType: Desktop Icon,Idx,Idx
-apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Toggle Full Width,To&#39;liq kenglikni almashtirish
+apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Toggle Full Width,To'liq kenglikni almashtirish
 DocType: Address,Madhya Pradesh,Madhya Pradesh
 DocType: Deleted Document,New Name,Yangi ism
 DocType: System Settings,Is First Startup,Birinchi start
 DocType: Communication,Email Status,E-pochta manzili
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Please save the document before removing assignment,Belgini olishdan oldin hujjatni saqlang
-apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Insert Above,Yuqoridagi qo&#39;shib qo&#39;ying
-apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Add script for Child Table,Bolalar jadvali uchun skript qo&#39;shing
+apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Insert Above,Yuqoridagi qo'shib qo'ying
+apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Add script for Child Table,Bolalar jadvali uchun skript qo'shing
 apps/frappe/frappe/desk/form/utils.py,Comment can only be edited by the owner,Fikr faqat egasi tomonidan tahrirlanishi mumkin
-DocType: Data Import,Do not send Emails,Elektron pochta xabarlarini jo&#39;natmang
+DocType: Data Import,Do not send Emails,Elektron pochta xabarlarini jo'natmang
 apps/frappe/frappe/utils/password_strength.py,Common names and surnames are easy to guess.,Umumiy ism va familiyalar tahmin qilish oson.
 DocType: Google Drive,Google Drive,Google Drive
 apps/frappe/frappe/public/js/frappe/model/indicator.js,Draft,Taslak
-apps/frappe/frappe/utils/password_strength.py,This is similar to a commonly used password.,Bu ko&#39;pincha ishlatiladigan parolga o&#39;xshaydi.
+apps/frappe/frappe/utils/password_strength.py,This is similar to a commonly used password.,Bu ko'pincha ishlatiladigan parolga o'xshaydi.
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Female,Ayol
 DocType: Success Action,Success Action,Muvaffaqiyat harakati
 apps/frappe/frappe/public/js/frappe/model/indicator.js,Not Saved,Saqlanmagan
 apps/frappe/frappe/www/third_party_apps.html,Revoke,Bekor qiling
-apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You are now following this document. You will receive daily updates via email. You can change this in User Settings.,Siz hozir ushbu hujjatni kuzatmoqdasiz. Siz har kuni yangilanishlarni elektron pochta orqali olasiz. Siz buni foydalanuvchi sozlamalarida o&#39;zgartirishingiz mumkin.
+apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You are now following this document. You will receive daily updates via email. You can change this in User Settings.,Siz hozir ushbu hujjatni kuzatmoqdasiz. Siz har kuni yangilanishlarni elektron pochta orqali olasiz. Siz buni foydalanuvchi sozlamalarida o'zgartirishingiz mumkin.
 DocType: Contact,Replied,Javob berdi
 DocType: Newsletter,Test,Viktorina
 DocType: Custom Field,Default Value,Standart qiymat
@@ -1953,90 +1953,90 @@ DocType: Workflow Document State,Update Field,Yangilash maydonchasi
 DocType: Chat Profile,Enable Chat,Chatni yoqish
 DocType: LDAP Settings,Base Distinguished Name (DN),Asosiy ajratuvchi ism (DN)
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Leave this conversation,Ushbu suhbatni qoldiring
-apps/frappe/frappe/model/base_document.py,Options not set for link field {0},{0} havola maydoniga o&#39;rnatilmagan imkoniyatlar
+apps/frappe/frappe/model/base_document.py,Options not set for link field {0},{0} havola maydoniga o'rnatilmagan imkoniyatlar
 apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker,Navbat / ishchi
 DocType: S3 Backup Settings,ap-southeast-1,ap-janubi-sharqiy-1
-DocType: DocType,"Must be of type ""Attach Image""",Turi bo&#39;lishi kerak &quot;Rasm qo&#39;shish&quot;
+DocType: DocType,"Must be of type ""Attach Image""",Turi bo'lishi kerak &quot;Rasm qo'shish&quot;
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,Barchasini tanlash
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},{0} uchun &quot;Faqat o&#39;qish&quot; funksiyasini o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},{0} uchun &quot;Faqat o'qish&quot; funksiyasini o'chirib bo'lmaydi
 DocType: Auto Email Report,Zero means send records updated at anytime,"Nolinchi yozuvlar, istalgan vaqtda yangilangan yozuvlarni yangilab turishni anglatadi"
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,To&#39;liq O&#39;rnatish
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,To'liq O'rnatish
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Updated successfully,Muvaffaqiyatli yangilandi
 DocType: Workflow State,asterisk,yulduzcha
 DocType: Data Import,Successful,Muvaffaqiyatli
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Please do not change the template headings.,"Iltimos, shablon sarlavhalarini o&#39;zgartirmang."
-DocType: Activity Log,Linked,Bog&#39;langan
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Please do not change the template headings.,"Iltimos, shablon sarlavhalarini o'zgartirmang."
+DocType: Activity Log,Linked,Bog'langan
 apps/frappe/frappe/config/desk.py,Activity log of all users.,Barcha foydalanuvchilarning jurnali.
 DocType: Workflow State,shopping-cart,xarid savati
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Week,Hafta
 DocType: DocType,Open a dialog with mandatory fields to create a new record quickly,Yangi yozuvni tezda yaratish uchun majburiy maydonlar bilan muloqot oynasini oching
-apps/frappe/frappe/templates/includes/login/login.js,Not Allowed: Disabled User,Ruxsat berilmagan: o&#39;chirilgan foydalanuvchi
+apps/frappe/frappe/templates/includes/login/login.js,Not Allowed: Disabled User,Ruxsat berilmagan: o'chirilgan foydalanuvchi
 DocType: Social Login Key,Google,Google
 DocType: Email Domain,Example Email Address,Misol elektron pochta manzili
-apps/frappe/frappe/public/js/frappe/ui/sort_selector.js,Most Used,Eng ko&#39;p ishlatilgan
+apps/frappe/frappe/public/js/frappe/ui/sort_selector.js,Most Used,Eng ko'p ishlatilgan
 ,user-profile,foydalanuvchi profili
 apps/frappe/frappe/www/login.html,Forgot Password,Parolni unutdingizmi
 DocType: Dropbox Settings,Backup Frequency,Zaxiralash chastotasi
 DocType: Workflow State,Inverse,Teskari
-DocType: DocField,User permissions should not apply for this Link,Ushbu havola uchun foydalanuvchi ruxsatnomalari qo&#39;llanilmasligi kerak
-apps/frappe/frappe/model/naming.py,Invalid naming series (. missing),Noto&#39;g&#39;ri nomlash seriyasi (yo&#39;qolgan)
-DocType: Web Form,Show Attachments,Ilovalarni ko&#39;rsatish
+DocType: DocField,User permissions should not apply for this Link,Ushbu havola uchun foydalanuvchi ruxsatnomalari qo'llanilmasligi kerak
+apps/frappe/frappe/model/naming.py,Invalid naming series (. missing),Noto'g'ri nomlash seriyasi (yo'qolgan)
+DocType: Web Form,Show Attachments,Ilovalarni ko'rsatish
 DocType: Language,Language,Til
-apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Brauzer qo&#39;llab-quvvatlanmaydi
-DocType: Social Login Key,Client URLs,Mijoz URL&#39;lari
-apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Some information is missing,Ba&#39;zi ma&#39;lumotlar yo&#39;q
+apps/frappe/frappe/public/js/frappe/desk.js,Browser not supported,Brauzer qo'llab-quvvatlanmaydi
+DocType: Social Login Key,Client URLs,Mijoz URL'lari
+apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Some information is missing,Ba'zi ma'lumotlar yo'q
 apps/frappe/frappe/public/js/frappe/views/interaction.js,{0} created successfully,{0} muvaffaqiyatli yaratildi
-apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Skipping {0} of {1}, {2}","{1}, {2} ning {0} o&#39;tkazib yuborilishi"
+apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Skipping {0} of {1}, {2}","{1}, {2} ning {0} o'tkazib yuborilishi"
 DocType: Custom DocPerm,Cancel,Bekor qilish
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Bulk Delete,Ommaviy o&#39;chirish
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Bulk Delete,Ommaviy o'chirish
 apps/frappe/frappe/core/doctype/file/file.py,File {0} does not exist,{0} fayl mavjud emas
 DocType: Dashboard Chart,Dashboard Chart,Dashboard jadvali
-DocType: Dashboard Chart,Last Quarter,So&#39;nggi chorak
-apps/frappe/frappe/config/website.py,List of themes for Website.,Veb-sayt uchun mavzular ro&#39;yxati.
+DocType: Dashboard Chart,Last Quarter,So'nggi chorak
+apps/frappe/frappe/config/website.py,List of themes for Website.,Veb-sayt uchun mavzular ro'yxati.
 apps/frappe/frappe/templates/emails/delete_data_confirmation.html,"Dear User,","Hurmatli foydalanuvchi,"
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Successfully Updated,Muvaffaqiyatli yangilandi
 DocType: Activity Log,Logout,Chiqish
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,Yuqori darajadagi ruxsatlar maydon darajasidagi ruxsatnomalardir. Barcha maydonlar ularga qarshi ruxsat darajasiga ega va ushbu ruxsatnomada belgilangan qoidalar bu sohada qo&#39;llaniladi. Bu sizning aniq rolni bajarish uchun faqat ma&#39;lum maydonni o&#39;qish uchun yashirishni xohlasangiz foydali bo&#39;ladi.
-DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, password=1234 etc.)","Statik url parametrlarini bu erga kiriting (masalan, jo&#39;natuvchi = ERPNext, username = ERPNext, parol = 1234 va hokazo)"
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles.,Yuqori darajadagi ruxsatlar maydon darajasidagi ruxsatnomalardir. Barcha maydonlar ularga qarshi ruxsat darajasiga ega va ushbu ruxsatnomada belgilangan qoidalar bu sohada qo'llaniladi. Bu sizning aniq rolni bajarish uchun faqat ma'lum maydonni o'qish uchun yashirishni xohlasangiz foydali bo'ladi.
+DocType: SMS Settings,"Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, password=1234 etc.)","Statik url parametrlarini bu erga kiriting (masalan, jo'natuvchi = ERPNext, username = ERPNext, parol = 1234 va hokazo)"
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Google Font,Google Shrift
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Ushbu ko&#39;rsatmalar foydali bo&#39;lmasa, iltimos, GitHub muammolari bo&#39;yicha takliflaringizni qo&#39;shing."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"If these instructions where not helpful, please add in your suggestions on GitHub Issues.","Ushbu ko'rsatmalar foydali bo'lmasa, iltimos, GitHub muammolari bo'yicha takliflaringizni qo'shing."
 DocType: Workflow State,bookmark,manzil belgisi
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Folder name should not include '/' (slash),Papka nomi &quot;/&quot; (slash)
 DocType: Note,Note,Eslatma
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.html,Error Report,Xato hisoboti
-apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Ma&#39;lumotlarni CSV / Excel formatida eksport qilish.
+apps/frappe/frappe/config/settings.py,Export Data in CSV / Excel format.,Ma'lumotlarni CSV / Excel formatida eksport qilish.
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Setting up Global Search documents.,Global qidirish hujjatlarini sozlash.
-apps/frappe/frappe/www/qrcode.html,Authentication Apps you can use are: ,Siz foydalanishingiz mumkin bo&#39;lgan haqiqiylikni tekshirish dasturlari quyidagilardir:
+apps/frappe/frappe/www/qrcode.html,Authentication Apps you can use are: ,Siz foydalanishingiz mumkin bo'lgan haqiqiylikni tekshirish dasturlari quyidagilardir:
 apps/frappe/frappe/public/js/frappe/form/controls/data.js,{0} already exists. Select another name,{0} allaqachon mavjud. Boshqa nomni tanlang
-DocType: S3 Backup Settings,None,Yo&#39;q
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a valid fieldname,Vaqt jadvalining maydoni tegishli maydon nomi bo&#39;lishi kerak
+DocType: S3 Backup Settings,None,Yo'q
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Timeline field must be a valid fieldname,Vaqt jadvalining maydoni tegishli maydon nomi bo'lishi kerak
 DocType: Contact,Email Ids,Elektron pochta identifikatorlari
 DocType: GCalendar Account,Session Token,Kirish Token
 DocType: Currency,Symbol,Ramz
 apps/frappe/frappe/model/base_document.py,Row #{0}:,# {0} qatori:
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,Confirm Deletion of Data,Ma&#39;lumotni yo&#39;q qilishni tasdiqlang
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,Confirm Deletion of Data,Ma'lumotni yo'q qilishni tasdiqlang
 apps/frappe/frappe/auth.py,Login not allowed at this time,Bu vaqtda kirish uchun ruxsat berilmaydi
 DocType: Data Migration Run,Current Mapping Action,Joriy xaritalash harakati
 DocType: Dashboard Chart Source,Source Name,Manba nomi
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Foydalanuvchi bilan bog&#39;langan elektron pochta hisobi yo&#39;q. Iltimos, foydalanuvchi> Elektron pochta qutisi ostida hisob qaydnomasini qo&#39;shing."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Foydalanuvchi bilan bog'langan elektron pochta hisobi yo'q. Iltimos, foydalanuvchi> Elektron pochta qutisi ostida hisob qaydnomasini qo'shing."
 DocType: Email Account,Email Sync Option,Elektron pochtani sinxronlashtirish opsiyasi
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Roy №
 DocType: Async Task,Runtime,Ish vaqti
-DocType: Post,Is Pinned,Yig&#39;ilgan
+DocType: Post,Is Pinned,Yig'ilgan
 DocType: Contact Us Settings,Introduction,Kirish
-apps/frappe/frappe/public/js/frappe/social/components/Post.vue,Pin Globally,Dunyo bo&#39;ylab pin
-apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Followed by,Dan so&#39;ng
+apps/frappe/frappe/public/js/frappe/social/components/Post.vue,Pin Globally,Dunyo bo'ylab pin
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Followed by,Dan so'ng
 DocType: LDAP Settings,LDAP Email Field,LDAP elektron pochta manzili
-apps/frappe/frappe/core/page/dashboard/dashboard.js,{0} List,{0} Ro&#39;yxat
+apps/frappe/frappe/core/page/dashboard/dashboard.js,{0} List,{0} Ro'yxat
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export {0} records,{0} yozuvlarni eksport qilish
-apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Siz allaqachon foydalanuvchi bajaradigan ro&#39;yxatida
+apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Siz allaqachon foydalanuvchi bajaradigan ro'yxatida
 DocType: User Email,Enable Outgoing,Chiqishni yoqish
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,Maxsus teglar
 apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,"Elektron pochta qayd hisobi sozlanmadi. Iltimos, sozlash> Elektron pochta> Elektron pochta qayd hisobi orqali yangi elektron pochta qayd yozuvini yarating"
 DocType: Comment,Submitted,Taklif qilingan
 DocType: Contact,Pulled from Google Contacts,Google Contacts-dan tortib olindi
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Qabul qilingan so&#39;rovda
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Qabul qilingan so'rovda
 apps/frappe/frappe/website/doctype/website_theme/website_theme.py,Compiled Successfully,Muvaffaqiyatli tuzilgan
 DocType: System Settings,Email Footer Address,E-pochta manzili manzili
 apps/frappe/frappe/public/js/frappe/form/grid.js,Table updated,Jadval yangilandi
@@ -2044,7 +2044,7 @@ DocType: Activity Log,Timeline DocType,Timeline DocType
 DocType: Success Action,Action Timeout (Seconds),Vaqt tugashi (soniya)
 DocType: DocField,Text,Matn
 apps/frappe/frappe/email/doctype/email_account/email_account_list.js,Default Sending,Standart yuborish
-DocType: Workflow State,volume-off,ovozni o&#39;chirish
+DocType: Workflow State,volume-off,ovozni o'chirish
 apps/frappe/frappe/public/js/frappe/form/templates/timeline_item.html,Liked by {0},{0} tomonidan yoqdi
 DocType: LDAP Settings,LDAP Security,LDAP xavfsizligi
 DocType: Footer Item,Footer Item,Olmashlar elementi
@@ -2053,45 +2053,45 @@ DocType: Energy Point Log,Points,Ballar
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1,Bosh sahifa / Jildni tekshirish 1
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Assign to me,Menga topshiring
 DocType: DocField,Dynamic Link,Dynamic Link
-apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Press Alt Key to trigger additional shortcuts in Menu and Sidebar,Menyu va yon panelda qo&#39;shimcha yorliqlarni ishga tushirish uchun Alt tugmachasini bosing
-DocType: List View Setting,List View Setting,Ro&#39;yxat ko&#39;rinishini sozlash
-apps/frappe/frappe/core/page/background_jobs/background_jobs_outer.html,Show failed jobs,Muvaffaqiyatsiz ishlarni ko&#39;rsatish
+apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Press Alt Key to trigger additional shortcuts in Menu and Sidebar,Menyu va yon panelda qo'shimcha yorliqlarni ishga tushirish uchun Alt tugmachasini bosing
+DocType: List View Setting,List View Setting,Ro'yxat ko'rinishini sozlash
+apps/frappe/frappe/core/page/background_jobs/background_jobs_outer.html,Show failed jobs,Muvaffaqiyatsiz ishlarni ko'rsatish
 DocType: Event,Details,Batafsil
 DocType: Property Setter,DocType or Field,DocType yoki Field
 apps/frappe/frappe/public/js/frappe/form/sidebar/document_follow.js,You unfollowed this document,Siz ushbu hujjatni bekor qildingiz
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Primary Color,Birlamchi rang
 DocType: Communication,Soft-Bounced,Yumshoq tus oldi
-DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Agar yoqilsa, barcha foydalanuvchilar ikkita omildan foydalangan holda har qanday IP-manzildan kirishlari mumkin. Bu faqat foydalanuvchi sahifasida muayyan foydalanuvchi (lar) uchun o&#39;rnatilishi mumkin"
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Seems Publishable Key or Secret Key is wrong !!!,Nashr etilgan kaliti yoki maxfiy kalit noto&#39;g&#39;ri deb o&#39;ylaydi !!!
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Quick Help for Setting Permissions,Ruxsatlar o&#39;rnatish uchun tez yordam
+DocType: System Settings,"If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page","Agar yoqilsa, barcha foydalanuvchilar ikkita omildan foydalangan holda har qanday IP-manzildan kirishlari mumkin. Bu faqat foydalanuvchi sahifasida muayyan foydalanuvchi (lar) uchun o'rnatilishi mumkin"
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Seems Publishable Key or Secret Key is wrong !!!,Nashr etilgan kaliti yoki maxfiy kalit noto'g'ri deb o'ylaydi !!!
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Quick Help for Setting Permissions,Ruxsatlar o'rnatish uchun tez yordam
 DocType: Tag Doc Category,Doctype to Assign Tags,Teglar tayinlash uchun doctype
-apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.js,Show Relapses,Relapslarni ko&#39;rsating
-apps/frappe/frappe/core/doctype/communication/communication.js,Email has been moved to trash,E-pochta zaxiraga o&#39;tkazildi
+apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot.js,Show Relapses,Relapslarni ko'rsating
+apps/frappe/frappe/core/doctype/communication/communication.js,Email has been moved to trash,E-pochta zaxiraga o'tkazildi
 DocType: Report,Report Builder,Report Builder
 DocType: Async Task,Task Name,Vazifa nomi
 DocType: Website Route Meta,Meta Tags,Meta Teglar
 apps/frappe/frappe/app.py,"Your session has expired, please login again to continue.","Sizning seansingiz tugadi, davom etish uchun yana tizimga kiring."
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Invalid Subscription,Noto&#39;g&#39;ri obuna
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Invalid Subscription,Noto'g'ri obuna
 DocType: Comment,Workflow,Ish oqimi
 DocType: Website Settings,Welcome Message,Xush kelibsiz xabar
-DocType: Webhook,Webhook Headers,Webhook to&#39;plamlari
+DocType: Webhook,Webhook Headers,Webhook to'plamlari
 DocType: Workflow State,Upload,Yuklash
 DocType: User Permission,Advanced Control,Murakkab boshqaruv
 DocType: System Settings,Date Format,Sana formati
 apps/frappe/frappe/website/doctype/blog_post/blog_post_list.js,Not Published,Nashr qilinmadi
 apps/frappe/frappe/config/settings.py,"Actions for workflow (e.g. Approve, Cancel).","Ish yuritish uchun harakatlar (masalan, Tasdiqlash, Bekor qilish)."
-DocType: Data Import,Skip rows with errors,Xatlardagi satrlarni o&#39;tkazib yuborish
+DocType: Data Import,Skip rows with errors,Xatlardagi satrlarni o'tkazib yuborish
 DocType: Workflow State,flag,bayroq
 DocType: Web Page,Text Align,Matnni tekislang
 apps/frappe/frappe/model/naming.py,Name cannot contain special characters like {0},Odatda {0} kabi maxsus belgilar mavjud emas
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Print Documents,Hujjatlarni chop eting
-apps/frappe/frappe/public/js/frappe/form/toolbar.js,Jump to field,Maydonga o&#39;ting
-DocType: Contact Us Settings,Forward To Email Address,E-pochta manziliga yo&#39;naltirish
+apps/frappe/frappe/public/js/frappe/form/toolbar.js,Jump to field,Maydonga o'ting
+DocType: Contact Us Settings,Forward To Email Address,E-pochta manziliga yo'naltirish
 DocType: Contact Phone,Is Primary Phone,Bu asosiy telefon
-apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,Bu yerga bog&#39;lash uchun {0} ga elektron pochta xabarini yuboring.
+apps/frappe/frappe/public/js/frappe/form/templates/timeline.html,Send an email to {0} to link it here.,Bu yerga bog'lash uchun {0} ga elektron pochta xabarini yuboring.
 DocType: Auto Email Report,Weekdays,Hafta kunlari
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,{0} records will be exported,{0} yozuvlar eksport qilinadi
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Sarlavha maydoni tegishli maydon nomi bo&#39;lishi kerak
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Title field must be a valid fieldname,Sarlavha maydoni tegishli maydon nomi bo'lishi kerak
 DocType: Post Comment,Post Comment,Fikr qoldiring
 apps/frappe/frappe/config/core.py,Documents,Hujjatlar
 apps/frappe/frappe/config/users_and_permissions.py,Activity Log by ,Faoliyat jurnali
@@ -2105,32 +2105,32 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Soatdagi amal qilis
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Bu maydon faqat bu erda ko&#39;rsatilgan maydon nomiga qiymat yoki qoidalar haqiqiy (misollar) bo&#39;lsa paydo bo&#39;ladi: myfield eval: doc.myfield == &#39;Mening qiymatim&#39; eval: doc.age> 18
+eval:doc.age>18",Bu maydon faqat bu erda ko'rsatilgan maydon nomiga qiymat yoki qoidalar haqiqiy (misollar) bo'lsa paydo bo'ladi: myfield eval: doc.myfield == 'Mening qiymatim' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Bugun
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Siz buni o&#39;rnatganingizdan so&#39;ng, foydalanuvchilar faqatgina link mavjud bo&#39;lgan hujjatlarga (masalan, Blog Post) kirish imkoniyatiga ega bo&#39;ladi (masalan, Blogger)."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Siz buni o'rnatganingizdan so'ng, foydalanuvchilar faqatgina link mavjud bo'lgan hujjatlarga (masalan, Blog Post) kirish imkoniyatiga ega bo'ladi (masalan, Blogger)."
 DocType: Data Import Beta,Submit After Import,Import qilinganidan keyin yuborish
-DocType: Error Log,Log of Scheduler Errors,Jadvaldagi xatolar ro&#39;yxati
+DocType: Error Log,Log of Scheduler Errors,Jadvaldagi xatolar ro'yxati
 DocType: User,Bio,Bio
 DocType: OAuth Client,App Client Secret,Ilova mijoz sirlari
 apps/frappe/frappe/public/js/frappe/form/save.js,Submitting,Yuborish
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of the document to which the data will get added to.,Ota-ona ma&#39;lumotlar kiritiladigan hujjatning nomi.
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Google Drive-da papka yaratib bo&#39;lmadi - {0} xato kodi
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Parent is the name of the document to which the data will get added to.,Ota-ona ma'lumotlar kiritiladigan hujjatning nomi.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not create folder in Google Drive - Error Code {0},Google Drive - Google Drive-da papka yaratib bo'lmadi - {0} xato kodi
 DocType: DocType,UPPER CASE,Yuqori holat
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Maxsus HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Jildning nomini kiriting
 apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"Birlamchi manzil shabloni topilmadi. Iltimos, sozlash> Bosib chiqarish va markalash> Manzil shablonidan yangisini yarating."
-apps/frappe/frappe/auth.py,Unknown User,Noma&#39;lum foydalanuvchi
+apps/frappe/frappe/auth.py,Unknown User,Noma'lum foydalanuvchi
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Rolni tanlang
-DocType: Comment,Deleted,O&#39;chirilgan
+DocType: Comment,Deleted,O'chirilgan
 DocType: Workflow State,adjust,sozlang
 DocType: Web Form,Sidebar Settings,Yon paneli sozlamalari
 DocType: DocType,"If enabled, document views are tracked, this can happen multiple times","Agar yoqilgan bo‘lsa, hujjat ko‘rishlar kuzatiladi, bu bir necha bor sodir bo‘lishi mumkin"
-DocType: Website Settings,Disable Customer Signup link in Login page,Kirish sahifasida xaridorni ro&#39;yxatdan o&#39;tkazish havolasini o&#39;chirib qo&#39;yish
+DocType: Website Settings,Disable Customer Signup link in Login page,Kirish sahifasida xaridorni ro'yxatdan o'tkazish havolasini o'chirib qo'yish
 apps/frappe/frappe/desk/report/todo/todo.py,Assigned To/Owner,Tayinlangan / Sohibi
-DocType: Workflow State,arrow-left,o&#39;q-chap
+DocType: Workflow State,arrow-left,o'q-chap
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export 1 record,1 yozuvni eksport qiling
-DocType: Workflow State,fullscreen,to&#39;liq ekran
+DocType: Workflow State,fullscreen,to'liq ekran
 DocType: Chat Token,Chat Token,Chat Token
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Create Chart,Grafik yarating
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,john@doe.com,john@doe.com
@@ -2139,44 +2139,44 @@ DocType: Web Page,Center,Markaziy
 DocType: Notification,Value To Be Set,Qiymati belgilanadi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Edit {0},{0} tahrirlash
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,First Level,Birinchi daraja
-DocType: Workflow Document State,Represents the states allowed in one document and role assigned to change the state.,Biror hujjat va davlatni o&#39;zgartirishga tayinlangan roli uchun ruxsat berilgan davlatlarni anglatadi.
-DocType: Data Migration Connector,Database Name,Ma&#39;lumotlar bazasi nomi
+DocType: Workflow Document State,Represents the states allowed in one document and role assigned to change the state.,Biror hujjat va davlatni o'zgartirishga tayinlangan roli uchun ruxsat berilgan davlatlarni anglatadi.
+DocType: Data Migration Connector,Database Name,Ma'lumotlar bazasi nomi
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Yangilash formasini
 DocType: DocField,Select,Tanlang
-apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,To&#39;liq jurnalni ko&#39;rish
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Oddiy Python iborasi, masalan: status == &#39;Ochish&#39; va == &#39;Bug&#39; deb yozing."
+apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,To'liq jurnalni ko'rish
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Oddiy Python iborasi, masalan: status == 'Ochish' va == 'Bug' deb yozing."
 apps/frappe/frappe/utils/csvutils.py,File not attached,Fayl biriktirilmagan
-apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Aloqa yo&#39;qoldi. Ba&#39;zi xususiyatlar ishlamasligi mumkin.
+apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Aloqa yo'qoldi. Ba'zi xususiyatlar ishlamasligi mumkin.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",&quot;AAA&quot; kabi takrorlash oson
 apps/frappe/frappe/public/js/frappe/chat.js,New Chat,Yangi chat
-DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","Agar siz buni o&#39;rnatgan bo&#39;lsangiz, ushbu element tanlangan ota-onalar ostida ochiladi."
-DocType: Print Format,Show Section Headings,Bo&#39;lim sarlavhalarini ko&#39;rsatish
+DocType: Top Bar Item,"If you set this, this Item will come in a drop-down under the selected parent.","Agar siz buni o'rnatgan bo'lsangiz, ushbu element tanlangan ota-onalar ostida ochiladi."
+DocType: Print Format,Show Section Headings,Bo'lim sarlavhalarini ko'rsatish
 DocType: Bulk Update,Limit,Limit
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Add a new section,Yangi bo&#39;lim qo&#39;shish
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Add a new section,Yangi bo'lim qo'shish
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Filtered Records,Filtrlangan yozuvlar
-apps/frappe/frappe/www/printview.py,No template found at path: {0},Yo&#39;lda hech shablon topilmadi: {0}
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Email Account,E-pochta hisob yo&#39;q
+apps/frappe/frappe/www/printview.py,No template found at path: {0},Yo'lda hech shablon topilmadi: {0}
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Email Account,E-pochta hisob yo'q
 DocType: Comment,Cancelled,Bekor qilindi
-DocType: Chat Room,Avatar,Barcha e&#39;lonlar
+DocType: Chat Room,Avatar,Barcha e'lonlar
 DocType: Blogger,Posts,Xabarlar
 DocType: Social Login Key,Salesforce,Salesforce
 DocType: DocType,Has Web View,Veb-versiyasi mavjud
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"DocType's name should start with a letter and it can only consist of letters, numbers, spaces and underscores","DocType ning nomi harf bilan boshlanishi kerak va u faqat harflardan, raqamlardan, bo&#39;shliqlardan va pastki ostidan bo&#39;lishi mumkin"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"DocType's name should start with a letter and it can only consist of letters, numbers, spaces and underscores","DocType ning nomi harf bilan boshlanishi kerak va u faqat harflardan, raqamlardan, bo'shliqlardan va pastki ostidan bo'lishi mumkin"
 DocType: Dashboard,Dashboard Name,Dashboard nomi
 apps/frappe/frappe/www/update-password.html,The password of your account has expired.,Hisobingizning paroli eskirgan.
 DocType: Communication,Spam,Spam
-DocType: Integration Request,Integration Request,Integratsiya so&#39;rovi
+DocType: Integration Request,Integration Request,Integratsiya so'rovi
 apps/frappe/frappe/public/js/frappe/views/communication.js,Dear,Hurmatli
-apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Add Group,Guruh qo&#39;shish
+apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Add Group,Guruh qo'shish
 DocType: Address,Maharashtra,Maharashtra
 DocType: Auto Repeat,Accounts User,Hisoblar foydalanuvchisi
-DocType: Web Page,HTML for header section. Optional,Header bo&#39;limi uchun HTML. Majburiy emas
+DocType: Web Page,HTML for header section. Optional,Header bo'limi uchun HTML. Majburiy emas
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,This feature is brand new and still experimental,Bu xususiyat yangi va hali eksperimentaldir
-apps/frappe/frappe/model/rename_doc.py,Maximum {0} rows allowed,Eng ko&#39;p {0} qator ruxsat berilgan
+apps/frappe/frappe/model/rename_doc.py,Maximum {0} rows allowed,Eng ko'p {0} qator ruxsat berilgan
 DocType: Dashboard Chart Link,Chart,Grafika
 DocType: Email Unsubscribe,Global Unsubscribe,Global obunani bekor qilish
 apps/frappe/frappe/utils/password_strength.py,This is a very common password.,Bu juda keng tarqalgan parol.
-apps/frappe/frappe/email/doctype/email_group/email_group.js,View,Ko&#39;rish
+apps/frappe/frappe/email/doctype/email_group/email_group.js,View,Ko'rish
 DocType: Comment,Assigned,Belgilangan
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access.,<b>Google Drive Access-</b> ga avtorizatsiya qilish uchun <b>Google Drive-ga kirish-</b> ga ruxsat berish-ni bosing.
 DocType: Print Format,Js,Js
@@ -2184,7 +2184,7 @@ apps/frappe/frappe/public/js/frappe/views/communication.js,Select Print Format,B
 apps/frappe/frappe/utils/password_strength.py,Short keyboard patterns are easy to guess,Qisqa klaviatura naqshlari taxmin qilish oson
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Generate New Report,Yangi hisobot yaratish
 DocType: Portal Settings,Portal Menu,Portal menyusi
-apps/frappe/frappe/database/schema.py,Length of {0} should be between 1 and 1000,{0} uzunligi 1 va 1000 orasida bo&#39;lishi kerak
+apps/frappe/frappe/database/schema.py,Length of {0} should be between 1 and 1000,{0} uzunligi 1 va 1000 orasida bo'lishi kerak
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,Search for anything,Hech narsa qidirish
 DocType: Data Migration Connector,Hostname,Hostname
 DocType: Data Migration Mapping,Condition Detail,Ahvol batafsil
@@ -2193,8 +2193,8 @@ DocType: DocField,Print Hide,Chop etish uchun yashirish
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,To User,Foydalanuvchi uchun
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Enter Value,Qiymatni kiriting
 DocType: Workflow State,tint,ranglar
-DocType: DocField,In Preview,Ko&#39;rib chiqishda
-DocType: Webhook,JSON Request Body,JSON so&#39;rovining tanasi
+DocType: DocField,In Preview,Ko'rib chiqishda
+DocType: Webhook,JSON Request Body,JSON so'rovining tanasi
 DocType: Web Page,Style,Uslub
 DocType: Prepared Report,Report End Time,Hisobotni tugatish vaqti
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,e.g.:,Masalan:
@@ -2205,137 +2205,137 @@ DocType: Workflow State,forward,oldinga
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} edited this {1},{0} bu {1}
 DocType: Custom DocPerm,Submit,Yuboring
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,New Folder,Yangi papka
-DocType: Email Account,Uses the Email Address mentioned in this Account as the Sender for all emails sent using this Account. ,Ushbu Hisobda ko&#39;rsatilgan E-pochta manzilini ushbu hisob yordamida yuborilgan barcha elektron pochta xabarlari uchun Yuboruvchi sifatida foydalanadi.
+DocType: Email Account,Uses the Email Address mentioned in this Account as the Sender for all emails sent using this Account. ,Ushbu Hisobda ko'rsatilgan E-pochta manzilini ushbu hisob yordamida yuborilgan barcha elektron pochta xabarlari uchun Yuboruvchi sifatida foydalanadi.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Toggle Charts,Grafiklarni almashtirish
 DocType: Website Settings,Sub-domain provided by erpnext.com,Erpnext.com tomonidan taqdim etilgan pastki domen
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Setting up your system,Tizimingizni sozlash
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Descendants Of,Avlodlari
 DocType: System Settings,dd-mm-yyyy,dd-mm-yyyy
-apps/frappe/frappe/desk/query_report.py,Must have report permission to access this report.,Ushbu hisobotga kirish uchun hisobot ruxsatiga ega bo&#39;lishi kerak.
+apps/frappe/frappe/desk/query_report.py,Must have report permission to access this report.,Ushbu hisobotga kirish uchun hisobot ruxsatiga ega bo'lishi kerak.
 apps/frappe/frappe/core/doctype/system_settings/system_settings.py,Please select Minimum Password Score,Minimal parolni tanlang
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Added,Qo&#39;shilgan
-DocType: Personal Data Download Request,Personal Data Download Request,Shaxsiy ma&#39;lumotlarni yuklab olish so&#39;rovi
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,Added,Qo'shilgan
+DocType: Personal Data Download Request,Personal Data Download Request,Shaxsiy ma'lumotlarni yuklab olish so'rovi
 DocType: DocField,Table MultiSelect,MultiSelect jadvali
 apps/frappe/frappe/config/integrations.py,Google Calendar Integration.,Google Calendar Integration.
 DocType: Auto Repeat,Half-yearly,Yarim yillik
-apps/frappe/frappe/templates/emails/upcoming_events.html,Daily Event Digest is sent for Calendar Events where reminders are set.,Kundalik voqealar to&#39;plami eslatmalar o&#39;rnatilgan joyda Taqvim voqealari uchun yuboriladi.
+apps/frappe/frappe/templates/emails/upcoming_events.html,Daily Event Digest is sent for Calendar Events where reminders are set.,Kundalik voqealar to'plami eslatmalar o'rnatilgan joyda Taqvim voqealari uchun yuboriladi.
 DocType: Braintree Settings,Header Image,Header tasvir
-apps/frappe/frappe/website/doctype/website_settings/website_settings.js,View Website,Veb-saytni ko&#39;rish
-DocType: Web Form,Message to be displayed on successful completion (only for Guest users),Muvaffaqiyatli bajarilishi haqida xabar ko&#39;rsatiladi (faqat Mehmonlar uchun)
+apps/frappe/frappe/website/doctype/website_settings/website_settings.js,View Website,Veb-saytni ko'rish
+DocType: Web Form,Message to be displayed on successful completion (only for Guest users),Muvaffaqiyatli bajarilishi haqida xabar ko'rsatiladi (faqat Mehmonlar uchun)
 DocType: Workflow State,remove,olib tashlang
-DocType: Email Domain,If non standard port (e.g. 587),"Agar standart bo&#39;lmagan port (masalan, 587)"
+DocType: Email Domain,If non standard port (e.g. 587),"Agar standart bo'lmagan port (masalan, 587)"
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} criticism points for {1} {2},{0} {1} {2} uchun tanqidiy fikrlar
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} criticism point for {1} {2},{0} {1} {2} uchun tanqidiy nuqta
-apps/frappe/frappe/templates/includes/comments/comments.py,Comments cannot have links or email addresses,Sharhlarda havolalar yoki elektron pochta manzillari bo&#39;lmasligi kerak
+apps/frappe/frappe/templates/includes/comments/comments.py,Comments cannot have links or email addresses,Sharhlarda havolalar yoki elektron pochta manzillari bo'lmasligi kerak
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,Reload,Qayta yuklash
-apps/frappe/frappe/config/customization.py,Add your own Tag Categories,O&#39;z toifangiz bo&#39;limlarini qo&#39;shing
+apps/frappe/frappe/config/customization.py,Add your own Tag Categories,O'z toifangiz bo'limlarini qo'shing
 apps/frappe/frappe/desk/query_report.py,Total,Jami
 DocType: Event,Participants,Ishtirokchilar
-DocType: Integration Request,Reference DocName,Yo&#39;naltirilgan DocName
+DocType: Integration Request,Reference DocName,Yo'naltirilgan DocName
 DocType: Web Form,Success Message,Muvaffaqiyatli xabar
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Export Customizations,Eksportni eksport qilish
-apps/frappe/frappe/website/doctype/web_page/web_page.py,End Date cannot be before Start Date!,Tugash sanasi boshlanish sanasidan oldin bo&#39;lishi mumkin emas!
+apps/frappe/frappe/website/doctype/web_page/web_page.py,End Date cannot be before Start Date!,Tugash sanasi boshlanish sanasidan oldin bo'lishi mumkin emas!
 DocType: DocType,User Cannot Search,Foydalanuvchining qidirish mumkin emas
 DocType: Communication Link,Communication Link,Aloqa aloqasi
-apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Invalid Output Format,Chiqish formati noto&#39;g&#39;ri
+apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py,Invalid Output Format,Chiqish formati noto'g'ri
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Cannot {0} {1},{0} {1}
-DocType: Custom DocPerm,Apply this rule if the User is the Owner,"Agar foydalanuvchi foydalanuvchi bo&#39;lsa, ushbu qoidani qo&#39;llang"
+DocType: Custom DocPerm,Apply this rule if the User is the Owner,"Agar foydalanuvchi foydalanuvchi bo'lsa, ushbu qoidani qo'llang"
 DocType: Global Search Settings,Global Search Settings,Global qidirish sozlamalari
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Will be your login ID,Kirish identifikatoringiz bo&#39;ladi
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Will be your login ID,Kirish identifikatoringiz bo'ladi
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.js,Global Search Document Types Reset.,Global qidiruv hujjatlari turlarini tiklash.
-,Lead Conversion Time,Qo&#39;rg&#39;oshin ishlab chiqarish vaqti
+,Lead Conversion Time,Qo'rg'oshin ishlab chiqarish vaqti
 apps/frappe/frappe/desk/page/activity/activity.js,Build Report,Hisobotni tuzing
 DocType: Note,Notify users with a popup when they log in,Foydalanuvchilarga kirishda popup bilan xabar bering
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Core Modules {0} cannot be searched in Global Search.,{0} asosiy modullarini Global Search-da qidirish mumkin emas.
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Open Chat,Chat-ni oching
-apps/frappe/frappe/model/rename_doc.py,"{0} {1} does not exist, select a new target to merge","{0} {1} yo&#39;q, birlashtirish uchun yangi maqsadni tanlang"
+apps/frappe/frappe/model/rename_doc.py,"{0} {1} does not exist, select a new target to merge","{0} {1} yo'q, birlashtirish uchun yangi maqsadni tanlang"
 DocType: Data Migration Connector,Python Module,Python moduli
-apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Navigate Home,Uyga o&#39;ting
-DocType: GSuite Settings,Google Credentials,Google hisobga olish ma&#39;lumotlari
+apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Navigate Home,Uyga o'ting
+DocType: GSuite Settings,Google Credentials,Google hisobga olish ma'lumotlari
 apps/frappe/frappe/www/qrcode.html,QR Code for Login Verification,Kirishni tekshirish uchun QR kodi
-apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Add to To Do,Bunga qo&#39;shish
+apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Add to To Do,Bunga qo'shish
 DocType: Footer Item,Company,Kompaniya
-apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Average of {0},O&#39;rtacha {0}
-DocType: User,Logout from all devices while changing Password,Parol o&#39;zgartirilayotganda barcha qurilmalardan chiqish
+apps/frappe/frappe/public/js/frappe/ui/group_by/group_by.js,Average of {0},O'rtacha {0}
+DocType: User,Logout from all devices while changing Password,Parol o'zgartirilayotganda barcha qurilmalardan chiqish
 apps/frappe/frappe/public/js/frappe/ui/messages.js,Verify Password,Parolni tasdiqlang
 apps/frappe/frappe/public/js/frappe/form/sidebar/attachments.js,There were errors,Xatolar bor edi
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Enter Client Id and Client Secret in Google Settings.,Google sozlamalarida Client ID va Client sirini kiriting.
 apps/frappe/frappe/core/doctype/communication/communication.js,Close,Yoping
-apps/frappe/frappe/model/document.py,Cannot change docstatus from 0 to 2,Docstatusni 0 dan 2 gacha o&#39;zgartira olmaydi
+apps/frappe/frappe/model/document.py,Cannot change docstatus from 0 to 2,Docstatusni 0 dan 2 gacha o'zgartira olmaydi
 DocType: File,Attached To Field,Tegishli maydonga
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta_list.js,Update,Yangilash
 DocType: Transaction Log,Transaction Hash,Transaction Hash
-DocType: Error Snapshot,Snapshot View,Oniy tasvir ko&#39;rinishi
+DocType: Error Snapshot,Snapshot View,Oniy tasvir ko'rinishi
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Please save the Newsletter before sending,"Iltimos, xabarni yuborishdan oldin saqlang"
-DocType: Webhook,The webhook will be triggered if this expression is true,"Agar ushbu ifoda to&#39;g&#39;ri bo&#39;lsa, veb-brauzer ishga tushadi"
+DocType: Webhook,The webhook will be triggered if this expression is true,"Agar ushbu ifoda to'g'ri bo'lsa, veb-brauzer ishga tushadi"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Edit Properties,Xususiyatlarni tahrirlash
-DocType: Patch Log,List of patches executed,Bajarilgan tuzatishlar ro&#39;yxati
+DocType: Patch Log,List of patches executed,Bajarilgan tuzatishlar ro'yxati
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,{0} already unsubscribed,{0} allaqachon bekor qilindi
-DocType: Data Import,Show only errors,Faqatgina xatolar ko&#39;rsatilsin
+DocType: Data Import,Show only errors,Faqatgina xatolar ko'rsatilsin
 DocType: Website Settings,Banner HTML,Banner HTML
 DocType: Workflow,Send Email Alert,E-pochta xabari yubor
-apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Boshqa to&#39;lov usulini tanlang. Razorpay &quot;{0}&quot; valyutasidagi operatsiyalarni qo&#39;llab-quvvatlamaydi
+apps/frappe/frappe/integrations/doctype/razorpay_settings/razorpay_settings.py,Please select another payment method. Razorpay does not support transactions in currency '{0}',Boshqa to'lov usulini tanlang. Razorpay &quot;{0}&quot; valyutasidagi operatsiyalarni qo'llab-quvvatlamaydi
 DocType: Data Import,In Progress,Jarayonda
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Zaxira uchun navbatga qo&#39;yildi. Bir soatdan bir necha daqiqa o&#39;tishi mumkin.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Queued for backup. It may take a few minutes to an hour.,Zaxira uchun navbatga qo'yildi. Bir soatdan bir necha daqiqa o'tishi mumkin.
 DocType: Error Snapshot,Pyver,Pyver
 apps/frappe/frappe/core/doctype/user_permission/user_permission.py,User permission already exists,Foydalanuvchi ruxsati allaqachon mavjud
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Mapping column {0} to field {1},{0} ustunini {1} maydoniga solishtirish
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,View {0},{0} ko&#39;rinishi
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,View {0},{0} ko'rinishi
 DocType: User,Hourly,Soat
-apps/frappe/frappe/config/integrations.py,Register OAuth Client App,OAuth mijoz ilovasini ro&#39;yxatdan o&#39;tkazing
-DocType: DocField,Fetch If Empty,"Bo&#39;sh bo&#39;lsa, olish"
-DocType: Data Migration Connector,Authentication Credentials,Hisobga olish haqiqiyligini tekshirish ma&#39;lumotlari
+apps/frappe/frappe/config/integrations.py,Register OAuth Client App,OAuth mijoz ilovasini ro'yxatdan o'tkazing
+DocType: DocField,Fetch If Empty,"Bo'sh bo'lsa, olish"
+DocType: Data Migration Connector,Authentication Credentials,Hisobga olish haqiqiyligini tekshirish ma'lumotlari
 DocType: Role,Two Factor Authentication,Ikki omil haqiqiyligini tekshirish
-apps/frappe/frappe/templates/pages/integrations/braintree_checkout.html,Pay,To&#39;lash
+apps/frappe/frappe/templates/pages/integrations/braintree_checkout.html,Pay,To'lash
 DocType: Energy Point Settings,Point Allocation Periodicity,Nuqtalarni taqsimlash davriyligi
 DocType: SMS Settings,SMS Gateway URL,SMS Gateway URL manzili
-apps/frappe/frappe/model/base_document.py,"{0} {1} cannot be ""{2}"". It should be one of ""{3}""",{0} {1} &quot;{2}&quot; bo&#39;lishi mumkin emas. Bu &quot;{3}&quot; dan biri bo&#39;lishi kerak
-apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,gained by {0} via automatic rule {1},{1} avtomatik qoida orqali {0} tomonidan qo&#39;lga kiritildi
+apps/frappe/frappe/model/base_document.py,"{0} {1} cannot be ""{2}"". It should be one of ""{3}""",{0} {1} &quot;{2}&quot; bo'lishi mumkin emas. Bu &quot;{3}&quot; dan biri bo'lishi kerak
+apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,gained by {0} via automatic rule {1},{1} avtomatik qoida orqali {0} tomonidan qo'lga kiritildi
 apps/frappe/frappe/utils/data.py,{0} or {1},{0} yoki {1}
 DocType: Workflow State,trash,axlat
-DocType: System Settings,Older backups will be automatically deleted,Eski zaxiralashlar avtomatik ravishda o&#39;chirib tashlanadi
-apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Invalid Access Key ID or Secret Access Key.,Noto&#39;g&#39;ri kirish kalit identifikatori yoki maxfiy kirish tugmachasi.
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You lost some energy points,Siz ba&#39;zi energiya nuqtalarini yo&#39;qotdingiz
+DocType: System Settings,Older backups will be automatically deleted,Eski zaxiralashlar avtomatik ravishda o'chirib tashlanadi
+apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py,Invalid Access Key ID or Secret Access Key.,Noto'g'ri kirish kalit identifikatori yoki maxfiy kirish tugmachasi.
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,You lost some energy points,Siz ba'zi energiya nuqtalarini yo'qotdingiz
 DocType: Post,Is Globally Pinned,Umuman olqishlar
-apps/frappe/frappe/desk/page/user_profile/user_profile.html,Recent Activity,So&#39;nggi faoliyat
+apps/frappe/frappe/desk/page/user_profile/user_profile.html,Recent Activity,So'nggi faoliyat
 DocType: Workflow Transition,Conditions,Shartlar
-DocType: Event,Leave blank to repeat always,Har doim takrorlash uchun bo&#39;sh qoldiring
+DocType: Event,Leave blank to repeat always,Har doim takrorlash uchun bo'sh qoldiring
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Confirmed,Tasdiqlangan
 DocType: Event,Ends on,Tugadi
 DocType: Payment Gateway,Gateway,Gateway
-DocType: LDAP Settings,Path to Server Certificate,Server sertifikatiga yo&#39;l
-apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ulanishlarni ko&#39;rish uchun etarli ruxsat yo&#39;q
+DocType: LDAP Settings,Path to Server Certificate,Server sertifikatiga yo'l
+apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ulanishlarni ko'rish uchun etarli ruxsat yo'q
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Manzil sarlavhasi majburiydir.
 DocType: Google Contacts,Push to Google Contacts,Google Contacts-ga bosing
 DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",Veb-sahifaning <bosh> qismida HTMLni birinchi navbatda veb-saytni tekshirish va SEO uchun ishlatilgan
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nafaqaga chiqqan
-apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Mavzu o&#39;z avlodlariga qo&#39;shilmaydi
+apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Mavzu o'z avlodlariga qo'shilmaydi
 DocType: Session Default Settings,Session Defaults,Sessiya standartlari
 DocType: System Settings,Expiry time of QR Code Image Page,QR kodining tugash vaqti Image Page
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,Umumiy hisoblarni ko&#39;rsatish
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Show Totals,Umumiy hisoblarni ko'rsatish
 DocType: Error Snapshot,Relapses,Tushkunliklar
 apps/frappe/frappe/public/js/frappe/social/pages/UserList.vue,No user found,Hech qanday foydalanuvchi topilmadi
-DocType: Address,Preferred Shipping Address,Tanlangan yuk jo&#39;natish manzili
+DocType: Address,Preferred Shipping Address,Tanlangan yuk jo'natish manzili
 apps/frappe/frappe/public/js/frappe/form/print.js,With Letter head,Letter boshi bilan
 apps/frappe/frappe/public/js/frappe/form/sidebar/form_sidebar.js,{0} created this {1},{0} bu {1}
 apps/frappe/frappe/permissions.py,Not allowed for {0}: {1} in Row {2}. Restricted field: {3},{2} qatorda {0}: {1} uchun ruxsat berilmagan. Cheklangan maydon: {3}
-DocType: S3 Backup Settings,eu-west-1,eu-g&#39;arbiy-1
-DocType: Data Import,"If this is checked, rows with valid data will be imported and invalid rows will be dumped into a new file for you to import later.","Agar bu belgilansa, joriy ma&#39;lumotlarga ega bo&#39;lgan qatorlar import qilinadi va keyinroq import qilish uchun bekor qilingan qatorlar yangi faylga tashlanadi."
+DocType: S3 Backup Settings,eu-west-1,eu-g'arbiy-1
+DocType: Data Import,"If this is checked, rows with valid data will be imported and invalid rows will be dumped into a new file for you to import later.","Agar bu belgilansa, joriy ma'lumotlarga ega bo'lgan qatorlar import qilinadi va keyinroq import qilish uchun bekor qilingan qatorlar yangi faylga tashlanadi."
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Document is only editable by users of role,Hujjat faqatgina foydalanuvchilar tomonidan tahrir qilinadi
 apps/frappe/frappe/desk/form/assign_to.py,"The task {0}, that you assigned to {1}, has been closed by {2}.",{1} ga tayinlangan {0} vazifasi {2} tomonidan yopildi.
-DocType: Print Format,Show Line Breaks after Sections,Bo&#39;limlardan keyin chiziqli signallarni ko&#39;rsatish
-DocType: Communication,Read by Recipient On,Qabul qiluvchining On tomonidan o&#39;qing
+DocType: Print Format,Show Line Breaks after Sections,Bo'limlardan keyin chiziqli signallarni ko'rsatish
+DocType: Communication,Read by Recipient On,Qabul qiluvchining On tomonidan o'qing
 DocType: Blogger,Short Name,Qisqa ism
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Linked with {0},{0} bilan bog&#39;langan
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Linked with {0},{0} bilan bog'langan
 apps/frappe/frappe/email/doctype/email_account/email_account.js,"You are selecting Sync Option as ALL, It will resync all \
 				read as well as unread message from server. This may also cause the duplication\
-				of Communication (emails).","Sinxronlashtirish parametrini ALL deb tanlayotibsiz, serverdan hamma o&#39;qilgan va o&#39;qilmagan xabarlarni qayta tinglaydi. Bu, shuningdek, aloqa (elektron pochta) ning takrorlanishiga ham sabab bo&#39;lishi mumkin."
+				of Communication (emails).","Sinxronlashtirish parametrini ALL deb tanlayotibsiz, serverdan hamma o'qilgan va o'qilmagan xabarlarni qayta tinglaydi. Bu, shuningdek, aloqa (elektron pochta) ning takrorlanishiga ham sabab bo'lishi mumkin."
 DocType: Workflow State,magnet,magnitlangan
-apps/frappe/frappe/geo/doctype/currency/currency.js,This Currency is disabled. Enable to use in transactions,Ushbu valyuta o&#39;chirilgan. Jurnallarda foydalanishni yoqish
+apps/frappe/frappe/geo/doctype/currency/currency.js,This Currency is disabled. Enable to use in transactions,Ushbu valyuta o'chirilgan. Jurnallarda foydalanishni yoqish
 DocType: Desktop Icon,Blocked,Bloklangan
-DocType: Contact Us Settings,"Default: ""Contact Us""",Default: &quot;Biz bilan bog&#39;laning&quot;
+DocType: Contact Us Settings,"Default: ""Contact Us""",Default: &quot;Biz bilan bog'laning&quot;
 DocType: Contact,Purchase Manager,Sotib olish menejeri
-DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Agar yoqilgan bo&#39;lsa, bu sizning mehmonlaringizga dasturingizga fayllarni yuklash imkoniyatini beradi, agar siz foydalanuvchi fayllarini tizimga kirmasdan, masalan, ish ilovalari veb-shaklida to&#39;plashni xohlasangiz, buni yoqishingiz mumkin."
+DocType: System Settings,"When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form.","Agar yoqilgan bo'lsa, bu sizning mehmonlaringizga dasturingizga fayllarni yuklash imkoniyatini beradi, agar siz foydalanuvchi fayllarini tizimga kirmasdan, masalan, ish ilovalari veb-shaklida to'plashni xohlasangiz, buni yoqishingiz mumkin."
 apps/frappe/frappe/public/js/frappe/ui/tags.js,toggle Tag,toggle kirish
 DocType: Custom Script,Sample,Namuna
 apps/frappe/frappe/public/js/frappe/form/controls/table.js,"For performance, only the first 100 rows were processed.",Ishlash uchun faqat dastlabki 100 ta qatorga ishlov berildi.
@@ -2343,38 +2343,38 @@ DocType: Braintree Settings,Private Key,Xususiy kalit
 DocType: S3 Backup Settings,ap-northeast-2,shimoli-sharqiy-2
 DocType: Custom Field,Is Mandatory Field,Majburiy maydon
 DocType: User,Website User,Sayt foydalanuvchisi
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,PDF-ga chop etishda ba&#39;zi ustunlar kesilishi mumkin. Ustunlar sonini 10 tagacha saqlashga harakat qiling.
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Some columns might get cut off when printing to PDF. Try to keep number of columns under 10.,PDF-ga chop etishda ba'zi ustunlar kesilishi mumkin. Ustunlar sonini 10 tagacha saqlashga harakat qiling.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not equals,Teng emas
 DocType: Data Import Beta,Don't Send Emails,Elektron pochta xabarlarini yubormang
 DocType: Integration Request,Integration Request Service,Integration Request Service
 DocType: Access Log,Access Log,Kirish jurnali
 DocType: Website Script,Script to attach to all web pages.,Barcha veb-sahifalarga biriktirish uchun skript.
-DocType: Web Form,Allow Multiple,Ko&#39;p hollarda ruxsat ber
+DocType: Web Form,Allow Multiple,Ko'p hollarda ruxsat ber
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Assign,Belgilash
 DocType: Translation,PR sent,PR yuborildi
 DocType: Auto Email Report,Only Send Records Updated in Last X Hours,Oxirgi X soatida Yangilangan Records yuborish
 DocType: Communication,Feedback,Fikr-mulohaza
 apps/frappe/frappe/public/js/frappe/form/controls/base_control.js,Open Translation,Tarjimani oching
 apps/frappe/frappe/templates/emails/auto_repeat_fail.html,This email is autogenerated,Ushbu e-pochta autentifikatsiyalangan
-DocType: Workflow State,Icon will appear on the button,Icon tugmachada paydo bo&#39;ladi
-apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Click to Set Filters,Filtrlarni o&#39;rnatish uchun bosing
+DocType: Workflow State,Icon will appear on the button,Icon tugmachada paydo bo'ladi
+apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Click to Set Filters,Filtrlarni o'rnatish uchun bosing
 DocType: Energy Point Log,Revert,Qaytish
-apps/frappe/frappe/public/js/frappe/socketio_client.js,Socketio is not connected. Cannot upload,Socketio ulanmagan. Yuklab bo&#39;lmadi
+apps/frappe/frappe/public/js/frappe/socketio_client.js,Socketio is not connected. Cannot upload,Socketio ulanmagan. Yuklab bo'lmadi
 DocType: Website Settings,Website Settings,Veb-sayt sozlamalari
 apps/frappe/frappe/public/js/frappe/views/gantt/gantt_view.js,Month,Oy
 DocType: Email Account,ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> to send document reference,ProTip: Hujjat havolasini yuborish uchun <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> qo'shing
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Only users involved in the document are listed,Faqatgina hujjatda ishtirok etgan foydalanuvchilar ro&#39;yxati keltirilgan
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,Only users involved in the document are listed,Faqatgina hujjatda ishtirok etgan foydalanuvchilar ro'yxati keltirilgan
 DocType: DocField,Fetch From,Fetch From
 apps/frappe/frappe/modules/utils.py,App not found,Ilova topilmadi
-apps/frappe/frappe/core/doctype/communication/communication.py,Cannot create a {0} against a child document: {1},{0} bolani hujjatiga qarshi yaratib bo&#39;lmaydi: {1}
+apps/frappe/frappe/core/doctype/communication/communication.py,Cannot create a {0} against a child document: {1},{0} bolani hujjatiga qarshi yaratib bo'lmaydi: {1}
 DocType: Social Login Key,Social Login Key,Ijtimoiy kirish usuli
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options {1} must be the same as doctype name {2} for the field {3},{0}: {1} opsiyalari {3} maydoni uchun {2} doktip nomi bilan bir xil bo&#39;lishi kerak.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Options {1} must be the same as doctype name {2} for the field {3},{0}: {1} opsiyalari {3} maydoni uchun {2} doktip nomi bilan bir xil bo'lishi kerak.
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Clear Cache and Reload,Keshni tozalash va qayta yuklash
 DocType: Portal Settings,Custom Sidebar Menu,Maxsus chekka menyusi menyusi
 DocType: Workflow State,pencil,qalam
 apps/frappe/frappe/config/desk.py,Chat messages and other notifications.,Chat xabarlari va boshqa bildirishnomalar.
 apps/frappe/frappe/public/js/frappe/social/Home.vue,Social Home,Ijtimoiy uy
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Insert After cannot be set as {0},Qo&#39;shib qo&#39;yish so&#39;ng {0}
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Insert After cannot be set as {0},Qo'shib qo'yish so'ng {0}
 apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Share {0} with,Share bilan {0}
 apps/frappe/frappe/public/js/frappe/desk.js,Email Account setup please enter your password for: ,E-pochta hisobini sozlash uchun quyidagi parolni kiriting:
 DocType: Workflow State,hand-up,topshirish
@@ -2384,49 +2384,49 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Doc
 DocType: Contact,Passive,Passiv
 DocType: Auto Repeat,Accounts Manager,Hisob menejeri
 apps/frappe/frappe/desk/form/assign_to.py,Assignment for {0} {1},{0} {1} uchun topshirish
-apps/frappe/frappe/templates/pages/integrations/payment-cancel.html,Your payment is cancelled.,To&#39;lovingiz bekor qilinadi.
+apps/frappe/frappe/templates/pages/integrations/payment-cancel.html,Your payment is cancelled.,To'lovingiz bekor qilinadi.
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Select File Type,Fayl turini tanlang
-apps/frappe/frappe/core/doctype/success_action/success_action.js,View All,Hammasini ko&#39;rish
-DocType: Help Article,Knowledge Base Editor,Ma&#39;lumotlar bazasi muharriri
+apps/frappe/frappe/core/doctype/success_action/success_action.js,View All,Hammasini ko'rish
+DocType: Help Article,Knowledge Base Editor,Ma'lumotlar bazasi muharriri
 apps/frappe/frappe/public/js/frappe/views/container.js,Page not found,sahifa topilmadi
 DocType: DocField,Precision,Nozik
 DocType: Website Slideshow,Slideshow Items,Slayd-shou buyumlari
-apps/frappe/frappe/utils/password_strength.py,Try to avoid repeated words and characters,Takroriy so&#39;zlar va belgilardan qochishga harakat qiling
+apps/frappe/frappe/utils/password_strength.py,Try to avoid repeated words and characters,Takroriy so'zlar va belgilardan qochishga harakat qiling
 DocType: Workflow Action,Workflow State,Ish oqimining holati
-apps/frappe/frappe/core/doctype/version/version_view.html,Rows Added,Qatorlar qo&#39;shilgan
+apps/frappe/frappe/core/doctype/version/version_view.html,Rows Added,Qatorlar qo'shilgan
 apps/frappe/frappe/www/list.py,My Account,Mening hisobim
 DocType: ToDo,Allocated To,Ajratildi
-apps/frappe/frappe/templates/emails/password_reset.html,Please click on the following link to set your new password,Yangi parolni o&#39;rnatish uchun quyidagi havolani bosing
+apps/frappe/frappe/templates/emails/password_reset.html,Please click on the following link to set your new password,Yangi parolni o'rnatish uchun quyidagi havolani bosing
 DocType: Notification,Days After,Kunlardan keyin
 apps/frappe/frappe/public/js/frappe/form/print.js,QZ Tray Connection Active!,QZ laganda ulanishi faol!
-DocType: Contact Us Settings,Settings for Contact Us Page,Biz bilan bog&#39;lanish uchun sozlamalar
+DocType: Contact Us Settings,Settings for Contact Us Page,Biz bilan bog'lanish uchun sozlamalar
 DocType: Print Settings,Enable Print Server,Chop etish serverini yoqish
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} weeks ago,{0} hafta oldin
 DocType: Email Account,Footer,Olmashlar
 apps/frappe/frappe/config/integrations.py,Authentication,Autentifikatsiya
-apps/frappe/frappe/utils/verified_command.py,Invalid Link,Noto&#39;g&#39;ri bog&#39;lanish
+apps/frappe/frappe/utils/verified_command.py,Invalid Link,Noto'g'ri bog'lanish
 DocType: Web Form,Client Script,Mijozlar skripti
-DocType: Web Page,Show Title,Sarlavhani ko&#39;rsatish
-DocType: Chat Message,Direct,To&#39;g&#39;ridan to&#39;g&#39;ri
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname {1} appears multiple times in rows {2},{0}: {1} maydon nomi {2} qatorlarda bir necha marta paydo bo&#39;ladi.
+DocType: Web Page,Show Title,Sarlavhani ko'rsatish
+DocType: Chat Message,Direct,To'g'ridan to'g'ri
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname {1} appears multiple times in rows {2},{0}: {1} maydon nomi {2} qatorlarda bir necha marta paydo bo'ladi.
 DocType: Property Setter,Property Type,Mulk turi
 DocType: Workflow State,screenshot,ekran tasvirini
-apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,"Faqat ma&#39;mur standart hisobotni saqlashi mumkin. Iltimos, qayta nomlash va saqlash."
+apps/frappe/frappe/core/doctype/report/report.py,Only Administrator can save a standard report. Please rename and save.,"Faqat ma'mur standart hisobotni saqlashi mumkin. Iltimos, qayta nomlash va saqlash."
 DocType: System Settings,Background Workers,Asosiy ishchilar
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Meta obyekti bilan zid bo&#39;lgan maydonning nomi {0}
-DocType: Deleted Document,Data,Ma&#39;lumotlar
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Fieldname {0} conflicting with meta object,Meta obyekti bilan zid bo'lgan maydonning nomi {0}
+DocType: Deleted Document,Data,Ma'lumotlar
 apps/frappe/frappe/public/js/frappe/model/model.js,Document Status,Hujjat holati
 apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,Approval Required,Tasdiqlash talab etiladi
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,The following records needs to be created before we can import your file.,Faylingizni import qilishdan oldin quyidagi yozuvlar yaratilishi kerak.
 DocType: OAuth Authorization Code,OAuth Authorization Code,OAuth avtorizatsiya kodi
 apps/frappe/frappe/core/doctype/data_import/importer.py,Not allowed to Import,Import qilish mumkin emas
-DocType: Deleted Document,Deleted DocType,O&#39;chirilgan DocType
+DocType: Deleted Document,Deleted DocType,O'chirilgan DocType
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permission Levels,Ruxsat darajasi
 DocType: Workflow State,Warning,Ogohlantirish
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Bu bir nechta sahifada chop etilishi mumkin
-DocType: Data Migration Run,Percent Complete,Foiz to&#39;liq
+DocType: Data Migration Run,Percent Complete,Foiz to'liq
 DocType: Tag Category,Tag Category,Yorliq kategoriyasi
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Taqqoslash uchun> 5, <10 yoki = 324 dan foydalaning. O&#39;lchovlar uchun 5:10 dan foydalaning (5 va 10 orasidagi qiymatlar uchun)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Taqqoslash uchun> 5, <10 yoki = 324 dan foydalaning. O'lchovlar uchun 5:10 dan foydalaning (5 va 10 orasidagi qiymatlar uchun)."
 DocType: Google Calendar,Pull from Google Calendar,Google Calendar-dan tortib oling
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Yordam bering
 DocType: User,Login Before,Avval kirish
@@ -2437,35 +2437,35 @@ apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Hide Weekends,Haf
 apps/frappe/frappe/config/settings.py,Automatically generates recurring documents.,Avtomatik ravishda takrorlanadigan hujjatlarni yaratadi.
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Is,Bu
 DocType: Workflow State,info-sign,info-belgisi
-apps/frappe/frappe/model/base_document.py,Value for {0} cannot be a list,{0} uchun qiymat bir ro&#39;yxat bo&#39;la olmaydi
-DocType: Currency,"How should this currency be formatted? If not set, will use system defaults","Ushbu pul qanday shakllantirilishi kerak? Agar sozlanmagan bo&#39;lsa, tizimdagi standartlarni ishlatadi"
+apps/frappe/frappe/model/base_document.py,Value for {0} cannot be a list,{0} uchun qiymat bir ro'yxat bo'la olmaydi
+DocType: Currency,"How should this currency be formatted? If not set, will use system defaults","Ushbu pul qanday shakllantirilishi kerak? Agar sozlanmagan bo'lsa, tizimdagi standartlarni ishlatadi"
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Submit {0} documents?,{0} hujjatlarni yuborish kerakmi?
-apps/frappe/frappe/utils/response.py,You need to be logged in and have System Manager Role to be able to access backups.,Zaxiraga ega bo&#39;lish uchun siz tizimga kirishingiz va tizim boshqaruvchisi rolini bajarishingiz kerak.
+apps/frappe/frappe/utils/response.py,You need to be logged in and have System Manager Role to be able to access backups.,Zaxiraga ega bo'lish uchun siz tizimga kirishingiz va tizim boshqaruvchisi rolini bajarishingiz kerak.
 apps/frappe/frappe/public/js/frappe/form/print.js,Printer Mapping,Printer xaritasi
 apps/frappe/frappe/public/js/frappe/form/form.js,Please save before attaching.,"Iltimos, biriktirishdan oldin saqlang."
-apps/frappe/frappe/public/js/frappe/form/link_selector.js,Added {0} ({1}),Qo&#39;shilgan {0} ({1})
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Fieldtype cannot be changed from {0} to {1} in row {2},Maydon turini {2} qatordan {0} dan {1} ga o&#39;zgartirish mumkin emas.
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,Added {0} ({1}),Qo'shilgan {0} ({1})
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Fieldtype cannot be changed from {0} to {1} in row {2},Maydon turini {2} qatordan {0} dan {1} ga o'zgartirish mumkin emas.
 apps/frappe/frappe/public/js/frappe/roles_editor.js,Role Permissions,Ishtirok huquqi
-DocType: Help Article,Intermediate,O&#39;rta darajada
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} changed {1} to {2},{0} {1} ni {2} ga o&#39;zgartirdi
+DocType: Help Article,Intermediate,O'rta darajada
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,{0} changed {1} to {2},{0} {1} ni {2} ga o'zgartirdi
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Cancelled Document restored as Draft,Bekor qilingan hujjat loyiha sifatida qayta tiklandi
 DocType: Data Migration Run,Start Time,Boshlanish vaqti
-apps/frappe/frappe/model/delete_doc.py,Cannot delete or cancel because {0} {1} is linked with {2} {3} {4},{0} {1} {2} {3} {4} bilan bog&#39;langanligi uchun uni o&#39;chirib bo&#39;lmaydi yoki bekor qilolmaydi
-apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Read,O&#39;qish mumkin
+apps/frappe/frappe/model/delete_doc.py,Cannot delete or cancel because {0} {1} is linked with {2} {3} {4},{0} {1} {2} {3} {4} bilan bog'langanligi uchun uni o'chirib bo'lmaydi yoki bekor qilolmaydi
+apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Read,O'qish mumkin
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,{0} Chart,{0} Grafika
 DocType: Custom Role,Response,Javob
 DocType: DocField,Geolocation,Geolocation
 DocType: Workflow,Emails will be sent with next possible workflow actions,E-pochta xabari kelgusidagi ishchi harakatlari bilan yuboriladi
-apps/frappe/frappe/public/js/frappe/form/workflow.js,Workflow will start after saving.,Ish oqimi saqlanganidan so&#39;ng boshlanadi.
+apps/frappe/frappe/public/js/frappe/form/workflow.js,Workflow will start after saving.,Ish oqimi saqlanganidan so'ng boshlanadi.
 DocType: S3 Backup Settings,ap-northeast-1,shimoli-sharqiy-1
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Belgilarni ishlab chiqarish jarayonida nimadir noto&#39;g&#39;ri ketdi. Yangisini yaratish uchun {0} ustiga bosing.
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Something went wrong during the token generation. Click on {0} to generate a new one.,Belgilarni ishlab chiqarish jarayonida nimadir noto'g'ri ketdi. Yangisini yaratish uchun {0} ustiga bosing.
 apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Can Share,Ishtirok etishi mumkin
-apps/frappe/frappe/email/smtp.py,Invalid recipient address,Qabul qiluvchining manzili noto&#39;g&#39;ri
+apps/frappe/frappe/email/smtp.py,Invalid recipient address,Qabul qiluvchining manzili noto'g'ri
 DocType: Workflow State,step-forward,qadam oldinga
-DocType: System Settings,Allow Login After Fail,Kirishdan so&#39;ng kirishga ruxsat berish
-DocType: Role Permission for Page and Report,Set Role For,Rolni o&#39;rnating
-DocType: GCalendar Account,The name that will appear in Google Calendar,Google Taqvimda ko&#39;rinadigan ism
-apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Direct room with {0} already exists.,{0} bilan to&#39;g&#39;ridan-to&#39;g&#39;ri xona mavjud.
+DocType: System Settings,Allow Login After Fail,Kirishdan so'ng kirishga ruxsat berish
+DocType: Role Permission for Page and Report,Set Role For,Rolni o'rnating
+DocType: GCalendar Account,The name that will appear in Google Calendar,Google Taqvimda ko'rinadigan ism
+apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Direct room with {0} already exists.,{0} bilan to'g'ridan-to'g'ri xona mavjud.
 apps/frappe/frappe/core/doctype/user/user.js,Refreshing...,Yangilash ...
 DocType: Event,Starts on,Boshlanadi
 DocType: System Settings,System Settings,Tizim sozlamalari
@@ -2482,72 +2482,72 @@ DocType: Email Rule,Is Spam,Spammi?
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Report {0},Hisobot {0}
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Open {0},{0} oching
 DocType: Data Import Beta,Import Warnings,Import haqida ogohlantirishlar
-DocType: OAuth Client,Default Redirect URI,Standart yo&#39;naltirish URI
+DocType: OAuth Client,Default Redirect URI,Standart yo'naltirish URI
 DocType: Auto Repeat,Recipients,Qabul qiluvchilar
 DocType: System Settings,Choose authentication method to be used by all users,Barcha foydalanuvchilar tomonidan ishlatiladigan autentifikatsiya usulini tanlang
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Doctype required,Doctype kerak
 DocType: Workflow State,ok-sign,OK-belgisi
-apps/frappe/frappe/config/settings.py,Deleted Documents,O&#39;chirilgan hujjatlar
+apps/frappe/frappe/config/settings.py,Deleted Documents,O'chirilgan hujjatlar
 apps/frappe/frappe/public/js/frappe/form/grid.js,The CSV format is case sensitive,CSV formati katta-kichikligi sezgir
 apps/frappe/frappe/desk/doctype/desktop_icon/desktop_icon.py,Desktop Icon already exists,Stol belgisi allaqachon mavjud
 apps/frappe/frappe/public/js/frappe/form/toolbar.js,Duplicate,Duplikat
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} cannot be hidden and mandatory without default,{0}: {2} qatoridagi {1} maydonchasi odatiy holisiz yashirin va majburiy bo&#39;lishi mumkin emas
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} in row {2} cannot be hidden and mandatory without default,{0}: {2} qatoridagi {1} maydonchasi odatiy holisiz yashirin va majburiy bo'lishi mumkin emas
 DocType: Newsletter,Create and Send Newsletters,Xabarlarni yaratish va yuborish
 apps/frappe/frappe/templates/includes/comments/comments.html,Thank you for your comment. It will be published after approval,Izohingiz uchun rahmat. Tasdiqlanganidan keyin nashr etiladi
 DocType: Address,Andaman and Nicobar Islands,Andaman va Nikobar orollari
 DocType: Google Contacts,Pull from Google Contacts,Google Contacts-dan torting
-apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,"Iltimos, qanday qiymat maydonini tekshirish kerakligini ko&#39;rsating"
+apps/frappe/frappe/email/doctype/notification/notification.py,Please specify which value field must be checked,"Iltimos, qanday qiymat maydonini tekshirish kerakligini ko'rsating"
 DocType: Event,Google Calendar Event ID,Google Calendar Event ID
-apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added",&quot;Ota-ona&quot; ushbu satrni qo&#39;shish kerak bo&#39;lgan ota-jadvalni bildiradi
-apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,Ko&#39;rib chiqish nuqtalari:
+apps/frappe/frappe/core/doctype/data_export/exporter.py,"""Parent"" signifies the parent table in which this row must be added",&quot;Ota-ona&quot; ushbu satrni qo'shish kerak bo'lgan ota-jadvalni bildiradi
+apps/frappe/frappe/desk/page/user_profile/user_profile.js,Review Points: ,Ko'rib chiqish nuqtalari:
 apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Shared With,Bilan birgalikda
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,Fayllarni / urllarni qo&#39;shing va jadvalga qo&#39;shing.
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Attach files / urls and add in table.,Fayllarni / urllarni qo'shing va jadvalga qo'shing.
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Message not setup,Xabar sozlanmagan
 DocType: Help Category,Help Articles,Yordam Maqolalar
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Type:,Turi:
-apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Your payment has failed.,To&#39;lovingiz amalga oshmadi.
+apps/frappe/frappe/templates/pages/integrations/payment-failed.html,Your payment has failed.,To'lovingiz amalga oshmadi.
 DocType: Comment,Unshared,Ajralmagan
 DocType: Address,Karnataka,Karnataka
 apps/frappe/frappe/desk/moduleview.py,Module Not Found,Module topilmadi
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,{0}: {1} is set to state {2},{0}: {1} {2}
 DocType: User,Location,Manzil
-apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move to Row Number,Qator raqamiga o&#39;ting
+apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move to Row Number,Qator raqamiga o'ting
 ,Permitted Documents For User,Foydalanuvchi uchun ruxsat etilgan hujjatlar
-apps/frappe/frappe/core/doctype/docshare/docshare.py,"You need to have ""Share"" permission",Siz &quot;ulashish&quot; ruxsatiga ega bo&#39;lishingiz kerak
+apps/frappe/frappe/core/doctype/docshare/docshare.py,"You need to have ""Share"" permission",Siz &quot;ulashish&quot; ruxsatiga ega bo'lishingiz kerak
 DocType: Comment,Assignment Completed,Topshirish tugadi
 apps/frappe/frappe/public/js/frappe/form/grid.js,Bulk Edit {0},Ommaviy tahrir {0}
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Download Report,Hisobotni yuklab olish
 apps/frappe/frappe/workflow/doctype/workflow/workflow_list.js,Not active,Faol emas
 apps/frappe/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py,Only Administrator is allowed to create Dashboard Chart Sources,Faqatgina Administratorga Dashboard Chart manbalarini yaratishga ruxsat berilgan
 DocType: About Us Settings,Settings for the About Us Page,Biz haqimizda haqida sozlamalar
-apps/frappe/frappe/config/integrations.py,Stripe payment gateway settings,Stripe to&#39;lov shluzi sozlamalari
+apps/frappe/frappe/config/integrations.py,Stripe payment gateway settings,Stripe to'lov shluzi sozlamalari
 apps/frappe/frappe/public/js/frappe/form/print.js,Print Sent to the printer!,Chop etish uchun printerga yuborildi!
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Energy Points,Energiya punktlari
 DocType: Email Account,e.g. pop.gmail.com / imap.gmail.com,"masalan, pop.gmail.com / imap.gmail.com"
 DocType: User,Generate Keys,Kalitlarni yaratish
-apps/frappe/frappe/templates/emails/delete_data_confirmation.html,This will permanently remove your data.,Bu ma&#39;lumotlaringizni butunlay yo&#39;q qiladi.
-DocType: DocType,View Settings,Sozlamalarni ko&#39;rish
+apps/frappe/frappe/templates/emails/delete_data_confirmation.html,This will permanently remove your data.,Bu ma'lumotlaringizni butunlay yo'q qiladi.
+DocType: DocType,View Settings,Sozlamalarni ko'rish
 DocType: Email Account,Outlook.com,Outlook.com
 DocType: Webhook,Request Structure,Talabning tuzilishi
 DocType: Personal Data Deletion Request,Pending Verification,Tasdiqlash kutilmoqda
 DocType: Website Meta Tag,Website Meta Tag,Meta Tag veb-sayti
-DocType: Email Account,"If non standard port (e.g. 587). If on Google Cloud, try port 2525.","Standart bo&#39;lmagan port (masalan, 587). Agar &quot;Google Cloud&quot; xizmatida 2525 portini sinab ko&#39;ring."
-apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.",Nashr qilingan sahifalar uchun o&#39;tmishda bo&#39;lishi mumkin bo&#39;lmaganligi uchun tugatish sanasini tozalab turish.
+DocType: Email Account,"If non standard port (e.g. 587). If on Google Cloud, try port 2525.","Standart bo'lmagan port (masalan, 587). Agar &quot;Google Cloud&quot; xizmatida 2525 portini sinab ko'ring."
+apps/frappe/frappe/website/doctype/web_page/web_page.py,"Clearing end date, as it cannot be in the past for published pages.",Nashr qilingan sahifalar uchun o'tmishda bo'lishi mumkin bo'lmaganligi uchun tugatish sanasini tozalab turish.
 DocType: User,Send Me A Copy of Outgoing Emails,Menga yuborilgan elektron pochta xabarlarining nusxasini yuboring
 DocType: System Settings,Scheduler Last Event,Vaqtinchalik reja
-DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Google Analytics ID raqamini qo&#39;shing: masalan. UA-89XXX57-1. Qo&#39;shimcha ma&#39;lumot uchun Google Analytics-da yordam so&#39;rang.
+DocType: Website Settings,Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.,Google Analytics ID raqamini qo'shing: masalan. UA-89XXX57-1. Qo'shimcha ma'lumot uchun Google Analytics-da yordam so'rang.
 apps/frappe/frappe/utils/password.py,Password cannot be more than 100 characters long,Parol 100 belgidan oshmasligi kerak
 DocType: OAuth Client,App Client ID,Ilova mijoz identifikatori
 DocType: Kanban Board,Kanban Board Name,Kanbanning nomi
 DocType: Notification Recipient,"Expression, Optional","Ifoda, majburiy emas"
-DocType: GSuite Settings,Copy and paste this code into and empty Code.gs in your project at script.google.com,Ushbu kodni nusxalash va joylashtirish va script.google.com saytidagi loyihangizda Code.gs-ni bo&#39;shating
+DocType: GSuite Settings,Copy and paste this code into and empty Code.gs in your project at script.google.com,Ushbu kodni nusxalash va joylashtirish va script.google.com saytidagi loyihangizda Code.gs-ni bo'shating
 apps/frappe/frappe/email/queue.py,This email was sent to {0},Ushbu e-pochta {0} ga yuborildi
 DocType: System Settings,Hide footer in auto email reports,Avtomatik elektron pochta hisobotlaridagi footerni yashirish
 DocType: DocField,Remember Last Selected Value,Oxirgi tanlangan qiymatni eslab qoling
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,This document cannot be reverted,Ushbu hujjatni qaytarib bo‘lmaydi
 DocType: Email Account,Check this to pull emails from your mailbox,Pochta qutingizdan elektron pochta xabarlarini olish uchun buni tanlang
 apps/frappe/frappe/integrations/doctype/google_settings/google_settings.js,click here,bu yerni bosing
-apps/frappe/frappe/model/document.py,Cannot edit cancelled document,Bekor qilingan hujjatni tahrirlab bo&#39;lmadi
+apps/frappe/frappe/model/document.py,Cannot edit cancelled document,Bekor qilingan hujjatni tahrirlab bo'lmadi
 DocType: Transaction Log,Checksum Version,Checksum Version
 DocType: User,Allow Modules,Modullarga ruxsat berish
 DocType: Unhandled Email,Unhandled Email,Ishga tushmagan elektron pochta
@@ -2555,7 +2555,7 @@ DocType: Assignment Rule Day,Monday,Dushanba
 apps/frappe/frappe/utils/password_strength.py,Make use of longer keyboard patterns,Keyinchalik klaviatura naqshlaridan foydalaning
 apps/frappe/frappe/templates/includes/integrations/stripe_checkout.js,Processing...,Ishlov berilmoqda ...
 DocType: Data Import,Don't create new records,Yangi yozuvlar yaratmang
-apps/frappe/frappe/utils/nestedset.py,Nested set error. Please contact the Administrator.,Nested set error. Administrator bilan bog&#39;laning.
+apps/frappe/frappe/utils/nestedset.py,Nested set error. Please contact the Administrator.,Nested set error. Administrator bilan bog'laning.
 DocType: Workflow State,envelope,zarf
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 2,Variant 2
 apps/frappe/frappe/utils/print_format.py,Printing failed,Chop etish amalga oshmadi
@@ -2567,28 +2567,28 @@ apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Googl
 apps/frappe/frappe/config/website.py,"Setup of top navigation bar, footer and logo.","Yuqori navigatsiya satrini, altbilgiyi va logotipni sozlash."
 DocType: Web Form Field,Max Value,Maksimal qiymat
 apps/frappe/frappe/core/doctype/doctype/doctype.py,For {0} at level {1} in {2} in row {3},{1} {2} qatorida {3} qatorda {0} uchun
-DocType: Auto Repeat,Preview Message,Xabarni oldindan ko&#39;rish
+DocType: Auto Repeat,Preview Message,Xabarni oldindan ko'rish
 DocType: User Social Login,User Social Login,Foydalanuvchining ijtimoiy kirish
 DocType: Contact,All,Hammasi
 DocType: Email Queue,Recipient,Qabul qiluvchi
 DocType: Communication,Has  Attachment,Attachaga ega
 DocType: Address,Sales User,Savdo foydalanuvchisi
 apps/frappe/frappe/config/settings.py,Drag and Drop tool to build and customize Print Formats.,Bosib chiqarish formatlarini yaratish va sozlash uchun asbobni sudrab olib tashlash.
-apps/frappe/frappe/core/doctype/user/user.py,Temporarily Disabled,Vaqtincha o&#39;chirilgan
+apps/frappe/frappe/core/doctype/user/user.py,Temporarily Disabled,Vaqtincha o'chirilgan
 DocType: Address,Sikkim,Sikkim
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Set Chart,Grafikni belgilang
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Are you sure?,Ishonchingiz komilmi?
-apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Set,To&#39;siq qiling
-apps/frappe/frappe/desk/search.py,This query style is discontinued,Ushbu so&#39;rov uslubi to&#39;xtatildi
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Set,To'siq qiling
+apps/frappe/frappe/desk/search.py,This query style is discontinued,Ushbu so'rov uslubi to'xtatildi
 DocType: Notification,Trigger Method,Trigger uslubi
-apps/frappe/frappe/utils/data.py,Operator must be one of {0},Operator {0} dan biri bo&#39;lishi kerak
+apps/frappe/frappe/utils/data.py,Operator must be one of {0},Operator {0} dan biri bo'lishi kerak
 DocType: Dropbox Settings,Dropbox Access Token,Dropbox Kirish tokeni
-DocType: Workflow State,align-right,Hizala-o&#39;ng
+DocType: Workflow State,align-right,Hizala-o'ng
 DocType: Auto Email Report,Email To,Emailga yuborish
-apps/frappe/frappe/core/doctype/file/file.py,Folder {0} is not empty,{0} jildi bo&#39;sh emas
+apps/frappe/frappe/core/doctype/file/file.py,Folder {0} is not empty,{0} jildi bo'sh emas
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,{0} Google Contacts synced.,{0} Google Kontaktlar sinxronlandi.
 DocType: Page,Roles,Rollar
-apps/frappe/frappe/model/base_document.py,Error: Value missing for {0}: {1},Xato: {0} uchun qiymat yo&#39;q: {1}
+apps/frappe/frappe/model/base_document.py,Error: Value missing for {0}: {1},Xato: {0} uchun qiymat yo'q: {1}
 DocType: Blog Post,Content (Markdown),Tarkib (Markdown)
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,Field {0} is not selectable.,Field {0} tanlanmaydi.
 DocType: Webhook,Webhook,Webhook
@@ -2596,20 +2596,20 @@ DocType: System Settings,Session Expiry,Seans amal qilish muddati
 DocType: Workflow State,ban-circle,taqiqlash doirasi
 apps/frappe/frappe/desk/query_report.py,Report updated successfully,Hisobot muvaffaqiyatli yangilandi
 apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,Slack Webhook Error,Webhook xatolik yuz berdi
-DocType: Email Flag Queue,Unread,O&#39;qilmagan
+DocType: Email Flag Queue,Unread,O'qilmagan
 DocType: Bulk Update,Desk,Stol
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Skipping column {0},{0} ustunini o‘tkazib yuborish
-apps/frappe/frappe/utils/data.py,Filter must be a tuple or list (in a list),Filtrni bir nusxa yoki ro&#39;yxat bo&#39;lishi kerak (ro&#39;yxatda)
-apps/frappe/frappe/core/doctype/report/report.js,Write a SELECT query. Note result is not paged (all data is sent in one go).,TANLOV so&#39;rovini yozing. Izoh natija olinmaydi (barcha ma&#39;lumotlar bir martalik yuboriladi).
-DocType: Email Account,Attachment Limit (MB),Qo&#39;shimcha cheklov (MB)
+apps/frappe/frappe/utils/data.py,Filter must be a tuple or list (in a list),Filtrni bir nusxa yoki ro'yxat bo'lishi kerak (ro'yxatda)
+apps/frappe/frappe/core/doctype/report/report.js,Write a SELECT query. Note result is not paged (all data is sent in one go).,TANLOV so'rovini yozing. Izoh natija olinmaydi (barcha ma'lumotlar bir martalik yuboriladi).
+DocType: Email Account,Attachment Limit (MB),Qo'shimcha cheklov (MB)
 DocType: Address,Arunachal Pradesh,Arunachal Pradesh
-DocType: DocType,Child Tables are shown as a Grid in other DocTypes,Bolalar jadvallari boshqa DocTypes-da panjara sifatida ko&#39;rsatilgan
+DocType: DocType,Child Tables are shown as a Grid in other DocTypes,Bolalar jadvallari boshqa DocTypes-da panjara sifatida ko'rsatilgan
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Setup Auto Email,Avtomatik E-pochtani sozlash
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Down,Ctrl + Down
-DocType: Chat Profile,Message Preview,Xabarni ko&#39;rish
+DocType: Chat Profile,Message Preview,Xabarni ko'rish
 apps/frappe/frappe/utils/password_strength.py,This is a top-10 common password.,Bu 10 ta umumiy parol.
 DocType: User,User Defaults,Foydalanuvchi parametrlari
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Core DocTypes cannot be customized.,Core DocTypes-ni sozlab bo&#39;lmaydi.
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Core DocTypes cannot be customized.,Core DocTypes-ni sozlab bo'lmaydi.
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Create New,Yangi yaratish
 DocType: Workflow State,chevron-down,chevron pastga
 apps/frappe/frappe/public/js/frappe/views/communication.js,Email not sent to {0} (unsubscribed / disabled),{0} ga yuborilgan xat (e-pochta manzili)
@@ -2621,18 +2621,18 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Assign To,Belgilash
 DocType: Workflow State,th-list,th-list
 DocType: Web Page,Enable Comments,Sharhlarni yoqish
 apps/frappe/frappe/desk/doctype/note/note_list.js,Notes,Eslatmalar
-DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Foydalanuvchini bu IP manzildan cheklash. Ko&#39;p IP-manzillar vergul bilan ajralib turishi mumkin. Shuningdek, (111.111.111) kabi qisman IP manzillarni qabul qiladi,"
-DocType: Data Import Beta,Import Preview,Oldindan ko&#39;rish
+DocType: User,Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111),"Foydalanuvchini bu IP manzildan cheklash. Ko'p IP-manzillar vergul bilan ajralib turishi mumkin. Shuningdek, (111.111.111) kabi qisman IP manzillarni qabul qiladi,"
+DocType: Data Import Beta,Import Preview,Oldindan ko'rish
 DocType: Communication,From,From
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Select a group node first.,Avval guruh tugunni tanlang.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Find {0} in {1},{1} da {0} toping
-apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No posts yet,Hali xabarlar yo&#39;q
+apps/frappe/frappe/public/js/frappe/social/components/PostLoader.vue,No posts yet,Hali xabarlar yo'q
 DocType: OAuth Client,Implicit,Yopiq
-DocType: Email Account,"Append as communication against this DocType (must have fields, ""Status"", ""Subject"")","Ushbu DocType-ga qarshi aloqa sifatida qo&#39;shilsin (&quot;Field&quot;, &quot;Subject&quot;, &quot;Subject&quot; bo&#39;lishi kerak)"
+DocType: Email Account,"Append as communication against this DocType (must have fields, ""Status"", ""Subject"")","Ushbu DocType-ga qarshi aloqa sifatida qo'shilsin (&quot;Field&quot;, &quot;Subject&quot;, &quot;Subject&quot; bo'lishi kerak)"
 DocType: Letter Head,Default Letter Head,Standart xat rahbari
 DocType: OAuth Client,"URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.
 <br>e.g. http://hostname//api/method/frappe.www.login.login_via_facebook","Foydalanuvchi ruxsat berganidan keyin avtorizatsiya kodini olish uchun URI'lar, shuningdek, xato javob. Odatda Client App tomonidan ta'sirlangan REST so'nggi nuqta. <br> masalan, http: //hostname//api/method/frappe.login.login_via_facebook"
-apps/frappe/frappe/model/base_document.py,Not allowed to change {0} after submission,Tasdiqdan keyin {0} o&#39;zgartirishga ruxsat berilmaydi
+apps/frappe/frappe/model/base_document.py,Not allowed to change {0} after submission,Tasdiqdan keyin {0} o'zgartirishga ruxsat berilmaydi
 DocType: Data Migration Mapping,Migration ID Field,Migratsiya ID maydoni
 DocType: Dashboard Chart,Last Synced On,So‘nggi sinxronlash yoqilgan
 DocType: Comment,Comment Type,Fikr turi
@@ -2647,86 +2647,86 @@ DocType: S3 Backup Settings,ap-southeast-2,ap-janubi-sharqiy-2
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Loading,Yuklanmoqda
 apps/frappe/frappe/config/integrations.py,"Enter keys to enable login via Facebook, Google, GitHub.","Facebook, Google, GitHub orqali kirish uchun kalitlarni kiriting."
 DocType: Event,Sent/Received Email,Yuborilgan / qabul qilingan elektron pochta
-DocType: Data Import,Insert new records,Yangi yozuvlarni qo&#39;shing
-apps/frappe/frappe/core/doctype/file/file.py,Unable to read file format for {0},{0} uchun fayl formatini o&#39;qib bo&#39;lmadi
+DocType: Data Import,Insert new records,Yangi yozuvlarni qo'shing
+apps/frappe/frappe/core/doctype/file/file.py,Unable to read file format for {0},{0} uchun fayl formatini o'qib bo'lmadi
 apps/frappe/frappe/recorder.py,Only Administrator is allowed to use Recorder,Yozuvchidan faqat Administratorga ruxsat berilgan
-DocType: Auto Email Report,Filter Data,Ma&#39;lumotlar filtri
+DocType: Auto Email Report,Filter Data,Ma'lumotlar filtri
 apps/frappe/frappe/public/js/frappe/form/controls/select.js,Please attach a file first.,Avval faylni ilova qiling.
 apps/frappe/frappe/templates/emails/download_data.html,Dear {0},Hurmatli {0}
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 week,1 hafta
-apps/frappe/frappe/model/naming.py,"There were some errors setting the name, please contact the administrator","Ismni sozlashda xatolik yuz berdi, administrator bilan bog&#39;laning"
-apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email account not correct,Kiruvchi elektron pochta hisoboti to&#39;g&#39;ri emas
+apps/frappe/frappe/model/naming.py,"There were some errors setting the name, please contact the administrator","Ismni sozlashda xatolik yuz berdi, administrator bilan bog'laning"
+apps/frappe/frappe/email/doctype/email_domain/email_domain.py,Incoming email account not correct,Kiruvchi elektron pochta hisoboti to'g'ri emas
 apps/frappe/frappe/templates/includes/contact.js,"You seem to have written your name instead of your email. \
-				Please enter a valid email address so that we can get back.","E-pochtangiz o&#39;rniga o&#39;z ismingizni yozgandek tuyuladi. \ Iltimos, qaytarib olish uchun, iltimos, to&#39;g&#39;ri elektron pochta manzilini kiriting."
+				Please enter a valid email address so that we can get back.","E-pochtangiz o'rniga o'z ismingizni yozgandek tuyuladi. \ Iltimos, qaytarib olish uchun, iltimos, to'g'ri elektron pochta manzilini kiriting."
 DocType: Website Slideshow Item,Website Slideshow Item,Sayt Slaydshou Mavzu
-apps/frappe/frappe/model/workflow.py,Self approval is not allowed,O&#39;z-o&#39;zidan rozilik berilmaydi
+apps/frappe/frappe/model/workflow.py,Self approval is not allowed,O'z-o'zidan rozilik berilmaydi
 DocType: GSuite Templates,Template ID,Andoza identifikatori
 apps/frappe/frappe/integrations/doctype/oauth_client/oauth_client.py,Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed,Grant turi ( <code>{0}</code> ) va Response Type ( <code>{1}</code> ) ning birikmasiga ruxsat berilmaydi
 apps/frappe/frappe/desk/form/assign_to.py,New Message from {0},{0} dan yangi xabar
-DocType: Portal Settings,Default Role at Time of Signup,Ro&#39;yxatdan o&#39;tish vaqtida standart rol
+DocType: Portal Settings,Default Role at Time of Signup,Ro'yxatdan o'tish vaqtida standart rol
 DocType: DocType,Title Case,Title Case
-apps/frappe/frappe/templates/emails/download_data.html,Click on the link below to download your data,Ma&#39;lumotlaringizni yuklab olish uchun quyidagi havolani bosing
+apps/frappe/frappe/templates/emails/download_data.html,Click on the link below to download your data,Ma'lumotlaringizni yuklab olish uchun quyidagi havolani bosing
 apps/frappe/frappe/core/doctype/user/user.py,Enabled email inbox for user {0},{0} foydalanuvchisi uchun elektron pochta xabarlarini yoqish
-DocType: Data Migration Run,Data Migration Run,Ma&#39;lumotni ko&#39;chirishga o&#39;tish
+DocType: Data Migration Run,Data Migration Run,Ma'lumotni ko'chirishga o'tish
 DocType: Blog Post,Email Sent,E-pochta yuborildi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Older,Keksa
-DocType: DocField,Ignore XSS Filter,XSS Filtrini e&#39;tiborsiz qoldiring
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,removed,o&#39;chirildi
+DocType: DocField,Ignore XSS Filter,XSS Filtrini e'tiborsiz qoldiring
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,removed,o'chirildi
 apps/frappe/frappe/config/integrations.py,Dropbox backup settings,Dropbox zahiralash sozlamalari
 DocType: Webhook,Webhook Trigger,Webhook Trigger
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,{0} Google Calendar Events synced.,{0} Google Taqvim tadbirlari sinxronlandi.
 DocType: Dashboard Chart,Time Series,Vaqt seriyalari
-apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be disabled,{0} foydalanuvchini o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be disabled,{0} foydalanuvchini o'chirib bo'lmaydi
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Google Settings,Google sozlamalari
 apps/frappe/frappe/templates/emails/administrator_logged_in.html,"Dear System Manager,","Aziz tizim boshqaruvchisi,"
-apps/frappe/frappe/desk/doctype/todo/todo.py,{0} self assigned this task: {1},{0} o&#39;z vazifasini o&#39;z zimmasiga olgan: {1}
+apps/frappe/frappe/desk/doctype/todo/todo.py,{0} self assigned this task: {1},{0} o'z vazifasini o'z zimmasiga olgan: {1}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Your Country,Mamlakatingiz
 DocType: Assignment Rule Day,Sunday,yakshanba
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: Maydon nomi {1} dan biri bo&#39;lolmaydi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Fieldname cannot be one of {1},{0}: Maydon nomi {1} dan biri bo'lolmaydi
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Standings,Tayanchlar
-apps/frappe/frappe/core/doctype/doctype/doctype.js,In Grid View,To&#39;r ko&#39;rinishida
+apps/frappe/frappe/core/doctype/doctype/doctype.js,In Grid View,To'r ko'rinishida
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,No More Activity,Boshqa faoliyat yo‘q
 DocType: Auto Repeat,Template,Andoza
 DocType: Address,Delhi,Dehli
-apps/frappe/frappe/desk/doctype/calendar_view/calendar_view.js,Show Calendar,Taqvimni ko&#39;rsatish
+apps/frappe/frappe/desk/doctype/calendar_view/calendar_view.js,Show Calendar,Taqvimni ko'rsatish
 apps/frappe/frappe/config/integrations.py,LDAP Settings,LDAP sozlamalari
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js,Entity Name,Vakil nomi
-apps/frappe/frappe/public/js/frappe/form/save.js,Amending,O&#39;zgartirish
-apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal to&#39;lov shluzi sozlamalari
+apps/frappe/frappe/public/js/frappe/form/save.js,Amending,O'zgartirish
+apps/frappe/frappe/config/integrations.py,PayPal payment gateway settings,PayPal to'lov shluzi sozlamalari
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Top Performer,Eng yaxshi ijrochi
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Moslashtirilgan maydonlarni asosiy DocTypes-ga qo&#39;shib bo&#39;lmaydi.
-apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: &#39;{1}&#39; ({3}) qisqartirildi, chunki ruxsat etilgan maksimal belgilar {2}"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields cannot be added to core DocTypes.,Moslashtirilgan maydonlarni asosiy DocTypes-ga qo'shib bo'lmaydi.
+apps/frappe/frappe/model/base_document.py,"{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}","{0}: '{1}' ({3}) qisqartirildi, chunki ruxsat etilgan maksimal belgilar {2}"
 DocType: OAuth Client,Response Type,Javob turi
-DocType: Contact Us Settings,Send enquiries to this email address,Ushbu e-pochta manziliga so&#39;rov yuboring
+DocType: Contact Us Settings,Send enquiries to this email address,Ushbu e-pochta manziliga so'rov yuboring
 DocType: Letter Head,Letter Head Name,Harf nomining nomi
-DocType: DocField,Number of columns for a field in a List View or a Grid (Total Columns should be less than 11),Ro&#39;yxat ko&#39;rinishidagi yoki Griddagi bitta maydon uchun ustunlar soni (Total Sütunlar 11 dan kam bo&#39;lishi kerak)
+DocType: DocField,Number of columns for a field in a List View or a Grid (Total Columns should be less than 11),Ro'yxat ko'rinishidagi yoki Griddagi bitta maydon uchun ustunlar soni (Total Sütunlar 11 dan kam bo'lishi kerak)
 apps/frappe/frappe/config/website.py,User editable form on Website.,Foydalanuvchi tomonidan tuziladigan veb-sayt.
 DocType: Workflow State,file,fayl
 apps/frappe/frappe/www/login.html,Back to Login,Kirish sahifasiga qaytish
 DocType: Data Migration Mapping,Local DocType,Mahalliy DocType
-apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} {1} added,{0} {1} qo&#39;shildi
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} {1} added,{0} {1} qo'shildi
 apps/frappe/frappe/model/rename_doc.py,You need write permission to rename,Qayta nom berish uchun sizga yozma ruxsatnoma kerak
 DocType: Email Account,Use ASCII encoding for password,Parol uchun ASCII kodidan foydalaning
 DocType: User,Karma,Karma
 DocType: Report,Custom Report,Custom hisobot
 DocType: Dashboard Chart,Bar,Bar
-apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Ushbu chop etish formati uchun printerni xaritasini Printer sozlamalarida o&#39;rnating
+apps/frappe/frappe/public/js/frappe/form/print.js,Please set a printer mapping for this print format in the Printer Settings,Ushbu chop etish formati uchun printerni xaritasini Printer sozlamalarida o'rnating
 DocType: DocField,Table,Jadval
 DocType: File,File Size,Fayl hajmi
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You must login to submit this form,Ushbu formani yuborish uchun siz tizimga kirishingiz kerak
-apps/frappe/frappe/email/doctype/notification/notification.py,Cannot set Notification on Document Type {0},{0} ning hujjat turi bo&#39;yicha bildirishnoma sozlanmadi
+apps/frappe/frappe/email/doctype/notification/notification.py,Cannot set Notification on Document Type {0},{0} ning hujjat turi bo'yicha bildirishnoma sozlanmadi
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,"Select your Country, Time Zone and Currency","Mamlakatni, vaqt zonasini va valyutani tanlang"
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Mx,Mx
-apps/frappe/frappe/templates/emails/energy_points_summary.html,gained {0} points,{0} ball to&#39;pladi
-apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Between,O&#39;rtasida
+apps/frappe/frappe/templates/emails/energy_points_summary.html,gained {0} points,{0} ball to'pladi
+apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Between,O'rtasida
 DocType: Social Login Key,fairlogin,Fairlogin
-DocType: Async Task,Queued,Navbatga qo&#39;yildi
+DocType: Async Task,Queued,Navbatga qo'yildi
 DocType: Braintree Settings,Use Sandbox,Sandboxdan foydalaning
 apps/frappe/frappe/utils/goal.py,This month,Shu oy
 apps/frappe/frappe/public/js/frappe/form/print.js,New Custom Print Format,Yangi maxsus chop formati
 DocType: Custom DocPerm,Create,Yarating
 apps/frappe/frappe/public/js/frappe/web_form/web_form_list.js,No more items to display,Ko‘rsatish uchun boshqa narsalar yo‘q
-apps/frappe/frappe/public/js/frappe/form/form.js,Go to previous record,Oldingi yozuvga o&#39;ting
+apps/frappe/frappe/public/js/frappe/form/form.js,Go to previous record,Oldingi yozuvga o'ting
 DocType: Email Account,no failed attempts,muvaffaqiyatsiz urinishlar
 DocType: GSuite Settings,refresh_token,refresh_token
 DocType: Dropbox Settings,App Access Key,Ilovaga kirish uchun kalit
@@ -2745,89 +2745,89 @@ DocType: Web Form,Allow Edit,Tartibga ruxsat berish
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Paste,Joylashtiring
 DocType: Webhook,Doc Events,Doc voqealari
 DocType: Auto Email Report,Based on Permissions For User,Foydalanuvchi uchun ruxsatlar asosida
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Cannot change state of Cancelled Document. Transition row {0},Bekor qilingan hujjatning holatini o&#39;zgartirib bo&#39;lmaydi. O&#39;tish satri {0}
-DocType: Workflow,"Rules for how states are transitions, like next state and which role is allowed to change state etc.","Shtatlarning qanday davlatlar o&#39;tish davri qoidalari, keyingi davlat kabi va qanday davlatning davlatni o&#39;zgartirishi mumkinligi va boshqalar."
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Cannot change state of Cancelled Document. Transition row {0},Bekor qilingan hujjatning holatini o'zgartirib bo'lmaydi. O'tish satri {0}
+DocType: Workflow,"Rules for how states are transitions, like next state and which role is allowed to change state etc.","Shtatlarning qanday davlatlar o'tish davri qoidalari, keyingi davlat kabi va qanday davlatning davlatni o'zgartirishi mumkinligi va boshqalar."
 apps/frappe/frappe/desk/form/save.py,{0} {1} already exists,{0} {1} allaqachon mavjud
-apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be one of {0},Qo&#39;shish {0} dan biri bo&#39;lishi mumkin
-DocType: Customize Form,Image View,Rasm ko&#39;rinishi
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Jurnal paytida biror narsa noto&#39;g&#39;ri ketdi. To&#39;lovni tasdiqlamagani uchun, PayPal sizni ushbu summani avtomatik ravishda qaytaradi. Agar shunday bo&#39;lmasa, bizga elektron pochta orqali xabar yuboring va Correlation identifikatorini eslang: {0}."
+apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be one of {0},Qo'shish {0} dan biri bo'lishi mumkin
+DocType: Customize Form,Image View,Rasm ko'rinishi
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Jurnal paytida biror narsa noto'g'ri ketdi. To'lovni tasdiqlamagani uchun, PayPal sizni ushbu summani avtomatik ravishda qaytaradi. Agar shunday bo'lmasa, bizga elektron pochta orqali xabar yuboring va Correlation identifikatorini eslang: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Parolga simvollar, raqamlar va bosh harflarni kiriting"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",&quot;{1}&quot; Maxsus maydonida ko&#39;rsatilgan &quot;{0}&quot; maydonidan so&#39;ng &quot;{2}&quot; belgisi mavjud emas
-DocType: List Filter,List Filter,Ro&#39;yxat filtri
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist",&quot;{1}&quot; Maxsus maydonida ko'rsatilgan &quot;{0}&quot; maydonidan so'ng &quot;{2}&quot; belgisi mavjud emas
+DocType: List Filter,List Filter,Ro'yxat filtri
 DocType: Workflow State,signal,signal
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Qo&#39;shilganlar bor
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Qo'shilganlar bor
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.js,New Email Account,Yangi elektron pochta qaydnomasi
 DocType: S3 Backup Settings,us-east-2,us-sharq-2
-apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atleast 10 characters,Sharh kamida 10 ta belgidan iborat bo&#39;lishi kerak
+apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atleast 10 characters,Sharh kamida 10 ta belgidan iborat bo'lishi kerak
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,Hujjat tiklandi
-DocType: Data Export,Data Export,Ma&#39;lumotlarni eksport qilish
+DocType: Data Export,Data Export,Ma'lumotlarni eksport qilish
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Tilni tanlang ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},{0} uchun &quot;Tanlovlar&quot; ni o&#39;rnatib bo&#39;lmaydi
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},{0} uchun &quot;Tanlovlar&quot; ni o'rnatib bo'lmaydi
 DocType: Help Article,Author,Muallif
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Resume yuborish
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Qayta oching
-apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Show Warnings,Ogohlantirishlarni ko&#39;rsating
+apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Show Warnings,Ogohlantirishlarni ko'rsating
 apps/frappe/frappe/core/doctype/communication/communication.js,Re: {0},Re: {0}
 DocType: Address,Purchase User,Foydalanuvchini sotib oling
 DocType: Data Migration Run,Push Failed,Push Failed
-DocType: Workflow,"Different ""States"" this document can exist in. Like ""Open"", ""Pending Approval"" etc.","Turli &quot;Shtatlar&quot; bu hujjat &quot;Open&quot;, &quot;Pending Approval&quot; va boshqalar kabi mavjud bo&#39;lishi mumkin."
-apps/frappe/frappe/utils/verified_command.py,This link is invalid or expired. Please make sure you have pasted correctly.,"Ushbu bog&#39;lanish noto&#39;g&#39;ri yoki muddati tugagan. Iltimos, to&#39;g&#39;ri joylashtirilganligiga ishonch hosil qiling."
+DocType: Workflow,"Different ""States"" this document can exist in. Like ""Open"", ""Pending Approval"" etc.","Turli &quot;Shtatlar&quot; bu hujjat &quot;Open&quot;, &quot;Pending Approval&quot; va boshqalar kabi mavjud bo'lishi mumkin."
+apps/frappe/frappe/utils/verified_command.py,This link is invalid or expired. Please make sure you have pasted correctly.,"Ushbu bog'lanish noto'g'ri yoki muddati tugagan. Iltimos, to'g'ri joylashtirilganligiga ishonch hosil qiling."
 DocType: Web Page,Slideshow,Slaydshou
-apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Standart manzil shablonini o&#39;chirib bo&#39;lmaydi
+apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Standart manzil shablonini o'chirib bo'lmaydi
 DocType: Contact,Maintenance Manager,Xizmat menejeri
 DocType: Workflow State,Search,Qidirmoq
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Boshqa to&#39;lov usulini tanlang. Stripe &#39;{0}&#39; valyutasidagi operatsiyalarni qo&#39;llab-quvvatlamaydi
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Boshqa to'lov usulini tanlang. Stripe '{0}' valyutasidagi operatsiyalarni qo'llab-quvvatlamaydi
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Chiqindilarni olib tashlash
 DocType: Web Form,Web Form Fields,Veb formasi Maydonlari
-DocType: Data Import,Amended From,O&#39;zgartirishlar
-apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Ogohlantirish: {1} bilan bog&#39;liq har qanday jadvalda {0} topilmadi
+DocType: Data Import,Amended From,O'zgartirishlar
+apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Ogohlantirish: {1} bilan bog'liq har qanday jadvalda {0} topilmadi
 DocType: S3 Backup Settings,eu-north-1,eu-shimol-1
-apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,"Ushbu hujjat hozircha ijro uchun navbatda. Iltimos, yana bir bor urinib ko&#39;ring"
+apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,"Ushbu hujjat hozircha ijro uchun navbatda. Iltimos, yana bir bor urinib ko'ring"
 apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,&quot;{0}&quot; fayl topilmadi
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Bo&#39;limni olib tashlang
-DocType: User,Change Password,Kalit so&#39;zni o&#39;zgartirish
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Bo'limni olib tashlang
+DocType: User,Change Password,Kalit so'zni o'zgartirish
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X eksa maydoni
-apps/frappe/frappe/public/js/frappe/form/controls/data.js,Invalid Email: {0},Noto&#39;g&#39;ri E-pochta: {0}
+apps/frappe/frappe/public/js/frappe/form/controls/data.js,Invalid Email: {0},Noto'g'ri E-pochta: {0}
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Hello!,Salom!
-apps/frappe/frappe/config/integrations.py,Braintree payment gateway settings,Braintree to&#39;lov shluzi sozlamalari
+apps/frappe/frappe/config/integrations.py,Braintree payment gateway settings,Braintree to'lov shluzi sozlamalari
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Rebuild,Qayta tiklash
 apps/frappe/frappe/www/third_party_apps.html,This will log out {0} from all other devices,Bu barcha boshqa qurilmalardan {0} chiqadi
-apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Sizda hisobotni olish uchun ruxsat yo&#39;q: {0}
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Taqvimi - Google Taqvimga {0}, xato kodi {1} kiritib bo&#39;lmadi."
-DocType: System Settings,Apply Strict User Permissions,Qattiq foydalanuvchi ruxsatlarini qo&#39;llang
-DocType: S3 Backup Settings,us-west-1,us-g&#39;arb-1
+apps/frappe/frappe/desk/query_report.py,You don't have permission to get a report on: {0},Sizda hisobotni olish uchun ruxsat yo'q: {0}
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not insert event in Google Calendar {0}, error code {1}.","Google Taqvimi - Google Taqvimga {0}, xato kodi {1} kiritib bo'lmadi."
+DocType: System Settings,Apply Strict User Permissions,Qattiq foydalanuvchi ruxsatlarini qo'llang
+DocType: S3 Backup Settings,us-west-1,us-g'arb-1
 DocType: DocField,Allow Bulk Edit,Ommaviy tahrirlashga ruxsat berish
 DocType: Blog Post,Blog Post,Blog post
 DocType: Access Log,Export From,Eksport qilish
 apps/frappe/frappe/public/js/frappe/form/controls/link.js,Advanced Search,Kengaytirilgan qidiruv
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,You are not permitted to view the newsletter.,Axborot byulletenlarini ko`rishingiz mumkin emas.
 DocType: User,Interests,Qiziqishlar
-apps/frappe/frappe/core/doctype/user/user.py,Password reset instructions have been sent to your email,Parolni tiklash ko&#39;rsatmalari elektron pochtangizga yuborildi
+apps/frappe/frappe/core/doctype/user/user.py,Password reset instructions have been sent to your email,Parolni tiklash ko'rsatmalari elektron pochtangizga yuborildi
 DocType: Energy Point Rule,Allot Points To Assigned Users,Belgilangan foydalanuvchilarga ajratish
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,"Level 0 is for document level permissions, \
 								higher levels for field level permissions.","0-darajali hujjat darajasidagi ruxsatnomalar uchun, \ maydon darajasi ruxsatnomalari uchun yuqori darajalar."
 DocType: Contact Email,Is Primary,Birlamchi
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,From Document Type,Hujjat turidan
 DocType: DocType,Tree structures are implemented using Nested Set,Daraxt konstruktsiyalari Nested Set yordamida amalga oshiriladi
-apps/frappe/frappe/core/doctype/data_import/data_import.py,Can't save the form as data import is in progress.,Ma&#39;lumotlar import qilinayotganda shaklni saqlab bo&#39;lmadi.
+apps/frappe/frappe/core/doctype/data_import/data_import.py,Can't save the form as data import is in progress.,Ma'lumotlar import qilinayotganda shaklni saqlab bo'lmadi.
 DocType: Workflow,States,Shtatlar
-DocType: Notification,Attach Print,Chop etish qo&#39;shish
+DocType: Notification,Attach Print,Chop etish qo'shish
 DocType: Assignment Rule,Assignment Rule,Topshirish qoidalari
 apps/frappe/frappe/core/doctype/user/user.py,Suggested Username: {0},Tavsiya etilgan foydalanuvchi nomi: {0}
 DocType: Assignment Rule Day,Day,Kun
 apps/frappe/frappe/public/js/frappe/desk.js,Modules,Moduli
-apps/frappe/frappe/templates/pages/integrations/payment-success.html,Payment Success,To&#39;lov muvaffaqiyati
+apps/frappe/frappe/templates/pages/integrations/payment-success.html,Payment Success,To'lov muvaffaqiyati
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No {0} mail,Hech qanday {0} pochta
 DocType: OAuth Bearer Token,Revoked,Bekor qilindi
 DocType: Web Page,Sidebar and Comments,Yon panel va sharhlar
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Bekor qilgandan keyin hujjatni o&#39;zgartirsangiz va uni saqlasangiz, eski raqam versiyasi bo&#39;lgan yangi raqamni oladi."
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number.","Bekor qilgandan keyin hujjatni o'zgartirsangiz va uni saqlasangiz, eski raqam versiyasi bo'lgan yangi raqamni oladi."
 apps/frappe/frappe/email/doctype/notification/notification.py,"Not allowed to attach {0} document,
-				please enable Allow Print For {0} in Print Settings","{0} hujjatni biriktirishga ruxsat berilmadi, iltimos Print Settings&#39;da {0} uchun Chop etish uchun ruxsat berishni yoqing"
-apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,See the document at {0},{0} da hujjatni ko&#39;ring
+				please enable Allow Print For {0} in Print Settings","{0} hujjatni biriktirishga ruxsat berilmadi, iltimos Print Settings'da {0} uchun Chop etish uchun ruxsat berishni yoqing"
+apps/frappe/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py,See the document at {0},{0} da hujjatni ko'ring
 DocType: Stripe Settings,Publishable Key,Nashr etilgan kalit
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Start Import,Importni boshlang
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Type,Eksport turi
-DocType: Workflow State,circle-arrow-left,doira-o&#39;q-chap
+DocType: Workflow State,circle-arrow-left,doira-o'q-chap
 DocType: System Settings,Force User to Reset Password,Parolni tiklash uchun foydalanuvchini majburlash
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"To get the updated report, click on {0}.",Yangilangan hisobotni olish uchun {0} ustiga bosing.
 apps/frappe/frappe/sessions.py,Redis cache server not running. Please contact Administrator / Tech support,Redis kesh-server ishlamayapti. Administrator / Texnik yordamga murojaat qiling
@@ -2836,15 +2836,15 @@ DocType: Currency,Fraction,Fraktsiya
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,Event Synced with Google Calendar.,Google Calendar bilan sinxronlangan tadbir.
 DocType: LDAP Settings,LDAP First Name Field,LDAP Ism maydoni
 DocType: Contact,Middle Name,Otasini ismi
-DocType: Custom Field,Field Description,Yarim ta&#39;rif
-apps/frappe/frappe/model/naming.py,Name not set via Prompt,Nomi &quot;Tez so&#39;raladigan&quot; orqali o&#39;rnatilmadi
+DocType: Custom Field,Field Description,Yarim ta'rif
+apps/frappe/frappe/model/naming.py,Name not set via Prompt,Nomi &quot;Tez so'raladigan&quot; orqali o'rnatilmadi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Email Inbox,Elektron pochta qutisi
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,"Updating {0} of {1}, {2}","{1}, {2} ning {0} yangilanishi"
-DocType: Auto Email Report,Filters Display,Filtrlar ko&#39;rsatish
-apps/frappe/frappe/public/js/frappe/form/form.js,"""amended_from"" field must be present to do an amendment.",O&#39;zgartirish kiritish uchun &quot;amended_from&quot; maydoni bo&#39;lishi kerak.
+DocType: Auto Email Report,Filters Display,Filtrlar ko'rsatish
+apps/frappe/frappe/public/js/frappe/form/form.js,"""amended_from"" field must be present to do an amendment.",O'zgartirish kiritish uchun &quot;amended_from&quot; maydoni bo'lishi kerak.
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,{0} appreciated your work on {1} {2},{0} {1} {2} dagi ishlaringizni baholadi
 apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,Save filters,Filtrlarni saqlang
-DocType: Address,Plant,O&#39;simlik
+DocType: Address,Plant,O'simlik
 apps/frappe/frappe/core/doctype/communication/communication.js,Reply All,Hammaga javob bering
 DocType: DocType,Setup,Sozlash
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,All Records,Barcha yozuvlar
@@ -2854,14 +2854,14 @@ DocType: Workflow State,glass,shisha
 DocType: DocType,Timeline Field,Xronologiya maydoni
 DocType: Country,Time Zones,Vaqt mintaqalari
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list up,Ro‘yxatni yuqoriga o‘tish
-apps/frappe/frappe/core/page/permission_manager/permission_manager.py,There must be atleast one permission rule.,Eng kamida bitta ruxsatnoma qoidasi bo&#39;lishi kerak.
+apps/frappe/frappe/core/page/permission_manager/permission_manager.py,There must be atleast one permission rule.,Eng kamida bitta ruxsatnoma qoidasi bo'lishi kerak.
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Get Items,Elementlarni oling
 DocType: Contact,Image,Rasm
 DocType: Workflow State,remove-sign,olib tashlash belgisi
-apps/frappe/frappe/printing/doctype/print_settings/print_settings.py,Failed to connect to server,Serverga ulanib bo&#39;lmadi
-apps/frappe/frappe/core/doctype/data_export/exporter.py,There is no data to be exported,Eksport qilinadigan hech qanday ma&#39;lumot yo&#39;q
+apps/frappe/frappe/printing/doctype/print_settings/print_settings.py,Failed to connect to server,Serverga ulanib bo'lmadi
+apps/frappe/frappe/core/doctype/data_export/exporter.py,There is no data to be exported,Eksport qilinadigan hech qanday ma'lumot yo'q
 DocType: Domain Settings,Domains HTML,HTML domenlari
-apps/frappe/frappe/templates/includes/search_template.html,Type something in the search box to search,Qo&#39;ng&#39;iroq qilish uchun qidiruv qutisiga biror narsa yozing
+apps/frappe/frappe/templates/includes/search_template.html,Type something in the search box to search,Qo'ng'iroq qilish uchun qidiruv qutisiga biror narsa yozing
 apps/frappe/frappe/config/settings.py,Define workflows for forms.,Formalar uchun ish oqimlarini aniqlang.
 DocType: Address,Other,Boshqa
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Authorize URL,"Iltimos, URL manzilini kiriting"
@@ -2871,150 +2871,150 @@ apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,St
 DocType: Workflow State,font,shrift
 DocType: DocType,Show Preview Popup,Oldindan ko‘rish qalqonini ko‘rsatish
 apps/frappe/frappe/utils/password_strength.py,This is a top-100 common password.,Bu top-100 umumiy parol.
-apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Please enable pop-ups,"Iltimos, pop-up&#39;larni yoqing"
+apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.js,Please enable pop-ups,"Iltimos, pop-up'larni yoqing"
 DocType: Contact,Mobile No,Mobil raqami
 DocType: Communication,Text Content,Matn mazmuni
 DocType: Customize Form Field,Is Custom Field,Maxsus maydon bormi?
-DocType: Workflow,"If checked, all other workflows become inactive.","Belgilangan bo&#39;lsa, boshqa barcha ishchi oqimlar faolsiz qoladi."
-DocType: Access Log,File Information,Fayl haqida ma&#39;lumot
+DocType: Workflow,"If checked, all other workflows become inactive.","Belgilangan bo'lsa, boshqa barcha ishchi oqimlar faolsiz qoladi."
+DocType: Access Log,File Information,Fayl haqida ma'lumot
 apps/frappe/frappe/core/doctype/report/report.js,[Label]:[Field Type]/[Options]:[Width],[Label]: [maydon turi] / [Tanlovlar]: [kenglik]
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Open Settings,Sozlamalarni oching
 DocType: Workflow State,folder-close,jildni yopish
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Report:,Hisobot:
 DocType: Print Settings,Print taxes with zero amount,Soliqlarni nolga teng miqdorda chop eting
-apps/frappe/frappe/model/rename_doc.py,{0} not allowed to be renamed,{0} nomi o&#39;zgartirilgan
+apps/frappe/frappe/model/rename_doc.py,{0} not allowed to be renamed,{0} nomi o'zgartirilgan
 DocType: Custom Script,Custom Script,Maxsus skript
-DocType: Address,Address Line 2,Manzil yo&#39;nalish 2
+DocType: Address,Address Line 2,Manzil yo'nalish 2
 DocType: Address,Reference,Malumot
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Tayinlangan
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,"Iltimos, standart elektron pochta hisob qaydnomasini O&#39;rnatish> Elektron pochta> Elektron pochta hisob qaydnomasini o&#39;rnating"
-DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Ma&#39;lumotlar Migratsiya xaritalash detali
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,"Iltimos, standart elektron pochta hisob qaydnomasini O'rnatish> Elektron pochta> Elektron pochta hisob qaydnomasini o'rnating"
+DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Ma'lumotlar Migratsiya xaritalash detali
 DocType: Data Import,Action,Harakat
 DocType: GSuite Settings,Script URL,Skript URL manzili
 apps/frappe/frappe/www/update-password.html,Please enter the password,"Iltimos, parolni kiriting"
 apps/frappe/frappe/www/printview.py,Not allowed to print cancelled documents,Bekor qilingan hujjatlarni chop etishga ruxsat berilmaydi
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,Ustunlarni yaratishga ruxsat yo&#39;q
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_board.js,You are not allowed to create columns,Ustunlarni yaratishga ruxsat yo'q
 DocType: Data Import,If you don't want to create any new records while updating the older records.,Eski yozuvlarni yangilash paytida yangi yozuvlar yaratishni xohlamasangiz.
-apps/frappe/frappe/core/doctype/data_export/exporter.py,Info:,Ma&#39;lumot:
+apps/frappe/frappe/core/doctype/data_export/exporter.py,Info:,Ma'lumot:
 DocType: Custom Field,Permission Level,Ruxsat darajasi
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Cannot set Submit, Cancel, Amend without Write","{0}: Yuborish, Bekor qilish, Yozmasdan o&#39;zgartirish mumkin emas"
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Cannot set Submit, Cancel, Amend without Write","{0}: Yuborish, Bekor qilish, Yozmasdan o'zgartirish mumkin emas"
 DocType: List View Setting,Disable Count,Hisobni o‘chirib qo‘yish
 DocType: Google Maps Settings,Client Key,Mijoz kalitlari
-apps/frappe/frappe/public/js/frappe/form/sidebar/attachments.js,Are you sure you want to delete the attachment?,Ilovani o&#39;chirmoqchimisiz?
+apps/frappe/frappe/public/js/frappe/form/sidebar/attachments.js,Are you sure you want to delete the attachment?,Ilovani o'chirmoqchimisiz?
 apps/frappe/frappe/__init__.py,Thank you,rahmat
 apps/frappe/frappe/public/js/frappe/form/save.js,Saving,Saqlash
-DocType: Print Settings,Print Style Preview,Stil uslubini ko&#39;rib chiqish
+DocType: Print Settings,Print Style Preview,Stil uslubini ko'rib chiqish
 apps/frappe/frappe/core/doctype/file/test_file.py,Test_Folder,Test_Folder
 apps/frappe/frappe/website/doctype/web_form/web_form.py,You are not allowed to update this Web Form Document,Ushbu Veb Forma hujjatini yangilashga ruxsat berilmaydi
-apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,"Iltimos, Frappe uchun Ijtimoiy Kirish Klaviaturasida taglik URLni o&#39;rnating"
+apps/frappe/frappe/integrations/oauth2.py,Please set Base URL in Social Login Key for Frappe,"Iltimos, Frappe uchun Ijtimoiy Kirish Klaviaturasida taglik URLni o'rnating"
 DocType: About Us Settings,About Us Settings,Biz haqimizda Sozlamalar
 DocType: Website Settings,Website Theme,Veb-sayt mavzusi
 DocType: User,Api Access,Api Kirish
-DocType: DocField,In List View,Ro&#39;yxat ko&#39;rinishida
+DocType: DocField,In List View,Ro'yxat ko'rinishida
 DocType: Email Account,Use TLS,TLS dan foydalaning
-apps/frappe/frappe/email/smtp.py,Invalid login or password,Parol noto&#39;g&#39;ri
+apps/frappe/frappe/email/smtp.py,Invalid login or password,Parol noto'g'ri
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Download Template,Andoza yuklab oling
-apps/frappe/frappe/config/customization.py,Add custom javascript to forms.,Formalarga maxsus javascript qo&#39;shing.
+apps/frappe/frappe/config/customization.py,Add custom javascript to forms.,Formalarga maxsus javascript qo'shing.
 ,Role Permissions Manager,Rollarni boshqarish menejeri
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Name of the new Print Format,Yangi Print Formatining nomi
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Toggle Sidebar,Yon panelini almashtirish
-DocType: Data Migration Run,Pull Insert,Qo&#39;shing
+DocType: Data Migration Run,Pull Insert,Qo'shing
 DocType: Energy Point Rule,"Maximum points allowed after multiplying points with the multiplier value
-(Note: For no limit leave this field empty or set 0)",Ballarni multiplikator qiymati bilan ko&#39;paytirgandan so&#39;ng ruxsat etilgan maksimal ballar (Eslatma: Cheklovsiz bu maydonni bo&#39;sh qoldiring yoki 0 o&#39;rnating)
+(Note: For no limit leave this field empty or set 0)",Ballarni multiplikator qiymati bilan ko'paytirgandan so'ng ruxsat etilgan maksimal ballar (Eslatma: Cheklovsiz bu maydonni bo'sh qoldiring yoki 0 o'rnating)
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Invalid Template,Andoza noto‘g‘ri
-apps/frappe/frappe/model/db_query.py,Illegal SQL Query,Noqonuniy SQL so&#39;rovi
+apps/frappe/frappe/model/db_query.py,Illegal SQL Query,Noqonuniy SQL so'rovi
 apps/frappe/frappe/core/doctype/data_export/exporter.py,Mandatory:,Majburiy:
 DocType: Chat Message,Mentions,Mentions
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.js,"To use Google Contacts, enable {0}.",Google kontaktlaridan foydalanish uchun {0} -ni yoqing.
 apps/frappe/frappe/public/js/frappe/utils/utils.js,{0} Modules,{0} Modullar
 DocType: Chat Room,Chat Room,Chat xonasi
 DocType: Chat Profile,Conversation Tones,Suhbatlar Ohanglar
-DocType: Property Setter,New value to be set,O&#39;rnatilgan yangi qiymat
+DocType: Property Setter,New value to be set,O'rnatilgan yangi qiymat
 DocType: Notification,Days Before or After,Avval yoki keyingi kunlar
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Select Document Types to set which User Permissions are used to limit access.,Qaysi foydalanuvchi ruxsatlaridan foydalanishni cheklash uchun ishlatiladigan hujjat turlarini tanlang.
 DocType: User Permission,User Permission,Foydalanuvchi ruxsati
 apps/frappe/frappe/templates/includes/blog/blog.html,Blog,Blog
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,LDAP Not Installed,LDAP o&#39;rnatilmagan
-apps/frappe/frappe/core/doctype/data_import/data_import.js,Download with data,Ma&#39;lumotlarni yuklab olish
-apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed values for {0} {1},{0} {1} uchun o&#39;zgargan qiymatlar
-DocType: Workflow State,hand-right,qo&#39;l-o&#39;ng
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,LDAP Not Installed,LDAP o'rnatilmagan
+apps/frappe/frappe/core/doctype/data_import/data_import.js,Download with data,Ma'lumotlarni yuklab olish
+apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,changed values for {0} {1},{0} {1} uchun o'zgargan qiymatlar
+DocType: Workflow State,hand-right,qo'l-o'ng
 DocType: Website Settings,Subdomain,Subdomain
 DocType: S3 Backup Settings,Region,Mintaqa
 apps/frappe/frappe/config/integrations.py,Settings for OAuth Provider,OAuth Provayder uchun sozlamalar
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Current status,Hozirgi holat
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.js,Delete Data,Ma&#39;lumotlarni o&#39;chirish
-DocType: Web Form,Allow Delete,O&#39;chirishga ruxsat berish
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.js,Delete Data,Ma'lumotlarni o'chirish
+DocType: Web Form,Allow Delete,O'chirishga ruxsat berish
 DocType: Notification,Message Examples,Xabar misollar
 DocType: Web Form,Login Required,Kirish kerak
 DocType: Email Account,Email Login ID,E-pochtada kirish ID raqami
-apps/frappe/frappe/templates/pages/integrations/payment-cancel.html,Payment Cancelled,To&#39;lov bekor qilindi
+apps/frappe/frappe/templates/pages/integrations/payment-cancel.html,Payment Cancelled,To'lov bekor qilindi
 ,Addresses And Contacts,Manzillar va kontaktlar
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Please select document type first.,"Iltimos, avval hujjat turini tanlang."
 apps/frappe/frappe/core/doctype/error_log/error_log_list.js,Clear Error Logs,Xato jurnallarini tozalash
 apps/frappe/frappe/core/doctype/user/user.js,Reset OTP Secret,OTP Secret-ni tiklash
-DocType: Email Account,Notify if unreplied for (in mins),Qo&#39;llanilmasligi haqida ogohlantirish (daqiqa)
+DocType: Email Account,Notify if unreplied for (in mins),Qo'llanilmasligi haqida ogohlantirish (daqiqa)
 apps/frappe/frappe/templates/emails/energy_points_summary.html,Points Given,Berilgan ballar
 apps/frappe/frappe/config/website.py,Categorize blog posts.,Blog postlarini kategorizatsiya qilish.
 DocType: Workflow State,Time,Vaqt
-DocType: DocField,Attach,Qo&#39;shing
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{{{0}}} is not a valid fieldname pattern. It should be {{field_name}}.,{{{0}}} - bu joriy maydon nomining namunasi emas. Bu {{field_name}} bo&#39;lishi kerak.
+DocType: DocField,Attach,Qo'shing
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{{{0}}} is not a valid fieldname pattern. It should be {{field_name}}.,{{{0}}} - bu joriy maydon nomining namunasi emas. Bu {{field_name}} bo'lishi kerak.
 DocType: Custom Role,Permission Rules,Ruxsatnoma qoidalari
 DocType: Braintree Settings,Public Key,Umumiy kalit
 DocType: GSuite Settings,GSuite Settings,GSuite sozlamalari
 DocType: Address,Links,Linklar
-DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Ushbu hisob qaydnomasida ko&#39;rsatilgan elektron pochta manzili nomini ushbu hisob qaydnomasi yordamida yuborilgan barcha elektron pochta xabarlari uchun Yuboruvchining ismi sifatida ishlatadi.
+DocType: Email Account,Uses the Email Address Name mentioned in this Account as the Sender's Name for all emails sent using this Account.,Ushbu hisob qaydnomasida ko'rsatilgan elektron pochta manzili nomini ushbu hisob qaydnomasi yordamida yuborilgan barcha elektron pochta xabarlari uchun Yuboruvchining ismi sifatida ishlatadi.
 DocType: Energy Point Rule,Field To Check,Tekshirish uchun maydon
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not update contact in Google Contacts {0}, error code {1}.","Google Contacts - {0}, xato kodi {1} da kontaktni yangilab bo‘lmadi."
 apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Document Type.,"Iltimos, Hujjat turini tanlang."
-apps/frappe/frappe/model/base_document.py,Value missing for,Qiymati yo&#39;q
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Bola qo&#39;shish
+apps/frappe/frappe/model/base_document.py,Value missing for,Qiymati yo'q
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Bola qo'shish
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Import jarayoni
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-","Agar talab qondirilsa, foydalanuvchi ballar bilan taqdirlanadi. masalan. doc.status == &#39;Yopiq&#39;"
-apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: yuborilgan yozuvni o&#39;chirib bo&#39;lmaydi.
+","Agar talab qondirilsa, foydalanuvchi ballar bilan taqdirlanadi. masalan. doc.status == 'Yopiq'"
+apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}: yuborilgan yozuvni o'chirib bo'lmaydi.
 DocType: GSuite Templates,Template Name,Andoza nomi
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,yangi hujjat turi
-DocType: Communication,Read,O&#39;qing
+DocType: Communication,Read,O'qing
 DocType: Address,Chhattisgarh,Chhattisgarh
 DocType: Role Permission for Page and Report,Role Permission for Page and Report,Sahifa va hisobot uchun rolga ruxsat
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Align Value,Qiymatni tekislang
 apps/frappe/frappe/www/update-password.html,Old Password,eski parol
 DocType: S3 Backup Settings,us-east-1,us-sharq-1
 apps/frappe/frappe/website/doctype/blog_post/blog_post.py,Posts by {0},{0} tomonidan yuborilgan
-apps/frappe/frappe/core/doctype/report/report.js,"To format columns, give column labels in the query.",Ustunlarni formatlash uchun so&#39;rovda ustunlar yorlig&#39;ini bering.
+apps/frappe/frappe/core/doctype/report/report.js,"To format columns, give column labels in the query.",Ustunlarni formatlash uchun so'rovda ustunlar yorlig'ini bering.
 DocType: Has Domain,Has Domain,Domenga ega
 DocType: User,Allowed In Mentions,Mentiylarda ruxsat berilgan
-apps/frappe/frappe/www/login.html,Don't have an account? Sign up,Hisobingiz yo&#39;qmi? Ro&#39;yxatdan o&#39;tish
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Cannot remove ID field,ID maydonini o&#39;chirib bo&#39;lmadi
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Assign Amend if not Submittable,"{0}: Mavjud emas, agar Assign Assign ni o&#39;rnatib bo&#39;lmadi"
+apps/frappe/frappe/www/login.html,Don't have an account? Sign up,Hisobingiz yo'qmi? Ro'yxatdan o'tish
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Cannot remove ID field,ID maydonini o'chirib bo'lmadi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Assign Amend if not Submittable,"{0}: Mavjud emas, agar Assign Assign ni o'rnatib bo'lmadi"
 DocType: Address,Bihar,Bihar
 apps/frappe/frappe/desk/page/user_profile/user_profile_sidebar.html,User Settings,Foydalanuvchi sozlamalari
-DocType: Report,Reference Report,Ma&#39;lumotnoma
-DocType: Activity Log,Link DocType,DocType bilan bog&#39;laning
-apps/frappe/frappe/public/js/frappe/chat.js,You don't have any messages yet.,Sizda hech qanday xabar yo&#39;q.
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Remove all customizations?,Barcha sozlamalar o&#39;chirib tashlansinmi?
+DocType: Report,Reference Report,Ma'lumotnoma
+DocType: Activity Log,Link DocType,DocType bilan bog'laning
+apps/frappe/frappe/public/js/frappe/chat.js,You don't have any messages yet.,Sizda hech qanday xabar yo'q.
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Remove all customizations?,Barcha sozlamalar o'chirib tashlansinmi?
 DocType: Website Slideshow,Slideshow Name,Slaydshou nomi
 DocType: Address,Andhra Pradesh,Andhra Pradesh
 apps/frappe/frappe/public/js/frappe/form/save.js,Cancelling,Bekor qilish
-DocType: DocType,Allow Rename,Nomni o&#39;zgartirishga ruxsat berish
-DocType: Activity Log,Full Name,To&#39;liq ismi sharif
+DocType: DocType,Allow Rename,Nomni o'zgartirishga ruxsat berish
+DocType: Activity Log,Full Name,To'liq ismi sharif
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Duplicate Filter Name,Filtrni nomini ikki nusxadagi
 DocType: Chat Room User,Chat Room User,Chat xonasi foydalanuvchisi
-apps/frappe/frappe/model/workflow.py,Workflow State not set,Ish oqimi holati o&#39;rnatilmagan
+apps/frappe/frappe/model/workflow.py,Workflow State not set,Ish oqimi holati o'rnatilmagan
 DocType: Google Calendar,Authorize Google Calendar Access,Google Calendar Access-ga avtorizatsiya qilish
-apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,"Siz izlayotgan sahifa etishmayotgan. Buning sababi shundaki, u ko&#39;chiriladi yoki havolada typo mavjud."
+apps/frappe/frappe/www/404.html,The page you are looking for is missing. This could be because it is moved or there is a typo in the link.,"Siz izlayotgan sahifa etishmayotgan. Buning sababi shundaki, u ko'chiriladi yoki havolada typo mavjud."
 apps/frappe/frappe/www/404.html,Error Code: {0},Xato kodi: {0}
-DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Lug&#39;at sahifasining tavsifi, tekis matnda, faqat bir nechta satr. (maksimal 140 belgi)"
+DocType: Blog Post,"Description for listing page, in plain text, only a couple of lines. (max 140 characters)","Lug'at sahifasining tavsifi, tekis matnda, faqat bir nechta satr. (maksimal 140 belgi)"
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,{0} are mandatory fields,{0} - majburiy maydonlar
-DocType: Workflow,Allow Self Approval,O&#39;zingizni tasdiqlang
+DocType: Workflow,Allow Self Approval,O'zingizni tasdiqlang
 DocType: Event,Event Category,Voqealar kategoriyasi
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,John Doe,Jon Doe
 DocType: DocType,Name Case,Nomi holatlari
-apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with everyone,Hammaga qo&#39;shildi
-apps/frappe/frappe/model/base_document.py,Data missing in table,Jadvalda ma&#39;lumot yo&#39;q
+apps/frappe/frappe/public/js/frappe/form/sidebar/share.js,Shared with everyone,Hammaga qo'shildi
+apps/frappe/frappe/model/base_document.py,Data missing in table,Jadvalda ma'lumot yo'q
 DocType: Web Form,Success URL,Muvaffaqiyatning URL manzili
-DocType: Email Account,Append To,Qo&#39;shish
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Number of DB backups cannot be less than 1,DB zaxira nusxalari soni 1dan kam bo&#39;lishi mumkin emas
+DocType: Email Account,Append To,Qo'shish
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Number of DB backups cannot be less than 1,DB zaxira nusxalari soni 1dan kam bo'lishi mumkin emas
 DocType: Workflow Document State,Only Allow Edit For,Faqat tahrirlashga ruxsat berish
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,Backing up to Google Drive.,Google Drive-ga zaxiralash
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: {0},Majburiy maydon: {0}
@@ -3025,72 +3025,72 @@ DocType: DocType,Default Sort Field,Odatiy saralash maydoni
 DocType: File,Is Folder,Folder
 DocType: Document Follow,DocType,DocType
 DocType: Website Theme,Theme JSON,JSON mavzusi
-DocType: User,Mute Sounds,Ovozni o&#39;chirish
+DocType: User,Mute Sounds,Ovozni o'chirish
 DocType: Top Bar Item,Top Bar Item,Top Bar elementi
-apps/frappe/frappe/utils/csvutils.py,"Unknown file encoding. Tried utf-8, windows-1250, windows-1252.","Noma&#39;lum fayl kodlash. Utf-8, windows-1250, windows-1252-da ishlagan."
-apps/frappe/frappe/printing/doctype/print_style/print_style.py,Standard Print Style cannot be changed. Please duplicate to edit.,"Standart Chop uslubi o&#39;zgartirilishi mumkin emas. Iltimos, tahrir qilish uchun takrorlang."
+apps/frappe/frappe/utils/csvutils.py,"Unknown file encoding. Tried utf-8, windows-1250, windows-1252.","Noma'lum fayl kodlash. Utf-8, windows-1250, windows-1252-da ishlagan."
+apps/frappe/frappe/printing/doctype/print_style/print_style.py,Standard Print Style cannot be changed. Please duplicate to edit.,"Standart Chop uslubi o'zgartirilishi mumkin emas. Iltimos, tahrir qilish uchun takrorlang."
 DocType: Website Settings,Robots.txt,Robots.txt
 DocType: LDAP Settings,LDAP Last Name Field,LDAP familiyasi maydoni
 DocType: S3 Backup Settings,eu-central-1,eu-markaziy-1
-apps/frappe/frappe/core/doctype/user/user.py,Sorry! Sharing with Website User is prohibited.,Kechirasiz! Sayt foydalanuvchi bilan baham ko&#39;rish taqiqlangan.
-apps/frappe/frappe/public/js/frappe/roles_editor.js,Add all roles,Barcha rollarni qo&#39;shing
+apps/frappe/frappe/core/doctype/user/user.py,Sorry! Sharing with Website User is prohibited.,Kechirasiz! Sayt foydalanuvchi bilan baham ko'rish taqiqlangan.
+apps/frappe/frappe/public/js/frappe/roles_editor.js,Add all roles,Barcha rollarni qo'shing
 apps/frappe/frappe/templates/includes/contact.js,"Please enter both your email and message so that we \
 				can get back to you. Thanks!","Iltimos, sizga qaytarib olish uchun, iltimos, elektron pochta va xabaringizni kiriting. Rahmat!"
 DocType: Assignment Rule,"Simple Python Expression, Example: Status in (""Closed"", ""Cancelled"")","Oddiy Python iborasi, misol: in status (&quot;yopiq&quot;, &quot;bekor qilingan&quot;)"
-apps/frappe/frappe/email/smtp.py,Could not connect to outgoing email server,Chiquvchi elektron pochta serveriga ulanib bo&#39;lmadi
+apps/frappe/frappe/email/smtp.py,Could not connect to outgoing email server,Chiquvchi elektron pochta serveriga ulanib bo'lmadi
 DocType: Blog Post,Rich Text,Boy matn
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Thank you for your interest in subscribing to our updates,Bizning yangilanishlarimizga qiziqish bildirganingiz uchun tashakkur
-DocType: Braintree Settings,Payment Gateway Name,To&#39;lov daftarining nomi
-DocType: Workflow State,resize-full,to&#39;liq o&#39;lchamda
+DocType: Braintree Settings,Payment Gateway Name,To'lov daftarining nomi
+DocType: Workflow State,resize-full,to'liq o'lchamda
 DocType: Workflow State,off,yopiq
 apps/frappe/frappe/public/js/frappe/ui/capture.js,Retake,Qaytaring
-apps/frappe/frappe/desk/query_report.py,Report {0} is disabled,Hisoboti {0} o&#39;chirib qo&#39;yilgan
+apps/frappe/frappe/desk/query_report.py,Report {0} is disabled,Hisoboti {0} o'chirib qo'yilgan
 DocType: Access Log,Core,Core
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Set Permissions,Ruxsatlar o&#39;rnatish
-DocType: DocField,Set non-standard precision for a Float or Currency field,Float yoki Valyuta maydoni uchun standart bo&#39;lmagan aniqlikni o&#39;rnating
-DocType: Email Account,Ignore attachments over this size,Bu o&#39;lchamdagi biriktirmalarni e&#39;tiborsiz qoldiring
-apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move To,Ga o&#39;tish
-DocType: Address,Preferred Billing Address,Tanlangan to&#39;lov manzili
-apps/frappe/frappe/database/database.py,Too many writes in one request. Please send smaller requests,Juda ko&#39;p odamlar bir so&#39;rovda yozadilar. Kichik so&#39;rovlarni yuboring
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Set Permissions,Ruxsatlar o'rnatish
+DocType: DocField,Set non-standard precision for a Float or Currency field,Float yoki Valyuta maydoni uchun standart bo'lmagan aniqlikni o'rnating
+DocType: Email Account,Ignore attachments over this size,Bu o'lchamdagi biriktirmalarni e'tiborsiz qoldiring
+apps/frappe/frappe/public/js/frappe/form/grid_row.js,Move To,Ga o'tish
+DocType: Address,Preferred Billing Address,Tanlangan to'lov manzili
+apps/frappe/frappe/database/database.py,Too many writes in one request. Please send smaller requests,Juda ko'p odamlar bir so'rovda yozadilar. Kichik so'rovlarni yuboring
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive has been configured.,Google Drive sozlandi.
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Document Type {0} has been repeated.,{0} hujjat turi takrorlangan.
-apps/frappe/frappe/core/doctype/version/version_view.html,Values Changed,Qadriyatlar o&#39;zgartirildi
-DocType: Workflow State,arrow-up,o&#39;q-up
-DocType: Dynamic Link,Link Document Type,Hujjat turini bog&#39;lash
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for {0} table,{0} jadval uchun atreast bitta qator bo&#39;lishi kerak
+apps/frappe/frappe/core/doctype/version/version_view.html,Values Changed,Qadriyatlar o'zgartirildi
+DocType: Workflow State,arrow-up,o'q-up
+DocType: Dynamic Link,Link Document Type,Hujjat turini bog'lash
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,There should be atleast one row for {0} table,{0} jadval uchun atreast bitta qator bo'lishi kerak
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure Auto Repeat, enable ""Allow Auto Repeat"" from {0}.",Avtomatik takrorlashni sozlash uchun {0} dan &quot;Avtomatik takrorlashga ruxsat berish&quot; ni yoqing.
 DocType: OAuth Bearer Token,Expires In,Muddati tugaydi
 DocType: DocField,Allow on Submit,Yuborishga ruxsat berish
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Istisno turi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Ustunlarni tanlash
-DocType: Web Page,Add code as <script>,Kodni <script> deb qo&#39;shing
+DocType: Web Page,Add code as <script>,Kodni <script> deb qo'shing
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Foydalanuvchi ruxsatlarini tozalash
 DocType: Webhook,Headers,Sarlavhalar
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kutilayotgan voqealar
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js,Please enter values for App Access Key and App Secret Key,Ilovaga kirish uchun kalit va ilovaning maxfiy kalitini kiriting
-DocType: Web Form,Accept Payment,To&#39;lovni qabul qilish
+DocType: Web Form,Accept Payment,To'lovni qabul qilish
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Select list item,Ro‘yxat bandini tanlang
-apps/frappe/frappe/config/core.py,A log of request errors,So&#39;rov xatolarining logi
+apps/frappe/frappe/config/core.py,A log of request errors,So'rov xatolarining logi
 DocType: Report,Letter Head,Xat boshi
 DocType: DocType,Quick Entry,Tez kirish
 DocType: Web Form,Button Label,Tugma belgisi
 apps/frappe/frappe/public/js/frappe/list/list_view.js,{0} items selected,{0} ta element tanlandi
-apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Suspend Sending,Yuborishni to&#39;xtatib turish
+apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Suspend Sending,Yuborishni to'xtatib turish
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,User Permissions created sucessfully,Foydalanuvchi ruxsati muvaffaqiyatli yaratildi
 apps/frappe/frappe/desk/doctype/global_search_settings/global_search_settings.py,Fetching default Global Search documents.,Standart Global qidirish hujjatlari olinmoqda.
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Drag elements from the sidebar to add. Drag them back to trash.,Qo&#39;shish uchun yon paneldan elementlarni harakatlantiring. Ularni zaxiraga qaytarib olib tashlang.
-DocType: Workflow State,resize-small,kichik o&#39;lchamli - kichik
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_layout.html,Drag elements from the sidebar to add. Drag them back to trash.,Qo'shish uchun yon paneldan elementlarni harakatlantiring. Ularni zaxiraga qaytarib olib tashlang.
+DocType: Workflow State,resize-small,kichik o'lchamli - kichik
 DocType: Address,Postal Code,Pochta Indeksi
 apps/frappe/frappe/core/doctype/communication/communication.js,Relink Communication,Aloqa aloqasi
-DocType: Translation,Contributed,Hissa qo&#39;shgan
+DocType: Translation,Contributed,Hissa qo'shgan
 apps/frappe/frappe/config/customization.py,Form Customization,Shaklni sozlash
-apps/frappe/frappe/www/third_party_apps.html,No Active Sessions,Faol sessiyalar yo&#39;q
-DocType: Web Form,Route to Success Link,Muvaffaqiyatga yo&#39;nalish aloqasi
-DocType: Top Bar Item,Right,To&#39;g&#39;ri
-apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,No Upcoming Events,Hodisalar yo&#39;q
+apps/frappe/frappe/www/third_party_apps.html,No Active Sessions,Faol sessiyalar yo'q
+DocType: Web Form,Route to Success Link,Muvaffaqiyatga yo'nalish aloqasi
+DocType: Top Bar Item,Right,To'g'ri
+apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,No Upcoming Events,Hodisalar yo'q
 DocType: User,User Type,Foydalanuvchi turi
-DocType: Prepared Report,Ref Report DocType,DocType hisobotini ko&#39;rsatish
+DocType: Prepared Report,Ref Report DocType,DocType hisobotini ko'rsatish
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Click table to edit,Tahrir qilish uchun jadvalni bosing
 DocType: GCalendar Settings,Client ID,Mijoz identifikatori
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,This report was generated {0}.,Ushbu hisobot {0} tuzilgan.
@@ -3101,102 +3101,102 @@ DocType: Dashboard Chart,Chart Name,Jadval nomi
 DocType: Dashboard Chart,Chart Type,Grafik turi
 DocType: DocType,Auto Name,Avtomatik nom
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,"Abc yoki 6543 kabi ketma-ketliklardan qochinglar, chunki ular taxmin qilish oson"
-apps/frappe/frappe/public/js/frappe/request.js,Please try again,"Iltimos, yana bir bor urinib ko&#39;ring"
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL &#39;http: //&#39; yoki &#39;https: //&#39; bilan boshlanishi kerak.
+apps/frappe/frappe/public/js/frappe/request.js,Please try again,"Iltimos, yana bir bor urinib ko'ring"
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL 'http: //' yoki 'https: //' bilan boshlanishi kerak.
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Variant 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Tahrirlash
 DocType: Website Settings,Chat Operators,Chat operatorlari
 DocType: S3 Backup Settings,ca-central-1,ca-markaziy-1
 DocType: Contact Us Settings,Pincode,Pincode
-apps/frappe/frappe/core/doctype/data_import/importer.py,Please make sure that there are no empty columns in the file.,"Iltimos, faylda bo&#39;sh ustunlar yo&#39;qligiga ishonch hosil qiling."
-apps/frappe/frappe/config/settings.py,Tracks milestones on the lifecycle of a document if it undergoes multiple stages.,"Hujjat bir necha bosqichlarni bosib o&#39;tgan bo&#39;lsa, uning hayotiy tsiklidagi bosqichlarni kuzatib boradi."
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"Renamed files and replaced code in controllers, please check!","Fayllar nomini o&#39;zgartiring va kontrolörlerde kodni o&#39;zgartiring, iltimos tekshiring!"
+apps/frappe/frappe/core/doctype/data_import/importer.py,Please make sure that there are no empty columns in the file.,"Iltimos, faylda bo'sh ustunlar yo'qligiga ishonch hosil qiling."
+apps/frappe/frappe/config/settings.py,Tracks milestones on the lifecycle of a document if it undergoes multiple stages.,"Hujjat bir necha bosqichlarni bosib o'tgan bo'lsa, uning hayotiy tsiklidagi bosqichlarni kuzatib boradi."
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"Renamed files and replaced code in controllers, please check!","Fayllar nomini o'zgartiring va kontrolörlerde kodni o'zgartiring, iltimos tekshiring!"
 apps/frappe/frappe/utils/oauth.py,Please ensure that your profile has an email address,"Iltimos, profilingiz elektron pochta manziliga ega ekanligiga ishonch hosil qiling"
-apps/frappe/frappe/public/js/frappe/model/create_new.js,You have unsaved changes in this form. Please save before you continue.,Ushbu shaklda saqlanmagan o&#39;zgarishlar mavjud. Davom etishdan oldin saqlab qo&#39;ying.
+apps/frappe/frappe/public/js/frappe/model/create_new.js,You have unsaved changes in this form. Please save before you continue.,Ushbu shaklda saqlanmagan o'zgarishlar mavjud. Davom etishdan oldin saqlab qo'ying.
 DocType: Address,Telangana,Telangana
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for {0} must be an option,{0} uchun standart variant bo&#39;lishi kerak
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for {0} must be an option,{0} uchun standart variant bo'lishi kerak
 DocType: Tag Doc Category,Tag Doc Category,Tag hujjat kategoriyasi
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Report with more than 10 columns looks better in Landscape mode.,10 dan ortiq ustunlar bilan hisobot Landshaft rejimida yaxshiroq ko&#39;rinadi.
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Report with more than 10 columns looks better in Landscape mode.,10 dan ortiq ustunlar bilan hisobot Landshaft rejimida yaxshiroq ko'rinadi.
 apps/frappe/frappe/database/database.py,Invalid field name: {0},Noto‘g‘ri maydon nomi: {0}
 DocType: Milestone,Milestone,Bosqich
 DocType: User,User Image,Foydalanuvchi Foydalanuvchi bilan
-apps/frappe/frappe/core/doctype/doctype/doctype.js,Go to {0},{0} ga o&#39;tish
-apps/frappe/frappe/email/queue.py,Emails are muted,E-pochta xabarlari o&#39;chirilgan
+apps/frappe/frappe/core/doctype/doctype/doctype.js,Go to {0},{0} ga o'tish
+apps/frappe/frappe/email/queue.py,Emails are muted,E-pochta xabarlari o'chirilgan
 apps/frappe/frappe/config/integrations.py,Google Services,Google xizmatlari
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,Ctrl + Up,Ctrl + Up
 apps/frappe/frappe/utils/data.py,1 weeks ago,1 hafta oldin
 DocType: Communication,Error,Xato
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,Please setup a message first,"Iltimos, avval xabarni sozlang"
 DocType: Auto Repeat,End Date,Tugash sanasi
-DocType: Data Import,Ignore encoding errors,Kodlash xatolariga e&#39;tibor berilmasin
+DocType: Data Import,Ignore encoding errors,Kodlash xatolariga e'tibor berilmasin
 DocType: Chat Profile,Notifications,Bildirishnomalar
 DocType: DocField,Column Break,Ustunli tanaffus
 DocType: Assignment Rule Day,Thursday,Payshanba
-apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough review points,Sizda yetarli sharhlar yo&#39;q
-apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Ushbu faylga kirish uchun ruxsat yo&#39;q
+apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,You do not have enough review points,Sizda yetarli sharhlar yo'q
+apps/frappe/frappe/utils/response.py,You don't have permission to access this file,Ushbu faylga kirish uchun ruxsat yo'q
 apps/frappe/frappe/core/doctype/user/user.js,Save API Secret: ,API sirini saqlash:
-apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},Bekor qilingan hujjatni bog&#39;lay olmadingiz: {0}
-apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,"Standart hisobotni tahrirlab bo&#39;lmadi. Iltimos, takrorlang va yangi hisobot tuzing"
-apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address",Kompaniya sizning kompaniyangiz manzili bo&#39;lgani uchun majburiydir
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,"For example: If you want to include the document ID, use {0}","Misol uchun: hujjat identifikatorini kiritish zarur bo&#39;lsa, {0}"
+apps/frappe/frappe/model/document.py,Cannot link cancelled document: {0},Bekor qilingan hujjatni bog'lay olmadingiz: {0}
+apps/frappe/frappe/core/doctype/report/report.py,Cannot edit a standard report. Please duplicate and create a new report,"Standart hisobotni tahrirlab bo'lmadi. Iltimos, takrorlang va yangi hisobot tuzing"
+apps/frappe/frappe/contacts/doctype/address/address.py,"Company is mandatory, as it is your company address",Kompaniya sizning kompaniyangiz manzili bo'lgani uchun majburiydir
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,"For example: If you want to include the document ID, use {0}","Misol uchun: hujjat identifikatorini kiritish zarur bo'lsa, {0}"
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Table Columns for {0},{0} uchun jadval ustunlarini tanlang
 DocType: Custom Field,Options Help,Tanlovlar yordami
-DocType: Footer Item,Group Label,Guruh yorlig&#39;i
+DocType: Footer Item,Group Label,Guruh yorlig'i
 DocType: Kanban Board,Kanban Board,Kanban kengashi
 apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,Google Contacts has been configured.,Google Kontaktlar sozlandi.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,1 record will be exported,1 yozuv eksport qilinadi
 DocType: DocField,Report Hide,Hide hisoboti
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Tree view not available for {0},{0} uchun daraxt ko&#39;rinishi mavjud emas
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Tree view not available for {0},{0} uchun daraxt ko'rinishi mavjud emas
 DocType: DocType,Restrict To Domain,Domen uchun cheklov
 DocType: Domain,Domain,Domen
 DocType: Custom Field,Label Help,Yorliqli yordam
-DocType: Workflow State,star-empty,yulduz-bo&#39;sh
-apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,Vaqtlarni ko&#39;pincha oson topish mumkin.
-apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Google Contacts - Google kontaktlaridan {0}, xato kodi {1} bilan kontaktlarni sinxronlab bo&#39;lmadi."
+DocType: Workflow State,star-empty,yulduz-bo'sh
+apps/frappe/frappe/utils/password_strength.py,Dates are often easy to guess.,Vaqtlarni ko'pincha oson topish mumkin.
+apps/frappe/frappe/integrations/doctype/google_contacts/google_contacts.py,"Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}.","Google Contacts - Google kontaktlaridan {0}, xato kodi {1} bilan kontaktlarni sinxronlab bo'lmadi."
 apps/frappe/frappe/public/js/frappe/form/workflow.js,Next actions,Keyingi amallar
-apps/frappe/frappe/email/doctype/notification/notification.py,"Cannot edit Standard Notification. To edit, please disable this and duplicate it","Standart bildirishnomani tahrirlab bo&#39;lmadi. Tahrirlash uchun, iltimos, buni o&#39;chirib qo&#39;ying va uni takrorlang"
-apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,Tasdiqlash kodi elektron pochtasi yuborilmadi. Ma&#39;mur bilan bog&#39;laning.
+apps/frappe/frappe/email/doctype/notification/notification.py,"Cannot edit Standard Notification. To edit, please disable this and duplicate it","Standart bildirishnomani tahrirlab bo'lmadi. Tahrirlash uchun, iltimos, buni o'chirib qo'ying va uni takrorlang"
+apps/frappe/frappe/templates/includes/login/login.js,Verification code email not sent. Please contact Administrator.,Tasdiqlash kodi elektron pochtasi yuborilmadi. Ma'mur bilan bog'laning.
 DocType: Workflow State,ok,ok
-DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Ushbu qadriyatlar avtomatik ravishda tranzaktsiyalarda yangilanadi va ushbu qiymatlarni o&#39;z ichiga olgan operatsiyalarda ushbu foydalanuvchi uchun ruxsatlarni cheklash foydali bo&#39;ladi.
+DocType: User,These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Ushbu qadriyatlar avtomatik ravishda tranzaktsiyalarda yangilanadi va ushbu qiymatlarni o'z ichiga olgan operatsiyalarda ushbu foydalanuvchi uchun ruxsatlarni cheklash foydali bo'ladi.
 apps/frappe/frappe/twofactor.py,Verfication Code,Verfikatsiya kodi
 DocType: Webhook,Webhook Request,Webhook Request
 apps/frappe/frappe/model/rename_doc.py,** Failed: {0} to {1}: {2},** bajarilmadi: {0} dan {1} ga: {2}
 DocType: Data Migration Mapping,Mapping Type,Turi turi
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Select Mandatory,Majburiy tanlang
-apps/frappe/frappe/public/js/frappe/ui/upload.html,Browse,Ko&#39;zdan kechiring
+apps/frappe/frappe/public/js/frappe/ui/upload.html,Browse,Ko'zdan kechiring
 apps/frappe/frappe/utils/password_strength.py,"No need for symbols, digits, or uppercase letters.","Belgilar, raqamlar yoki katta harflar kerak emas."
 DocType: DocField,Currency,Valyuta
 DocType: Async Task,Running,Yugurish
-DocType: DocType,Track Views,Tomlarni ko&#39;rish
+DocType: DocType,Track Views,Tomlarni ko'rish
 apps/frappe/frappe/core/doctype/user/user.js,Reset Password,Parolni tiklash
-DocType: Workflow State,hand-left,qo&#39;lda-chapda
+DocType: Workflow State,hand-left,qo'lda-chapda
 DocType: Data Import,If you are updating/overwriting already created records.,Agar siz allaqachon yaratilgan yozuvlarni yangilab tursangiz / yozsangiz.
 apps/frappe/frappe/public/js/frappe/list/list_filter.js,Is Global,Global
 DocType: Email Account,Use SSL,SSLdan foydalaning
-DocType: Workflow State,play-circle,o&#39;ynash doirasi
-apps/frappe/frappe/public/js/frappe/views/interaction.js,The document could not be correctly assigned,Hujjat to&#39;g&#39;ri berilmagan
-apps/frappe/frappe/public/js/frappe/form/layout.js,"Invalid ""depends_on"" expression",&quot;Depend_on&quot; ifodasi noto&#39;g&#39;ri
+DocType: Workflow State,play-circle,o'ynash doirasi
+apps/frappe/frappe/public/js/frappe/views/interaction.js,The document could not be correctly assigned,Hujjat to'g'ri berilmagan
+apps/frappe/frappe/public/js/frappe/form/layout.js,"Invalid ""depends_on"" expression",&quot;Depend_on&quot; ifodasi noto'g'ri
 DocType: Communication,Keeps track of all communications,Barcha aloqalarni kuzatib boradi
 apps/frappe/frappe/public/js/frappe/chat.js,Group Name,Guruh nomi
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Print Format to Edit,O&#39;zgartirishni chop etish formatini tanlang
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select Print Format to Edit,O'zgartirishni chop etish formatini tanlang
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Enable Shadows,Soyalarni yoqish
 DocType: Address,Shipping,yuk tashish; yetkazib berish
-DocType: Workflow State,circle-arrow-down,aylana-o&#39;q-pastga
+DocType: Workflow State,circle-arrow-down,aylana-o'q-pastga
 apps/frappe/frappe/config/desk.py,Private and public Notes.,Xususiy va jamoat izohlari.
 DocType: DocField,Datetime,Datetime
 apps/frappe/frappe/templates/includes/login/login.js,Not a valid user,Haqiqiy foydalanuvchi emas
 apps/frappe/frappe/templates/includes/comments/comments.html,Please enter a valid email address.,Iltimos amaldagi e-pochta manzilingizni kiriting.
-apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Last refreshed,So&#39;nggi yangilandi
+apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Last refreshed,So'nggi yangilandi
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,For Document Type,Hujjat turi uchun
-DocType: Workflow State,arrow-right,o&#39;q-o&#39;ng
+DocType: Workflow State,arrow-right,o'q-o'ng
 DocType: Workflow State,Workflow state represents the current state of a document.,Ish oqimining holati hujjatning hozirgi holatini bildiradi.
 DocType: Letter Head,Letter Head Based On,Bosh harfga asoslangan
-apps/frappe/frappe/utils/oauth.py,Token is missing,To&#39;xan yo&#39;q
-apps/frappe/frappe/www/update-password.html,Set Password,Parol o&#39;rnating
+apps/frappe/frappe/utils/oauth.py,Token is missing,To'xan yo'q
+apps/frappe/frappe/www/update-password.html,Set Password,Parol o'rnating
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} records.,{0} yozuvlar muvaffaqiyatli import qilindi.
-apps/frappe/frappe/public/js/frappe/utils/utils.js,Note: Changing the Page Name will break previous URL to this page.,Eslatma: Sahifa nomini o&#39;zgartirish ushbu sahifaga avvalgi URLni buzadi.
-apps/frappe/frappe/utils/file_manager.py,Removed {0},{0} o&#39;chirib tashlandi
+apps/frappe/frappe/public/js/frappe/utils/utils.js,Note: Changing the Page Name will break previous URL to this page.,Eslatma: Sahifa nomini o'zgartirish ushbu sahifaga avvalgi URLni buzadi.
+apps/frappe/frappe/utils/file_manager.py,Removed {0},{0} o'chirib tashlandi
 DocType: SMS Settings,SMS Settings,SMS sozlamalari
 DocType: Company History,Highlight,Ajratib turing
 DocType: Dashboard Chart,Sum,Sum
@@ -3204,35 +3204,35 @@ apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,via Data Import,Data
 DocType: OAuth Provider Settings,Force,Majburlash
 apps/frappe/frappe/core/page/dashboard/dashboard.js,Last synced {0},So‘nggi sinxronlangan {0}
 DocType: DocField,Fold,Kattalashtirilgan
-apps/frappe/frappe/printing/doctype/print_format/print_format.py,Standard Print Format cannot be updated,Standart Chop formati yangilanib bo&#39;lmadi
+apps/frappe/frappe/printing/doctype/print_format/print_format.py,Standard Print Format cannot be updated,Standart Chop formati yangilanib bo'lmadi
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field {1} of type {2} cannot be mandatory,{0}: {2} turdagi {1} maydon majburiy emas
 DocType: System Settings,In Days,Kunlarda
 apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py,Miss,Miss
-apps/frappe/frappe/public/js/frappe/model/model.js,Please specify,"Iltimos, ko&#39;rsating"
+apps/frappe/frappe/public/js/frappe/model/model.js,Please specify,"Iltimos, ko'rsating"
 DocType: Comment,Bot,Bot
 DocType: Help Article,Help Article,Yordam Maqola
 DocType: Page,Page Name,Sahifa nomi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Also adding the dependent currency field {0},"Bundan tashqari, qaram valyuta maydoni {0}"
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not locate locate - {0},Google Drive - Joylashuvni topib bo&#39;lmadi - {0}
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not locate locate - {0},Google Drive - Joylashuvni topib bo'lmadi - {0}
 DocType: S3 Backup Settings,ap-south-1,ap-janub-1
 apps/frappe/frappe/core/doctype/file/file.js,Unzip,Unzip
-apps/frappe/frappe/model/document.py,Incorrect value in row {0}: {1} must be {2} {3},{0} qatorida noto&#39;g&#39;ri qiymat: {1} {2} {3}
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Submitted Document cannot be converted back to draft. Transition row {0},Yuborilgan hujjat taslakga o&#39;tkazilmaydi. O&#39;tish satri {0}
+apps/frappe/frappe/model/document.py,Incorrect value in row {0}: {1} must be {2} {3},{0} qatorida noto'g'ri qiymat: {1} {2} {3}
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Submitted Document cannot be converted back to draft. Transition row {0},Yuborilgan hujjat taslakga o'tkazilmaydi. O'tish satri {0}
 DocType: Assignment Rule,Assignment Days,Topshirish kunlari
 apps/frappe/frappe/desk/reportview.py,Deleting {0},{0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_start.html,Select an existing format to edit or start a new format.,Yangi formatni tahrirlash yoki boshlash uchun mavjud formatni tanlang.
-DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,"Ikki faktor tasdiqlangan bo&#39;lsa, Bypass cheklangan IP manzilini tekshirish"
+DocType: System Settings,Bypass restricted IP Address check If Two Factor Auth Enabled,"Ikki faktor tasdiqlangan bo'lsa, Bypass cheklangan IP manzilini tekshirish"
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Created Custom Field {0} in {1},{1} da {0} uchun maxsus maydon yaratildi
 DocType: System Settings,Time Zone,Vaqt zonasi
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Special Characters are not allowed,Maxsus belgilarga ruxsat berilmaydi
 DocType: Comment,Relinked,Qaytib ketdi
 DocType: Print Settings,Compact Item Print,Yilni mahsulot Chop etish
 DocType: Email Account,uidnext,uidnext
-DocType: User,Redirect URL,URL manzilini yo&#39;naltirish
+DocType: User,Redirect URL,URL manzilini yo'naltirish
 DocType: SMS Settings,Enter url parameter for receiver nos,Receiver nos uchun url parametrini kiriting
 DocType: Chat Profile,Online,Onlaynda
 DocType: Email Account,Always use Account's Name as Sender's Name,Hisobning nomini har doim yuboruvchining ismi sifatida ishlatish
-apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,Faqat Administrator Email Queue-ni o&#39;chirishi mumkin
+apps/frappe/frappe/email/doctype/email_queue/email_queue.py,Only Administrator can delete Email Queue,Faqat Administrator Email Queue-ni o'chirishi mumkin
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Setting this Address Template as default as there is no other default,Ushbu manzilni shablonini asl qiymati sifatida belgilash boshqa hech qanday standart emas
 DocType: Workflow State,Home,Bosh sahifa
 DocType: OAuth Provider Settings,Auto,Avto
@@ -3244,7 +3244,7 @@ apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Insert Column B
 DocType: Energy Point Rule,The user from this field will be rewarded points,Ushbu maydondan foydalanuvchi yutuqli ballarni oladi
 DocType: Assignment Rule,Close Condition,Vaziyatni yoping
 DocType: Dropbox Settings,Number of DB Backups,DB Backups soni
-DocType: Email Account,Add Signature,Imzo qo&#39;shing
+DocType: Email Account,Add Signature,Imzo qo'shing
 apps/frappe/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py,Left this conversation,Ushbu suhbatni qoldiring
 DocType: Print Format,Raw Printing,Xom bosma
 ,Background Jobs,Fon ishi
@@ -3252,20 +3252,20 @@ apps/frappe/frappe/public/js/frappe/form/print.js,Printer Settings,Printer sozla
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py,Time series based on is required to create a dashboard chart,Boshqaruv jadvalini tuzish uchun vaqt ketma-ketligi talab qilinadi
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Energy Points: ,Energiya punktlari:
 DocType: ToDo,ToDo,Qilmoq
-DocType: DocField,No Copy,Nusxalash yo&#39;q
+DocType: DocField,No Copy,Nusxalash yo'q
 DocType: Workflow State,qrcode,qrcode
 DocType: Chat Token,IP Address,IP manzili
-DocType: Data Import,Submit after importing,Importdan so&#39;ng yuboring
+DocType: Data Import,Submit after importing,Importdan so'ng yuboring
 apps/frappe/frappe/www/login.html,Login with LDAP,LDAP bilan kiring
 DocType: Web Form,Breadcrumbs,Breadcrumbs
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,Rank: ,Tartib:
-apps/frappe/frappe/core/doctype/doctype/doctype.py,If Owner,Agar egasi bo&#39;lsa
+apps/frappe/frappe/core/doctype/doctype/doctype.py,If Owner,Agar egasi bo'lsa
 DocType: Data Migration Mapping,Push,Durang
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Drop files here,Fayllarni bu yerga tashlang
-DocType: OAuth Authorization Code,Expiration time,O&#39;tkazish vaqti
+DocType: OAuth Authorization Code,Expiration time,O'tkazish vaqti
 DocType: Web Page,Website Sidebar,Veb-sayt shkafi
-DocType: Web Form,Show Sidebar,Yon paneli ko&#39;rsatilsin
-apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be logged in to access this {0}.,{0} ga kirish uchun siz tizimga kirgan bo&#39;lishingiz kerak.
+DocType: Web Form,Show Sidebar,Yon paneli ko'rsatilsin
+apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be logged in to access this {0}.,{0} ga kirish uchun siz tizimga kirgan bo'lishingiz kerak.
 apps/frappe/frappe/public/js/frappe/form/sidebar/assign_to.js,Complete By,Komple By
 apps/frappe/frappe/utils/password_strength.py,All-uppercase is almost as easy to guess as all-lowercase.,Katta kattalikdagi kichik harflar sonini taxmin qilish oson.
 DocType: Website Settings,Top Bar Items,Top Bar buyumlari
@@ -3277,109 +3277,109 @@ DocType: Calendar View,End Date Field,Tugash sanasi maydoni
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Global Shortcuts,Global yorliqlar
 DocType: Desktop Icon,Page,Sahifa
 apps/frappe/frappe/utils/bot.py,Could not find {0} in {1},{1} da {0} topilmadi
-apps/frappe/frappe/utils/password_strength.py,Names and surnames by themselves are easy to guess.,Ism va familiyalar o&#39;zlarini taxmin qilish oson.
-apps/frappe/frappe/config/website.py,Knowledge Base,Ma&#39;lumotlar bazasi
+apps/frappe/frappe/utils/password_strength.py,Names and surnames by themselves are easy to guess.,Ism va familiyalar o'zlarini taxmin qilish oson.
+apps/frappe/frappe/config/website.py,Knowledge Base,Ma'lumotlar bazasi
 DocType: Workflow State,briefcase,portfel
-apps/frappe/frappe/model/document.py,Value cannot be changed for {0},{0} uchun qiymatni o&#39;zgartirish mumkin emas
-DocType: Workflow State,"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange","Uslub tugma rangini ifodalaydi: muvaffaqiyat - yashil, xavf - qizil, teskari - qora, birlamchi - quyuq moviy, ma&#39;lumot - ochiq moviy, ogohlantirish - sariq"
-apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Ushbu so&#39;rov hali foydalanuvchi tomonidan ma&#39;qullanmagan.
-apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Please Install the ldap3 library via pip to use ldap functionality.,Iltimos ldap funksiyasidan foydalanish uchun ldap3 kutubxonasini pip orqali o&#39;rnating.
+apps/frappe/frappe/model/document.py,Value cannot be changed for {0},{0} uchun qiymatni o'zgartirish mumkin emas
+DocType: Workflow State,"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange","Uslub tugma rangini ifodalaydi: muvaffaqiyat - yashil, xavf - qizil, teskari - qora, birlamchi - quyuq moviy, ma'lumot - ochiq moviy, ogohlantirish - sariq"
+apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This request has not yet been approved by the user.,Ushbu so'rov hali foydalanuvchi tomonidan ma'qullanmagan.
+apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Please Install the ldap3 library via pip to use ldap functionality.,Iltimos ldap funksiyasidan foydalanish uchun ldap3 kutubxonasini pip orqali o'rnating.
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,Qator holati
 DocType: S3 Backup Settings,sa-east-1,sa-sharq-1
-DocType: Workflow Transition,Workflow Transition,Ish oqimi o&#39;tish
+DocType: Workflow Transition,Workflow Transition,Ish oqimi o'tish
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,{0} oy oldin
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Shaxsiy maydonlarni faqat standart DocType-ga qo&#39;shish mumkin.
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Shaxsiy maydonlarni faqat standart DocType-ga qo'shish mumkin.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Created By,Tomonidan yaratilgan
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Dropbox sozlamalari
 DocType: Assignment Rule Day,Assignment Rule Day,Topshiriq berish kuni
-DocType: Workflow State,resize-horizontal,o&#39;lchamli-gorizontal
+DocType: Workflow State,resize-horizontal,o'lchamli-gorizontal
 apps/frappe/frappe/templates/emails/download_data.html,Download Link,Havolani yuklab oling
 DocType: Chat Message,Content,Kontent
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} reverted your point on {1},{0} fikringizni {1} ga qaytardi
-DocType: Data Migration Run,Push Insert,Qo&#39;shib qo&#39;yish tugmasi
+DocType: Data Migration Run,Push Insert,Qo'shib qo'yish tugmasi
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Group Node,Guruh tugunni
 DocType: Auto Repeat,Notification,Bildirishnoma
 DocType: Contact Phone,Contact Phone,Murojaat uchun telefon
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} appreciated {1},{0} baholandi {1}
 DocType: Milestone,Document,Hujjat
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Series {0} already used in {1},{0} qatori {1} da allaqachon ishlatilgan
-apps/frappe/frappe/core/doctype/data_import/importer.py,Unsupported File Format,Fayl formati qo&#39;llab-quvvatlanmaydi
+apps/frappe/frappe/core/doctype/data_import/importer.py,Unsupported File Format,Fayl formati qo'llab-quvvatlanmaydi
 apps/frappe/frappe/public/js/frappe/form/print.js,Attempting to launch QZ Tray...,QZ Tray-ni ishga tushirishga urinish ...
 DocType: Assignment Rule,Example: {{ subject }},Masalan: {{mavzu}}
 DocType: DocField,Code,Kod
-DocType: Workflow,"All possible Workflow States and roles of the workflow. Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Ish yuritishning barcha mumkin bo&#39;lgan davlatlari va biznes rivoji. Docstatus imkoniyatlari: 0 &quot;saqlangan&quot;, 1 &quot;topshirilgan&quot; va 2 &quot;bekor qilindi&quot;"
+DocType: Workflow,"All possible Workflow States and roles of the workflow. Docstatus Options: 0 is""Saved"", 1 is ""Submitted"" and 2 is ""Cancelled""","Ish yuritishning barcha mumkin bo'lgan davlatlari va biznes rivoji. Docstatus imkoniyatlari: 0 &quot;saqlangan&quot;, 1 &quot;topshirilgan&quot; va 2 &quot;bekor qilindi&quot;"
 apps/frappe/frappe/printing/doctype/print_format/print_format.py,{0} are required,{0} shart
-apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Last Modified On,Oxirgi o&#39;zgartirilgan
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document.","0-darajadagi ruxsatlar Hujjat darajasi darajasidagi ruxsatnomalar, ya&#39;ni hujjatga kirish uchun asosiy hisoblanadi."
+apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.js,Last Modified On,Oxirgi o'zgartirilgan
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document.","0-darajadagi ruxsatlar Hujjat darajasi darajasidagi ruxsatnomalar, ya'ni hujjatga kirish uchun asosiy hisoblanadi."
 DocType: Auto Repeat,Print Format,Bosib chiqarish formati
-apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Toggle Grid View,Grid ko&#39;rinishini almashtirish
-apps/frappe/frappe/public/js/frappe/form/form.js,Go to next record,Keyingi yozuvga o&#39;ting
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Invalid payment gateway credentials,To&#39;lov shlyuzi hisob ma&#39;lumotlari noto&#39;g&#39;ri
-DocType: Data Import,This is the template file generated with only the rows having some error. You should use this file for correction and import.,Bu faqat ba&#39;zi bir xatolarga ega bo&#39;lgan qatorlar bilan yaratilgan shablon fayli. Ushbu faylni tuzatish va import qilish uchun ishlatishingiz kerak.
-apps/frappe/frappe/config/users_and_permissions.py,Set Permissions on Document Types and Roles,Hujjat turlari va rollarda ruxsatlarni o&#39;rnatish
+apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Toggle Grid View,Grid ko'rinishini almashtirish
+apps/frappe/frappe/public/js/frappe/form/form.js,Go to next record,Keyingi yozuvga o'ting
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Invalid payment gateway credentials,To'lov shlyuzi hisob ma'lumotlari noto'g'ri
+DocType: Data Import,This is the template file generated with only the rows having some error. You should use this file for correction and import.,Bu faqat ba'zi bir xatolarga ega bo'lgan qatorlar bilan yaratilgan shablon fayli. Ushbu faylni tuzatish va import qilish uchun ishlatishingiz kerak.
+apps/frappe/frappe/config/users_and_permissions.py,Set Permissions on Document Types and Roles,Hujjat turlari va rollarda ruxsatlarni o'rnatish
 DocType: Data Migration Run,Remote ID,Masofali identifikator
-apps/frappe/frappe/model/meta.py,No Label,Yorliq yo&#39;q
+apps/frappe/frappe/model/meta.py,No Label,Yorliq yo'q
 DocType: System Settings,Use socketio to upload file,Faylni yuklash uchun socketio-dan foydalaning
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Refreshing,Yangilash
 apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.js,Modified By,Modifikatsiya qilingan
-apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specified,E-pochta manzili ko&#39;rsatilmagan
+apps/frappe/frappe/public/js/frappe/request.js,Support Email Address Not Specified,E-pochta manzili ko'rsatilmagan
 DocType: Energy Point Log,Criticism,Tanqid
 DocType: Address,Tripura,Tripura
 DocType: About Us Settings,"""Company History""",&quot;Kompaniya tarixi&quot;
-apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Ushbu hujjat elektron pochta orqali yuborilganidan so&#39;ng o&#39;zgartirildi.
-DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","Agar belgilansa, agar qiymat allaqachon mavjud bo&#39;lsa, ushbu maydon Fetch From asosida yozilmaydi."
-DocType: Access Log,Show Report,Hisobotni ko&#39;rsatish
+apps/frappe/frappe/www/confirm_workflow_action.html,This document has been modified after the email was sent.,Ushbu hujjat elektron pochta orqali yuborilganidan so'ng o'zgartirildi.
+DocType: DocField,"If checked, this field will be not overwritten based on Fetch From if a value already exists.","Agar belgilansa, agar qiymat allaqachon mavjud bo'lsa, ushbu maydon Fetch From asosida yozilmaydi."
+DocType: Access Log,Show Report,Hisobotni ko'rsatish
 DocType: Address,Tamil Nadu,Tamil Nadu
 DocType: Email Rule,Email Rule,Email qoidasi
 apps/frappe/frappe/core/doctype/docshare/docshare.py,{0} shared this document with everyone,{0} ushbu hujjatni har kimga ulashdi
 apps/frappe/frappe/desk/page/activity/activity_row.html,Commented on {0}: {1},{0} ga sharh berdi: {1}
-apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Looks like someone sent you to an incomplete URL. Please ask them to look into it.,"Kimdir sizni tugallanmagan URL manziliga yuborganga o&#39;xshaydi. Iltimos, ularga murojaat qiling."
-apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Your payment has been successfully registered.,To&#39;lovingiz muvaffaqiyatli ro&#39;yxatga olingan.
+apps/frappe/frappe/templates/pages/integrations/braintree_checkout.py,Looks like someone sent you to an incomplete URL. Please ask them to look into it.,"Kimdir sizni tugallanmagan URL manziliga yuborganga o'xshaydi. Iltimos, ularga murojaat qiling."
+apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,Your payment has been successfully registered.,To'lovingiz muvaffaqiyatli ro'yxatga olingan.
 DocType: Stripe Settings,Secret Key,Yashirin kalit
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Translate {0},Tarjima {0}
-DocType: Notification,Send alert if this field's value changes,Ushbu maydonning qiymati o&#39;zgarganda ogohlantirish yuborish
+DocType: Notification,Send alert if this field's value changes,Ushbu maydonning qiymati o'zgarganda ogohlantirish yuborish
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Mavzu ranglari
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Yangi format yaratish uchun DocType-ni tanlang
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Foydalanuvchi mavjud emas
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Qabul qiluvchilar&#39; ko&#39;rsatilmagan
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Qabul qiluvchilar' ko'rsatilmagan
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,hozirgina
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Ilova qiling
 DocType: Footer Item,Policy,Siyosat
 apps/frappe/frappe/integrations/utils.py,{0} Settings not found,{0} Sozlamalar topilmadi
 DocType: Module Def,Module Def,Module Def
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Upload file,Faylni yuklash
-apps/frappe/frappe/public/js/frappe/social/components/Post.vue,Are you sure you want to delete this post?,Haqiqatan ham ushbu xabarni yo&#39;q qilmoqchimisiz?
+apps/frappe/frappe/public/js/frappe/social/components/Post.vue,Are you sure you want to delete this post?,Haqiqatan ham ushbu xabarni yo'q qilmoqchimisiz?
 DocType: Chat Profile,Busy,Band
 apps/frappe/frappe/core/page/dashboard/dashboard.js,{0} Dashboard,{0} asboblar paneli
-DocType: Data Migration Plan,Data Migration Plan,Ma&#39;lumotlarni ko&#39;chirish rejasi
+DocType: Data Migration Plan,Data Migration Plan,Ma'lumotlarni ko'chirish rejasi
 apps/frappe/frappe/core/doctype/communication/communication.js,Reply,Javob bering
 apps/frappe/frappe/config/core.py,Pages in Desk (place holders),Stoldagi sahifalar (egalari)
-DocType: DocField,Collapsible Depends On,Yig&#39;ilgan bo&#39;ladi
+DocType: DocField,Collapsible Depends On,Yig'ilgan bo'ladi
 DocType: Print Style,Print Style Name,Stil nomini chop etish
 DocType: Print Settings,Allow page break inside tables,Jadvallar ichidagi sahifa soniga ruxsat berish
 DocType: Email Account,SMTP Server,SMTP Server
 DocType: Print Format,Print Format Help,Chop etish uchun yordam
-apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,{0} room must have atmost one user.,{0} xonada atmost bitta foydalanuvchi bo&#39;lishi kerak.
+apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,{0} room must have atmost one user.,{0} xonada atmost bitta foydalanuvchi bo'lishi kerak.
 DocType: DocType,Beta,Beta
 DocType: Dashboard Chart,Count,Hisoblash
 apps/frappe/frappe/templates/includes/comments/comments.py,New Comment on {0}: {1},{0}: {1} haqida yangi sharh
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,restored {0} as {1},{1} sifatida {0}
-apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are updating, please select ""Overwrite"" else existing rows will not be deleted.","Yangilashni davom ettirsangiz, iltimos, mavjud satrlarni &quot;Overwrite&quot; -ni tanlang, o&#39;chirilmaydi."
+apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are updating, please select ""Overwrite"" else existing rows will not be deleted.","Yangilashni davom ettirsangiz, iltimos, mavjud satrlarni &quot;Overwrite&quot; -ni tanlang, o'chirilmaydi."
 DocType: DocField,Translatable,Translatable
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,Syncing {0} of {1},Sinxronlash: {0} ning {1}
 DocType: Letter Head,Letter Head in HTML,HTML-dagi Letter Head
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User Profile,Foydalanuvchi anketasi
 DocType: Web Form,Web Form,Veb shakl
-apps/frappe/frappe/public/js/frappe/form/controls/date.js,Date {0} must be in format: {1},Sana {0} formati bo&#39;lishi kerak: {1}
+apps/frappe/frappe/public/js/frappe/form/controls/date.js,Date {0} must be in format: {1},Sana {0} formati bo'lishi kerak: {1}
 DocType: About Us Settings,Org History Heading,Org tarixi sarlavhasi
 DocType: Print Settings,Allow Print for Cancelled,Chop etish uchun Bekor qilish uchun ruxsat ber
-DocType: Communication,Integrations can use this field to set email delivery status,Integratsiyalashuvlar ushbu maydondan elektron pochta manzilini o&#39;rnatish uchun foydalanishi mumkin
-DocType: Web Form,Web Page Link Text,Veb-sahifaga bog&#39;langan matn
+DocType: Communication,Integrations can use this field to set email delivery status,Integratsiyalashuvlar ushbu maydondan elektron pochta manzilini o'rnatish uchun foydalanishi mumkin
+DocType: Web Form,Web Page Link Text,Veb-sahifaga bog'langan matn
 DocType: Page,System Page,Tizim sahifasi
-apps/frappe/frappe/config/settings.py,"Set default format, page size, print style etc.","Standart formatni, sahifa o&#39;lchamini, bosib chiqarish uslubini va boshqalarni o&#39;rnating."
+apps/frappe/frappe/config/settings.py,"Set default format, page size, print style etc.","Standart formatni, sahifa o'lchamini, bosib chiqarish uslubini va boshqalarni o'rnating."
 apps/frappe/frappe/public/js/frappe/form/grid_row_form.js,ESC,ESC
 apps/frappe/frappe/modules/utils.py,Customizations for <b>{0}</b> exported to:<br>{1},<b>{0}</b> uchun <b>moslamalar quyidagiga</b> eksport qilinadi: <br> {1}
-DocType: Website Settings,Include Search in Top Bar,Top barda qidirishni qo&#39;shish
+DocType: Website Settings,Include Search in Top Bar,Top barda qidirishni qo'shish
 DocType: GSuite Settings,Allow GSuite access,GSuite xizmatiga ruxsat berish
 DocType: DocType,DESC,DESC
 DocType: DocType,Naming,Nomlanishi
@@ -3389,45 +3389,45 @@ apps/frappe/frappe/config/customization.py,Custom Translations,Maxsus tarjimalar
 apps/frappe/frappe/public/js/frappe/socketio_client.js,Progress,Harakatlaning
 apps/frappe/frappe/public/js/frappe/form/workflow.js, by Role ,Rol bilan
 apps/frappe/frappe/public/js/frappe/form/save.js,Missing Fields,Missing joylar
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Avtotransportda &quot;{0}&quot; maydon nomeri noto&#39;g&#39;ri
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Invalid fieldname '{0}' in autoname,Avtotransportda &quot;{0}&quot; maydon nomeri noto'g'ri
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search in a document type,Hujjat turini qidirish
 DocType: Custom DocPerm,Role and Level,Rol va daraja
 DocType: File,Thumbnail URL,Kichik URL manzili
 apps/frappe/frappe/desk/moduleview.py,Custom Reports,Maxsus hisobotlar
 DocType: Website Script,Website Script,Sayt skripti
-DocType: GSuite Settings,If you aren't using own publish Google Apps Script webapp you can use the default https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec ,"Agar o&#39;z nashriyoti Google Apps skriptlari veb-ilovasidan foydalanmasangiz, https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec"
+DocType: GSuite Settings,If you aren't using own publish Google Apps Script webapp you can use the default https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec ,"Agar o'z nashriyoti Google Apps skriptlari veb-ilovasidan foydalanmasangiz, https://script.google.com/macros/s/AKfycbxIFOx3301xwtF2IFPJ4pUQGqkNF3hBiBebppWkeKn6fKZRQvk/exec"
 apps/frappe/frappe/config/settings.py,Customized HTML Templates for printing transactions.,Jurnallarni chop etish uchun tayyorlangan HTML Shablonlar.
-apps/frappe/frappe/public/js/frappe/form/print.js,Orientation,Yo&#39;nalish
+apps/frappe/frappe/public/js/frappe/form/print.js,Orientation,Yo'nalish
 DocType: Workflow,Is Active,Faol
 apps/frappe/frappe/desk/query_report.py,{0} saved successfully,{0} muvaffaqiyatli saqlandi
-apps/frappe/frappe/desk/form/utils.py,No further records,Boshqa yozuvlar yo&#39;q
+apps/frappe/frappe/desk/form/utils.py,No further records,Boshqa yozuvlar yo'q
 DocType: DocField,Long Text,Uzoq matn
 DocType: Workflow State,Primary,Birlamchi
 DocType: User,Home Settings,Uy sozlamalari
-apps/frappe/frappe/core/doctype/data_import/importer.py,Please do not change the rows above {0},"Iltimos, {0} ustidagi satrlarni o&#39;zgartirmang."
-DocType: Web Form,Go to this URL after completing the form (only for Guest users),Shaklni to&#39;ldirgandan so&#39;ng ushbu URL manziliga o&#39;ting (faqat Mehmonlar uchun)
+apps/frappe/frappe/core/doctype/data_import/importer.py,Please do not change the rows above {0},"Iltimos, {0} ustidagi satrlarni o'zgartirmang."
+DocType: Web Form,Go to this URL after completing the form (only for Guest users),Shaklni to'ldirgandan so'ng ushbu URL manziliga o'ting (faqat Mehmonlar uchun)
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html,(Ctrl + G),(Ctrl + G)
-DocType: Contact,More Information,Qo&#39;shimcha ma&#39;lumot
+DocType: Contact,More Information,Qo'shimcha ma'lumot
 DocType: Data Migration Mapping,Field Maps,Erlarning xaritalari
 DocType: Desktop Icon,Desktop Icon,Ish stoli belgisi
-apps/frappe/frappe/templates/pages/integrations/payment-success.html,Your payment was successfully accepted,To&#39;lovingiz muvaffaqiyatli qabul qilindi
-apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! You are not permitted to view this page.,Kechirasiz! Ushbu sahifani ko&#39;rishga siz ruxsat berilmaydi.
-DocType: Workflow State,bell,qo&#39;ng&#39;iroq
+apps/frappe/frappe/templates/pages/integrations/payment-success.html,Your payment was successfully accepted,To'lovingiz muvaffaqiyatli qabul qilindi
+apps/frappe/frappe/public/js/frappe/views/pageview.js,Sorry! You are not permitted to view this page.,Kechirasiz! Ushbu sahifani ko'rishga siz ruxsat berilmaydi.
+DocType: Workflow State,bell,qo'ng'iroq
 DocType: LDAP Settings,LDAP Mobile Field,LDAP mobil maydoni
-apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Share this document with,Ushbu hujjatni birgalikda baham ko&#39;ring
-apps/frappe/frappe/utils/nestedset.py,{0} {1} cannot be a leaf node as it has children,{0} {1} bolalari bo&#39;lgani uchun barg tugunni bo&#39;la olmaydi
-DocType: Comment,Info,Ma&#39;lumot
-apps/frappe/frappe/public/js/frappe/views/interaction.js,Add Attachment,Attach qo&#39;shish
+apps/frappe/frappe/public/js/frappe/form/templates/set_sharing.html,Share this document with,Ushbu hujjatni birgalikda baham ko'ring
+apps/frappe/frappe/utils/nestedset.py,{0} {1} cannot be a leaf node as it has children,{0} {1} bolalari bo'lgani uchun barg tugunni bo'la olmaydi
+DocType: Comment,Info,Ma'lumot
+apps/frappe/frappe/public/js/frappe/views/interaction.js,Add Attachment,Attach qo'shish
 DocType: Data Migration Mapping,Sync,Sinx
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client Secret before social login is enabled,Ijtimoiy kirishni yoqishdan oldin mijozlar sirini kiriting
 DocType: Communication,Email,E-pochta
 apps/frappe/frappe/templates/includes/contact.js,Thank you for your message,Xabaringiz uchun rahmat
-apps/frappe/frappe/public/js/frappe/views/communication.js,Send Read Receipt,O&#39;qish olishni jo&#39;nating
+apps/frappe/frappe/public/js/frappe/views/communication.js,Send Read Receipt,O'qish olishni jo'nating
 DocType: Stripe Settings,Stripe Settings,Strip Sozlamalari
-DocType: Data Migration Mapping,Data Migration Mapping,Ma&#39;lumotlarni ko&#39;chirish xaritalash
+DocType: Data Migration Mapping,Data Migration Mapping,Ma'lumotlarni ko'chirish xaritalash
 DocType: Auto Email Report,Period,Davr
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,About {0} minute remaining,Taxminan {0} daqiqa qoldi
-apps/frappe/frappe/www/login.py,Invalid Login Token,Noto&#39;g&#39;ri kirish tokeni
+apps/frappe/frappe/www/login.py,Invalid Login Token,Noto'g'ri kirish tokeni
 apps/frappe/frappe/public/js/frappe/chat.js,Discard,Bekor qiling
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 hour ago,1 soat oldin
 DocType: Website Settings,Home Page,Bosh sahifa
@@ -3435,7 +3435,7 @@ DocType: Error Snapshot,Parent Error Snapshot,Ota-ona xatosi
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Map columns from {0} to fields in {1},{0} dan ustunlarni {1} maydonlariga xaritalash
 DocType: Access Log,Filters,Filtrlar
 DocType: Workflow State,share-alt,ulush-alt
-apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Navbat {0} dan biri bo&#39;lishi kerak
+apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Navbat {0} dan biri bo'lishi kerak
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
 <pre><code>{{ address_line1 }}<br>
@@ -3450,63 +3450,63 @@ DocType: Address Template,"<h4>Default Template</h4>
 </code></pre>","<h4> Standart shablon </h4><p> <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating-ni</a> ishlatadi va barcha manzillar (agar mavjud bo'lsa, Maxsus maydonlar) mavjud bo'ladi </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Boshlash sanasi maydoni
 DocType: Role,Role Name,Romen nomi
-apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Stolga o&#39;tish
-apps/frappe/frappe/config/core.py,Script or Query reports,Skript yoki So&#39;rov hisobotlari
+apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Stolga o'tish
+apps/frappe/frappe/config/core.py,Script or Query reports,Skript yoki So'rov hisobotlari
 DocType: Contact Phone,Is Primary Mobile,Birlamchi mobil
 DocType: Workflow Document State,Workflow Document State,Ish yuritish hujjati holati
 apps/frappe/frappe/public/js/frappe/request.js,File too big,Fayl juda katta
-apps/frappe/frappe/core/doctype/user/user.py,Email Account added multiple times,E-pochta hisobi bir necha marta qo&#39;shilgan
-DocType: Energy Point Settings,Last Point Allocation Date,So&#39;nggi punktni ajratish sanasi
-DocType: Payment Gateway,Payment Gateway,To&#39;lov shlyuzi
+apps/frappe/frappe/core/doctype/user/user.py,Email Account added multiple times,E-pochta hisobi bir necha marta qo'shilgan
+DocType: Energy Point Settings,Last Point Allocation Date,So'nggi punktni ajratish sanasi
+DocType: Payment Gateway,Payment Gateway,To'lov shlyuzi
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} appreciated your work on {1} with {2} point,{0} sizning {1} ishingizni {2} ball bilan baholadi
 DocType: Milestone Tracker,Field to Track,Kuzatish uchun maydon
 apps/frappe/frappe/utils/change_log.py,New updates are available,Yangi yangilanishlar mavjud
 DocType: Portal Settings,Hide Standard Menu,Standart Menyuni yashirish
-apps/frappe/frappe/config/settings.py,Add / Manage Email Domains.,E-pochta domeni-ni qo&#39;shish / boshqarish.
+apps/frappe/frappe/config/settings.py,Add / Manage Email Domains.,E-pochta domeni-ni qo'shish / boshqarish.
 apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py,This link has already been activated for verification.,Ushbu havola tekshirish uchun allaqachon faollashtirilgan.
-apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Cannot cancel before submitting. See Transition {0},Yuborishdan oldin bekor qilolmaysiz. O&#39;tish {0} ga qarang.
-apps/frappe/frappe/www/printview.py,Print Format {0} is disabled,Chop etish formati {0} o&#39;chirib qo&#39;yilgan
+apps/frappe/frappe/workflow/doctype/workflow/workflow.py,Cannot cancel before submitting. See Transition {0},Yuborishdan oldin bekor qilolmaysiz. O'tish {0} ga qarang.
+apps/frappe/frappe/www/printview.py,Print Format {0} is disabled,Chop etish formati {0} o'chirib qo'yilgan
 ,Address and Contacts,Manzil va Kontaktlar
-DocType: Notification,Send days before or after the reference date,Yo&#39;naltirilgan kundan oldin yoki keyin yuboring
+DocType: Notification,Send days before or after the reference date,Yo'naltirilgan kundan oldin yoki keyin yuboring
 DocType: User,Allow user to login only after this hour (0-24),Foydalanuvchiga faqat shu soatlardan keyin kirishga ruxsat berish (0-24)
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,"Assign one by one, in sequence",Birin-ketin ketma-ket tayinlang
 DocType: Integration Request,Subscription Notification,Obuna bildirishnomasi
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,or attach a,yoki qo&#39;shing a
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,or attach a,yoki qo'shing a
 DocType: Auto Repeat,Start Date,Boshlanish vaqti
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,Value,Qiymat
 DocType: Dashboard Chart,Filters JSON,JSON filtrlari
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,Tasdiqlash uchun bu yerni bosing
-DocType: Email Account,Disable SMTP server authentication,SMTP server autentifikatsiyasini o&#39;chirib qo&#39;ying
+DocType: Email Account,Disable SMTP server authentication,SMTP server autentifikatsiyasini o'chirib qo'ying
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,Vaqtinchalik xotiraga nusxa olindi
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,&quot;A&quot; o&#39;rniga &quot;@&quot; kabi prognozli almashtirishlar juda ko&#39;p yordam bermaydi.
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,&quot;A&quot; o'rniga &quot;@&quot; kabi prognozli almashtirishlar juda ko'p yordam bermaydi.
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,Men tomonidan tayinlanganman
 apps/frappe/frappe/utils/data.py,Zero,Zero
 DocType: Google Drive,Backup Folder ID,Zaxira papka identifikatori
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Dasturchi rejimida emas! Site_config.json saytida joylang yoki &#39;Custom&#39; DocType ni tanlang.
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,Dasturchi rejimida emas! Site_config.json saytida joylang yoki 'Custom' DocType ni tanlang.
 DocType: Workflow State,globe,Dunyo
 DocType: System Settings,dd.mm.yyyy,dd.mm.yyyy
-DocType: Assignment Rule,Priority,Birinchi o&#39;ringa
+DocType: Assignment Rule,Priority,Birinchi o'ringa
 DocType: Email Queue,Unsubscribe Param,Paramni bekor qilish
 DocType: DocType,Hide Sidebar and Menu,Yon panel va menyuni yashirish
 DocType: Auto Repeat,Weekly,Haftalik
-apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Dark Color,To&#39;q rang
+apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Dark Color,To'q rang
 DocType: SMS Settings,Eg. smsgateway.com/api/send_sms.cgi,Misol uchun. smsgateway.com/api/send_sms.cgi
 DocType: Communication,In Reply To,Javob berish uchun
-DocType: DocType,Allow Import (via Data Import Tool),Import qilishni ruxsat berish (ma&#39;lumotni import qilish vositasi orqali)
+DocType: DocType,Allow Import (via Data Import Tool),Import qilishni ruxsat berish (ma'lumotni import qilish vositasi orqali)
 apps/frappe/frappe/public/js/frappe/web_form/web_form_list.js,Sr,Sr
 DocType: DocField,Float,Float
 DocType: Print Settings,Page Settings,Sahifa sozlamalari
 apps/frappe/frappe/public/js/frappe/form/quick_entry.js,Saving...,Saqlanmoqda ...
-apps/frappe/frappe/www/update-password.html,Invalid Password,Parol noto&#39;g&#39;ri
+apps/frappe/frappe/www/update-password.html,Invalid Password,Parol noto'g'ri
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record out of {1}.,{1} dan {0} yozuv muvaffaqiyatli olib kirildi.
 DocType: Contact,Purchase Master Manager,Master Manager sotib oling
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Click on the lock icon to toggle public/private,Umumiy yoki shaxsiy holatni almashtirish uchun qulflash belgisini bosing
 DocType: Module Def,Module Name,Moduli nomi
-DocType: S3 Backup Settings,eu-west-3,eu-g&#39;arbiy-3
+DocType: S3 Backup Settings,eu-west-3,eu-g'arbiy-3
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Uploading {0} of {1},{1} dan {0} yuklanmoqda
 DocType: DocType,DocType is a Table / Form in the application.,DocType - ilovadagi jadval / shakl.
 DocType: Social Login Key,Authorize URL,URLni tasdiqlash
-apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Calendar - Google Taqvimdan tadbirni yuklab bo&#39;lmadi, xato kodi {0}."
+apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.py,"Google Calendar - Could not fetch event from Google Calendar, error code {0}.","Google Calendar - Google Taqvimdan tadbirni yuklab bo'lmadi, xato kodi {0}."
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Auto Repeat Document Creation Failed,Avtomatik takrorlash Hujjatni yaratish amalga oshmadi
 DocType: Email Account,GMail,GMail
 DocType: Letter Head,Letter Head Image,Bosh harfning tasviri
@@ -3518,22 +3518,22 @@ apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,Fetch 
 DocType: DocType,Web View,Veb versiyasi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Totals,Jami
 DocType: DocField,Print Width,Chop etish kengligi
-,Setup Wizard,O&#39;rnatish ustasi
+,Setup Wizard,O'rnatish ustasi
 DocType: Address,GST State Number,GST shtati raqami
 DocType: Chat Message,Visitor,Mehmon
 DocType: User,Allow user to login only before this hour (0-24),Foydalanuvchini bu soatdan oldin kirishga ruxsat berish (0-24)
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"Drag and drop files, ","Fayllarni torting va tashlang,"
-DocType: Social Login Key,Access Token URL,To&#39;xan URL manziliga kirish
+DocType: Social Login Key,Access Token URL,To'xan URL manziliga kirish
 apps/frappe/frappe/config/integrations.py,Google Drive Backup.,Google Drive-ning zaxira nusxasi.
 apps/frappe/frappe/desk/doctype/todo/todo.py,{0} assigned {1}: {2},{0} tayinlangan {1}: {2}
 apps/frappe/frappe/www/contact.py,New Message from Website Contact Page,Saytning kontakt sahifasidan yangi xabar
 DocType: Notification,Reference Date,Malumot sanasi
-apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP App yordamida OTP sozlash tugallanmadi. Ma&#39;mur bilan bog&#39;laning.
+apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was not completed. Please contact Administrator.,OTP App yordamida OTP sozlash tugallanmadi. Ma'mur bilan bog'laning.
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,"Iltimos, tegishli mobil noslarni kiriting"
-apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Ba&#39;zi xususiyatlar brauzeringizda ishlamasligi mumkin. Brauzeringizni so&#39;nggi versiyasini yangilang.
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Bilmayman, &quot;yordam&quot; so&#39;rash"
+apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,Ba'zi xususiyatlar brauzeringizda ishlamasligi mumkin. Brauzeringizni so'nggi versiyasini yangilang.
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'","Bilmayman, &quot;yordam&quot; so'rash"
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},ushbu hujjatni bekor qildi {0}
-DocType: DocType,Comments and Communications will be associated with this linked document,Sharh va aloqalar ushbu bog&#39;langan hujjat bilan bog&#39;liq bo&#39;ladi
+DocType: DocType,Comments and Communications will be associated with this linked document,Sharh va aloqalar ushbu bog'langan hujjat bilan bog'liq bo'ladi
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,Filtrni ...
 DocType: Workflow State,bold,qalin
 DocType: Auto Repeat,Status,Holat
@@ -3546,8 +3546,8 @@ DocType: OAuth Client, Advanced Settings,Murakkab sozlamalar
 apps/frappe/frappe/website/doctype/website_settings/website_settings.py,{0} does not exist in row {1},{0} satrida {1} qatorida mavjud emas
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please Update SMS Settings,SMS-sozlamalarni yangilang
 DocType: Event,Event Type,Voqealar turi
-DocType: User,Last Known Versions,Oxirgi ma&#39;lum versiyalar
-apps/frappe/frappe/config/settings.py,Add / Manage Email Accounts.,E-pochta hisoblarini qo&#39;shish / boshqarish.
+DocType: User,Last Known Versions,Oxirgi ma'lum versiyalar
+apps/frappe/frappe/config/settings.py,Add / Manage Email Accounts.,E-pochta hisoblarini qo'shish / boshqarish.
 DocType: Comment,Published,Nashr etildi
 apps/frappe/frappe/templates/emails/auto_reply.html,Thank you for your email,E-pochtangiz uchun rahmat
 DocType: DocField,Small Text,Kichik matn
@@ -3556,18 +3556,18 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Save Report,Hi
 DocType: Webhook,on_cancel,on_cancel
 DocType: Social Login Key,API Endpoint Args,API Endpoint Args
 apps/frappe/frappe/core/doctype/user/user.py,Administrator accessed {0} on {1} via IP Address {2}.,Administrator {1} da {0} IP manzilida {2} orqali ruxsat oldi.
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid fieldname,Ota-ona maydoni to&#39;g&#39;ri maydon nomi bo&#39;lishi kerak
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Obunani o&#39;zgartirish vaqtida muvaffaqiyatsiz tugadi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Parent Field must be a valid fieldname,Ota-ona maydoni to'g'ri maydon nomi bo'lishi kerak
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Failed while amending subscription,Obunani o'zgartirish vaqtida muvaffaqiyatsiz tugadi
 DocType: LDAP Settings,LDAP Group Field,LDAP guruh maydoni
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Equals,Teng
-apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Variantlarning &#39;Dynamic Link&#39; turi maydonda &quot;DocType&quot; variantlari bilan boshqa bog&#39;lanadigan maydonga ishora qilishi kerak
-DocType: About Us Settings,Team Members Heading,Jamoa a&#39;zolari
-apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Noto&#39;g&#39;ri CSV formati
-apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ Tray dasturiga ulanishda xato ... <br><br> Raw Print xususiyatidan foydalanish uchun sizga QZ Tray ilovasi o&#39;rnatilishi va ishlashi kerak. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ Trayni yuklab olish va o&#39;rnatish uchun shu erni bosing</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Xom bosma haqida ko&#39;proq ma&#39;lumot olish uchun bu erni bosing</a> ."
+apps/frappe/frappe/core/doctype/doctype/doctype.py,Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType',Variantlarning 'Dynamic Link' turi maydonda &quot;DocType&quot; variantlari bilan boshqa bog'lanadigan maydonga ishora qilishi kerak
+DocType: About Us Settings,Team Members Heading,Jamoa a'zolari
+apps/frappe/frappe/utils/csvutils.py,Invalid CSV Format,Noto'g'ri CSV formati
+apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","QZ Tray dasturiga ulanishda xato ... <br><br> Raw Print xususiyatidan foydalanish uchun sizga QZ Tray ilovasi o'rnatilishi va ishlashi kerak. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">QZ Trayni yuklab olish va o'rnatish uchun shu erni bosing</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Xom bosma haqida ko'proq ma'lumot olish uchun bu erni bosing</a> ."
 apps/frappe/frappe/desk/page/backups/backups.js,Set Number of Backups,Zaxira soni
-DocType: DocField,Do not allow user to change after set the first time,Birinchi marta o&#39;rnatilgandan keyin foydalanuvchining o&#39;zgarishiga yo&#39;l qo&#39;ymang
+DocType: DocField,Do not allow user to change after set the first time,Birinchi marta o'rnatilgandan keyin foydalanuvchining o'zgarishiga yo'l qo'ymang
 apps/frappe/frappe/utils/data.py,1 year ago,1 yil oldin
-apps/frappe/frappe/config/users_and_permissions.py,"View Log of all print, download and export events","Barcha bosib chiqarish, yuklab olish va eksport qilish tadbirlarining jurnalini ko&#39;rish"
+apps/frappe/frappe/config/users_and_permissions.py,"View Log of all print, download and export events","Barcha bosib chiqarish, yuklab olish va eksport qilish tadbirlarining jurnalini ko'rish"
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,1 month,1 oy
 DocType: Contact,Contact,Aloqa
 DocType: User,Third Party Authentication,Uchinchi shaxsning haqiqiyligini tekshirish
@@ -3580,13 +3580,13 @@ apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Export Report:
 DocType: Data Migration Run,Push Update,Yangilashni bosing
 DocType: Email Account,Port,Port
 DocType: Print Format,Arial,Arial
-apps/frappe/frappe/auth.py,Incomplete login details,To&#39;liq kirish ma&#39;lumotlari
+apps/frappe/frappe/auth.py,Incomplete login details,To'liq kirish ma'lumotlari
 apps/frappe/frappe/config/core.py,Models (building blocks) of the Application,Ilovaning modellari (qurilish bloklari)
-DocType: Website Slideshow,Slideshow like display for the website,Veb-sayt uchun ekranga o&#39;xshash slideshow
-apps/frappe/frappe/config/settings.py,Setup Notifications based on various criteria.,Bildirishnomalarni turli mezonlarga asoslangan o&#39;rnatish.
+DocType: Website Slideshow,Slideshow like display for the website,Veb-sayt uchun ekranga o'xshash slideshow
+apps/frappe/frappe/config/settings.py,Setup Notifications based on various criteria.,Bildirishnomalarni turli mezonlarga asoslangan o'rnatish.
 DocType: Comment,Updated,Yangilandi
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Select Module,Modulni tanlang
-apps/frappe/frappe/public/js/frappe/chat.js,Search or Create a New Chat,Yangi qo&#39;ng&#39;iroqni qidirish yoki yaratish
+apps/frappe/frappe/public/js/frappe/chat.js,Search or Create a New Chat,Yangi qo'ng'iroqni qidirish yoki yaratish
 apps/frappe/frappe/sessions.py,Cache Cleared,Kesh tozalandi
 DocType: Auto Email Report,Dynamic Report Filters,Dinamik hisobot filtrlari
 DocType: Email Account,UIDVALIDITY,UIDVALIDITY
@@ -3595,21 +3595,21 @@ DocType: Custom DocPerm,Export,Eksport
 apps/frappe/frappe/integrations/doctype/google_calendar/google_calendar.js,"To use Google Calendar, enable {0}.",Google Calendar-dan foydalanish uchun {0} -ni yoqing.
 apps/frappe/frappe/public/js/frappe/form/print.js,QZ Tray Failed: ,QZ tarnovi ishlamadi:
 DocType: Dropbox Settings,Dropbox Settings,Dropbox sozlamalari
-DocType: About Us Settings,More content for the bottom of the page.,Sahifaning pastki qismi uchun ko&#39;proq tarkib.
+DocType: About Us Settings,More content for the bottom of the page.,Sahifaning pastki qismi uchun ko'proq tarkib.
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.js,This document has been reverted,Ushbu hujjat qaytarildi
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive Backup Successful.,Google Drive-ning zaxira nusxasi muvaffaqiyatli chiqdi.
-DocType: Workflow,DocType on which this Workflow is applicable.,Ushbu ish oqimining qo&#39;llanilishi mumkin bo&#39;lgan DocType.
+DocType: Workflow,DocType on which this Workflow is applicable.,Ushbu ish oqimining qo'llanilishi mumkin bo'lgan DocType.
 DocType: User,Enabled,Faol
-apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,O&#39;rnatishni tugallamadi
+apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Failed to complete setup,O'rnatishni tugallamadi
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,New {0}: {1},Yangi {0}: {1}
 DocType: Tag Category,Category Name,Turkum nomi
-apps/frappe/frappe/model/db_query.py,Parent is required to get child table data,Ota-onalar bolalar jadvali ma&#39;lumotlarini olishlari kerak
+apps/frappe/frappe/model/db_query.py,Parent is required to get child table data,Ota-onalar bolalar jadvali ma'lumotlarini olishlari kerak
 apps/frappe/frappe/email/doctype/email_group/email_group.js,Import Subscribers,Abonentlarni import qilish
 DocType: Print Settings,PDF Settings,PDF sozlamalari
 DocType: Kanban Board Column,Column Name,Ustun nomi
 DocType: Language,Based On,Shunga asosan
-DocType: Email Account,"For more information, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">click here</a>.","Qo&#39;shimcha ma&#39;lumot olish uchun <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">bu erni bosing</a> ."
-apps/frappe/frappe/core/doctype/data_import/importer_new.py,Number of columns does not match with data,Ustunlar soni ma&#39;lumotlar bilan mos kelmadi
+DocType: Email Account,"For more information, <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">click here</a>.","Qo'shimcha ma'lumot olish uchun <a class=""text-muted"" href=""https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document"">bu erni bosing</a> ."
+apps/frappe/frappe/core/doctype/data_import/importer_new.py,Number of columns does not match with data,Ustunlar soni ma'lumotlar bilan mos kelmadi
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Make Default,Varsaylik qilish
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Execution Time: {0} sec,Bajarilish vaqti: {0} sek
 apps/frappe/frappe/model/utils/__init__.py,Invalid include path,Yo‘l noto‘g‘ri ko‘rsatilgan
@@ -3620,19 +3620,19 @@ DocType: Async Task,Result,Natija
 DocType: Webhook,on_update_after_submit,on_update_after_submit
 DocType: System Settings,Allow Login using User Name,Foydalanuvchi nomidan foydalanib kirishga ruxsat berish
 apps/frappe/frappe/core/doctype/report/report.js,Enable Report,Hisobotni yoqish
-DocType: DocField,Display Depends On,Displey-ga bog&#39;liq
+DocType: DocField,Display Depends On,Displey-ga bog'liq
 DocType: Social Login Key,API Endpoint,API Endpoint
 DocType: Web Page,Insert Code,Kodni kiriting
 DocType: Data Migration Run,Current Mapping Type,Joriy xaritalash turi
 DocType: ToDo,Low,Kam
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,Jinja templating yordamida hujjatning dinamik xususiyatlarini qo&#39;shishingiz mumkin.
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,List a document type,Hujjat turini ro&#39;yxatlash
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,You can add dynamic properties from the document by using Jinja templating.,Jinja templating yordamida hujjatning dinamik xususiyatlarini qo'shishingiz mumkin.
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,List a document type,Hujjat turini ro'yxatlash
 DocType: Web Page,"Header, Breadcrumbs and Meta Tags","Sarlavha, breadcrumbs va meta-teglar"
-apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"browse,","ko&#39;rib chiqmoq,"
+apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,"browse,","ko'rib chiqmoq,"
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,3 months,3 oy
 apps/frappe/frappe/public/js/frappe/views/components/DeskSection.vue,Shortcuts,Yorliqlar
-apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, leave the ""name"" (ID) column blank.","Agar siz yangi yozuvlarni yuklamoqchi bo&#39;lsangiz, &quot;nom&quot; (ID) ustunini bo&#39;sh qoldiring."
-DocType: Data Migration Run,Current Mapping Delete Start,Joriy xaritalash O&#39;chirishni boshlash
+apps/frappe/frappe/core/doctype/data_export/exporter.py,"If you are uploading new records, leave the ""name"" (ID) column blank.","Agar siz yangi yozuvlarni yuklamoqchi bo'lsangiz, &quot;nom&quot; (ID) ustunini bo'sh qoldiring."
+DocType: Data Migration Run,Current Mapping Delete Start,Joriy xaritalash O'chirishni boshlash
 apps/frappe/frappe/config/core.py,Errors in Background Events,Orqa narsalardagi xatolar
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,No of Columns,Ustunlarning soni
 DocType: Workflow State,Calendar,Kalendar
@@ -3641,29 +3641,29 @@ apps/frappe/frappe/config/website.py,A user who posts blogs.,Bloglarni joylashti
 apps/frappe/frappe/model/rename_doc.py,"Another {0} with name {1} exists, select another name","{1} ismli boshqa {0} mavjud, boshqa nomni tanlang"
 DocType: DocType,Custom?,Maxsusmi?
 DocType: Website Settings,Website Theme Image,Veb-sayt mavzusi tasvirlari
-DocType: Workflow State,road,yo&#39;l
+DocType: Workflow State,road,yo'l
 DocType: User,Timezone,Vaqt zonasi
-apps/frappe/frappe/public/js/frappe/model/model.js,Unable to load: {0},Yuklab bo&#39;lmadi: {0}
+apps/frappe/frappe/public/js/frappe/model/model.js,Unable to load: {0},Yuklab bo'lmadi: {0}
 apps/frappe/frappe/config/integrations.py,Backup,Zaxiralash
 apps/frappe/frappe/desk/doctype/dashboard_chart/dashboard_chart.py,Document type is required to create a dashboard chart,Boshqaruv jadvali yaratish uchun hujjat turi talab qilinadi
-DocType: DocField,Read Only,Faqat o&#39;qish
+DocType: DocField,Read Only,Faqat o'qish
 apps/frappe/frappe/email/doctype/email_group/email_group.js,New Newsletter,Yangi xabarnoma
 DocType: Energy Point Log,Energy Point Log,Energiya nuqtasi jurnali
 DocType: Print Settings,Send Print as PDF,PDF sifatida chop etish
 DocType: Web Form,Amount,Miqdori
 DocType: Workflow Transition,Allowed,Ruxsat berilgan
 DocType: Dashboard Chart,Chart Source,Jadval manbai
-apps/frappe/frappe/core/doctype/doctype/doctype.py,There can be only one Fold in a form,Shakli shaklda bitta katlama bo&#39;lishi mumkin
-apps/frappe/frappe/core/doctype/file/file.py,Unable to write file format for {0},{0} uchun fayl formatini yozib bo&#39;lmadi
+apps/frappe/frappe/core/doctype/doctype/doctype.py,There can be only one Fold in a form,Shakli shaklda bitta katlama bo'lishi mumkin
+apps/frappe/frappe/core/doctype/file/file.py,Unable to write file format for {0},{0} uchun fayl formatini yozib bo'lmadi
 apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py,No records present in {0},{0} da yozuvlar mavjud emas
 apps/frappe/frappe/website/doctype/portal_settings/portal_settings.js,Restore to default settings?,Standart sozlamalarga qayta tiklansinmi?
-apps/frappe/frappe/website/doctype/website_settings/website_settings.py,Invalid Home Page,Bosh sahifa noto&#39;g&#39;ri
-apps/frappe/frappe/templates/includes/login/login.js,Invalid Login. Try again.,Kirish noto&#39;g&#39;ri. Qayta urinib ko&#39;ring.
-DocType: Auto Email Report,Send only if there is any data,"Faqatgina ma&#39;lumotlar mavjud bo&#39;lsa, jo&#39;natish"
+apps/frappe/frappe/website/doctype/website_settings/website_settings.py,Invalid Home Page,Bosh sahifa noto'g'ri
+apps/frappe/frappe/templates/includes/login/login.js,Invalid Login. Try again.,Kirish noto'g'ri. Qayta urinib ko'ring.
+DocType: Auto Email Report,Send only if there is any data,"Faqatgina ma'lumotlar mavjud bo'lsa, jo'natish"
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Totals Row,Totals Row
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Permission at level 0 must be set before higher levels are set,{0}: Yuqori sathi o&#39;rnatilishdan oldin 0 darajasida ruxsat berish kerak
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Permission at level 0 must be set before higher levels are set,{0}: Yuqori sathi o'rnatilishdan oldin 0 darajasida ruxsat berish kerak
 DocType: Contact,Sync with Google Contacts,Google Kontaktlar bilan sinxronlash
-DocType: Tag Link,Document Tag,Hujjat yorlig&#39;i
+DocType: Tag Link,Document Tag,Hujjat yorlig'i
 apps/frappe/frappe/desk/doctype/todo/todo.py,Assignment closed by {0},Tayin {0} tomonidan yopildi
 DocType: Integration Request,Remote,Masofaviy
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Calculate,Hisoblang
@@ -3680,47 +3680,47 @@ DocType: Integration Request,Integration Type,Integratsiya turi
 DocType: Newsletter,Send Attachements,Attektsiyani yuborish
 apps/frappe/frappe/config/integrations.py,Google Contacts Integration.,Google Contacts Integration.
 DocType: Transaction Log,Transaction Log,Jurnal jurnali
-apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last month's performance (from {0} to {1}),O&#39;tgan oyning ishlashiga asoslangan statistika ({0} dan {1} gacha)
+apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last month's performance (from {0} to {1}),O'tgan oyning ishlashiga asoslangan statistika ({0} dan {1} gacha)
 DocType: Contact Us Settings,City,Shahar
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Enable Allow Auto Repeat for the doctype {0} in Customize Form,Customize Form-dagi {0} dokip turi uchun avtomatik takrorlashga ruxsat berish
 DocType: DocField,Perm Level,Perm bosqichi
-apps/frappe/frappe/www/confirm_workflow_action.html,View document,Hujjatni ko&#39;rish
+apps/frappe/frappe/www/confirm_workflow_action.html,View document,Hujjatni ko'rish
 apps/frappe/frappe/desk/doctype/event/event.py,Events In Today's Calendar,Tadbirlar bugungi taqvimida
 DocType: Web Page,Web Page,Veb-sahifa
 DocType: Workflow Document State,Next Action Email Template,Keyingi tadbir E-mail shabloni
 DocType: Blog Category,Blogger,Blogger
-DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Agar yoqilgan bo&#39;lsa, hujjatdagi o&#39;zgarishlar kuzatiladi va vaqt jadvalida ko&#39;rsatiladi"
+DocType: DocType,"If enabled, changes to the document are tracked and shown in timeline","Agar yoqilgan bo'lsa, hujjatdagi o'zgarishlar kuzatiladi va vaqt jadvalida ko'rsatiladi"
 apps/frappe/frappe/core/doctype/doctype/doctype.py,'In Global Search' not allowed for type {0} in row {1},{1} qatorida {0} uchun &quot;Global Search&quot; da ruxsat berilmagan
 DocType: Energy Point Log,Appreciation,Minnatdorchilik
-apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Ro&#39;yxatni ko&#39;rish
+apps/frappe/frappe/public/js/frappe/views/treeview.js,View List,Ro'yxatni ko'rish
 DocType: Workflow,Don't Override Status,Holatni bekor qilmang
-apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Search term,Qidiruv so&#39;zi
+apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Search term,Qidiruv so'zi
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,The First User: You,Birinchi foydalanuvchi: Siz
-apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Newsletter should have atleast one recipient,Axborot byulletenida bitta qabul qiluvchidan kamida bittasi bo&#39;lishi kerak
+apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Newsletter should have atleast one recipient,Axborot byulletenida bitta qabul qiluvchidan kamida bittasi bo'lishi kerak
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Upload {0} files,{0} fayllarni yuklang
 DocType: Deleted Document,GCalendar Sync ID,GCalendar sinxronlash identifikatori
 DocType: Prepared Report,Report Start Time,Hisobotni boshlash vaqti
-apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Data,Ma&#39;lumotlarni eksport qilish
+apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,Export Data,Ma'lumotlarni eksport qilish
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Select Columns,Ustunlar-ni tanlang
 DocType: Translation,Source Text,Manba matni
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,This is a background report. Please set the appropriate filters and then generate a new one.,"Bu orqa hisobot. Iltimos, mos filtrlarni o&#39;rnating va keyin yangisini yarating."
-apps/frappe/frappe/www/login.py,Missing parameters for login,Kirish uchun parametrlar yo&#39;q
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,This is a background report. Please set the appropriate filters and then generate a new one.,"Bu orqa hisobot. Iltimos, mos filtrlarni o'rnating va keyin yangisini yarating."
+apps/frappe/frappe/www/login.py,Missing parameters for login,Kirish uchun parametrlar yo'q
 DocType: Workflow State,folder-open,papkani ochish
-DocType: DocType,"Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended.","Taqdim etilgandan so&#39;ng, topshiriladigan hujjatlar o&#39;zgartirilmaydi. Ular faqat bekor qilinishi va o&#39;zgartirilishi mumkin."
+DocType: DocType,"Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended.","Taqdim etilgandan so'ng, topshiriladigan hujjatlar o'zgartirilmaydi. Ular faqat bekor qilinishi va o'zgartirilishi mumkin."
 DocType: OAuth Authorization Code,Validity,Haqiqat
 apps/frappe/frappe/config/website.py,Single Post (article).,Yagona xabar (maqola).
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Reports,Hisobotlar
-DocType: Page,No,Yo&#39;q
+DocType: Page,No,Yo'q
 DocType: Property Setter,Set Value,Qiymatni belgilash
 DocType: Webhook,Webhook Data,Webhook Data
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Creating {0},{0} yaratish
-DocType: Report,Disable Prepared Report,Tayyorlangan hisobotni o&#39;chirish
-apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,{0} foydalanuvchisi ma&#39;lumotlarni o&#39;chirishni so&#39;radi
-apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,"Noqonuniy kirish uchun tok. Iltimos, yana bir bor urinib ko&#39;ring"
+DocType: Report,Disable Prepared Report,Tayyorlangan hisobotni o'chirish
+apps/frappe/frappe/templates/emails/data_deletion_approval.html,User {0} has requested for data deletion,{0} foydalanuvchisi ma'lumotlarni o'chirishni so'radi
+apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Illegal Access Token. Please try again,"Noqonuniy kirish uchun tok. Iltimos, yana bir bor urinib ko'ring"
 apps/frappe/frappe/public/js/frappe/desk.js,"The application has been updated to a new version, please refresh this page","Dastur yangi versiyaga yangilandi, iltimos ushbu sahifani yangilang"
-DocType: Notification,Optional: The alert will be sent if this expression is true,Majburiy emas: Agar bu ifoda to&#39;g&#39;ri bo&#39;lsa ogohlantirish yuboriladi
+DocType: Notification,Optional: The alert will be sent if this expression is true,Majburiy emas: Agar bu ifoda to'g'ri bo'lsa ogohlantirish yuboriladi
 DocType: Data Migration Plan,Plan Name,Muzika nomi
-DocType: Print Settings,Print with letterhead,Antetli qog&#39;oz bilan chop etish
+DocType: Print Settings,Print with letterhead,Antetli qog'oz bilan chop etish
 apps/frappe/frappe/public/js/frappe/file_uploader/WebLink.vue,Attach a web link,Veb havolasini biriktiring
 DocType: Unhandled Email,Raw Email,Raw Email
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select records for assignment,Belgilash uchun yozuvlarni tanlang
@@ -3730,38 +3730,38 @@ apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,You
 DocType: Dashboard Chart Source,Timeseries,Tayyor gazetalar
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Select Your Region,Hududingizni tanlang
 apps/frappe/frappe/public/js/frappe/form/sidebar/review.js,{0} appreciation point for {1} {2},{0} {1} {2} ning bahosi
-DocType: S3 Backup Settings,cn-northwest-1,cn-shimoli-g&#39;arbiy-1
+DocType: S3 Backup Settings,cn-northwest-1,cn-shimoli-g'arbiy-1
 DocType: Dropbox Settings,Limit Number of DB Backups,Jadvaldagi zaxiralarni cheklash soni
 DocType: Custom DocPerm,Level,Darajali
-apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Last 30 days,So&#39;nggi 30 kun
+apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Last 30 days,So'nggi 30 kun
 DocType: Custom DocPerm,Report,Hisobot
-apps/frappe/frappe/website/doctype/web_form/web_form.py,Amount must be greater than 0.,Miqdori 0 dan katta bo&#39;lishi kerak.
+apps/frappe/frappe/website/doctype/web_form/web_form.py,Amount must be greater than 0.,Miqdori 0 dan katta bo'lishi kerak.
 apps/frappe/frappe/public/js/frappe/form/print.js,Connected to QZ Tray!,QZ trayiga ulandi!
 apps/frappe/frappe/desk/reportview.py,{0} is saved,{0} saqlanadi
-apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be renamed,{0} foydalanuvchi nomini o&#39;zgartirib bo&#39;lmaydi
+apps/frappe/frappe/core/doctype/user/user.py,User {0} cannot be renamed,{0} foydalanuvchi nomini o'zgartirib bo'lmaydi
 apps/frappe/frappe/database/schema.py,Fieldname is limited to 64 characters ({0}),Joy nomlari 64 ta belgidan iborat ({0})
 apps/frappe/frappe/public/js/frappe/form/grid_row.js,Cannot move row,Qatorni siljitib bo‘lmadi
-apps/frappe/frappe/config/desk.py,Email Group List,Email guruhlari ro&#39;yxati
-DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],.ico kengaytmasi bilan belgi fayli. 16 x 16 piksel bo&#39;lishi kerak. Favikon generatoridan foydalanib ishlab chiqarilgan. [favicon-generator.org]
+apps/frappe/frappe/config/desk.py,Email Group List,Email guruhlari ro'yxati
+DocType: Website Settings,An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org],.ico kengaytmasi bilan belgi fayli. 16 x 16 piksel bo'lishi kerak. Favikon generatoridan foydalanib ishlab chiqarilgan. [favicon-generator.org]
 DocType: Auto Email Report,Format,Formatlash
 DocType: Email Account,Email Addresses,E-pochta manzillari
-DocType: Web Form,Allow saving if mandatory fields are not filled,Majburiy maydonlarni to&#39;ldirmasdan saqlashga ruxsat bering
-DocType: S3 Backup Settings,us-west-2,us-g&#39;arb-2
+DocType: Web Form,Allow saving if mandatory fields are not filled,Majburiy maydonlarni to'ldirmasdan saqlashga ruxsat bering
+DocType: S3 Backup Settings,us-west-2,us-g'arb-2
 apps/frappe/frappe/custom/doctype/custom_script/custom_script.js,Select Child Table,Bolalar jadvalini tanlang
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Trigger Primary Action,Trigger asosiy harakati
-apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Change,O&#39;zgartirish
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Change,O'zgartirish
 DocType: Email Domain,domain name,domen nomi
 DocType: Contact Email,Contact Email,E-pochtaga murojaat qiling
 DocType: Kanban Board Column,Order,Buyurtma
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,No results found for {0} in Global Search,Global Qidiruvda {0} uchun hech qanday natija topilmadi
 DocType: Report,Ref DocType,Qayta DocType
 apps/frappe/frappe/integrations/doctype/social_login_key/social_login_key.py,Please enter Client ID before social login is enabled,Ijtimoiy kirishni yoqishdan oldin mijoz identifikatorini kiriting
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Amend without Cancel,{0}: Bekor qilmasdan o&#39;zgartirish mumkin emas
-apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Full Page,To&#39;liq sahifa
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set Amend without Cancel,{0}: Bekor qilmasdan o'zgartirish mumkin emas
+apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Full Page,To'liq sahifa
 DocType: DocType,Is Child Table,Bolalar jadvali
 DocType: Data Import Beta,Template Options,Andoza parametrlari
-apps/frappe/frappe/utils/csvutils.py,{0} must be one of {1},{0} {1} dan biri bo&#39;lishi kerak
-apps/frappe/frappe/public/js/frappe/form/sidebar/form_viewers.js,{0} is currently viewing this document,{0} hozirda ushbu hujjatni ko&#39;rib turibdi
+apps/frappe/frappe/utils/csvutils.py,{0} must be one of {1},{0} {1} dan biri bo'lishi kerak
+apps/frappe/frappe/public/js/frappe/form/sidebar/form_viewers.js,{0} is currently viewing this document,{0} hozirda ushbu hujjatni ko'rib turibdi
 apps/frappe/frappe/config/core.py,Background Email Queue,Background Email Queue
 apps/frappe/frappe/core/doctype/user/user.py,Password Reset,Parolni tiklash
 DocType: Communication,Opened,Ochilgan
@@ -3770,23 +3770,23 @@ DocType: Communication,Sending,Yuborilmoqda
 DocType: Website Slideshow,This goes above the slideshow.,Bu slaydshouning ustida.
 DocType: Contact,Last Name,Familiya
 DocType: Event,Private,Xususiy
-apps/frappe/frappe/email/doctype/notification/notification.js,No alerts for today,Bugungi kunda hech qanday ogohlantirish yo&#39;q
-DocType: Print Settings,Send Email Print Attachments as PDF (Recommended),E-pochta orqali yuboring Qo&#39;shimcha fayllarni PDF sifatida chop etish (tavsiya etiladi)
+apps/frappe/frappe/email/doctype/notification/notification.js,No alerts for today,Bugungi kunda hech qanday ogohlantirish yo'q
+DocType: Print Settings,Send Email Print Attachments as PDF (Recommended),E-pochta orqali yuboring Qo'shimcha fayllarni PDF sifatida chop etish (tavsiya etiladi)
 DocType: Web Page,Left,Chapdan
 DocType: Event,All Day,Butun kun
-apps/frappe/frappe/integrations/utils.py,Looks like something is wrong with this site's payment gateway configuration. No payment has been made.,Bu saytning to&#39;lov shluzi sozlamalari bilan bog&#39;liq biror narsa noto&#39;g&#39;ri. Hech qanday to&#39;lov amalga oshirilmadi.
+apps/frappe/frappe/integrations/utils.py,Looks like something is wrong with this site's payment gateway configuration. No payment has been made.,Bu saytning to'lov shluzi sozlamalari bilan bog'liq biror narsa noto'g'ri. Hech qanday to'lov amalga oshirilmadi.
 DocType: GCalendar Settings,State,Davlat
 DocType: Workflow Action,Workflow Action,Ish xarishi
 apps/frappe/frappe/utils/bot.py,I found these: ,Buni topdim:
 DocType: Event,Send an email reminder in the morning,Ertalab e-pochta xabari yuboring
 DocType: Blog Post,Published On,Chop etildi
 DocType: Contact,Gender,Jins
-apps/frappe/frappe/website/doctype/web_form/web_form.py,Mandatory Information missing:,Majburiy ma&#39;lumot yo&#39;q:
+apps/frappe/frappe/website/doctype/web_form/web_form.py,Mandatory Information missing:,Majburiy ma'lumot yo'q:
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,{0} reverted your points on {1},{0} sizning ballaringizni {1} ga qaytardi
-apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Check Request URL,URL so&#39;rovini tekshiring
-apps/frappe/frappe/client.py,Only 200 inserts allowed in one request,Bitta so&#39;rovga faqat 200 ta qo&#39;shimchalar ruxsat berilgan
+apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Check Request URL,URL so'rovini tekshiring
+apps/frappe/frappe/client.py,Only 200 inserts allowed in one request,Bitta so'rovga faqat 200 ta qo'shimchalar ruxsat berilgan
 DocType: Footer Item,URL,URL
-apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,Tasdiqlash ekraniga qayting va autentifikatsiya ilova tomonidan ko&#39;rsatilgan kodni kiriting
+apps/frappe/frappe/www/qrcode.html,Return to the Verification screen and enter the code displayed by your authentication app,Tasdiqlash ekraniga qayting va autentifikatsiya ilova tomonidan ko'rsatilgan kodni kiriting
 DocType: ToDo,Reference Type,Malumot turi
 apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migration_connector.py,Please enable developer mode to create new connection,"Iltimos, yangi aloqa yaratish uchun ishlab chiquvchi rejimini yoqing"
 DocType: Event,Repeat On,Qayta ishlating
@@ -3795,97 +3795,97 @@ DocType: Auto Email Report,Half Yearly,Yarim yillik
 DocType: Communication,Marked As Spam,Spam sifatida belgilandi
 apps/frappe/frappe/utils/file_manager.py,There is some problem with the file url: {0},Fayl urlida muammo mavjud: {0}
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Tree,Daraxt
-apps/frappe/frappe/public/js/frappe/views/treeview.js,You are not allowed to print this report,Ushbu hisobotni chop etishga ruxsat yo&#39;q
+apps/frappe/frappe/public/js/frappe/views/treeview.js,You are not allowed to print this report,Ushbu hisobotni chop etishga ruxsat yo'q
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,User Permissions,Foydalanuvchi ruxsati
 DocType: Workflow State,warning-sign,ogohlantirish belgisi
 DocType: Prepared Report,Prepared Report,Tayyorlangan hisobot
-apps/frappe/frappe/config/website.py,Add meta tags to your web pages,Veb-sahifalaringizga meta-teglar qo&#39;shing
+apps/frappe/frappe/config/website.py,Add meta tags to your web pages,Veb-sahifalaringizga meta-teglar qo'shing
 DocType: Workflow State,User,Foydalanuvchi
 DocType: Website Settings,"Show title in browser window as ""Prefix - title""",Brauzer oynasida &quot;Prefiks - sarlavha&quot;
 DocType: Payment Gateway,Gateway Settings,Gateway sozlamalari
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,text in document type,hujjat turidagi matn
 apps/frappe/frappe/core/doctype/test_runner/test_runner.js,Run Tests,Sinovlarni ishga tushirish
 apps/frappe/frappe/handler.py,Logged Out,Chiqdi
-apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,More...,Ko&#39;proq...
+apps/frappe/frappe/public/js/frappe/ui/toolbar/search.js,More...,Ko'proq...
 DocType: System Settings,User can login using Email id or Mobile number,"E-mail identifikatoridan yoki mobil raqamidan foydalanib, foydalanuvchi login qilishi mumkin"
 DocType: Bulk Update,Update Value,Yangilash qiymati
 apps/frappe/frappe/core/doctype/communication/communication.js,Mark as {0},{0} sifatida belgilash
 apps/frappe/frappe/model/rename_doc.py,Please select a new name to rename,"Iltimos, qayta nomlash uchun yangi nomni tanlang"
-apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Invalid column,Ustun noto&#39;g&#39;ri
-DocType: Data Migration Connector,Data Migration,Ma&#39;lumotlarni ko&#39;chirish
-DocType: User,API Key cannot be  regenerated,API kaliti yangilanib bo&#39;lmadi
-apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Something went wrong,Nimadir noto&#39;g&#39;ri bajarildi
+apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Invalid column,Ustun noto'g'ri
+DocType: Data Migration Connector,Data Migration,Ma'lumotlarni ko'chirish
+DocType: User,API Key cannot be  regenerated,API kaliti yangilanib bo'lmadi
+apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Something went wrong,Nimadir noto'g'ri bajarildi
 DocType: System Settings,Number Format,Raqamli format
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully imported {0} record.,{0} yozuvi muvaffaqiyatli import qilindi.
 apps/frappe/frappe/public/js/frappe/views/interaction.js,Summary,Xulosa
 DocType: Event,Event Participants,Tadbir ishtirokchilari
 DocType: Auto Repeat,Frequency,Chastotani
-DocType: Custom Field,Insert After,Keyin qo&#39;shing
+DocType: Custom Field,Insert After,Keyin qo'shing
 DocType: Event,Sync with Google Calendar,Google Taqvim bilan sinxronlashtiring
 DocType: Access Log,Report Name,Hisobot nomi
 DocType: Desktop Icon,Reverse Icon Color,Orqa rangli teskari rang
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Save,Saqlash
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat_schedule.html,Next Scheduled Date,Keyingi rejalashtirilgan sana
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.js,Assign to the one who has the least assignments,Eng kam topshiriq olgan odamga tayinlang
-apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Section Heading,Bo&#39;lim sarlavhasi
+apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Section Heading,Bo'lim sarlavhasi
 DocType: Website Settings,Title Prefix,Sarlavha prefiksi
 DocType: Email Account,Notifications and bulk mails will be sent from this outgoing server.,Ushbu chiquvchi serverdan xabarlar va ommaviy xabarlar yuboriladi.
-DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,Har qanday satrga asoslangan printer tillaridan foydalanish mumkin. Xom buyruqlarni yozish uchun printer ishlab chiqaruvchisi tomonidan taqdim etilgan ona tilini bilish talab etiladi. O&#39;zingizning buyruqlaringizni qanday yozishni printerning ishlab chiqaruvchisi tomonidan taqdim etilgan dasturchi qo&#39;llanmasiga murojaat qiling. Ushbu buyruqlar Jinja Templating Tilidan foydalanib server tomonida ko&#39;rsatiladi.
+DocType: Print Format,Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.,Har qanday satrga asoslangan printer tillaridan foydalanish mumkin. Xom buyruqlarni yozish uchun printer ishlab chiqaruvchisi tomonidan taqdim etilgan ona tilini bilish talab etiladi. O'zingizning buyruqlaringizni qanday yozishni printerning ishlab chiqaruvchisi tomonidan taqdim etilgan dasturchi qo'llanmasiga murojaat qiling. Ushbu buyruqlar Jinja Templating Tilidan foydalanib server tomonida ko'rsatiladi.
 DocType: Workflow State,cog,yigit
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Sync on Migrate,Ko&#39;chib o&#39;tish bo&#39;yicha sinxronlash
-apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently Viewing,Hozir ko&#39;rish
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Sync on Migrate,Ko'chib o'tish bo'yicha sinxronlash
+apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently Viewing,Hozir ko'rish
 DocType: DocField,Default,Standart
 DocType: Translation,Verified,Tasdiqlangan
-apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} qo&#39;shildi
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&quot;{0}&quot; so&#39;zini qidirish
+apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0} qo'shildi
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',&quot;{0}&quot; so'zini qidirish
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,"Iltimos, avval hisobotni saqlang"
-apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ta obunachi qo&#39;shildi
+apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0} ta obunachi qo'shildi
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,In emas
 DocType: Workflow State,star,yulduz
 apps/frappe/frappe/public/js/frappe/ui/toolbar/search_utils.js,Hub,Hub
 apps/frappe/frappe/public/js/frappe/ui/filters/filters.js,values separated by commas,qiymatlari vergul bilan ajralib turadi
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Max width for type Currency is 100px in row {0},Valyuta uchun maksimal kenglik Valyuta ({0} qatorida 100px)
 apps/frappe/frappe/config/website.py,Content web page.,Kontent veb-sahifasi.
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Add a New Role,Yangi rolni qo&#39;shing
-DocType: Google Contacts,Last Sync On,So&#39;nggi sinxronlash yoqilgan
-DocType: Deleted Document,Deleted Document,O&#39;chirilgan hujjat
-apps/frappe/frappe/templates/includes/login/login.js,Oops! Something went wrong,Xato! Nimadir noto&#39;g&#39;ri bajarildi
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Add a New Role,Yangi rolni qo'shing
+DocType: Google Contacts,Last Sync On,So'nggi sinxronlash yoqilgan
+DocType: Deleted Document,Deleted Document,O'chirilgan hujjat
+apps/frappe/frappe/templates/includes/login/login.js,Oops! Something went wrong,Xato! Nimadir noto'g'ri bajarildi
 DocType: Desktop Icon,Category,Turkum
 apps/frappe/frappe/core/doctype/data_import/importer_new.py,Value {0} missing for {1},{1} uchun {0} qiymati yo‘q
-apps/frappe/frappe/desk/doctype/event/event.js,Add Contacts,Kontaktlarni qo&#39;shish
+apps/frappe/frappe/desk/doctype/event/event.js,Add Contacts,Kontaktlarni qo'shish
 apps/frappe/frappe/public/js/frappe/form/print.js,Landscape,Landshaft
-apps/frappe/frappe/config/core.py,Client side script extensions in Javascript,Javascriptdagi mijozlar buyrug&#39;i kengaytmalari
+apps/frappe/frappe/config/core.py,Client side script extensions in Javascript,Javascriptdagi mijozlar buyrug'i kengaytmalari
 DocType: Webhook,on_trash,on_trash
 apps/frappe/frappe/core/doctype/user_permission/user_permission_help.html,Records for following doctypes will be filtered,Quyidagi doctype uchun yozuvlar filtri qilinadi
 apps/frappe/frappe/public/js/frappe/desk.js,Scheduler Inactive,Rejalashtiruvchi faol emas
 DocType: Blog Settings,Blog Introduction,Mazkur foydalanuvchiga yozish Kirish
 DocType: Global Search Settings,Search Priorities,Ustuvorliklarni qidirish
 DocType: Address,Office,Ofis
-apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,This Kanban Board will be private,Ushbu Kanban kengashi maxsus bo&#39;ladi
+apps/frappe/frappe/public/js/frappe/views/kanban/kanban_view.js,This Kanban Board will be private,Ushbu Kanban kengashi maxsus bo'ladi
 apps/frappe/frappe/desk/moduleview.py,Standard Reports,Standart hisobotlar
 DocType: Dashboard Chart Link,Dashboard Chart Link,Boshqaruv panelidagi jadval havolasi
 DocType: User,Email Settings,Email sozlamalari
 apps/frappe/frappe/public/js/frappe/ui/dropzone.js,Drop Here,Bu erga tashlang
-DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Agar bu parametr yoniq bo&#39;lsa, foydalanuvchi Ikki faktorli tasdiqdan foydalangan holda har qanday IP manzilidan tizimga kirishi mumkin, buni tizim sozlamalarida barcha foydalanuvchilar uchun o&#39;rnatish mumkin"
+DocType: User,"If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings","Agar bu parametr yoniq bo'lsa, foydalanuvchi Ikki faktorli tasdiqdan foydalangan holda har qanday IP manzilidan tizimga kirishi mumkin, buni tizim sozlamalarida barcha foydalanuvchilar uchun o'rnatish mumkin"
 apps/frappe/frappe/public/js/frappe/form/templates/print_layout.html,Printer Settings...,Printer sozlamalari ...
 apps/frappe/frappe/public/js/frappe/desk.js,Please Enter Your Password to Continue,Davom etish uchun parolingizni kiriting
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Me,Men
 apps/frappe/frappe/workflow/doctype/workflow/workflow.py,{0} not a valid State,{0} haqiqiy davlat emas
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Apply to all Documents Types,Barcha hujjatlar turlariga murojaat qiling
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Energy point update,Energiya nuqtasini yangilash
-apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Boshqa to&#39;lov usulini tanlang. PayPal &quot;{0}&quot; valyutasidagi operatsiyalarni qo&#39;llab-quvvatlamaydi
+apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,Please select another payment method. PayPal does not support transactions in currency '{0}',Boshqa to'lov usulini tanlang. PayPal &quot;{0}&quot; valyutasidagi operatsiyalarni qo'llab-quvvatlamaydi
 DocType: Chat Message,Room Type,Xona turi
-DocType: Data Import Beta,Import Log Preview,Jurnalni oldindan ko&#39;rishni import qilish
+DocType: Data Import Beta,Import Log Preview,Jurnalni oldindan ko'rishni import qilish
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Search field {0} is not valid,{0} qidiruv maydoni haqiqiy emas
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,uploaded file,yuklangan fayl
 DocType: Workflow State,ok-circle,ok-doira
 DocType: LDAP Settings,LDAP User Creation and Mapping,LDAP foydalanuvchisini yaratish va xaritalash
 apps/frappe/frappe/utils/bot.py,You can find things by asking 'find orange in customers',&quot;Xaridorlarda apelsinni topish&quot;
-apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Kechirasiz! Foydalanuvchiga o&#39;z yozuvlariga to&#39;liq kirish kerak.
-,Usage Info,Foydalanish haqida ma&#39;lumot
-apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Klaviatura yorliqlarini ko&#39;rsatish
-apps/frappe/frappe/utils/oauth.py,Invalid Token,To&#39;g&#39;ri token
-apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not upload backup - Error {0},Google Drive - Zaxira nusxasini yuklab bo&#39;lmadi - Xato {0}
+apps/frappe/frappe/core/doctype/user/user.py,Sorry! User should have complete access to their own record.,Kechirasiz! Foydalanuvchiga o'z yozuvlariga to'liq kirish kerak.
+,Usage Info,Foydalanish haqida ma'lumot
+apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Show Keyboard Shortcuts,Klaviatura yorliqlarini ko'rsatish
+apps/frappe/frappe/utils/oauth.py,Invalid Token,To'g'ri token
+apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Drive - Could not upload backup - Error {0},Google Drive - Zaxira nusxasini yuklab bo'lmadi - Xato {0}
 DocType: Email Account,Email Server,E-pochta serveri
 DocType: Assignment Rule,Document Type,Hujjat turi
 DocType: Address,Tax Category,Soliq toifasi
@@ -3906,32 +3906,32 @@ apps/frappe/frappe/public/js/frappe/views/interaction.js,New Activity,Yangi faol
 apps/frappe/frappe/handler.py,You have been successfully logged out,Siz muvaffaqiyatli chiqdi
 DocType: Calendar View,Calendar View,Taqvim versiyasi
 apps/frappe/frappe/printing/doctype/print_format/print_format.js,Edit Format,Formatni tahrirlash
-apps/frappe/frappe/templates/emails/new_user.html,Complete Registration,To&#39;liq ro&#39;yxatga olish
+apps/frappe/frappe/templates/emails/new_user.html,Complete Registration,To'liq ro'yxatga olish
 DocType: GCalendar Settings,Enable,Yoqish
 DocType: Google Maps Settings,Home Address,Uy manzili
-apps/frappe/frappe/core/doctype/data_export/exporter.py,You can only upload upto 5000 records in one go. (may be less in some cases),Siz faqatgina bitta 5000 ta yozuvni yuklashingiz mumkin. (ayrim hollarda kamroq bo&#39;lishi mumkin)
-apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Applicable Document Types,Qo&#39;llaniladigan hujjatlar turlari
+apps/frappe/frappe/core/doctype/data_export/exporter.py,You can only upload upto 5000 records in one go. (may be less in some cases),Siz faqatgina bitta 5000 ta yozuvni yuklashingiz mumkin. (ayrim hollarda kamroq bo'lishi mumkin)
+apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Applicable Document Types,Qo'llaniladigan hujjatlar turlari
 apps/frappe/frappe/config/settings.py,Set up rules for user assignments.,Foydalanuvchi topshiriqlari uchun qoidalarni sozlang.
-apps/frappe/frappe/model/document.py,Insufficient Permission for {0},{0} uchun yetarli ruxsat yo&#39;q
+apps/frappe/frappe/model/document.py,Insufficient Permission for {0},{0} uchun yetarli ruxsat yo'q
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Report was not saved (there were errors),Hisobot saqlanmadi (xatolar bor edi)
-apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,Sarlavha mazmunini o&#39;zgartirib bo&#39;lmaydi
+apps/frappe/frappe/core/doctype/data_import/importer.py,Cannot change header content,Sarlavha mazmunini o'zgartirib bo'lmaydi
 DocType: Print Settings,Print Style,Uslubni chop etish
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not Linked to any record,Hech qanday yozuvga aloqador emas
 DocType: Custom DocPerm,Import,Import
 DocType: User,Social Logins,Ijtimoiy kirishlar
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,Row {0}: Not allowed to enable Allow on Submit for standard fields,Row {0}: Foydalanuvchi uchun standart maydonlarga ruxsat berish uchun ruxsat berilmadi
-apps/frappe/frappe/core/doctype/role/role.py,Standard roles cannot be renamed,Standart rollar nomini o&#39;zgartira olmaydi
+apps/frappe/frappe/core/doctype/role/role.py,Standard roles cannot be renamed,Standart rollar nomini o'zgartira olmaydi
 DocType: Communication,To and CC,Va
 DocType: SMS Settings,Static Parameters,Statik parametrlar
 DocType: Chat Message,Room,Xona
 apps/frappe/frappe/public/js/frappe/change_log.html,updated to {0},{0} ga yangilangan
-apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,Fonda ishlamayapti. Ma&#39;mur bilan bog&#39;laning
-DocType: Portal Settings,Custom Menu Items,Maxsus menyu ma&#39;lumotlar
-apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,Sayt Slaydshouiga biriktirilgan barcha rasmlar ommaviy bo&#39;lishi kerak
-DocType: Workflow State,chevron-right,chevron-o&#39;ng
+apps/frappe/frappe/public/js/frappe/desk.js,Background jobs are not running. Please contact Administrator,Fonda ishlamayapti. Ma'mur bilan bog'laning
+DocType: Portal Settings,Custom Menu Items,Maxsus menyu ma'lumotlar
+apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.py,All Images attached to Website Slideshow should be public,Sayt Slaydshouiga biriktirilgan barcha rasmlar ommaviy bo'lishi kerak
+DocType: Workflow State,chevron-right,chevron-o'ng
 apps/frappe/frappe/integrations/doctype/google_drive/google_drive.js,"To use Google Drive, enable {0}.",Google Drive-dan foydalanish uchun {0} -ni yoqing.
-apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be in developer mode to edit a Standard Web Form,Standart veb-formasini tahrirlash uchun ishlab chiquvchi rejimida bo&#39;lishingiz kerak
-DocType: Personal Data Deletion Request,Personal Data Deletion Request,Shaxsiy ma&#39;lumotlarni yo&#39;q qilish uchun so&#39;rov
+apps/frappe/frappe/website/doctype/web_form/web_form.py,You need to be in developer mode to edit a Standard Web Form,Standart veb-formasini tahrirlash uchun ishlab chiquvchi rejimida bo'lishingiz kerak
+DocType: Personal Data Deletion Request,Personal Data Deletion Request,Shaxsiy ma'lumotlarni yo'q qilish uchun so'rov
 DocType: Payment Gateway,Gateway Controller,Gateway tekshiruvi
 apps/frappe/frappe/core/doctype/session_default_settings/session_default_settings.py,Default {0},Odatiy {0}
 DocType: Workflow State,camera,kamera
@@ -3943,28 +3943,28 @@ apps/frappe/frappe/public/js/frappe/form/controls/multiselect_list.js,No values 
 DocType: Desktop Icon,_doctype,_doctype
 DocType: Communication,Email Template,Email shablonni
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Successfully updated {0} record.,{0} yozuvi muvaffaqiyatli yangilandi.
-apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},{0} foydalanuvchisida {1} hujjat uchun rolga ruxsat berish orqali hujjatlar turiga kirish huquqi yo&#39;q.
+apps/frappe/frappe/permissions.py,User {0} does not have doctype access via role permission for document {1},{0} foydalanuvchisida {1} hujjat uchun rolga ruxsat berish orqali hujjatlar turiga kirish huquqi yo'q.
 apps/frappe/frappe/templates/includes/login/login.js,Both login and password required,Har ikkala login va parol talab qilinadi
 apps/frappe/frappe/model/document.py,Please refresh to get the latest document.,"Iltimos, eng yangi hujjatni olish uchun yangilang."
 DocType: User,Security Settings,Xavfsizlik sozlamalari
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Add Column,Ustun qo&#39;shish
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Add Column,Ustun qo'shish
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Select Filters,Filtrlarni tanlang
 ,Desktop,Ish stoli
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Export Report: {0},Eksport hisobot: {0}
 DocType: Auto Email Report,Filter Meta,Filtrni metan
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,Please find attached {0}: {1},Ilova qilingan {0}: {1} ni toping.
-DocType: Web Page,Set Meta Tags,Meta teglarini o&#39;rnating
-DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,"Ushbu forma veb-sahifasi bo&#39;lsa, Veb-sahifaga ulanish uchun ko&#39;rsatiladigan matn. Ulanish yo&#39;nalishi avtomatik ravishda &quot;page_name&quot; va &quot;parent_website_route&quot; asosida yaratiladi"
+DocType: Web Page,Set Meta Tags,Meta teglarini o'rnating
+DocType: Web Form,Text to be displayed for Link to Web Page if this form has a web page. Link route will be automatically generated based on `page_name` and `parent_website_route`,"Ushbu forma veb-sahifasi bo'lsa, Veb-sahifaga ulanish uchun ko'rsatiladigan matn. Ulanish yo'nalishi avtomatik ravishda &quot;page_name&quot; va &quot;parent_website_route&quot; asosida yaratiladi"
 DocType: S3 Backup Settings,Backup Limit,Zaxiralash limiti
 DocType: Dashboard Chart,Line,Chiziq
 DocType: Unhandled Email,Message-id,Xabar-id
 DocType: Patch Log,Patch,Patch
 DocType: Activity Log,Failed,Muvaffaqiyatsiz
 DocType: Web Form,Allow Comments,Izohlarga ruxsat berish
-DocType: Dashboard Chart,Last Week,O&#39;tgan hafta
+DocType: Dashboard Chart,Last Week,O'tgan hafta
 DocType: System Settings,Bypass Two Factor Auth for users who login from restricted IP Address,IP-manzildan cheklangan foydalanuvchilar uchun ikkita omilni aniqlash
 DocType: Event,Google Calendar,Google Taqvim
-apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,{0} ushbu turdagi elektron pochta xabarlarini qabul qilishni to&#39;xtatish
+apps/frappe/frappe/email/queue.py,{0} to stop receiving emails of this type,{0} ushbu turdagi elektron pochta xabarlarini qabul qilishni to'xtatish
 apps/frappe/frappe/www/qrcode.html,Open your authentication app on your mobile phone.,Mobil telefoningizda autentifikatsiya qilish ilovasini oching.
 apps/frappe/frappe/model/rename_doc.py,merged {0} into {1},{1} ga birlashtirilgan {0}
 DocType: System Settings,mm-dd-yyyy,mm-dd-yyyy
@@ -3972,18 +3972,18 @@ apps/frappe/frappe/data_migration/doctype/data_migration_connector/data_migratio
 apps/frappe/frappe/chat/__init__.py,"Sorry, you're not authorized.","Kechirasiz, siz ruxsat berilmagan."
 apps/frappe/frappe/core/doctype/activity_log/feed.py,{0} logged in,{0} tizimga kirish
 apps/frappe/frappe/public/js/frappe/form/multi_select_dialog.js,Make {0},{0} qiling
-DocType: Website Route Redirect,Website Route Redirect,Veb-sayt yo&#39;nalishini yo&#39;naltirish
+DocType: Website Route Redirect,Website Route Redirect,Veb-sayt yo'nalishini yo'naltirish
 apps/frappe/frappe/templates/emails/new_user.html,Your login id is,Sizning kirish identifikatoringiz
-apps/frappe/frappe/permissions.py,Document Type is not submittable,Hujjat turi qo&#39;shilmaydi
-DocType: OAuth Client,Skip Authorization,Yetkilendirme o&#39;tish
+apps/frappe/frappe/permissions.py,Document Type is not submittable,Hujjat turi qo'shilmaydi
+DocType: OAuth Client,Skip Authorization,Yetkilendirme o'tish
 DocType: Web Form,Amount Field,Miqdori maydoni
 DocType: Dropbox Settings,Send Notifications To,Bildirishnomalarni yuborish
-DocType: Bulk Update,Max 500 records at a time,Bir vaqtning o&#39;zida maksimal 500 yozuv
-DocType: Translation,"If your data is in HTML, please copy paste the exact HTML code with the tags.","Ma&#39;lumotlaringiz HTML-da bo&#39;lsa, iltimos, aniq HTML kodni teglar bilan joylashtirishingiz mumkin."
+DocType: Bulk Update,Max 500 records at a time,Bir vaqtning o'zida maksimal 500 yozuv
+DocType: Translation,"If your data is in HTML, please copy paste the exact HTML code with the tags.","Ma'lumotlaringiz HTML-da bo'lsa, iltimos, aniq HTML kodni teglar bilan joylashtirishingiz mumkin."
 DocType: Communication,Meeting,Uchrashuv
-apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,Biriktirilgan faylni ochib bo&#39;lmadi. Uni CSV sifatida eksport qildingizmi?
-DocType: DocField,Ignore User Permissions,Foydalanuvchi ruxsatlarini e&#39;tiborsiz qoldiring
+apps/frappe/frappe/utils/csvutils.py,Unable to open attached file. Did you export it as CSV?,Biriktirilgan faylni ochib bo'lmadi. Uni CSV sifatida eksport qildingizmi?
+DocType: DocField,Ignore User Permissions,Foydalanuvchi ruxsatlarini e'tiborsiz qoldiring
 apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Saved Successfully,Muvaffaqiyatli saqlandi
-apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,Administratordan ro&#39;yxatdan o&#39;tishni tasdiqlashini so&#39;rang
+apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,Administratordan ro'yxatdan o'tishni tasdiqlashini so'rang
 DocType: Domain Settings,Active Domains,Faol domenlar
-apps/frappe/frappe/public/js/integrations/razorpay.js,Show Log,Jurnalni ko&#39;rsatish
+apps/frappe/frappe/public/js/integrations/razorpay.js,Show Log,Jurnalni ko'rsatish

--- a/frappe/translations/uz.csv
+++ b/frappe/translations/uz.csv
@@ -740,7 +740,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Fayl zahira
 DocType: DocField,In Global Search,Global izlovchilarda
 DocType: System Settings,Brute Force Security,Brute Force Xavfsizlik
 DocType: Workflow State,indent-left,indent-chap
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} yil oldin
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} yil oldin
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,"Ushbu faylni o&#39;chirish xavfli: {0}. Iltimos, tizim boshqaruvchisiga murojaat qiling."
 DocType: Currency,Currency Name,Valyuta nomi
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,E-pochtalar yo&#39;q
@@ -1034,7 +1034,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Hech qanday {
 apps/frappe/frappe/config/customization.py,Add custom forms.,Maxsus shakllar qo&#39;shing.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {2} da {1}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,ushbu hujjatni taqdim etdi
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Sozlash&gt; Foydalanuvchi ruxsati
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Sozlash> Foydalanuvchi ruxsati
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Tizim oldindan belgilangan ko&#39;plab rollarni ta&#39;minlaydi. Yaxshiroq ruxsatlarni o&#39;rnatish uchun yangi rollarni qo&#39;shishingiz mumkin.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1253,7 +1253,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Agar foydalanuvchining roli tekshirilsa, foydalanuvchi &quot;tizim foydalanuvchisi&quot; bo&#39;ladi. &quot;Tizim foydalanuvchisi&quot; stolga kirish huquqiga ega"
 DocType: System Settings,Date and Number Format,Sana va raqam formati
 apps/frappe/frappe/model/document.py,one of,bittasi
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Sozlash&gt; Formani sozlash
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Sozlash> Formani sozlash
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Bir onni tekshirib ko&#39;rish
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Teglarni ko&#39;rsatish
 DocType: DocField,HTML Editor,HTML tahrirlovchisi
@@ -1261,7 +1261,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,Billing
 DocType: Email Queue,Not Sent,Yuborilmadi
 DocType: Web Form,Actions,Amallar
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Sozlash&gt; Foydalanuvchi
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Sozlash> Foydalanuvchi
 DocType: Workflow State,align-justify,tekislang
 DocType: User,Middle Name (Optional),O&#39;rtacha nomi (majburiy emas)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Ruxsat berilmadi
@@ -1408,7 +1408,7 @@ DocType: User,System User,Tizim foydalanuvchisi
 DocType: Report,Is Standard,Standart
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,To&#39;liq
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","HTML &lt;skript&gt; kabi HTML teglar bilan kodlash yoki &lt;yoki&gt; kabi oddiy belgilarni kiritmang, chunki ular ushbu sohada qasddan ishlatilishi mumkin"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","HTML &lt;skript> kabi HTML teglar bilan kodlash yoki &lt;yoki> kabi oddiy belgilarni kiritmang, chunki ular ushbu sohada qasddan ishlatilishi mumkin"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} {1} da tanqid qilingan
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Yugurish
@@ -1787,7 +1787,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Taglik faqat PDF 
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Kutilmoqda
 DocType: System Settings,Allow only one session per user,Bir foydalanuvchi uchun bitta seansga ruxsat berish
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Bosh sahifa / Sinovlarni tekshirish 1 / Tasvirni tekshirish 3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;bosh&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;bosh> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Yangi hodisa yaratish uchun vaqt oraliqlarini tanlang yoki harakatlantiring.
 DocType: Contact,Contact Details,Aloqa tafsilotlari
 DocType: DocField,In Filter,Filtrda
@@ -2018,7 +2018,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Bu vaqtda kirish uchun ruxsat berilmaydi
 DocType: Data Migration Run,Current Mapping Action,Joriy xaritalash harakati
 DocType: Dashboard Chart Source,Source Name,Manba nomi
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,"Foydalanuvchi bilan bog&#39;langan elektron pochta hisobi yo&#39;q. Iltimos, foydalanuvchi&gt; Elektron pochta qutisi ostida hisob qaydnomasini qo&#39;shing."
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,"Foydalanuvchi bilan bog&#39;langan elektron pochta hisobi yo&#39;q. Iltimos, foydalanuvchi> Elektron pochta qutisi ostida hisob qaydnomasini qo&#39;shing."
 DocType: Email Account,Email Sync Option,Elektron pochtani sinxronlashtirish opsiyasi
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Roy №
 DocType: Async Task,Runtime,Ish vaqti
@@ -2033,7 +2033,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Siz allaq
 DocType: User Email,Enable Outgoing,Chiqishni yoqish
 DocType: Address,Fax,Faks
 apps/frappe/frappe/config/customization.py,Custom Tags,Maxsus teglar
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,"Elektron pochta qayd hisobi sozlanmadi. Iltimos, sozlash&gt; Elektron pochta&gt; Elektron pochta qayd hisobi orqali yangi elektron pochta qayd yozuvini yarating"
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,"Elektron pochta qayd hisobi sozlanmadi. Iltimos, sozlash> Elektron pochta> Elektron pochta qayd hisobi orqali yangi elektron pochta qayd yozuvini yarating"
 DocType: Comment,Submitted,Taklif qilingan
 DocType: Contact,Pulled from Google Contacts,Google Contacts-dan tortib olindi
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Qabul qilingan so&#39;rovda
@@ -2105,7 +2105,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,"Soatdagi amal qilis
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Bu maydon faqat bu erda ko&#39;rsatilgan maydon nomiga qiymat yoki qoidalar haqiqiy (misollar) bo&#39;lsa paydo bo&#39;ladi: myfield eval: doc.myfield == &#39;Mening qiymatim&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Bu maydon faqat bu erda ko&#39;rsatilgan maydon nomiga qiymat yoki qoidalar haqiqiy (misollar) bo&#39;lsa paydo bo&#39;ladi: myfield eval: doc.myfield == &#39;Mening qiymatim&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Bugun
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).","Siz buni o&#39;rnatganingizdan so&#39;ng, foydalanuvchilar faqatgina link mavjud bo&#39;lgan hujjatlarga (masalan, Blog Post) kirish imkoniyatiga ega bo&#39;ladi (masalan, Blogger)."
@@ -2119,7 +2119,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,Yuqori holat
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Maxsus HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Jildning nomini kiriting
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,"Birlamchi manzil shabloni topilmadi. Iltimos, sozlash&gt; Bosib chiqarish va markalash&gt; Manzil shablonidan yangisini yarating."
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,"Birlamchi manzil shabloni topilmadi. Iltimos, sozlash> Bosib chiqarish va markalash> Manzil shablonidan yangisini yarating."
 apps/frappe/frappe/auth.py,Unknown User,Noma&#39;lum foydalanuvchi
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Rolni tanlang
 DocType: Comment,Deleted,O&#39;chirilgan
@@ -2307,7 +2307,7 @@ DocType: LDAP Settings,Path to Server Certificate,Server sertifikatiga yo&#39;l
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ulanishlarni ko&#39;rish uchun etarli ruxsat yo&#39;q
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Manzil sarlavhasi majburiydir.
 DocType: Google Contacts,Push to Google Contacts,Google Contacts-ga bosing
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",Veb-sahifaning &lt;bosh&gt; qismida HTMLni birinchi navbatda veb-saytni tekshirish va SEO uchun ishlatilgan
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",Veb-sahifaning &lt;bosh> qismida HTMLni birinchi navbatda veb-saytni tekshirish va SEO uchun ishlatilgan
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nafaqaga chiqqan
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Mavzu o&#39;z avlodlariga qo&#39;shilmaydi
 DocType: Session Default Settings,Session Defaults,Sessiya standartlari
@@ -2426,7 +2426,7 @@ DocType: Workflow State,Warning,Ogohlantirish
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Bu bir nechta sahifada chop etilishi mumkin
 DocType: Data Migration Run,Percent Complete,Foiz to&#39;liq
 DocType: Tag Category,Tag Category,Yorliq kategoriyasi
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Taqqoslash uchun&gt; 5, &lt;10 yoki = 324 dan foydalaning. O&#39;lchovlar uchun 5:10 dan foydalaning (5 va 10 orasidagi qiymatlar uchun)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Taqqoslash uchun> 5, &lt;10 yoki = 324 dan foydalaning. O&#39;lchovlar uchun 5:10 dan foydalaning (5 va 10 orasidagi qiymatlar uchun)."
 DocType: Google Calendar,Pull from Google Calendar,Google Calendar-dan tortib oling
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Yordam bering
 DocType: User,Login Before,Avval kirish
@@ -2887,7 +2887,7 @@ DocType: Custom Script,Custom Script,Maxsus skript
 DocType: Address,Address Line 2,Manzil yo&#39;nalish 2
 DocType: Address,Reference,Malumot
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Tayinlangan
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,"Iltimos, standart elektron pochta hisob qaydnomasini O&#39;rnatish&gt; Elektron pochta&gt; Elektron pochta hisob qaydnomasini o&#39;rnating"
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,"Iltimos, standart elektron pochta hisob qaydnomasini O&#39;rnatish> Elektron pochta> Elektron pochta hisob qaydnomasini o&#39;rnating"
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Ma&#39;lumotlar Migratsiya xaritalash detali
 DocType: Data Import,Action,Harakat
 DocType: GSuite Settings,Script URL,Skript URL manzili
@@ -3064,7 +3064,7 @@ DocType: DocField,Allow on Submit,Yuborishga ruxsat berish
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Istisno turi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Ustunlarni tanlash
-DocType: Web Page,Add code as &lt;script&gt;,Kodni &lt;script&gt; deb qo&#39;shing
+DocType: Web Page,Add code as &lt;script>,Kodni &lt;script> deb qo&#39;shing
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Foydalanuvchi ruxsatlarini tozalash
 DocType: Webhook,Headers,Sarlavhalar
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kutilayotgan voqealar
@@ -3438,16 +3438,16 @@ DocType: Workflow State,share-alt,ulush-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Navbat {0} dan biri bo&#39;lishi kerak
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
-</code></pre>","<h4> Standart shablon </h4><p> <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating-ni</a> ishlatadi va barcha manzillar (agar mavjud bo'lsa, Maxsus maydonlar) mavjud bo'ladi </p><pre> <code>{{ address_line1 }}&lt;br&gt; {% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%} {{ city }}&lt;br&gt; {% if state %}{{ state }}&lt;br&gt;{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br&gt;{% endif -%} {{ country }}&lt;br&gt; {% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+</code></pre>","<h4> Standart shablon </h4><p> <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating-ni</a> ishlatadi va barcha manzillar (agar mavjud bo'lsa, Maxsus maydonlar) mavjud bo'ladi </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Boshlash sanasi maydoni
 DocType: Role,Role Name,Romen nomi
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Stolga o&#39;tish

--- a/frappe/translations/uz.csv
+++ b/frappe/translations/uz.csv
@@ -1408,7 +1408,7 @@ DocType: User,System User,Tizim foydalanuvchisi
 DocType: Report,Is Standard,Standart
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,To&#39;liq
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","HTML &lt;skript> kabi HTML teglar bilan kodlash yoki &lt;yoki> kabi oddiy belgilarni kiritmang, chunki ular ushbu sohada qasddan ishlatilishi mumkin"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","HTML <skript> kabi HTML teglar bilan kodlash yoki <yoki> kabi oddiy belgilarni kiritmang, chunki ular ushbu sohada qasddan ishlatilishi mumkin"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} {1} da tanqid qilingan
 DocType: Website Settings,FavIcon,FavIcon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Yugurish
@@ -1787,7 +1787,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Taglik faqat PDF 
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Kutilmoqda
 DocType: System Settings,Allow only one session per user,Bir foydalanuvchi uchun bitta seansga ruxsat berish
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Bosh sahifa / Sinovlarni tekshirish 1 / Tasvirni tekshirish 3
-DocType: Website Settings,&lt;head> HTML,&lt;bosh> HTML
+DocType: Website Settings,<head> HTML,<bosh> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Yangi hodisa yaratish uchun vaqt oraliqlarini tanlang yoki harakatlantiring.
 DocType: Contact,Contact Details,Aloqa tafsilotlari
 DocType: DocField,In Filter,Filtrda
@@ -2307,7 +2307,7 @@ DocType: LDAP Settings,Path to Server Certificate,Server sertifikatiga yo&#39;l
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Ulanishlarni ko&#39;rish uchun etarli ruxsat yo&#39;q
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Manzil sarlavhasi majburiydir.
 DocType: Google Contacts,Push to Google Contacts,Google Contacts-ga bosing
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",Veb-sahifaning &lt;bosh> qismida HTMLni birinchi navbatda veb-saytni tekshirish va SEO uchun ishlatilgan
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",Veb-sahifaning <bosh> qismida HTMLni birinchi navbatda veb-saytni tekshirish va SEO uchun ishlatilgan
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Nafaqaga chiqqan
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Mavzu o&#39;z avlodlariga qo&#39;shilmaydi
 DocType: Session Default Settings,Session Defaults,Sessiya standartlari
@@ -2426,7 +2426,7 @@ DocType: Workflow State,Warning,Ogohlantirish
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Bu bir nechta sahifada chop etilishi mumkin
 DocType: Data Migration Run,Percent Complete,Foiz to&#39;liq
 DocType: Tag Category,Tag Category,Yorliq kategoriyasi
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Taqqoslash uchun> 5, &lt;10 yoki = 324 dan foydalaning. O&#39;lchovlar uchun 5:10 dan foydalaning (5 va 10 orasidagi qiymatlar uchun)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Taqqoslash uchun> 5, <10 yoki = 324 dan foydalaning. O&#39;lchovlar uchun 5:10 dan foydalaning (5 va 10 orasidagi qiymatlar uchun)."
 DocType: Google Calendar,Pull from Google Calendar,Google Calendar-dan tortib oling
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Yordam bering
 DocType: User,Login Before,Avval kirish
@@ -3064,7 +3064,7 @@ DocType: DocField,Allow on Submit,Yuborishga ruxsat berish
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Istisno turi
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Ustunlarni tanlash
-DocType: Web Page,Add code as &lt;script>,Kodni &lt;script> deb qo&#39;shing
+DocType: Web Page,Add code as <script>,Kodni <script> deb qo&#39;shing
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Foydalanuvchi ruxsatlarini tozalash
 DocType: Webhook,Headers,Sarlavhalar
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,Kutilayotgan voqealar
@@ -3438,16 +3438,16 @@ DocType: Workflow State,share-alt,ulush-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Navbat {0} dan biri bo&#39;lishi kerak
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
-</code></pre>","<h4> Standart shablon </h4><p> <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating-ni</a> ishlatadi va barcha manzillar (agar mavjud bo'lsa, Maxsus maydonlar) mavjud bo'ladi </p><pre> <code>{{ address_line1 }}&lt;br> {% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%} {{ city }}&lt;br> {% if state %}{{ state }}&lt;br>{% endif -%} {% if pincode %} PIN: {{ pincode }}&lt;br>{% endif -%} {{ country }}&lt;br> {% if phone %}Phone: {{ phone }}&lt;br>{% endif -%} {% if fax %}Fax: {{ fax }}&lt;br>{% endif -%} {% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}</code> </pre>"
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
+</code></pre>","<h4> Standart shablon </h4><p> <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja templating-ni</a> ishlatadi va barcha manzillar (agar mavjud bo'lsa, Maxsus maydonlar) mavjud bo'ladi </p><pre> <code>{{ address_line1 }}<br> {% if address_line2 %}{{ address_line2 }}<br>{% endif -%} {{ city }}<br> {% if state %}{{ state }}<br>{% endif -%} {% if pincode %} PIN: {{ pincode }}<br>{% endif -%} {{ country }}<br> {% if phone %}Phone: {{ phone }}<br>{% endif -%} {% if fax %}Fax: {{ fax }}<br>{% endif -%} {% if email_id %}Email: {{ email_id }}<br>{% endif -%}</code> </pre>"
 DocType: Calendar View,Start Date Field,Boshlash sanasi maydoni
 DocType: Role,Role Name,Romen nomi
 apps/frappe/frappe/templates/includes/navbar/navbar_login.html,Switch To Desk,Stolga o&#39;tish

--- a/frappe/translations/vi.csv
+++ b/frappe/translations/vi.csv
@@ -1424,7 +1424,7 @@ DocType: Report,Is Standard,Là tiêu chuẩn
 DocType: Desktop Icon,_report,_bài báo cáo
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Đầy
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Không thẻ HTML Mã hóa HTML như &lt;script> hay chỉ là nhân vật như &lt;hoặc>, vì chúng có thể được cố ý sử dụng trong lĩnh vực này"
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field","Không thẻ HTML Mã hóa HTML như <script> hay chỉ là nhân vật như <hoặc>, vì chúng có thể được cố ý sử dụng trong lĩnh vực này"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} bị chỉ trích vào {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Chạy
@@ -1806,7 +1806,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer sẽ chỉ
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Chờ
 DocType: System Settings,Allow only one session per user,Chỉ cho phép một phiên mỗi người dùng
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Trang chủ / Kiểm tra Thư mục 1 / Kiểm tra thư mục 3
-DocType: Website Settings,&lt;head> HTML,HTML
+DocType: Website Settings,<head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Chọn hoặc kéo trên các khe thời gian để tạo ra một sự kiện mới.
 DocType: Contact,Contact Details,Chi tiết Liên hệ
 DocType: DocField,In Filter,Bộ lọc trong
@@ -2334,7 +2334,7 @@ DocType: LDAP Settings,Path to Server Certificate,Đường dẫn đến chứng
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Không có đủ quyền để xem liên kết
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Địa chỉ Tiêu đề là bắt buộc.
 DocType: Google Contacts,Push to Google Contacts,Nhấn vào Danh bạ Google
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Thêm HTML vào trong &lt;head> của trang web, chủ yếu được sử dụng để xác minh trang web và SEO"
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO","Thêm HTML vào trong <head> của trang web, chủ yếu được sử dụng để xác minh trang web và SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Tái phát
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Mẫu hàng không thể được thêm vào các phần sau của mình
 DocType: Session Default Settings,Session Defaults,Mặc định phiên
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Cảnh báo
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Điều này có thể được in trên nhiều trang
 DocType: Data Migration Run,Percent Complete,Phần trăm hoàn thành
 DocType: Tag Category,Tag Category,Tag Thể loại
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Để so sánh, sử dụng> 5, &lt;10 hoặc = 324. Đối với phạm vi, sử dụng 5:10 (cho các giá trị trong khoảng từ 5 đến 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Để so sánh, sử dụng> 5, <10 hoặc = 324. Đối với phạm vi, sử dụng 5:10 (cho các giá trị trong khoảng từ 5 đến 10)."
 DocType: Google Calendar,Pull from Google Calendar,Kéo từ Lịch Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Trợ giúp
 DocType: User,Login Before,Trước khi đăng nhập
@@ -3102,7 +3102,7 @@ DocType: DocField,Allow on Submit,Cho phép khi Đệ trình
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Loại ngoại lệ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Chọn cột
-DocType: Web Page,Add code as &lt;script>,Thêm mã như <script>
+DocType: Web Page,Add code as <script>,Thêm mã như <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Xóa quyền người dùng
 DocType: Webhook,Headers,Tiêu đề
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,sự kiện sắp tới
@@ -3479,26 +3479,26 @@ DocType: Workflow State,share-alt,cổ alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Hàng chờ nên là một trong {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> Sử dụng <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> và tất cả các lĩnh vực của Địa chỉ ( bao gồm Tuỳ chỉnh Fields nếu có) sẽ có sẵn </ p> 
- <pre> <code> {{address_line1}} & lt; br & gt; 
- {% nếu address_line2%} {{address_line2}} & lt; br & gt; { endif% -%} {{
- thành phố}} & lt; br & gt; 
- {% nếu nhà nước%} {{}} nhà nước & lt; br & gt; {% endif -%} {
-% nếu mã pin%} PIN: {{mã pin}} & lt; br & gt; {% endif -%} 
- {{country}} & lt; br & gt; 
- {% nếu điện thoại%} Điện thoại: {{phone}} & lt; br & gt; { % endif -%} 
- {% nếu fax%} Fax: {{fax}} & lt; br & gt; {% endif -%} 
- {% nếu email_id%} Email: {{email_id}} & lt; br & gt ; {% endif -}% 
+ <pre> <code> {{address_line1}} <br> 
+ {% nếu address_line2%} {{address_line2}} <br> { endif% -%} {{
+ thành phố}} <br> 
+ {% nếu nhà nước%} {{}} nhà nước <br> {% endif -%} {
+% nếu mã pin%} PIN: {{mã pin}} <br> {% endif -%} 
+ {{country}} <br> 
+ {% nếu điện thoại%} Điện thoại: {{phone}} <br> { % endif -%} 
+ {% nếu fax%} Fax: {{fax}} <br> {% endif -%} 
+ {% nếu email_id%} Email: {{email_id}} <br> {% endif -}% 
  </ code> </ pre>"
 DocType: Calendar View,Start Date Field,Trường ngày bắt đầu
 DocType: Role,Role Name,Tên vai trò

--- a/frappe/translations/vi.csv
+++ b/frappe/translations/vi.csv
@@ -747,7 +747,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,Sao lưu t�
 DocType: DocField,In Global Search,Trong Tìm kiếm Toàn cầu
 DocType: System Settings,Brute Force Security,Brute Force Security
 DocType: Workflow State,indent-left,thụt lề trái
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} năm trước
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0} năm trước
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,Có rủi ro khi xóa tập tin này: {0}. Vui lòng liên hệ Quản lý Hệ thống của bạn.
 DocType: Currency,Currency Name,Tên tiền tệ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,không có  email
@@ -1046,7 +1046,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,Không tìm t
 apps/frappe/frappe/config/customization.py,Add custom forms.,Thêm các hình thức tùy chỉnh.
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}: {1} trong {2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,gửi tài liệu này
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,Thiết lập&gt; Quyền người dùng
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,Thiết lập> Quyền người dùng
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,Hệ thống cung cấp nhiều vai trò được xác định trước. Bạn có thể thêm vai trò mới để thiết lập quyền tốt hơn.
 DocType: Communication,CC,CC
 DocType: Country,Geo,Geo
@@ -1267,7 +1267,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop","Nếu người dùng có bất kỳ vai trò nào được kiểm tra, sau đó người dùng sẽ trở thành một ""người dùng hệ thống"". ""Người dùng hệ thống"" có quyền truy cập vào các máy tính để bàn"
 DocType: System Settings,Date and Number Format,định dạng ngày và số
 apps/frappe/frappe/model/document.py,one of,Một trong
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,Cài đặt&gt; Tùy chỉnh biểu mẫu
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,Cài đặt> Tùy chỉnh biểu mẫu
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,Kiểm tra một khoảnh khắc
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,Hiện tags
 DocType: DocField,HTML Editor,Trình chỉnh sửa HTML
@@ -1275,7 +1275,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,thanh toán
 DocType: Email Queue,Not Sent,Không gửi
 DocType: Web Form,Actions,Các thao tác
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,Cài đặt&gt; Người dùng
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,Cài đặt> Người dùng
 DocType: Workflow State,align-justify,sắp xếp biện minh cho
 DocType: User,Middle Name (Optional),Tên đệm (bắt buộc)
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,Không được phép
@@ -1424,7 +1424,7 @@ DocType: Report,Is Standard,Là tiêu chuẩn
 DocType: Desktop Icon,_report,_bài báo cáo
 DocType: Desktop Icon,_report,_report
 DocType: Dashboard Chart,Full,Đầy
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field","Không thẻ HTML Mã hóa HTML như &lt;script&gt; hay chỉ là nhân vật như &lt;hoặc&gt;, vì chúng có thể được cố ý sử dụng trong lĩnh vực này"
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field","Không thẻ HTML Mã hóa HTML như &lt;script> hay chỉ là nhân vật như &lt;hoặc>, vì chúng có thể được cố ý sử dụng trong lĩnh vực này"
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0} bị chỉ trích vào {1}
 DocType: Website Settings,FavIcon,Favicon
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,Chạy
@@ -1806,7 +1806,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,Footer sẽ chỉ
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,Chờ
 DocType: System Settings,Allow only one session per user,Chỉ cho phép một phiên mỗi người dùng
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,Trang chủ / Kiểm tra Thư mục 1 / Kiểm tra thư mục 3
-DocType: Website Settings,&lt;head&gt; HTML,HTML
+DocType: Website Settings,&lt;head> HTML,HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,Chọn hoặc kéo trên các khe thời gian để tạo ra một sự kiện mới.
 DocType: Contact,Contact Details,Chi tiết Liên hệ
 DocType: DocField,In Filter,Bộ lọc trong
@@ -2040,7 +2040,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,Đăng nhập không được phép tại thời điểm này
 DocType: Data Migration Run,Current Mapping Action,Hành động lập bản đồ hiện tại
 DocType: Dashboard Chart Source,Source Name,Tên nguồn
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,Không có tài khoản email liên kết với Người dùng. Vui lòng thêm một tài khoản trong Người dùng&gt; Hộp thư đến Email.
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,Không có tài khoản email liên kết với Người dùng. Vui lòng thêm một tài khoản trong Người dùng> Hộp thư đến Email.
 DocType: Email Account,Email Sync Option,Đồng bộ hóa email Tùy chọn
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,Hàng Không
 DocType: Async Task,Runtime,chạy thời gian
@@ -2055,7 +2055,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,Đã đư
 DocType: User Email,Enable Outgoing,Kích hoạt Outgoing
 DocType: Address,Fax,Fax
 apps/frappe/frappe/config/customization.py,Custom Tags,Thẻ tùy chỉnh
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,Tài khoản email không được thiết lập. Vui lòng tạo Tài khoản Email mới từ Cài đặt&gt; Email&gt; Tài khoản Email
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,Tài khoản email không được thiết lập. Vui lòng tạo Tài khoản Email mới từ Cài đặt> Email> Tài khoản Email
 DocType: Comment,Submitted,Đã lần gửi
 DocType: Contact,Pulled from Google Contacts,Kéo từ Danh bạ Google
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,Yêu cầu không hợp lệ
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Phiên làm việc c
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",Trường này sẽ chỉ xuất hiện nếu fieldname định nghĩa ở đây có giá trị hoặc các quy định là đúng (ví dụ): myfield eval: doc.myfield == &#39;Giá trị của tôi&#39; eval: doc.age&gt; 18
+eval:doc.age>18",Trường này sẽ chỉ xuất hiện nếu fieldname định nghĩa ở đây có giá trị hoặc các quy định là đúng (ví dụ): myfield eval: doc.myfield == &#39;Giá trị của tôi&#39; eval: doc.age> 18
 DocType: Social Login Key,Office 365,Văn phòng 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hôm nay
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hôm nay
@@ -2144,7 +2144,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,CHỮ HOA
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,Tuỳ chỉnh HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,Nhập tên thư mục
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,Không tìm thấy mẫu địa chỉ mặc định. Vui lòng tạo một cái mới từ Cài đặt&gt; In và Nhãn hiệu&gt; Mẫu địa chỉ.
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,Không tìm thấy mẫu địa chỉ mặc định. Vui lòng tạo một cái mới từ Cài đặt> In và Nhãn hiệu> Mẫu địa chỉ.
 apps/frappe/frappe/auth.py,Unknown User,Người dùng không biết
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,Chọn Vai trò
 DocType: Comment,Deleted,Đã bị xóa
@@ -2334,7 +2334,7 @@ DocType: LDAP Settings,Path to Server Certificate,Đường dẫn đến chứng
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,Không có đủ quyền để xem liên kết
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,Địa chỉ Tiêu đề là bắt buộc.
 DocType: Google Contacts,Push to Google Contacts,Nhấn vào Danh bạ Google
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO","Thêm HTML vào trong &lt;head&gt; của trang web, chủ yếu được sử dụng để xác minh trang web và SEO"
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO","Thêm HTML vào trong &lt;head> của trang web, chủ yếu được sử dụng để xác minh trang web và SEO"
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,Tái phát
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,Mẫu hàng không thể được thêm vào các phần sau của mình
 DocType: Session Default Settings,Session Defaults,Mặc định phiên
@@ -2454,7 +2454,7 @@ DocType: Workflow State,Warning,Cảnh báo
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,Điều này có thể được in trên nhiều trang
 DocType: Data Migration Run,Percent Complete,Phần trăm hoàn thành
 DocType: Tag Category,Tag Category,Tag Thể loại
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Để so sánh, sử dụng&gt; 5, &lt;10 hoặc = 324. Đối với phạm vi, sử dụng 5:10 (cho các giá trị trong khoảng từ 5 đến 10)."
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).","Để so sánh, sử dụng> 5, &lt;10 hoặc = 324. Đối với phạm vi, sử dụng 5:10 (cho các giá trị trong khoảng từ 5 đến 10)."
 DocType: Google Calendar,Pull from Google Calendar,Kéo từ Lịch Google
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,Trợ giúp
 DocType: User,Login Before,Trước khi đăng nhập
@@ -2923,7 +2923,7 @@ DocType: Custom Script,Custom Script,Tùy chỉnh Script
 DocType: Address,Address Line 2,Địa chỉ Dòng 2
 DocType: Address,Reference,Tham chiếu
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,Để giao
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,Vui lòng thiết lập Tài khoản Email mặc định từ Cài đặt&gt; Email&gt; Tài khoản Email
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,Vui lòng thiết lập Tài khoản Email mặc định từ Cài đặt> Email> Tài khoản Email
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,Chi tiết bản đồ chuyển đổi dữ liệu
 DocType: Data Import,Action,thao tác
 DocType: GSuite Settings,Script URL,URL bản thảo
@@ -3102,7 +3102,7 @@ DocType: DocField,Allow on Submit,Cho phép khi Đệ trình
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,Loại ngoại lệ
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,Chọn cột
-DocType: Web Page,Add code as &lt;script&gt;,Thêm mã như <script>
+DocType: Web Page,Add code as &lt;script>,Thêm mã như <script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,Xóa quyền người dùng
 DocType: Webhook,Headers,Tiêu đề
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,sự kiện sắp tới
@@ -3479,15 +3479,15 @@ DocType: Workflow State,share-alt,cổ alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},Hàng chờ nên là một trong {0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4> Default Template </ h4> 
  <p> Sử dụng <a href=""http://jinja.pocoo.org/docs/templates/""> Jinja Templating </a> và tất cả các lĩnh vực của Địa chỉ ( bao gồm Tuỳ chỉnh Fields nếu có) sẽ có sẵn </ p> 
  <pre> <code> {{address_line1}} & lt; br & gt; 

--- a/frappe/translations/vi.csv
+++ b/frappe/translations/vi.csv
@@ -561,7 +561,7 @@ apps/frappe/frappe/public/js/frappe/file_uploader/FilePreview.vue,Upload Failed,
 apps/frappe/frappe/social/doctype/energy_point_log/energy_point_log.py,Stats based on last week's performance (from {0} to {1}),Số liệu thống kê dựa trên hiệu suất của tuần trước (từ {0} đến {1})
 DocType: LDAP Settings,LDAP Phone Field,Trường điện thoại LDAP
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,"document type..., e.g. customer","loại tài liệu ..., ví dụ: khách hàng"
-apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Điều kiện &#39;{0}&#39; không hợp lệ
+apps/frappe/frappe/email/doctype/notification/notification.py,The Condition '{0}' is invalid,Điều kiện '{0}' không hợp lệ
 DocType: Workflow State,barcode,mã vạch
 apps/frappe/frappe/model/db_query.py,Use of sub-query or function is restricted,Việc sử dụng truy vấn phụ hoặc chức năng bị hạn chế
 apps/frappe/frappe/config/customization.py,Add your own translations,Thêm bản dịch của riêng bạn
@@ -711,7 +711,7 @@ DocType: Slack Webhook URL,Webhook URL,URL Webhook
 apps/frappe/frappe/core/doctype/user/user.py,Username {0} already exists,Tên đăng nhập {0} đã tồn tại
 apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Cannot set import as {1} is not importable,"{0}: Không thể thiết lập""nhập vào"" vì {1} không thể nhập vào được"
 apps/frappe/frappe/contacts/doctype/address/address.py,There is an error in your Address Template {0},Có một lỗi trong mẫu Địa chỉ của bạn {0}
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} là địa chỉ email không hợp lệ trong &#39;Người nhận&#39;
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} is an invalid email address in 'Recipients',{0} là địa chỉ email không hợp lệ trong 'Người nhận'
 DocType: Footer Item,"target = ""_blank""","mục tiêu = ""_trống"""
 DocType: Workflow State,hdd,hdd
 DocType: Integration Request,Host,Chủ
@@ -753,7 +753,7 @@ DocType: Currency,Currency Name,Tên tiền tệ
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,không có  email
 apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py,Link Expired,Liên kết đã hết hạn
 apps/frappe/frappe/database/schema.py,"Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.",Hoàn nguyên độ dài thành {0} cho &#39;{1}&#39; trong &#39;{2}&#39;; Đặt độ dài là {3} sẽ làm giảm dữ liệu.
+							Setting the length as {3} will cause truncation of data.",Hoàn nguyên độ dài thành {0} cho '{1}' trong '{2}'; Đặt độ dài là {3} sẽ làm giảm dữ liệu.
 apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,Select File Format,Chọn Định dạng tệp
 DocType: Report,Javascript,Javascript
 DocType: File,Content Hash,Nội dung Hash
@@ -775,7 +775,7 @@ DocType: Custom Field,Select the label after which you want to insert new field.
 ,Document Share Report,Tài liệu Chia sẻ Báo cáo
 DocType: Social Login Key,Base URL,URL cơ sở
 DocType: User,Last Login,Lần Đăng nhập Cuối
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Bạn không thể đặt &#39;Có thể dịch được&#39; cho trường {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Translatable' for field {0},Bạn không thể đặt 'Có thể dịch được' cho trường {0}
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html,Column,Trụ
 DocType: Chat Profile,Chat Profile,Hồ sơ trò chuyện
 DocType: Custom Field,Adds a custom field to a DocType,Thêm một thông tin một DOCTYPE
@@ -784,7 +784,7 @@ DocType: File,Is Home Folder,Là thư mục gốc
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Navbar Style,Phong cách thanh
 apps/frappe/frappe/utils/__init__.py,{0} is not a valid Email Address,{0} không phải là một địa chỉ email hợp lệ
 apps/frappe/frappe/public/js/frappe/list/bulk_operations.js,Select atleast 1 record for printing,Chọn ít nhất 1 kỷ lục cho in ấn
-apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Tài &#39;{0}&#39; đã có vai trò &#39;{1}&#39;
+apps/frappe/frappe/core/doctype/has_role/has_role.py,User '{0}' already has the role '{1}',Tài '{0}' đã có vai trò '{1}'
 DocType: System Settings,Two Factor Authentication method,Phương pháp xác thực hai yếu tố
 apps/frappe/frappe/website/doctype/website_slideshow/website_slideshow.js,First set the name and save the record.,Trước tiên hãy đặt tên và lưu bản ghi.
 apps/frappe/frappe/public/js/frappe/data_import/data_exporter.js,5 Records,5 hồ sơ
@@ -1455,7 +1455,7 @@ apps/frappe/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts
 apps/frappe/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js,Mandatory field: set role for,lĩnh vực bắt buộc: thiết lập vai trò cho
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized {1},{0} bị chỉ trích {1}
 DocType: Data Migration Mapping,Mapping Name,Tên lập bản đồ
-apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Không thể đặt trường &#39;{1}&#39; là Duy nhất vì nó có các giá trị không duy nhất
+apps/frappe/frappe/core/doctype/doctype/doctype.py,{0}: Field '{1}' cannot be set as Unique as it has non-unique values,{0}: Không thể đặt trường '{1}' là Duy nhất vì nó có các giá trị không duy nhất
 apps/frappe/frappe/public/js/frappe/list/list_view.js,Navigate list down,Điều hướng danh sách xuống
 DocType: Currency,A symbol for this currency. For e.g. $,Biểu tượng đồng tiền này. Ví dụ như $
 apps/frappe/frappe/public/js/frappe/views/translation_manager.js,Successfully updated translations,Đã cập nhật thành công bản dịch
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,Phiên làm việc c
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",Trường này sẽ chỉ xuất hiện nếu fieldname định nghĩa ở đây có giá trị hoặc các quy định là đúng (ví dụ): myfield eval: doc.myfield == &#39;Giá trị của tôi&#39; eval: doc.age> 18
+eval:doc.age>18",Trường này sẽ chỉ xuất hiện nếu fieldname định nghĩa ở đây có giá trị hoặc các quy định là đúng (ví dụ): myfield eval: doc.myfield == 'Giá trị của tôi' eval: doc.age> 18
 DocType: Social Login Key,Office 365,Văn phòng 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hôm nay
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,Hôm nay
@@ -2169,7 +2169,7 @@ DocType: Data Migration Connector,Database Name,Tên cơ sở dữ liệu
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,Dạng làm mới
 DocType: DocField,Select,Chọn
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,Xem nhật ký đầy đủ
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Biểu thức Python đơn giản, Ví dụ: status == &#39;Open&#39; và gõ == &#39;Bug&#39;"
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'","Biểu thức Python đơn giản, Ví dụ: status == 'Open' và gõ == 'Bug'"
 apps/frappe/frappe/utils/csvutils.py,File not attached,File chưa được đính kèm
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,Kết nối bị mất. Một số tính năng có thể không hoạt động.
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",Lặp đi lặp lại như &quot;aaa&quot; rất dễ đoán
@@ -2784,7 +2784,7 @@ apps/frappe/frappe/email/doctype/email_account/email_account.py,Append To can be
 DocType: Customize Form,Image View,Xem hình ảnh
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,"Looks like something went wrong during the transaction. Since we haven't confirmed the payment, Paypal will automatically refund you this amount. If it doesn't, please send us an email and mention the Correlation ID: {0}.","Hình như cái gì đó đã đi sai trong quá trình giao dịch. Kể từ khi chúng tôi đã không xác nhận việc thanh toán, Paypal sẽ tự động trả lại bạn số tiền này. Nếu không, xin vui lòng gửi email cho chúng tôi và đề cập đến các ID tương quan: {0}."
 apps/frappe/frappe/public/js/frappe/form/controls/password.js,"Include symbols, numbers and capital letters in the password","Bao gồm các ký hiệu, số và chữ hoa trong mật khẩu"
-apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Chèn Sau trường &#39;{0}&#39; đề cập trong trường tùy chỉnh &#39;{1}&#39;, với nhãn &#39;{2}&#39;, không tồn tại"
+apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,"Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist","Chèn Sau trường '{0}' đề cập trong trường tùy chỉnh '{1}', với nhãn '{2}', không tồn tại"
 DocType: List Filter,List Filter,Lọc danh sách
 DocType: Workflow State,signal,tín hiệu
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,Has Attachments,Có tệp đính kèm
@@ -2794,7 +2794,7 @@ apps/frappe/frappe/templates/includes/comments/comments.py,Comment Should be atl
 apps/frappe/frappe/core/doctype/deleted_document/deleted_document.py,Document Restored,tài liệu được khôi phục
 DocType: Data Export,Data Export,Xuất dữ liệu
 apps/frappe/frappe/public/js/frappe/form/print.js,Select Language...,Chọn ngôn ngữ...
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Bạn không thể đặt &#39;Tùy chọn&#39; cho trường {0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You can't set 'Options' for field {0},Bạn không thể đặt 'Tùy chọn' cho trường {0}
 DocType: Help Article,Author,tác giả
 apps/frappe/frappe/email/doctype/email_queue/email_queue_list.js,Resume Sending,Tiếp tục gửi
 apps/frappe/frappe/core/doctype/communication/communication.js,Reopen,Mở cửa trở lại
@@ -2808,15 +2808,15 @@ DocType: Web Page,Slideshow,Ảnh Slideshow
 apps/frappe/frappe/contacts/doctype/address_template/address_template.py,Default Address Template cannot be deleted,Địa chỉ mặc định mẫu không thể bị xóa
 DocType: Contact,Maintenance Manager,Quản lý bảo trì
 DocType: Workflow State,Search,Tìm kiếm
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vui lòng chọn một phương thức thanh toán khác. Sọc không hỗ trợ giao dịch bằng tiền tệ &#39;{0}&#39;
-apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vui lòng chọn một phương thức thanh toán khác. Sọc không hỗ trợ giao dịch bằng tiền tệ &#39;{0}&#39;
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vui lòng chọn một phương thức thanh toán khác. Sọc không hỗ trợ giao dịch bằng tiền tệ '{0}'
+apps/frappe/frappe/integrations/doctype/stripe_settings/stripe_settings.py,Please select another payment method. Stripe does not support transactions in currency '{0}',Vui lòng chọn một phương thức thanh toán khác. Sọc không hỗ trợ giao dịch bằng tiền tệ '{0}'
 apps/frappe/frappe/core/doctype/communication/communication.js,Move To Trash,Di chuyển vào thùng rác
 DocType: Web Form,Web Form Fields,Các đoạn mẫu web
 DocType: Data Import,Amended From,Sửa đổi Từ
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},Cảnh báo: Không thể tìm thấy {0} trong bất kỳ bảng liên quan đến {1}
 DocType: S3 Backup Settings,eu-north-1,eu-bắc-1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,Tài liệu này hiện đang chờ để thực hiện. Vui lòng thử lại
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File &#39;{0}&#39; không tìm thấy
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,File '{0}' không tìm thấy
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,Xóa đoạn
 DocType: User,Change Password,Đổi mật khẩu
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,Trục X
@@ -3007,7 +3007,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,Giá trị mất tí
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,Thêm mẫu con
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,Tiến độ nhập khẩu
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",Nếu điều kiện được thỏa mãn người dùng sẽ được thưởng điểm. ví dụ. doc.status == &#39;Đã đóng&#39;
+",Nếu điều kiện được thỏa mãn người dùng sẽ được thưởng điểm. ví dụ. doc.status == 'Đã đóng'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}:đã đệ trình bản ghi không thể xóa
 DocType: GSuite Templates,Template Name,Tên mẫu
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,loại tài liệu mới
@@ -3140,7 +3140,7 @@ DocType: Dashboard Chart,Chart Type,Loại biểu đồ
 DocType: DocType,Auto Name,Tên tự động
 apps/frappe/frappe/utils/password_strength.py,Avoid sequences like abc or 6543 as they are easy to guess,Tránh trình tự như abc hay 6543 khi họ rất dễ đoán
 apps/frappe/frappe/public/js/frappe/request.js,Please try again,Vui lòng thử lại
-apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL phải bắt đầu bằng &#39;http: //&#39; hoặc &#39;https: //&#39;
+apps/frappe/frappe/core/doctype/file/file.py,URL must start with 'http://' or 'https://',URL phải bắt đầu bằng 'http: //' hoặc 'https: //'
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js,Option 3,Lựa chọn 3
 DocType: Communication,uid,uid
 DocType: Workflow State,Edit,Sửa
@@ -3380,7 +3380,7 @@ DocType: Notification,Send alert if this field's value changes,Gửi cảnh báo
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,Màu sắc chủ đề
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,Chọn một DOCTYPE để thực hiện một định dạng mới
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,người dùng không tồn tại
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;Người nhận&#39; không được chỉ định
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'Người nhận' không được chỉ định
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,vừa mới đây
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Ứng dụng
 DocType: Footer Item,Policy,chính sách
@@ -3892,7 +3892,7 @@ apps/frappe/frappe/public/js/frappe/form/templates/form_sidebar.html,Currently V
 DocType: DocField,Default,Mặc định
 DocType: Translation,Verified,Đã xác minh
 apps/frappe/frappe/public/js/frappe/form/link_selector.js,{0} added,{0}đã thêm
-apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Tìm kiếm &#39;{0}&#39;
+apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,Search for '{0}',Tìm kiếm '{0}'
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Please save the report first,Hãy lưu lại báo cáo đầu tiên
 apps/frappe/frappe/email/doctype/email_group/email_group.py,{0} subscribers added,{0}người đăng ký đã được thêm
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not In,Không chứa

--- a/frappe/translations/zh-TW.csv
+++ b/frappe/translations/zh-TW.csv
@@ -1095,7 +1095,7 @@ DocType: User,System User,系統用戶
 DocType: Report,Is Standard,為標準
 DocType: Desktop Icon,_report,_報告
 DocType: Desktop Icon,_report,_報告
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如&lt;SCRIPT>或者就像字符&lt;或>，因為他們可以在此字段中故意使用
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如<SCRIPT>或者就像字符<或>，因為他們可以在此字段中故意使用
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +278,Specify a default value,指定一個預設值
 DocType: Website Settings,FavIcon,網站圖標
 apps/frappe/frappe/core/doctype/feedback_trigger/feedback_trigger.py +116,At least one reply is mandatory before requesting feedback,至少有一個答复要求得到反饋前強制性
@@ -1763,7 +1763,7 @@ DocType: Payment Gateway,Gateway,網關
 apps/frappe/frappe/public/js/frappe/form/linked_with.js +104,Not enough permission to see links,沒有足夠的權限查看鏈接
 apps/frappe/frappe/public/js/frappe/form/linked_with.js +104,Not enough permission to see links,沒有足夠的權限查看鏈接
 apps/frappe/frappe/contacts/doctype/address/address.py +37,Address Title is mandatory.,地址標題是強制性的。
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",在&lt;head>添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",在<head>添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js +9,Relapsed,復發
 apps/frappe/frappe/utils/nestedset.py +183,Item cannot be added to its own descendents,項目不能被添加到自己的後代
 DocType: System Settings,Expiry time of QR Code Image Page,QR碼圖像頁面的到期時間
@@ -2354,7 +2354,7 @@ DocType: Workflow State,arrow-up,向上箭頭
 DocType: OAuth Bearer Token,Expires In,過期日期在
 DocType: DocField,Allow on Submit,允許在提交
 DocType: Error Snapshot,Exception Type,異常類型
-DocType: Web Page,Add code as &lt;script>,添加源碼為&lt;script>
+DocType: Web Page,Add code as <script>,添加源碼為<script>
 DocType: Webhook,Headers,頭
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js +35,Please enter values for App Access Key and App Secret Key,為App訪問鍵和App保密密鑰請輸入值
 apps/frappe/frappe/config/core.py +62,A log of request errors,日誌請求錯誤的
@@ -2636,15 +2636,15 @@ DocType: Workflow State,share-alt,股份ALT
 apps/frappe/frappe/utils/background_jobs.py +216,Queue should be one of {0},隊列應該是{0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4>默認模板</ H4> 
  <p> <a用途神社href=""http://jinja.pocoo.org/docs/templates/"">模板</A>和地址的所有領域（包括自定義字段如果有的話）將可</ P> 
  <前> <代碼> {{address_line1}}＆LT; BR＆GT; 

--- a/frappe/translations/zh-TW.csv
+++ b/frappe/translations/zh-TW.csv
@@ -194,7 +194,7 @@ apps/frappe/frappe/core/doctype/report/report.js +37,Disable Report,禁用報告
 DocType: Website Theme,Apply Text Styles,應用文本樣式
 apps/frappe/frappe/www/feedback.html +34,Detailed feedback,詳細的反饋
 DocType: Data Migration Mapping,Pull,拉
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript的格式：frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript的格式：frappe.query_reports ['REPORTNAME'] = {}
 DocType: Workflow State,chevron-up,人字形-上
 DocType: DocType,Allow Guest to View,允許訪客查看
 apps/frappe/frappe/public/js/frappe/ui/toolbar/navbar.html +58,Documentation,文檔
@@ -814,7 +814,7 @@ DocType: Kanban Board Column,Blue,藍色
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +168,All customizations will be removed. Please confirm.,所有自定義都將被刪除。請確認。
 DocType: Page,Page HTML,頁面的HTML
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py +68,Group name cannot be empty.,組名不能為空。
-apps/frappe/frappe/public/js/frappe/views/treeview.js +295,Further nodes can be only created under 'Group' type nodes,此外節點可以在&#39;集團&#39;類型的節點上創建
+apps/frappe/frappe/public/js/frappe/views/treeview.js +295,Further nodes can be only created under 'Group' type nodes,此外節點可以在'集團'類型的節點上創建
 DocType: SMS Parameter,Header,頁首
 apps/frappe/frappe/public/js/frappe/model/model.js +90,Unknown Column: {0},未知專欄： {0}
 DocType: Notification Recipient,Email By Role,電子郵件按角色
@@ -1505,7 +1505,7 @@ apps/frappe/frappe/core/doctype/communication/email.py +151,Leave this conversat
 apps/frappe/frappe/model/base_document.py +444,Options not set for link field {0},對於鏈接欄位沒有設置選項{0}
 DocType: Customize Form,"Must be of type ""Attach Image""",類型必須為“附加圖片”
 apps/frappe/frappe/core/doctype/data_import/data_import.js +220,Unselect All,全部取消選擇
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +208,You cannot unset 'Read Only' for field {0},你不能沒有設置&#39;只讀&#39;現場{0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py +208,You cannot unset 'Read Only' for field {0},你不能沒有設置'只讀'現場{0}
 DocType: Auto Email Report,Zero means send records updated at anytime,零表示隨時更新發送記錄
 DocType: Auto Email Report,Zero means send records updated at anytime,零表示隨時更新發送記錄
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js +55,Complete Setup,完成安裝
@@ -1615,7 +1615,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,連線過期的小�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield ==&#39;我的價值&#39;的eval：doc.age> 18
+eval:doc.age>18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield =='我的價值'的eval：doc.age> 18
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +35,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",一旦你設置這個，用戶將只能訪問有聯結的文檔（如博客文章）。
 DocType: Error Log,Log of Scheduler Errors,日程安排程序錯誤日誌
 DocType: User,Bio,生物
@@ -2674,7 +2674,7 @@ DocType: User,Allow user to login only after this hour (0-24),允許用戶在幾
 DocType: Integration Request,Subscription Notification,訂閱通知
 DocType: Auto Repeat,Start Date,開始日期
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py +171,Click here to verify,點擊這裡核實
-apps/frappe/frappe/utils/password_strength.py +202,Predictable substitutions like '@' instead of 'a' don't help very much.,可預見的替換像&#39;@&#39;而不是&#39;一&#39;不要太大幫助。
+apps/frappe/frappe/utils/password_strength.py +202,Predictable substitutions like '@' instead of 'a' don't help very much.,可預見的替換像'@'而不是'一'不要太大幫助。
 apps/frappe/frappe/desk/doctype/todo/todo_list.js +22,Assigned By Me,指定由我
 apps/frappe/frappe/core/doctype/doctype/doctype.py +102,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,不是在開發模式！坐落在site_config.json或進行“自定義”的DocType。
 DocType: Workflow State,globe,地球
@@ -2712,7 +2712,7 @@ DocType: Notification,Reference Date,參考日期
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py +28,Please enter valid mobile nos,請輸入有效的手機號
 apps/frappe/frappe/public/js/frappe/desk.js +18,Some of the features might not work in your browser. Please update your browser to the latest version.,您的瀏覽器中的某些功能可能無法正常工作。請將您的瀏覽器更新到最新版本。
 apps/frappe/frappe/public/js/frappe/desk.js +18,Some of the features might not work in your browser. Please update your browser to the latest version.,您的瀏覽器中的某些功能可能無法正常工作。請將您的瀏覽器更新到最新版本。
-apps/frappe/frappe/utils/bot.py +185,"Don't know, ask 'help'",不知道，問&#39;幫助&#39;
+apps/frappe/frappe/utils/bot.py +185,"Don't know, ask 'help'",不知道，問'幫助'
 DocType: DocType,Comments and Communications will be associated with this linked document,評論與通訊將與此鏈接的文檔關聯
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html +3,Filter...,過濾器...
 DocType: Workflow State,bold,粗體

--- a/frappe/translations/zh-TW.csv
+++ b/frappe/translations/zh-TW.csv
@@ -1095,7 +1095,7 @@ DocType: User,System User,系統用戶
 DocType: Report,Is Standard,為標準
 DocType: Desktop Icon,_report,_報告
 DocType: Desktop Icon,_report,_報告
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如&lt;SCRIPT&gt;或者就像字符&lt;或&gt;，因為他們可以在此字段中故意使用
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如&lt;SCRIPT>或者就像字符&lt;或>，因為他們可以在此字段中故意使用
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +278,Specify a default value,指定一個預設值
 DocType: Website Settings,FavIcon,網站圖標
 apps/frappe/frappe/core/doctype/feedback_trigger/feedback_trigger.py +116,At least one reply is mandatory before requesting feedback,至少有一個答复要求得到反饋前強制性
@@ -1615,7 +1615,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,連線過期的小�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield ==&#39;我的價值&#39;的eval：doc.age&gt; 18
+eval:doc.age>18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield ==&#39;我的價值&#39;的eval：doc.age> 18
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html +35,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",一旦你設置這個，用戶將只能訪問有聯結的文檔（如博客文章）。
 DocType: Error Log,Log of Scheduler Errors,日程安排程序錯誤日誌
 DocType: User,Bio,生物
@@ -1763,7 +1763,7 @@ DocType: Payment Gateway,Gateway,網關
 apps/frappe/frappe/public/js/frappe/form/linked_with.js +104,Not enough permission to see links,沒有足夠的權限查看鏈接
 apps/frappe/frappe/public/js/frappe/form/linked_with.js +104,Not enough permission to see links,沒有足夠的權限查看鏈接
 apps/frappe/frappe/contacts/doctype/address/address.py +37,Address Title is mandatory.,地址標題是強制性的。
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",在&lt;head&gt;添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",在&lt;head>添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js +9,Relapsed,復發
 apps/frappe/frappe/utils/nestedset.py +183,Item cannot be added to its own descendents,項目不能被添加到自己的後代
 DocType: System Settings,Expiry time of QR Code Image Page,QR碼圖像頁面的到期時間
@@ -2354,7 +2354,7 @@ DocType: Workflow State,arrow-up,向上箭頭
 DocType: OAuth Bearer Token,Expires In,過期日期在
 DocType: DocField,Allow on Submit,允許在提交
 DocType: Error Snapshot,Exception Type,異常類型
-DocType: Web Page,Add code as &lt;script&gt;,添加源碼為&lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,添加源碼為&lt;script>
 DocType: Webhook,Headers,頭
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.js +35,Please enter values for App Access Key and App Secret Key,為App訪問鍵和App保密密鑰請輸入值
 apps/frappe/frappe/config/core.py +62,A log of request errors,日誌請求錯誤的
@@ -2386,7 +2386,7 @@ apps/frappe/frappe/utils/password_strength.py +125,Avoid sequences like abc or 6
 apps/frappe/frappe/public/js/frappe/request.js +144,Please try again,請再試一次
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.js +63,Option 3,選項3
 DocType: Workflow State,Edit,編輯
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup &gt; Role Permissions Manager,權限可以通過設置＆gt進行管理;角色權限管理
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.js +229,Permissions can be managed via Setup > Role Permissions Manager,權限可以通過設置＆gt進行管理;角色權限管理
 DocType: Website Settings,Chat Operators,聊天運營商
 DocType: Contact Us Settings,Pincode,PIN代碼
 apps/frappe/frappe/core/doctype/data_import/importer.py +106,Please make sure that there are no empty columns in the file.,請確保沒有空欄在文件中。
@@ -2636,15 +2636,15 @@ DocType: Workflow State,share-alt,股份ALT
 apps/frappe/frappe/utils/background_jobs.py +216,Queue should be one of {0},隊列應該是{0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4>默認模板</ H4> 
  <p> <a用途神社href=""http://jinja.pocoo.org/docs/templates/"">模板</A>和地址的所有領域（包括自定義字段如果有的話）將可</ P> 
  <前> <代碼> {{address_line1}}＆LT; BR＆GT; 

--- a/frappe/translations/zh.csv
+++ b/frappe/translations/zh.csv
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,是否为标准
 DocType: Desktop Icon,_report,_报告
 DocType: Desktop Icon,_report,_报告
 DocType: Dashboard Chart,Full,充分
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",不要HTML编码的HTML标签，如&lt;SCRIPT>或者就像字符&lt;或>，因为他们可以在此字段中故意使用
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",不要HTML编码的HTML标签，如<SCRIPT>或者就像字符<或>，因为他们可以在此字段中故意使用
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}批评{1}
 DocType: Website Settings,FavIcon,网站图标
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,跑
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,页脚仅以PDF�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,有待
 DocType: System Settings,Allow only one session per user,允许每个用户只有一个会话
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,主页/测试文件夹1 /测试文件夹3
-DocType: Website Settings,&lt;head> HTML,&lt;HEAD> HTML
+DocType: Website Settings,<head> HTML,<HEAD> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,选择或拖动整个时隙，以创建一个新的事件。
 DocType: Contact,Contact Details,联系人信息
 DocType: DocField,In Filter,在过滤器中
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,没有足够的权限查看链接
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,地址标题是必须项。
 DocType: Google Contacts,Push to Google Contacts,推送到Google通讯录
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",在&lt;head>添加HTML网页的部分，主要用于网站的验证和搜索引擎优化
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",在<head>添加HTML网页的部分，主要用于网站的验证和搜索引擎优化
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,复发
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,项目不能被添加到自己的后代
 DocType: Session Default Settings,Session Defaults,会话默认值
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,警告
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,这可能会打印在多个页面上
 DocType: Data Migration Run,Percent Complete,完成百分比
 DocType: Tag Category,Tag Category,标签类别
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",为了进行比较，请使用> 5，&lt;10或= 324。对于范围，请使用5:10（对于5到10之间的值）。
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",为了进行比较，请使用> 5，<10或= 324。对于范围，请使用5:10（对于5到10之间的值）。
 DocType: Google Calendar,Pull from Google Calendar,从Google日历中提取
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,帮助
 DocType: User,Login Before,登录前
@@ -3103,7 +3103,7 @@ DocType: DocField,Allow on Submit,允许提交
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,异常类型
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,摘列
-DocType: Web Page,Add code as &lt;script>,添加为script标签
+DocType: Web Page,Add code as <script>,添加为script标签
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,清除用户权限
 DocType: Webhook,Headers,头
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,即将举行的活动
@@ -3480,15 +3480,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},队列应该是{0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4>默认模板</ H4> 
  <p> <a用途神社href=""http://jinja.pocoo.org/docs/templates/"">模板</A>和地址的所有领域（包括自定义字段如果有的话）将可</ P> 
  <前> <代码> {{address_line1}}＆LT; BR＆GT; 

--- a/frappe/translations/zh.csv
+++ b/frappe/translations/zh.csv
@@ -2169,7 +2169,7 @@ DocType: Data Migration Connector,Database Name,数据库名称
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,刷新表格
 DocType: DocField,Select,选择
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,查看完整日志
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",简单的Python表达式，例如：status ==&#39;Open&#39;并输入==&#39;Bug&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",简单的Python表达式，例如：status =='Open'并输入=='Bug'
 apps/frappe/frappe/utils/csvutils.py,File not attached,文件未附加
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,连接丢失。某些功能可能无法使用。
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",像“AAA”重复很容易被猜到
@@ -2817,7 +2817,7 @@ DocType: Data Import,Amended From,修订源
 apps/frappe/frappe/public/js/frappe/model/meta.js,Warning: Unable to find {0} in any table related to {1},警告：无法找到{0}与任何表{1}
 DocType: S3 Backup Settings,eu-north-1,欧盟 - 北 -  1
 apps/frappe/frappe/model/document.py,This document is currently queued for execution. Please try again,这份文件目前正在排队等待执行。请再试一次
-apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,文件&#39;{0}&#39;未找到
+apps/frappe/frappe/core/doctype/file/file.py,File '{0}' not found,文件'{0}'未找到
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Remove Section,删除部分
 DocType: User,Change Password,更改密码
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,X Axis Field,X轴字段
@@ -3008,7 +3008,7 @@ apps/frappe/frappe/model/base_document.py,Value missing for,缺少值
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,添加子项
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,进口进度
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",如果条件满足，用户将获得积分奖励。例如。 doc.status ==&#39;已关闭&#39;
+",如果条件满足，用户将获得积分奖励。例如。 doc.status =='已关闭'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}：提交记录不能被删除。
 DocType: GSuite Templates,Template Name,模板名称
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,新类型的文件
@@ -3381,7 +3381,7 @@ DocType: Notification,Send alert if this field's value changes,如果这个字�
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,主题色彩
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,请选择新格式的原始文档类型
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,用户不存在
-apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,&#39;收件人&#39;未指定
+apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,'收件人'未指定
 apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,刚刚
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,应用
 DocType: Footer Item,Policy,政策
@@ -3531,7 +3531,7 @@ DocType: Dashboard Chart,Filters JSON,过滤JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,点击这里核实
 DocType: Email Account,Disable SMTP server authentication,禁用SMTP服务器验证
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,复制到剪贴板。
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,可预见的替换像&#39;@&#39;而不是&#39;一&#39;不要太大帮助。
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,可预见的替换像'@'而不是'一'不要太大帮助。
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,由我指定
 apps/frappe/frappe/utils/data.py,Zero,零
 DocType: Google Drive,Backup Folder ID,备份文件夹ID
@@ -3585,7 +3585,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,请输入有效的手机号
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,您的浏览器中的某些功能可能无法正常工作。请将您的浏览器更新到最新版本。
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,您的浏览器中的某些功能可能无法正常工作。请将您的浏览器更新到最新版本。
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",不知道，问&#39;帮助&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",不知道，问'帮助'
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},取消了此文档{0}
 DocType: DocType,Comments and Communications will be associated with this linked document,评论与通讯将与此链接的文档关联
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,过滤器...

--- a/frappe/translations/zh.csv
+++ b/frappe/translations/zh.csv
@@ -749,7 +749,7 @@ apps/frappe/frappe/desk/page/backups/backups.py,File backup is ready,文件备�
 DocType: DocField,In Global Search,在全局搜索
 DocType: System Settings,Brute Force Security,蛮力安全
 DocType: Workflow State,indent-left,靠左缩进
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0}年之前
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,> {0} year(s) ago,> {0}年之前
 apps/frappe/frappe/utils/file_manager.py,It is risky to delete this file: {0}. Please contact your System Manager.,删除这个文件是有风险的：{0}。请联系您的系统管理员。
 DocType: Currency,Currency Name,货币名称
 apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No Emails,没有电子邮件
@@ -1047,7 +1047,7 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,没有找到{
 apps/frappe/frappe/config/customization.py,Add custom forms.,添加自定义表单。
 apps/frappe/frappe/desk/like.py,{0}: {1} in {2},{0}：{1}在{2}
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,提交这份文件
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,设置&gt;用户权限
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,设置>用户权限
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,该系统提供了许多预先定义的角色。您可以添加新的角色设定更精细的权限。
 DocType: Communication,CC,抄送
 DocType: Country,Geo,GEO
@@ -1268,7 +1268,7 @@ apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",如果用户有任何检查的作用，那么用户就变成了“系统用户”。 “系统用户”访问桌面
 DocType: System Settings,Date and Number Format,日期和数字格式
 apps/frappe/frappe/model/document.py,one of,其中
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,设置&gt;自定义表格
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,设置>自定义表格
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,检查一个时刻
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,显示标签
 DocType: DocField,HTML Editor,HTML编辑器
@@ -1276,7 +1276,7 @@ DocType: System Settings,"If Apply Strict User Permission is checked and User Pe
 DocType: Address,Billing,账单
 DocType: Email Queue,Not Sent,未发送
 DocType: Web Form,Actions,操作
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,设置&gt;用户
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,设置>用户
 DocType: Workflow State,align-justify,段落两端对齐
 DocType: User,Middle Name (Optional),中间名（可选）
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,不允许
@@ -1425,7 +1425,7 @@ DocType: Report,Is Standard,是否为标准
 DocType: Desktop Icon,_report,_报告
 DocType: Desktop Icon,_report,_报告
 DocType: Dashboard Chart,Full,充分
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",不要HTML编码的HTML标签，如&lt;SCRIPT&gt;或者就像字符&lt;或&gt;，因为他们可以在此字段中故意使用
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",不要HTML编码的HTML标签，如&lt;SCRIPT>或者就像字符&lt;或>，因为他们可以在此字段中故意使用
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}批评{1}
 DocType: Website Settings,FavIcon,网站图标
 apps/frappe/frappe/data_migration/doctype/data_migration_plan/data_migration_plan.js,Run,跑
@@ -1807,7 +1807,7 @@ DocType: Letter Head,Footer will display correctly only in PDF,页脚仅以PDF�
 apps/frappe/frappe/core/doctype/data_import/data_import_list.js,Pending,有待
 DocType: System Settings,Allow only one session per user,允许每个用户只有一个会话
 apps/frappe/frappe/core/doctype/file/test_file.py,Home/Test Folder 1/Test Folder 3,主页/测试文件夹1 /测试文件夹3
-DocType: Website Settings,&lt;head&gt; HTML,&lt;HEAD&gt; HTML
+DocType: Website Settings,&lt;head> HTML,&lt;HEAD> HTML
 apps/frappe/frappe/public/js/frappe/views/calendar/calendar.js,Select or drag across time slots to create a new event.,选择或拖动整个时隙，以创建一个新的事件。
 DocType: Contact,Contact Details,联系人信息
 DocType: DocField,In Filter,在过滤器中
@@ -2040,7 +2040,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,不允许在这个时候登录
 DocType: Data Migration Run,Current Mapping Action,当前映射行为
 DocType: Dashboard Chart Source,Source Name,源名称
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,没有与该用户关联的电子邮件帐户。请在“用户”&gt;“电子邮件收件箱”下添加一个帐户。
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,没有与该用户关联的电子邮件帐户。请在“用户”>“电子邮件收件箱”下添加一个帐户。
 DocType: Email Account,Email Sync Option,电子邮件同步选项
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,行号
 DocType: Async Task,Runtime,运行
@@ -2055,7 +2055,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,已经在
 DocType: User Email,Enable Outgoing,通过该邮箱发送邮件
 DocType: Address,Fax,传真
 apps/frappe/frappe/config/customization.py,Custom Tags,自定义标记
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,电子邮件帐户未设置。请从设置&gt;电子邮件&gt;电子邮件帐户创建一个新的电子邮件帐户
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,电子邮件帐户未设置。请从设置>电子邮件>电子邮件帐户创建一个新的电子邮件帐户
 DocType: Comment,Submitted,已提交
 DocType: Contact,Pulled from Google Contacts,来自Google通讯录
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,非法请求
@@ -2129,7 +2129,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,会话过期的时�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",该字段只有在此处定义的字段名具有值或规则是真时才显示（例子）：myfield eval:doc.myfield=='My Value' eval:doc.age&gt;18
+eval:doc.age>18",该字段只有在此处定义的字段名具有值或规则是真时才显示（例子）：myfield eval:doc.myfield=='My Value' eval:doc.age>18
 DocType: Social Login Key,Office 365,Office 365
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,今天
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,Today,今天
@@ -2144,7 +2144,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,大写字母
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,自定义HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,输入文件夹名称
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,找不到默认的地址模板。请从设置&gt;打印和品牌&gt;地址模板中创建一个新地址。
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,找不到默认的地址模板。请从设置>打印和品牌>地址模板中创建一个新地址。
 apps/frappe/frappe/auth.py,Unknown User,未知用户
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,选择角色
 DocType: Comment,Deleted,已删除
@@ -2335,7 +2335,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,没有足够的权限查看链接
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,地址标题是必须项。
 DocType: Google Contacts,Push to Google Contacts,推送到Google通讯录
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",在&lt;head&gt;添加HTML网页的部分，主要用于网站的验证和搜索引擎优化
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",在&lt;head>添加HTML网页的部分，主要用于网站的验证和搜索引擎优化
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,复发
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,项目不能被添加到自己的后代
 DocType: Session Default Settings,Session Defaults,会话默认值
@@ -2455,7 +2455,7 @@ DocType: Workflow State,Warning,警告
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,这可能会打印在多个页面上
 DocType: Data Migration Run,Percent Complete,完成百分比
 DocType: Tag Category,Tag Category,标签类别
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",为了进行比较，请使用&gt; 5，&lt;10或= 324。对于范围，请使用5:10（对于5到10之间的值）。
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",为了进行比较，请使用> 5，&lt;10或= 324。对于范围，请使用5:10（对于5到10之间的值）。
 DocType: Google Calendar,Pull from Google Calendar,从Google日历中提取
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,帮助
 DocType: User,Login Before,登录前
@@ -2924,7 +2924,7 @@ DocType: Custom Script,Custom Script,自定义脚本
 DocType: Address,Address Line 2,地址行2
 DocType: Address,Reference,参考
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,已分配给
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,请从设置&gt;电子邮件&gt;电子邮件帐户设置默认的电子邮件帐户
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,请从设置>电子邮件>电子邮件帐户设置默认的电子邮件帐户
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,数据迁移映射细节
 DocType: Data Import,Action,行动
 DocType: GSuite Settings,Script URL,脚本网址
@@ -3103,7 +3103,7 @@ DocType: DocField,Allow on Submit,允许提交
 DocType: DocField,HTML,HTML
 DocType: Error Snapshot,Exception Type,异常类型
 apps/frappe/frappe/public/js/frappe/views/reports/report_view.js,Pick Columns,摘列
-DocType: Web Page,Add code as &lt;script&gt;,添加为script标签
+DocType: Web Page,Add code as &lt;script>,添加为script标签
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,清除用户权限
 DocType: Webhook,Headers,头
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,即将举行的活动
@@ -3480,15 +3480,15 @@ DocType: Workflow State,share-alt,share-alt
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},队列应该是{0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4>默认模板</ H4> 
  <p> <a用途神社href=""http://jinja.pocoo.org/docs/templates/"">模板</A>和地址的所有领域（包括自定义字段如果有的话）将可</ P> 
  <前> <代码> {{address_line1}}＆LT; BR＆GT; 

--- a/frappe/translations/zh_tw.csv
+++ b/frappe/translations/zh_tw.csv
@@ -710,7 +710,7 @@ apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Scheduled to send to {
 apps/frappe/frappe/public/js/frappe/ui/keyboard.js,Page Shortcuts,頁面快捷方式
 DocType: DocShare,Everyone,大家
 DocType: Workflow State,backward,落後
-apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Only one rule allowed with the same Role, Level and {1}",{0}：只具允許有一個同的角色，級別和{1}
+apps/frappe/frappe/core/doctype/doctype/doctype.py,"{0}: Only one rule allowed with the same Role, Level and {1}",{0}：���具允許有一個同的角色，級別和{1}
 DocType: Email Queue,Add Unsubscribe Link,添加退訂鏈接
 apps/frappe/frappe/templates/includes/comments/comments.html,No comments yet. Start a new discussion.,還沒有評論。開始一個新的討論。
 apps/frappe/frappe/config/settings.py,Set numbering series for transactions.,設置編號系列交易。
@@ -902,7 +902,7 @@ DocType: Dropbox Settings,File Backup,文件備份
 apps/frappe/frappe/public/js/frappe/list/list_view.js,No {0} found,沒有找到{0}
 apps/frappe/frappe/config/customization.py,Add custom forms.,添加自定義表單。
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,submitted this document,提交這份文件
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User Permissions,設置&gt;用戶權限
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User Permissions,設置>用戶權限
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,The system provides many pre-defined roles. You can add new roles to set finer permissions.,該系統提供了許多預先定義的角色。您可以添加新的角色設定更精細的權限。
 DocType: Communication,CC,CC
 DocType: Data Migration Run,Trigger Name,觸發器名稱
@@ -1104,14 +1104,14 @@ DocType: Transaction Log,Chaining Hash,鏈接哈希
 apps/frappe/frappe/contacts/doctype/contact/contact.py,Please set Email Address,請設置電子郵件地址
 DocType: User,"If the user has any role checked, then the user becomes a ""System User"". ""System User"" has access to the desktop",如果用戶有任何檢查的作用，那麼用戶就變成了“系統用戶”。 “系統用戶”訪問桌面
 DocType: System Settings,Date and Number Format,日期和數字格式
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; Customize Form,設置&gt;自定義表格
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > Customize Form,設置>自定義表格
 apps/frappe/frappe/public/js/frappe/desk.js,Checking one moment,檢查一個時刻
 apps/frappe/frappe/public/js/frappe/list/list_sidebar.html,Show Tags,顯示標籤
 DocType: DocField,HTML Editor,HTML編輯器
 DocType: System Settings,"If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User",如果選中了“嚴格用戶權限”，並為用戶定義了“用戶權限”，則該鏈接的值為空的所有文檔將不會顯示給該用戶
 DocType: Address,Billing,計費
 DocType: Email Queue,Not Sent,未發送
-apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup &gt; User,設置&gt;用戶
+apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Setup > User,設置>用戶
 DocType: Workflow State,align-justify,對齊對齊
 DocType: User,Middle Name (Optional),中間名（可選）
 apps/frappe/frappe/public/js/frappe/request.js,Not Permitted,不允許
@@ -1238,7 +1238,7 @@ DocType: User,System User,系統用戶
 DocType: Report,Is Standard,為標準
 DocType: Desktop Icon,_report,_報告
 DocType: Desktop Icon,_report,_報告
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如&lt;SCRIPT&gt;或者就像字符&lt;或&gt;，因為他們可以在此字段中故意使用
+DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如&lt;SCRIPT>或者就像字符&lt;或>，因為他們可以在此字段中故意使用
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}批評{1}
 DocType: Website Settings,FavIcon,網站圖標
 DocType: Blog Post,Content (HTML),內容（HTML）
@@ -1762,7 +1762,7 @@ apps/frappe/frappe/website/doctype/personal_data_deletion_request/personal_data_
 apps/frappe/frappe/auth.py,Login not allowed at this time,在這個時候不允許登錄
 DocType: Data Migration Run,Current Mapping Action,當前映射行為
 DocType: Dashboard Chart Source,Source Name,源名稱
-apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User &gt; Email Inbox.,沒有與該用戶關聯的電子郵件帳戶。請在“用戶”&gt;“電子郵件收件箱”下添加一個帳戶。
+apps/frappe/frappe/public/js/frappe/views/inbox/inbox_view.js,No email account associated with the User. Please add an account under User > Email Inbox.,沒有與該用戶關聯的電子郵件帳戶。請在“用戶”>“電子郵件收件箱”下添加一個帳戶。
 DocType: Email Account,Email Sync Option,電子郵件同步選項
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row No,行號
 DocType: Async Task,Runtime,運行時
@@ -1775,7 +1775,7 @@ apps/frappe/frappe/desk/form/assign_to.py,Already in user's To Do list,已經在
 DocType: User Email,Enable Outgoing,啟用外
 DocType: Address,Fax,傳真
 apps/frappe/frappe/config/customization.py,Custom Tags,自定義標記
-apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup &gt; Email &gt; Email Account,電子郵件帳戶未設置。請從設置&gt;電子郵件&gt;電子郵件帳戶創建一個新的電子郵件帳戶
+apps/frappe/frappe/email/smtp.py,Email Account not setup. Please create a new Email Account from Setup > Email > Email Account,電子郵件帳戶未設置。請從設置>電子郵件>電子郵件帳戶創建一個新的電子郵件帳戶
 DocType: Comment,Submitted,提交
 DocType: Contact,Pulled from Google Contacts,來自Google通訊錄
 apps/frappe/frappe/integrations/doctype/paypal_settings/paypal_settings.py,In Valid Request,非法請求
@@ -1840,7 +1840,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,連線過期的小�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age&gt;18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield ==&#39;我的價值&#39;的eval：doc.age&gt; 18
+eval:doc.age>18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield ==&#39;我的價值&#39;的eval：doc.age> 18
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",一旦你設置這個，用戶將只能訪問有聯結的文檔（如博客文章）。
 DocType: Data Import Beta,Submit After Import,導入後提交
 DocType: Error Log,Log of Scheduler Errors,日程安排程序錯誤日誌
@@ -1851,7 +1851,7 @@ apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py,Google Driv
 DocType: DocType,UPPER CASE,大寫字母
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Custom HTML,自定義HTML
 apps/frappe/frappe/public/js/frappe/views/file/file_view.js,Enter folder name,輸入文件夾名稱
-apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup &gt; Printing and Branding &gt; Address Template.,找不到默認的地址模板。請從設置&gt;打印和品牌&gt;地址模板中創建一個新地址。
+apps/frappe/frappe/contacts/doctype/address/address.py,No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template.,找不到默認的地址模板。請從設置>打印和品牌>地址模板中創建一個新地址。
 apps/frappe/frappe/auth.py,Unknown User,未知用戶
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Role,選擇角色
 DocType: Comment,Deleted,刪除
@@ -2019,7 +2019,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,沒有足夠的權限查看鏈接
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,地址標題是強制性的。
 DocType: Google Contacts,Push to Google Contacts,推送到Google通訊錄
-DocType: Website Settings,"Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO",在&lt;head&gt;添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
+DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",在&lt;head>添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,復發
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,項目不能被添加到自己的後代
 DocType: Session Default Settings,Session Defaults,會話默認值
@@ -2127,7 +2127,7 @@ DocType: Deleted Document,Deleted DocType,刪除的DocType
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permission Levels,權限級別
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,這可能會打印在多個頁面上
 DocType: Tag Category,Tag Category,標籤分類
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use &gt;5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",為了進行比較，請使用&gt; 5，&lt;10或= 324。對於範圍，請使用5:10（對於5到10之間的值）。
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",為了進行比較，請使用> 5，&lt;10或= 324。對於範圍，請使用5:10（對於5到10之間的值）。
 DocType: Google Calendar,Pull from Google Calendar,從Google日曆中提取
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,幫助
 DocType: User,Login Before,登錄前
@@ -2539,7 +2539,7 @@ apps/frappe/frappe/model/rename_doc.py,{0} not allowed to be renamed,{0}不允�
 DocType: Custom Script,Custom Script,自定義腳本
 DocType: Address,Reference,參考
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Assigned To,指派給
-apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup &gt; Email &gt; Email Account,請從設置&gt;電子郵件&gt;電子郵件帳戶設置默認的電子郵件帳戶
+apps/frappe/frappe/email/smtp.py,Please setup default Email Account from Setup > Email > Email Account,請從設置>電子郵件>電子郵件帳戶設置默認的電子郵件帳戶
 DocType: Data Migration Mapping Detail,Data Migration Mapping Detail,數據遷移映射細節
 DocType: Data Import,Action,行動
 DocType: GSuite Settings,Script URL,腳本網址
@@ -2692,7 +2692,7 @@ apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure A
 DocType: OAuth Bearer Token,Expires In,過期日期在
 DocType: DocField,Allow on Submit,允許在提交
 DocType: Error Snapshot,Exception Type,異常類型
-DocType: Web Page,Add code as &lt;script&gt;,添加源碼為&lt;script&gt;
+DocType: Web Page,Add code as &lt;script>,添加源碼為&lt;script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,清除用戶權限
 DocType: Webhook,Headers,頭
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,活動預告
@@ -3012,15 +3012,15 @@ DocType: Workflow State,share-alt,股份ALT
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},隊列應該是{0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br&gt;
-{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
-{{ city }}&lt;br&gt;
-{% if state %}{{ state }}&lt;br&gt;{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br&gt;{% endif -%}
-{{ country }}&lt;br&gt;
-{% if phone %}Phone: {{ phone }}&lt;br&gt;{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br&gt;{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br&gt;{% endif -%}
+<pre><code>{{ address_line1 }}&lt;br>
+{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
+{{ city }}&lt;br>
+{% if state %}{{ state }}&lt;br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
+{{ country }}&lt;br>
+{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
+{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
 </code></pre>","<H4>默認模板</ H4> 
  <p> <a用途神社href=""http://jinja.pocoo.org/docs/templates/"">模板</A>和地址的所有領域（包括自定義字段如果有的話）將可</ P> 
  <前> <代碼> {{address_line1}}＆LT; BR＆GT; 

--- a/frappe/translations/zh_tw.csv
+++ b/frappe/translations/zh_tw.csv
@@ -1238,7 +1238,7 @@ DocType: User,System User,系統用戶
 DocType: Report,Is Standard,為標準
 DocType: Desktop Icon,_report,_報告
 DocType: Desktop Icon,_report,_報告
-DocType: DocField,"Don't HTML Encode HTML tags like &lt;script> or just characters like &lt; or >, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如&lt;SCRIPT>或者就像字符&lt;或>，因為他們可以在此字段中故意使用
+DocType: DocField,"Don't HTML Encode HTML tags like <script> or just characters like < or >, as they could be intentionally used in this field",不要HTML編碼的HTML標籤，如<SCRIPT>或者就像字符<或>，因為他們可以在此字段中故意使用
 apps/frappe/frappe/public/js/frappe/utils/energy_point_utils.js,{0} criticized on {1},{0}批評{1}
 DocType: Website Settings,FavIcon,網站圖標
 DocType: Blog Post,Content (HTML),內容（HTML）
@@ -2019,7 +2019,7 @@ apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to
 apps/frappe/frappe/public/js/frappe/form/linked_with.js,Not enough permission to see links,沒有足夠的權限查看鏈接
 apps/frappe/frappe/contacts/doctype/address/address.py,Address Title is mandatory.,地址標題是強制性的。
 DocType: Google Contacts,Push to Google Contacts,推送到Google通訊錄
-DocType: Website Settings,"Added HTML in the &lt;head> section of the web page, primarily used for website verification and SEO",在&lt;head>添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
+DocType: Website Settings,"Added HTML in the <head> section of the web page, primarily used for website verification and SEO",在<head>添加HTML網頁的部分，主要用於網站的驗證和搜索引擎優化
 apps/frappe/frappe/core/doctype/error_snapshot/error_snapshot_list.js,Relapsed,復發
 apps/frappe/frappe/utils/nestedset.py,Item cannot be added to its own descendents,項目不能被添加到自己的後代
 DocType: Session Default Settings,Session Defaults,會話默認值
@@ -2127,7 +2127,7 @@ DocType: Deleted Document,Deleted DocType,刪除的DocType
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,Permission Levels,權限級別
 apps/frappe/frappe/public/js/frappe/form/print.js,This may get printed on multiple pages,這可能會打印在多個頁面上
 DocType: Tag Category,Tag Category,標籤分類
-apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, &lt;10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",為了進行比較，請使用> 5，&lt;10或= 324。對於範圍，請使用5:10（對於5到10之間的值）。
+apps/frappe/frappe/public/js/frappe/views/reports/query_report.js,"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 &amp; 10).",為了進行比較，請使用> 5，<10或= 324。對於範圍，請使用5:10（對於5到10之間的值）。
 DocType: Google Calendar,Pull from Google Calendar,從Google日曆中提取
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Help,幫助
 DocType: User,Login Before,登錄前
@@ -2692,7 +2692,7 @@ apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.js,"To configure A
 DocType: OAuth Bearer Token,Expires In,過期日期在
 DocType: DocField,Allow on Submit,允許在提交
 DocType: Error Snapshot,Exception Type,異常類型
-DocType: Web Page,Add code as &lt;script>,添加源碼為&lt;script>
+DocType: Web Page,Add code as <script>,添加源碼為<script>
 apps/frappe/frappe/core/doctype/user_permission/user_permission_list.js,Clear User Permissions,清除用戶權限
 DocType: Webhook,Headers,頭
 apps/frappe/frappe/public/js/frappe/social/components/ActivitySidebar.vue,Upcoming Events,活動預告
@@ -3012,15 +3012,15 @@ DocType: Workflow State,share-alt,股份ALT
 apps/frappe/frappe/utils/background_jobs.py,Queue should be one of {0},隊列應該是{0}
 DocType: Address Template,"<h4>Default Template</h4>
 <p>Uses <a href=""http://jinja.pocoo.org/docs/templates/"">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>
-<pre><code>{{ address_line1 }}&lt;br>
-{% if address_line2 %}{{ address_line2 }}&lt;br>{% endif -%}
-{{ city }}&lt;br>
-{% if state %}{{ state }}&lt;br>{% endif -%}
-{% if pincode %} PIN:  {{ pincode }}&lt;br>{% endif -%}
-{{ country }}&lt;br>
-{% if phone %}Phone: {{ phone }}&lt;br>{% endif -%}
-{% if fax %}Fax: {{ fax }}&lt;br>{% endif -%}
-{% if email_id %}Email: {{ email_id }}&lt;br>{% endif -%}
+<pre><code>{{ address_line1 }}<br>
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{{ city }}<br>
+{% if state %}{{ state }}<br>{% endif -%}
+{% if pincode %} PIN:  {{ pincode }}<br>{% endif -%}
+{{ country }}<br>
+{% if phone %}Phone: {{ phone }}<br>{% endif -%}
+{% if fax %}Fax: {{ fax }}<br>{% endif -%}
+{% if email_id %}Email: {{ email_id }}<br>{% endif -%}
 </code></pre>","<H4>默認模板</ H4> 
  <p> <a用途神社href=""http://jinja.pocoo.org/docs/templates/"">模板</A>和地址的所有領域（包括自定義字段如果有的話）將可</ P> 
  <前> <代碼> {{address_line1}}＆LT; BR＆GT; 

--- a/frappe/translations/zh_tw.csv
+++ b/frappe/translations/zh_tw.csv
@@ -222,7 +222,7 @@ apps/frappe/frappe/core/doctype/communication/communication_list.js,Mark as Read
 apps/frappe/frappe/core/doctype/report/report.js,Disable Report,禁用報告
 DocType: Translation,Contributed Translation Doctype Name,貢獻翻譯文檔類型名稱
 DocType: Data Migration Mapping,Pull,拉
-DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript的格式：frappe.query_reports [&#39;REPORTNAME&#39;] = {}
+DocType: Report,JavaScript Format: frappe.query_reports['REPORTNAME'] = {},JavaScript的格式：frappe.query_reports ['REPORTNAME'] = {}
 DocType: Workflow State,chevron-up,人字形-上
 DocType: DocType,Allow Guest to View,允許訪客查看
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,{0} should not be same as {1},{0}不應與{1}相同
@@ -917,7 +917,7 @@ apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,All customiza
 DocType: Page,Page HTML,頁面的HTML
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Export Errored Rows,導出錯誤的行
 apps/frappe/frappe/chat/doctype/chat_room/chat_room.py,Group name cannot be empty.,組名不能為空。
-apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,此外節點可以在&#39;集團&#39;類型的節點上創建
+apps/frappe/frappe/public/js/frappe/views/treeview.js,Further nodes can be only created under 'Group' type nodes,此外節點可以在'集團'類型的節點上創建
 DocType: SMS Parameter,Header,頁首
 apps/frappe/frappe/public/js/frappe/model/model.js,Unknown Column: {0},未知專欄： {0}
 DocType: Notification Recipient,Email By Role,電子郵件按角色
@@ -1708,7 +1708,7 @@ apps/frappe/frappe/core/page/background_jobs/background_jobs.html,Queue / Worker
 DocType: S3 Backup Settings,ap-southeast-1,AP-東南-1
 DocType: DocType,"Must be of type ""Attach Image""",類型必須為“附加圖片”
 apps/frappe/frappe/core/doctype/data_import/data_import.js,Unselect All,全部取消選擇
-apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},你不能沒有設置&#39;只讀&#39;現場{0}
+apps/frappe/frappe/custom/doctype/customize_form/customize_form.py,You cannot unset 'Read Only' for field {0},你不能沒有設置'只讀'現場{0}
 DocType: Auto Email Report,Zero means send records updated at anytime,零表示隨時更新發送記錄
 DocType: Auto Email Report,Zero means send records updated at anytime,零表示隨時更新發送記錄
 apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.js,Complete Setup,完成安裝
@@ -1840,7 +1840,7 @@ DocType: System Settings,Session Expiry in Hours e.g. 06:00,連線過期的小�
 DocType: Customize Form Field,"This field will appear only if the fieldname defined here has value OR the rules are true (examples): 
 myfield
 eval:doc.myfield=='My Value'
-eval:doc.age>18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield ==&#39;我的價值&#39;的eval：doc.age> 18
+eval:doc.age>18",該字段將顯示僅在此處定義的字段名具有值或規則是真實的（例子）：MyField的EVAL：doc.myfield =='我的價值'的eval：doc.age> 18
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger).",一旦你設置這個，用戶將只能訪問有聯結的文檔（如博客文章）。
 DocType: Data Import Beta,Submit After Import,導入後提交
 DocType: Error Log,Log of Scheduler Errors,日程安排程序錯誤日誌
@@ -1872,7 +1872,7 @@ DocType: Data Migration Connector,Database Name,數據庫名稱
 apps/frappe/frappe/custom/doctype/customize_form/customize_form.js,Refresh Form,更新表格
 DocType: DocField,Select,選擇
 apps/frappe/frappe/public/js/frappe/ui/toolbar/energy_points_notifications.js,View Full Log,查看完整日誌
-DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",簡單的Python表達式，例如：status ==&#39;Open&#39;並輸入==&#39;Bug&#39;
+DocType: Assignment Rule,"Simple Python Expression, Example: status == 'Open' and type == 'Bug'",簡單的Python表達式，例如：status =='Open'並輸入=='Bug'
 apps/frappe/frappe/utils/csvutils.py,File not attached,文件未附
 apps/frappe/frappe/public/js/frappe/dom.js,Connection lost. Some features might not work.,連接丟失。某些功能可能無法使用。
 apps/frappe/frappe/utils/password_strength.py,"Repeats like ""aaa"" are easy to guess",像“AAA”重複很容易被猜到
@@ -2615,7 +2615,7 @@ apps/frappe/frappe/core/doctype/data_export/data_export.js,Please select the Doc
 apps/frappe/frappe/public/js/frappe/views/treeview.js,Add Child,新增子項目
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,Import Progress,進口進度
 DocType: Energy Point Rule,"If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'
-",如果條件滿足，用戶將獲得積分獎勵。例如。 doc.status ==&#39;已關閉&#39;
+",如果條件滿足，用戶將獲得積分獎勵。例如。 doc.status =='已關閉'
 apps/frappe/frappe/model/delete_doc.py,{0} {1}: Submitted Record cannot be deleted.,{0} {1}：已呈交的記錄不能被刪除。
 DocType: GSuite Templates,Template Name,模板名稱
 apps/frappe/frappe/public/js/frappe/ui/toolbar/awesome_bar.js,new type of document,新類型的文件
@@ -3060,7 +3060,7 @@ DocType: Dashboard Chart,Filters JSON,過濾JSON
 apps/frappe/frappe/email/doctype/newsletter/newsletter.py,Click here to verify,點擊這裡核實
 DocType: Email Account,Disable SMTP server authentication,禁用SMTP服務器驗證
 apps/frappe/frappe/public/js/frappe/utils/utils.js,Copied to clipboard.,複製到剪貼板。
-apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,可預見的替換像&#39;@&#39;而不是&#39;一&#39;不要太大幫助。
+apps/frappe/frappe/utils/password_strength.py,Predictable substitutions like '@' instead of 'a' don't help very much.,可預見的替換像'@'而不是'一'不要太大幫助。
 apps/frappe/frappe/desk/doctype/todo/todo_list.js,Assigned By Me,指定由我
 DocType: Google Drive,Backup Folder ID,備份文件夾ID
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Not in Developer Mode! Set in site_config.json or make 'Custom' DocType.,不是在開發模式！坐落在site_config.json或進行“自定義”的DocType。
@@ -3106,7 +3106,7 @@ apps/frappe/frappe/templates/includes/login/login.js,OTP setup using OTP App was
 apps/frappe/frappe/core/doctype/sms_settings/sms_settings.py,Please enter valid mobile nos,請輸入有效的手機號
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,您的瀏覽器中的某些功能可能無法正常工作。請將您的瀏覽器更新到最新版本。
 apps/frappe/frappe/public/js/frappe/desk.js,Some of the features might not work in your browser. Please update your browser to the latest version.,您的瀏覽器中的某些功能可能無法正常工作。請將您的瀏覽器更新到最新版本。
-apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",不知道，問&#39;幫助&#39;
+apps/frappe/frappe/utils/bot.py,"Don't know, ask 'help'",不知道，問'幫助'
 apps/frappe/frappe/public/js/frappe/form/footer/timeline.js,cancelled this document {0},取消了此文檔{0}
 DocType: DocType,Comments and Communications will be associated with this linked document,評論與通訊將與此鏈接的文檔關聯
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html,Filter...,過濾器...

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -1,15 +1,18 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals, print_function
+from __future__ import print_function, unicode_literals
+
+import os
+import re
+
+import frappe
+import frappe.sessions
+from frappe import _
 
 no_cache = 1
 base_template_path = "templates/www/desk.html"
 
-import os, re
-import frappe
-from frappe import _
-import frappe.sessions
 
 def get_context(context):
 	if (frappe.session.user == "Guest" or
@@ -82,6 +85,8 @@ def get_desk_assets(build_version):
 	}
 
 def get_build_version():
+	if frappe.is_dev_mode():
+		return frappe.utils.random_string(8)
 	try:
 		return str(os.path.getmtime(os.path.join(frappe.local.sites_path, '.build')))
 	except OSError:


### PR DESCRIPTION
Replacement of the special characters' unicodes by their normal value utf-8 to display correctly as text in html tags.
![Capture d’écran de 2020-01-27 01-35-34](https://user-images.githubusercontent.com/36489637/73144898-674dee80-40aa-11ea-82a1-b0a6f826c502.png)

Added build version change on development mode assets when the site is reloaded at browser level