### PR TITLE
fix: Skip Email Queue doctype in delete_doc

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -21,7 +21,7 @@ from frappe.exceptions import FileNotFoundError
 
 
 doctypes_to_skip = ("Communication", "ToDo", "DocShare", "Email Unsubscribe", "Activity Log", "File",
-	"Version", "Document Follow", "Comment" , "View Log", "Tag Link", "Notification Log")
+	"Version", "Document Follow", "Comment" , "View Log", "Tag Link", "Notification Log", "Email Queue")
 
 def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reload=False,
 	ignore_permissions=False, flags=None, ignore_on_trash=False, ignore_missing=True):


### PR DESCRIPTION
Port of https://github.com/frappe/frappe/pull/9364