### PR TITLE
fix: always return frappedict from frappe.parse_json

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -581,6 +581,7 @@ def parse_json(val):
 	"""
 	if isinstance(val, string_types):
 		val = json.loads(val)
+		val = frappe._dict(val)
 	if isinstance(val, dict):
 		val = frappe._dict(val)
 	return val


### PR DESCRIPTION
Issue: When a JSON string is passed to `frappe.parse_json` it returns python dictionary and when a python dictionary is passed it returns a frappedict.

Fix: always return a frappedict from `frappe.parse_json`