### PR TITLE
fix(Letter Head): Remove default letterhead

### DIFF
--- a/frappe/printing/doctype/letter_head/letter_head.py
+++ b/frappe/printing/doctype/letter_head/letter_head.py
@@ -43,3 +43,6 @@ class LetterHead(Document):
 
 			# update control panel - so it loads new letter directly
 			frappe.db.set_default("default_letter_head_content", self.content)
+		else:
+			frappe.defaults.clear_default('letter_head', self.name)
+			frappe.defaults.clear_default("default_letter_head_content", self.content)


### PR DESCRIPTION
- If the default letter head was removed, it did not remove the default letter head entry from `DefaultValue`, which resulted in setting the undesired Letter Head