### PR TITLE
fix(sms_settings): add support for sending data as json

### DIFF
--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -68,7 +68,7 @@ def send_via_gateway(arg):
 	headers = get_headers(ss)
 	use_json = "Content-Type" in headers and headers["Content-Type"] == "application/json"
 
-	message = arg.get('message').decode('utf-8') if use_json else arg.get('message')
+	message = frappe.safe_decode(arg.get('message'))
 	args = {ss.message_parameter: message}
 	for d in ss.get("parameters"):
 		if not d.header:

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -66,8 +66,10 @@ def send_sms(receiver_list, msg, sender_name = '', success_msg = True):
 def send_via_gateway(arg):
 	ss = frappe.get_doc('SMS Settings', 'SMS Settings')
 	headers = get_headers(ss)
+	use_json = "Content-Type" in headers and headers["Content-Type"] == "application/json"
 
-	args = {ss.message_parameter: arg.get('message')}
+	message = arg.get('message').decode('utf-8') if use_json else arg.get('message')
+	args = {ss.message_parameter: message}
 	for d in ss.get("parameters"):
 		if not d.header:
 			args[d.parameter] = d.value
@@ -75,7 +77,7 @@ def send_via_gateway(arg):
 	success_list = []
 	for d in arg.get('receiver_list'):
 		args[ss.receiver_parameter] = d
-		status = send_request(ss.sms_gateway_url, args, headers, ss.use_post)
+		status = send_request(ss.sms_gateway_url, args, headers, ss.use_post, use_json)
 
 		if 200 <= status < 300:
 			success_list.append(d)
@@ -97,16 +99,24 @@ def get_headers(sms_settings=None):
 
 	return headers
 
-def send_request(gateway_url, params, headers=None, use_post=False):
+def send_request(gateway_url, params, headers=None, use_post=False, use_json=False):
 	import requests
 
 	if not headers:
 		headers = get_headers()
+	kwargs = {"headers": headers}
+
+	if use_json:
+		kwargs["json"] = params
+	elif use_post:
+		kwargs["data"] = params
+	else:
+		kwargs["params"] = params
 
 	if use_post:
-		response = requests.post(gateway_url, headers=headers, data=params)
+		response = requests.post(gateway_url, **kwargs)
 	else:
-		response = requests.get(gateway_url, headers=headers, params=params)
+		response = requests.get(gateway_url, **kwargs)
 	response.raise_for_status()
 	return response.status_code
 

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -66,7 +66,7 @@ def send_sms(receiver_list, msg, sender_name = '', success_msg = True):
 def send_via_gateway(arg):
 	ss = frappe.get_doc('SMS Settings', 'SMS Settings')
 	headers = get_headers(ss)
-	use_json = "Content-Type" in headers and headers["Content-Type"] == "application/json"
+	use_json = headers.get("Content-Type") == "application/json"
 
 	message = frappe.safe_decode(arg.get('message'))
 	args = {ss.message_parameter: message}


### PR DESCRIPTION
Many SMS gateways expect data in raw JSON and do not accept plain
form data. This change enables this by detecting a "Content-Type"
header in the parameters with a value of "application/json", and
in this case decoding the message text to unicode as expected by
the `requests` module before passing the data to the `json`
parameter.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
https://discuss.erpnext.com/t/tweaking-for-the-sms-gateway/7748/24

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
