### PR TITLE
fix:  Send password notification email if password is not set

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -97,8 +97,8 @@ class User(Document):
 		self.share_with_self()
 		clear_notifications(user=self.name)
 		frappe.clear_cache(user=self.name)
+		self.send_password_notification(self.__new_password)
 		if self.__new_password:
-			self.send_password_notification(self.__new_password)
 			self.reset_password_key = ''
 		create_contact(self, ignore_mandatory=True)
 		if self.name not in ('Administrator', 'Guest') and not self.user_image:


### PR DESCRIPTION
Send password notification email if the password is not set.

Due to this bug, new signed up users were not getting verification/password emails.

The bug was introduced [in this PR](https://github.com/frappe/frappe/pull/8982)
