### PR TITLE
fix: set initial auto repeat day count to max

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -274,13 +274,11 @@ def get_next_schedule_date(schedule_date, frequency, start_date, repeat_on_day=N
 	else:
 		month_count = 0
 
-	day_count = 0
+	day_count = 31
 	if month_count and repeat_on_last_day:
-		next_date = get_next_date(start_date, month_count, 31)
 		day_count = 31
 		next_date = get_next_date(start_date, month_count, day_count)
 	elif month_count and repeat_on_day:
-		next_date = get_next_date(start_date, month_count, repeat_on_day)
 		day_count = repeat_on_day
 		next_date = get_next_date(start_date, month_count, day_count)
 	elif month_count:


### PR DESCRIPTION
Backport of: https://github.com/frappe/frappe/pull/9387

**Bug**: 

wrong day_count set while calculating the next schedule date

![failing test](https://user-images.githubusercontent.com/24353136/73524800-e5f0b600-4433-11ea-812f-91c02db926d2.png)

![wrong_date](https://user-images.githubusercontent.com/24353136/73524811-e8eba680-4433-11ea-8c85-e2542937cf15.png)


**Fix**:

Initialize the day count to max, then change according to condition

![date_correct](https://user-images.githubusercontent.com/24353136/73524790-e2f5c580-4433-11ea-8318-27099e0e2399.png)