### PR TITLE
fix: open print preview in new tab

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -155,10 +155,10 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	}
 
 	print() {
-		window.location.href = `/printview?
+		window.open(`/printview?
 			doctype=${this.doc_type}
 			&name=${this.doc.name}
-			&format=${this.print_format || "Standard"}`;
+			&format=${this.print_format || "Standard"}`, '_blank');
 	}
 
 	cancel() {


### PR DESCRIPTION
Open print preview within the web form in new tab using window.open
![Kapture 2020-02-04 at 19 41 17](https://user-images.githubusercontent.com/14824451/73752154-6b52ce00-4786-11ea-914c-55fd24158e79.gif)
