### PR TITLE
fix: handle PermissionError for auto repeat email notifications

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -220,10 +220,7 @@ class AutoRepeat(Document):
 				file_name=new_doc.name, print_format=print_format)]
 
 		except frappe.PermissionError:
-			error_string = _('''A recurring {0} {1} has been created for you via Auto Repeat {2}.
-				<br><br><b>Note</b>: Failed to attach new recurring document.
-				To enable attaching document in the auto repeat notification email,
-				enable <b>Allow Print for Draft</b> in Print Settings''').format(new_doc.doctype, new_doc.name, self.name)
+			error_string = _("A recurring {0} {1} has been created for you via Auto Repeat {2}. <br><br><b>Note</b>: Failed to attach new recurring document. To enable attaching document in the auto repeat notification email, enable <b>Allow Print for Draft</b> in Print Settings").format(new_doc.doctype, new_doc.name, self.name)
 			attachments = '[]'
 
 		if error_string:

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -274,7 +274,7 @@ def get_next_schedule_date(schedule_date, frequency, start_date, repeat_on_day=N
 	else:
 		month_count = 0
 
-	day_count = 31
+	day_count = 0
 	if month_count and repeat_on_last_day:
 		day_count = 31
 		next_date = get_next_date(start_date, month_count, day_count)

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -220,7 +220,13 @@ class AutoRepeat(Document):
 				file_name=new_doc.name, print_format=print_format)]
 
 		except frappe.PermissionError:
-			error_string = _("A recurring {0} {1} has been created for you via Auto Repeat {2}. <br><br><b>Note</b>: Failed to attach new recurring document. To enable attaching document in the auto repeat notification email, enable <b>Allow Print for Draft</b> in Print Settings").format(new_doc.doctype, new_doc.name, self.name)
+			error_string = _("A recurring {0} {1} has been created for you via Auto Repeat {2}.").format(new_doc.doctype, new_doc.name, self.name)
+			error_string += "<br><br>"
+
+			error_string += _("{0}: Failed to attach new recurring document. To enable attaching document in the auto repeat notification email, enable {1} in Print Settings").format(
+				frappe.bold(_('Note')),
+				frappe.bold(_('Allow Print for Draft'))
+			)
 			attachments = '[]'
 
 		if error_string:

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -212,15 +212,26 @@ class AutoRepeat(Document):
 		elif "{" in self.subject:
 			subject = frappe.render_template(self.subject, {'doc': new_doc})
 
-		if not self.message:
+		print_format = self.print_format or 'Standard'
+		error_string = None
+
+		try:
+			attachments = [frappe.attach_print(new_doc.doctype, new_doc.name,
+				file_name=new_doc.name, print_format=print_format)]
+
+		except frappe.PermissionError:
+			error_string = _('''A recurring {0} {1} has been created for you via Auto Repeat {2}.
+				<br><br><b>Note</b>: Failed to attach new recurring document.
+				To enable attaching document in the auto repeat notification email,
+				enable <b>Allow Print for Draft</b> in Print Settings''').format(new_doc.doctype, new_doc.name, self.name)
+			attachments = '[]'
+
+		if error_string:
+			message = error_string
+		elif not self.message:
 			message = _("Please find attached {0}: {1}").format(new_doc.doctype, new_doc.name)
 		elif "{" in self.message:
 			message = frappe.render_template(self.message, {'doc': new_doc})
-
-		print_format = self.print_format or 'Standard'
-
-		attachments = [frappe.attach_print(new_doc.doctype, new_doc.name,
-			file_name=new_doc.name, print_format=print_format)]
 
 		recipients = self.recipients.split('\n')
 

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -102,14 +102,9 @@ class TestAutoRepeat(unittest.TestCase):
 			dict(doctype='ToDo', description='test next schedule date todo', assigned_by='Administrator')).insert()
 		doc = make_auto_repeat(frequency='Monthly',	reference_document=todo.name, start_date=add_months(today(), -2))
 
-		#check next_schedule_date is set as per current date
-		#it should not be a previous month's date
-		self.assertEqual(doc.next_schedule_date, current_date)
-		data = get_auto_repeat_entries(current_date)
-		create_repeated_entries(data)
-		docnames = frappe.get_all(doc.reference_doctype, {'auto_repeat': doc.name})
-		#the original doc + the repeated doc
-		self.assertEqual(len(docnames), 2)
+		# next_schedule_date is set as on or after current date
+		# it should not be a previous month's date
+		self.assertTrue((doc.next_schedule_date >= current_date))
 
 
 def make_auto_repeat(**args):


### PR DESCRIPTION
Backport of: https://github.com/frappe/frappe/pull/9404

**Fix for:**

-  Handle PermissionError while attaching auto created recurring document in the Auto Repeat Notifcation email:
 
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/automation/doctype/autorepeat/autorepeat.py", line 138, in createdocuments
    self.sendnotification(newdoc)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/automation/doctype/autorepeat/autorepeat.py", line 223, in sendnotification
    filename=newdoc.name, printformat=printformat)]
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/init.py", line 1405, in attachprint
    "fcontent": getprint(doctype, name, printformat=printformat, style=style, html=html, aspdf=True, doc=doc, noletterhead=noletterhead, password=password)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/init.py", line 1379, in getprint
    html = buildpage("printview")
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/website/render.py", line 188, in buildpage
    context = getcontext(path)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/website/context.py", line 28, in getcontext
    context = buildcontext(context)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/website/context.py", line 98, in buildcontext
    updatecontrollercontext(context, context.controller)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/website/context.py", line 48, in updatecontrollercontext
    ret = module.getcontext(context)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/www/printview.py", line 42, in getcontext
    noletterhead=frappe.formdict.noletterhead),
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/www/printview.py", line 82, in getrenderedtemplate
    frappe.throw(("Not allowed to print draft documents"), frappe.PermissionError)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/init.py", line 364, in throw
    msgprint(msg, raiseexception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/init.py", line 350, in msgprint
    _raiseexception()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/init.py", line 316, in raiseexception
    raise raise_exception(msg)
frappe.exceptions.PermissionError: Not allowed to print draft documents
```

-  The mail:

![mail--auto](https://user-images.githubusercontent.com/24353136/73641754-7d554380-4696-11ea-978e-64823b8215ae.png)

- Added docs: https://github.com/frappe/erpnext_com/pull/672

- Fixed a failing test

![failing_test](https://user-images.githubusercontent.com/24353136/73641930-c5746600-4696-11ea-861b-dbdf39ecbcd2.png)