### PR TITLE
fix(Report View): don't render/add status if value not found

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1059,7 +1059,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					};
 				} else {
 					// no status values found
-					this.remove_column_from_datatable(col)
+					this.remove_column_from_datatable(col);
 				}
 			} else if (col.field in d) {
 				const value = d[col.field];

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -791,7 +791,13 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		let std_fields = frappe.model.std_fields.filter( df => df.fieldname !== 'docstatus');
 
 		// add status field derived from docstatus, if status is not a standard field
-		if (!frappe.meta.has_field(this.doctype, 'status')) {
+		let has_status_values = false;
+
+		if (this.data) {
+			has_status_values = frappe.get_indicator(this.data[0], this.doctype);
+		}
+
+		if (!frappe.meta.has_field(this.doctype, 'status') && has_status_values) {
 			doctype_fields = [{
 				label: __('Status'),
 				fieldname: 'docstatus',
@@ -1038,18 +1044,23 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			if (col.field === 'docstatus' && !frappe.meta.has_field(this.doctype, 'status')) {
 				// get status from docstatus
 				let status = frappe.get_indicator(d, this.doctype);
-				if (!status[0]) {
-					// get_indicator returns the dependent field's condition as the 3rd parameter
-					let dependent_col = status[2].split(',')[0];
-					// add status dependency column
-					this.add_status_dependency_column(dependent_col, this.doctype);
+				if (status) {
+					if (!status[0]) {
+						// get_indicator returns the dependent field's condition as the 3rd parameter
+						let dependent_col = status[2].split(',')[0];
+						// add status dependency column
+						this.add_status_dependency_column(dependent_col, this.doctype);
+					}
+					return {
+						name: d.name,
+						doctype: col.docfield.parent,
+						content: status[0],
+						editable: false
+					};
+				} else {
+					// no status values found
+					this.remove_column_from_datatable(col)
 				}
-				return {
-					name: d.name,
-					doctype: col.docfield.parent,
-					content: status[0],
-					editable: false
-				};
 			} else if (col.field in d) {
 				const value = d[col.field];
 				return {


### PR DESCRIPTION
Backport of: https://github.com/frappe/frappe/pull/9408

**Fixes a bug from PR:** https://github.com/frappe/frappe/pull/9278

For DocTypes that are not submittable, do not have any workflow, list view setting or disable/enable fields, Report View was breaking:

![report-view](https://user-images.githubusercontent.com/24353136/73654381-8bfd2400-46b1-11ea-824c-c33568d79bd5.png)

**After Fix:**

The status column is not shown in Pick Columns nor rendered if:
- Its not a docfield in the doctype
- The DocType is not submittable
- There is no workflow set up on that doctype
- There are no List View Settings for it
- There is no enable/disable field contributing to the status

![no_status_field_shown](https://user-images.githubusercontent.com/24353136/73654441-b9e26880-46b1-11ea-9c0f-472233cd7a18.png)

For a doctype with any of the above conditions matching (eg: Journal Entry) the docstatus column is shown as Status as it is in List View and the values are obtained from get_indicator function in indicator.js

![2020-02-03 18 16 19](https://user-images.githubusercontent.com/24353136/73654686-5efd4100-46b2-11ea-9e44-91474a5f4813.gif)