### PR TITLE
fix: Options for custom columns with datatype as Link

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1125,7 +1125,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								label: df.label,
 								link_field: this.doctype_field_map[values.doctype],
 								doctype: values.doctype,
-								options: df.fieldtype === "Link" ? frappe.model.unscrub(df.fieldname) : undefined,
+								options: df.fieldtype === "Link" ? df.options : undefined,
 								width: 100
 							});
 


### PR DESCRIPTION
After saving a report with custom column with fieldtype as Link and the unscrub of fieldname is not same as options following error occurs

![Error](https://user-images.githubusercontent.com/42651287/73838137-fc827d00-4838-11ea-9af3-a18feb4b0b7e.png)
  