### PR TITLE
fix: filter default print format in Customize Form by doctype

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -20,7 +20,8 @@ frappe.ui.form.on("Customize Form", {
 		frm.set_query("default_print_format", function() {
 			return {
 				filters: {
-					'print_format_type': ['!=', 'JS']
+					'print_format_type': ['!=', 'JS'],
+					'doc_type': ['=', frm.doc.doc_type]
 				}
 			}
 		});


### PR DESCRIPTION
Added filter for doctype in Default Print Format field in Customize Form