### PR TITLE
feat (ux): enabled tnum font feature for report

### DIFF
--- a/frappe/public/less/report.less
+++ b/frappe/public/less/report.less
@@ -113,3 +113,8 @@
     right: 0px;
     display: flex;
 }
+
+// Enable tnum for report
+.dt-scrollable .dt-cell__content {
+	font-feature-settings: "tnum", "zero";
+}


### PR DESCRIPTION
> Here's a feature most people won't notice. Here's a silent hero that will make looking at large sheets of numeric misery a little less difficult. This is a feature that does not transcends limits of technology, but leaves the world a better place nonetheless

### Changes
This PR enables [tabular numbers font feature](https://docs.microsoft.com/en-us/typography/opentype/spec/features_pt#tnum) in css for datatable in reports. The font feature property works in all major browsers. The font feature itself is supported by all [OpenType](https://docs.microsoft.com/en-us/typography/opentype/spec/) fonts, which includes most modern fonts. [[MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings)]
Mono spaced digits are easier to parse when scrubbing vertically as the digits are aligned.

### Before
<img width="609" alt="Screenshot 2020-02-06 at 12 41 19 PM" src="https://user-images.githubusercontent.com/18097732/73914056-6c970e80-48de-11ea-97ce-cea07aa5ec6d.png">

### After
<img width="604" alt="Screenshot 2020-02-06 at 12 41 39 PM" src="https://user-images.githubusercontent.com/18097732/73914051-6a34b480-48de-11ea-9fa9-cc68cc029d16.png">

The style is applied to the entire scrollable portion of the datatable, this includes the index column as well (intentional). The style will not affect alphabets. For instance "Supplier" won't be affected, however in "May 2019", "2019" will be monospaced.