### PR TITLE
feat: allow list structure to be changed for the web view

### DIFF
--- a/frappe/www/list.html
+++ b/frappe/www/list.html
@@ -25,7 +25,7 @@
 {% block page_content %}
 
 {% if introduction %}<p>{{ introduction }}</p>{% endif %}
-{% include "templates/includes/list/list.html" %}
+{% include list_template or "templates/includes/list/list.html" %}
 {% if list_footer %}{{ list_footer }}{% endif %}
 
 {% endblock %}

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -19,7 +19,6 @@ def get_context(context, **dict_params):
 	context.meta = frappe.get_meta(doctype)
 	context.update(get_list_context(context, doctype) or {})
 	context.doctype = doctype
-	context.title = context.doctype
 	context.txt = frappe.local.form_dict.txt
 	context.update(get(**frappe.local.form_dict))
 


### PR DESCRIPTION
- Currently, a predefined list structure exists in frappe, there is no direct way to change the vertical list structure. This PR proposes to change that by allowing an extra parameter list_template for the web view. Users can change the way the list structure is defined via this change.

[Documentation Link](https://github.com/frappe/frappe_io/pull/253)