### PR TITLE
fix(Contact): Dont reroute from Contact to unrelated document

### DIFF
--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -47,7 +47,7 @@ frappe.ui.form.on("Address", {
 			() => frappe.timeout(1),
 			() => {
 				const last_doc = frappe.contacts.get_last_doc(frm);
-				if(frappe.dynamic_link && frappe.dynamic_link.doc && frappe.dynamic_link.doc.name == last_doc.docname) {
+				if (frappe.dynamic_link && frappe.dynamic_link.doc && frappe.dynamic_link.doc.name == last_doc.docname) {
 					for (let i in frm.doc.links) {
 						let link = frm.doc.links[i];
 						if (last_doc.doctype == link.link_doctype && last_doc.docname == link.link_name) {

--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -30,7 +30,7 @@ frappe.ui.form.on("Address", {
 				let link = frm.doc.links[i];
 				frm.add_custom_button(__("{0}: {1}", [__(link.link_doctype), __(link.link_name)]), function() {
 					frappe.set_route("Form", link.link_doctype, link.link_name);
-				}, "Links");
+				}, __("Links"));
 			}
 		}
 	},

--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -24,6 +24,15 @@ frappe.ui.form.on("Address", {
 			}
 		});
 		frm.refresh_field("links");
+
+		if (frm.doc.links) {
+			for (let i in frm.doc.links) {
+				let link = frm.doc.links[i];
+				frm.add_custom_button(__("{0}: {1}", [__(link.link_doctype), __(link.link_name)]), function() {
+					frappe.set_route("Form", link.link_doctype, link.link_name);
+				}, "Links");
+			}
+		}
 	},
 	validate: function(frm) {
 		// clear linked customer / supplier / sales partner on saving...
@@ -38,9 +47,13 @@ frappe.ui.form.on("Address", {
 			() => frappe.timeout(1),
 			() => {
 				const last_doc = frappe.contacts.get_last_doc(frm);
-				if(frappe.dynamic_link && frappe.dynamic_link.doc
-					&& frappe.dynamic_link.doc.name == last_doc.docname){
-					frappe.set_route('Form', last_doc.doctype, last_doc.docname);
+				if(frappe.dynamic_link && frappe.dynamic_link.doc && frappe.dynamic_link.doc.name == last_doc.docname) {
+					for (let i in frm.doc.links) {
+						let link = frm.doc.links[i];
+						if (last_doc.doctype == link.link_doctype && last_doc.docname == link.link_name) {
+							frappe.set_route('Form', last_doc.doctype, last_doc.docname);
+						}
+					}
 				}
 			}
 		]);

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -80,7 +80,7 @@ frappe.ui.form.on("Contact", {
 			() => frappe.timeout(1),
 			() => {
 				const last_doc = frappe.contacts.get_last_doc(frm);
-				if(frappe.dynamic_link && frappe.dynamic_link.doc && frappe.dynamic_link.doc.name == last_doc.docname) {
+				if (frappe.dynamic_link && frappe.dynamic_link.doc && frappe.dynamic_link.doc.name == last_doc.docname) {
 					for (let i in frm.doc.links) {
 						let link = frm.doc.links[i];
 						if (last_doc.doctype == link.link_doctype && last_doc.docname == link.link_name) {

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -63,7 +63,7 @@ frappe.ui.form.on("Contact", {
 				let link = frm.doc.links[i];
 				frm.add_custom_button(__("{0}: {1}", [__(link.link_doctype), __(link.link_name)]), function() {
 					frappe.set_route("Form", link.link_doctype, link.link_name);
-				}, "Links");
+				}, __("Links"));
 			}
 		}
 	},

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -42,7 +42,7 @@ frappe.ui.form.on("Contact", {
 		});
 		frm.refresh_field("links");
 
-		if (frm.doc.links.length > 0) {
+		if (frm.doc.links) {
 			frappe.call({
 				method: "frappe.contacts.doctype.contact.contact.address_query",
 				args: {links: frm.doc.links},
@@ -58,6 +58,13 @@ frappe.ui.form.on("Contact", {
 					}
 				}
 			});
+
+			for (let i in frm.doc.links) {
+				let link = frm.doc.links[i];
+				frm.add_custom_button(__("{0}: {1}", [__(link.link_doctype), __(link.link_name)]), function() {
+					frappe.set_route("Form", link.link_doctype, link.link_name);
+				}, "Links");
+			}
 		}
 	},
 	validate: function(frm) {
@@ -73,9 +80,13 @@ frappe.ui.form.on("Contact", {
 			() => frappe.timeout(1),
 			() => {
 				const last_doc = frappe.contacts.get_last_doc(frm);
-				if(frappe.dynamic_link && frappe.dynamic_link.doc
-					&& frappe.dynamic_link.doc.name == last_doc.docname){
-					frappe.set_route('Form', last_doc.doctype, last_doc.docname);
+				if(frappe.dynamic_link && frappe.dynamic_link.doc && frappe.dynamic_link.doc.name == last_doc.docname) {
+					for (let i in frm.doc.links) {
+						let link = frm.doc.links[i];
+						if (last_doc.doctype == link.link_doctype && last_doc.docname == link.link_name) {
+							frappe.set_route('Form', last_doc.doctype, last_doc.docname);
+						}
+					}
 				}
 			}
 		]);


### PR DESCRIPTION
- Auto rerouting used to take place using `frappe.dynamic_link` which sometimes works as expected, but if you visit an unrelated Contact from Customer, it'll still redirect you to the Customer again
- Issue
    - If from any Customer I open an unrelated issue and click on save, after saving, it'll redirect to the Customer again.
    - If a good feature but validation was missing to check if that Contact is linked to the Customer.
     ![contact_reroute_unfix](https://user-images.githubusercontent.com/7310479/73923285-a1ac5c80-48f0-11ea-8d38-57d33b8262ec.gif)
- Fix
    - System will now check if that particular `dynamic_link` exists in the links child table before rerouting
    - Editing unrelated Contact
    ![contact_reroute_fix_1](https://user-images.githubusercontent.com/7310479/73922786-b805e880-48ef-11ea-9251-410e6dc36896.gif)
    - Editing Contact linked to Customer
    ![contact_reroute_fix_2](https://user-images.githubusercontent.com/7310479/73922792-ba684280-48ef-11ea-86df-0be316f554af.gif)