### PR TITLE
chore: pin werkzeug to v0.16.1

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -10,8 +10,8 @@ import logging
 from werkzeug.wrappers import Request
 from werkzeug.local import LocalManager
 from werkzeug.exceptions import HTTPException, NotFound
-from werkzeug.contrib.profiler import ProfilerMiddleware
-from werkzeug.wsgi import SharedDataMiddleware
+from werkzeug.middleware.profiler import ProfilerMiddleware
+from werkzeug.middleware.shared_data import SharedDataMiddleware
 
 import frappe
 import frappe.handler

--- a/frappe/middlewares.py
+++ b/frappe/middlewares.py
@@ -6,8 +6,9 @@ from __future__ import unicode_literals
 import frappe
 import os
 from werkzeug.exceptions import NotFound
-from werkzeug.wsgi import SharedDataMiddleware
-from frappe.utils import get_site_name, get_site_path, get_site_base_path, get_path, cstr
+from werkzeug.middleware.shared_data import SharedDataMiddleware
+from frappe.utils import get_site_name, cstr
+
 
 class StaticDataMiddleware(SharedDataMiddleware):
 	def __call__(self, environ, start_response):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ maxminddb-geolite2
 python-dateutil
 pytz
 six
-werkzeug
+werkzeug==0.16.1
 semantic_version
 rauth>=0.6.2
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ maxminddb-geolite2
 python-dateutil
 pytz
 six
-werkzeug==0.16.1
+werkzeug==1.0.0
 semantic_version
 rauth>=0.6.2
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ maxminddb-geolite2
 python-dateutil
 pytz
 six
-werkzeug==1.0.0
+werkzeug==0.16.1
 semantic_version
 rauth>=0.6.2
 requests


### PR DESCRIPTION
according to changes in v1.0, werkzeug has moved middleware from `werkzeug.wsgi` and `werkzeug.contrib` to `werkzeug.middleware`, which currently breaks frappe. so until that is fixed, we'll ~pin werkzeug to 0.16.1 to fix this issue~ update werkzeug to 0.16.1 and fix all imports.

relevant PR: https://github.com/pallets/werkzeug/pull/1452