### PR TITLE
chore: update werkzeug to v0.16.1

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -10,8 +10,8 @@ import logging
 from werkzeug.wrappers import Request
 from werkzeug.local import LocalManager
 from werkzeug.exceptions import HTTPException, NotFound
-from werkzeug.contrib.profiler import ProfilerMiddleware
-from werkzeug.wsgi import SharedDataMiddleware
+from werkzeug.middleware.profiler import ProfilerMiddleware
+from werkzeug.middleware.shared_data import SharedDataMiddleware
 
 import frappe
 import frappe.handler

--- a/frappe/middlewares.py
+++ b/frappe/middlewares.py
@@ -6,8 +6,9 @@ from __future__ import unicode_literals
 import frappe
 import os
 from werkzeug.exceptions import NotFound
-from werkzeug.wsgi import SharedDataMiddleware
-from frappe.utils import get_site_name, get_site_path, get_site_base_path, get_path, cstr
+from werkzeug.middleware.shared_data import SharedDataMiddleware
+from frappe.utils import get_site_name, cstr
+
 
 class StaticDataMiddleware(SharedDataMiddleware):
 	def __call__(self, environ, start_response):

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,6 @@ stripe==2.40.0
 unittest-xml-reporting==2.5.2
 urllib3==1.25.7
 watchdog==0.8.0
-Werkzeug==0.16.0
+Werkzeug==1.0.0
 xlrd==1.2.0
 zxcvbn-python==4.4.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,6 @@ stripe==2.40.0
 unittest-xml-reporting==2.5.2
 urllib3==1.25.7
 watchdog==0.8.0
-Werkzeug==1.0.0
+Werkzeug==0.16.1
 xlrd==1.2.0
 zxcvbn-python==4.4.24


### PR DESCRIPTION
* move all `werkzeug.wsgi` and `werkzeug.contrib` imports to `werkzeug.middleware` to make things work.
* update pinned requirement to `0.1.16`

more information at #9437 