### PR TITLE
fix: Bulk Workflow Action rollback on Error

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -347,6 +347,9 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None,
 	if alert:
 		out.alert = 1
 
+	if raise_exception:
+		out.raise_exception = 1
+
 	if primary_action:
 		out.primary_action = primary_action
 
@@ -359,6 +362,13 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None,
 
 def clear_messages():
 	local.message_log = []
+
+def get_message_log():
+	log = []
+	for msg_out in local.message_log:
+		log.append(json.loads(msg_out))
+
+	return log
 
 def clear_last_message():
 	if len(local.message_log) > 0:

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -187,6 +187,7 @@ def bulk_workflow_approval(docnames, doctype, action):
 		try:
 			show_progress(docnames, _('Applying: {0}').format(action), i, docname)
 			apply_workflow(frappe.get_doc(doctype, docname), action)
+			frappe.db.commit()
 		except frappe.ValidationError:
 			frappe.log_error(frappe.get_traceback(), "Workflow {0} threw an error for {1} {2}".format(action, doctype, docname))
 			frappe.db.rollback()

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -188,7 +188,8 @@ def bulk_workflow_approval(docnames, doctype, action):
 			show_progress(docnames, _('Applying: {0}').format(action), i, docname)
 			apply_workflow(frappe.get_doc(doctype, docname), action)
 		except frappe.ValidationError:
-			pass
+			frappe.log_error(frappe.get_traceback(), "Workflow {0} threw an error for {1} {2}".format(action, doctype, docname))
+			frappe.db.rollback()
 
 @frappe.whitelist()
 def get_common_transition_actions(docs, doctype):

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -182,15 +182,58 @@ def get_workflow_field_value(workflow_name, field):
 
 @frappe.whitelist()
 def bulk_workflow_approval(docnames, doctype, action):
+	from collections import defaultdict
+
+	# dictionaries for logging
+	errored_documents = defaultdict(list)
+	successful_documents = defaultdict(list)
+
+	# WARN: message log is cleared
+	print("Clearing frappe.message_log...")
+	frappe.clear_messages()
+
 	docnames = json.loads(docnames)
-	for (i, docname) in enumerate(docnames, 1):
+	for (idx, docname) in enumerate(docnames, 1):
 		try:
-			show_progress(docnames, _('Applying: {0}').format(action), i, docname)
+			show_progress(docnames, _('Applying: {0}').format(action), idx, docname)
 			apply_workflow(frappe.get_doc(doctype, docname), action)
 			frappe.db.commit()
 		except frappe.ValidationError:
 			frappe.log_error(frappe.get_traceback(), "Workflow {0} threw an error for {1} {2}".format(action, doctype, docname))
 			frappe.db.rollback()
+		finally:
+			if frappe.message_log:
+				messages = frappe.get_message_log()
+				for message in messages:
+					frappe.message_log.pop()
+					message_dict = {"docname": docname, "message": message.get("message")}
+
+					if message.get("raise_exception", False):
+						errored_documents[docname].append(message_dict)
+					else:
+						successful_documents[docname].append(message_dict)
+			else:
+				successful_documents[docname].append({"docname": docname, "message": None})
+
+	print_workflow_log(errored_documents, "Errored Documents", doctype)
+	print_workflow_log(successful_documents, "Successful Documents", doctype)
+
+def print_workflow_log(messages, title, doctype):
+	if messages.keys():
+		msg = "<h4>{0}</h4>".format(title)
+
+		for doc in messages.keys():
+			if len(messages[doc]):
+				html = "<details><summary>{0}</summary>".format(frappe.utils.get_link_to_form(doctype, doc))
+				for log in messages[doc]:
+					if log.get('message'):
+						html += "<div class='small text-muted' style='padding:2.5px'>{0}</div>".format(log.get('message'))
+				html += "</details>"
+			else:
+				html = "<div>{0}</div>".format(doc)
+			msg += html
+
+		frappe.msgprint(msg, title="Workflow Log")
 
 @frappe.whitelist()
 def get_common_transition_actions(docs, doctype):

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -185,8 +185,8 @@ def bulk_workflow_approval(docnames, doctype, action):
 	from collections import defaultdict
 
 	# dictionaries for logging
-	errored_documents = defaultdict(list)
-	successful_documents = defaultdict(list)
+	errored_transactions = defaultdict(list)
+	successful_transactions = defaultdict(list)
 
 	# WARN: message log is cleared
 	print("Clearing frappe.message_log...")
@@ -209,16 +209,23 @@ def bulk_workflow_approval(docnames, doctype, action):
 					message_dict = {"docname": docname, "message": message.get("message")}
 
 					if message.get("raise_exception", False):
-						errored_documents[docname].append(message_dict)
+						errored_transactions[docname].append(message_dict)
 					else:
-						successful_documents[docname].append(message_dict)
+						successful_transactions[docname].append(message_dict)
 			else:
-				successful_documents[docname].append({"docname": docname, "message": None})
+				successful_transactions[docname].append({"docname": docname, "message": None})
 
-	print_workflow_log(errored_documents, "Errored Documents", doctype)
-	print_workflow_log(successful_documents, "Successful Documents", doctype)
+	if errored_transactions and successful_transactions:
+		indicator = "orange"
+	elif errored_transactions:
+		indicator  = "red"
+	else:
+		indicator = "green"
 
-def print_workflow_log(messages, title, doctype):
+	print_workflow_log(errored_transactions, _("Errored Transactions"), doctype, indicator)
+	print_workflow_log(successful_transactions, _("Successful Transactions"), doctype, indicator)
+
+def print_workflow_log(messages, title, doctype, indicator):
 	if messages.keys():
 		msg = "<h4>{0}</h4>".format(title)
 
@@ -233,7 +240,7 @@ def print_workflow_log(messages, title, doctype):
 				html = "<div>{0}</div>".format(doc)
 			msg += html
 
-		frappe.msgprint(msg, title="Workflow Log")
+		frappe.msgprint(msg, title=_("Workflow Status"), indicator=indicator)
 
 @frappe.whitelist()
 def get_common_transition_actions(docs, doctype):


### PR DESCRIPTION
- On Failure of applying workflow in bulk, transaction passed anyway
- Inconsistent Data due to partial transaction

**After Fix:**
- Commit successful transactions and rollback failed ones
- Show consolidated message with highlights of the bulk transaction
  - Orange indicator for partially errorred bulk transaction
![Screenshot 2020-02-19 at 3 37 44 PM](https://user-images.githubusercontent.com/25857446/74825318-bac0fe80-532f-11ea-9598-77490378268f.png)


  -  Green for fully complete bulk transaction
     ![Screenshot 2020-02-19 at 3 38 39 PM](https://user-images.githubusercontent.com/25857446/74825169-7a618080-532f-11ea-957f-e9ce0d5e28c9.png)

  - Red for fully failed bulk transaction
    ![Screenshot 2020-02-19 at 3 39 08 PM](https://user-images.githubusercontent.com/25857446/74825177-7d5c7100-532f-11ea-9c92-4801c1e70481.png)


**How to test:**
- Apply workflow on a doctype
- Try to apply bulk workflow action from list view with one of the entries faulty
- Successful documents should pass and unsuccessful ones should rollback
**e.g.** bulk approve some documents 001,002,003,004,005 from the List View
003 must be faulty (not enough stock, etc.)