### PR TITLE
fix(ListView): use meta sort by and sort order

### DIFF
--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -92,17 +92,16 @@ frappe.ui.SortSelector = Class.extend({
 		var meta = frappe.get_meta(this.doctype);
 		if (!meta) return;
 
+		// default sort order
+		this.args.sort_by = 'modified';
+		this.args.sort_order = 'desc';
+
 		var { meta_sort_field, meta_sort_order } = this.get_meta_sort_field();
 
-		if(!this.args.sort_by) {
-			if(meta_sort_field) {
-				this.args.sort_by = meta_sort_field;
-				this.args.sort_order = meta_sort_order;
-			} else {
-				// default
-				this.args.sort_by = 'modified';
-				this.args.sort_order = 'desc';
-			}
+		// If sort field is set in meta, use it else fallabck to default
+		if(meta_sort_field && meta_sort_order) {
+			this.args.sort_by = meta_sort_field;
+			this.args.sort_order = meta_sort_order;
 		}
 
 		if(!this.args.sort_by_label) {


### PR DESCRIPTION
- Default `sort by` and `sort order` was being set inspite of being set in meta.
- Now `sort by` and `sort order` set in meta is considered else it'll fallback to `modified`.
- Before fix
![unsort](https://user-images.githubusercontent.com/7310479/74047686-c68af780-49f6-11ea-8279-32d5e3360cf4.gif)
- After fix
![sort](https://user-images.githubusercontent.com/7310479/74047131-da822980-49f5-11ea-834f-270427771a6a.gif)
