### PR TITLE
fix(Link): Set Link DocField default if permission ignored

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -144,7 +144,10 @@ $.extend(frappe.model, {
 				return default_doc;
 			}
 
-			if(!df.ignore_user_permissions) {
+			if(df.ignore_user_permissions) {
+				// 2 - If User Permission is ignored, only then set docfield default
+				user_default = df["default"];
+			} else {
 				// 2 - look in user defaults
 				var user_defaults = frappe.defaults.get_user_defaults(df.options);
 				if (user_defaults && user_defaults.length===1) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -144,10 +144,9 @@ $.extend(frappe.model, {
 				return default_doc;
 			}
 
-			if(df.ignore_user_permissions) {
-				// 2 - If User Permission is ignored, only then set docfield default
-				user_default = df["default"];
-			} else {
+			user_default = df["default"];
+
+			if(!df.ignore_user_permissions && !user_default) {
 				// 2 - look in user defaults
 				var user_defaults = frappe.defaults.get_user_defaults(df.options);
 				if (user_defaults && user_defaults.length===1) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -144,7 +144,9 @@ $.extend(frappe.model, {
 				return default_doc;
 			}
 
-			user_default = df["default"];
+			if (df["default"] && (!has_user_permissions || allowed_records.includes(df["default"]))) {
+				user_default = df["default"];
+			}
 
 			if(!df.ignore_user_permissions && !user_default) {
 				// 2 - look in user defaults

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -144,7 +144,7 @@ $.extend(frappe.model, {
 				return default_doc;
 			}
 
-			if (df["default"] && (!has_user_permissions || allowed_records.includes(df["default"]))) {
+			if (this.check_permission(df["default"], has_user_permissions, allowed_records)) {
 				user_default = df["default"];
 			}
 
@@ -165,8 +165,7 @@ $.extend(frappe.model, {
 				user_default = frappe.boot.user.last_selected_values[df.options];
 			}
 
-			var is_allowed_user_default = user_default &&
-				(!has_user_permissions || allowed_records.includes(user_default));
+			var is_allowed_user_default = this.check_permission(user_default, has_user_permissions, allowed_records);
 
 			// is this user default also allowed as per user permissions?
 			if (is_allowed_user_default) {
@@ -322,6 +321,10 @@ $.extend(frappe.model, {
 				}
 			}
 		})
+	},
+
+	check_permission: function(default_value, has_user_permissions, allowed_records) {
+		return default_value && (!has_user_permissions || allowed_records.includes(default_value));
 	}
 });
 

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -146,7 +146,7 @@ $.extend(frappe.model, {
 
 			user_default = df["default"];
 
-			if(!df.ignore_user_permissions && !user_default) {
+			if (!df.ignore_user_permissions && !user_default) {
 				// 2 - look in user defaults
 				var user_defaults = frappe.defaults.get_user_defaults(df.options);
 				if (user_defaults && user_defaults.length===1) {


### PR DESCRIPTION
- While creating a new Document, for Link Fields, if a corresponding `user.defaults` is found for the DocType, then the value is set depending on the User Permissions.
- Inspite of default value is set in Link DocField, value is set from `user.defaults` and not from DocField default.
- Consider the following example:
        - In Contact, a custom Link Field is added for `Language` and `de` is set as default value. Now when a new Contact is created, the system will link `en` to the Link Filed instead of `de` since `en` is set in system default .
        - The system will set the Link Field value mentioned in DocField default and check the permission.

![def](https://user-images.githubusercontent.com/7310479/74056757-96e4eb00-4a08-11ea-9776-78ab63cf7550.gif)
