### PR TITLE
revert: "fix(security): invalidate reset_password_key on password reset"

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -98,8 +98,6 @@ class User(Document):
 		clear_notifications(user=self.name)
 		frappe.clear_cache(user=self.name)
 		self.send_password_notification(self.__new_password)
-		if self.__new_password:
-			self.reset_password_key = ''
 		create_contact(self, ignore_mandatory=True)
 		if self.name not in ('Administrator', 'Guest') and not self.user_image:
 			frappe.enqueue('frappe.core.doctype.user.user.update_gravatar', name=self.name)


### PR DESCRIPTION
This reverts commit 35024c18fc86d51e0e414068c3494510d2ad14e3.

This is because whenever a new user registered from the sign-up page, the `reset_password_key` was being set and then instantly unset inside `on_update()`