### PR TITLE
fix: Cypress run command

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -523,7 +523,7 @@ def run_ui_tests(context, app, headless=False):
 
 	# run for headless mode
 	run_or_open = 'run' if headless else 'open'
-	command = '{site_env} {password_env} yarn run cypress:{run_or_open}'
+	command = '{site_env} {password_env} yarn run cypress {run_or_open}'
 	formatted_command = command.format(site_env=site_env, password_env=password_env, run_or_open=run_or_open)
 	frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)
 


### PR DESCRIPTION
Cypress command should not depend on `package.json` script entry.