### PR TITLE
feat: honour quick entry settings for tree doctypes

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -321,7 +321,6 @@ $.extend(frappe.model, {
 	}
 });
 
-frappe.create_routes = {};
 frappe.new_doc = function (doctype, opts, init_callback) {
 	if (doctype === 'File') {
 		new frappe.ui.FileUploader({
@@ -334,13 +333,8 @@ frappe.new_doc = function (doctype, opts, init_callback) {
 			frappe.route_options = opts;
 		}
 		frappe.model.with_doctype(doctype, function() {
-			if(frappe.create_routes[doctype]) {
-				frappe.set_route(frappe.create_routes[doctype])
-					.then(() => resolve());
-			} else {
-				frappe.ui.form.make_quick_entry(doctype, null, init_callback)
-					.then(() => resolve());
-			}
+			frappe.ui.form.make_quick_entry(doctype, null, init_callback)
+				.then(() => resolve());
 		});
 
 	});

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -193,7 +193,7 @@ frappe.views.TreeView = Class.extend({
 					return me.can_create && node.expandable && !node.hide_add;
 				},
 				click: function(node) {
-					me.new_node();
+					me.add_new_node();
 				},
 				btnClass: "hidden-xs"
 			},
@@ -235,6 +235,14 @@ frappe.views.TreeView = Class.extend({
 			return this.opts.toolbar
 		} else {
 			return toolbar
+		}
+	},
+	add_new_node: function () {
+		var me = this;
+		if (frappe.get_meta(me.doctype).quick_entry) {
+			me.new_node();
+		} else {
+			frappe.new_doc(me.doctype);
 		}
 	},
 	new_node: function() {
@@ -349,8 +357,8 @@ frappe.views.TreeView = Class.extend({
 	set_primary_action: function(){
 		var me = this;
 		if (!this.opts.disable_add_node && this.can_create) {
-			me.page.set_primary_action(__("New"), function() {
-				me.new_node();
+			me.page.set_primary_action(__("New"), function () {
+				me.add_new_node();
 			}, "octicon octicon-plus")
 		}
 	},
@@ -395,11 +403,3 @@ frappe.views.TreeView = Class.extend({
 		});
 	}
 });
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Cleanup for related ERPNext objects at https://github.com/frappe/erpnext/pull/20558.

<hr>

**Problem:**

Treeview DocTypes don't honour their "Quick Entry" settings, causing a quick entry form to pop up while trying to create new nodes.