### PR TITLE
feat: add button to resend welcome email

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -114,7 +114,6 @@ frappe.ui.form.on('User', {
 				});
 			}, __("Password"));
 
-
 			frm.trigger('enabled');
 
 			if (frm.roles_editor && frm.can_edit_roles) {

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -73,7 +73,6 @@ frappe.ui.form.on('User', {
 
 		if(!frm.is_new()) {
 			if(has_access_to_edit_user()) {
-
 				frm.add_custom_button(__("Resend Welcome Email"), function(){
 					frappe.call({
 						method : 'frappe.core.doctype.user.user.resend_welcome_email',
@@ -82,7 +81,6 @@ frappe.ui.form.on('User', {
 						},
 					})
 				})
-
 
 				frm.add_custom_button(__("Set User Permissions"), function() {
 					frappe.route_options = {

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -74,6 +74,7 @@ frappe.ui.form.on('User', {
 		if(!frm.is_new()) {
 			if(has_access_to_edit_user()) {
 				frm.add_custom_button(__("Resend Welcome Email"), function(){
+<<<<<<< HEAD
 					frappe.call({
 						method : 'frappe.core.doctype.user.user.resend_welcome_email',
 						args: {
@@ -82,6 +83,12 @@ frappe.ui.form.on('User', {
 					})
 				})
 
+=======
+					frm.call('send_welcome_mail_to_user').then(()=>{
+						frappe.msgprint(__(`Email has been sent to $(frm.doc.email)`));
+					})
+				})
+>>>>>>> Send welcome mail called from frm
 				frm.add_custom_button(__("Set User Permissions"), function() {
 					frappe.route_options = {
 						"user": doc.name

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -73,22 +73,11 @@ frappe.ui.form.on('User', {
 
 		if(!frm.is_new()) {
 			if(has_access_to_edit_user()) {
-				frm.add_custom_button(__("Resend Welcome Email"), function(){
-<<<<<<< HEAD
-					frappe.call({
-						method : 'frappe.core.doctype.user.user.resend_welcome_email',
-						args: {
-							email: frm.doc.name
-						},
-					})
-				})
-
-=======
+				frm.add_custom_button(__("Resend Welcome Email"), function() {
 					frm.call('send_welcome_mail_to_user').then(()=>{
-						frappe.msgprint(__(`Email has been sent to $(frm.doc.email)`));
-					})
-				})
->>>>>>> Send welcome mail called from frm
+						frappe.msgprint(__("Email has been sent to {0}", [frm.doc.email]));
+					});
+				});
 				frm.add_custom_button(__("Set User Permissions"), function() {
 					frappe.route_options = {
 						"user": doc.name

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -74,6 +74,16 @@ frappe.ui.form.on('User', {
 		if(!frm.is_new()) {
 			if(has_access_to_edit_user()) {
 
+				frm.add_custom_button(__("Resend Welcome Email"), function(){
+					frappe.call({
+						method : 'frappe.core.doctype.user.user.resend_welcome_email',
+						args: {
+							email: frm.doc.name
+						},
+					})
+				})
+
+
 				frm.add_custom_button(__("Set User Permissions"), function() {
 					frappe.route_options = {
 						"user": doc.name
@@ -105,6 +115,7 @@ frappe.ui.form.on('User', {
 					}
 				});
 			}, __("Password"));
+
 
 			frm.trigger('enabled');
 

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -78,6 +78,7 @@ frappe.ui.form.on('User', {
 						frappe.msgprint(__("Email has been sent to {0}", [frm.doc.email]));
 					});
 				});
+				
 				frm.add_custom_button(__("Set User Permissions"), function() {
 					frappe.route_options = {
 						"user": doc.name

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -603,6 +603,12 @@ def test_password_strength(new_password, key=None, old_password=None, user_data=
 def has_email_account(email):
 	return frappe.get_list("Email Account", filters={"email_id": email})
 
+@frappe.whitelist()
+def resend_welcome_email(email):
+	user_doc = frappe.get_doc("User",email)
+	user_doc.send_welcome_mail_to_user()
+	
+
 @frappe.whitelist(allow_guest=False)
 def get_email_awaiting(user):
 	waiting = frappe.db.sql("""select email_account,email_id

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -601,11 +601,6 @@ def test_password_strength(new_password, key=None, old_password=None, user_data=
 @frappe.whitelist()
 def has_email_account(email):
 	return frappe.get_list("Email Account", filters={"email_id": email})
-
-@frappe.whitelist()
-def resend_welcome_email(email):
-	user_doc = frappe.get_doc("User", email)
-	user_doc.send_welcome_mail_to_user()
 	
 @frappe.whitelist(allow_guest=False)
 def get_email_awaiting(user):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -174,7 +174,6 @@ class User(Document):
 				and name in ({0}) limit 1""".format(', '.join(['%s'] * len(self.roles))),
 				[d.role for d in self.roles]))
 
-
 	def share_with_self(self):
 		if self.user_type=="System User":
 			frappe.share.add(self.doctype, self.name, self.name, write=1, share=1,
@@ -605,7 +604,7 @@ def has_email_account(email):
 
 @frappe.whitelist()
 def resend_welcome_email(email):
-	user_doc = frappe.get_doc("User",email)
+	user_doc = frappe.get_doc("User", email)
 	user_doc.send_welcome_mail_to_user()
 	
 @frappe.whitelist(allow_guest=False)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -608,7 +608,6 @@ def resend_welcome_email(email):
 	user_doc = frappe.get_doc("User",email)
 	user_doc.send_welcome_mail_to_user()
 	
-
 @frappe.whitelist(allow_guest=False)
 def get_email_awaiting(user):
 	waiting = frappe.db.sql("""select email_account,email_id

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -601,7 +601,7 @@ def test_password_strength(new_password, key=None, old_password=None, user_data=
 @frappe.whitelist()
 def has_email_account(email):
 	return frappe.get_list("Email Account", filters={"email_id": email})
-	
+
 @frappe.whitelist(allow_guest=False)
 def get_email_awaiting(user):
 	waiting = frappe.db.sql("""select email_account,email_id

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -800,7 +800,6 @@ class Document(BaseDocument):
 			fn = lambda self, *args, **kwargs: None
 
 		fn.__name__ = str(method)
-		print("**********************************", fn)
 		out = Document.hook(fn)(self, *args, **kwargs)
 
 		self.run_notifications(method)
@@ -1087,7 +1086,6 @@ class Document(BaseDocument):
 				+ doc_events.get("*", {}).get(method, []):
 				hooks.append(frappe.get_attr(handler))
 
-			print("------------------------------------------------", f)
 			composed = compose(f, *hooks)
 			return composed(self, method, *args, **kwargs)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -800,6 +800,7 @@ class Document(BaseDocument):
 			fn = lambda self, *args, **kwargs: None
 
 		fn.__name__ = str(method)
+		print("**********************************", fn)
 		out = Document.hook(fn)(self, *args, **kwargs)
 
 		self.run_notifications(method)
@@ -1086,6 +1087,7 @@ class Document(BaseDocument):
 				+ doc_events.get("*", {}).get(method, []):
 				hooks.append(frappe.get_attr(handler))
 
+			print("------------------------------------------------", f)
 			composed = compose(f, *hooks)
 			return composed(self, method, *args, **kwargs)
 


### PR DESCRIPTION
When You create a new user, there was a checkbox with checked of 
As a user it was difficult to send the resend welcome email, 

port of #9466 