### PR TITLE
fix(base_list): Verify that filters was not undefined/empty.

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -230,7 +230,7 @@ frappe.views.BaseList = class BaseList {
 	setup_filter_area() {
 		this.filter_area = new FilterArea(this);
 
-		if (this.filters.length > 0) {
+		if(this.filters && this.filters.length > 0) {
 			return this.filter_area.set(this.filters);
 		}
 	}


### PR DESCRIPTION
Fixes the verification for undefined or empty filters
closes #9467 