### PR TITLE
Better only for message

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -544,7 +544,7 @@ def only_for(roles, message=False):
 	myroles = set(get_roles())
 	if not roles.intersection(myroles):
 		if message:
-			msgprint(_('Only for {}').format(', '.join(roles)))
+			msgprint(_('This action is only allowed for {}').format(bold(', '.join(roles))), _('Not Permitted'))
 		raise PermissionError
 
 def get_domain_data(module):

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1163,7 +1163,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			}
 		];
 
-		if(frappe.user.is_report_manager()) {
+		if (frappe.user.is_report_manager()) {
 			items.push({
 				label: __('Save'),
 				action: () => {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1022,7 +1022,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	get_menu_items() {
-		return [
+		let items = [
 			{
 				label: __('Refresh'),
 				action: () => this.refresh(),
@@ -1153,6 +1153,18 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				standard: true
 			},
 			{
+				label: __('User Permissions'),
+				action: () => frappe.set_route('List', 'User Permission', {
+					doctype: 'Report',
+					name: this.report_name
+				}),
+				condition: () => frappe.model.can_set_user_permissions('Report'),
+				standard: true
+			}
+		];
+
+		if(frappe.user.is_report_manager()) {
+			items.push({
 				label: __('Save'),
 				action: () => {
 					let d = new frappe.ui.Dialog({
@@ -1163,6 +1175,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								fieldname: 'report_name',
 								label: __("Report Name"),
 								default: this.report_doc.is_standard == 'No' ? this.report_name : "",
+								reqd: true
 							}
 						],
 						primary_action: (values) => {
@@ -1184,17 +1197,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					d.show();
 				},
 				standard: true
-			},
-			{
-				label: __('User Permissions'),
-				action: () => frappe.set_route('List', 'User Permission', {
-					doctype: 'Report',
-					name: this.report_name
-				}),
-				condition: () => frappe.model.can_set_user_permissions('Report'),
-				standard: true
-			}
-		];
+			})
+		}
+
+		return items
 	}
 
 	add_portrait_warning(dialog) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1200,7 +1200,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			})
 		}
 
-		return items
+		return items;
 	}
 
 	add_portrait_warning(dialog) {


### PR DESCRIPTION
### Better `only for` message

<img width="404" alt="Screenshot 2020-02-17 at 1 53 45 PM" src="https://user-images.githubusercontent.com/18097732/74636913-f83a5600-518e-11ea-824f-cd037ebcbd6c.png">

### Report Fixes
- Show save option only to report manager
- Make report name mandatory, clicking submit otherwise would break.

![image](https://user-images.githubusercontent.com/18097732/74636889-ebb5fd80-518e-11ea-9e91-f821e23ecbf0.png)
