### PR TITLE
feat: don't try to export empty report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -303,6 +303,11 @@ def export_query():
 	if file_format_type == "Excel":
 		data = run(report_name, filters)
 		data = frappe._dict(data)
+		if not data.columns:
+			frappe.respond_as_web_page(_("No data to export"),
+			_("You can try changing the filters of your report."))
+			return
+
 		columns = get_columns_dict(data.columns)
 
 		from frappe.utils.xlsxutils import make_xlsx


### PR DESCRIPTION
Port of https://github.com/frappe/frappe/pull/9480

Exporting an empty report would break

<img width="692" alt="Screenshot 2020-02-17 at 4 12 30 PM" src="https://user-images.githubusercontent.com/18097732/74646673-4d329800-51a0-11ea-8360-e8c9e936efd6.png">

This PR fixes that