### PR TITLE
Stock Balance Report Shows Fatal Error #20602

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -185,7 +185,7 @@ def run(report_name, filters=None, user=None, ignore_prepared_report=False):
 	else:
 		result = generate_report_result(report, filters, user)
 
-	result["add_total_row"] = report.add_total_row and not result['skip_total_row']
+	result["add_total_row"] = report.add_total_row and not result.get('skip_total_row')
 
 	return result
 


### PR DESCRIPTION
**Stock Balance Report Shows Fatal Error #20602 #9470**

**Description of the issue**
After Creating Stock Entry for particular Item, Goes to Stock Balance Report for Balance Check in Warehouse. And Show Fatal Error On Screen

**Context information (for bug reports)
Output of bench version**

erpnext 12.x.x-develop
frappe 12.x.x-develop

**Steps to reproduce the issue**
1.Create Stock Entry for Item with Material Receipt
**Child Table Details:**

Target Warehouse: Store - I
Item Code: RTX-2070 Armor
Item Group: Products
Qty: 2
2.After Submit Goes to Stock Balance Report For Checking Stock in Warehouse.
3.Fatal Error Comes on Screen

**Observed result**
Stock Balance Report not showing some data in report
**Expected result**
Stock Balance Report need to Show some data in report
**Stacktrace / full error message**
```
Traceback (most recent call last):
  File "/home/indictrans/workspace/v12-develop/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/indictrans/workspace/v12-develop/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/indictrans/workspace/v12-develop/frappe-bench/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/indictrans/workspace/v12-develop/frappe-bench/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/indictrans/workspace/v12-develop/frappe-bench/apps/frappe/frappe/__init__.py", line 1058, in call
    return fn(*args, **newargs)
  File "/home/indictrans/workspace/v12-develop/frappe-bench/apps/frappe/frappe/__init__.py", line 521, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/indictrans/workspace/v12-develop/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 188, in run
    result["add_total_row"] = report.add_total_row and not result['skip_total_row']
KeyError: 'skip_total_row'

**```**
**After Codebase Changes I am Able to see Generate New Report Button**
![image](https://user-images.githubusercontent.com/41181281/74586638-7243d100-500f-11ea-9855-d44834b84e75.png)



**Additional information**
OS Details:

Ubuntu 16.04 LTS

**Installation Steps:**

virtualenv -p /usr/bin/python3 .
source ./bin/activate
git clone bench-repo
bench init
bench get-app erpnext