### PR TITLE
fix(base_list): Verify that filters are not undefined/empty. #9468

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -230,7 +230,7 @@ frappe.views.BaseList = class BaseList {
 	setup_filter_area() {
 		this.filter_area = new FilterArea(this);
 
-		if(this.filters && this.filters.length > 0) {
+		if (this.filters && this.filters.length > 0) {
 			return this.filter_area.set(this.filters);
 		}
 	}

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -230,7 +230,7 @@ frappe.views.BaseList = class BaseList {
 	setup_filter_area() {
 		this.filter_area = new FilterArea(this);
 
-		if (this.filters.length > 0) {
+		if(this.filters && this.filters.length > 0) {
 			return this.filter_area.set(this.filters);
 		}
 	}


### PR DESCRIPTION
Fixes an issue with empty filters in certain list views as referenced in #9467

Explain the details for making this change. What existing problem does the pull request solve?
Certain lists in ERPNext reports create issues due to an insufficient handling of not defined or empty filters.

<img width="802" alt="Screenshot 2020-02-14 at 14 56 03" src="https://user-images.githubusercontent.com/579379/74674140-05683c80-51b1-11ea-8dbc-d2c2602d539f.png">
closes #9467 