### PR TITLE
fix: Remove unnecessary code from treeview

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -57,9 +57,6 @@ def add_node():
 	args = make_tree_args(**frappe.form_dict)
 	doc = frappe.get_doc(args)
 
-	if args.doctype == "Sales Person":
-		doc.employee = frappe.form_dict.get('employee')
-
 	doc.save()
 
 def make_tree_args(**kwarg):


### PR DESCRIPTION
Sales Person related code should exist in ERPNext and not in Frappe. So removed it. Sales Person addition worked just fine even without this piece of code, not sure why it existed in the first place.