### PR TITLE
fix: skip columns not sent

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -185,7 +185,7 @@ def run(report_name, filters=None, user=None, ignore_prepared_report=False):
 	else:
 		result = generate_report_result(report, filters, user)
 
-	result["add_total_row"] = report.add_total_row and not result['skip_total_row']
+	result["add_total_row"] = report.add_total_row and not result.get('skip_total_row', False)
 
 	return result
 


### PR DESCRIPTION
For a new prepared report the following error would occur.

```
Traceback (most recent call last):
  File "/Users/shivammishra/Projects/ERPNext/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/shivammishra/Projects/ERPNext/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/shivammishra/Projects/ERPNext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/shivammishra/Projects/ERPNext/frappe-bench/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/shivammishra/Projects/ERPNext/frappe-bench/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/Users/shivammishra/Projects/ERPNext/frappe-bench/apps/frappe/frappe/__init__.py", line 515, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/Users/shivammishra/Projects/ERPNext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 188, in run
    result["add_total_row"] = report.add_total_row and not result['skip_total_row']
KeyError: 'skip_total_row'
```

<img width="1189" alt="Screenshot 2020-02-17 at 3 31 25 PM" src="https://user-images.githubusercontent.com/18097732/74643424-b1eaf400-519a-11ea-9257-0e6cf2828158.png">


This PR fixes that

port-of: https://github.com/frappe/frappe/pull/9478