### PR TITLE
refactor: improvements for setup_wizard

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -10,8 +10,6 @@ from six import iteritems, binary_type, text_type, string_types
 from werkzeug.local import Local, release_local
 import os, sys, importlib, inspect, json
 from past.builtins import cmp
-from functools import wraps
-from time import time
 
 from faker import Faker
 
@@ -505,16 +503,6 @@ def whitelist(allow_guest=False, xss_safe=False):
 		return fn
 
 	return innerfn
-
-def timing(f):
-	@wraps(f)
-	def wrap(*args, **kw):
-		ts = time()
-		result = f(*args, **kw)
-		te = time()
-		print('TIMING: {0} > {1} took: {2:2.4f} sec'.format(f.__module__, f.__name__, te-ts))
-		return result
-	return wrap
 
 def read_only():
 	def innfn(fn):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -10,6 +10,8 @@ from six import iteritems, binary_type, text_type, string_types
 from werkzeug.local import Local, release_local
 import os, sys, importlib, inspect, json
 from past.builtins import cmp
+from functools import wraps
+from time import time
 
 from faker import Faker
 
@@ -503,6 +505,18 @@ def whitelist(allow_guest=False, xss_safe=False):
 		return fn
 
 	return innerfn
+
+def timing(f):
+
+    @wraps(f)
+    def wrap(*args, **kw):
+        ts = time()
+        result = f(*args, **kw)
+        te = time()
+        print('TIMING: {0} > {1} took: {2:2.4f} sec'.format(f.__module__, f.__name__, te-ts))
+        return result
+
+    return wrap
 
 def read_only():
 	def innfn(fn):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -507,16 +507,14 @@ def whitelist(allow_guest=False, xss_safe=False):
 	return innerfn
 
 def timing(f):
-
-    @wraps(f)
-    def wrap(*args, **kw):
-        ts = time()
-        result = f(*args, **kw)
-        te = time()
-        print('TIMING: {0} > {1} took: {2:2.4f} sec'.format(f.__module__, f.__name__, te-ts))
-        return result
-
-    return wrap
+	@wraps(f)
+	def wrap(*args, **kw):
+		ts = time()
+		result = f(*args, **kw)
+		te = time()
+		print('TIMING: {0} > {1} took: {2:2.4f} sec'.format(f.__module__, f.__name__, te-ts))
+		return result
+	return wrap
 
 def read_only():
 	def innfn(fn):

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -170,7 +170,7 @@ def reopen_closed_assignment(doc):
 	return True
 
 def apply(doc, method=None, doctype=None, name=None):
-	if frappe.flags.in_patch or frappe.flags.in_install:
+	if frappe.flags.in_patch or frappe.flags.in_install or frappe.flags.in_setup_wizard:
 		return
 
 	if not doc and doctype and name:

--- a/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
@@ -30,6 +30,10 @@ class MilestoneTracker(Document):
 			)).insert(ignore_permissions=True)
 
 def evaluate_milestone(doc, event):
+	if (frappe.flags.in_install
+		or frappe.flags.in_migrate
+		or frappe.flags.in_setup_wizard):
+		return
 	for d in frappe.cache_manager.get_doctype_map('Milestone Tracker', doc.doctype,
 		dict(document_type = doc.doctype, disabled=0)):
 		frappe.get_doc('Milestone Tracker', d.name).apply(doc)

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -117,7 +117,11 @@ def clear_doctype_map(doctype, name):
 	frappe.cache().hdel(cache_key, name)
 
 def build_table_count_cache(*args, **kwargs):
-	if frappe.flags.in_patch or frappe.flags.in_install or frappe.flags.in_import:
+	if (frappe.flags.in_patch
+		or frappe.flags.in_install
+		or frappe.flags.in_migrate
+		or frappe.flags.in_import
+		or frappe.flags.in_setup_wizard):
 		return
 	_cache = frappe.cache()
 	data = frappe.db.multisql({
@@ -138,7 +142,11 @@ def build_table_count_cache(*args, **kwargs):
 	return counts
 
 def build_domain_restriced_doctype_cache(*args, **kwargs):
-	if frappe.flags.in_patch or frappe.flags.in_install or frappe.flags.in_import:
+	if (frappe.flags.in_patch
+		or frappe.flags.in_install
+		or frappe.flags.in_migrate
+		or frappe.flags.in_import
+		or frappe.flags.in_setup_wizard):
 		return
 	_cache = frappe.cache()
 	active_domains = frappe.get_active_domains()
@@ -149,7 +157,11 @@ def build_domain_restriced_doctype_cache(*args, **kwargs):
 	return doctypes
 
 def build_domain_restriced_page_cache(*args, **kwargs):
-	if frappe.flags.in_patch or frappe.flags.in_install or frappe.flags.in_import:
+	if (frappe.flags.in_patch
+		or frappe.flags.in_install
+		or frappe.flags.in_migrate
+		or frappe.flags.in_import
+		or frappe.flags.in_setup_wizard):
 		return
 	_cache = frappe.cache()
 	active_domains = frappe.get_active_domains()

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -351,6 +351,11 @@ def email_setup_wizard_exception(traceback, args):
 		message=message,
 		delayed=False)
 
+def log_setup_wizard_exception(traceback, args):
+	with open('../logs/setup-wizard.log', 'w+') as setup_log:
+		setup_log.write(traceback)
+		setup_log.write(json.dumps(args))
+
 def get_language_code(lang):
 	return frappe.db.get_value('Language', {'language_name':lang})
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -61,6 +61,7 @@ def setup_complete(args):
 	stages = get_setup_stages(args)
 
 	try:
+		frappe.flags.in_setup_wizard = True
 		current_task = None
 		for idx, stage in enumerate(stages):
 			frappe.publish_realtime('setup_task', {"progress": [idx, len(stages)],
@@ -75,6 +76,8 @@ def setup_complete(args):
 	else:
 		run_setup_success(args)
 		return {'status': 'ok'}
+	finally:
+		frappe.flags.in_setup_wizard = False
 
 def update_global_settings(args):
 	if args.language and args.language != "English":

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -141,6 +141,7 @@ doc_events = {
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points"
 		],
 		"after_insert": "frappe.cache_manager.build_table_count_cache",
+		"on_trash": "frappe.cache_manager.build_table_count_cache",
 	},
 	"Event": {
 		"after_insert": "frappe.integrations.doctype.google_calendar.google_calendar.insert_event_in_google_calendar",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -251,7 +251,10 @@ bot_parsers = [
 	'frappe.utils.bot.CountBot'
 ]
 
-setup_wizard_exception = "frappe.desk.page.setup_wizard.setup_wizard.email_setup_wizard_exception"
+setup_wizard_exception = [
+	"frappe.desk.page.setup_wizard.setup_wizard.email_setup_wizard_exception",
+	"frappe.desk.page.setup_wizard.setup_wizard.log_setup_wizard_exception"
+]
 
 before_migrate = ['frappe.patches.v11_0.sync_user_permission_doctype_before_migrate.execute']
 after_migrate = ['frappe.website.doctype.website_theme.website_theme.generate_theme_files_if_not_exist']

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -135,13 +135,13 @@ doc_events = {
 		],
 		"on_trash": [
 			"frappe.desk.notifications.clear_doctype_notifications",
-			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions"
+			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
+			"frappe.cache_manager.build_table_count_cache"
 		],
 		"on_change": [
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points"
 		],
-		"after_insert": "frappe.cache_manager.build_table_count_cache",
-		"on_trash": "frappe.cache_manager.build_table_count_cache",
+		"after_insert": "frappe.cache_manager.build_table_count_cache"
 	},
 	"Event": {
 		"after_insert": "frappe.integrations.doctype.google_calendar.google_calendar.insert_event_in_google_calendar",

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -263,7 +263,7 @@ class Document(BaseDocument):
 		if hasattr(self, "__islocal"):
 			delattr(self, "__islocal")
 
-		if not (frappe.flags.in_migrate or frappe.local.flags.in_install):
+		if not (frappe.flags.in_migrate or frappe.local.flags.in_install or frappe.flags.in_setup_wizard):
 			follow_document(self.doctype, self.name, frappe.session.user)
 		return self
 

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -84,7 +84,8 @@ def process_energy_points(doc, state):
 	if (frappe.flags.in_patch
 		or frappe.flags.in_install
 		or frappe.flags.in_migrate
-		or frappe.flags.in_import):
+		or frappe.flags.in_import
+		or frappe.flags.in_setup_wizard):
 		return
 
 	if not is_energy_point_enabled():


### PR DESCRIPTION
This PR has the following changes
1. Add a timing decorator that can be used to time any function
2. Added a `in_setup_wizard` flag
3. Skip the following in setup wizard
    - Rebuilding Table count cache
    - Document Follow
    - Energy Points
    - Assignment Rule
    - Milestone

Skipping these reduces the query count by ~30% and installation time by ~45% 