### PR TITLE
fix: set read only fieldtype as data for standard filters

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -614,7 +614,7 @@ class FilterArea {
 			let options = df.options;
 			let condition = '=';
 			let fieldtype = df.fieldtype;
-			if (['Text', 'Small Text', 'Text Editor', 'HTML Editor', 'Data', 'Code'].includes(fieldtype)) {
+			if (['Text', 'Small Text', 'Text Editor', 'HTML Editor', 'Data', 'Code', 'Read Only'].includes(fieldtype)) {
 				fieldtype = 'Data';
 				condition = 'like';
 			}


### PR DESCRIPTION
Read Only fieldtype fields should not remain as read only in standard filters.

For example:
<img width="1208" alt="Screenshot 2020-02-19 at 6 08 41 PM" src="https://user-images.githubusercontent.com/19775888/74835220-e3062880-5342-11ea-953e-b46d2dbd55a2.png">

The Employee Name filter is read only. 