### PR TITLE
fix(workflow action): De-duplicate actions sent in mail

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -146,7 +146,7 @@ def update_completed_workflow_actions(doc, user=None):
 
 def get_next_possible_transitions(workflow_name, state, doc=None):
 	transitions = frappe.get_all('Workflow Transition',
-		fields=['allowed', 'action', 'state', 'allow_self_approval', 'next_state', 'condition'],
+		fields=['allowed', 'action', 'state', 'allow_self_approval', 'next_state', '`condition`'],
 		filters=[['parent', '=', workflow_name],
 		['state', '=', state]])
 
@@ -170,15 +170,15 @@ def get_users_next_action_data(transitions, doc):
 		filtered_users = filter_allowed_users(users, doc, transition)
 		for user in filtered_users:
 			if not user_data_map.get(user):
-				user_data_map[user] = {
+				user_data_map[user] = frappe._dict({
 					'possible_actions': [],
 					'email': frappe.db.get_value('User', user, 'email'),
-				}
+				})
 
-			user_data_map[user].get('possible_actions').append({
+			user_data_map[user].get('possible_actions').append(frappe._dict({
 				'action_name': transition.action,
 				'action_link': get_workflow_action_url(transition.action, doc, user)
-			})
+			}))
 	return user_data_map
 
 

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -46,7 +46,7 @@ def process_workflow_actions(doc, state):
 	update_completed_workflow_actions(doc)
 	clear_doctype_notifications('Workflow Action')
 
-	next_possible_transitions = get_next_possible_transitions(workflow, get_doc_workflow_state(doc))
+	next_possible_transitions = get_next_possible_transitions(workflow, get_doc_workflow_state(doc), doc)
 
 	if not next_possible_transitions: return
 
@@ -144,9 +144,9 @@ def update_completed_workflow_actions(doc, user=None):
 		WHERE `reference_doctype`=%s AND `reference_name`=%s AND `user`=%s AND `status`='Open'""",
 		(user, doc.get('doctype'), doc.get('name'), user))
 
-def get_next_possible_transitions(workflow_name, state):
+def get_next_possible_transitions(workflow_name, state, doc=None):
 	transitions = frappe.get_all('Workflow Transition',
-		fields=['allowed', 'action', 'state', 'allow_self_approval', 'next_state'],
+		fields=['allowed', 'action', 'state', 'allow_self_approval', 'next_state', 'condition'],
 		filters=[['parent', '=', workflow_name],
 		['state', '=', state]])
 
@@ -155,6 +155,8 @@ def get_next_possible_transitions(workflow_name, state):
 	for transition in transitions:
 		is_next_state_optional = get_state_optional_field_value(workflow_name, transition.next_state)
 		# skip transition if next state of the transition is optional
+		if transition.condition and not frappe.safe_eval(transition.condition, None, {'doc': doc.as_dict()}):
+			continue
 		if is_next_state_optional:
 			continue
 		transitions_to_return.append(transition)
@@ -198,7 +200,7 @@ def send_workflow_action_email(users_data, doc):
 		email_args = {
 			'recipients': [d.get('email')],
 			'args': {
-				'actions': d.get('possible_actions'),
+				'actions': deduplicate_actions(d.get('possible_actions')),
 				'message': message
 			},
 			'reference_name': doc.name,
@@ -206,6 +208,14 @@ def send_workflow_action_email(users_data, doc):
 		}
 		email_args.update(common_args)
 		enqueue(method=frappe.sendmail, queue='short', **email_args)
+
+def deduplicate_actions(action_list):
+	action_map = {}
+	for action_data in action_list:
+		if not action_map.get(action_data.action_name):
+			action_map[action_data.action_name] = action_data
+
+	return action_map.values()
 
 def get_workflow_action_url(action, doc, user):
 	apply_action_method = "/api/method/frappe.workflow.doctype.workflow_action.workflow_action.apply_action"


### PR DESCRIPTION
Consider a scenario where there are multiple transitions with same action but with different Roles and Conditions.
<img width="915" alt="Screenshot 2020-02-07 at 6 14 52 PM" src="https://user-images.githubusercontent.com/13928957/74030726-c3cbda80-49d5-11ea-8d92-6fa8e2fc5660.png">

Then the user used to receive an email with a duplicate action button if that user had all the roles mentioned in the transition config. 

- De-duplicate workflow actions sent in the mail

Before:
<img width="408" alt="Screenshot 2020-02-07 at 6 05 43 PM" src="https://user-images.githubusercontent.com/13928957/74030560-5fa91680-49d5-11ea-909a-36f4e24bdb31.png">

After:
<img width="677" alt="Screenshot 2020-02-07 at 5 59 25 PM" src="https://user-images.githubusercontent.com/13928957/74030569-63d53400-49d5-11ea-8f87-61e69b3b17e6.png">

- Honor conditions set in the workflow transition while getting the next possible transitions.

port-of: https://github.com/frappe/frappe/pull/9439