### PR TITLE
fix(patch): delete depricated Google Maps Settings

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -260,3 +260,4 @@ frappe.patches.v12_0.create_notification_settings_for_user
 frappe.patches.v11_0.make_all_prepared_report_attachments_private #2019-11-26
 frappe.patches.v12_0.setup_email_linking
 frappe.patches.v12_0.fix_home_settings_for_all_users
+execute:frappe.delete_doc_if_exists('DocType', 'Google Maps Settings')


### PR DESCRIPTION
`raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))\nImportError: Module import failed for Google Maps Settings (frappe.integrations.doctype.google_maps_settings.google_maps_settings Error: No module named 'frappe.integrations.doctype.google_maps_settings.google_maps_settings')"`