### PR TITLE
fix: Raise for permission error

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -33,7 +33,7 @@ def print_has_permission_check_logs(func):
 			msgprint(
 				title=_("Not Permitted"),
 				msg=('<br>').join(frappe.flags.get('has_permission_check_logs', []))
-				raise_exception=True
+				raise_exception=frappe.PermissionError
 			)
 		frappe.flags.pop('has_permission_check_logs', None)
 		return result

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -32,7 +32,7 @@ def print_has_permission_check_logs(func):
 		if not result and self_perm_check and raise_exception:
 			msgprint(
 				title=_("Not Permitted"),
-				msg=('<br>').join(frappe.flags.get('has_permission_check_logs', []))
+				msg=('<br>').join(frappe.flags.get('has_permission_check_logs', [])),
 				raise_exception=frappe.PermissionError
 			)
 		frappe.flags.pop('has_permission_check_logs', None)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -30,7 +30,11 @@ def print_has_permission_check_logs(func):
 		# print only if access denied
 		# and if user is checking his own permission
 		if not result and self_perm_check and raise_exception:
-			msgprint(('<br>').join(frappe.flags.get('has_permission_check_logs', [])))
+			msgprint(
+				title=_("Not Permitted"),
+				msg=('<br>').join(frappe.flags.get('has_permission_check_logs', []))
+				raise_exception=True
+			)
 		frappe.flags.pop('has_permission_check_logs', None)
 		return result
 	return inner


### PR DESCRIPTION
This avoids redundant error messages.

**Before:**
<img width="1440" alt="Screenshot 2020-02-20 at 4 24 30 PM" src="https://user-images.githubusercontent.com/13928957/74932610-41490f00-5408-11ea-9200-15f8b0ce73b5.png">

**After:**
<img width="1189" alt="Screenshot 2020-02-20 at 5 42 24 PM" src="https://user-images.githubusercontent.com/13928957/74932692-705f8080-5408-11ea-8397-d867892462a5.png">

