### PR TITLE
fix: recheck zero count

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -55,7 +55,7 @@ def get_data(module, build=True):
 		exists_cache = get_table_with_counts()
 		def doctype_contains_a_record(name):
 			exists = exists_cache.get(name)
-			if not type(exists) == int:
+			if not exists:
 				if not frappe.db.get_value('DocType', name, 'issingle'):
 					exists = frappe.db.count(name)
 				else:


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/pull/9536

information schema counts cannot be trusted, they are only an approximation. 
This PR modifies the moduleview count to recheck with db.count if cache indicates zero count