### PR TITLE
feat: Monitor

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -25,6 +25,7 @@ from frappe.utils.error import make_error_snapshot
 from frappe.core.doctype.comment.comment import update_comments_in_parent_after_request
 from frappe import _
 import frappe.recorder
+import frappe.monitor
 
 local_manager = LocalManager([frappe.local])
 
@@ -52,6 +53,7 @@ def application(request):
 		init_request(request)
 
 		frappe.recorder.record()
+		frappe.monitor.start()
 
 		if frappe.local.form_dict.cmd:
 			response = frappe.handler.handle()
@@ -91,6 +93,7 @@ def application(request):
 		if response and hasattr(frappe.local, 'cookie_manager'):
 			frappe.local.cookie_manager.flush_cookies(response=response)
 
+		frappe.monitor.stop()
 		frappe.recorder.dump()
 
 		frappe.destroy()

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -93,7 +93,7 @@ def application(request):
 		if response and hasattr(frappe.local, 'cookie_manager'):
 			frappe.local.cookie_manager.flush_cookies(response=response)
 
-		frappe.monitor.stop()
+		frappe.monitor.stop(response)
 		frappe.recorder.dump()
 
 		frappe.destroy()

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -174,7 +174,8 @@ scheduler_events = {
 		"frappe.email.doctype.email_account.email_account.pull",
 		"frappe.email.doctype.email_account.email_account.notify_unreplied",
 		"frappe.integrations.doctype.razorpay_settings.razorpay_settings.capture_payment",
-		'frappe.utils.global_search.sync_global_search'
+		'frappe.utils.global_search.sync_global_search',
+		"frappe.monitor.flush",
 	],
 	"hourly": [
 		"frappe.model.utils.link_count.update_link_count",

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -4,7 +4,7 @@
 
 from __future__ import unicode_literals
 
-from datetime import datetime, timezone
+from datetime import datetime
 import json
 import traceback
 import frappe
@@ -35,7 +35,7 @@ class Monitor:
 	def __init__(self, transaction_type=None, method=None, kwargs=None):
 		try:
 			self.site = frappe.local.site
-			self.timestamp = datetime.now(timezone.utc)
+			self.timestamp = datetime.utcnow()
 			self.transaction_type = transaction_type
 			self.uuid = uuid.uuid4()
 
@@ -52,7 +52,7 @@ class Monitor:
 
 	def dump(self):
 		try:
-			timediff = datetime.now(timezone.utc) - self.timestamp
+			timediff = datetime.utcnow() - self.timestamp
 			# Obtain duration in microseconds
 			self.duration = int(timediff.total_seconds() * 1000000)
 			data = {

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+
+from datetime import datetime, timezone
+import json
+import time
+import traceback
+import frappe
+import os
+
+
+MONITOR_REDIS_KEY = "monitor-transactions"
+
+
+def start(transaction_type="request", method=None, kwargs=None):
+	if frappe.conf.monitor:
+		frappe.local.monitor = Monitor(
+			transaction_type=transaction_type, method=method, kwargs=kwargs
+		)
+
+
+def stop():
+	if frappe.conf.monitor and hasattr(frappe.local, "monitor"):
+		frappe.local.monitor.dump()
+
+
+def log_file():
+	return os.path.join(frappe.utils.get_bench_path(), "logs", "monitor.json.log")
+
+
+class Monitor:
+	def __init__(self, transaction_type=None, method=None, kwargs=None):
+		try:
+			self.site = frappe.local.site
+			self.timestamp = datetime.now(timezone.utc)
+			self.transaction_type = transaction_type
+
+			if self.transaction_type == "request":
+				self.data = frappe.form_dict
+				self.headers = dict(frappe.request.headers)
+				self.method = frappe.request.method
+				self.path = frappe.request.path
+			else:
+				self.kwargs = kwargs
+				self.method = method
+		except Exception:
+			traceback.print_exc()
+
+	def dump(self):
+		try:
+			timediff = datetime.now(timezone.utc) - self.timestamp
+			# Obtain duration in microseconds
+			self.duration = int(timediff.total_seconds() * 1000000)
+			data = {
+				"duration": self.duration,
+				"site": self.site,
+				"timestamp": self.timestamp.isoformat(sep=" "),
+				"transaction_type": self.transaction_type,
+			}
+
+			if self.transaction_type == "request":
+				update = {
+					"data": self.data,
+					"headers": self.headers,
+					"method": self.method,
+					"path": self.path,
+				}
+			else:
+				update = {
+					"kwargs": self.kwargs,
+					"method": self.method,
+				}
+			data.update(update)
+			json_data = json.dumps(data, sort_keys=True, default=str)
+			store(json_data)
+		except Exception:
+			traceback.print_exc()
+
+
+def store(json_data):
+	if frappe.cache().llen(MONITOR_REDIS_KEY) >= 1000000:
+		frappe.cache().ltrim(MONITOR_REDIS_KEY, len(logs) - 1, -1)
+		frappe.cache().rpush(MONITOR_REDIS_KEY, json_data)
+	else:
+		frappe.cache().rpush(MONITOR_REDIS_KEY, json_data)
+
+
+def flush():
+	try:
+		# Fetch all the logs without removing from cache
+		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		logs = list(map(frappe.safe_decode, logs))
+		with open(log_file(), "a", os.O_NONBLOCK) as f:
+			f.write("\n".join(logs))
+
+		# Remove fetched entries from cache
+		frappe.cache().ltrim(MONITOR_REDIS_KEY, len(logs) - 1, -1)
+	except Exception:
+		traceback.print_exc()

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -42,6 +42,7 @@ class Monitor:
 			if self.transaction_type == "request":
 				self.data = frappe.form_dict
 				self.headers = dict(frappe.request.headers)
+				self.ip = frappe.local.request_ip
 				self.method = frappe.request.method
 				self.path = frappe.request.path
 			else:
@@ -67,6 +68,7 @@ class Monitor:
 				update = {
 					"data": self.data,
 					"headers": self.headers,
+					"ip": self.ip,
 					"method": self.method,
 					"path": self.path,
 				}

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -81,11 +81,10 @@ class Monitor:
 
 
 def store(json_data):
-	if frappe.cache().llen(MONITOR_REDIS_KEY) >= 1000000:
-		frappe.cache().ltrim(MONITOR_REDIS_KEY, len(logs) - 1, -1)
-		frappe.cache().rpush(MONITOR_REDIS_KEY, json_data)
-	else:
-		frappe.cache().rpush(MONITOR_REDIS_KEY, json_data)
+	MAX_LOGS = 1000000
+	if frappe.cache().llen(MONITOR_REDIS_KEY) > MAX_LOGS:
+		frappe.cache().ltrim(MONITOR_REDIS_KEY, 1, -1)
+	frappe.cache().rpush(MONITOR_REDIS_KEY, json_data)
 
 
 def flush():

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -9,6 +9,7 @@ import json
 import traceback
 import frappe
 import os
+import uuid
 
 
 MONITOR_REDIS_KEY = "monitor-transactions"
@@ -36,6 +37,7 @@ class Monitor:
 			self.site = frappe.local.site
 			self.timestamp = datetime.now(timezone.utc)
 			self.transaction_type = transaction_type
+			self.uuid = uuid.uuid4()
 
 			if self.transaction_type == "request":
 				self.data = frappe.form_dict
@@ -54,6 +56,7 @@ class Monitor:
 			# Obtain duration in microseconds
 			self.duration = int(timediff.total_seconds() * 1000000)
 			data = {
+				"uuid": self.uuid,
 				"duration": self.duration,
 				"site": self.site,
 				"timestamp": self.timestamp.isoformat(sep=" "),

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 from datetime import datetime, timezone
 import json
-import time
 import traceback
 import frappe
 import os

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -96,6 +96,7 @@ def flush():
 		logs = list(map(frappe.safe_decode, logs))
 		with open(log_file(), "a", os.O_NONBLOCK) as f:
 			f.write("\n".join(logs))
+			f.write("\n")
 
 		# Remove fetched entries from cache
 		frappe.cache().ltrim(MONITOR_REDIS_KEY, len(logs) - 1, -1)

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -1,0 +1,57 @@
+#  -*- coding: utf-8 -*-
+# Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import unittest
+import frappe
+import frappe.monitor
+from frappe.utils import set_request
+from frappe.monitor import MONITOR_REDIS_KEY
+import json
+
+
+class TestMonitor(unittest.TestCase):
+	def setUp(self):
+		frappe.conf.monitor = 1
+		frappe.cache().delete_value(MONITOR_REDIS_KEY)
+
+	def test_enable_monitor(self):
+		set_request()
+		frappe.monitor.start()
+		frappe.monitor.stop()
+
+		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		self.assertEqual(len(logs), 1)
+		log = json.loads(logs[0].decode())
+		self.assertEqual(log["transaction_type"], "request")
+
+	def test_flush(self):
+		set_request()
+		frappe.monitor.start()
+		frappe.monitor.stop()
+
+		open(frappe.monitor.log_file(), "w").close()
+		frappe.monitor.flush()
+
+		with open(frappe.monitor.log_file()) as f:
+			logs = f.readlines()
+
+		self.assertEqual(len(logs), 1)
+		log = json.loads(logs[0])
+		self.assertEqual(log["transaction_type"], "request")
+
+	def test_job(self):
+		frappe.utils.background_jobs.execute_job(
+			frappe.local.site, "frappe.ping", None, None, {}, is_async=False
+		)
+
+		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		self.assertEqual(len(logs), 1)
+		log = json.loads(logs[0].decode())
+		self.assertEqual(log["transaction_type"], "job")
+		self.assertEqual(log["method"], "frappe.ping")
+
+	def tearDown(self):
+		frappe.conf.monitor = 0
+		frappe.cache().delete_value(MONITOR_REDIS_KEY)

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -35,10 +35,6 @@ class TestMonitor(unittest.TestCase):
 		self.assertEqual(log.transaction_type, "request")
 		self.assertEqual(log.request["method"], "GET")
 
-		# Reponse body will be set as "{}"
-		self.assertEqual(log.request["response_length"], 2)
-		self.assertEqual(log.request["status_code"], 200)
-
 	def test_job(self):
 		frappe.utils.background_jobs.execute_job(
 			frappe.local.site, "frappe.ping", None, None, {}, is_async=False

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -9,7 +9,6 @@ import frappe.monitor
 from frappe.utils import set_request
 from frappe.utils.response import build_response
 from frappe.monitor import MONITOR_REDIS_KEY
-import json
 
 
 class TestMonitor(unittest.TestCase):

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -1,5 +1,5 @@
 #  -*- coding: utf-8 -*-
-# Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
@@ -7,6 +7,7 @@ import unittest
 import frappe
 import frappe.monitor
 from frappe.utils import set_request
+from frappe.utils.response import build_response
 from frappe.monitor import MONITOR_REDIS_KEY
 import json
 
@@ -17,29 +18,27 @@ class TestMonitor(unittest.TestCase):
 		frappe.cache().delete_value(MONITOR_REDIS_KEY)
 
 	def test_enable_monitor(self):
-		set_request()
+		set_request(method="GET", path="/api/method/frappe.ping")
+		response = build_response("json")
+
 		frappe.monitor.start()
-		frappe.monitor.stop()
+		frappe.monitor.stop(response)
 
 		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
 		self.assertEqual(len(logs), 1)
-		log = json.loads(logs[0].decode())
-		self.assertEqual(log["transaction_type"], "request")
 
-	def test_flush(self):
-		set_request()
-		frappe.monitor.start()
-		frappe.monitor.stop()
+		log = frappe.parse_json(logs[0].decode())
+		self.assertTrue(log.duration)
+		self.assertTrue(log.site)
+		self.assertTrue(log.timestamp)
+		self.assertTrue(log.uuid)
+		self.assertTrue(log.request)
+		self.assertEqual(log.transaction_type, "request")
+		self.assertEqual(log.request["method"], "GET")
 
-		open(frappe.monitor.log_file(), "w").close()
-		frappe.monitor.flush()
-
-		with open(frappe.monitor.log_file()) as f:
-			logs = f.readlines()
-
-		self.assertEqual(len(logs), 1)
-		log = json.loads(logs[0])
-		self.assertEqual(log["transaction_type"], "request")
+		# Reponse body will be set as "{}"
+		self.assertEqual(log.request["response_length"], 2)
+		self.assertEqual(log.request["status_code"], 200)
 
 	def test_job(self):
 		frappe.utils.background_jobs.execute_job(
@@ -48,9 +47,28 @@ class TestMonitor(unittest.TestCase):
 
 		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
 		self.assertEqual(len(logs), 1)
-		log = json.loads(logs[0].decode())
-		self.assertEqual(log["transaction_type"], "job")
-		self.assertEqual(log["method"], "frappe.ping")
+		log = frappe.parse_json(logs[0].decode())
+		self.assertEqual(log.transaction_type, "job")
+		self.assertTrue(log.job)
+		self.assertEqual(log.job["method"], "frappe.ping")
+		self.assertEqual(log.job["scheduled"], False)
+		self.assertEqual(log.job["wait"], 0)
+
+	def test_flush(self):
+		set_request(method="GET", path="/api/method/frappe.ping")
+		response = build_response("json")
+		frappe.monitor.start()
+		frappe.monitor.stop(response)
+
+		open(frappe.monitor.log_file(), "w").close()
+		frappe.monitor.flush()
+
+		with open(frappe.monitor.log_file()) as f:
+			logs = f.readlines()
+
+		self.assertEqual(len(logs), 1)
+		log = frappe.parse_json(logs[0])
+		self.assertEqual(log.transaction_type, "request")
 
 	def tearDown(self):
 		frappe.conf.monitor = 0

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -95,7 +95,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	else:
 		method_name = cstr(method.__name__)
 
-	frappe.monitor.start(transaction_type="job", method=method_name, kwargs=kwargs)
+	frappe.monitor.start("job", method_name, kwargs)
 	try:
 		method(**kwargs)
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -9,6 +9,7 @@ import os, socket, time
 from frappe import _
 from six import string_types
 from uuid import uuid4
+import frappe.monitor
 
 # imports - third-party imports
 
@@ -94,6 +95,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	else:
 		method_name = cstr(method.__name__)
 
+	frappe.monitor.start(transaction_type="job", method=method_name, kwargs=kwargs)
 	try:
 		method(**kwargs)
 
@@ -128,6 +130,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 		frappe.db.commit()
 
 	finally:
+		frappe.monitor.stop()
 		if is_async:
 			frappe.destroy()
 

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -140,6 +140,12 @@ class RedisWrapper(redis.Redis):
 	def llen(self, key):
 		return super(RedisWrapper, self).llen(self.make_key(key))
 
+	def lrange(self, key, start, stop):
+		return super(RedisWrapper, self).lrange(self.make_key(key), start, stop)
+
+	def ltrim(self, key, start, stop):
+		return super(RedisWrapper, self).ltrim(self.make_key(key), start, stop)
+
 	def hset(self, name, key, value, shared=False):
 		if key is None:
 			return


### PR DESCRIPTION
Collect HTTP Request and Job logs

Collected data is put in `logs/monitor.json.log` in JSON format

e.g.

```
{"duration": 807142, "request": {"ip": "127.0.0.1",   ...  "request", "uuid": "83be6a4c-27a1-497a-9ce6-c815bca4e420"}
{"duration": 1364, "job": {"method": "frappe.ping",   ...   "uuid": "8225ab76-8bee-462c-b9fc-a556406b1ee7"}
{"duration": 26300, "job": {"method": "frappe.utils.  ...   "uuid": "e7c987e1-81ac-4d4b-845b-0fdd364aa963"}
```

Note: Set `monitor: true` in `site_config.json` or `common_site_config.json`

e.g. For a request
```JSON
{
    "duration": 807142,
    "request": {
        "ip": "127.0.0.1",
        "method": "GET",
        "path": "/api/method/frappe.realtime.get_user_info",
        "response_length": 9687,
        "status_code": 500
    },
    "site": "frappe.local",
    "timestamp": "2020-03-05 09:37:17.397884",
    "transaction_type": "request",
    "uuid": "83be6a4c-27a1-497a-9ce6-c815bca4e420"
} 
```
For an enqueued job
```JSON
{
    "duration": 1364,
    "job": {
        "method": "frappe.ping",
        "scheduled": false,
        "wait": 90204
    },
    "site": "frappe.local",
    "timestamp": "2020-03-05 09:37:40.124682",
    "transaction_type": "job",
    "uuid": "8225ab76-8bee-462c-b9fc-a556406b1ee7"
}
```
For a scheduled job
```JSON
{
    "duration": 26300,
    "job": {
        "method": "frappe.utils.global_search.sync_global_search",
        "scheduled": true,
        "wait": 10984295
    },
    "site": "frappe.local",
    "timestamp": "2020-03-05 09:38:03.158618",
    "transaction_type": "job",
    "uuid": "e7c987e1-81ac-4d4b-845b-0fdd364aa963"
}
```


Documentation PR: https://github.com/frappe/frappe_io/pull/261