### PR TITLE
feat(scheduler): Frequent job scheduling

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -84,6 +84,10 @@ class ScheduledJobType(Document):
 
 	def update_scheduler_log(self, status):
 		if not self.create_log:
+			# self.get_next_execution will work properly iff self.last_execution is properly set
+			if self.frequency == "All" and status == 'Start':
+				self.db_set('last_execution', now_datetime(), update_modified=False)
+				frappe.db.commit()
 			return
 		if not self.scheduler_log:
 			self.scheduler_log = frappe.get_doc(dict(doctype = 'Scheduled Job Log', scheduled_job_type=self.name)).insert(ignore_permissions=True)

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -24,7 +24,7 @@ def start_scheduler():
 	'''Run enqueue_events_for_all_sites every 2 minutes (default).
 	Specify scheduler_interval in seconds in common_site_config.json'''
 
-	schedule.every(60).seconds.do(enqueue_events_for_all_sites)
+	schedule.every(frappe.get_conf().scheduler_tick_interval or 60).seconds.do(enqueue_events_for_all_sites)
 
 	while True:
 		schedule.run_pending()


### PR DESCRIPTION
The minimum configurable frequency for scheduled jobs, as of now is 60 seconds, as defined by 

```python3
schedule.every(60).seconds.do(enqueue_events_for_all_sites)
```
This PR attempts to circumvent this limit and allow sub-minute frequencies without affecting existing configurations by making it configurable with `scheduler_tick_interval` key in `common_site_config.json`

e.g. Now a job can be scheduled once every 15 seconds with 
```python3
scheduler_events = {
	"cron": {
		"* * * * * */15": [ ... ],
	}
}

```
 in `hooks.py` and
```JSON
"scheduler_tick_interval": 15
```
 or lower in `common_site_config.json`

Documentation PR: https://github.com/frappe/frappe_io/pull/261