### PR TITLE
fix: Missing bucket name check

### DIFF
--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -37,7 +37,6 @@ class S3BackupSettings(Document):
 		try:
 			response = conn.head_bucket(Bucket=bucket_lower)
 			# The operation returns a 200 OK if the bucket exists and you have permission to access it.
-			bucket_name_exist = True
 		except ClientError as e:
 			# If a client error is thrown, then check that it was a 403 error or 404 error.
 			error_code = e.response['Error']['Code']

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -27,7 +27,7 @@ class S3BackupSettings(Document):
 		)
 
 		bucket_lower = str(self.bucket)
-		
+
 		bucket_name_exist = False
 		try:
 			response = conn.list_buckets()

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -27,18 +27,24 @@ class S3BackupSettings(Document):
 		)
 
 		bucket_lower = str(self.bucket)
-
+		
+		bucket_name_exist = False
 		try:
-			conn.list_buckets()
+			response = conn.list_buckets()
+			for bucket in response['Buckets']:
+				if bucket['Name'] == bucket_lower:
+					bucket_name_exist = True
+					break
 
 		except ClientError:
 			frappe.throw(_("Invalid Access Key ID or Secret Access Key."))
 
-		try:
-			conn.create_bucket(Bucket=bucket_lower, CreateBucketConfiguration={
-				'LocationConstraint': self.region})
-		except ClientError:
-			frappe.throw(_("Unable to create bucket: {0}. Change it to a more unique name.").format(bucket_lower))
+		if not bucket_name_exist:
+			try:
+				conn.create_bucket(Bucket=bucket_lower, CreateBucketConfiguration={
+					'LocationConstraint': self.region})
+			except ClientError:
+				frappe.throw(_("Unable to create bucket: {0}. Change it to a more unique name.").format(bucket_lower))
 
 
 @frappe.whitelist()

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -30,6 +30,7 @@ class S3BackupSettings(Document):
 
 		try:
 			conn.list_buckets()
+
 		except ClientError:
 			frappe.throw(_("Invalid Access Key ID or Secret Access Key."))
 

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -35,17 +35,17 @@ class S3BackupSettings(Document):
 			frappe.throw(_("Invalid Access Key ID or Secret Access Key."))
 
 		try:
-			# The response returns a 200 OK if the bucket exists and you have permission to access it.
-			response = conn.head_bucket(Bucket=bucket_lower)
+			# Head_bucket returns a 200 OK if the bucket exists and have access to it.
+			conn.head_bucket(Bucket=bucket_lower)
 		except ClientError as e:
-			# If a client error is thrown, then check if it is 403 error, other 4xx errors should follow a operation to create a new bucket.
 			error_code = e.response['Error']['Code']
 			if error_code == '403':
-				frappe.throw(_("403 Forbidden. Do not have permission to access {0} bucket.").format(bucket_lower))
+				frappe.throw(_("Do not have permission to access {0} bucket.").format(bucket_lower))
 			else:   # '400'-Bad request or '404'-Not Found return
 				# try to create bucket
 				conn.create_bucket(Bucket=bucket_lower, CreateBucketConfiguration={
 					'LocationConstraint': self.region})
+
 
 @frappe.whitelist()
 def take_backup():

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -34,7 +34,6 @@ class S3BackupSettings(Document):
 		except ClientError:
 			frappe.throw(_("Invalid Access Key ID or Secret Access Key."))
 
-		bucket_name_exist = False
 		try:
 			response = conn.head_bucket(Bucket=bucket_lower)
 			# The operation returns a 200 OK if the bucket exists and you have permission to access it.
@@ -50,13 +49,6 @@ class S3BackupSettings(Document):
 					'LocationConstraint': self.region})
 			else:
 				frappe.throw(e)
-		if not bucket_name_exist:
-			try:
-				conn.create_bucket(Bucket=bucket_lower, CreateBucketConfiguration={
-					'LocationConstraint': self.region})
-			except ClientError:
-				frappe.throw(_("Unable to create bucket: {0}. Change it to a more unique name.").format(bucket_lower))
-
 
 @frappe.whitelist()
 def take_backup():

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -35,19 +35,17 @@ class S3BackupSettings(Document):
 			frappe.throw(_("Invalid Access Key ID or Secret Access Key."))
 
 		try:
+			# The response returns a 200 OK if the bucket exists and you have permission to access it.
 			response = conn.head_bucket(Bucket=bucket_lower)
-			# The operation returns a 200 OK if the bucket exists and you have permission to access it.
 		except ClientError as e:
-			# If a client error is thrown, then check that it was a 403 error or 404 error.
+			# If a client error is thrown, then check if it is 403 error, other 4xx errors should follow a operation to create a new bucket.
 			error_code = e.response['Error']['Code']
 			if error_code == '403':
 				frappe.throw(_("403 Forbidden. Do not have permission to access {0} bucket.").format(bucket_lower))
-			elif error_code == '404':
-				# Bucket not found, set bucket_name_exist flag to False to try create bucket
+			else:   # '400'-Bad request or '404'-Not Found return
+				# try to create bucket
 				conn.create_bucket(Bucket=bucket_lower, CreateBucketConfiguration={
 					'LocationConstraint': self.region})
-			else:
-				frappe.throw(e)
 
 @frappe.whitelist()
 def take_backup():

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -46,7 +46,8 @@ class S3BackupSettings(Document):
 				frappe.throw(_(f"403 Forbidden. Do not have permission to access this bucket: {bucket_lower}"))
 			elif error_code == '404':
 				# Bucket not found, set bucket_name_exist flag to False to try create bucket
-				bucket_name_exist = False
+				conn.create_bucket(Bucket=bucket_lower, CreateBucketConfiguration={
+					'LocationConstraint': self.region})
 			else:
 				frappe.throw(e)
 		if not bucket_name_exist:

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -42,7 +42,7 @@ class S3BackupSettings(Document):
 			# If a client error is thrown, then check that it was a 403 error or 404 error.
 			error_code = e.response['Error']['Code']
 			if error_code == '403':
-				frappe.throw(_(f"403 Forbidden. Do not have permission to access this bucket: {bucket_lower}"))
+				frappe.throw(_("403 Forbidden. Do not have permission to access {0} bucket.").format(bucket_lower))
 			elif error_code == '404':
 				# Bucket not found, set bucket_name_exist flag to False to try create bucket
 				conn.create_bucket(Bucket=bucket_lower, CreateBucketConfiguration={


### PR DESCRIPTION

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Problem: If the user changed the backup limit, then press save. The validate function will give an error message that the bucket name already exists. It would be inconvenient for the user to use a different bucket name to save any changes.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

So I implemented a flag ''bucket_name_exist'' to indicate if the bucket name exists, if not, then go to the flow of trying to create a bucket.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->


<!-- Add images/recordings to better visualize the change: expected/current behviour -->
