### PR TITLE
chore: pin gitdb due to package update in PYPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Faker==2.0.4
 frontmatter==3.0.5
 future==0.18.2
 GitPython==2.1.11
+gitdb2==2.0.6;python_version<'3.4'
 google-api-python-client==1.7.11
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1


### PR DESCRIPTION
backport of #9553 