### PR TITLE
fix(Dashboard): Throw "Invalid Filter Value" error on getting TypeError

### DIFF
--- a/frappe/core/page/dashboard/dashboard.py
+++ b/frappe/core/page/dashboard/dashboard.py
@@ -3,7 +3,8 @@
 from __future__ import unicode_literals
 import json
 import frappe
-from frappe.utils import add_to_date
+from frappe import _
+from frappe.utils import add_to_date, get_link_to_form
 
 
 def cache_source(function):
@@ -29,7 +30,21 @@ def cache_source(function):
 	return wrapper
 
 def generate_and_cache_results(chart, chart_name, function, cache_key):
-	results = function(chart_name = chart_name)
+	try:
+		results = function(chart_name = chart_name)
+	except TypeError as e:
+		if e.message == "'NoneType' object is not iterable":
+			# Probably because of invalid link filter
+			#
+			# Note: Do not try to find the right way of doing this because
+			# it results in an inelegant & inefficient solution
+			# ref: https://github.com/frappe/frappe/pull/9403
+			frappe.throw(_('Please check the filter values set for Dashboard Chart: {}').format(
+				get_link_to_form(chart.doctype, chart.name)), title=_('Invalid Filter Value'))
+			return
+		else:
+			raise
+
 	frappe.cache().set_value(cache_key, json.dumps(results, default=str))
 	frappe.db.set_value("Dashboard Chart", chart_name, "last_synced_on", frappe.utils.now(), update_modified = False)
 	return results


### PR DESCRIPTION
Throw "Invalid Filter Value" error on getting TypeError

<img width="1181" alt="Screenshot 2020-02-10 at 6 31 54 PM" src="https://user-images.githubusercontent.com/13928957/74161042-5a9dce80-4c44-11ea-940a-177f7e81241e.png">


Handles the following error while visiting a dashboard that has an old filter(filter with old document name) in the dashboard chart.

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/core/page/dashboard/dashboard.py", line 27, in wrapper
    results = generate_and_cache_results(chart, chart_name, function, cache_key)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/core/page/dashboard/dashboard.py", line 32, in generate_and_cache_results
    results = function(chart_name = chart_name)
  File "/home/frappe/benches/bench-2020-01-16/apps/erpnext/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py", line 46, in get
    gl_entries = get_gl_entries(account, get_period_ending(to_date, timegrain))
  File "/home/frappe/benches/bench-2020-01-16/apps/erpnext/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py", line 89, in get_gl_entries
    child_accounts = get_descendants_of('Account', account, ignore_permissions=True)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/utils/nestedset.py", line 281, in get_descendants_of
    lft, rgt = frappe.db.get_value(doctype, name, ['lft', 'rgt'])
TypeError: 'NoneType' object is not iterable
```
TypeError with message "'NoneType' object is not iterable" will mostly occur if a link field value is invalid i.e., the actual doc does not exist.


port-of: https://github.com/frappe/frappe/pull/9457