### PR TITLE
fix: Do not allow single doctypes in dashboard chart

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -12,6 +12,13 @@ frappe.ui.form.on('Dashboard Chart', {
 	refresh: function(frm) {
 		frm.chart_filters = null;
 		frm.set_df_property("filters_section", "hidden", 1);
+		frm.set_query('document_type', function() {
+			return {
+				filters: {
+					'issingle': false
+				}
+			}
+		});
 		frm.trigger('update_options');
 	},
 

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -279,6 +279,7 @@ class DashboardChart(Document):
 	def validate(self):
 		if self.chart_type != 'Custom':
 			self.check_required_field()
+		self.check_document_type()
 
 	def check_required_field(self):
 		if not self.document_type:
@@ -292,3 +293,7 @@ class DashboardChart(Document):
 		else:
 			if not self.based_on:
 				frappe.throw(_("Time series based on is required to create a dashboard chart"))
+
+	def check_document_type(self):
+		if frappe.get_meta(self.document_type).issingle:
+			frappe.throw("You cannot create a dashboard chart from single DocTypes")

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -154,3 +154,18 @@ class TestDashboardChart(unittest.TestCase):
 		self.assertEqual(result.get('datasets')[0].get('values')[0], todo_status_count)
 
 		frappe.db.rollback()
+
+	def test_dashboard_with_single_doctype(self):
+		if frappe.db.exists('Dashboard Chart', 'Test Single DocType In Dashboard Chart'):
+			frappe.delete_doc('Dashboard Chart', 'Test Single DocType In Dashboard Chart')
+
+		chart_doc = frappe.get_doc(dict(
+			doctype = 'Dashboard Chart',
+			chart_name = 'Test Single DocType In Dashboard Chart',
+			chart_type = 'Count',
+			document_type = 'System Settings',
+			group_by_based_on = 'Created On',
+			filters_json = '{}',
+		))
+
+		self.assertRaises(frappe.ValidationError, chart_doc.insert)


### PR DESCRIPTION
Do not allow single doctypes in Dashboard Chart