### PR TITLE
fix(Dialog): depends_on fix in Dialog

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -155,7 +155,8 @@ frappe.ui.form.Layout = Class.extend({
 			doctype: this.doctype,
 			parent: this.column.wrapper.get(0),
 			frm: this.frm,
-			render_input: render
+			render_input: render,
+			doc: this.doc
 		});
 
 		fieldobj.layout = this;

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -30,6 +30,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 		let me = this;
 		return new Promise(resolve => {
 			frappe.model.with_doctype(this.doctype, function() {
+				me.check_quick_entry_doc();
 				me.set_meta_and_mandatory_fields();
 				if(me.is_quick_entry()) {
 					me.render_dialog();
@@ -44,16 +45,15 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 	},
 
 	set_meta_and_mandatory_fields: function(){
-		let fields = frappe.get_meta(this.doctype).fields;
-		if (fields.length < 7) {
-			// if less than 7 fields, then show everything
-			this.mandatory = fields;
-		} else {
-			// prepare a list of mandatory and bold fields
-			this.mandatory = $.map(fields,
-				function(d) { return ((d.reqd || d.bold || d.allow_in_quick_entry) && !d.read_only) ? $.extend({}, d) : null; });
-		}
 		this.meta = frappe.get_meta(this.doctype);
+		let fields = this.meta.fields;
+
+		// prepare a list of mandatory, bold and allow in quick entry fields
+		this.mandatory = $.map(fields,
+				function(d) { return ((d.reqd || d.bold || d.allow_in_quick_entry) && !d.read_only) ? $.extend({}, d) : null; });
+	},
+
+	check_quick_entry_doc: function() {
 		if (!this.doc) {
 			this.doc = frappe.model.get_new_doc(this.doctype, null, null, true);
 		}
@@ -66,8 +66,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 
 		this.validate_for_prompt_autoname();
 
-		if (this.has_child_table()
-			|| !this.mandatory.length) {
+		if (this.has_child_table() || !this.mandatory.length) {
 			return false;
 		}
 
@@ -103,8 +102,8 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 		this.dialog = new frappe.ui.Dialog({
 			title: __("New {0}", [__(this.doctype)]),
 			fields: this.mandatory,
+			doc: this.doc
 		});
-		this.dialog.doc = this.doc;
 
 		this.register_primary_action();
 		this.render_edit_in_full_page_link();

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -49,8 +49,9 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 		let fields = this.meta.fields;
 
 		// prepare a list of mandatory, bold and allow in quick entry fields
-		this.mandatory = $.map(fields,
-				function(d) { return ((d.reqd || d.bold || d.allow_in_quick_entry) && !d.read_only) ? $.extend({}, d) : null; });
+		this.mandatory = $.map(fields, function(d) {
+			return ((d.reqd || d.bold || d.allow_in_quick_entry) && !d.read_only) ? $.extend({}, d) : null;
+		});
 	},
 
 	check_quick_entry_doc: function() {

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -94,8 +94,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 			})
 			.on('scroll', function() {
 				var $input = $('input:focus');
-				if($input.length && ['Date', 'Datetime',
-					'Time'].includes($input.attr('data-fieldtype'))) {
+				if ($input.length && ['Date', 'Datetime', 'Time'].includes($input.attr('data-fieldtype'))) {
 					$input.blur();
 				}
 			});
@@ -197,5 +196,3 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		this.header.find('.modal-title').toggleClass('cursor-pointer');
 	}
 };
-
-


### PR DESCRIPTION
- For Frappe Dialog, `depends_on` did not work as the doc was not found attached properly in Dialog object.
- Fixes #9458
![img](https://user-images.githubusercontent.com/7310479/75514667-05bccf00-5a1e-11ea-834d-ef4dcd4cac7e.gif)
