### PR TITLE
fix: Check if themefile url exists

### DIFF
--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -78,8 +78,11 @@ class WebsiteTheme(Document):
 
 	def generate_theme_if_not_exist(self):
 		bench_path = frappe.utils.get_bench_path()
-		theme_path = join_path(bench_path, 'sites', self.theme_url[1:])
-		if not path_exists(theme_path):
+		if self.theme_url:
+			theme_path = join_path(bench_path, 'sites', self.theme_url[1:])
+			if not path_exists(theme_path):
+				self.generate_bootstrap_theme()
+		else:
 			self.generate_bootstrap_theme()
 
 	def set_as_default(self):


### PR DESCRIPTION
Without the theme_url field set, accessing it like a string will return TypeError. this PR fixes it

<img width="704" alt="image" src="https://user-images.githubusercontent.com/18097732/75653781-3c941e80-5c84-11ea-8453-56cffb00031c.png">
