### PR TITLE
fix(rq): randomize worker name with uuid

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -8,6 +8,7 @@ import frappe
 import os, socket, time
 from frappe import _
 from six import string_types
+from uuid import uuid4
 
 # imports - third-party imports
 
@@ -152,7 +153,8 @@ def get_worker_name(queue):
 
 	if queue:
 		# hostname.pid is the default worker name
-		name = '{hostname}.{pid}.{queue}'.format(
+		name = '{uuid}.{hostname}.{pid}.{queue}'.format(
+			uuid=uuid4().hex,
 			hostname=socket.gethostname(),
 			pid=os.getpid(),
 			queue=queue)


### PR DESCRIPTION
fixes issue with rq where worker with the same name already exists. cases where a pid gets killed and is respawned with the same pid, when the worker isn't dead and a new worker is being spawned; causes the following error:

```python-traceback
ValueError: There exists an active worker named u'xxxxxxxxxxxx.y' already
```

fixed by appending random hex uuid for every worker.

inspo: https://github.com/rq/rq/blob/master/rq/worker.py#L187