### PR TITLE
revert: "chore(deps): bump pyyaml from 5.1 to 5.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pypng==0.0.20
 PyQRCode==1.2.1
 python-dateutil==2.8.1
 pytz==2019.3
-PyYAML==5.3
+PyYAML==5.1
 rauth==0.7.3
 redis>=3.0
 requests-oauthlib==1.3.0


### PR DESCRIPTION
Reverts frappe/frappe#9577

Frontmatter 3.0.6 from https://github.com/frappe/frappe/pull/9621 depends on pyyaml 5.1
![image](https://user-images.githubusercontent.com/13928957/75700795-a76f4500-5cd8-11ea-932a-55935475810a.png)
