### PR TITLE
chore(deps): bump frontmatter to 3.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cryptography==2.8
 dropbox==9.1.0
 email-reply-parser==0.5.9
 Faker==2.0.4
-frontmatter==3.0.5
+frontmatter==3.0.6
 future==0.18.2
 GitPython==2.1.15
 gitdb2==2.0.6;python_version<'3.4'


### PR DESCRIPTION
One of the many threads open on discuss: https://discuss.erpnext.com/t/frontmatter-3-0-5-has-requirement-pyyaml-3-13/51080

Thanks to @jonbeebe, we can say goodbye to this issue:
![Screenshot 2020-03-02 at 11 03 03 PM](https://user-images.githubusercontent.com/36654812/75701550-fe294e80-5cd9-11ea-8c27-77976b4f115e.png)
