### PR TITLE
chore(snyk): Ignore PYYAML from snyk check

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.14.1
+version: v1.13.5
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-AWESOMPLETE-174474:
@@ -10,6 +10,10 @@ ignore:
     - showdown > yargs > os-locale > mem:
         reason: No patch available
         expires: '2019-06-11T14:12:04.995Z'
+  SNYK-PYTHON-PYYAML-550022:
+    - '*':
+        reason: Project is not directly dependant on the package
+        expires: 2021-04-01T18:02:21.256Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:extend:20180424':
@@ -18,5 +22,3 @@ patch:
   SNYK-JS-LODASH-450202:
     - frappe-datatable > lodash:
         patched: '2020-01-31T01:33:09.889Z'
-    - snyk > snyk-nuget-plugin > dotnet-deps-parser > lodash:
-        patched: '2020-02-21T02:41:07.568Z'


### PR DESCRIPTION
- Frappe does not use PYYAML directly.

fixes failing checks in: https://github.com/frappe/frappe/pull/9620