### PR TITLE
feat: disable fields for comment

### DIFF
--- a/frappe/templates/includes/comments/comments.html
+++ b/frappe/templates/includes/comments/comments.html
@@ -33,12 +33,12 @@
 					<div class="row {% if _login_required %} hidden {% endif %}"
 						style="margin-bottom: 15px;">
 						<div class="col-sm-6">
-							<input class="form-control" name="comment_by"
-								placeholder="{{ _("Your Name") }}" type="text" disabled>
+							<input class="form-control comment_by" name="comment_by"
+								placeholder="{{ _("Your Name") }}" type="text">
 						</div>
 						<div class="col-sm-6">
-							<input class="form-control" name="comment_email"
-								placeholder="{{ _("Your Email Address") }}" type="email" disabled>
+							<input class="form-control comment_email" name="comment_email"
+								placeholder="{{ _("Your Email Address") }}" type="email">
 						</div>
 					</div>
 					<p><textarea class="form-control" name="comment" rows=10
@@ -57,6 +57,11 @@
 
 		if (login_required && !frappe.is_user_logged_in()) {
 			$(".login-required, .comment-form-wrapper").toggleClass("hidden");
+		}
+
+		if(frappe.is_user_logged_in()) {
+			$('input.comment_by').prop("disabled", true);
+			$('input.comment_email').prop("disabled", true);
 		}
 
 		var n_comments = $(".comment-row").length;

--- a/frappe/templates/includes/comments/comments.html
+++ b/frappe/templates/includes/comments/comments.html
@@ -34,11 +34,11 @@
 						style="margin-bottom: 15px;">
 						<div class="col-sm-6">
 							<input class="form-control" name="comment_by"
-								placeholder="{{ _("Your Name") }}" type="text">
+								placeholder="{{ _("Your Name") }}" type="text" disabled>
 						</div>
 						<div class="col-sm-6">
 							<input class="form-control" name="comment_email"
-								placeholder="{{ _("Your Email Address") }}" type="email">
+								placeholder="{{ _("Your Email Address") }}" type="email" disabled>
 						</div>
 					</div>
 					<p><textarea class="form-control" name="comment" rows=10


### PR DESCRIPTION
**Task:** Disable Email and Name fields for logged in users on the comment form

**Screenshot:**
**If a user is logged in**
![disable_fields_1](https://user-images.githubusercontent.com/45919049/75872044-82431980-5e33-11ea-9ec7-bed8c6272fea.png)


**If a user is not logged in**
![disable_fields_2](https://user-images.githubusercontent.com/45919049/75872063-8cfdae80-5e33-11ea-9b84-5fe2e0d8794f.png)
