### PR TITLE
feat(db): add new-site flag to use tcp/ip instead of unix socket

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -50,10 +50,6 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 		print('--no-mariadb-socket requires db_type to be set to mariadb.')
 		sys.exit(1)
 
-	if no_mariadb_socket:
-		print('Using % as Database Host.')
-		db_host = "%"
-
 	if not db_name:
 		db_name = '_' + hashlib.sha1(site.encode()).hexdigest()[:16]
 
@@ -77,7 +73,7 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 
 		install_db(root_login=mariadb_root_username, root_password=mariadb_root_password,
 				   db_name=db_name, admin_password=admin_password, verbose=verbose,
-				   source_sql=source_sql, force=force, reinstall=reinstall, db_type=db_type, db_host=db_host, db_port=db_port)
+				   source_sql=source_sql, force=force, reinstall=reinstall, db_type=db_type, db_host=db_host, db_port=db_port, no_mariadb_socket=no_mariadb_socket)
 
 		apps_to_install = ['frappe'] + (frappe.conf.get("install_apps") or []) + (list(install_apps) or [])
 		for app in apps_to_install:

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -17,33 +17,42 @@ from six import text_type
 @click.option('--db-port', type=int, help='Database Port')
 @click.option('--mariadb-root-username', default='root', help='Root username for MariaDB')
 @click.option('--mariadb-root-password', help='Root password for MariaDB')
+@click.option('--no-mariadb-socket', is_flag=True, default=False, help='Set MariaDB host to % and use TCP/IP Socket instead of using the UNIX Socket')
 @click.option('--admin-password', help='Administrator password for new site', default=None)
 @click.option('--verbose', is_flag=True, default=False, help='Verbose')
 @click.option('--force', help='Force restore if site/database already exists', is_flag=True, default=False)
 @click.option('--source_sql', help='Initiate database with a SQL file')
 @click.option('--install-app', multiple=True, help='Install app after installation')
 def new_site(site, mariadb_root_username=None, mariadb_root_password=None, admin_password=None,
-			 verbose=False, install_apps=None, source_sql=None, force=None, install_app=None,
-			 db_name=None, db_type=None, db_host=None, db_port=None):
+			 verbose=False, install_apps=None, source_sql=None, force=None, no_mariadb_socket=False,
+			 install_app=None, db_name=None, db_type=None, db_host=None, db_port=None):
 	"Create a new site"
 	frappe.init(site=site, new_site=True)
 
 	_new_site(db_name, site, mariadb_root_username=mariadb_root_username,
 			  mariadb_root_password=mariadb_root_password, admin_password=admin_password,
 			  verbose=verbose, install_apps=install_app, source_sql=source_sql, force=force,
-			  db_type=db_type, db_host=db_host, db_port=db_port)
+			  no_mariadb_socket=no_mariadb_socket, db_type=db_type, db_host=db_host, db_port=db_port)
 
 	if len(frappe.utils.get_sites()) == 1:
 		use(site)
 
 def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=None,
 			  admin_password=None, verbose=False, install_apps=None, source_sql=None, force=False,
-			  reinstall=False, db_type=None, db_host=None, db_port=None):
+			  no_mariadb_socket=False, reinstall=False, db_type=None, db_host=None, db_port=None):
 	"""Install a new Frappe site"""
 
 	if not force and os.path.exists(site):
 		print('Site {0} already exists'.format(site))
 		sys.exit(1)
+
+	if no_mariadb_socket and not db_type == "mariadb":
+		print('--no-mariadb-socket requires db_type to be set to mariadb.')
+		sys.exit(1)
+
+	if no_mariadb_socket:
+		print('Using % as Database Host.')
+		db_host = "%"
 
 	if not db_name:
 		db_name = '_' + hashlib.sha1(site.encode()).hexdigest()[:16]

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -6,14 +6,14 @@
 
 from __future__ import unicode_literals
 
-def setup_database(force, source_sql=None, verbose=None):
+def setup_database(force, source_sql=None, verbose=None, no_mariadb_socket=False):
 	import frappe
 	if frappe.conf.db_type == 'postgres':
 		import frappe.database.postgres.setup_db
 		return frappe.database.postgres.setup_db.setup_database(force, source_sql, verbose)
 	else:
 		import frappe.database.mariadb.setup_db
-		return frappe.database.mariadb.setup_db.setup_database(force, source_sql, verbose)
+		return frappe.database.mariadb.setup_db.setup_database(force, source_sql, verbose, no_mariadb_socket=no_mariadb_socket)
 
 def drop_user_and_database(db_name, root_login=None, root_password=None):
 	import frappe

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -30,7 +30,7 @@ def get_mariadb_versions():
 	return versions
 
 
-def setup_database(force, source_sql, verbose):
+def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
 	frappe.local.session = frappe._dict({'user':'Administrator'})
 
 	db_name = frappe.local.conf.db_name
@@ -38,17 +38,23 @@ def setup_database(force, source_sql, verbose):
 	dbman = DbManager(root_conn)
 	if force or (db_name not in dbman.get_database_list()):
 		dbman.delete_user(db_name)
+		if no_mariadb_socket:
+			dbman.delete_user(db_name, host="%")
 		dbman.drop_database(db_name)
 	else:
 		raise Exception("Database %s already exists" % (db_name,))
 
 	dbman.create_user(db_name, frappe.conf.db_password)
+	if no_mariadb_socket:
+		dbman.create_user(db_name, frappe.conf.db_password, host="%")
 	if verbose: print("Created user %s" % db_name)
 
 	dbman.create_database(db_name)
 	if verbose: print("Created database %s" % db_name)
 
 	dbman.grant_all_privileges(db_name, db_name)
+	if no_mariadb_socket:
+		dbman.grant_all_privileges(db_name, db_name, host="%")
 	dbman.flush_privileges()
 	if verbose: print("Granted privileges to user %s and database %s" % (db_name, db_name))
 
@@ -75,7 +81,7 @@ def setup_help_database(help_db_name):
 def drop_user_and_database(db_name, root_login, root_password):
 	frappe.local.db = get_root_connection(root_login, root_password)
 	dbman = DbManager(frappe.local.db)
-	dbman.delete_user(db_name)
+	dbman.delete_user(db_name, host="%")
 	dbman.drop_database(db_name)
 
 def bootstrap_database(db_name, verbose, source_sql=None):

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -82,6 +82,7 @@ def drop_user_and_database(db_name, root_login, root_password):
 	frappe.local.db = get_root_connection(root_login, root_password)
 	dbman = DbManager(frappe.local.db)
 	dbman.delete_user(db_name, host="%")
+	dbman.delete_user(db_name)
 	dbman.drop_database(db_name)
 
 def bootstrap_database(db_name, verbose, source_sql=None):

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -22,7 +22,7 @@ from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
 
 def install_db(root_login="root", root_password=None, db_name=None, source_sql=None,
 			   admin_password=None, verbose=True, force=0, site_config=None, reinstall=False,
-			   db_type=None, db_host=None, db_port=None):
+			   db_type=None, db_host=None, db_port=None, no_mariadb_socket=False):
 
 	if not db_type:
 		db_type = frappe.conf.db_type or 'mariadb'
@@ -32,7 +32,7 @@ def install_db(root_login="root", root_password=None, db_name=None, source_sql=N
 
 	frappe.flags.root_login = root_login
 	frappe.flags.root_password = root_password
-	setup_database(force, source_sql, verbose)
+	setup_database(force, source_sql, verbose, no_mariadb_socket)
 
 	frappe.conf.admin_password = frappe.conf.admin_password or admin_password
 


### PR DESCRIPTION
ref: frappe/bench#949

basically sets the host to `%` instead of `localhost` (default), allowing to use mariadb over TCP/IP Socket instead of the standard UNIX Socket.