### PR TITLE
fix: duplicate entry error while renaming item

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -16,15 +16,14 @@ def update_document_title(doctype, docname, title_field=None, old_title=None, ne
 	"""
 		Update title from header in form view
 	"""
+	if docname and new_name and not docname == new_name:
+		docname = rename_doc(doctype=doctype, old=docname, new=new_name, merge=merge)
+
 	if old_title and new_title and not old_title == new_title:
 		frappe.db.set_value(doctype, docname, title_field, new_title)
 		frappe.msgprint(_('Saved'), alert=True, indicator='green')
 
-	if docname and new_name and not docname == new_name:
-		return rename_doc(doctype=doctype, old=docname, new=new_name, merge=merge)
-
 	return docname
-
 
 @frappe.whitelist()
 def rename_doc(doctype, old, new, force=False, merge=False, ignore_permissions=False, ignore_if_exists=False, show_alert=True):


### PR DESCRIPTION
**Issue**

Steps to replicate the issue

- Keep the title field as "item_code" for the item doctype, item_code has unique key constraint

- Rename the item Test Item Pen 2 and merge with existing item (Iphone 7)

- System throws below error

<img width="1249" alt="Screenshot 2020-03-05 at 11 02 43 AM" src="https://user-images.githubusercontent.com/8780500/75951162-3e065680-5ed1-11ea-9ec8-bbc2efa7d0c6.png">


Traceback:
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1051, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/rename_doc.py", line 21, in update_document_title
    frappe.db.set_value(doctype, docname, title_field, new_title)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/database/database.py", line 653, in set_value
    values, debug=debug)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
IntegrityError: (1062, u"Duplicate entry 'iPhone 7' for key 'item_code'")
```

port-of: https://github.com/frappe/frappe/pull/9642