### PR TITLE
fix(requirements): set required rq and redis versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,11 +49,11 @@ python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.1
 rauth==0.7.3
-redis==2.10.6
+redis>=3.0.0
 requests-oauthlib==1.3.0
 requests==2.22.0
 RestrictedPython==5.0
-rq==0.12.0
+rq==1.2.0
 schedule==0.6.0
 selenium==3.141.0
 semantic-version==2.8.2


### PR DESCRIPTION
redis needs to be `>=3.0.0` for server scripts, and rq should have been `1.2.0`, and was instead pinned to `0.12.0`; which is a really old release of rq. the previous release has been causing most background jobs with emails to fail with the following issue:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py", line 210, in send_workflow_action_email
    enqueue(method=frappe.sendmail, queue='short', **email_args)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 69, in enqueue
    kwargs=queue_args)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/queue.py", line 258, in enqueue_call
    job = self.enqueue_job(job, at_front=at_front)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/queue.py", line 324, in enqueue_job
    job.save(pipeline=pipe)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 516, in save
    connection.hmset(key, self.to_dict(include_meta=include_meta))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 469, in to_dict
    obj['data'] = zlib.compress(self.data)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 234, in data
    self._data = dumps(job_tuple)
TypeError: can't pickle dict_values objects
```