### PR TITLE
fix(requirements): set required rq and redis versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ werkzeug==0.16.1
 semantic_version
 rauth>=0.6.2
 requests
-redis==2.10.6
+redis>=3.0.0
 selenium
 babel==2.6.0
 ipython
@@ -26,7 +26,7 @@ bleach==2.1.4
 bleach-whitelist
 Pillow
 beautifulsoup4
-rq==0.12.0
+rq==1.2.0
 schedule
 cryptography
 pyopenssl

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ werkzeug==0.16.1
 semantic_version
 rauth>=0.6.2
 requests
-redis>=3.0.0
+redis-=2.10.6
 selenium
 babel==2.6.0
 ipython


### PR DESCRIPTION
redis needs to be `>=3.0.0` for server scripts, and rq should have been `1.2.0`, and was instead pinned to `0.12.0`; which is a really old release of rq. the previous release has been causing most background jobs with emails to fail with the following issue:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py", line 210, in send_workflow_action_email
    enqueue(method=frappe.sendmail, queue='short', **email_args)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 69, in enqueue
    kwargs=queue_args)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/queue.py", line 258, in enqueue_call
    job = self.enqueue_job(job, at_front=at_front)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/queue.py", line 324, in enqueue_job
    job.save(pipeline=pipe)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 516, in save
    connection.hmset(key, self.to_dict(include_meta=include_meta))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 469, in to_dict
    obj['data'] = zlib.compress(self.data)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 234, in data
    self._data = dumps(job_tuple)
TypeError: can't pickle dict_values objects
```

port of: #9654 