### PR TITLE
fix: correctly pickle email_args for workflow emails

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -200,7 +200,7 @@ def send_workflow_action_email(users_data, doc):
 		email_args = {
 			'recipients': [d.get('email')],
 			'args': {
-				'actions': deduplicate_actions(d.get('possible_actions')),
+				'actions': list(deduplicate_actions(d.get('possible_actions'))),
 				'message': message
 			},
 			'reference_name': doc.name,


### PR DESCRIPTION
currently, since we return possible actions as dict_values, pickle fails to work with it with the following error:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py", line 210, in send_workflow_action_email
    enqueue(method=frappe.sendmail, queue='short', **email_args)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 69, in enqueue
    kwargs=queue_args)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/queue.py", line 258, in enqueue_call
    job = self.enqueue_job(job, at_front=at_front)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/queue.py", line 324, in enqueue_job
    job.save(pipeline=pipe)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 516, in save
    connection.hmset(key, self.to_dict(include_meta=include_meta))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 469, in to_dict
    obj['data'] = zlib.compress(self.data)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/rq/job.py", line 234, in data
    self._data = dumps(job_tuple)
TypeError: can't pickle dict_values objects
```

passing the values as a list instead works fine.

port of: #9662