### PR TITLE
fix: Enable Cypress dashboard service

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -522,7 +522,7 @@ def run_ui_tests(context, app, headless=False):
 	password_env = 'CYPRESS_adminPassword={}'.format(admin_password) if admin_password else ''
 
 	# run for headless mode
-	run_or_open = 'run' if headless else 'open'
+	run_or_open = 'run --record --key 4a48f41c-11b3-425b-aa88-c58048fa69eb' if headless else 'open'
 	command = '{site_env} {password_env} yarn run cypress {run_or_open}'
 	formatted_command = command.format(site_env=site_env, password_env=password_env, run_or_open=run_or_open)
 	frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)


### PR DESCRIPTION
Cypress dashboard service got disabled after [this PR](https://github.com/frappe/frappe/pull/9454)

Re-enabling it.