### PR TITLE
fix: do not reuse razorpay payment link

### DIFF
--- a/frappe/templates/pages/integrations/razorpay_checkout.py
+++ b/frappe/templates/pages/integrations/razorpay_checkout.py
@@ -18,6 +18,8 @@ def get_context(context):
 
 	try:
 		doc = frappe.get_doc("Integration Request", frappe.form_dict['token'])
+		if doc.status != 'Queued':
+			raise Exception
 		payment_details = json.loads(doc.data)
 
 		for key in expected_keys:

--- a/frappe/templates/pages/integrations/razorpay_checkout.py
+++ b/frappe/templates/pages/integrations/razorpay_checkout.py
@@ -12,6 +12,11 @@ no_cache = 1
 expected_keys = ('amount', 'title', 'description', 'reference_doctype', 'reference_docname',
 	'payer_name', 'payer_email', 'order_id')
 
+
+class TokenAlreadyUsedError(Exception):
+	pass
+
+
 def get_context(context):
 	context.no_cache = 1
 	context.api_key = get_api_key()
@@ -19,7 +24,7 @@ def get_context(context):
 	try:
 		doc = frappe.get_doc("Integration Request", frappe.form_dict['token'])
 		if doc.status != 'Queued':
-			raise Exception
+			raise TokenAlreadyUsedError
 		payment_details = json.loads(doc.data)
 
 		for key in expected_keys:
@@ -30,9 +35,17 @@ def get_context(context):
 		context['subscription_id'] = payment_details['subscription_id'] \
 			if payment_details.get('subscription_id') else ''
 
-	except Exception as e:
+	except frappe.exceptions.DoesNotExistError as e:
 		frappe.redirect_to_message(_('Invalid Token'),
 			_('Seems token you are using is invalid!'),
+			http_status_code=400, indicator_color='red')
+
+		frappe.local.flags.redirect_location = frappe.local.response.location
+		raise frappe.Redirect
+
+	except TokenAlreadyUsedError as e:
+		frappe.redirect_to_message(_('Token Already Used'),
+			_('It seems you have already paid through this link!'),
 			http_status_code=400, indicator_color='red')
 
 		frappe.local.flags.redirect_location = frappe.local.response.location


### PR DESCRIPTION
This prevents the payment link from being reused if the payment has been authorized or captured. The **Exception** thrown will be caught by the existing handler for the **DoesNotExistError**.

However, instead of the general message, a more specific error message could be returned to the user specifying the payment has already occured.