### PR TITLE
fix(GSuite): remove deprecated GSuite doctypes

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -261,3 +261,5 @@ frappe.patches.v11_0.make_all_prepared_report_attachments_private #2019-11-26
 frappe.patches.v12_0.setup_email_linking
 frappe.patches.v12_0.fix_home_settings_for_all_users
 execute:frappe.delete_doc_if_exists('DocType', 'Google Maps Settings')
+execute:frappe.delete_doc_if_exists('DocType', 'GSuite Settings')
+execute:frappe.delete_doc_if_exists('DocType', 'GSuite Templates')


### PR DESCRIPTION
backport of https://github.com/frappe/frappe/pull/9672

```raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))\nImportError: Module import failed for GSuite Settings (frappe.integrations.doctype.gsuite_settings.gsuite_settings Error: No module named 'frappe.integrations.doctype.gsuite_settings')"```