### PR TITLE
fix(GSuite): remove deprecated GSuite doctypes

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -266,3 +266,5 @@ frappe.patches.v12_0.change_existing_dashboard_chart_filters
 execute:frappe.delete_doc("Test Runner")
 execute:frappe.delete_doc_if_exists('DocType', 'Google Maps Settings')
 execute:frappe.db.set_default('desktop:home_page', 'workspace')
+execute:frappe.delete_doc_if_exists('DocType', 'GSuite Settings')
+execute:frappe.delete_doc_if_exists('DocType', 'GSuite Templates')


### PR DESCRIPTION
```raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))\nImportError: Module import failed for GSuite Settings (frappe.integrations.doctype.gsuite_settings.gsuite_settings Error: No module named 'frappe.integrations.doctype.gsuite_settings')"```