### PR TITLE
fix(dashboard chart): Hide filters if hide_actions is set

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -180,7 +180,7 @@ Cypress.Commands.add('fill_field', (fieldname, value, fieldtype = 'Data') => {
 		cy.get('.datepickers-container .datepicker.active').should('exist');
 	}
 	if (fieldtype === 'Time') {
-		cy.get('@input').clear();
+		cy.get('@input').clear().wait(200);
 	}
 
 	if (fieldtype === 'Select') {

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -78,7 +78,6 @@ class Workspace:
 		cards = self.doc.cards + get_custom_reports_and_doctypes(self.doc.module)
 		if len(self.extended_cards):
 			cards = cards + self.extended_cards
-		print(cards)
 		default_country = frappe.db.get_default("country")
 
 		def _doctype_contains_a_record(name):

--- a/frappe/public/js/frappe/ui/dashboard_chart.js
+++ b/frappe/public/js/frappe/ui/dashboard_chart.js
@@ -14,9 +14,9 @@ frappe.ui.DashboardChart = class DashboardChart {
 		this.get_settings().then(() => {
 			this.prepare_chart_object();
 			this.prepare_container();
-			this.setup_filter_button();
 
 			if (!this.options.hide_actions || this.options.hide_actions == undefined) {
+				this.setup_filter_button();
 				if (this.chart_doc.timeseries && this.chart_doc.chart_type !== 'Custom') {
 					this.render_time_series_filters();
 				}


### PR DESCRIPTION
This PR has the following changes

1. Remove stray print statement
2. Hide Filter button in dashboard chart if hide actions is set