### PR TITLE
fix: delete as much indexes from each table

### DIFF
--- a/frappe/patches/v12_0/delete_duplicate_indexes.py
+++ b/frappe/patches/v12_0/delete_duplicate_indexes.py
@@ -1,12 +1,14 @@
 import frappe
+from pymysql import InternalError
 
 # This patch deletes all the duplicate indexes created for same column
 # The patch only checks for indexes with UNIQUE constraints
 
 def execute():
-	if frappe.db.db_type != 'mariadb': return
-	all_tables = frappe.db.get_tables()
+	if frappe.db.db_type != 'mariadb':
+		return
 
+	all_tables = frappe.db.get_tables()
 	final_deletion_map = frappe._dict()
 
 	for table in all_tables:
@@ -34,11 +36,14 @@ def execute():
 
 	# build drop index query
 	for (table_name, index_list) in final_deletion_map.items():
-		query = "ALTER TABLE `{}` ".format(table_name)
-		query_parts = []
+		query_list = []
+		alter_query = "ALTER TABLE `{}`".format(table_name)
+
 		for index in index_list:
-			query_parts.append("DROP INDEX `{}`".format(index))
+			query_list.append("{} DROP INDEX `{}`".format(alter_query, index))
 
-		query = query + ', '.join(query_parts)
-
-		frappe.db.sql(query)
+		for query in query_list:
+			try:
+				frappe.db.sql(query)
+			except InternalError:
+				pass


### PR DESCRIPTION
in cases of customization, errors such as `pymysql.err.InternalError: (1091, "Can't DROP 'unique_item'; check that column/key exists")` may rise up

![Screenshot 2020-03-13 at 3 00 32 PM](https://user-images.githubusercontent.com/36654812/76608355-7ba35900-653b-11ea-898d-75ca92526cf8.png)


_Note:_ This may take longer to execute but will drop all duplicate indexes