### PR TITLE
fix: Add missing bottom border for chart in report

### DIFF
--- a/frappe/public/less/report.less
+++ b/frappe/public/less/report.less
@@ -72,6 +72,10 @@
 	overflow: auto;
 }
 
+.chart-container {
+	border-bottom: 1px solid @border-color;
+}
+
 .groupby-box {
 	border-bottom: 1px solid #d1d8dd;
 	padding: 10px 15px 3px;


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/19775888/76733138-3cb51380-6786-11ea-8b48-807933707cbd.png)
**After:**
<img width="1201" alt="Screenshot 2020-03-16 at 4 05 53 PM" src="https://user-images.githubusercontent.com/13928957/76748010-0edcc880-67a0-11ea-8c6f-114e9a042557.png">

