### PR TITLE
fix: use agent style for details & summary

### DIFF
--- a/frappe/public/css/bootstrap.css
+++ b/frappe/public/css/bootstrap.css
@@ -15,7 +15,6 @@ body {
 }
 article,
 aside,
-details,
 figcaption,
 figure,
 footer,
@@ -24,8 +23,7 @@ hgroup,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 audio,


### PR DESCRIPTION
Fix summary detail element styling on Firefox


![2020-03-16 16 14 17](https://user-images.githubusercontent.com/18097732/76748677-32544300-67a1-11ea-8768-5f9106f2bbd7.jpg)
