### PR TITLE
fix: Change mysql host from localhost to 127.0.0.1

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -48,7 +48,7 @@ class Database(object):
 
 	def __init__(self, host=None, user=None, password=None, ac_name=None, use_default=0, port=None):
 		self.setup_type_map()
-		self.host = host or frappe.conf.db_host or 'localhost'
+		self.host = host or frappe.conf.db_host or '127.0.0.1'
 		self.port = port or frappe.conf.db_port or ''
 		self.user = user or frappe.conf.db_name
 		self.db_name = frappe.conf.db_name


### PR DESCRIPTION
Having localhost makes mandatory to connect via mysqld.sock
changing host to 127.0.0.1 makes it connect via TCP

Ref:
https://dev.mysql.com/doc/refman/8.0/en/can-not-connect-to-server.html