### PR TITLE
fix: Set fields in grid form as read only for non-editable grids

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -22,6 +22,7 @@ export default class GridRow {
 				if(me.grid.allow_on_grid_editing() && me.grid.is_editable()) {
 					// pass
 				} else {
+					me.docfields.map(df => df.read_only = 1);
 					me.toggle_view();
 					return false;
 				}

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -22,7 +22,7 @@ export default class GridRow {
 				if(me.grid.allow_on_grid_editing() && me.grid.is_editable()) {
 					// pass
 				} else {
-					if (me.grid.allow_on_grid_editing()) {
+					if (!me.grid.is_editable()) {
 						me.docfields.map(df => df.read_only = 1);
 					}
 					me.toggle_view();

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -22,7 +22,9 @@ export default class GridRow {
 				if(me.grid.allow_on_grid_editing() && me.grid.is_editable()) {
 					// pass
 				} else {
-					me.docfields.map(df => df.read_only = 1);
+					if (me.grid.allow_on_grid_editing()) {
+						me.docfields.map(df => df.read_only = 1);
+					}
 					me.toggle_view();
 					return false;
 				}


### PR DESCRIPTION
If a child table was non-editable for any reason (set as read only, permissions set), the form would still be editable.

**Before:**

<img width="908" alt="Screenshot 2020-03-16 at 8 59 39 PM" src="https://user-images.githubusercontent.com/19775888/76773955-47dd6300-67c9-11ea-8c09-5b68ed2518de.png">

**After:**

<img width="942" alt="Screenshot 2020-03-16 at 8 59 14 PM" src="https://user-images.githubusercontent.com/19775888/76773977-53308e80-67c9-11ea-8961-69ffc6c5ade0.png">
