### PR TITLE
fix: Calculation of week ending date in dashboard charts

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -232,7 +232,7 @@ def get_week_ending(date):
 	if week_of_the_year == 52:
 		date = add_to_date(date, years=1)
 	# first day of next week
-	date = add_to_date('{}-01-01'.format(date.year), weeks = (week_of_the_year + 1)%52)
+	date = add_to_date('{}-01-01'.format(date.year), weeks = (week_of_the_year%52) + 1)
 	# last day of this week
 	return add_to_date(date, days = -1)
 


### PR DESCRIPTION
Fixes a bug caused by #9407

Date was calculated as:
`date = add_to_date('{}-01-01'.format(date.year), weeks = (week_of_the_year + 1)%52) `

If `week_of_the_year` is 51, `weeks` = 0 which leads to an infinite loop.