### PR TITLE
feat: 0 precision for currency fields

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-02-22 01:27:33",
  "doctype": "DocType",
@@ -116,7 +117,7 @@
    "fieldname": "precision",
    "fieldtype": "Select",
    "label": "Precision",
-   "options": "\n1\n2\n3\n4\n5\n6\n7\n8\n9",
+   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9",
    "print_hide": 1
   },
   {
@@ -450,8 +451,9 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-11-15 12:28:24.461628",
- "modified_by": "umair@erpnext.com",
+ "links": [],
+ "modified": "2020-03-16 14:49:49.672099",
+ "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",
  "owner": "Administrator",

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -149,7 +149,7 @@
    "fieldname": "currency_precision",
    "fieldtype": "Select",
    "label": "Currency Precision",
-   "options": "\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
   },
   {
    "collapsible": 1,
@@ -412,7 +412,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2020-01-31 06:03:35.595384",
+ "modified": "2020-03-16 14:50:40.914532",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -124,7 +124,7 @@
    "fieldname": "precision",
    "fieldtype": "Select",
    "label": "Precision",
-   "options": "\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
   },
   {
    "fieldname": "options",
@@ -376,7 +376,7 @@
  "icon": "fa fa-glass",
  "idx": 1,
  "links": [],
- "modified": "2020-02-01 11:50:09.222967",
+ "modified": "2020-03-16 14:52:43.954709",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -149,7 +149,7 @@
    "fieldname": "precision",
    "fieldtype": "Select",
    "label": "Precision",
-   "options": "\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+   "options": "\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
   },
   {
    "depends_on": "eval:in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image'], doc.fieldtype)",
@@ -385,7 +385,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2019-12-27 12:50:51.419763",
+ "modified": "2020-03-16 14:53:40.619043",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -549,7 +549,7 @@ def get_field_precision(df, doc=None, currency=None):
 
 	elif df.fieldtype == "Currency":
 		if df.precision and cint(df.precision) == 0:
-			precision = cint(df.precision)
+			precision = 0
 		else:
 			precision = cint(frappe.db.get_default("currency_precision"))
 			if not precision:

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -544,17 +544,14 @@ def get_field_precision(df, doc=None, currency=None):
 	"""get precision based on DocField options and fieldvalue in doc"""
 	from frappe.utils import get_number_format_info
 
-	if cint(df.precision):
+	if df.precision:
 		precision = cint(df.precision)
 
 	elif df.fieldtype == "Currency":
-		if df.precision and cint(df.precision) == 0:
-			precision = 0
-		else:
-			precision = cint(frappe.db.get_default("currency_precision"))
-			if not precision:
-				number_format = frappe.db.get_default("number_format") or "#,###.##"
-				decimal_str, comma_str, precision = get_number_format_info(number_format)
+		precision = cint(frappe.db.get_default("currency_precision"))
+		if not precision:
+			number_format = frappe.db.get_default("number_format") or "#,###.##"
+			decimal_str, comma_str, precision = get_number_format_info(number_format)
 	else:
 		precision = cint(frappe.db.get_default("float_precision")) or 3
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -548,10 +548,13 @@ def get_field_precision(df, doc=None, currency=None):
 		precision = cint(df.precision)
 
 	elif df.fieldtype == "Currency":
-		precision = cint(frappe.db.get_default("currency_precision"))
-		if not precision:
-			number_format = frappe.db.get_default("number_format") or "#,###.##"
-			decimal_str, comma_str, precision = get_number_format_info(number_format)
+		if df.precision and cint(df.precision) == 0:
+			precision = cint(df.precision)
+		else:
+			precision = cint(frappe.db.get_default("currency_precision"))
+			if not precision:
+				number_format = frappe.db.get_default("number_format") or "#,###.##"
+				decimal_str, comma_str, precision = get_number_format_info(number_format)
 	else:
 		precision = cint(frappe.db.get_default("float_precision")) or 3
 

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -61,7 +61,13 @@ frappe.form.formatters = {
 	},
 	Currency: function (value, docfield, options, doc) {
 		var currency  = frappe.meta.get_field_currency(docfield, doc);
-		var precision = docfield.precision || cint(frappe.boot.sysdefaults.currency_precision) || 2;
+		var precision;
+
+		if (docfield.precision === 0) {
+			precision = docfield.precision;
+		} else {
+			precision = docfield.precision || cint(frappe.boot.sysdefaults.currency_precision) || 2;
+		}
 
 		// If you change anything below, it's going to hurt a company in UAE, a bit.
 		if (precision > 2) {

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -63,8 +63,8 @@ frappe.form.formatters = {
 		var currency  = frappe.meta.get_field_currency(docfield, doc);
 		var precision;
 
-		if (docfield.precision === 0) {
-			precision = docfield.precision;
+		if (docfield.precision && cint(docfield.precision) === 0) {
+			precision = 0;
 		} else {
 			precision = docfield.precision || cint(frappe.boot.sysdefaults.currency_precision) || 2;
 		}

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -61,13 +61,7 @@ frappe.form.formatters = {
 	},
 	Currency: function (value, docfield, options, doc) {
 		var currency  = frappe.meta.get_field_currency(docfield, doc);
-		var precision;
-
-		if (docfield.precision && cint(docfield.precision) === 0) {
-			precision = 0;
-		} else {
-			precision = docfield.precision || cint(frappe.boot.sysdefaults.currency_precision) || 2;
-		}
+		var precision = docfield.precision || cint(frappe.boot.sysdefaults.currency_precision) || 2;
 
 		// If you change anything below, it's going to hurt a company in UAE, a bit.
 		if (precision > 2) {

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -257,7 +257,7 @@ $.extend(frappe.meta, {
 			precision = cint(df.precision);
 		} else if(df && df.fieldtype === "Currency") {
 			if (df.precision && cint(df.precision) === 0) {
-				precision = cint(df.precision);
+				precision = 0;
 			} else {
 				precision = cint(frappe.defaults.get_default("currency_precision"));
 				if(!precision) {

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -256,11 +256,15 @@ $.extend(frappe.meta, {
 		if (df && cint(df.precision)) {
 			precision = cint(df.precision);
 		} else if(df && df.fieldtype === "Currency") {
-			precision = cint(frappe.defaults.get_default("currency_precision"));
-			if(!precision) {
-				var number_format = get_number_format();
-				var number_format_info = get_number_format_info(number_format);
-				precision = number_format_info.precision;
+			if (df.precision && cint(df.precision) === 0) {
+				precision = cint(df.precision);
+			} else {
+				precision = cint(frappe.defaults.get_default("currency_precision"));
+				if(!precision) {
+					var number_format = get_number_format();
+					var number_format_info = get_number_format_info(number_format);
+					precision = number_format_info.precision;
+				}
 			}
 		} else {
 			precision = cint(frappe.defaults.get_default("float_precision")) || 3;

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -253,18 +253,14 @@ $.extend(frappe.meta, {
 
 	get_field_precision: function(df, doc) {
 		var precision = null;
-		if (df && cint(df.precision)) {
+		if (df && df.precision) {
 			precision = cint(df.precision);
 		} else if(df && df.fieldtype === "Currency") {
-			if (df.precision && cint(df.precision) === 0) {
-				precision = 0;
-			} else {
-				precision = cint(frappe.defaults.get_default("currency_precision"));
-				if(!precision) {
-					var number_format = get_number_format();
-					var number_format_info = get_number_format_info(number_format);
-					precision = number_format_info.precision;
-				}
+			precision = cint(frappe.defaults.get_default("currency_precision"));
+			if(!precision) {
+				var number_format = get_number_format();
+				var number_format_info = get_number_format_info(number_format);
+				precision = number_format_info.precision;
 			}
 		} else {
 			precision = cint(frappe.defaults.get_default("float_precision")) || 3;


### PR DESCRIPTION
There are many cases where the currency should be rounded off to the nearest integer, 0 precision for currency seems a good way of doing so