### PR TITLE
fix: Return empty string if title arg is falsey

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -89,7 +89,7 @@ def is_signup_enabled():
 def cleanup_page_name(title):
 	"""make page name from title"""
 	if not title:
-		return title
+		return ''
 
 	name = title.lower()
 	name = re.sub('[~!@#$%^&*+()<>,."\'\?]', '', name)


### PR DESCRIPTION
[cleanup_page_name is expected to return a string](https://github.com/frappe/frappe/blob/develop/frappe/website/website_generator.py#L78). Currently the passed value is returned as is if it's falsey, so if you call `cleanup_page_name(None).replace('_', '-')` you get an error. This PR changes `cleanup_page_name` to return an empty string if the passed argument is falsey.