### PR TITLE
fix(Desk): cross-compatible check to see if object is string

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -7,6 +7,7 @@ import frappe
 import json
 from frappe import _, DoesNotExistError
 from frappe.boot import get_allowed_pages, get_allowed_reports
+from six import string_types
 from frappe.cache_manager import build_domain_restriced_doctype_cache, build_domain_restriced_page_cache, build_table_count_cache
 
 class Workspace:
@@ -109,7 +110,7 @@ class Workspace:
 		new_data = []
 		for section in cards:
 			new_items = []
-			if isinstance(section.links, str):
+			if isinstance(section.links, string_types):
 				links = json.loads(section.links)
 			else:
 				links = section.links


### PR DESCRIPTION
Fixes:

<img width="1184" alt="Screenshot 2020-03-17 at 2 38 48 PM" src="https://user-images.githubusercontent.com/19775888/76841968-8aea1580-685f-11ea-8c83-1f1908396c9e.png">
