### PR TITLE
fix: Add missing bottom border for chart in report

### DIFF
--- a/frappe/public/less/report.less
+++ b/frappe/public/less/report.less
@@ -72,6 +72,10 @@
 	overflow: auto;
 }
 
+.chart-container {
+	border-bottom: 1px solid @border-color;
+}
+
 .groupby-box {
 	border-bottom: 1px solid #d1d8dd;
 	padding: 10px 15px 3px;


### PR DESCRIPTION
port-of: #9699 