### PR TITLE
refactor: Allow more field types in group by fields

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -98,7 +98,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 
 	get_group_by_dropdown_fields() {
 		let group_by_fields = [];
-		let fields = this.list_view.meta.fields.filter((f)=> ["Select", "Link"].includes(f.fieldtype));
+		let fields = this.list_view.meta.fields.filter((f)=> ["Select", "Link", "Data", "Int", "Check"].includes(f.fieldtype));
 		group_by_fields.push({
 			label: __(this.doctype),
 			fieldname: 'group_by_fields',
@@ -167,7 +167,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 		this.$wrapper.on('click', '.group-by-item', (e) => {
 			let $target = $(e.currentTarget);
 			let fieldname = $target.parents('.group-by-field').find('a').data('fieldname');
-			let value = decodeURIComponent($target.data('value').trim());
+			let value = $target.data('value') instanceof String? decodeURIComponent($target.data('value').trim()): $target.data('value');
 			fieldname = fieldname === 'assigned_to' ? '_assign': fieldname;
 
 			return this.list_view.filter_area.remove(fieldname)

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -252,7 +252,7 @@ frappe.ui.GroupBy = class {
 		this.group_by_fields = {};
 		this.all_fields = {};
 
-		let fields = this.report_view.meta.fields.filter(f => ["Select", "Link", "Data", "Int"].includes(f.fieldtype));
+		let fields = this.report_view.meta.fields.filter(f => ["Select", "Link", "Data", "Int", "Check"].includes(f.fieldtype));
 		this.group_by_fields[this.doctype] = fields;
 		this.all_fields[this.doctype] = this.report_view.meta.fields;
 


### PR DESCRIPTION
- Allow `Check` type fields in report group by:

- Allow `Data`, `Int`, and `Check` type fields in list sidebar filters
