### PR TITLE
fix(EPS): parse email address for eps

### DIFF
--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 from frappe.social.doctype.energy_point_log.energy_point_log import \
 	create_energy_points_log
+from frappe.utils import extract_email_id
 
 class EnergyPointRule(Document):
 	def on_update(self):
@@ -47,7 +48,7 @@ class EnergyPointRule(Document):
 					if not user or user == 'Administrator': continue
 					create_energy_points_log(reference_doctype, reference_name, {
 						'points': points,
-						'user': user,
+						'user': extract_email_id(user),
 						'rule': rule
 					}, self.apply_only_once)
 			except Exception as e:


### PR DESCRIPTION
- If EPS is enabled for Communication, the email id is of the format `John Doe <johndoe@gmail.com>` and the system tries to set this as user in Energy Point Log, and this results in the error.
![image](https://user-images.githubusercontent.com/7310479/77320804-39e29180-6d37-11ea-813f-5ece9487e872.png)
- Now email id is parsed to get email address