### PR TITLE
fix: Remove margin from form-group

### DIFF
--- a/frappe/public/less/page.less
+++ b/frappe/public/less/page.less
@@ -132,8 +132,8 @@
 	background-color: @panel-bg;
 
 	.form-group {
-		padding: 0px;
-		margin: 5px;
+		padding: 5px;
+		margin: 0;
 	}
 	.checkbox {
 		margin-top: 4px;


### PR DESCRIPTION
Remove margin from .form-group which is a bootstrap col in the standard filters. Bootstrap cols can not have margin.

Before

![image](https://user-images.githubusercontent.com/8351245/77353440-41a73380-6d41-11ea-85ed-8c7c2a2f4271.png)

After

![image](https://user-images.githubusercontent.com/8351245/77353450-4835ab00-6d41-11ea-84ef-5df54ce1ed28.png)
