### PR TITLE
fix: use db.set_value while resetting _seen value

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -978,7 +978,7 @@ class Document(BaseDocument):
 	def reset_seen(self):
 		"""Clear _seen property and set current user as seen"""
 		if getattr(self.meta, 'track_seen', False):
-			self.db_set('_seen', json.dumps([frappe.session.user]), update_modified=False)
+			frappe.db.set_value(self.doctype, self.name, "_seen", json.dumps([frappe.session.user]), update_modified=False)
 
 	def notify_update(self):
 		"""Publish realtime that the current document is modified"""

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -10,7 +10,6 @@ from frappe.model.document import Document
 from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 from frappe.social.doctype.energy_point_log.energy_point_log import \
 	create_energy_points_log
-from frappe.utils import extract_email_id
 
 class EnergyPointRule(Document):
 	def on_update(self):
@@ -48,7 +47,7 @@ class EnergyPointRule(Document):
 					if not user or user == 'Administrator': continue
 					create_energy_points_log(reference_doctype, reference_name, {
 						'points': points,
-						'user': extract_email_id(user),
+						'user': user,
 						'rule': rule
 					}, self.apply_only_once)
 			except Exception as e:


### PR DESCRIPTION
- use `db.set_value` instead of `db_set` as it triggers `on_change` function which inturn triggers `process_energy_points` before `validate` is called.

Reverts: https://github.com/frappe/frappe/pull/9764

Fixes issue introduced with: https://github.com/frappe/frappe/pull/9400/commits/b9bb6e651302ca7a9451df982c7c7e72f995d6a3 
