### PR TITLE
fix: use typeof instead of instanceof

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -167,7 +167,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 		this.$wrapper.on('click', '.group-by-item', (e) => {
 			let $target = $(e.currentTarget);
 			let fieldname = $target.parents('.group-by-field').find('a').data('fieldname');
-			let value = $target.data('value') instanceof String? decodeURIComponent($target.data('value').trim()): $target.data('value');
+			let value = typeof $target.data('value') === 'string' ? decodeURIComponent($target.data('value').trim()) : $target.data('value');
 			fieldname = fieldname === 'assigned_to' ? '_assign': fieldname;
 
 			return this.list_view.filter_area.remove(fieldname)


### PR DESCRIPTION
instanceof fails to check for string, instead classifying the `$target.data('value')` as `instanceof Object`; which causes the ternary check to fail and pass filter without `decodeURIComponent()`, causing filter to be applied like: `email%40example.com` instead of `email@example.com`

we can instead just use `typeof` to check whether the passed value is a string