### PR TITLE
feat(Reports): Enable depends on for script report filters

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -307,12 +307,12 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					this.evaluate_depends_on_value(filter.df.depends_on, filter.df.label);
 
 				if (filter.guardian_has_value) {
-					if(filter.df.hidden_due_to_dependency) {
+					if (filter.df.hidden_due_to_dependency) {
 						filter.df.hidden_due_to_dependency = false;
 						this.toggle_filter_display(filter.df.fieldname, false);
 					}
 				} else {
-					if(!filter.df.hidden_due_to_dependency) {
+					if (!filter.df.hidden_due_to_dependency) {
 						filter.df.hidden_due_to_dependency = true;
 						this.toggle_filter_display(filter.df.fieldname, true);
 						filter.set_value(filter.df.default || null);
@@ -327,17 +327,17 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		let out = null;
 		let doc = this.get_filter_values();
 		if (doc) {
-			if(typeof(expression) === 'boolean') {
+			if (typeof expression === 'boolean') {
 				out = expression;
-			} else if(expression.substr(0,5)=='eval:') {
+			} else if (expression.substr(0, 5) == 'eval:') {
 				try {
 					out = eval(expression.substr(5));
-				} catch(e) {
+				} catch (e) {
 					frappe.throw(__(`Invalid "depends_on" expression set in filter ${filter_label}`));
 				}
 			} else {
 				var value = doc[expression];
-				if($.isArray(value)) {
+				if ($.isArray(value)) {
 					out = !!value.length;
 				} else {
 					out = !!value;

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -325,8 +325,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	evaluate_depends_on_value(expression, filter_label) {
 		let out = null;
-		let doc = this.get_filter_values();
-		if (doc) {
+		let filters = this.get_filter_values();
+		if (filters) {
 			if (typeof expression === 'boolean') {
 				out = expression;
 			} else if (expression.substr(0, 5) == 'eval:') {
@@ -336,7 +336,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					frappe.throw(__(`Invalid "depends_on" expression set in filter ${filter_label}`));
 				}
 			} else {
-				var value = doc[expression];
+				var value = filters[expression];
 				if ($.isArray(value)) {
 					out = !!value.length;
 				} else {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -298,6 +298,55 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}, 1000);
 	}
 
+	refresh_filters_dependency() {
+		this.filters.forEach(filter => {
+			filter.guardian_has_value = true;
+
+			if (filter.df.depends_on) {
+				filter.guardian_has_value =
+					this.evaluate_depends_on_value(filter.df.depends_on, filter.df.label);
+
+				if (filter.guardian_has_value) {
+					if(filter.df.hidden_due_to_dependency) {
+						filter.df.hidden_due_to_dependency = false;
+						this.toggle_filter_display(filter.df.fieldname, false);
+					}
+				} else {
+					if(!filter.df.hidden_due_to_dependency) {
+						filter.df.hidden_due_to_dependency = true;
+						this.toggle_filter_display(filter.df.fieldname, true);
+						filter.set_value(filter.df.default || null);
+					}
+				}
+			}
+
+		});
+	}
+
+	evaluate_depends_on_value(expression, filter_label) {
+		let out = null;
+		let doc = this.get_filter_values();
+		if (doc) {
+			if(typeof(expression) === 'boolean') {
+				out = expression;
+			} else if(expression.substr(0,5)=='eval:') {
+				try {
+					out = eval(expression.substr(5));
+				} catch(e) {
+					frappe.throw(__(`Invalid "depends_on" expression set in filter ${filter_label}`));
+				}
+			} else {
+				var value = doc[expression];
+				if($.isArray(value)) {
+					out = !!value.length;
+				} else {
+					out = !!value;
+				}
+			}
+		}
+		return out;
+	}
+
 	setup_filters() {
 		this.clear_filters();
 		const { filters = [] } = this.report_settings;
@@ -315,6 +364,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			if (df.on_change) f.on_change = df.on_change;
 
 			df.onchange = () => {
+				this.refresh_filters_dependency();
+
 				let current_filters = this.get_filter_value();
 				if (this.previous_filters
 					&& (JSON.stringify(this.previous_filters) === JSON.stringify(current_filters))) {
@@ -344,6 +395,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		}).filter(Boolean);
 
+		this.refresh_filters_dependency();
 		if (this.filters.length === 0) {
 			// hide page form if no filters
 			this.page.hide_form();
@@ -1472,8 +1524,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 	}
 
-	toggle_filter(fieldname, flag) {
-		$(`div[data-fieldname=${fieldname}]`).toggleClass('hide-control', flag);
+	toggle_filter_display(fieldname, flag) {
+		this.$page.find(`div[data-fieldname=${fieldname}]`).toggleClass('hide-control', flag);
 	}
 
 	toggle_report(flag) {


### PR DESCRIPTION
Enable `depends_on` for report filters, similar to doctype fields:

Example:
```
{
	"fieldname":"report_date",
	"label": __("Posting Date"),
	"fieldtype": "Date",
	"default": frappe.datetime.get_today(),
	"depends_on": "eval:filters.company == 'Facebook'"
},

```

In this case, the **report_date** field is only visible when the **company** filter value is Facebook:

![report filters dependson](https://user-images.githubusercontent.com/19775888/77417402-50e2bb80-6deb-11ea-8bce-a627d37b450c.gif)
