### PR TITLE
fix: add custom fields from query report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -77,9 +77,9 @@ def generate_report_result(report, filters=None, user=None):
 		if len(res) > 5:
 			skip_total_row = cint(res[5])
 
-		if report.custom_columns:
-			columns = json.loads(report.custom_columns)
-			result = add_data_to_custom_columns(columns, result)
+	if report.custom_columns:
+		columns = json.loads(report.custom_columns)
+		result = add_data_to_custom_columns(columns, result)
 
 	if result:
 		result = get_filtered_data(report.ref_doctype, columns, result, user)


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/pull/9786

For query reports, if you make a custom report after adding a new column, the report would be saved with the correct JSON. However, when loading the report those columns won't be added.

This PR fixes it