### PR TITLE
fix: redirect to defined success URL (develop)

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -174,7 +174,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			title: __("Saved Successfully"),
 			secondary_action: () => {
 				if (this.success_url) {
-					window.location.pathname = this.success_url;
+					window.location.href = this.success_url;
 				} else if(this.login_required) {
 					window.location.href =
 						window.location.pathname + "?name=" + data.name;


### PR DESCRIPTION
Backported to [v12](https://github.com/frappe/frappe/pull/9793).

<hr>

**Problem:**

Web Form redirects on the portal would only change the final component of the path without refreshing its query params, which would cause any new form submit (example path: `/issues?new=1`) to keep redirecting to a new web form, even if the success URL was set to a specific path (example path: `/issues`).

**Solution:**

Set the full redirect path to the one defined in the "Success URL" for any given Web Form.