### PR TITLE
fix(control): Wrap text in markdown editor

### DIFF
--- a/frappe/public/js/frappe/form/controls/markdown_editor.js
+++ b/frappe/public/js/frappe/form/controls/markdown_editor.js
@@ -6,6 +6,8 @@ frappe.ui.form.ControlMarkdownEditor = frappe.ui.form.ControlCode.extend({
 		this.ace_editor_target.wrap(`<div class="${this.editor_class}-container">`);
 		this.markdown_container = this.$input_wrapper.find(`.${this.editor_class}-container`);
 
+		this.editor.getSession().setUseWrapMode(true);
+
 		this.showing_preview = false;
 		this.preview_toggle_btn = $(`<button class="btn btn-default btn-xs ${this.editor_class}-toggle">${__('Preview')}</button>`)
 			.click(e => {


### PR DESCRIPTION
Text wrapping for markdown so its easier to write paragraphs

<img width="934" alt="Screenshot 2020-03-27 at 11 39 15 AM" src="https://user-images.githubusercontent.com/140076/77727258-e4043700-701f-11ea-9b30-346f7d6359c6.png">
