### PR TITLE
fix(patch): set parent and parenttype as None for print formats

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -270,3 +270,4 @@ execute:frappe.delete_doc_if_exists('DocType', 'GSuite Settings')
 execute:frappe.delete_doc_if_exists('DocType', 'GSuite Templates')
 execute:frappe.delete_doc_if_exists('DocType', 'GCalendar Account')
 execute:frappe.delete_doc_if_exists('DocType', 'GCalendar Settings')
+frappe.patches.v12_0.remove_parent_and_parenttype_from_print_formats

--- a/frappe/patches/v12_0/remove_parent_and_parenttype_from_print_formats.py
+++ b/frappe/patches/v12_0/remove_parent_and_parenttype_from_print_formats.py
@@ -1,0 +1,14 @@
+import frappe
+
+def execute():
+    frappe.db.sql("""
+        UPDATE
+            `tabPrint Format`
+        SET
+            `tabPrint Format`.`parent`='',
+            `tabPrint Format`.`parenttype`='',
+            `tabPrint Format`.parentfield=''
+        WHERE
+            `tabPrint Format`.parent != ''
+            OR `tabPrint Format`.parenttype != ''
+        """)


### PR DESCRIPTION
Print Formats are not supposed to have parent and parenttype field set. 
Fixes:
![image](https://user-images.githubusercontent.com/19775888/77751264-5c342200-704b-11ea-81b8-757f08df49ed.png)
