### PR TITLE
fix: Incorrect translation of short format time difference strings

### DIFF
--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -3,61 +3,49 @@
 function prettyDate(time, mini) {
 	if (!time) {
 		time = new Date();
-	}
-	if ('moment' in window) { // use frappe.ImportError ;)
-		let ret;
-		if (frappe.sys_defaults && frappe.sys_defaults.time_zone) {
-			ret = moment.tz(time, frappe.sys_defaults.time_zone).locale(frappe.boot.lang).fromNow(mini);
+	}	
+	if (!time) return '';
+	var date = time;
+	if (typeof (time) == "string")
+		date = new Date((time || "").replace(/-/g, "/").replace(/[TZ]/g, " ").replace(/\.[0-9]*/, ""));
+
+	let diff = (((new Date()).getTime() - date.getTime()) / 1000);
+	let day_diff = Math.floor(diff / 86400);
+
+	if (isNaN(day_diff) || day_diff < 0) return '';
+
+	if (mini) {
+		// Return short format of time difference
+		if (day_diff == 0) {
+			if (diff < 60) return __("Now")
+			else if (diff < 3600) return __("{0} m", [Math.floor(diff / 60)])
+			else if (diff < 86400) return __("{0} h", [Math.floor(diff / 3600)])
 		} else {
-			ret = moment(time).locale(frappe.boot.lang).fromNow(mini);
+			if (day_diff < 7) return __("{0} D", [day_diff])
+			else if (diff < 31) return __("{0} W", [Math.ceil(day_diff / 7)])
+			else if (diff < 365) return __("{0} M", [Math.ceil(day_diff / 30)])
+			else return __("{0} Y", [Math.ceil(day_diff / 365)])
 		}
-		if (mini) {
-			if (ret === moment().locale(frappe.boot.lang).fromNow(mini)) {
-				ret = __("now");
-			} else {
-				var parts = ret.split(" ");
-				if (parts.length > 1) {
-					if (parts[0] === "a" || parts[0] === "an") {
-						parts[0] = 1;
-					}
-					if (parts[1].substr(0, 2) === "mo") {
-						ret = parts[0] + " M";
-					} else {
-						ret = parts[0] + " " + parts[1].substr(0, 1);
-					}
-				}
-			}
-			ret = ret.substr(0, 5);
-		}
-		return ret;
 	} else {
-		if (!time) return '';
-		var date = time;
-		if (typeof (time) == "string")
-			date = new Date((time || "").replace(/-/g, "/").replace(/[TZ]/g, " ").replace(/\.[0-9]*/, ""));
-
-		var diff = (((new Date()).getTime() - date.getTime()) / 1000),
-			day_diff = Math.floor(diff / 86400);
-
-		if (isNaN(day_diff) || day_diff < 0)
-			return '';
-
-		var when = day_diff == 0 && (
-			diff < 60 && __("just now") ||
-			diff < 120 && __("1 minute ago") ||
-			diff < 3600 && __("{0} minutes ago", [Math.floor(diff / 60)]) ||
-			diff < 7200 && __("1 hour ago") ||
-			diff < 86400 && ("{0} hours ago", [Math.floor(diff / 3600)])) ||
-			day_diff == 1 && __("Yesterday") ||
-			day_diff < 7 && __("{0} days ago", day_diff) ||
-			day_diff < 31 && __("{0} weeks ago", [Math.ceil(day_diff / 7)]) ||
-			day_diff < 365 && __("{0} months ago", [Math.ceil(day_diff / 30)]) ||
-			__("> {0} year(s) ago", [Math.floor(day_diff / 365)]);
-
-		return when;
+		// Return long format of time difference
+		if (day_diff == 0) {
+			if (diff < 60) return __("Just now")
+			else if (diff < 120) return __("1 minute ago")
+			else if (diff < 3600) return __("{0} minutes ago", [Math.floor(diff / 60)])
+			else if (diff < 7200) return __("1 hour ago")
+			else if (diff < 86400) return __("{0} hours ago", [Math.floor(diff / 3600)])
+		} else {
+			if (day_diff == 1) return __("Yesterday")
+			else if (day_diff < 7) return __("{0} days ago", [day_diff])
+			else if (day_diff < 14) return __("1 week ago")
+			else if (day_diff < 31) return __("{0} week ago", [Math.ceil(day_diff / 7)])
+			else if (day_diff < 62) return __("1 month ago")
+			else if (day_diff < 365) return __("{0} months ago", [Math.ceil(day_diff / 30)])
+			else if (day_diff < 730) return __("1 year ago")
+			else return __("{0} years ago", [Math.ceil(day_diff / 365)])
+		}
 	}
 }
-
 
 frappe.provide("frappe.datetime");
 window.comment_when = function(datetime, mini) {

--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -1,13 +1,8 @@
-// moment strings for translation
+function prettyDate(date, mini) {
+	if (!date) return '';
 
-function prettyDate(time, mini) {
-	if (!time) {
-		time = new Date();
-	}	
-	if (!time) return '';
-	var date = time;
-	if (typeof (time) == "string")
-		date = new Date((time || "").replace(/-/g, "/").replace(/[TZ]/g, " ").replace(/\.[0-9]*/, ""));
+	if (typeof (date) == "string")
+		date = new Date((date || "").replace(/-/g, "/").replace(/[TZ]/g, " ").replace(/\.[0-9]*/, ""));
 
 	let diff = (((new Date()).getTime() - date.getTime()) / 1000);
 	let day_diff = Math.floor(diff / 86400);

--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -12,32 +12,56 @@ function prettyDate(date, mini) {
 	if (mini) {
 		// Return short format of time difference
 		if (day_diff == 0) {
-			if (diff < 60) { return __("Now"); }
-			else if (diff < 3600) { return __("{0} m", [Math.floor(diff / 60)]); }
-			else if (diff < 86400) { return __("{0} h", [Math.floor(diff / 3600)]); }
+			if (diff < 60) {
+				return __("Now");
+			} else if (diff < 3600) {
+				return __("{0} m", [Math.floor(diff / 60)]);
+			} else if (diff < 86400) {
+				return __("{0} h", [Math.floor(diff / 3600)]);
+			}
 		} else {
-			if (day_diff < 7) { return __("{0} D", [day_diff]); }
-			else if (diff < 31) { return __("{0} W", [Math.ceil(day_diff / 7)]); }
-			else if (diff < 365) { return __("{0} M", [Math.ceil(day_diff / 30)]); }
-			else { return __("{0} Y", [Math.ceil(day_diff / 365)]); }
+			if (day_diff < 7) {
+				return __("{0} D", [day_diff]);
+			} else if (diff < 31) {
+				return __("{0} W", [Math.ceil(day_diff / 7)]);
+			} else if (diff < 365) {
+				return __("{0} M", [Math.ceil(day_diff / 30)]);
+			} else {
+				return __("{0} Y", [Math.ceil(day_diff / 365)]);
+			}
 		}
 	} else {
 		// Return long format of time difference
 		if (day_diff == 0) {
-			if (diff < 60) { return __("Just now"); }
-			else if (diff < 120) { return __("1 minute ago"); }
-			else if (diff < 3600) { return __("{0} minutes ago", [Math.floor(diff / 60)]); }
-			else if (diff < 7200) { return __("1 hour ago"); }
-			else if (diff < 86400) { return __("{0} hours ago", [Math.floor(diff / 3600)]); }
+			if (diff < 60) {
+				return __("Just now");
+			} else if (diff < 120) {
+				return __("1 minute ago");
+			} else if (diff < 3600) {
+				return __("{0} minutes ago", [Math.floor(diff / 60)]);
+			} else if (diff < 7200) {
+				return __("1 hour ago");
+			} else if (diff < 86400) {
+				return __("{0} hours ago", [Math.floor(diff / 3600)]);
+			}
 		} else {
-			if (day_diff == 1) { return __("Yesterday"); }
-			else if (day_diff < 7) { return __("{0} days ago", [day_diff]); }
-			else if (day_diff < 14) { return __("1 week ago"); }
-			else if (day_diff < 31) { return __("{0} week ago", [Math.ceil(day_diff / 7)]); }
-			else if (day_diff < 62) { return __("1 month ago"); }
-			else if (day_diff < 365) { return __("{0} months ago", [Math.ceil(day_diff / 30)]); }
-			else if (day_diff < 730) { return __("1 year ago"); }
-			else { return __("{0} years ago", [Math.ceil(day_diff / 365)]); }
+			if (day_diff == 1) {
+				return __("Yesterday");
+			} else if (day_diff < 7) {
+				return __("{0} days ago", [day_diff]);
+			} else if (day_diff < 14) {
+				return __("1 week ago");
+			} else if (day_diff < 31) {
+				return __("{0} weeks ago", [Math.ceil(day_diff / 7)]);
+			} else if (day_diff < 62) {
+				return __("1 month ago");
+			} else if (day_diff < 365) {
+				return __("{0} months ago", [Math.ceil(day_diff / 30)]);
+			} else if (day_diff < 730) {
+				return __("1 year ago");
+			} else {
+				return __("{0} years ago", [Math.ceil(day_diff / 365)]);
+			}
 		}
 	}
 }

--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -22,9 +22,9 @@ function prettyDate(date, mini) {
 		} else {
 			if (day_diff < 7) {
 				return __("{0} D", [day_diff]);
-			} else if (diff < 31) {
+			} else if (day_diff < 31) {
 				return __("{0} W", [Math.ceil(day_diff / 7)]);
-			} else if (diff < 365) {
+			} else if (day_diff < 365) {
 				return __("{0} M", [Math.ceil(day_diff / 30)]);
 			} else {
 				return __("{0} Y", [Math.ceil(day_diff / 365)]);

--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -12,32 +12,32 @@ function prettyDate(date, mini) {
 	if (mini) {
 		// Return short format of time difference
 		if (day_diff == 0) {
-			if (diff < 60) return __("Now")
-			else if (diff < 3600) return __("{0} m", [Math.floor(diff / 60)])
-			else if (diff < 86400) return __("{0} h", [Math.floor(diff / 3600)])
+			if (diff < 60) { return __("Now"); }
+			else if (diff < 3600) { return __("{0} m", [Math.floor(diff / 60)]); }
+			else if (diff < 86400) { return __("{0} h", [Math.floor(diff / 3600)]); }
 		} else {
-			if (day_diff < 7) return __("{0} D", [day_diff])
-			else if (diff < 31) return __("{0} W", [Math.ceil(day_diff / 7)])
-			else if (diff < 365) return __("{0} M", [Math.ceil(day_diff / 30)])
-			else return __("{0} Y", [Math.ceil(day_diff / 365)])
+			if (day_diff < 7) { return __("{0} D", [day_diff]); }
+			else if (diff < 31) { return __("{0} W", [Math.ceil(day_diff / 7)]); }
+			else if (diff < 365) { return __("{0} M", [Math.ceil(day_diff / 30)]); }
+			else { return __("{0} Y", [Math.ceil(day_diff / 365)]); }
 		}
 	} else {
 		// Return long format of time difference
 		if (day_diff == 0) {
-			if (diff < 60) return __("Just now")
-			else if (diff < 120) return __("1 minute ago")
-			else if (diff < 3600) return __("{0} minutes ago", [Math.floor(diff / 60)])
-			else if (diff < 7200) return __("1 hour ago")
-			else if (diff < 86400) return __("{0} hours ago", [Math.floor(diff / 3600)])
+			if (diff < 60) { return __("Just now"); }
+			else if (diff < 120) { return __("1 minute ago"); }
+			else if (diff < 3600) { return __("{0} minutes ago", [Math.floor(diff / 60)]); }
+			else if (diff < 7200) { return __("1 hour ago"); }
+			else if (diff < 86400) { return __("{0} hours ago", [Math.floor(diff / 3600)]); }
 		} else {
-			if (day_diff == 1) return __("Yesterday")
-			else if (day_diff < 7) return __("{0} days ago", [day_diff])
-			else if (day_diff < 14) return __("1 week ago")
-			else if (day_diff < 31) return __("{0} week ago", [Math.ceil(day_diff / 7)])
-			else if (day_diff < 62) return __("1 month ago")
-			else if (day_diff < 365) return __("{0} months ago", [Math.ceil(day_diff / 30)])
-			else if (day_diff < 730) return __("1 year ago")
-			else return __("{0} years ago", [Math.ceil(day_diff / 365)])
+			if (day_diff == 1) { return __("Yesterday"); }
+			else if (day_diff < 7) { return __("{0} days ago", [day_diff]); }
+			else if (day_diff < 14) { return __("1 week ago"); }
+			else if (day_diff < 31) { return __("{0} week ago", [Math.ceil(day_diff / 7)]); }
+			else if (day_diff < 62) { return __("1 month ago"); }
+			else if (day_diff < 365) { return __("{0} months ago", [Math.ceil(day_diff / 30)]); }
+			else if (day_diff < 730) { return __("1 year ago"); }
+			else { return __("{0} years ago", [Math.ceil(day_diff / 365)]); }
 		}
 	}
 }

--- a/frappe/translations/de.csv
+++ b/frappe/translations/de.csv
@@ -63,7 +63,6 @@ apps/frappe/frappe/templates/emails/download_data.html,We have received a reques
 DocType: System Settings,"If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong.","Falls diese Option aktiviert ist, wird die Passwortstärke auf der Grundlage des Minimum Password Score Wertes erzwungen. Ein Wert von 2 ist mittelstark und 4 sehr stark."
 DocType: About Us Settings,"""Team Members"" or ""Management""",„Teammitglieder“ oder „Management“
 apps/frappe/frappe/core/doctype/doctype/doctype.py,Default for 'Check' type of field must be either '0' or '1',Standard für 'Prüfen'-Feldtyp muss entweder '0' oder '1' sein
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Gestern
 DocType: Contact,Designation,Bezeichnung
 apps/frappe/frappe/email/doctype/email_account/email_account.py,Automatic Linking can be activated only for one Email Account.,Die automatische Verknüpfung kann nur für ein E-Mail-Konto aktiviert werden.
 DocType: Test Runner,Test Runner,Tester
@@ -120,7 +119,6 @@ DocType: Dashboard Chart,Timespan,Zeitspanne
 apps/frappe/frappe/public/js/frappe/file_uploader/FileUploader.vue,Web Link,Weblink
 DocType: Deleted Document,Restored,Restauriert
 apps/frappe/frappe/public/js/frappe/form/print.js,"Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a href=""https://qz.io/download/"" target=""_blank"">Click here to Download and install QZ Tray</a>.<br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Click here to learn more about Raw Printing</a>.","Fehler beim Verbinden mit der QZ-Tray-Anwendung ... <br><br> Sie müssen die QZ Tray-Anwendung installiert haben und ausführen, um die Raw Print-Funktion verwenden zu können. <br><br> <a href=""https://qz.io/download/"" target=""_blank"">Klicken Sie hier, um QZ Tray herunterzuladen und zu installieren</a> . <br> <a href=""https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing"" target=""_blank"">Klicken Sie hier, um mehr über den Rohdruck zu erfahren</a> ."
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 minute ago,Vor 1 Minute
 apps/frappe/frappe/core/page/permission_manager/permission_manager_help.html,"Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type.",Zusätzlich zum System-Manager können Rollen mit der Erlaubnis Benutzer anzulegen Berechtigungen für andere Nutzer für diesen Dokumententyp setzen.
 apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Configure Theme,Thema konfigurieren
 DocType: Company History,Company History,Unternehmensgeschichte
@@ -971,7 +969,6 @@ apps/frappe/frappe/public/js/frappe/list/list_view.js,Share URL,URL teilen
 DocType: System Settings,Allow Consecutive Login Attempts ,Erlaube aufeinanderfolgende Login-Versuche
 apps/frappe/frappe/templates/pages/integrations/stripe_checkout.html,An error occured during the payment process. Please contact us.,Während des Bezahlvorgangs ist ein Fehler aufgetreten. Bitte kontaktieren Sie uns.
 DocType: Onboarding Slide,If Slide Type is Create or Settings there should be a 'create_onboarding_docs' method in the {ref_doctype}.py file bound to be executed after the slide is completed.,"Wenn der Folientyp &quot;Erstellen&quot; oder &quot;Einstellungen&quot; ist, sollte die Methode &quot;create_onboarding_docs&quot; in der Datei &quot;{ref_doctype} .py&quot; enthalten sein, die nach Abschluss der Folie ausgeführt werden soll."
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} days ago,vor {0} Tag(en)
 DocType: Email Account,Awaiting Password,Warte auf Passwort
 DocType: Address,Address Line 1,Adresse Zeile 1
 apps/frappe/frappe/public/js/frappe/ui/filters/filter.js,Not Descendants Of,Nicht Nachkommen von
@@ -1360,7 +1357,6 @@ apps/frappe/frappe/social/doctype/energy_point_rule/energy_point_rule.py,Referen
 DocType: PayPal Settings,PayPal Settings,PayPal-Einstellungen
 apps/frappe/frappe/core/page/permission_manager/permission_manager.js,Select Document Type,Dokumenttyp auswählen
 apps/frappe/frappe/utils/nestedset.py,Cannot delete {0} as it has child nodes,"{0} kann nicht gelöscht werden, da es Unterknoten gibt"
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} minutes ago,vor {0} Minute(n)
 apps/frappe/frappe/automation/doctype/assignment_rule/assignment_rule.py,Assignment Day {0} has been repeated.,Der Zuordnungstag {0} wurde wiederholt.
 DocType: Kanban Board Column,lightblue,hellblau
 apps/frappe/frappe/integrations/doctype/webhook/webhook.py,Same Field is entered more than once,Gleiches Feld wird mehrmals eingegeben
@@ -1787,7 +1783,6 @@ DocType: Notification Log,Assignment,Zuordnung
 DocType: Notification,Slack Channel,Slack-Kanal
 DocType: About Us Team Member,Image Link,Bildverknüpfung
 DocType: Auto Email Report,Report Filters,Berichtsfilter
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,now,jetzt
 DocType: Workflow State,step-backward,Schritt zurück
 apps/frappe/frappe/utils/boilerplate.py,{app_title},{app_title}
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Please set Dropbox access keys in your site config,Bitte Dropbox-Zugriffsdaten in den Einstellungen der Seite setzen
@@ -2520,7 +2515,6 @@ apps/frappe/frappe/public/js/frappe/form/print.js,QZ Tray Connection Active!,QZ-
 DocType: Contact Us Settings,Settings for Contact Us Page,Einstellungen Kontakt
 DocType: Server Script,Script Type,Skripttyp
 DocType: Print Settings,Enable Print Server,Aktivieren Sie den Druckserver
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} weeks ago,vor {0} Woche(n)
 DocType: Email Account,Footer,Fußzeile
 apps/frappe/frappe/config/integrations.py,Authentication,Authentifizierung
 apps/frappe/frappe/utils/verified_command.py,Invalid Link,Ungültige Verknüpfung
@@ -3444,7 +3438,6 @@ apps/frappe/frappe/integrations/doctype/ldap_settings/ldap_settings.py,Please In
 apps/frappe/frappe/core/doctype/data_import/log_details.html,Row Status,Zeilenstatus
 DocType: S3 Backup Settings,sa-east-1,sa-east-1
 DocType: Workflow Transition,Workflow Transition,Workflow-Übergang
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,vor {0} Monate(n)
 apps/frappe/frappe/custom/doctype/custom_field/custom_field.py,Custom Fields can only be added to a standard DocType.,Benutzerdefinierte Felder können nur zu einem Standard-DocType hinzugefügt werden.
 apps/frappe/frappe/public/js/frappe/list/list_sidebar_group_by.js,Created By,Erstellt von
 apps/frappe/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py,Dropbox Setup,Dropbox-Setup
@@ -3500,7 +3493,6 @@ apps/frappe/frappe/website/doctype/website_theme/website_theme.js,Theme Colors,T
 apps/frappe/frappe/printing/page/print_format_builder/print_format_builder.js,Select a DocType to make a new format,"DocType auswählen, um ein neues Format zu erstellen"
 apps/frappe/frappe/desk/page/user_profile/user_profile.js,User does not exist,Benutzer existiert nicht
 apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py,'Recipients' not specified,"Keine ""Empfänger"" angegeben"
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,just now,gerade eben
 apps/frappe/frappe/public/js/frappe/ui/filters/edit_filter.html,Apply,Anwenden
 DocType: Footer Item,Policy,Politik
 apps/frappe/frappe/integrations/utils.py,{0} Settings not found,{0} Einstellungen nicht gefunden
@@ -3592,7 +3584,6 @@ DocType: Auto Email Report,Period,Periode
 apps/frappe/frappe/core/doctype/data_import_beta/data_import_beta.js,About {0} minute remaining,Noch ungefähr {0} Minuten
 apps/frappe/frappe/www/login.py,Invalid Login Token,Invalid Login Token
 apps/frappe/frappe/public/js/frappe/chat.js,Discard,Verwerfen
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 hour ago,vor 1 Stunde
 DocType: Website Settings,Home Page,Startseite
 DocType: Error Snapshot,Parent Error Snapshot,Momentaufnahme des übergeordneten Fehlers
 apps/frappe/frappe/public/js/frappe/data_import/import_preview.js,Map columns from {0} to fields in {1},Ordnen Sie Spalten von {0} Feldern in {1} zu.
@@ -3804,7 +3795,6 @@ DocType: Webhook,on_update_after_submit,on_update_after_submit
 DocType: System Settings,Allow Login using User Name,Login mit Benutzernamen zulassen
 apps/frappe/frappe/core/doctype/report/report.js,Enable Report,Bericht aktivieren
 DocType: DocField,Display Depends On,Anzeige ist abhängig von
-apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,&gt; {0} year(s) ago,&gt; {0} Jahr (e) her
 DocType: Social Login Key,API Endpoint,API-Endpunkt
 DocType: Web Page,Insert Code,Code einfügen
 DocType: Data Migration Run,Current Mapping Type,Aktueller Kartentyp
@@ -4188,3 +4178,23 @@ DocType: DocField,Ignore User Permissions,Ignorieren von Benutzerberechtigungen
 apps/frappe/frappe/public/js/frappe/web_form/web_form.js,Saved Successfully,Erfolgreich gespeichert
 apps/frappe/frappe/core/doctype/user/user.py,Please ask your administrator to verify your sign-up,Bitte fragen Sie Ihren Administrator Ihre Anmeldung bis zum überprüfen
 DocType: Domain Settings,Active Domains,Aktive Domains
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Now,Jetzt
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} m,{0} m
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} h,{0} h
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} D,{0} T
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} W,{0} W
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} M,{0} M
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} Y,{0} J
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Just now,Gerade eben
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 minute ago,Vor einer Minute
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} minutes ago,Vor {0} Minuten
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 hour ago,Vor einer Stunde
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} hours ago,Vor {0} Stunden
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,Yesterday,Gestern
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} days ago,Vor {0} Tagen
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 week ago,Vor einer Woche
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} weeks ago,Vor {0} Wochen
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 month ago,Vor einem Monat
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} months ago,Vor {0} Monaten
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,1 year ago,Vor einem Jahr
+apps/frappe/frappe/public/js/frappe/utils/pretty_date.js,{0} years ago,Vor {0} Jahren


### PR DESCRIPTION
The output of relative time, for example in the timeline, is controlled by Moment.js, which also handles the localization of time strings.

The problem exists with the short format strings (mini) of time, because Moment.js outputs singular values with the word instead of the number. So for example "1 hour ago" is returned as "An hour ago". In order to make the string shorter "a" and "an" are replaced by "1". Of course this only works if the system language is English, for example in German "Eine Stunde" doesn't get replaced, as you can see in the screenshot below.

Furthermore, the time unit is abbreviated with the first letter. This is also not correct in every language. In German, for example, it makes more sense to abbreviate the hour (**S**tunde) with h rather than with S.

![Anmerkung 2020-03-28 001742](https://user-images.githubusercontent.com/60393001/77807902-9de3bd80-7089-11ea-830b-ac03b64d5e22.png) --> ![Anmerkung 2020-03-28 002436](https://user-images.githubusercontent.com/60393001/77808190-b2748580-708a-11ea-89fe-9b207c1290e7.png)

This solution gets rid of using Moment.js for generating relative time string and instead uses its own function, which makes it more controllable and also translatable within frappe:

Note: The function uses "Math.floor" for time differences smaller than one day at the moment, so a difference of 1.5 hours will be displayed as "1 h". Can be changed to "Math.ceil" to display "2 h" instead, if preferred.

I also added the respective translations for German, however, translations for other languages still need to be made.