### PR TITLE
fix(permission-manager): Hide create, write options for DocTypes which cannot be created

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -217,6 +217,7 @@ frappe.PermissionEngine = Class.extend({
 
 			me.rights.forEach(r => {
 				if (!d.is_submittable && ['submit', 'cancel', 'amend'].includes(r)) return;
+				if (d.in_create && ['create', 'write', 'delete'].includes(r)) return;
 				me.add_check(perm_container, d, r);
 			});
 

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -66,6 +66,7 @@ def get_permissions(doctype=None, role=None):
 		meta = frappe.get_meta(d.parent)
 		if meta:
 			d.is_submittable = meta.is_submittable
+			d.in_create = meta.in_create
 
 	return out
 


### PR DESCRIPTION
Do not show 'Create', 'Write' and 'Delete' option in Role permission manager for Doctypes which user cannot create