### PR TITLE
fix: Get valid columns from meta only if table exists

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -68,7 +68,7 @@ def load_doctype_from_file(doctype):
 class Meta(Document):
 	_metaclass = True
 	default_fields = list(default_fields)[1:]
-	special_doctypes = ("DocField", "DocPerm", "Role", "DocType", "Module Def")
+	special_doctypes = ("DocField", "DocPerm", "Role", "DocType", "Module Def", 'DocType Action', 'DocType Link')
 
 	def __init__(self, doctype):
 		self._fields = {}
@@ -165,7 +165,8 @@ class Meta(Document):
 
 	def get_valid_columns(self):
 		if not hasattr(self, "_valid_columns"):
-			if self.name in ("DocType", "DocField", "DocPerm", 'DocType Action', 'DocType Link'):
+			table_exists = frappe.db.table_exists(self.name)
+			if self.name in self.special_doctypes and table_exists:
 				self._valid_columns = get_table_columns(self.name)
 			else:
 				self._valid_columns = self.default_fields + \


### PR DESCRIPTION
for doctype action

```
Executing execute:frappe.reload_doc('core', 'doctype', 'doctype_action', force=True) #2019-09-23 in test_site (test_frappe)
There was an issue while migrating the DocType: DocType Action
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 241, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 49, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 89, in execute_patch
    exec(patchmodule.split("execute:")[1],globals())
  File "<string>", line 1, in <module>
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 824, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/utils.py", line 174, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 27, in import_files
    reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 32, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 66, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 141, in import_doc
    doc.insert()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 264, in insert
    self.run_post_save_methods()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 936, in run_post_save_methods
    self.run_method("on_update")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 803, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1089, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1072, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 797, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 282, in on_update
    raise e
pymysql.err.ProgrammingError: (u'DocType', u'DocType Action')

```