### PR TITLE
fix: Show cancel button only if document is cancellable

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -403,9 +403,23 @@ frappe.ui.form.Toolbar = Class.extend({
 				me.frm.page.set_view('main');
 			}, 'octicon octicon-pencil');
 		} else if(status === "Cancel") {
-			this.page.set_secondary_action(__(status), function() {
-				me.frm.savecancel(this);
-			}, "octicon octicon-circle-slash");
+			let add_cancel_button = () => {
+				this.page.set_secondary_action(__(status), function() {
+					me.frm.savecancel(this);
+				}, "octicon octicon-circle-slash");
+			};
+			if (this.has_workflow()) {
+				frappe.xcall(
+					'frappe.model.workflow.can_cancel_document', {
+						'doctype': this.frm.doc.doctype,
+					}).then((can_cancel) => {
+					if (can_cancel) {
+						add_cancel_button();
+					}
+				});
+			} else {
+				add_cancel_button();
+			}
 		} else {
 			var click = {
 				"Save": function() {

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -87,7 +87,7 @@ frappe.ui.form.States = Class.extend({
 		frappe.workflow.get_transitions(this.frm.doc).then(transitions => {
 			this.frm.page.clear_actions_menu();
 			transitions.forEach(d => {
-				if(frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
+				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
 					me.frm.page.add_action_item(__(d.action), function() {
 						// set the workflow_action for use in form scripts
@@ -105,22 +105,8 @@ frappe.ui.form.States = Class.extend({
 					});
 				}
 			});
-			if (!added) {
-				//call function and clear cancel button if Cancel doc state is defined in the workflow
-				frappe.xcall(
-					'frappe.model.workflow.can_cancel_document',
-					{
-						doctype: this.frm.doc.doctype, 
-					}
-				).then((can_cancel) => {
-					if (!can_cancel) {
-						this.frm.page.clear_secondary_action();
-					}
-				});
-			} else {
-				this.setup_btn(added);
-			}
-			
+
+			this.setup_btn(added);
 		});
 
 	},


### PR DESCRIPTION
Check if **Cancel** button can be added before adding the button instead of hiding the button later (in  case of slow internet the button can still be clicked).

