### PR TITLE
fix(Grid): Fix grid form scrolling

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -550,6 +550,7 @@ export default class GridRow {
 	hide_form() {
 		frappe.dom.unfreeze();
 		this.row.toggle(true);
+		frappe.utils.scroll_to(this.row);
 		this.refresh();
 		if(cur_frm) cur_frm.cur_grid = null;
 		this.wrapper.removeClass("grid-row-open");

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -550,7 +550,7 @@ export default class GridRow {
 	hide_form() {
 		frappe.dom.unfreeze();
 		this.row.toggle(true);
-		frappe.utils.scroll_to(this.row, false, 15);
+		frappe.utils.scroll_to(this.row, true, 15);
 		this.refresh();
 		if(cur_frm) cur_frm.cur_grid = null;
 		this.wrapper.removeClass("grid-row-open");

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -550,7 +550,7 @@ export default class GridRow {
 	hide_form() {
 		frappe.dom.unfreeze();
 		this.row.toggle(true);
-		frappe.utils.scroll_to(this.row);
+		frappe.utils.scroll_to(this.row, false, 15);
 		this.refresh();
 		if(cur_frm) cur_frm.cur_grid = null;
 		this.wrapper.removeClass("grid-row-open");

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -9,7 +9,7 @@ export default class GridRowForm {
 		var me = this;
 		this.make_form();
 		this.form_area.empty();
-		frappe.utils.scroll_to(0, false, 0, this.wrapper.find('.grid-form-body'))
+		frappe.utils.scroll_to(0, false, 0, this.wrapper.find('.grid-form-body'));
 
 		this.layout = new frappe.ui.form.Layout({
 			fields: this.row.docfields,

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -9,6 +9,7 @@ export default class GridRowForm {
 		var me = this;
 		this.make_form();
 		this.form_area.empty();
+		frappe.utils.scroll_to(0, false, 0, this.wrapper.find('.grid-form-body'))
 
 		this.layout = new frappe.ui.form.Layout({
 			fields: this.row.docfields,

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -122,9 +122,11 @@ Object.assign(frappe.utils, {
 				</a></p>');
 		return content.html();
 	},
-	scroll_to: function(element, animate, additional_offset) {
+	scroll_to: function(element, animate, additional_offset, element_to_be_scrolled) {
+		element_to_be_scrolled = element_to_be_scrolled || $("html, body");
+
 		var y = 0;
-		if(element && typeof element==='number') {
+		if (element && typeof element==="number") {
 			y = element;
 		} else if(element) {
 			var header_offset = $(".navbar").height() + $(".page-head").height();
@@ -136,14 +138,14 @@ Object.assign(frappe.utils, {
 		}
 
 		// already there
-		if(y==$('html, body').scrollTop()) {
+		if (y == element_to_be_scrolled.scrollTop()) {
 			return;
 		}
 
-		if (animate!==false) {
-			$("html, body").animate({ scrollTop: y });
+		if (animate !== false) {
+			element_to_be_scrolled.animate({ scrollTop: y });
 		} else {
-			$(window).scrollTop(y);
+			element_to_be_scrolled.scrollTop(y);
 		}
 
 	},

--- a/frappe/public/less/form_grid.less
+++ b/frappe/public/less/form_grid.less
@@ -262,6 +262,11 @@
 	border-bottom: 1px solid @border-color;
 }
 
+.grid-form-body {
+	max-height: 75vh;
+	overflow-y: auto;
+}
+
 .grid-header-toolbar {
 	display: flow-root;
 }


### PR DESCRIPTION

- Added scroll to the grid form itself so there is no need to scroll the body
![grid form scroll](https://user-images.githubusercontent.com/19775888/77919972-7d02ae80-72bb-11ea-9bf5-4ff137fb3fa4.gif)

- In case body is scrolled, on closing the form the body scrolls back to the row:
![grid scroll to field](https://user-images.githubusercontent.com/19775888/77920047-93106f00-72bb-11ea-96d2-657d740e5f65.gif)
