### PR TITLE
fix: Response message style

### DIFF
--- a/frappe/templates/styles/card_style.css
+++ b/frappe/templates/styles/card_style.css
@@ -29,3 +29,11 @@
 .page-card p {
 	font-size: 14px;
 }
+
+.ellipsis {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 100%;
+	vertical-align: middle;
+}

--- a/frappe/www/message.html
+++ b/frappe/www/message.html
@@ -24,7 +24,7 @@ html, body {
 		<span class='indicator {{ indicator_color or "blue" }}'>
 			{{ title or _("Message") }}</span>
 	</h5>
-	<div class="page-card-body">
+	<div class="page-card-body ellipsis">
 	{% block message_body %}
 		<p>{{ message or "" }}</p>
 		{% if primary_action %}


### PR DESCRIPTION
**Before:**
<img width="868" alt="Screenshot 2020-03-26 at 5 50 38 PM" src="https://user-images.githubusercontent.com/13928957/77646511-ad301180-6f8a-11ea-819d-7475e5cbf4a3.png">

**After:**
<img width="705" alt="Screenshot 2020-03-26 at 5 50 10 PM" src="https://user-images.githubusercontent.com/13928957/77646530-b7eaa680-6f8a-11ea-8cde-3b63dbf15aad.png">

port-of: https://github.com/frappe/frappe/pull/9792