### PR TITLE
feat(Dashboard): Save dashboard chart config for user

### DIFF
--- a/frappe/core/page/dashboard/dashboard.js
+++ b/frappe/core/page/dashboard/dashboard.js
@@ -80,23 +80,27 @@ class Dashboard {
 			if (!charts.length) {
 				frappe.msgprint(__('No Permitted Charts on this Dashboard'), __('No Permitted Charts'))
 			}
-			this.charts = charts
-							.map(chart => {
-								return {
-									chart_name: chart.chart,
-									label: chart.chart,
-									...chart
-								}
-							});
 
-			this.chart_group = new frappe.widget.WidgetGroup({
-				title: null,
-				container: this.container,
-				type: "chart",
-				columns: 2,
-				allow_sorting: false,
-				widgets: this.charts,
-			});
+			frappe.dashboard_utils.get_dashboard_settings().then((settings) => {
+				let chart_config = settings.chart_config? JSON.parse(settings.chart_config): {};
+				this.charts =
+					charts.map(chart => {
+						return {
+							chart_name: chart.chart,
+							label: chart.chart,
+							chart_settings: chart_config[chart.chart] || {},
+							...chart
+						}
+					});
+				this.chart_group = new frappe.widget.WidgetGroup({
+					title: null,
+					container: this.container,
+					type: "chart",
+					columns: 2,
+					allow_sorting: false,
+					widgets: this.charts,
+				});
+			})
 		});
 	}
 

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.js
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2020, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Dashboard Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.json
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "autoname": "Prompt",
+ "creation": "2020-03-31 19:41:45.785014",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "chart_config"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "chart_config",
+   "fieldtype": "Code",
+   "label": "Chart Configuration",
+   "options": "JSON",
+   "read_only": 1
+  }
+ ],
+ "in_create": 1,
+ "links": [],
+ "modified": "2020-04-01 00:07:26.489561",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Dashboard Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "read_only": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+import frappe
+import json
+
+class DashboardSettings(Document):
+	pass
+
+
+@frappe.whitelist()
+def create_dashboard_settings(user):
+	if not frappe.db.exists("Dashboard Settings", user):
+		doc = frappe.new_doc('Dashboard Settings')
+		doc.name = user
+		doc.insert(ignore_permissions=True)
+		frappe.db.commit()
+		return doc
+
+def get_permission_query_conditions(user):
+	if not user: user = frappe.session.user
+
+	return '''(`tabDashboard Settings`.name = '{user}')'''.format(user=user)
+
+@frappe.whitelist()
+def save_chart_config(config, chart_name):
+	config = frappe.parse_json(config)
+	doc = frappe.get_doc('Dashboard Settings', frappe.session.user)
+	chart_config = frappe.parse_json(doc.chart_config) or {}
+
+	if not chart_name in chart_config:
+		chart_config[chart_name] = {}
+
+	chart_config[chart_name].update(config)
+	frappe.db.set_value('Dashboard Settings', frappe.session.user, 'chart_config', json.dumps(chart_config))

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
@@ -27,13 +27,17 @@ def get_permission_query_conditions(user):
 	return '''(`tabDashboard Settings`.name = '{user}')'''.format(user=user)
 
 @frappe.whitelist()
-def save_chart_config(config, chart_name):
-	config = frappe.parse_json(config)
+def save_chart_config(reset, config, chart_name):
+	reset = frappe.parse_json(reset)
 	doc = frappe.get_doc('Dashboard Settings', frappe.session.user)
 	chart_config = frappe.parse_json(doc.chart_config) or {}
 
-	if not chart_name in chart_config:
+	if reset:
 		chart_config[chart_name] = {}
+	else:
+		config = frappe.parse_json(config)
+		if not chart_name in chart_config:
+			chart_config[chart_name] = {}
+		chart_config[chart_name].update(config)
 
-	chart_config[chart_name].update(config)
 	frappe.db.set_value('Dashboard Settings', frappe.session.user, 'chart_config', json.dumps(chart_config))

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -86,6 +86,7 @@ permission_query_conditions = {
 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
 	"ToDo": "frappe.desk.doctype.todo.todo.get_permission_query_conditions",
 	"User": "frappe.core.doctype.user.user.get_permission_query_conditions",
+	"Dashboard Settings": "frappe.desk.doctype.dashboard_settings.dashboard_settings.get_permission_query_conditions",
 	"Notification Log": "frappe.desk.doctype.notification_log.notification_log.get_permission_query_conditions",
 	"Dashboard Chart": "frappe.desk.doctype.dashboard_chart.dashboard_chart.get_permission_query_conditions",
 	"Notification Settings": "frappe.desk.doctype.notification_settings.notification_settings.get_permission_query_conditions",

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -54,5 +54,26 @@ frappe.dashboard_utils = {
 		} else {
 			return Promise.resolve();
 		}
+	},
+
+	get_dashboard_settings() {
+		return frappe.model.with_doc('Dashboard Settings', frappe.session.user).then(settings => {
+			if (!settings) {
+				return this.create_dashboard_settings().then(settings => {
+					return settings;
+				});
+			} else {
+				return settings;
+			}
+		});
+	},
+
+	create_dashboard_settings() {
+		return frappe.xcall(
+			'frappe.desk.doctype.dashboard_settings.dashboard_settings.create_dashboard_settings',
+			{user: frappe.session.user}
+		).then(settings => {
+			return settings;
+		});
 	}
 };

--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -168,7 +168,7 @@ class DesktopPage {
 			let create_shortcuts_and_cards = () => {
 				this.data.shortcuts.items.length && this.make_shortcuts();
 				this.data.cards.items.length && this.make_cards();
-			}
+			};
 
 			if (!this.sections["onboarding"] && this.data.charts.items.length) {
 				this.make_charts().then(() => {
@@ -235,7 +235,7 @@ class DesktopPage {
 			let chart_config = settings.chart_config? JSON.parse(settings.chart_config): {};
 			if (this.data.charts.items) {
 				this.data.charts.items.map(chart => {
-					chart.chart_settings = chart_config[chart.chart_name] || {}
+					chart.chart_settings = chart_config[chart.chart_name] || {};
 				});
 			}
 

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -132,8 +132,7 @@ export default class ChartWidget extends Widget {
 				options: ["Yearly", "Quarterly", "Monthly", "Weekly", "Daily"],
 				action: selected_item => {
 					this.selected_time_interval = selected_item;
-
-					this.save_chart_config_for_user({'time_interval': this.selected_time_interval})
+					this.save_chart_config_for_user({'time_interval': this.selected_time_interval});
 					this.fetch_and_update_chart();
 				}
 			}
@@ -382,8 +381,7 @@ export default class ChartWidget extends Widget {
 
 	save_chart_config_for_user(config, reset=0) {
 		Object.assign(this.chart_settings, config);
-		frappe.xcall('frappe.desk.doctype.dashboard_settings.dashboard_settings.save_chart_config',
-		{
+		frappe.xcall('frappe.desk.doctype.dashboard_settings.dashboard_settings.save_chart_config', {
 			'reset': reset,
 			'config': this.chart_settings,
 			'chart_name': this.chart_doc.chart_name

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -243,7 +243,7 @@ export default class ChartWidget extends Widget {
 				}
 			},
 			{
-				label: __("Edit..."),
+				label: __("Edit"),
 				action: "action-edit",
 				handler: () => {
 					frappe.set_route(
@@ -251,6 +251,15 @@ export default class ChartWidget extends Widget {
 						"Dashboard Chart",
 						this.chart_doc.name
 					);
+				}
+			},
+			{
+				label: __("Reset Chart"),
+				action: "action-list",
+				handler: () => {
+					this.reset_chart();
+					delete this.dashboard_chart;
+					this.make_chart();
 				}
 			}
 		];
@@ -359,10 +368,17 @@ export default class ChartWidget extends Widget {
 		dialog.set_values(this.filters);
 	}
 
-	save_chart_config_for_user(config) {
+	reset_chart() {
+		this.save_chart_config_for_user(null, 1);
+		this.chart_settings = {};
+		this.filters = null;
+	}
+
+	save_chart_config_for_user(config, reset=0) {
 		Object.assign(this.chart_settings, config);
 		frappe.xcall('frappe.desk.doctype.dashboard_settings.dashboard_settings.save_chart_config',
 		{
+			'reset': reset,
 			'config': this.chart_settings,
 			'chart_name': this.chart_doc.chart_name
 		});

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -117,9 +117,14 @@ export default class ChartWidget extends Widget {
 							this.head.css('flex-direction', "row");
 						}
 
+						this.save_chart_config_for_user({
+							'timespan': this.selected_timespan,
+							'from_date': null,
+							'to_date': null
+
+						});
 						this.fetch_and_update_chart();
 					}
-					this.save_chart_config_for_user({'timespan': this.selected_timespan})
 				}
 			},
 			{
@@ -191,6 +196,7 @@ export default class ChartWidget extends Widget {
 
 						if (selected_date_range && selected_date_range.length == 2) {
 							this.save_chart_config_for_user({
+								'timespan': this.selected_timespan,
 								'from_date': this.selected_from_date,
 								'to_date': this.selected_to_date,
 							});

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -62,6 +62,9 @@ export default class ChartWidget extends Widget {
 
 	make_chart() {
 		this.get_settings().then(() => {
+			if (!this.chart_settings) {
+				this.chart_settings = {};
+			}
 			this.setup_container();
 			this.prepare_chart_object();
 			this.action_area.empty();
@@ -89,7 +92,7 @@ export default class ChartWidget extends Widget {
 	render_time_series_filters() {
 		let filters = [
 			{
-				label: this.chart_doc.timespan,
+				label: this.chart_settings.timespan || this.chart_doc.timespan,
 				options: [
 					"Select Date Range",
 					"Last Year",
@@ -116,13 +119,16 @@ export default class ChartWidget extends Widget {
 
 						this.fetch_and_update_chart();
 					}
+					this.save_chart_config_for_user({'timespan': this.selected_timespan})
 				}
 			},
 			{
-				label: this.chart_doc.time_interval,
+				label: this.chart_settings.time_interval || this.chart_doc.time_interval,
 				options: ["Yearly", "Quarterly", "Monthly", "Weekly", "Daily"],
 				action: selected_item => {
 					this.selected_time_interval = selected_item;
+
+					this.save_chart_config_for_user({'time_interval': this.selected_time_interval})
 					this.fetch_and_update_chart();
 				}
 			}
@@ -138,10 +144,10 @@ export default class ChartWidget extends Widget {
 
 	fetch_and_update_chart() {
 		this.args = {
-			timespan: this.selected_timespan,
-			time_interval: this.selected_time_interval,
-			from_date: this.selected_from_date,
-			to_date: this.selected_to_date
+			timespan: this.selected_timespan || this.chart_settings.timespan,
+			time_interval: this.selected_time_interval || this.chart_settings.time_interval,
+			from_date: this.selected_from_date || this.chart_settings.from_date,
+			to_date: this.selected_to_date || this.chart_settings.to_date
 		};
 
 		this.fetch(this.filters, true, this.args).then(data => {
@@ -176,16 +182,18 @@ export default class ChartWidget extends Widget {
 					fieldname: "from_date",
 					placeholder: "Date Range",
 					input_class: "input-xs",
+					default: [this.chart_settings.from_date, this.chart_settings.to_date],
 					reqd: 1,
 					change: () => {
 						let selected_date_range = this.date_range_field.get_value();
 						this.selected_from_date = selected_date_range[0];
 						this.selected_to_date = selected_date_range[1];
 
-						if (
-							selected_date_range &&
-							selected_date_range.length == 2
-						) {
+						if (selected_date_range && selected_date_range.length == 2) {
+							this.save_chart_config_for_user({
+								'from_date': this.selected_from_date,
+								'to_date': this.selected_to_date,
+							});
 							this.fetch_and_update_chart();
 						}
 					}
@@ -334,6 +342,7 @@ export default class ChartWidget extends Widget {
 					} else {
 						me.filters = values;
 					}
+					me.save_chart_config_for_user({'filters': me.filters});
 					me.fetch_and_update_chart();
 				}
 			},
@@ -348,6 +357,15 @@ export default class ChartWidget extends Widget {
 
 		dialog.show();
 		dialog.set_values(this.filters);
+	}
+
+	save_chart_config_for_user(config) {
+		Object.assign(this.chart_settings, config);
+		frappe.xcall('frappe.desk.doctype.dashboard_settings.dashboard_settings.save_chart_config',
+		{
+			'config': this.chart_settings,
+			'chart_name': this.chart_doc.chart_name
+		});
 	}
 
 	create_filter_group_and_add_filters(parent) {
@@ -406,10 +424,10 @@ export default class ChartWidget extends Widget {
 				filters: filters,
 				refresh: refresh ? 1 : 0,
 				time_interval:
-					args && args.time_interval ? args.time_interval : null,
-				timespan: args && args.timespan ? args.timespan : null,
-				from_date: args && args.from_date ? args.from_date : null,
-				to_date: args && args.to_date ? args.to_date : null
+					args && args.time_interval? args.time_interval: null,
+				timespan: args && args.timespan? args.timespan: null,
+				from_date: args && args.from_date? args.from_date: null,
+				to_date: args && args.to_date? args.to_date: null
 			};
 		}
 		return frappe.xcall(method, args);
@@ -481,8 +499,9 @@ export default class ChartWidget extends Widget {
 	}
 
 	prepare_chart_object() {
+		let saved_filters = this.chart_settings.filters || null;
 		this.filters =
-			this.filters || JSON.parse(this.chart_doc.filters_json || "[]");
+			saved_filters || this.filters || JSON.parse(this.chart_doc.filters_json || "[]");
 	}
 
 	get_settings() {


### PR DESCRIPTION
Created Dashboard Settings to save chart configuration(filters, timespan, time interval) for each user:



![save filters small](https://user-images.githubusercontent.com/19775888/78064310-2e364100-73af-11ea-9b9b-e035a24298ba.gif)
