### PR TITLE
fix: Send EP summary only if email notifications are enabled

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -6,14 +6,13 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.desk.doctype.notification_settings.notification_settings import (is_notifications_enabled,
-	is_email_notifications_enabled, is_email_notifications_enabled_for_type, set_seen_value)
+from frappe.desk.doctype.notification_settings.notification_settings import (is_notifications_enabled, is_email_notifications_enabled_for_type, set_seen_value)
 
 class NotificationLog(Document):
 	def after_insert(self):
 		frappe.publish_realtime('notification', after_commit=True, user=self.for_user)
 		set_notifications_as_unseen(self.for_user)
-		if is_email_notifications_enabled(self.for_user):
+		if is_email_notifications_enabled_for_type(self.for_user, self.type):
 			send_notification_email(self)
 
 
@@ -73,9 +72,6 @@ def make_notification_logs(doc, users):
 					_doc.insert(ignore_permissions=True)
 
 def send_notification_email(doc):
-	is_type_enabled = is_email_notifications_enabled_for_type(doc.for_user, doc.type)
-	if not is_type_enabled:
-		return
 
 	if doc.type == 'Energy Point' and doc.email_content is None:
 		return

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -25,6 +25,9 @@ def is_email_notifications_enabled(user):
 	return enabled
 
 def is_email_notifications_enabled_for_type(user, notification_type):
+	if not is_email_notifications_enabled(user):
+		return False
+
 	fieldname = 'enable_email_' + frappe.scrub(notification_type)
 	enabled = frappe.db.get_value('Notification Settings', user, fieldname)
 	if enabled is None:

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -9,6 +9,8 @@ import json
 from frappe.model.document import Document
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
 	get_title, get_title_html
+from frappe.desk.doctype.notification_settings.notification_settings\
+	import is_email_notifications_enabled_for_type, is_email_notifications_enabled
 from frappe.utils import cint, get_fullname, getdate, get_link_to_form
 
 class EnergyPointLog(Document):
@@ -300,6 +302,10 @@ def send_summary(timespan):
 
 	if not is_energy_point_enabled():
 		return
+
+	if not is_email_notifications_enabled_for_type(frappe.session.user, 'Energy Point'):
+		return
+
 	from_date = frappe.utils.add_to_date(None, weeks=-1)
 	if timespan == 'Monthly':
 		from_date = frappe.utils.add_to_date(None, months=-1)


### PR DESCRIPTION
Don't send energy points summary email to users who have disabled email notifications for energy points.