### PR TITLE
fix: Variable undefined issue in timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -561,10 +561,9 @@ frappe.ui.form.Timeline = class Timeline {
 			}
 
 			let updater_reference_link = null;
-
-			if (!$.isEmptyObject(data.updater_reference)) {
+			let updater_reference = data.updater_reference;
+			if (!$.isEmptyObject(updater_reference)) {
 				let label = updater_reference.label || __('via {0}', [updater_reference.doctype]);
-				let updater_reference = data.updater_reference;
 				updater_reference_link = frappe.utils.get_form_link(
 					updater_reference.doctype,
 					updater_reference.docname,


### PR DESCRIPTION
**Before:**

<img width="1440" alt="Screenshot 2020-04-03 at 12 53 46 AM" src="https://user-images.githubusercontent.com/13928957/78318088-8f157300-7581-11ea-9324-ef64a6b22110.png">

**After:**
<img width="671" alt="Screenshot 2020-04-03 at 1 20 12 AM" src="https://user-images.githubusercontent.com/13928957/78318116-9dfc2580-7581-11ea-93ac-175cf8b17dab.png">

Fixes bug introduced in https://github.com/frappe/frappe/pull/9400/ 