### PR TITLE
fix: HTTP headers should be URI escaped

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -211,7 +211,7 @@ frappe.request.call = function(opts) {
 	};
 
 	if (opts.args && opts.args.doctype) {
-		ajax_args.headers["X-Frappe-Doctype"] = opts.args.doctype;
+		ajax_args.headers["X-Frappe-Doctype"] = encodeURIComponent(opts.args.doctype);
 	}
 
 	frappe.last_request = ajax_args.data;

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -242,7 +242,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.setup_filters(),
 			() => this.set_route_filters(),
 			() => this.report_settings.onload && this.report_settings.onload(this),
-			() => this.get_user_settings(),
 			() => this.refresh()
 		]);
 	}
@@ -848,13 +847,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		// load preview after dialog animation
 		setTimeout(preview_chart, 500);
-	}
-
-	get_user_settings() {
-		return frappe.model.user_settings.get(this.report_name)
-			.then(user_settings => {
-				this.user_settings = user_settings;
-			});
 	}
 
 	prepare_columns(columns) {


### PR DESCRIPTION
This is needed for reports containing Chinese characters.

Without this fix, reports with Chinese names would not load
