### PR TITLE
fix(boilerplate): Adds missing escape characters.

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -152,8 +152,8 @@ app_license = "{app_license}"
 # web_include_js = "/assets/{app_name}/js/{app_name}.js"
 
 # include js, css files in header of web form
-# webform_include_js = {"doctype": "public/js/doctype.js"}
-# webform_include_css = {"doctype": "public/css/doctype.css"}
+# webform_include_js = {{"doctype": "public/js/doctype.js"}}
+# webform_include_css = {{"doctype": "public/css/doctype.css"}}
 
 # include js in page
 # page_js = {{"page" : "public/js/file.js"}}


### PR DESCRIPTION
Creating new app currently breaks due to comments in hooks.py do not properly escape sample configuration on `webform_include_js` and `webform_include_css` hooks:

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/vagrant/frappe-dev/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/vagrant/frappe-dev/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/vagrant/frappe-dev/env/lib/python3.5/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/vagrant/frappe-dev/env/lib/python3.5/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/vagrant/frappe-dev/env/lib/python3.5/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/vagrant/frappe-dev/env/lib/python3.5/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/vagrant/frappe-dev/env/lib/python3.5/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/vagrant/frappe-dev/env/lib/python3.5/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/vagrant/frappe-dev/apps/frappe/frappe/commands/utils.py", line 588, in make_app
    make_boilerplate(destination, app_name)
  File "/home/vagrant/frappe-dev/apps/frappe/frappe/utils/boilerplate.py", line 91, in make_boilerplate
    f.write(frappe.as_unicode(hooks_template.format(**hooks)))
KeyError: '"doctype"'
```