### PR TITLE
feat: Access awesomebar from desk

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -41,7 +41,7 @@ def get_bootinfo():
 
 	bootinfo.modules = {}
 	bootinfo.module_list = []
-	load_desktop_icons(bootinfo)
+	load_desktop_data(bootinfo)
 	bootinfo.letter_heads = get_letter_heads()
 	bootinfo.active_domains = frappe.get_active_domains()
 	bootinfo.all_domains = [d.get("name") for d in frappe.get_all("Domain")]
@@ -99,9 +99,11 @@ def load_conf_settings(bootinfo):
 	for key in ('developer_mode', 'socketio_port', 'file_watcher_port'):
 		if key in conf: bootinfo[key] = conf.get(key)
 
-def load_desktop_icons(bootinfo):
+def load_desktop_data(bootinfo):
 	from frappe.config import get_modules_from_all_apps_for_user
+	from frappe.desk.desktop import get_desk_sidebar_items
 	bootinfo.allowed_modules = get_modules_from_all_apps_for_user()
+	bootinfo.allowed_workspaces = get_desk_sidebar_items(True)
 
 def get_allowed_pages():
 	return get_user_pages_or_reports('Page')

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -209,7 +209,7 @@ def get_desktop_page(page):
 		return None
 
 @frappe.whitelist()
-def get_desk_sidebar_items():
+def get_desk_sidebar_items(flatten=False):
 	"""Get list of sidebar items for desk
 	"""
 	# don't get domain restricted pages
@@ -224,6 +224,8 @@ def get_desk_sidebar_items():
 	# pages sorted based on pinned to top and then by name
 	order_by = "pin_to_top desc, pin_to_bottom asc, name asc"
 	pages = frappe.get_all("Desk Page", fields=["name", "category"], filters=filters, order_by=order_by, ignore_permissions=True)
+	if flatten:
+		return pages
 
 	from collections import defaultdict
 	sidebar_items = defaultdict(list)

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -176,7 +176,7 @@ frappe.search.AwesomeBar = Class.extend({
 			frappe.search.utils.get_doctypes(txt),
 			frappe.search.utils.get_reports(txt),
 			frappe.search.utils.get_pages(txt),
-			frappe.search.utils.get_modules(txt),
+			frappe.search.utils.get_workspaces(txt),
 			frappe.search.utils.get_recent_pages(txt || ""),
 			frappe.search.utils.get_executables(txt)
 		);

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -283,31 +283,20 @@ frappe.search.utils = {
 		return out;
 	},
 
-	get_modules: function(keywords) {
+	get_workspaces: function(keywords) {
 		var me = this;
 		var out = [];
-		Object.keys(frappe.modules).forEach(function(item) {
-			var level = me.fuzzy_search(keywords, item);
+		frappe.boot.allowed_workspaces.forEach(function(item) {
+			var level = me.fuzzy_search(keywords, item.name);
 			if(level > 0) {
-				var module = frappe.modules[item];
-				if (module._doctype) return;
-
-				// disallow restricted modules
-				if (frappe.boot.user.allow_modules &&
-					!frappe.boot.user.allow_modules.includes(module.module_name)) {
-					return;
-				}
 				var ret = {
-					type: "Module",
-					label: __("Open {0}", [me.bolden_match_part(__(item), keywords)]),
-					value: __("Open {0}", [__(item)]),
+					type: "Workspace",
+					label: __("Open {0}", [me.bolden_match_part(__(item.name), keywords)]),
+					value: __("Open {0}", [__(item.name)]),
 					index: level,
+					route: ["workspace", item.name]
 				};
-				if(module.link) {
-					ret.route = [module.link];
-				} else {
-					ret.route = ["Module", item];
-				}
+
 				out.push(ret);
 			}
 		});
@@ -497,9 +486,9 @@ frappe.search.utils = {
 			results: sort_uniques(this.get_pages(keywords))
 		},
 		{
-			title: "Modules",
+			title: "Workspace",
 			fetch_type: "Nav",
-			results: sort_uniques(this.get_modules(keywords))
+			results: sort_uniques(this.get_workspaces(keywords))
 		},
 		{
 			title: "Setup",


### PR DESCRIPTION
The PR has the following changes

1. Rename function `load_desktop_icons` to `load_desktop_data`
1. Add flatten option to sidebar config
1. Replace modules utility for awesomebar with desk page