### PR TITLE
fix: allow dashboard chart type to be set only once

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -49,7 +49,8 @@
    "fieldname": "chart_type",
    "fieldtype": "Select",
    "label": "Chart Type",
-   "options": "Count\nSum\nAverage\nGroup By\nCustom\nReport"
+   "options": "Count\nSum\nAverage\nGroup By\nCustom\nReport",
+   "set_only_once": 1
   },
   {
    "depends_on": "eval:doc.chart_type === 'Custom'",
@@ -215,7 +216,7 @@
   }
  ],
  "links": [],
- "modified": "2020-03-31 16:00:01.987059",
+ "modified": "2020-04-08 18:54:36.739183",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",


### PR DESCRIPTION
Allow dashboard chart type to be set only once