### PR TITLE
fix: remove Customer & Supplier to hooks

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -65,7 +65,7 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 	com_doctypes = []
 	if len(txt)<2:
 
-		for name in ["Customer", "Supplier"]:
+		for name in frappe.get_hooks("communication_doctypes"):
 			try:
 				module = load_doctype_module(name, suffix='_dashboard')
 				if hasattr(module, 'get_data'):


### PR DESCRIPTION
- Move Customer and Supplier to hooks in ERPNext.
- Framework should be independent of any ERPNext related stuff
- ERPNext PR [#21205](https://github.com/frappe/erpnext/pull/21205) 