### PR TITLE
fix: Handle invalid date parsing

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -54,8 +54,8 @@ def get_datetime(datetime_str=None):
 	elif isinstance(datetime_str, datetime.date):
 		return datetime.datetime.combine(datetime_str, datetime.time())
 
-	# dateutil parser does not agree with dates like 0001-01-01
-	if not datetime_str or (datetime_str or "").startswith("0001-01-01"):
+	# dateutil parser does not agree with dates like "0001-01-01" or "0000-00-00"
+	if not datetime_str or (datetime_str or "").startswith(("0001-01-01", "0000-00-00")):
 		return None
 
 	try:


### PR DESCRIPTION
Handle invalid date parsing to avoids failure like following...

```
File "/home/frappe/benches/bench-version-12-2020-02-05/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2020-02-05/env/lib/python3.6/site-packages/pymysql/connections.py", line 1082, in read
    self._read_result_packet(first_packet)
  File "/home/frappe/benches/bench-version-12-2020-02-05/env/lib/python3.6/site-packages/pymysql/connections.py", line 1152, in _read_result_packet
    self._read_rowdata_packet()
  File "/home/frappe/benches/bench-version-12-2020-02-05/env/lib/python3.6/site-packages/pymysql/connections.py", line 1190, in _read_rowdata_packet
    rows.append(self._read_row_from_packet(packet))
  File "/home/frappe/benches/bench-version-12-2020-02-05/env/lib/python3.6/site-packages/pymysql/connections.py", line 1209, in _read_row_from_packet
    data = converter(data)
  File "/home/frappe/benches/bench-version-12-2020-02-05/apps/frappe/frappe/utils/data.py", line 64, in get_datetime
    return parser.parse(datetime_str)
  File "/home/frappe/benches/bench-version-12-2020-02-05/env/lib/python3.6/site-packages/dateutil/parser/_parser.py", line 1374, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-02-05/env/lib/python3.6/site-packages/dateutil/parser/_parser.py", line 657, in parse
    six.raise_from(ParserError(e.args[0] + ": %s", timestr), e)
  File "", line 3, in raise_from
dateutil.parser._parser.ParserError: year 0 is out of range: 0000-00-00 00:00:00.000000
```

port-of: https://github.com/frappe/frappe/pull/9889