### PR TITLE
fix: checking value of send_welcome_email

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -200,7 +200,7 @@ class User(Document):
 						_update_password(user=self.name, pwd=new_password,
 							logout_all_sessions=self.logout_all_sessions)
 
-					if not self.flags.no_welcome_mail and self.send_welcome_email:
+					if not self.flags.no_welcome_mail and cint(self.send_welcome_email):
 						self.send_welcome_mail_to_user()
 						self.flags.email_sent = 1
 						if frappe.session.user != 'Guest':


### PR DESCRIPTION
If send_welcome_email is set to 0 still it is triggering send_welcome_mail_to_user().
Need to check if send_welcome_email is 1 or True
This is required.

port-of: https://github.com/frappe/frappe/pull/9888