### PR TITLE
feat: Add frappe cmd to request headers on website for analytics purposes

### DIFF
--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -65,7 +65,7 @@ $.extend(frappe, {
 			url: "/",
 			data: opts.args,
 			dataType: "json",
-			headers: { "X-Frappe-CSRF-Token": frappe.csrf_token },
+			headers: { "X-Frappe-CSRF-Token": frappe.csrf_token, "X-Frappe-CMD": (opts.args && opts.args.cmd  || '') || '' },
 			statusCode: opts.statusCode || {
 				404: function() {
 					frappe.msgprint(__("Not found"));


### PR DESCRIPTION
Frappe command was previously added to the request headers for requests made within the Desk:
https://github.com/frappe/frappe/pull/7228

The purpose of this was to allow a reverse proxy to examine what command (if any) is being called and based on that determine which backend to forward the request to.

This change, however, did not reflect on calls made on the website/portal, since that code is defined in another file. We would like to do the same change to frappe.call used in the portal. This will allow a reverse proxy to also examine the command in requests made from the portal.