### PR TITLE
chore: Cleaner bench console

### DIFF
--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -43,9 +43,8 @@ def enqueue_events_for_all_sites():
 	for site in sites:
 		try:
 			enqueue_events_for_site(site=site)
-		except:
-			# it should try to enqueue other sites
-			print(frappe.get_traceback())
+		except Exception as e:
+			print(e.__class__, 'Failed to enqueue events for site: {}'.format(site))
 
 def enqueue_events_for_site(site):
 	def log_and_raise():

--- a/socketio.js
+++ b/socketio.js
@@ -73,6 +73,7 @@ io.on('connection', function (socket) {
 	});
 	// end frappe.chat
 
+	let retries = 0;
 	let join_chat_room = () => {
 		request.get(get_url(socket, '/api/method/frappe.realtime.get_user_info'))
 			.type('form')
@@ -85,11 +86,12 @@ io.on('connection', function (socket) {
 				socket.join(get_site_room(socket));
 			})
 			.catch(e => {
-				if (e.code === 'ECONNREFUSED') {
+				if (e.code === 'ECONNREFUSED' && retries < 5) {
 					// retry after 1s
+					retries += 1;
 					return setTimeout(join_chat_room, 1000);
 				}
-				log(e.code);
+				log(`Unable to join chat room. ${e}`);
 			});
 	};
 

--- a/socketio.js
+++ b/socketio.js
@@ -1,14 +1,15 @@
 var app = require('express')();
 var server = require('http').Server(app);
 var io = require('socket.io')(server);
-var cookie = require('cookie')
+var cookie = require('cookie');
 var fs = require('fs');
 var path = require('path');
 var request = require('superagent');
 var { get_conf, get_redis_subscriber } = require('./node_utils');
 
+const log = console.log; // eslint-disable-line
+
 var conf = get_conf();
-var flags = {};
 var files_struct = {
 	name: null,
 	type: null,
@@ -23,7 +24,7 @@ var subscriber = get_redis_subscriber();
 
 // serve socketio
 server.listen(conf.socketio_port, function () {
-	console.log('listening on *:', conf.socketio_port); //eslint-disable-line
+	log('listening on *:', conf.socketio_port); //eslint-disable-line
 });
 
 // on socket connection
@@ -36,7 +37,7 @@ io.on('connection', function (socket) {
 		return;
 	}
 
-	var sid = cookie.parse(socket.request.headers.cookie).sid
+	const sid = cookie.parse(socket.request.headers.cookie).sid;
 	if (!sid) {
 		return;
 	}
@@ -51,10 +52,10 @@ io.on('connection', function (socket) {
 		}
 
 		for (var room of rooms) {
-			console.log('frappe.chat: Subscribing ' + socket.user + ' to room ' + room);
+			log('frappe.chat: Subscribing ' + socket.user + ' to room ' + room);
 			room = get_chat_room(socket, room);
 
-			console.log('frappe.chat: Subscribing ' + socket.user + ' to event ' + room);
+			log('frappe.chat: Subscribing ' + socket.user + ' to event ' + room);
 			socket.join(room);
 		}
 	});
@@ -63,7 +64,7 @@ io.on('connection', function (socket) {
 		const user = data.user;
 		const room = get_chat_room(socket, data.room);
 
-		console.log('frappe.chat: Dispatching ' + user + ' typing to room ' + room);
+		log('frappe.chat: Dispatching ' + user + ' typing to room ' + room);
 
 		io.to(room).emit('frappe.chat.room:typing', {
 			room: data.room,
@@ -96,7 +97,7 @@ io.on('connection', function (socket) {
 
 	socket.on('disconnect', function () {
 		delete socket.files;
-	})
+	});
 
 	socket.on('task_subscribe', function (task_id) {
 		var room = get_task_room(socket, task_id);
@@ -116,11 +117,11 @@ io.on('connection', function (socket) {
 
 	socket.on('doc_subscribe', function (doctype, docname) {
 		can_subscribe_doc({
-			socket: socket,
-			sid: sid,
-			doctype: doctype,
-			docname: docname,
-			callback: function (err, res) {
+			socket,
+			sid,
+			doctype,
+			docname,
+			callback: () => {
 				var room = get_doc_room(socket, doctype, docname);
 				socket.join(room);
 			}
@@ -144,7 +145,7 @@ io.on('connection', function (socket) {
 			sid: sid,
 			doctype: doctype,
 			docname: docname,
-			callback: function (err, res) {
+			callback: () => {
 				var room = get_open_doc_room(socket, doctype, docname);
 				socket.join(room);
 
@@ -202,7 +203,7 @@ io.on('connection', function (socket) {
 				});
 			}
 		} catch (e) {
-			console.log(e);
+			log(e);
 			socket.emit('upload-error', {
 				error: e.message
 			});
@@ -210,7 +211,7 @@ io.on('connection', function (socket) {
 	});
 });
 
-subscriber.on("message", function (channel, message, room) {
+subscriber.on("message", function (_channel, message) {
 	message = JSON.parse(message);
 
 	if (message.room) {
@@ -225,7 +226,7 @@ subscriber.subscribe("events");
 
 function send_existing_lines(task_id, socket) {
 	var room = get_task_room(socket, task_id);
-	subscriber.hgetall('task_log:' + task_id, function (err, lines) {
+	subscriber.hgetall('task_log:' + task_id, function (_err, lines) {
 		io.to(room).emit('task_progress', {
 			"task_id": task_id,
 			"message": {
@@ -305,19 +306,19 @@ function can_subscribe_doc(args) {
 		})
 		.end(function (err, res) {
 			if (!res) {
-				console.log("No response for doc_subscribe");
+				log("No response for doc_subscribe");
 
 			} else if (res.status == 403) {
 				return;
 
 			} else if (err) {
-				console.log(err);
+				log(err);
 
 			} else if (res.status == 200) {
 				args.callback(err, res);
 
 			} else {
-				console.log("Something went wrong", err, res);
+				log("Something went wrong", err, res);
 			}
 		});
 }


### PR DESCRIPTION
Do not print traceback on the console while enqueuing events for all sites. Instead, print class of error and the site name (to keep console clutter-free)

**Before:**
<img width="966" alt="Screenshot 2020-04-11 at 9 24 20 PM" src="https://user-images.githubusercontent.com/13928957/79065019-0efeb400-7ccb-11ea-8077-e1c4b32f1740.png">

**After:**
<img width="1189" alt="Screenshot 2020-04-12 at 2 39 59 PM" src="https://user-images.githubusercontent.com/13928957/79065133-82a0c100-7ccb-11ea-9d1e-ef3acf9dbb97.png">

---

Retry to join chat room while starting the server to avoid following error.
(Because web server might not have started yet.)
<img width="1101" alt="Screenshot 2020-04-12 at 3 06 42 PM" src="https://user-images.githubusercontent.com/13928957/79070572-6402f000-7cf4-11ea-95bf-589a07c557de.png">
  


