### PR TITLE
fix: strip invalid characters before sanitizing url

### DIFF
--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -264,7 +264,7 @@ frappe.utils.sanitise_redirect = (url) => {
 	const is_external = (() => {
 		return (url) => {
 			function domain(url) {
-				let base_domain = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img.exec(url);
+				let base_domain = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:/\n?]+)/img.exec(url);
 				return base_domain == null ? "" : base_domain[1];
 			}
 
@@ -290,7 +290,7 @@ frappe.utils.sanitise_redirect = (url) => {
 	url = frappe.utils.strip_url(url);
 
 	return is_external(url) ? "" : sanitise_javascript(frappe.utils.xss_sanitise(url, {strategies: ["js"]}));
-}
+};
 
 frappe.utils.strip_url = (url) => {
 	// strips invalid characters from the beginning of the URL

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -264,14 +264,14 @@ frappe.utils.sanitise_redirect = (url) => {
 	const is_external = (() => {
 		return (url) => {
 			function domain(url) {
-				let base_domain = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img.exec(url);
+				let base_domain = /^(?:https?://)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img.exec(url);
 				return base_domain == null ? "" : base_domain[1];
 			}
 
 			function is_absolute(url) {
 				// returns true for url that have a defined scheme
 				// anything else, eg. internal urls return false
-				return /^(?:[a-z]+:)?\/\//i.test(url)
+				return /^(?:[a-z]+:)?\/\//i.test(url);
 			}
 
 			// check for base domain only if the url is absolute
@@ -287,7 +287,7 @@ frappe.utils.sanitise_redirect = (url) => {
 		return url.replace(REGEX_SCRIPT, "");
 	});
 
-	url = strip_url(url);
+	url = frappe.utils.strip_url(url);
 
 	return is_external(url) ? "" : sanitise_javascript(frappe.utils.xss_sanitise(url, {strategies: ["js"]}));
 }

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -264,7 +264,7 @@ frappe.utils.sanitise_redirect = (url) => {
 	const is_external = (() => {
 		return (url) => {
 			function domain(url) {
-				let base_domain = /^(?:https?://)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img.exec(url);
+				let base_domain = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img.exec(url);
 				return base_domain == null ? "" : base_domain[1];
 			}
 

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -261,26 +261,22 @@ frappe.utils.xss_sanitise = function (string, options) {
 }
 
 frappe.utils.sanitise_redirect = (url) => {
-	const is_absolute = ((url) => {
-		// https://github.com/sindresorhus/is-absolute-url
-		// Don't match Windows paths `c:\`
-		if (/^[a-zA-Z]:\\/.test(url)) {
-			return false;
-		}
-
-		// Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
-		// Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
-		return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
-	});
-
 	const is_external = (() => {
 		return (url) => {
 			function domain(url) {
-				let base_domain = /https?:\/\/((?:[\w\d]+\.)+[\w\d]{2,})/i.exec(url);
+				let base_domain = /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/img.exec(url);
 				return base_domain == null ? "" : base_domain[1];
 			}
 
-			return domain(location.href) !== domain(url);
+			function is_absolute(url) {
+				// returns true for url that have a defined scheme
+				// anything else, eg. internal urls return false
+				return /^(?:[a-z]+:)?\/\//i.test(url)
+			}
+
+			// check for base domain only if the url is absolute
+			// return true for relative url (except protocol-relative urls)
+			return is_absolute(url) ? domain(location.href) !== domain(url) : true;
 		}
 	})();
 
@@ -291,11 +287,16 @@ frappe.utils.sanitise_redirect = (url) => {
 		return url.replace(REGEX_SCRIPT, "");
 	});
 
-	if (is_absolute(url) && is_external(url)) {
-		return '';
-	}
+	url = strip_url(url);
 
-	return sanitise_javascript(frappe.utils.xss_sanitise(url, {strategies: ["js"]}));
+	return is_external(url) ? "" : sanitise_javascript(frappe.utils.xss_sanitise(url, {strategies: ["js"]}));
+}
+
+frappe.utils.strip_url = (url) => {
+	// strips invalid characters from the beginning of the URL
+	// in our case, the url can start with either a protocol, //, or even #
+	// so anything except those characters can be considered invalid
+	return url.replace(/^[^A-Za-z0-9(//)#]+/g, '');
 }
 
 frappe.utils.new_auto_repeat_prompt = function(frm) {

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -183,7 +183,7 @@ login.login_handlers = (function() {
 				login.set_indicator('{{ _("Success") }}', 'green');
 				window.location.href = frappe.utils.sanitise_redirect(frappe.utils.get_url_arg("redirect-to")) || data.home_page;
 			} else if(data.message == 'Password Reset'){
-				window.location.href = data.redirect_to;
+				window.location.href = frappe.utils.sanitise_redirect(data.redirect_to);
 			} else if(data.message=="No App") {
 				login.set_indicator("{{ _("Success") }}", 'green');
 				if(localStorage) {
@@ -194,7 +194,7 @@ login.login_handlers = (function() {
 				}
 
 				if(data.redirect_to) {
-					window.location.href = data.redirect_to;
+					window.location.href = frappe.utils.sanitise_redirect(data.redirect_to);
 				}
 
 				if(last_visited && last_visited != "/login") {


### PR DESCRIPTION
* make base_domain check stronger
* do not check base_domain if url is relative
* strip invalid characters from url before sanitizing

extension to: #9754 