### PR TITLE
fix: pop cmd from rename_doc

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -832,6 +832,8 @@ def rename_doc(*args, **kwargs):
 		Calls `frappe.model.rename_doc.rename_doc`
 	"""
 	kwargs.pop('ignore_permissions', None)
+	kwargs.pop('cmd', None)
+
 	from frappe.model.rename_doc import rename_doc
 	return rename_doc(*args, **kwargs)
 


### PR DESCRIPTION
fixes issue wherein rename_doc is called through an api call and is passed the entire unrolled frappe.form_dict, which causes the following error:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1068, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 832, in rename_doc
    return rename_doc(*args, **kwargs)
TypeError: rename_doc() got an unexpected keyword argument 'cmd'
```