### PR TITLE
perf: enqueue instance of send_one for better performance

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -348,13 +348,12 @@ def flush(from_test=False):
 				smtpserver = SMTPServer()
 				smtpserver_dict[email.sender] = smtpserver
 
-			# send_one(email.name, smtpserver, auto_commit, from_test=from_test)
 			from frappe import enqueue
 			send_one_args = {
 				'email': email.name,
-				'smtpserver':smtpserver,
+				'smtpserver': smtpserver,
 				'auto_commit': auto_commit,
-				'from_test':from_test
+				'from_test': from_test
 			}
 			enqueue(
 				method='frappe.email.queue.send_one',

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -348,7 +348,19 @@ def flush(from_test=False):
 				smtpserver = SMTPServer()
 				smtpserver_dict[email.sender] = smtpserver
 
-			send_one(email.name, smtpserver, auto_commit, from_test=from_test)
+			# send_one(email.name, smtpserver, auto_commit, from_test=from_test)
+			from frappe import enqueue
+			send_one_args = {
+				'email': email.name,
+				'smtpserver':smtpserver,
+				'auto_commit': auto_commit,
+				'from_test':from_test
+			}
+			enqueue(
+				method='frappe.email.queue.send_one',
+				queue='short',
+				**send_one_args
+			)
 
 		# NOTE: removing commit here because we pass auto_commit
 		# finally:

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -356,8 +356,8 @@ def flush(from_test=False):
 				'from_test': from_test
 			}
 			enqueue(
-				method='frappe.email.queue.send_one',
-				queue='short',
+				method = 'frappe.email.queue.send_one',
+				queue = 'short',
 				**send_one_args
 			)
 

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -6,7 +6,7 @@ import frappe
 import sys
 from six.moves import html_parser as HTMLParser
 import smtplib, quopri, json
-from frappe import msgprint, _, safe_decode, safe_encode
+from frappe import msgprint, _, safe_decode, safe_encode, enqueue
 from frappe.email.smtp import SMTPServer, get_outgoing_email_account
 from frappe.email.email_body import get_email, get_formatted_html, add_attachment
 from frappe.utils.verified_command import get_signed_params, verify_request
@@ -347,8 +347,7 @@ def flush(from_test=False):
 			if not smtpserver:
 				smtpserver = SMTPServer()
 				smtpserver_dict[email.sender] = smtpserver
-
-			from frappe import enqueue
+				
 			send_one_args = {
 				'email': email.name,
 				'smtpserver': smtpserver,


### PR DESCRIPTION
Usecase: Suppose I have hundred's of emails in the Email Queue and the flush job executes. While the execution of the flush job is going another flush job starts and so on. Because of this a list of flush jobs gets lined up in the background jobs queue. 
To avoid this it is better to enqueue the send_one function inside the flush job this will very efficiently improve the performance of the flush job.
