### PR TITLE
fix(Report Builder): do not show hidden field in report builder

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -837,6 +837,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			fieldtype: 'MultiCheck',
 			columns: 2,
 			options: columns[this.doctype]
+				.filter(df => {
+					return !df.hidden;
+				})
 				.map(df => ({
 					label: __(df.label),
 					value: df.fieldname,
@@ -858,6 +861,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				fieldtype: 'MultiCheck',
 				columns: 2,
 				options: columns[cdt]
+					.filter(df => {
+						return !df.hidden;
+					})
 					.map(df => ({
 						label: __(df.label),
 						value: df.fieldname,


### PR DESCRIPTION
- While picking columns in DocType's Report Builder, it also shows the hidden fields.
- This PR fixes that
- Before Fix
    ![Screenshot 2020-04-14 at 12 20 24 PM](https://user-images.githubusercontent.com/7310479/79194752-bb1ad900-7e4a-11ea-8ea3-4f70501f7197.png)
- After Fix
    ![Screenshot 2020-04-14 at 12 19 49 PM](https://user-images.githubusercontent.com/7310479/79194754-bc4c0600-7e4a-11ea-8452-6a8b5551233f.png)