### PR TITLE
feat: enable customizations for hidden sections

### DIFF
--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -203,8 +203,8 @@ class DesktopPage {
 		this.allow_customization && this.make_customization_link();
 
 		let create_shortcuts_and_cards = () => {
-			this.data.shortcuts.items.length && this.make_shortcuts();
-			this.data.cards.items.length && this.make_cards();
+			this.make_shortcuts();
+			this.make_cards();
 
 			if (this.allow_customization) {
 				// Move the widget group up to align with labels if customization is allowed
@@ -212,7 +212,7 @@ class DesktopPage {
 			}
 		};
 
-		if (!this.sections["onboarding"] && this.data.charts.items.length) {
+		if (!this.sections["onboarding"]) {
 			this.make_charts().then(() => {
 				create_shortcuts_and_cards();
 			});


### PR DESCRIPTION
This PR brings the following changes
1. Section is built even if empty
2. On enabling customize mode, empty sections show up with a new widget