### PR TITLE
fix: hide mandatory property for html, section / column break, button…

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -102,6 +102,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
    "fieldname": "reqd",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -452,7 +453,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-16 14:49:49.672099",
+ "modified": "2020-04-15 02:26:03.310781",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -93,6 +93,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:!in_list([\"Section Break\", \"Column Break\", \"Button\", \"HTML\"], doc.fieldtype)",
    "fieldname": "reqd",
    "fieldtype": "Check",
    "label": "Mandatory",
@@ -385,7 +386,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-07 14:53:40.619043",
+ "modified": "2020-04-15 02:26:59.673750",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",


### PR DESCRIPTION
Hide mandatory property for HTML, section/column break & button field types.