### PR TITLE
fix: ignore fieldtype check validation if new field type has unspecified maxlength

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -365,7 +365,12 @@ class CustomizeForm(Document):
 		for allowed_changes in allowed_fieldtype_change:
 			if (old_value in allowed_changes and new_value in allowed_changes):
 				allowed = True
-				if frappe.db.type_map.get(old_value)[1] > frappe.db.type_map.get(new_value)[1]:
+				old_value_length = cint(frappe.db.type_map.get(old_value)[1])
+				new_value_length = cint(frappe.db.type_map.get(new_value)[1])
+
+				# Ignore fieldtype check validation if new field type has unspecified maxlength
+				# Changes like DATA to TEXT, where new_value_lenth equals 0 will not be validated
+				if new_value_length and (old_value_length > new_value_length):
 					self.check_length_for_fieldtypes.append({'df': df, 'old_value': old_value})
 					self.validate_fieldtype_length()
 				else:
@@ -377,7 +382,7 @@ class CustomizeForm(Document):
 	def validate_fieldtype_length(self):
 		for field in self.check_length_for_fieldtypes:
 			df = field.get('df')
-			max_length = frappe.db.type_map.get(df.fieldtype)[1]
+			max_length = cint(frappe.db.type_map.get(df.fieldtype)[1])
 			fieldname = df.fieldname
 			docs = frappe.db.sql('''
 				SELECT name, {fieldname}, LENGTH({fieldname}) AS len

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -11,6 +11,7 @@ class TestDBUpdate(unittest.TestCase):
 		frappe.reload_doctype('User', force=True)
 		frappe.model.meta.trim_tables('User')
 		make_property_setter(doctype, 'bio', 'fieldtype', 'Text', 'Data')
+		make_property_setter(doctype, 'middle_name', 'fieldtype', 'Data', 'Text')
 		make_property_setter(doctype, 'enabled', 'default', '1', 'Int')
 
 		frappe.db.updatedb(doctype)


### PR DESCRIPTION
This PR brings the following changes
1. Ignore fieldtype check validation if new field type has unspecified maxlength. So changes like DATA to TEXT, where new_value_lenth equals 0 will not be validated for truncation
1. Updated test to check DATA to Text change

Port of https://github.com/frappe/frappe/pull/9949