### PR TITLE
fix: disable file browser for both attach and attach image

### DIFF
--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -113,8 +113,9 @@ frappe.ready(function() {
 					df.only_select = true;
 				}
 				if (["Attach", "Attach Image"].includes(df.fieldtype)) {
-					if (!df.options)
+					if (typeof df.options !== "object") {
 						df.options = {};
+					}
 					df.options.disable_file_browser = true;
 				}
 			});


### PR DESCRIPTION
Replace attach image options with an object and disable file browser
If options are set for Attach or Attach Image field in the doctype settings, `df.options.disable_file_browser = true;` would yield the following error as `df.options` would be a string

```javascript
TypeError: can't assign to property "disable_file_browser" on "image": not an object
    setup_fields webform_script.js:119
    map self-hosted:240
    setup_fields webform_script.js:87
    show_form webform_script.js:52
    jQuery 7
    call website.js:63
    get_data webform_script.js:75
    show_form webform_script.js:51
    <anonymous> webform_script.js:17
    trigger_ready website.js:262
    forEach self-hosted:225
    trigger_ready website.js:261
    <anonymous> website.js:445
    jQuery 7
    <anonymous> website.js:428
    jQuery 
```

This PR fixes the problem