### PR TITLE
fix: increase the length of the password

### DIFF
--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -131,9 +131,9 @@ def create_auth_table():
 	frappe.db.create_auth_table()
 
 def encrypt(pwd):
-	if len(pwd) > 100:
-		# encrypting > 100 chars will lead to truncation
-		frappe.throw(_('Password cannot be more than 100 characters long'))
+	if len(pwd) > 127:
+		# encrypting > 127 chars will lead to truncation
+		frappe.throw(_('Password cannot be more than 127 characters long'))
 
 	cipher_suite = Fernet(encode(get_encryption_key()))
 	cipher_text = cstr(cipher_suite.encrypt(encode(pwd)))


### PR DESCRIPTION
- Increase the length of the password field to 127 which is maximum under the given structure of auth table(255 characters)
- Allows to save secret key/ authorization code generated for integrated apps which are generally over the 100 limit

![photo_2020-04-16 15 26 57](https://user-images.githubusercontent.com/14824451/79442867-ba26aa80-7ff6-11ea-8b30-5aa18d45bd93.jpeg)
