### PR TITLE
chore: Add Release Notes for v12.5.0

### DIFF
--- a/frappe/change_log/v12/v12_5_0.md
+++ b/frappe/change_log/v12/v12_5_0.md
@@ -1,0 +1,28 @@
+## Version 12.5.0 Release Notes
+
+### Bug Fixes
+
+- Fixed incorrect calculation of week ending date in Dashboard Charts ([#9712](https://github.com/frappe/frappe/pull/9712))
+- Fixed issue with default value not getting set from user permission ([#9796](https://github.com/frappe/frappe/pull/9796))
+- Fixed report export in excel ([#9813](https://github.com/frappe/frappe/pull/9813))
+- Fixed invalid date parsing issue ([#9890](https://github.com/frappe/frappe/pull/9890))
+- Fixed issue welcome emails getting sent even after send_welcome_email was unchecked ([#9902](https://github.com/frappe/frappe/pull/9902))
+- Fixed print format occasional render failures ([#9821](https://github.com/frappe/frappe/pull/9821))
+- Fixed issue with private files being publicly accessible in some cases ([#9935](https://github.com/frappe/frappe/pull/9935))
+- Fixed random failures of Filter By option in sidebar ([#9892](https://github.com/frappe/frappe/pull/9892))
+- Fixed an issue with Query Report's custom fields not getting retained ([#9787](https://github.com/frappe/frappe/pull/9787))
+- Fixed Webform redirect issue ([#9793](https://github.com/frappe/frappe/pull/9793))
+
+### UI/UX Enhancements
+
+- Minor UI fixes ([#9699](https://github.com/frappe/frappe/pull/9699)), ([#9716](https://github.com/frappe/frappe/pull/9716)), ([#9800](https://github.com/frappe/frappe/pull/9800)), ([#9825](https://github.com/frappe/frappe/pull/9825))
+- Now Energy Point summary will be sent only if email notifications are enabled ([#9893](https://github.com/frappe/frappe/pull/9893))
+- Now, for workflow enabled Document Types, cancel button will only be visible if document is cancellable ([#9811](https://github.com/frappe/frappe/pull/9811))
+
+### Features
+
+- Allow System Managers to view Notification Settings list ([#9895](https://github.com/frappe/frappe/pull/9895))
+- Added ability to set 0 precision for currency fields ([#9725](https://github.com/frappe/frappe/pull/9725))
+- Now fields of type Data, Int & Check can be used for filter by option in the sidebar of List View ([#9767](https://github.com/frappe/frappe/pull/9767))
+- Introduced calendar for ToDo ([#9807](https://github.com/frappe/frappe/pull/9807))
+- Added more Genders and Salutations ([#9870](https://github.com/frappe/frappe/pull/9870))


### PR DESCRIPTION
<img width="772" alt="Screenshot 2020-04-16 at 3 40 58 PM" src="https://user-images.githubusercontent.com/13928957/79444491-ddeaf000-7ff8-11ea-956b-0988a5307b98.png">
