### PR TITLE
feat: show self xss warning in console

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -86,6 +86,14 @@ frappe.Application = Class.extend({
 			this.show_update_available();
 		}
 
+		if (!frappe.boot.developer_mode) {
+			let console_security_message = __("Using this console may allow attackers to impersonate you and steal your information. Do not enter or paste code that you do not understand.")
+			console.log(
+				`%c${console_security_message}`,
+				"font-size: large"
+			);
+		}
+
 		this.show_notes();
 
 		if (frappe.boot.is_first_startup) {

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -87,7 +87,7 @@ frappe.Application = Class.extend({
 		}
 
 		if (!frappe.boot.developer_mode) {
-			let console_security_message = __("Using this console may allow attackers to impersonate you and steal your information. Do not enter or paste code that you do not understand.")
+			let console_security_message = __("Using this console may allow attackers to impersonate you and steal your information. Do not enter or paste code that you do not understand.");
 			console.log(
 				`%c${console_security_message}`,
 				"font-size: large"


### PR DESCRIPTION
Feat, added console warning for [self-xss](https://en.wikipedia.org/wiki/Self-XSS)

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/18097732/79445002-95800200-7ff9-11ea-9e17-fb0f77f2aca3.png">

**This will only be visible when developer mode is disabled**
