### PR TITLE
feat: Add checkbox option to text editor's toolbar

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -147,7 +147,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 			[{ 'color': [] }, { 'background': [] }],
 			['blockquote', 'code-block'],
 			['link', 'image'],
-			[{ 'list': 'ordered' }, { 'list': 'bullet' }],
+			[{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'list': 'check' }],
 			[{ 'align': [] }],
 			[{ 'indent': '-1'}, { 'indent': '+1' }],
 			[{'table': [


### PR DESCRIPTION
Added checkbox option to Text Editor's toolbar

<img width="903" alt="Screenshot 2020-04-16 at 8 33 18 PM" src="https://user-images.githubusercontent.com/13928957/79472519-92990780-8021-11ea-9366-80437141593a.png">

![text-editor-list-item](https://user-images.githubusercontent.com/13928957/79472429-75643900-8021-11ea-856c-04af038620f8.gif)
Closes: https://github.com/frappe/frappe/issues/9960