### PR TITLE
fix(document): Check is_dirty only if action is save

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -21,7 +21,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 		remove_empty_rows();
 
 		$(frm.wrapper).addClass('validated-form');
-		if (frm.is_dirty() && check_mandatory()) {
+		if ((action !== 'Save' || frm.is_dirty()) && check_mandatory()) {
 			_call({
 				method: "frappe.desk.form.save.savedocs",
 				args: { doc: frm.doc, action: action },


### PR DESCRIPTION
Allow documents to submit or cancel without document value changes.

The bug was introduced through https://github.com/frappe/frappe/pull/9923

Fixes https://github.com/frappe/frappe/issues/9975