### PR TITLE
fix: User should not be able to create a language

### DIFF
--- a/frappe/core/doctype/language/language.json
+++ b/frappe/core/doctype/language/language.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:language_code",
  "creation": "2014-08-22 16:12:17.249590",
@@ -41,7 +42,9 @@
   }
  ],
  "icon": "fa fa-globe",
- "modified": "2019-07-19 16:32:12.652550",
+ "in_create": 1,
+ "links": [],
+ "modified": "2020-04-16 22:11:33.066852",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Language",


### PR DESCRIPTION
**Problem:**
`ValueError: expected only letters, got 'ar_ar'`
- On creating a new language it's language code was faulty. Due to which babel was unable to parse it.
- Also we use '-' as a separator so anything with '_' would also be problematic. (if I'm not wrong)

 _Two Arabic Languages_
![photo_2020-04-16 22 17 44](https://user-images.githubusercontent.com/25857446/79483548-10640f80-8030-11ea-97fc-0ab5b2eab656.jpeg)
                             
**Fix:**
- **Unable to Create** enabled in Language DocType
![Screenshot 2020-04-16 at 10 13 21 PM](https://user-images.githubusercontent.com/25857446/79483567-1659f080-8030-11ea-901d-26d07b472f77.png)
