### PR TITLE
test: Increase defaultCommandTimeout to 10sec

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,7 @@
 {
   "baseUrl": "http://test_site_ui:8000",
   "projectId": "92odwv",
-  "adminPassword": "admin"
+  "adminPassword": "admin",
+  "defaultCommandTimeout": 10000,
+  "pageLoadTimeout": 15000
 }


### PR DESCRIPTION
Increase `defaultCommandTimeout` to 10sec to avoid test failures due to timeouts.

[This was added before](https://github.com/frappe/frappe/pull/9115) but got removed after [a refactor](https://github.com/frappe/frappe/pull/9124)