### PR TITLE
fix: set from df default instead of user default

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -80,8 +80,18 @@ def get_user_default_value(df, defaults, doctype_user_permissions, allowed_recor
 			and not df.ignore_user_permissions and default_doc):
 				return default_doc
 
-		# 2 - Look in user defaults
-		user_default = defaults.get(df.fieldname)
+		# 2 - Look in field defaults before setting value from user defaults
+		if df.get("default"):
+			user_default = df.get("default")
+		else if df.get("default") and df.get("default").startswith(":"):
+			default_value = get_default_based_on_another_field(df, user_permissions, parent_doc)
+			if default_value is not None and not doc.get(df.fieldname):
+				user_default = default_value
+
+		# 3 - Look in user defaults
+		if not user_default:
+			user_default = defaults.get(df.fieldname)
+
 		is_allowed_user_default = user_default and (not user_permissions_exist(df, doctype_user_permissions)
 			or user_default in allowed_records)
 

--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -80,10 +80,11 @@ def get_user_default_value(df, defaults, doctype_user_permissions, allowed_recor
 			and not df.ignore_user_permissions and default_doc):
 				return default_doc
 
+		user_default = None
 		# 2 - Look in field defaults before setting value from user defaults
 		if df.get("default"):
 			user_default = df.get("default")
-		else if df.get("default") and df.get("default").startswith(":"):
+		elif df.get("default") and df.get("default").startswith(":"):
 			default_value = get_default_based_on_another_field(df, user_permissions, parent_doc)
 			if default_value is not None and not doc.get(df.fieldname):
 				user_default = default_value


### PR DESCRIPTION
- While creating a new Document, for Link Fields, if a corresponding `user.defaults` is found for the DocType, then the value is set.
- Inspite of default value is set in Link DocField, value is set from `user.defaults` and not from DocField default.
- Consider the following example:
        - In Contact, a custom Link Field is added for `Language` and `de` is set as default value. Now when a new Contact is created, the system will link `en` to the Link Filed instead of `de` since `en` is set in system default .
        - The system will set the Link Field value mentioned in DocField default and check the permission.

![def](https://user-images.githubusercontent.com/7310479/74056757-96e4eb00-4a08-11ea-9776-78ab63cf7550.gif)
