### PR TITLE
fix: form not being saved on setting empty value for some field types

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -184,13 +184,7 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.model.on(me.doctype, "*", function(fieldname, value, doc) {
 			// set input
 			if(doc.name===me.docname) {
-				if ((value==='' || value===null) && !doc[fieldname]) {
-					// both the incoming and outgoing values are falsy
-					// the texteditor, summernote, changes nulls to empty strings on render,
-					// so ignore those changes
-				} else {
-					me.dirty();
-				}
+				me.dirty();
 
 				let field = me.fields_dict[fieldname];
 				field && field.refresh(fieldname);


### PR DESCRIPTION
`frm.dirty()` wasn't being triggered on setting value as empty for some field types (ex. Data fields) because of this condition, preventing the form from being saved:
```
if ((value==='' || value===null) && !doc[fieldname]) {					
	// both the incoming and outgoing values are falsy	
	// the texteditor, summernote, changes nulls to empty strings on render,	
	// so ignore those changes	
}
```