### PR TITLE
fix: Check if Event Consumer exists before checking for consumers

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1318,6 +1318,9 @@ def make_event_update_log(doc, update_type):
 
 def check_doctype_has_consumers(doctype):
 	"""Check if doctype has event consumers for event streaming"""
+	if not frappe.db.exists("DocType", "Event Consumer"):
+		return False
+
 	event_consumers = frappe.get_all('Event Consumer')
 	for event_consumer in event_consumers:
 		consumer = frappe.get_doc('Event Consumer', event_consumer.name)


### PR DESCRIPTION
fix: Check if Event Consumer exists before checking for consumers

The logic for event streaming has been hardcoded into `document.py`

**Scenario:**
a site (say, v12) backup needs to be restored on a v13 bench and then updated.

**Solution:**
use `bench migrate`; works flawlessly.

However, if this site has an app installed that isn't available on the v13 bench, then bench migrate fails.

Also, `bench remove-from-installed-apps` fails, because of the absence of **Event Consumer**.