### PR TITLE
fix(background jobs): Show method name on Background Jobs page.

### DIFF
--- a/frappe/core/page/background_jobs/background_jobs.py
+++ b/frappe/core/page/background_jobs/background_jobs.py
@@ -28,6 +28,7 @@ def get_info(show_failed=False):
 		if j.kwargs.get('site')==frappe.local.site:
 			jobs.append({
 				'job_name': j.kwargs.get('kwargs', {}).get('playbook_method') \
+					or j.kwargs.get('kwargs', {}).get('job_type') \
 					or str(j.kwargs.get('job_name')),
 				'status': j.get_status(), 'queue': name,
 				'creation': format_datetime(convert_utc_to_user_timezone(j.created_at)),


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/8486 background jobs page doesn't provide any information.

**Before:**
![Screenshot_2020-04-20 Background Jobs(1)](https://user-images.githubusercontent.com/8528887/79726266-24499300-8308-11ea-9908-975d7102f15c.png)

**After:**
![Screenshot_2020-04-20 Background Jobs](https://user-images.githubusercontent.com/8528887/79726277-27dd1a00-8308-11ea-9b8c-57c16cce9bf5.png)
