### PR TITLE
fix(Data Import Beta): name field not visible in template

### DIFF
--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -268,12 +268,6 @@ frappe.data_import.DataExporter = class DataExporter {
 		}
 
 		return this.column_map[doctype]
-			.filter(df => {
-				if (autoname_field && df.fieldname === autoname_field.fieldname) {
-					return false;
-				}
-				return true;
-			})
 			.map(df => {
 				let label = __(df.label);
 				if (autoname_field && df.fieldname === 'name') {


### PR DESCRIPTION
- If a field is set in auto-name, then that field is not visible in Data Import Beta's download template
- Before Fix
![Screenshot 2020-04-20 at 2 41 31 PM](https://user-images.githubusercontent.com/7310479/79734865-08002300-8315-11ea-92d0-205288bc5e99.png)

![Screenshot 2020-04-20 at 2 50 52 PM](https://user-images.githubusercontent.com/7310479/79735730-57931e80-8316-11ea-9ffa-865a5a21a340.png)

- After Fix
![Screenshot 2020-04-20 at 2 41 31 PM](https://user-images.githubusercontent.com/7310479/79734865-08002300-8315-11ea-92d0-205288bc5e99.png)

![Screenshot 2020-04-20 at 2 41 43 PM](https://user-images.githubusercontent.com/7310479/79734884-0fbfc780-8315-11ea-9c78-ad5ac84ff0b1.png)

