### PR TITLE
fix: Migrate fails on `move_email_and_phone_to_child_table` patch

### DIFF
--- a/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
+++ b/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
@@ -1,6 +1,10 @@
 import frappe
 
 def execute():
+	frappe.reload_doc("contacts", "doctype", "contact_email")
+	frappe.reload_doc("contacts", "doctype", "contact_phone")
+	frappe.reload_doc("contacts", "doctype", "contact")
+
 	contact_details = frappe.db.sql("""
 		SELECT
 			`name`, `email_id`, `phone`, `mobile_no`, `modified_by`, `creation`, `modified`
@@ -9,10 +13,6 @@ def execute():
 			where `tabContact Email`.parent=`tabContact`.name
 			and `tabContact Email`.email_id=`tabContact`.email_id)
 	""", as_dict=True)
-
-	frappe.reload_doc("contacts", "doctype", "contact_email")
-	frappe.reload_doc("contacts", "doctype", "contact_phone")
-	frappe.reload_doc("contacts", "doctype", "contact")
 
 	email_values = []
 	phone_values = []


### PR DESCRIPTION
**Issue:**
`pymysql.err.ProgrammingError: (1146, u"Table '_99ba1bff2b2e720e.tabContact Email' doesn't exist")`

As seen in https://github.com/frappe/erpnext/issues/21198 and https://github.com/frappe/erpnext/issues/21246

**Fix:**
- Reload docs first followed by the rest