### PR TITLE
fix: change to custom theme logic and dont export theme in migrate

### DIFF
--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -14,10 +14,7 @@ class WebsiteTheme(Document):
 		self.validate_theme()
 
 	def on_update(self):
-		if (not self.custom
-			and frappe.local.conf.get('developer_mode')
-			and not (frappe.flags.in_import or frappe.flags.in_test)):
-
+		if self.is_standard_and_not_valid_user():
 			self.export_doc()
 
 		self.clear_cache_if_current_theme()
@@ -63,8 +60,10 @@ class WebsiteTheme(Document):
 		folder_path = join_path(frappe.utils.get_bench_path(), 'sites', 'assets', 'css')
 		self.delete_old_theme_files(folder_path)
 
-		# add a random suffix
-		file_name = frappe.scrub(self.name) + '_' + frappe.generate_hash('Website Theme', 8) + '.css'
+		if not self.custom:
+			file_name = ''.join([frappe.scrub(self.name), '_website_theme.css'])
+		else:
+			file_name = frappe.scrub(self.name) + '_' + frappe.generate_hash('Website Theme', 8) + '.css'
 		output_path = join_path(folder_path, file_name)
 
 		content = get_scss(self)
@@ -133,4 +132,3 @@ def generate_theme_files_if_not_exist():
 
 def get_scss(doc):
 	return (doc.theme_scss or '') + '\n' + (doc.custom_scss or '')
-

--- a/frappe/website/website_theme/standard/standard.json
+++ b/frappe/website/website_theme/standard/standard.json
@@ -8,13 +8,12 @@
  "doctype": "Website Theme",
  "font_properties": "300,600",
  "idx": 27,
- "modified": "2020-04-19 05:34:56.086984",
+ "modified": "2020-04-20 23:15:10.456782",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Standard",
  "owner": "Administrator",
- "primary_color": "Blue",
  "theme": "Standard",
- "theme_scss": "\n\n$primary: #5e3aa8;\n\n\n\n\n$enable-shadows: false;\n$enable-gradients: false;\n$enable-rounded: true;\n\n@import \"frappe/public/scss/website\";\n\nbody {\n    \n}",
- "theme_url": "/assets/css/standard_999ef15b.css"
+ "theme_scss": "$enable-shadows: false;\n$enable-gradients: false;\n$enable-rounded: true;\n\n@import \"frappe/public/scss/website\";\n\n",
+ "theme_url": "/assets/css/standard_website_theme.css"
 }


### PR DESCRIPTION
* `on_update`: do not export the theme if inside migrate, this will prevent unnecessary updation of the theme

* `generate_bootstrap_theme`: use a standard naming series if the theme is not custom

also fixes issue with current develop where migrating the current instance causes the css to fail to load

Fixes:
![image](https://user-images.githubusercontent.com/37302950/79783465-54bc1c00-835e-11ea-9b20-fff73602c0bf.png)

Caused by:
![image](https://user-images.githubusercontent.com/37302950/79783533-6ac9dc80-835e-11ea-9e81-7f6d7c273a0e.png)
