### PR TITLE
feat: source maps for css/scss/less files!

### DIFF
--- a/rollup/config.js
+++ b/rollup/config.js
@@ -11,6 +11,7 @@ const buble = require('rollup-plugin-buble');
 const { terser } = require('rollup-plugin-terser');
 const vue = require('rollup-plugin-vue');
 const frappe_html = require('./frappe-html-plugin');
+const less_loader = require('./less-loader');
 
 const production = process.env.FRAPPE_ENV === 'production';
 
@@ -116,6 +117,7 @@ function get_rollup_options_for_css(output_file, input_files) {
 		// less -> css
 		postcss({
 			extract: output_path,
+			loaders: [less_loader],
 			use: [
 				['less', {
 					// import other less/css files starting from these folders
@@ -130,7 +132,8 @@ function get_rollup_options_for_css(output_file, input_files) {
 				path.resolve(bench_path, '**/*.scss'),
 				path.resolve(bench_path, '**/*.css')
 			],
-			minimize: minimize_css
+			minimize: minimize_css,
+			sourceMap: output_file.startsWith('css/') && !production
 		})
 	];
 

--- a/rollup/less-loader.js
+++ b/rollup/less-loader.js
@@ -1,0 +1,54 @@
+const pify = require('pify');
+const importCwd = require('import-cwd');
+const path = require('path');
+
+const getFileName = filepath => path.basename(filepath);
+
+function loadModule(moduleId) {
+	// Trying to load module normally (relative to plugin directory)
+	try {
+		return require(moduleId)
+	} catch (_) {
+		// Ignore error
+	}
+
+	// Then, trying to load it relative to CWD
+	return importCwd.silent(moduleId)
+}
+
+module.exports = {
+	name: 'less',
+	test: /\.less$/,
+	async process({
+		code
+	}) {
+		const less = loadModule('less')
+		if (!less) {
+			throw new Error('You need to install "less" packages in order to process Less files')
+		}
+
+		let {
+			css,
+			map,
+			imports
+		} = await pify(less.render.bind(less))(code, {
+			...this.options,
+			sourceMap: this.sourceMap && { outputSourceFiles: true },
+			filename: this.id
+		})
+
+		for (const dep of imports) {
+			this.dependencies.add(dep)
+		}
+
+		if (map) {
+			map = JSON.parse(map)
+			map.sources = map.sources.map(source => getFileName(source))
+		}
+
+		return {
+			code: css,
+			map
+		}
+	}
+}

--- a/rollup/less-loader.js
+++ b/rollup/less-loader.js
@@ -7,13 +7,13 @@ const getFileName = filepath => path.basename(filepath);
 function loadModule(moduleId) {
 	// Trying to load module normally (relative to plugin directory)
 	try {
-		return require(moduleId)
+		return require(moduleId);
 	} catch (_) {
 		// Ignore error
 	}
 
 	// Then, trying to load it relative to CWD
-	return importCwd.silent(moduleId)
+	return importCwd.silent(moduleId);
 }
 
 module.exports = {
@@ -22,9 +22,9 @@ module.exports = {
 	async process({
 		code
 	}) {
-		const less = loadModule('less')
+		const less = loadModule('less');
 		if (!less) {
-			throw new Error('You need to install "less" packages in order to process Less files')
+			throw new Error('You need to install "less" packages in order to process Less files');
 		}
 
 		let {
@@ -35,20 +35,20 @@ module.exports = {
 			...this.options,
 			sourceMap: this.sourceMap && { outputSourceFiles: true },
 			filename: this.id
-		})
+		});
 
 		for (const dep of imports) {
-			this.dependencies.add(dep)
+			this.dependencies.add(dep);
 		}
 
 		if (map) {
-			map = JSON.parse(map)
-			map.sources = map.sources.map(source => getFileName(source))
+			map = JSON.parse(map);
+			map.sources = map.sources.map(source => getFileName(source));
 		}
 
 		return {
 			code: css,
 			map
-		}
+		};
 	}
-}
+};


### PR DESCRIPTION
- Tested locally with `.less`, `.scss` and `.css` files.
- Maps generated only for development instances.

Special treatment was required for generating source map for `.less` files:
Overrided the default less file loader provided by `rollup-plugin-postcss` package to include less source in source map and prevent 404 errors.

![Screenshot from 2020-04-22 02-15-27](https://user-images.githubusercontent.com/16315650/79912156-35e18680-843f-11ea-8efd-58a70b8b8d66.png)

![Screenshot from 2020-04-22 02-13-07](https://user-images.githubusercontent.com/16315650/79912204-4691fc80-843f-11ea-8e2c-027be1157709.png)

![Screenshot from 2020-04-22 02-15-43](https://user-images.githubusercontent.com/16315650/79912149-3417c300-843f-11ea-8da6-bde94d829f94.png)