### PR TITLE
fix: Fix build-docs command

### DIFF
--- a/frappe/templates/autodoc/dev_home.html
+++ b/frappe/templates/autodoc/dev_home.html
@@ -37,10 +37,10 @@
 <h3>Contents</h3>
 <ul>
 	<li>
-		<a href="/docs/current/models">Models (DocTypes)</a>
+		<a href="/docs/{{ app.docs_version }}/models">Models (DocTypes)</a>
 	</li>
 	<li>
-		<a href="/docs/current/api">Server-side API</a>
+		<a href="/docs/{{ app.docs_version }}/api">Server-side API</a>
 	</li>
 </ul>
 

--- a/frappe/templates/autodoc/doctype.html
+++ b/frappe/templates/autodoc/doctype.html
@@ -4,7 +4,6 @@
 {% from "templates/autodoc/macros.html" import automodule, version,
   source_link, doctype_link %}
 {% set doc = frappe.get_doc("DocType", doctype) %}
-{% set controller = autodoc.get_controller(doctype) %}
 
 <h1>{{ doctype }}</h1>
 <div class="dev-header">
@@ -59,9 +58,9 @@
 {% if not doc.istable %}
     <hr>
     <h3>Controller</h3>
-    <h4>{{ controller.__module__ }}</h4>
+    <h4>{{ controller_name }}</h4>
 
-    {{ automodule(controller.__module__) }}
+    {{ automodule(controller_name) }}
     {% set parents = frappe.get_list("DocField",
         filters = {"options": doctype, "fieldtype": "Link"}, fields = ["distinct parent"], order_by="parent asc") %}
     {% if parents %}


### PR DESCRIPTION
Signed-off-by: mathieu.brunot <mathieu.brunot@monogramm.io>

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->
Fix the build-docs command to be more robust.

This can be useful for apps that want to use this command to generate a developer / user guide for their app.
By the way, why was this command removed from Frappe 12 ?

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
 * do not copy paths that do not exist
* get controller name from frappe instead of Jinja (preventing "access to attribute __module__ is unsafe)
* use `docs_version` for paths.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
