### PR TITLE
fix: Validation on Select field with Default and no Options.

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -733,9 +733,9 @@ def validate_fields(meta):
 			frappe.throw(_("Default for 'Check' type of field must be either '0' or '1'"))
 		if d.fieldtype == "Select" and d.default:
 			if not d.options:
-				frappe.throw(_("Options for '{0}' must be set before Default.").format(d.fieldname))
+				frappe.throw(_("Options for {0} must be set before setting the default value.").format(d.fieldname.bold()))
 			elif d.default not in d.options.split("\n"):
-				frappe.throw(_("Default for '{0}' must be an Option").format(d.fieldname))
+				frappe.throw(_("Default value for {0} must be in the list of options").format(d.fieldname.bold()))
 
 	def check_precision(d):
 		if d.fieldtype in ("Currency", "Float", "Percent") and d.precision is not None and not (1 <= cint(d.precision) <= 6):

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -733,9 +733,9 @@ def validate_fields(meta):
 			frappe.throw(_("Default for 'Check' type of field must be either '0' or '1'"))
 		if d.fieldtype == "Select" and d.default:
 			if not d.options:
-				frappe.throw(_("Options for {0} must be set before setting the default value.").format(d.fieldname.bold()))
+				frappe.throw(_("Options for {0} must be set before setting the default value.").format(frappe.bold(d.fieldname)))
 			elif d.default not in d.options.split("\n"):
-				frappe.throw(_("Default value for {0} must be in the list of options").format(d.fieldname.bold()))
+				frappe.throw(_("Default value for {0} must be in the list of options.").format(frappe.bold(d.fieldname)))
 
 	def check_precision(d):
 		if d.fieldtype in ("Currency", "Float", "Percent") and d.precision is not None and not (1 <= cint(d.precision) <= 6):

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -731,8 +731,11 @@ def validate_fields(meta):
 			d.default = '0'
 		if d.fieldtype == "Check" and d.default not in ('0', '1'):
 			frappe.throw(_("Default for 'Check' type of field must be either '0' or '1'"))
-		if d.fieldtype == "Select" and d.default and (d.default not in d.options.split("\n")):
-			frappe.throw(_("Default for {0} must be an option").format(d.fieldname))
+		if d.fieldtype == "Select" and d.default:
+			if not d.options:
+				frappe.throw(_("Options for '{0}' must be set before Default.").format(d.fieldname))
+			elif d.default not in d.options.split("\n"):
+				frappe.throw(_("Default for '{0}' must be an Option").format(d.fieldname))
 
 	def check_precision(d):
 		if d.fieldtype in ("Currency", "Float", "Percent") and d.precision is not None and not (1 <= cint(d.precision) <= 6):


### PR DESCRIPTION
**Issue:**
On setting a Default for a Select field without options  -
`AttributeError: 'NoneType' object has no attribute 'split'`

**Fix:**
1) _On setting a Default for a Select field without options_
![Screenshot 2020-04-28 at 12 11 19 PM](https://user-images.githubusercontent.com/25857446/80455903-3f408680-894a-11ea-9ba5-cbc119c2742a.png)


2) _On setting a Default that isn't in the Options_
![Screenshot 2020-04-28 at 12 12 17 PM](https://user-images.githubusercontent.com/25857446/80455935-4a93b200-894a-11ea-852c-b7648b5f4891.png)

 