### PR TITLE
fix: move expand button after description and change label according to state

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -10,11 +10,11 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 			.appendTo(this.input_area);
 
 		this.expanded = false;
-		this.$expand_button = $(`<button class="margin-top btn btn-xs btn-default">${__('Expand / Collapse')}</button>`).click(() => {
+		this.$expand_button = $(`<button class="btn btn-xs btn-default">${__('Expand')}</button>`).click(() => {
 			this.expanded = !this.expanded;
 			this.refresh_height();
-		}).insertAfter(this.ace_editor_target);
-
+			this.toggle_label();
+		}).appendTo(this.$input_wrapper);
 		// styling
 		this.ace_editor_target.addClass('border rounded');
 		this.ace_editor_target.css('height', 300);
@@ -35,6 +35,11 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 	refresh_height() {
 		this.ace_editor_target.css('height', this.expanded ? 600 : 300);
 		this.editor.resize();
+	},
+
+	toggle_label() {
+		const button_label = this.expanded? __('Collapse'): __('Expand');
+		this.$expand_button.text(button_label);
 	},
 
 	set_language() {

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -38,7 +38,7 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 	},
 
 	toggle_label() {
-		const button_label = this.expanded? __('Collapse'): __('Expand');
+		const button_label = this.expanded ? __('Collapse') : __('Expand');
 		this.$expand_button.text(button_label);
 	},
 

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -770,6 +770,7 @@ h6.uppercase, .h6.uppercase {
 
 	.help-box {
 		margin-top: 3px;
+		margin-bottom: 6px;
 	}
 
 	pre {


### PR DESCRIPTION
Before:
<img width="952" alt="Screenshot 2020-04-22 at 12 40 12 PM" src="https://user-images.githubusercontent.com/19775888/79951507-715b6f80-8496-11ea-8585-04e6be951a86.png">


After:
<img width="950" alt="Screenshot 2020-04-22 at 12 39 20 PM" src="https://user-images.githubusercontent.com/19775888/79951452-55f06480-8496-11ea-98f4-2b818869d337.png">
