### PR TITLE
fix(requirements): pin ipython to 5.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ requests-oauthlib==1.3.0
 redis==2.10.6
 selenium==3.141.0
 babel==2.6.0
-ipython-genutils==0.2.0
+ipython==5.9.0
 html2text==2016.9.19
 email-reply-parser==0.5.9
 click==7.1.1


### PR DESCRIPTION
from pypi: `ipython_genutils` is deprecated and shouldn't be used, and requirements was missing `ipython`, which caused `bench console` to fail