### PR TITLE
fix: Override barcode svg width to fit in html area

### DIFF
--- a/frappe/public/js/frappe/form/controls/barcode.js
+++ b/frappe/public/js/frappe/form/controls/barcode.js
@@ -48,6 +48,7 @@ frappe.ui.form.ControlBarcode = frappe.ui.form.ControlData.extend({
 			const svg = this.barcode_area.find('svg')[0];
 			JsBarcode(svg, value, this.get_options(value));
 			$(svg).attr('data-barcode-value', value);
+			$(svg).attr('width', '100%');
 			return this.barcode_area.html();
 		}
 	},


### PR DESCRIPTION
Barcode width for larger payload would exceed html field bounds. This PR fixes it by manually setting the width of the SVG to 100%

Before
<img width="517" alt="Screenshot 2020-04-22 at 1 31 28 PM" src="https://user-images.githubusercontent.com/18097732/79956732-28a7b480-849e-11ea-9bd1-9e29687c6268.png">

After Fix - Long String
<img width="465" alt="image" src="https://user-images.githubusercontent.com/18097732/79956849-52f97200-849e-11ea-9b7b-bfb35f32dcd4.png">

After Fix - Small String
<img width="445" alt="Screenshot 2020-04-22 at 1 31 42 PM" src="https://user-images.githubusercontent.com/18097732/79956777-36f5d080-849e-11ea-87fa-223e32c321b1.png">
