### PR TITLE
feat: refresh shortcut count every time a page is shown

### DIFF
--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -145,6 +145,11 @@ class DesktopPage {
 	show() {
 		frappe.desk_page = this;
 		this.page.show();
+		if (this.sections.shortcuts) {
+			this.sections.shortcuts.widgets_list.forEach(wid => {
+				wid.set_actions();
+			})
+		}
 	}
 
 	hide() {

--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -148,7 +148,7 @@ class DesktopPage {
 		if (this.sections.shortcuts) {
 			this.sections.shortcuts.widgets_list.forEach(wid => {
 				wid.set_actions();
-			})
+			});
 		}
 	}
 


### PR DESCRIPTION
Shortcuts on desk does not auto refresh when some transactions of a doctype are updates. This PR fixes that