### PR TITLE
fix: don't set form as dirty if ignore_dirty flag is passed in set_value

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -131,8 +131,8 @@ frappe.ui.form.Control = Class.extend({
 			return this.doc[this.df.fieldname];
 		}
 	},
-	set_value: function(value) {
-		return this.validate_and_set_in_model(value);
+	set_value: function(value, ignore_dirty) {
+		return this.validate_and_set_in_model(value, null, ignore_dirty);
 	},
 	parse_validate_and_set_in_model: function(value, e) {
 		if(this.parse) {
@@ -140,7 +140,7 @@ frappe.ui.form.Control = Class.extend({
 		}
 		return this.validate_and_set_in_model(value, e);
 	},
-	validate_and_set_in_model: function(value, e) {
+	validate_and_set_in_model: function(value, e, ignore_dirty) {
 		var me = this;
 		if(this.inside_change_event) {
 			return Promise.resolve();
@@ -149,7 +149,7 @@ frappe.ui.form.Control = Class.extend({
 		var set = function(value) {
 			me.inside_change_event = false;
 			return frappe.run_serially([
-				() => me.set_model_value(value),
+				() => me.set_model_value(value, ignore_dirty),
 				() => {
 					me.set_mandatory && me.set_mandatory(value);
 					me.set_invalid && me.set_invalid();
@@ -168,7 +168,7 @@ frappe.ui.form.Control = Class.extend({
 			return value.then((value) => set(value));
 		} else {
 			// all clear
-			return set(value);
+			return set(value, ignore_dirty);
 		}
 	},
 	get_value: function() {
@@ -180,11 +180,11 @@ frappe.ui.form.Control = Class.extend({
 			return this.value || undefined;
 		}
 	},
-	set_model_value: function(value) {
+	set_model_value: function(value, ignore_dirty=false) {
 		if(this.frm) {
 			this.last_value = value;
 			return frappe.model.set_value(this.doctype, this.docname, this.df.fieldname,
-				value, this.df.fieldtype);
+				value, this.df.fieldtype, ignore_dirty);
 		} else {
 			if(this.doc) {
 				this.doc[this.df.fieldname] = value;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -184,7 +184,9 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.model.on(me.doctype, "*", function(fieldname, value, doc) {
 			// set input
 			if(doc.name===me.docname) {
-				me.dirty();
+				if (!me.doc.__ignore_dirty) {
+					me.dirty();
+				}
 
 				let field = me.fields_dict[fieldname];
 				field && field.refresh(fieldname);

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -360,7 +360,7 @@ $.extend(frappe.model, {
 		}
 	},
 
-	set_value: function(doctype, docname, fieldname, value, fieldtype) {
+	set_value: function(doctype, docname, fieldname, value, fieldtype, ignore_dirty) {
 		/* help: Set a value locally (if changed) and execute triggers */
 
 		var doc;
@@ -377,6 +377,8 @@ $.extend(frappe.model, {
 			to_update = {};
 			to_update[fieldname] = value;
 		}
+
+		doc.__ignore_dirty = ignore_dirty;
 
 		$.each(to_update, (key, value) => {
 			if (doc && doc[key] !== value) {


### PR DESCRIPTION
**Fix:**
If `ignore_dirty` is passed while calling `set_value()`, don't call `frm.dirty()`.

This is needed because in some forms (ex: transaction.js), value is set on refresh and in that case the form shows up as Not Saved. 

Fixes issue introduced in: https://github.com/frappe/frappe/pull/10012