### PR TITLE
fix(minor): Value Error during importing or exporting doc files in migrate

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -477,7 +477,8 @@ class DocType(Document):
 						field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict['fields']))
 						if field_dict:
 							new_field_dicts.append(field_dict[0])
-							remaining_field_names.remove(fieldname)
+							if fieldname in remaining_field_names:
+								remaining_field_names.remove(fieldname)
 
 					for fieldname in remaining_field_names:
 						field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict['fields']))
@@ -498,7 +499,8 @@ class DocType(Document):
 				field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict.get('fields', [])))
 				if field_dict:
 					new_field_dicts.append(field_dict[0])
-					remaining_field_names.remove(fieldname)
+					if fieldname in remaining_field_names:
+						remaining_field_names.remove(fieldname)
 
 			for fieldname in remaining_field_names:
 				field_dict = list(filter(lambda d: d['fieldname'] == fieldname, docdict.get('fields', [])))


### PR DESCRIPTION
fix for: 

 ```
File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/commands/site.py", line 252, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/migrate.py", line 52, in migrate
    frappe.model.sync.sync_all(verbose=verbose)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/model/sync.py", line 19, in sync_all
    sync_for(app, force, verbose=verbose, reset_permissions=reset_permissions)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/model/sync.py", line 65, in sync_for
    reset_permissions=reset_permissions, for_sync=True)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/modules/import_file.py", line 66, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/modules/import_file.py", line 104, in import_doc
    controller.prepare_for_import(docdict)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 502, in prepare_for_import
    remaining_field_names.remove(fieldname)
ValueError: list.remove(x): x not in list
```