### PR TITLE
fix: Pass explicit digestmod parameter

### DIFF
--- a/frappe/utils/verified_command.py
+++ b/frappe/utils/verified_command.py
@@ -17,7 +17,7 @@ def get_signed_params(params):
 	if not isinstance(params, string_types):
 		params = urlencode(params)
 
-	signature = hmac.new(params.encode())
+	signature = hmac.new(params.encode(), digestmod='MD5')
 	signature.update(get_secret().encode())
 	return params + "&_signature=" + signature.hexdigest()
 

--- a/frappe/utils/verified_command.py
+++ b/frappe/utils/verified_command.py
@@ -35,7 +35,7 @@ def verify_request():
 	if signature_string in query_string:
 		params, signature = query_string.split(signature_string)
 
-		given_signature = hmac.new(params.encode('utf-8'))
+		given_signature = hmac.new(params.encode('utf-8'), digestmod='MD5')
 
 		given_signature.update(get_secret().encode())
 		valid = signature == given_signature.hexdigest()
@@ -58,7 +58,7 @@ def get_signature(params, nonce, secret=None):
 	if not secret:
 		secret = frappe.local.conf.get("secret") or "secret"
 
-	signature = hmac.new(str(nonce))
+	signature = hmac.new(str(nonce), digestmod='MD5')
 	signature.update(secret)
 	signature.update(params)
 	return signature.hexdigest()


### PR DESCRIPTION
https://docs.python.org/3/library/hmac.html#hmac.new

This default `digestmod="MD5"` has been deprecated since python 3.8 and is required to be passed explicitly

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
