### PR TITLE
fix: Do not check for module for custom doctypes

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -268,8 +268,9 @@ def get_open_count(doctype, name, items=[]):
 		"count": out,
 	}
 
-	module = frappe.get_meta_module(doctype)
-	if hasattr(module, "get_timeline_data"):
-		out["timeline_data"] = module.get_timeline_data(doctype, name)
+	if not meta.custom:
+		module = frappe.get_meta_module(doctype)
+		if hasattr(module, "get_timeline_data"):
+			out["timeline_data"] = module.get_timeline_data(doctype, name)
 
 	return out


### PR DESCRIPTION
Fixes following issue when link is set for custom doctype.
<img width="1552" alt="Screenshot 2020-04-24 at 9 24 14 AM" src="https://user-images.githubusercontent.com/13928957/80174018-1c8f3480-860f-11ea-8531-7f36f2be3975.png">

Traceback:
```
Traceback (most recent call last):
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 1074, in call
    return fn(*args, **newargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 534, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/notifications.py", line 271, in get_open_count
    module = frappe.get_meta_module(doctype)
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 789, in get_meta_module
    return frappe.modules.load_doctype_module(doctype)
  File "/Users/sps/benches/develop/apps/frappe/frappe/modules/utils.py", line 206, in load_doctype_module
    raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))
ImportError: Module import failed for All Purpose Doctype (frappe.core.doctype.all_purpose_doctype.all_purpose_doctype Error: No module named all_purpose_doctype.all_purpose_doctype)
```