### PR TITLE
fix: Clear `__unsaved` flag after document save

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -329,6 +329,10 @@ class Document(BaseDocument):
 		self.update_children()
 		self.run_post_save_methods()
 
+		# clear unsaved flag
+		if hasattr(self, "__unsaved"):
+			delattr(self, "__unsaved")
+
 		return self
 
 	def copy_attachments_from_amended_from(self):


### PR DESCRIPTION
**Before:**
![for_save_bug](https://user-images.githubusercontent.com/13928957/80177725-1eaac080-861a-11ea-9647-83bf6a9cace8.gif)

**After:**
![for_save_bug_fix](https://user-images.githubusercontent.com/13928957/80177736-25d1ce80-861a-11ea-9079-2fccd7c1ab59.gif)

The bug was introduced after https://github.com/frappe/frappe/pull/10067