### PR TITLE
fix(File): Private file permissions

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -714,7 +714,10 @@ def has_permission(doc, ptype=None, user=None):
 	has_access = False
 	user = user or frappe.session.user
 
-	if not doc.is_private or doc.owner == user or user == 'Administrator':
+	if ptype == 'create':
+		has_access = frappe.has_permission('File', 'create', user=user)
+
+	if not doc.is_private or doc.owner in [user, 'Guest'] or user == 'Administrator':
 		has_access = True
 
 	if doc.attached_to_doctype and doc.attached_to_name:


### PR DESCRIPTION
`has_permission` should be true while uploading a file (considering role permissions) and if a file is uploaded by Guest.

Fixes issue introduced in https://github.com/frappe/frappe/pull/9926

Fixes https://github.com/frappe/frappe/issues/10073