### PR TITLE
fix: remove unused red indicator from the legend

### DIFF
--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -344,10 +344,6 @@ class DesktopPage {
 			{
 				color: "orange",
 				description: __("No Records Created")
-			},
-			{
-				color: "red",
-				description: __("Has Open Entries")
 			}
 		].map(item => {
 			return `<div class="legend-item small text-muted justify-flex-start">


### PR DESCRIPTION
Red indicator would mean doctype has open count. However its not implemented in the new desk. This PR removes the red indicator label from the legend