### PR TITLE
fix: don't reset the child doc fields value for new record

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -572,6 +572,9 @@ class Document(BaseDocument):
 		if high_permlevel_fields:
 			self.reset_values_if_no_permlevel_access(has_access_to, high_permlevel_fields)
 
+		# If new record then don't reset the values for child table
+		if self.is_new(): return
+
 		# check for child tables
 		for df in self.meta.get_table_fields():
 			high_permlevel_fields = frappe.get_meta(df.options).get_high_permlevel_fields()


### PR DESCRIPTION
### **Issue**

User 1 has created sales order with Price list rate 2000, discount percentage as 10 and rate as 1800

When user 2 trying to create the delivery note against the sales order then he has getting the below error
![image](https://user-images.githubusercontent.com/8780500/80206544-1f5b4b00-864a-11ea-8e86-7d14cd4d428e.png)

**Investigation** 
User 2 has no access of the fields like price list rate, discount, rate(permlevel has set), so system reset the values to old doc if user don't have access of that fields. During reset the values for those fields if doc is new, system consider the previous doc as new doc and the values which has set based on the mapped doc gets vanished.

**Solution** 
Don't reset the child doc fields value for the new record if user has not permission to view the fields.
