### PR TITLE
feat: events for clicking of grid rows in web forms

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -299,7 +299,7 @@ export default class GridRow {
 					$(col).find('input[type="Text"]:first').focus();
 				}, 500);
 				
-				var evt_name = me.parent_df.fieldname+"_grid_row_after_click";
+				var evt_name = me.parent_df.fieldname + "_grid_row_after_click";
 				frappe.web_form.events.trigger(evt_name, me);
 				
 				return out;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -298,6 +298,10 @@ export default class GridRow {
 				setTimeout(function() {
 					$(col).find('input[type="Text"]:first').focus();
 				}, 500);
+				
+				var evt_name = me.parent_df.fieldname+"_grid_row_after_click";
+				frappe.web_form.events.trigger(evt_name, me);
+				
 				return out;
 			});
 


### PR DESCRIPTION
This is necessary for updating options of a select HTML element based on the chosen values of other select HTML elements.

An example snippet utilizing this feature goes roughly as follows:

```
frappe.ready(function() {
        // invoked when clicking a column of a newly inserted row.
        frappe.web_form.events.on("{table_field_name}_grid_row_after_click", function(gridrow){
                gridrow.on_grid_fields_dict["column_name"].df.onchange = function(e) {
                        // update options of select HTML element
                };
       });
}
```

An example is shown in the below screenshots
![79135698-56c42f00-7de2-11ea-8de6-2de7a6b504df](https://user-images.githubusercontent.com/765222/80285498-03de6600-8758-11ea-8e38-68dcf038c939.png)
![79135723-5deb3d00-7de2-11ea-8809-4913bd5b88c3](https://user-images.githubusercontent.com/765222/80285502-0c36a100-8758-11ea-8843-ad057673affd.png)

