### PR TITLE
fix: convert max_file_size to int

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -696,7 +696,7 @@ def remove_file(fid=None, attached_to_doctype=None, attached_to_name=None, from_
 
 
 def get_max_file_size():
-	return conf.get('max_file_size') or 10485760
+	return cint(conf.get('max_file_size')) or 10485760
 
 
 def remove_all(dt, dn, from_delete=False):


### PR DESCRIPTION
fixes:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/handler.py", line 198, in upload_file
    ret.save(ignore_permissions=ignore_permissions)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/model/document.py", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/model/document.py", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/model/document.py", line 223, in insert
    self.run_method("before_insert")
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/model/document.py", line 794, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/model/document.py", line 1065, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/model/document.py", line 1048, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/model/document.py", line 788, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/core/doctype/file/file.py", line 55, in before_insert
    self.save_file(content=self.content, decode=self.decode)
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/core/doctype/file/file.py", line 439, in save_file
    self.file_size = self.check_max_file_size()
  File "/home/frappe/benches/bench-12-f1-0/apps/frappe/frappe/core/doctype/file/file.py", line 495, in check_max_file_size
    if file_size > max_file_size:
TypeError: '>' not supported between instances of 'int' and 'str'
```
