### PR TITLE
revert: "fix: Set fields in grid form as read only for non-editable grids"

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -22,9 +22,6 @@ export default class GridRow {
 				if(me.grid.allow_on_grid_editing() && me.grid.is_editable()) {
 					// pass
 				} else {
-					if (!me.grid.is_editable()) {
-						me.docfields.map(df => df.read_only = 1);
-					}
 					me.toggle_view();
 					return false;
 				}


### PR DESCRIPTION
Reverts frappe/frappe#9710

The child table's parentfield `permlevel` and child table field `permlevel` should be evaluated separately.

eg. if parentfield permlevel is 1 then the user should not be able to add or delete rows, but can edit row columns based on permlevel set for those child fields.

We do not need this extra code because per field display status based on permlevel/read-only is properly handled [here](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/controls/base_control.js#L65)
