### PR TITLE
fix: proper sass mapping and always failing test

### DIFF
--- a/rollup/config.js
+++ b/rollup/config.js
@@ -109,7 +109,7 @@ function get_rollup_options_for_js(output_file, input_files) {
 
 function get_rollup_options_for_css(output_file, input_files) {
 	const output_path = path.resolve(assets_path, output_file);
-	const minimize_css = output_path.startsWith('css/') && production;
+	const starts_with_css = output_file.startsWith('css/');
 
 	const plugins = [
 		// enables array of inputs
@@ -125,15 +125,19 @@ function get_rollup_options_for_css(output_file, input_files) {
 						path.resolve(get_public_path('frappe'), 'less')
 					]
 				}],
-				['sass', get_options_for_scss()]
+				['sass', {
+					...get_options_for_scss(),
+					outFile: output_path,
+					sourceMapContents: true
+				}]
 			],
 			include: [
 				path.resolve(bench_path, '**/*.less'),
 				path.resolve(bench_path, '**/*.scss'),
 				path.resolve(bench_path, '**/*.css')
 			],
-			minimize: minimize_css,
-			sourceMap: output_file.startsWith('css/') && !production
+			minimize: starts_with_css && production,
+			sourceMap: starts_with_css && !production
 		})
 	];
 


### PR DESCRIPTION
- `minimize_css` was always false because `output_path` was absolute and never started with `"css/"`
- Source map for `.scss` files linked to the processed css code instead of scss code. `node-sass` ignores the `sourceMap` option if `outFile` is not specified. Additionally, it also requires the `sourceMapContents` option for including the contents of `.scss` in the `.map` file. Specifying these options resolved the issue.

### Protip
You can now edit the source files from within your browser's developer tools. (tested on Chrome 80)

**Instructions for Chrome:**
Simply drag your desired app's `public` directory into the `Sources` panel of Chrome's developer tools. You should see new icons for the relevant files, like so:

![Screenshot from 2020-04-26 20-40-32](https://user-images.githubusercontent.com/16315650/80311614-4b1f3200-87fe-11ea-89bb-9a3c1143f370.png)


More information [here](https://developers.google.com/web/tools/chrome-devtools/workspaces).