### PR TITLE
fix: Grid Form style

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -85,6 +85,10 @@ frappe.dom = {
 		);
 	},
 
+	is_element_in_modal(element) {
+		return Boolean($(element).parents('.modal').length);
+	},
+
 	set_style: function(txt, id) {
 		if(!txt) return;
 

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -527,7 +527,7 @@ export default class GridRow {
 		return this;
 	}
 	show_form() {
-		if(!this.grid_form) {
+		if (!this.grid_form) {
 			this.grid_form = new GridRowForm({
 				row: this
 			});
@@ -536,13 +536,15 @@ export default class GridRow {
 		this.row.toggle(false);
 		// this.form_panel.toggle(true);
 		frappe.dom.freeze("", "dark");
-		if(cur_frm) cur_frm.cur_grid = this;
+		if (cur_frm) cur_frm.cur_grid = this;
 		this.wrapper.addClass("grid-row-open");
-		if(!frappe.dom.is_element_in_viewport(this.wrapper)) {
-			frappe.utils.scroll_to(this.wrapper, true, 15);
+		if (!frappe.dom.is_element_in_viewport(this.wrapper)
+			&& !frappe.dom.is_element_in_modal(this.wrapper)) {
+			// -15 offset to make form look visually centered
+			frappe.utils.scroll_to(this.wrapper, true, -15);
 		}
 
-		if(this.frm) {
+		if (this.frm) {
 			this.frm.script_manager.trigger(this.doc.parentfield + "_on_form_rendered");
 			this.frm.script_manager.trigger("form_render", this.doc.doctype, this.doc.name);
 		}
@@ -550,7 +552,9 @@ export default class GridRow {
 	hide_form() {
 		frappe.dom.unfreeze();
 		this.row.toggle(true);
-		frappe.utils.scroll_to(this.row, true, 15);
+		if (!frappe.dom.is_element_in_modal(this.row)) {
+			frappe.utils.scroll_to(this.row, true, 15);
+		}
 		this.refresh();
 		if(cur_frm) cur_frm.cur_grid = null;
 		this.wrapper.removeClass("grid-row-open");

--- a/frappe/public/less/form_grid.less
+++ b/frappe/public/less/form_grid.less
@@ -263,8 +263,10 @@
 }
 
 .grid-form-body {
-	max-height: 75vh;
-	overflow-y: auto;
+	.form-area {
+		max-height: 70vh;
+		overflow-y: auto;
+	}
 }
 
 .grid-header-toolbar {


### PR DESCRIPTION
- Exclude Grid Form footer from scrolling area
**Before:**
![scrolling_child_table_footer](https://user-images.githubusercontent.com/13928957/80312276-eebe1180-8801-11ea-86bb-f1185cc1171d.gif)
**After:**
![fixed_child_table_footer](https://user-images.githubusercontent.com/13928957/80312281-fc739700-8801-11ea-9a83-2430f6de7544.gif)


- Make Grid Form look visually centered
**Before:**
![Screenshot 2020-04-26 at 8 58 38 PM](https://user-images.githubusercontent.com/13928957/80312213-9c7cf080-8801-11ea-8a3c-1e2a3ee41ac9.png)
**After:**
![Screenshot 2020-04-26 at 8 56 45 PM](https://user-images.githubusercontent.com/13928957/80312222-a56dc200-8801-11ea-890a-ea022f34b32d.png)

- Do not scroll the main page if Grid is loaded on a modal
**Before:**
![scroll_when_grid_inside_modal](https://user-images.githubusercontent.com/13928957/80312334-57a58980-8802-11ea-8279-a53ef0fdd0c2.gif)
**After:**
![no_grid_scroll_in_modal](https://user-images.githubusercontent.com/13928957/80312351-6be98680-8802-11ea-8841-8a0fda0e768d.gif)


