### PR TITLE
fix(minor): Initialise filters in Dashboard Chart

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -79,7 +79,7 @@ def get(chart_name = None, chart = None, no_cache = None, filters = None, from_d
 			to_date = chart.to_date
 
 	timegrain = time_interval or chart.time_interval
-	filters = frappe.parse_json(filters) or frappe.parse_json(chart.filters_json)
+	filters = frappe.parse_json(filters) or frappe.parse_json(chart.filters_json) or []
 
 	# don't include cancelled documents
 	filters.append([chart.document_type, 'docstatus', '<', 2, False])


### PR DESCRIPTION
TypeError is thrown if no default filters are set for Dashboard Charts:

**Before:**

![filters-error](https://user-images.githubusercontent.com/24353136/80312780-e915fb00-8804-11ea-95c5-a8499497cc75.png)

**After:**

![after-fix](https://user-images.githubusercontent.com/24353136/80312948-ad2f6580-8805-11ea-82b3-2abfa609ec7b.png)


