### PR TITLE
feat: Section Break without border

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -43,6 +43,7 @@
   "report_hide",
   "remember_last_selected_value",
   "ignore_xss_filter",
+  "hide_border",
   "property_depends_on_section",
   "mandatory_depends_on",
   "column_break_38",
@@ -448,12 +449,19 @@
   {
    "fieldname": "column_break_38",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Section Break'",
+   "fieldname": "hide_border",
+   "fieldtype": "Check",
+   "label": "Hide Border"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-19 21:54:13.783908",
+ "modified": "2020-04-27 11:38:21.223185",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -48,6 +48,7 @@
   "allow_in_quick_entry",
   "ignore_xss_filter",
   "translatable",
+  "hide_border",
   "description",
   "permlevel",
   "width",
@@ -378,12 +379,19 @@
    "fieldname": "in_preview",
    "fieldtype": "Check",
    "label": "In Preview"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Section Break'",
+   "fieldname": "hide_border",
+   "fieldtype": "Check",
+   "label": "Hide Border"
   }
  ],
  "icon": "fa fa-glass",
  "idx": 1,
  "links": [],
- "modified": "2020-04-10 11:57:10.392218",
+ "modified": "2020-04-27 11:40:48.325481",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -76,7 +76,8 @@ docfield_properties = {
 	'remember_last_selected_value': 'Check',
 	'allow_bulk_edit': 'Check',
 	'auto_repeat': 'Link',
-	'allow_in_quick_entry': 'Check'
+	'allow_in_quick_entry': 'Check',
+	'hide_border': 'Check'
 }
 
 allowed_fieldtype_change = (('Currency', 'Float', 'Percent'), ('Small Text', 'Data'),

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -39,6 +39,7 @@
   "allow_on_submit",
   "report_hide",
   "remember_last_selected_value",
+  "hide_border",
   "property_depends_on_section",
   "mandatory_depends_on",
   "column_break_33",
@@ -388,12 +389,19 @@
    "fieldname": "in_preview",
    "fieldtype": "Check",
    "label": "In Preview"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.fieldtype=='Section Break'",
+   "fieldname": "hide_border",
+   "fieldtype": "Check",
+   "label": "Hide Border"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-10 11:58:44.573537",
+ "modified": "2020-04-27 11:39:26.389300",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -63,6 +63,7 @@ CREATE TABLE `tabDocField` (
   `precision` varchar(255) DEFAULT NULL,
   `length` int(11) NOT NULL DEFAULT 0,
   `translatable` int(1) NOT NULL DEFAULT 0,
+  `hide_border` int(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`name`),
   KEY `parent` (`parent`),
   KEY `label` (`label`),

--- a/frappe/database/postgres/framework_postgres.sql
+++ b/frappe/database/postgres/framework_postgres.sql
@@ -63,6 +63,7 @@ CREATE TABLE "tabDocField" (
   "precision" varchar(255) DEFAULT NULL,
   "length" bigint NOT NULL DEFAULT 0,
   "translatable" smallint NOT NULL DEFAULT 0,
+  "hide_border" smallint NOT NULL DEFAULT 0,
   PRIMARY KEY ("name")
 ) ;
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -236,7 +236,6 @@ frappe.ui.form.Layout = Class.extend({
 		// collapse sections
 		if(this.frm) {
 			this.refresh_section_collapse();
-			this.refresh_section_border();
 		}
 	},
 
@@ -306,16 +305,6 @@ frappe.ui.form.Layout = Class.extend({
 				section.collapse(collapse);
 			}
 		}
-	},
-
-	refresh_section_border: function() {
-		if (!this.doc) return;
-		this.sections.forEach(section => {
-			const df = section.df;
-			if (df && cint(df.hide_border)) {
-				section.hide_border(true);
-			}
-		});
 	},
 
 	attach_doc_and_docfields: function(refresh) {
@@ -610,12 +599,15 @@ frappe.ui.form.Section = Class.extend({
 			if(this.df.cssClass) {
 				this.wrapper.addClass(this.df.cssClass);
 			}
+			if (this.df.hide_border) {
+				this.wrapper.toggleClass("hide-border", true);
+			}
 		}
-
 
 		// for bc
 		this.body = $('<div class="section-body">').appendTo(this.wrapper);
 	},
+
 	make_head: function() {
 		var me = this;
 		if(!this.df.collapsible) {
@@ -674,12 +666,11 @@ frappe.ui.form.Section = Class.extend({
 			}
 		});
 	},
-	hide_border(hide) {
-		this.body.parent().toggleClass("hide-border", hide);
-	},
+
 	is_collapsed() {
 		return this.body.hasClass('hide');
 	},
+
 	has_missing_mandatory: function() {
 		var missing_mandatory = false;
 		for (var j=0, l=this.fields_list.length; j < l; j++) {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -236,6 +236,7 @@ frappe.ui.form.Layout = Class.extend({
 		// collapse sections
 		if(this.frm) {
 			this.refresh_section_collapse();
+			this.refresh_section_border();
 		}
 	},
 
@@ -305,6 +306,16 @@ frappe.ui.form.Layout = Class.extend({
 				section.collapse(collapse);
 			}
 		}
+	},
+
+	refresh_section_border: function() {
+		if(!this.doc) return;
+		this.sections.forEach(section => {
+			const df = section.df;
+			if (df && cint(df.hide_border)) {
+				section.hide_border(true);
+			}
+		})
 	},
 
 	attach_doc_and_docfields: function(refresh) {
@@ -662,6 +673,9 @@ frappe.ui.form.Section = Class.extend({
 				f.refresh();
 			}
 		});
+	},
+	hide_border(hide) {
+		this.body.parent().toggleClass("hide-border", hide);
 	},
 	is_collapsed() {
 		return this.body.hasClass('hide');

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -309,13 +309,13 @@ frappe.ui.form.Layout = Class.extend({
 	},
 
 	refresh_section_border: function() {
-		if(!this.doc) return;
+		if (!this.doc) return;
 		this.sections.forEach(section => {
 			const df = section.df;
 			if (df && cint(df.hide_border)) {
 				section.hide_border(true);
 			}
-		})
+		});
 	},
 
 	attach_doc_and_docfields: function(refresh) {

--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -314,10 +314,19 @@ h6.uppercase, .h6.uppercase {
 	}
 }
 
-.form-section:not(:last-child),
+.hide-border {
+	border-top: none !important;
+	padding-top: 0px;
+}
+
+.form-section:not(:first-child) {
+	border-top: 1px solid @border-color;
+}
+
 .form-inner-toolbar {
 	border-bottom: 1px solid @border-color;
 }
+
 
 .empty-section {
 	display: none !important;


### PR DESCRIPTION
Before:

<img width="1190" alt="Screenshot 2020-04-27 at 4 52 43 PM" src="https://user-images.githubusercontent.com/836784/80367091-1667b500-88a8-11ea-95cb-fe956646df85.png">

After:

<img width="1226" alt="Screenshot 2020-04-27 at 4 53 01 PM" src="https://user-images.githubusercontent.com/836784/80366860-a0634e00-88a7-11ea-826a-216253254a27.png">

[Docs Link](https://github.com/frappe/frappe_io/pull/303)