### PR TITLE
fix: change tooltip document types to type

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -45,7 +45,7 @@ frappe.PermissionEngine = Class.extend({
 	setup_page: function() {
 		var me = this;
 		this.doctype_select
-			= this.wrapper.page.add_select(__("Document Types"),
+			= this.wrapper.page.add_select(__("Document Type"),
 				[{value: "", label: __("Select Document Type")+"..."}].concat(this.options.doctypes))
 				.change(function() {
 					frappe.set_route("permission-manager", $(this).val());


### PR DESCRIPTION
In Role Permissions Manager, the tooltip for document type shows document types. Changed it to document type

![image](https://user-images.githubusercontent.com/50285544/80373189-50d64f80-88b2-11ea-9212-e2aef77f281c.png)
