### PR TITLE
fix(backup): Use fallback dbport if no port is set for a site

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -25,7 +25,7 @@ class BackupGenerator:
 	def __init__(self, db_name, user, password, backup_path_db=None, backup_path_files=None,
 		backup_path_private_files=None, db_host="localhost", db_port=3306):
 		self.db_host = db_host
-		self.db_port = db_port
+		self.db_port = db_port or 3306
 		self.db_name = db_name
 		self.user = user
 		self.password = password


### PR DESCRIPTION
Empty backup was getting generated if there was no port set for a site.

The issue was introduced after https://github.com/frappe/frappe/pull/10097

