### PR TITLE
fix: validate options for Table and Table Multiselect

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -903,6 +903,16 @@ def validate_fields(meta):
 
 				frappe.msgprint(text_str + df_options_str, title="Invalid Data Field", raise_exception=True)
 
+	def check_child_table_option(docfield):
+		if not docfield.fieldtype in ['Table MultiSelect', 'Table']: return
+
+		doctype = docfield.options
+		meta = frappe.get_meta(doctype)
+
+		if not meta.istable:
+			frappe.throw(_('Option {0} for field {1} is not a child table')
+				.format(frappe.bold(doctype), frappe.bold(docfield.fieldname)), title=_("Invalid Option"))
+
 
 	fields = meta.get("fields")
 	fieldname_list = [d.fieldname for d in fields]
@@ -931,6 +941,7 @@ def validate_fields(meta):
 		check_illegal_default(d)
 		check_unique_and_text(meta.get("name"), d)
 		check_illegal_depends_on_conditions(d)
+		check_child_table_option(d)
 		check_table_multiselect_option(d)
 		scrub_options_in_select(d)
 		scrub_fetch_from(d)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -904,7 +904,7 @@ def validate_fields(meta):
 				frappe.msgprint(text_str + df_options_str, title="Invalid Data Field", raise_exception=True)
 
 	def check_child_table_option(docfield):
-		if not docfield.fieldtype in ['Table MultiSelect', 'Table']: return
+		if docfield.fieldtype not in ['Table MultiSelect', 'Table']: return
 
 		doctype = docfield.options
 		meta = frappe.get_meta(doctype)


### PR DESCRIPTION
It is possible right now to add any doctype as an option to child table field. This PR adds a validation to check for the same

![image](https://user-images.githubusercontent.com/18097732/80460543-9b5ad900-8951-11ea-8ee7-138969cdb8e1.png)
