### PR TITLE
fix: update lead if contact details are changed (v12)

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -34,6 +34,7 @@ class Contact(Document):
 		self.set_primary("mobile_no")
 
 		self.set_user()
+		self.update_lead_phone_numbers()
 
 		set_link_title(self)
 
@@ -48,6 +49,28 @@ class Contact(Document):
 	def set_user(self):
 		if not self.user and self.email_id:
 			self.user = frappe.db.get_value("User", {"email": self.email_id})
+
+	def update_lead_phone_numbers(self):
+		if self.phone_nos:
+			contact_lead = self.get_link_for("Lead")
+			if contact_lead:
+				phone = mobile_no = self.phone_nos[0].phone
+
+				if len(self.phone_nos) > 1:
+					# get the default phone number
+					primary_phones = [phone.phone for phone in self.phone_nos if phone.is_primary_phone]
+					if primary_phones:
+						phone = primary_phones[0]
+
+					# get the default mobile number
+					primary_mobile_nos = [phone.phone for phone in self.phone_nos if phone.is_primary_mobile_no]
+					if primary_mobile_nos:
+						mobile_no = primary_mobile_nos[0]
+
+				lead = frappe.get_doc("Lead", contact_lead)
+				lead.phone = phone
+				lead.mobile_no = mobile_no
+				lead.save()
 
 	def get_link_for(self, link_doctype):
 		'''Return the link name, if exists for the given link DocType'''


### PR DESCRIPTION
**Problem:**

In the Lead DocType, we have fields to store its contact's phone information. After they're set, they become hidden, which can lead to outdated Lead reports.

**Solution:**

On saving a Contact linked with a Lead, update the info from Contact into the Lead.