### PR TITLE
fix: Events for web form

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -102,7 +102,9 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	}
 
 	save() {
-		this.validate && this.validate();
+		if (this.validate && !this.validate()) {
+			frappe.throw(__("Couldn't save, please check the data you have entered"), __("Validation"))
+		}
 
 		// validation hack: get_values will check for missing data
 		let doc_values = super.get_values(this.allow_incomplete);

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -103,7 +103,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 	save() {
 		if (this.validate && !this.validate()) {
-			frappe.throw(__("Couldn't save, please check the data you have entered"), __("Validation"))
+			frappe.throw(__("Couldn't save, please check the data you have entered"), __("Validation Error"))
 		}
 
 		// validation hack: get_values will check for missing data

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -29,7 +29,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 		// webform client script
 		frappe.init_client_script && frappe.init_client_script();
-		frappe.web_form.events.trigger('after_load');
+		this.after_load && this.after_load();
 	}
 
 	on(fieldname, handler) {
@@ -134,7 +134,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 				if (!response.exc) {
 					// Success
 					this.handle_success(response.message);
-					frappe.web_form.events.trigger('after_save');
+					this.after_save && this.after_save();
 				}
 			},
 			always: function() {

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -103,7 +103,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 	save() {
 		if (this.validate && !this.validate()) {
-			frappe.throw(__("Couldn't save, please check the data you have entered"), __("Validation Error"))
+			frappe.throw(__("Couldn't save, please check the data you have entered"), __("Validation Error"));
 		}
 
 		// validation hack: get_values will check for missing data


### PR DESCRIPTION
This PR makes the following fixes

1. Explicitly trigger after_load and after_save handlers for web form
1. Explicitly check for return value of validate