### PR TITLE
fix: Add `__unsaved` flag for newly created doc

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -45,6 +45,7 @@ def make_new_doc(doctype):
 	doc = doc.get_valid_dict(sanitize=False)
 	doc["doctype"] = doctype
 	doc["__islocal"] = 1
+	doc["__unsaved"] = 1
 
 	return doc
 

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -36,7 +36,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 				freeze_message: freeze_message
 			});
 		} else {
-			frappe.show_alert({message: __("Document not updated"), indicator: "yellow"});
+			frappe.show_alert({message: __("No changes in document"), indicator: "blue"});
 			$(btn).prop("disabled", false);
 		}
 	};


### PR DESCRIPTION
- Add `__unsaved` flag for a newly created doc to avoid the following issue:

**Before:**
![new_doc_save](https://user-images.githubusercontent.com/13928957/80467448-6d7a9200-895b-11ea-97be-a2ee971d57ae.gif)

**After:**
![new_doc_save_fix](https://user-images.githubusercontent.com/13928957/80467457-723f4600-895b-11ea-9be6-519ea576ab2d.gif)


- Fix message for document save without any changes.
Instead of "Document Not Updated" show "No changes in document" to avoid confusion

![no_doc_change_save_message_fix](https://user-images.githubusercontent.com/13928957/80467681-d104bf80-895b-11ea-9a79-22bb4ce9a33a.gif)

Continuation of https://github.com/frappe/frappe/pull/10094