### PR TITLE
feat: add default custom options to dashboard

### DIFF
--- a/frappe/desk/doctype/dashboard/dashboard.json
+++ b/frappe/desk/doctype/dashboard/dashboard.json
@@ -9,8 +9,12 @@
   "dashboard_name",
   "is_default",
   "charts",
+<<<<<<< HEAD
   "default_chart_custom_options",
   "cards"
+=======
+  "chart_options"
+>>>>>>> fix: better naming
  ],
  "fields": [
   {
@@ -49,7 +53,7 @@
   }
  ],
  "links": [],
- "modified": "2020-04-28 14:17:02.391084",
+ "modified": "2020-04-29 13:26:37.362482",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard",

--- a/frappe/desk/doctype/dashboard/dashboard.json
+++ b/frappe/desk/doctype/dashboard/dashboard.json
@@ -9,6 +9,7 @@
   "dashboard_name",
   "is_default",
   "charts",
+  "default_chart_custom_options",
   "cards"
  ],
  "fields": [
@@ -34,6 +35,13 @@
    "reqd": 1
   },
   {
+    "description": "Set Default Options for all charts on this Dashboard (Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"])",
+    "fieldname": "default_chart_custom_options",
+    "fieldtype": "Code",
+    "label": "Default Chart Custom Options",
+    "options": "JSON"
+  },
+  {
    "fieldname": "cards",
    "fieldtype": "Table",
    "label": "Cards",
@@ -41,7 +49,7 @@
   }
  ],
  "links": [],
- "modified": "2020-04-19 17:44:36.237163",
+ "modified": "2020-04-28 14:17:02.391084",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard",

--- a/frappe/desk/doctype/dashboard/dashboard.json
+++ b/frappe/desk/doctype/dashboard/dashboard.json
@@ -9,12 +9,8 @@
   "dashboard_name",
   "is_default",
   "charts",
-<<<<<<< HEAD
-  "default_chart_custom_options",
+  "chart_options",
   "cards"
-=======
-  "chart_options"
->>>>>>> fix: better naming
  ],
  "fields": [
   {
@@ -40,9 +36,9 @@
   },
   {
     "description": "Set Default Options for all charts on this Dashboard (Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"])",
-    "fieldname": "default_chart_custom_options",
+    "fieldname": "chart_options",
     "fieldtype": "Code",
-    "label": "Default Chart Custom Options",
+    "label": "Chart Options",
     "options": "JSON"
   },
   {

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -22,7 +22,7 @@ class Dashboard(Document):
 			try:
 				json.loads(self.chart_options)
 			except ValueError as error:
-				frappe.throw("Invalid json added in the custom options: %s" % error)
+				frappe.throw(_("Invalid json added in the custom options: %s" % error))
 
 @frappe.whitelist()
 def get_permitted_charts(dashboard_name):

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -19,7 +19,13 @@ def get_permitted_charts(dashboard_name):
 	dashboard = frappe.get_doc('Dashboard', dashboard_name)
 	for chart in dashboard.charts:
 		if frappe.has_permission('Dashboard Chart', doc=chart.chart):
-			permitted_charts.append(chart)
+			chart_dict = frappe._dict()
+			chart_dict.update(chart.as_dict())
+
+			if dashboard.get('default_chart_custom_options'):
+				chart_dict.custom_options = dashboard.get('default_chart_custom_options')
+			permitted_charts.append(chart_dict)
+
 	return permitted_charts
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 from frappe.model.document import Document
 import frappe
+from frappe import _
 import json
 
 class Dashboard(Document):

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -22,8 +22,8 @@ def get_permitted_charts(dashboard_name):
 			chart_dict = frappe._dict()
 			chart_dict.update(chart.as_dict())
 
-			if dashboard.get('default_chart_custom_options'):
-				chart_dict.custom_options = dashboard.get('default_chart_custom_options')
+			if dashboard.get('chart_options'):
+				chart_dict.custom_options = dashboard.get('chart_options')
 			permitted_charts.append(chart_dict)
 
 	return permitted_charts

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 from frappe.model.document import Document
 import frappe
+import json
 
 class Dashboard(Document):
 	def on_update(self):
@@ -12,6 +13,16 @@ class Dashboard(Document):
 			# make all other dashboards non-default
 			frappe.db.sql('''update
 				tabDashboard set is_default = 0 where name != %s''', self.name)
+
+	def validate(self):
+		self.validate_custom_options()
+
+	def validate_custom_options(self):
+		if self.chart_options:
+			try:
+				json.loads(self.chart_options)
+			except ValueError as error:
+				frappe.throw("Invalid json added in the custom options: %s" % error)
 
 @frappe.whitelist()
 def get_permitted_charts(dashboard_name):

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -23,7 +23,7 @@ class Dashboard(Document):
 			try:
 				json.loads(self.chart_options)
 			except ValueError as error:
-				frappe.throw(_("Invalid json added in the custom options: %s" % error))
+				frappe.throw(_("Invalid json added in the custom options: {0}").format(error))
 
 @frappe.whitelist()
 def get_permitted_charts(dashboard_name):

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -219,7 +219,7 @@
    "options": "Dashboard Chart Field"
   },
   {
-   "description": " Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"] (the options set here will override the chart options set in the Dashboard)",
+   "description": "Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"] (the options set here will override the chart options set in the Dashboard)",
    "fieldname": "custom_options",
    "fieldtype": "Code",
    "label": "Custom Options"

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -219,7 +219,7 @@
    "options": "Dashboard Chart Field"
   },
   {
-   "description": " Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"] (the options set here will override the default custom options set in the Dashboard)",
+   "description": " Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"] (the options set here will override the chart options set in the Dashboard)",
    "fieldname": "custom_options",
    "fieldtype": "Code",
    "label": "Custom Options"

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -219,7 +219,7 @@
    "options": "Dashboard Chart Field"
   },
   {
-   "description": "Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"]",
+   "description": " Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"] (the options set here will override the default custom options set in the Dashboard)",
    "fieldname": "custom_options",
    "fieldtype": "Code",
    "label": "Custom Options"

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -442,4 +442,4 @@ class DashboardChart(Document):
 			try:
 				json.loads(self.custom_options)
 			except ValueError as error:
-				frappe.throw(_("Invalid json added in the custom options: %s" % error))
+				frappe.throw(_("Invalid json added in the custom options: {0}").format(error))

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -435,11 +435,11 @@ class DashboardChart(Document):
 
 	def check_document_type(self):
 		if frappe.get_meta(self.document_type).issingle:
-			frappe.throw("You cannot create a dashboard chart from single DocTypes")
+			frappe.throw(_("You cannot create a dashboard chart from single DocTypes"))
 
 	def validate_custom_options(self):
 		if self.custom_options:
 			try:
 				json.loads(self.custom_options)
 			except ValueError as error:
-				frappe.throw("Invalid json added in the custom options: %s" % error)
+				frappe.throw(_("Invalid json added in the custom options: %s" % error))

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -523,7 +523,6 @@ export default class ChartWidget extends Widget {
 		}
 	}
 
-
 	get_chart_args() {
 		let colors = this.get_chart_colors();
 
@@ -551,6 +550,21 @@ export default class ChartWidget extends Widget {
 			const heatmap_year = parseInt(this.selected_heatmap_year || this.chart_settings.heatmap_year || this.chart_doc.heatmap_year);
 			chart_args.data.start = new Date(`${heatmap_year}-01-01`);
 			chart_args.data.end = new Date(`${heatmap_year+1}-01-01`);
+		}
+
+		let set_options = (options) => {
+			let custom_options = JSON.parse(options);
+			for (let key in custom_options) {
+				chart_args[key] = custom_options[key];
+			}
+		};
+
+		if (this.custom_options) {
+			set_options(this.custom_options);
+		}
+
+		if (this.chart_doc.custom_options) {
+			set_options(this.chart_doc.custom_options);
 		}
 
 		return chart_args;
@@ -591,59 +605,6 @@ export default class ChartWidget extends Widget {
 				`);
 			this.body.append(this.$heatmap_legend);
 		}
-	}
-
-	get_chart_args() {
-		let colors = this.get_chart_colors();
-
-		const chart_type_map = {
-			Line: "line",
-			Bar: "bar",
-			Percentage: "percentage",
-			Pie: "pie",
-			Donut: "donut"
-		};
-
-		let chart_args = {
-			data: this.data,
-			type: chart_type_map[this.chart_doc.type],
-			colors: colors,
-			height: this.height,
-			axisOptions: {
-				xIsSeries: this.chart_doc.timeseries,
-				shortenYAxisNumbers: 1
-			}
-		};
-
-		let set_options = (options) => {
-			let custom_options = JSON.parse(options);
-			for (let key in custom_options) {
-				chart_args[key] = custom_options[key];
-			}
-		};
-
-		if (this.custom_options) {
-			set_options(this.custom_options);
-		}
-
-		if (this.chart_doc.custom_options) {
-			set_options(this.chart_doc.custom_options);
-		}
-
-		return chart_args;
-	}
-
-	get_chart_colors() {
-		let colors = [];
-		if (this.chart_doc.y_axis.length) {
-			this.chart_doc.y_axis.map(field => {
-				colors.push(field.color);
-			});
-		} else if (["Line", "Bar"].includes(this.chart_doc.type)) {
-			colors = [this.chart_doc.color || "light-blue"];
-		}
-
-		return colors;
 	}
 
 	update_last_synced() {

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -593,6 +593,59 @@ export default class ChartWidget extends Widget {
 		}
 	}
 
+	get_chart_args() {
+		let colors = this.get_chart_colors();
+
+		const chart_type_map = {
+			Line: "line",
+			Bar: "bar",
+			Percentage: "percentage",
+			Pie: "pie",
+			Donut: "donut"
+		};
+
+		let chart_args = {
+			data: this.data,
+			type: chart_type_map[this.chart_doc.type],
+			colors: colors,
+			height: this.height,
+			axisOptions: {
+				xIsSeries: this.chart_doc.timeseries,
+				shortenYAxisNumbers: 1
+			}
+		};
+
+		let set_options = (options) => {
+			let custom_options = JSON.parse(options);
+			for (let key in custom_options) {
+				chart_args[key] = custom_options[key];
+			}
+		};
+
+		if (this.custom_options) {
+			set_options(this.custom_options);
+		}
+
+		if (this.chart_doc.custom_options) {
+			set_options(this.chart_doc.custom_options);
+		}
+
+		return chart_args;
+	}
+
+	get_chart_colors() {
+		let colors = [];
+		if (this.chart_doc.y_axis.length) {
+			this.chart_doc.y_axis.map(field => {
+				colors.push(field.color);
+			});
+		} else if (["Line", "Bar"].includes(this.chart_doc.type)) {
+			colors = [this.chart_doc.color || "light-blue"];
+		}
+
+		return colors;
+	}
+
 	update_last_synced() {
 		let last_synced_text = __("Last synced {0}", [
 			comment_when(this.chart_doc.last_synced_on)


### PR DESCRIPTION
Added default custom options to Dashboard so that custom options don't need to be set individually for each chart. If set for a chart, the chart options will override the dashboard options.
