### PR TITLE
fix: do not check for frappe.conf.monitor while stopping monitor

### DIFF
--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -23,7 +23,7 @@ def start(transaction_type="request", method=None, kwargs=None):
 
 
 def stop(response=None):
-	if frappe.conf.monitor and hasattr(frappe.local, "monitor"):
+	if hasattr(frappe.local, "monitor"):
 		frappe.local.monitor.dump(response)
 
 


### PR DESCRIPTION
```
[2020-04-28 03:27:26 +0300] [2664] [ERROR] Error handling request /
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 53, in application
    init_request(request)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 108, in init_request
    frappe.init(site=site, sites_path=_sites_path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 150, in init
    local.conf = _dict(get_site_config())
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 224, in get_site_config
    sys.exit(1)
SystemExit: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 72, in __getattr__
    return self.__storage__[self.__ident_func__()][name]
KeyError: 'conf'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 309, in _get_current_object
    return getattr(self.__local, self.__name__)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 74, in __getattr__
    raise AttributeError(name)
AttributeError: conf

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 231, in application
    return ClosingIterator(app(environ, start_response), self.cleanup)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/wrappers/base_request.py", line 237, in application
    resp = f(*args[:-2] + (request,))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 96, in application
    frappe.monitor.stop(response)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/monitor.py", line 26, in stop
    if frappe.conf.monitor and hasattr(frappe.local, "monitor"):
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 348, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 311, in _get_current_object
    raise RuntimeError("no object bound to %s" % self.__name__)
RuntimeError: no object bound to conf

```