### PR TITLE
perf: Cache get_tables values

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -776,7 +776,7 @@ class Database(object):
 				FROM information_schema.tables
 				WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
 			""")
-			tables = set([d[0] for d in table_rows])
+			tables = set(d[0] for d in table_rows)
 		frappe.cache().set_value('db_tables', tables)
 		return tables
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -769,7 +769,16 @@ class Database(object):
 		return ("tab" + doctype) in self.get_tables()
 
 	def get_tables(self):
-		return [d[0] for d in self.sql("select table_name from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema')")]
+		tables = frappe.cache().get_value('db_tables')
+		if not tables:
+			table_rows = self.sql("""
+				SELECT table_name
+				FROM information_schema.tables
+				WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+			""")
+			tables = set([d[0] for d in table_rows])
+		frappe.cache().set_value('db_tables', tables)
+		return tables
 
 	def a_row_exists(self, doctype):
 		"""Returns True if atleast one row exists."""

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -31,6 +31,7 @@ class DBTable:
 
 	def sync(self):
 		if self.is_new():
+			frappe.cache().delete_key('db_tables')
 			self.create()
 		else:
 			frappe.cache().hdel('table_columns', self.table_name)

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -144,10 +144,9 @@ class DBTable:
 					if max_length and max_length[0][0] and max_length[0][0] > new_length:
 						if col.fieldname in self.columns:
 							self.columns[col.fieldname].length = current_length
-
-						frappe.msgprint(_("""Reverting length to {0} for '{1}' in '{2}';
-							Setting the length as {3} will cause truncation of data.""")
-							.format(current_length, col.fieldname, self.doctype, new_length))
+						info_message = _("Reverting length to {0} for '{1}' in '{2}'. Setting the length as {3} will cause truncation of data.") \
+							.format(current_length, col.fieldname, self.doctype, new_length)
+						frappe.msgprint(info_message)
 
 	def is_new(self):
 		return self.table_name not in frappe.db.get_tables()


### PR DESCRIPTION
- To avoid redundant DB calls

Difference for the same query
**Before**
<img width="887" alt="Screenshot 2020-04-29 at 12 51 51 PM" src="https://user-images.githubusercontent.com/13928957/80570627-c5c39980-8a18-11ea-91d6-434232f2ca50.png">

**After**
<img width="877" alt="Screenshot 2020-04-29 at 12 53 57 PM" src="https://user-images.githubusercontent.com/13928957/80570864-310d6b80-8a19-11ea-9e30-a0f1f54ff277.png">


port-of: https://github.com/frappe/frappe/pull/10147