### PR TITLE
fix: Only show "No changes in document" if form is not dirty

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -36,7 +36,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 				freeze_message: freeze_message
 			});
 		} else {
-			frappe.show_alert({message: __("No changes in document"), indicator: "blue"});
+			!frm.is_dirty() && frappe.show_alert({message: __("No changes in document"), indicator: "blue"});
 			$(btn).prop("disabled", false);
 		}
 	};


### PR DESCRIPTION
It used to show "No changes in document" alert even for mandatory check failure.

Continuation of: https://github.com/frappe/frappe/pull/10138