### PR TITLE
fix: make arrow on select box clickable

### DIFF
--- a/frappe/public/less/controls.less
+++ b/frappe/public/less/controls.less
@@ -162,6 +162,6 @@
 		top: 8px;
 		height: 15px;
 		right: 12px;
-		top: 8px;
+		pointer-events: none;
 	}
 }


### PR DESCRIPTION
Made arrow on select box clickable by setting `pointer-events: none;`

**Before:**
![select arrow bug](https://user-images.githubusercontent.com/19775888/80675190-7c835080-8ad1-11ea-90b6-4cb0d3aa00f6.gif)


**After:**
![select arrow](https://user-images.githubusercontent.com/19775888/80675070-2e6e4d00-8ad1-11ea-9541-03ddaff32d84.gif)
