### PR TITLE
fix: set number as 0 if None

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -67,7 +67,7 @@ def get_result(doc, to_date=None):
 	res = frappe.db.get_all(doc.document_type, fields=fields, filters=filters)
 	number = res[0]['result'] if res else 0
 
-	return number
+	return number or 0
 
 @frappe.whitelist()
 def get_percentage_difference(doc, result):

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
+from frappe.utils import cint
 
 class NumberCard(Document):
 	pass

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -67,7 +67,7 @@ def get_result(doc, to_date=None):
 	res = frappe.db.get_all(doc.document_type, fields=fields, filters=filters)
 	number = res[0]['result'] if res else 0
 
-	return number or 0
+	return cint(number)
 
 @frappe.whitelist()
 def get_percentage_difference(doc, result):
@@ -141,4 +141,3 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 		search_conditions=search_conditions,
 		conditions=conditions
 	), values)
-


### PR DESCRIPTION
Return 0 if query returns no result for Number Card `get_number`