### PR TITLE
fix: patch set_existing_dashboard_charts_as_public

### DIFF
--- a/frappe/patches/v13_0/set_existing_dashboard_charts_as_public.py
+++ b/frappe/patches/v13_0/set_existing_dashboard_charts_as_public.py
@@ -1,7 +1,7 @@
 import frappe
 
 def execute():
-	frappe.reload_doctype('Dashboard Chart')
+	frappe.reload_doc('desk', 'doctype', 'dashboard_chart')
 
 	if not frappe.db.table_exists('Dashboard Chart'):
 		return


### PR DESCRIPTION
**Issue**

```
Executing frappe.patches.v13_0.set_existing_dashboard_charts_as_public in test_site (test_frappe)
Traceback (most recent call last):
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.14/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 252, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 49, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v13_0/set_existing_dashboard_charts_as_public.py", line 4, in execute
    frappe.reload_doctype('Dashboard Chart')
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 812, in reload_doctype
    reload_doc(scrub(db.get_value("DocType", doctype, "module")), "doctype", scrub(doctype),
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 846, in scrub
    return txt.replace(' ', '_').replace('-', '_').lower()
AttributeError: 'NoneType' object has no attribute 'replace'
Exception AttributeError: "'NoneType' object has no attribute 'error'" in <bound method Connection.__del__ of Connection<host=localhost,port=13000,db=0>> ignored
```