### PR TITLE
fix: Clear db_tables cache whenever a table is created or dropped

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -16,7 +16,7 @@ global_cache_keys = ("app_hooks", "installed_apps",
 		'scheduler_events', 'time_zone', 'webhooks', 'active_domains',
 		'active_modules', 'assignment_rule', 'server_script_map', 'wkhtmltopdf_version',
 		'domain_restricted_doctypes', 'domain_restricted_pages', 'information_schema:counts',
-		'sitemap_routes')
+		'sitemap_routes', 'db_tables')
 
 user_cache_keys = ("bootinfo", "user_recent", "roles", "user_doc", "lang",
 		"defaults", "user_permissions", "home_page", "linked_with",

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -124,6 +124,8 @@ class Database(object):
 		# in transaction validations
 		self.check_transaction_status(query)
 
+		self.clear_db_table_cache(query)
+
 		# autocommit
 		if auto_commit: self.commit()
 
@@ -276,6 +278,11 @@ class Database(object):
 
 			ret.append(frappe._dict(zip(keys, values)))
 		return ret
+
+	@staticmethod
+	def clear_db_table_cache(query):
+		if query and query.strip().split()[0].lower() in {'drop', 'create'}:
+			frappe.cache().delete_key('db_tables')
 
 	@staticmethod
 	def needs_formatting(result, formatted):

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -31,7 +31,6 @@ class DBTable:
 
 	def sync(self):
 		if self.is_new():
-			frappe.cache().delete_key('db_tables')
 			self.create()
 		else:
 			frappe.cache().hdel('table_columns', self.table_name)


### PR DESCRIPTION
Clear db_tables cache whenever a table is created or dropped because tables can be created or dropped directly via SQL.