### PR TITLE
fix: Clear db_tables cache whenever a table is created or dropped

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -16,7 +16,7 @@ global_cache_keys = ("app_hooks", "installed_apps",
 		'scheduler_events', 'time_zone', 'webhooks', 'active_domains',
 		'active_modules', 'assignment_rule', 'server_script_map', 'wkhtmltopdf_version',
 		'domain_restricted_doctypes', 'domain_restricted_pages', 'information_schema:counts',
-		'sitemap_routes')
+		'sitemap_routes', 'db_tables')
 
 user_cache_keys = ("bootinfo", "user_recent", "roles", "user_doc", "lang",
 		"defaults", "user_permissions", "home_page", "linked_with",

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -124,6 +124,8 @@ class Database(object):
 		# in transaction validations
 		self.check_transaction_status(query)
 
+		self.clear_db_table_cache(query)
+
 		# autocommit
 		if auto_commit: self.commit()
 
@@ -276,6 +278,11 @@ class Database(object):
 
 			ret.append(frappe._dict(zip(keys, values)))
 		return ret
+
+	@staticmethod
+	def clear_db_table_cache(query):
+		if query and query.strip().split()[0].lower() in {'drop', 'create'}:
+			frappe.cache().delete_key('db_tables')
 
 	@staticmethod
 	def needs_formatting(result, formatted):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -784,7 +784,7 @@ class Database(object):
 				WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
 			""")
 			tables = set(d[0] for d in table_rows)
-		frappe.cache().set_value('db_tables', tables)
+			frappe.cache().set_value('db_tables', tables)
 		return tables
 
 	def a_row_exists(self, doctype):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -783,7 +783,7 @@ class Database(object):
 				FROM information_schema.tables
 				WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
 			""")
-			tables = set(d[0] for d in table_rows)
+			tables = {d[0] for d in table_rows}
 			frappe.cache().set_value('db_tables', tables)
 		return tables
 

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -31,7 +31,6 @@ class DBTable:
 
 	def sync(self):
 		if self.is_new():
-			frappe.cache().delete_key('db_tables')
 			self.create()
 		else:
 			frappe.cache().hdel('table_columns', self.table_name)

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -137,8 +137,7 @@ class DBTable:
 						if frappe.db.is_missing_column(e):
 							# Unknown column 'column_name' in 'field list'
 							continue
-						else:
-							raise
+						raise
 
 					if max_length and max_length[0][0] and max_length[0][0] > new_length:
 						if col.fieldname in self.columns:


### PR DESCRIPTION
Clear db_tables cache whenever a table is created or dropped because tables can be created or dropped directly via SQL.

port-of: https://github.com/frappe/frappe/pull/10176