### PR TITLE
fix: check for self linking and circular linking while getting submitted linked docs

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -13,7 +13,7 @@ from frappe.modules import load_doctype_module
 
 
 @frappe.whitelist()
-def get_submitted_linked_docs(doctype, name, docs=None):
+def get_submitted_linked_docs(doctype, name, docs=None, linked=None):
 	"""
 	Get all nested submitted linked doctype linkinfo
 
@@ -31,12 +31,23 @@ def get_submitted_linked_docs(doctype, name, docs=None):
 	if not docs:
 		docs = []
 
+	if not linked:
+		linked = {}
+
 	linkinfo = get_linked_doctypes(doctype)
 	linked_docs = get_linked_docs(doctype, name, linkinfo)
 
 	link_count = 0
 	for link_doctype, link_names in linked_docs.items():
+		if link_doctype not in linked:
+			linked[link_doctype] = []
+
 		for link in link_names:
+			if linked and name in linked[link_doctype]:
+				continue
+
+			linked[link_doctype].append(link['name'])
+
 			docinfo = link.update({"doctype": link_doctype})
 			validated_doc = validate_linked_doc(docinfo)
 
@@ -47,7 +58,7 @@ def get_submitted_linked_docs(doctype, name, docs=None):
 			if link.name in [doc.get("name") for doc in docs]:
 				continue
 
-			links = get_submitted_linked_docs(link_doctype, link.name, docs)
+			links = get_submitted_linked_docs(link_doctype, link.name, docs, linked)
 			docs.append({
 				"doctype": link_doctype,
 				"name": link.name,


### PR DESCRIPTION
Prevents infinite recursion that was occurring due to documents being linked to themselves.

