### PR TITLE
chore: update frappe charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cssnano": "^4.1.10",
     "express": "^4.17.1",
     "fast-deep-equal": "^2.0.1",
-    "frappe-charts": "^1.3.0",
+    "frappe-charts": "^1.3.2",
     "frappe-datatable": "^1.15.1",
     "frappe-gantt": "^0.1.0",
     "fuse.js": "^3.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,10 +2304,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-frappe-charts@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.3.0.tgz#9ed033fa64833906bba16554187fa2f8a3a54ef6"
-  integrity sha512-hdLv4fOIVgIL5eV9KYlsQaEpxkcJvuEVVDJewJL8PG0ySPy5EEiG5KZGL2uj7YegVWbtsqJ4Oq/74mjgQoMdag==
+frappe-charts@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.3.2.tgz#28b26637f03efeb86a07a2a9180c0ef2d5f52c56"
+  integrity sha512-9VscidL7TUxgnI8dM+s0WIphnthUsDwnknHFnUH1zsISWzuw1FEUd2v29cn+E1+eNlD1a0bNBd+rJPtMdMnnvQ==
 
 frappe-datatable@^1.15.1:
   version "1.15.1"


### PR DESCRIPTION
Update frappe charts to 1.3.2 