### PR TITLE
fix: check for self linking

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -43,6 +43,9 @@ def get_submitted_linked_docs(doctype, name, docs=None, linked=None):
 			linked[link_doctype] = []
 
 		for link in link_names:
+			if link['name'] == name:
+				continue
+
 			if linked and name in linked[link_doctype]:
 				continue
 


### PR DESCRIPTION
Check for self linking while getting linked submitted docs for a document