### PR TITLE
fix: record home page

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -274,3 +274,4 @@ frappe.patches.v12_0.remove_parent_and_parenttype_from_print_formats
 execute:from frappe.desk.page.setup_wizard.install_fixtures import update_genders;update_genders()
 frappe.patches.v13_0.website_theme_custom_scss
 frappe.patches.v13_0.set_existing_dashboard_charts_as_public
+frappe.patches.v13_0.set_path_for_homepage_in_web_page_view

--- a/frappe/patches/v13_0/set_path_for_homepage_in_web_page_view.py
+++ b/frappe/patches/v13_0/set_path_for_homepage_in_web_page_view.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+	frappe.reload_doctype('Web Page View')
+	frappe.db.sql("""UPDATE `tabWeb Page View` set path="/" where path=''""")

--- a/frappe/website/doctype/web_page_view/web_page_view.py
+++ b/frappe/website/doctype/web_page_view/web_page_view.py
@@ -19,7 +19,7 @@ def make_view_log(path, referrer=None, browser=None, version=None, url=None, use
 	if referrer.startswith(url):
 		is_unique = False
 
-	if path.startswith('/'):
+	if path != "/" and path.startswith('/'):
 		path = path[1:]
 
 	if is_tracking_enabled():


### PR DESCRIPTION
On home page the path that is sent is `/` 
Previously we would clean up the path by removing the starting `/`. This would make `path` entry for home page logs empty.

This PR fixes it for home page