### PR TITLE
fix(webhooks): error message on invalid json

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -60,6 +60,7 @@ class Webhook(Document):
 			if self.request_structure == "Form URL-Encoded":
 				self.webhook_json = None
 			elif self.request_structure == "JSON":
+				validate_json(self.webhook_json)
 				validate_template(self.webhook_json)
 				self.webhook_data = []
 
@@ -130,3 +131,10 @@ def get_webhook_data(doc, webhook):
 		data = json.loads(data)
 
 	return data
+
+
+def validate_json(string):
+	try:
+		json.loads(string)
+	except:
+		frappe.throw(_("Request Body consists of an invalid JSON structure"))

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -136,5 +136,5 @@ def get_webhook_data(doc, webhook):
 def validate_json(string):
 	try:
 		json.loads(string)
-	except:
-		frappe.throw(_("Request Body consists of an invalid JSON structure"))
+	except (TypeError, ValueError):
+		frappe.throw(_("Request Body consists of an invalid JSON structure"), title=_("Invalid JSON"))


### PR DESCRIPTION
An empty `webhook_json` field would throw
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 893, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 794, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 1064, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 1047, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/model/document.py", line 788, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 25, in validate
    self.validate_request_body()
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 58, in validate_request_body
    validate_template(self.webhook_json)
  File "/home/frappe/benches/bench-version-12-2020-04-17/apps/frappe/frappe/utils/jinja.py", line 51, in validate_template
    jenv.from_string(html)
  File "/home/frappe/benches/bench-version-12-2020-04-17/env/lib/python3.6/site-packages/jinja2/environment.py", line 880, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/home/frappe/benches/bench-version-12-2020-04-17/env/lib/python3.6/site-packages/jinja2/environment.py", line 581, in compile
    defer_init=defer_init)
  File "/home/frappe/benches/bench-version-12-2020-04-17/env/lib/python3.6/site-packages/jinja2/environment.py", line 543, in _generate
    optimized=self.optimized)
  File "/home/frappe/benches/bench-version-12-2020-04-17/env/lib/python3.6/site-packages/jinja2/compiler.py", line 78, in generate
    raise TypeError('Can\'t compile non template nodes')
TypeError: Can't compile non template nodes
```

A validation has been added to throw a "better" error message


![Screenshot 2020-05-01 at 2 23 30 PM](https://user-images.githubusercontent.com/36654812/80794350-5c2dc180-8bb7-11ea-832b-8a4c03e49c8f.png)