### PR TITLE
fix: Number Card improvements

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -227,12 +227,11 @@
    "description": "This chart will be public to all Users if this is set",
    "fieldname": "is_public",
    "fieldtype": "Check",
-   "label": "Is Public",
-   "permlevel": 1
+   "label": "Is Public"
   }
  ],
  "links": [],
- "modified": "2020-04-23 13:01:07.178866",
+ "modified": "2020-05-01 15:22:03.640602",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -224,14 +224,14 @@
   },
   {
    "default": "0",
-   "description": "This chart will be public to all Users if this is set",
+   "description": "This chart will be available to all Users if this is set",
    "fieldname": "is_public",
    "fieldtype": "Check",
    "label": "Is Public"
   }
  ],
  "links": [],
- "modified": "2020-05-01 15:22:03.640602",
+ "modified": "2020-05-01 15:22:59.119341",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -72,7 +72,7 @@
   },
   {
    "default": "0",
-   "description": "This card will be public to all Users if this is set",
+   "description": "This card will be available to all Users if this is set",
    "fieldname": "is_public",
    "fieldtype": "Check",
    "label": "Is Public"
@@ -99,7 +99,7 @@
   }
  ],
  "links": [],
- "modified": "2020-05-01 11:10:20.788844",
+ "modified": "2020-05-01 15:23:29.550243",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -44,13 +44,11 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 				<div class="text-muted uppercase">${dashboard_name}</div>
 				<div class="text-muted customize-dashboard" data-action="customize">${__('Customize')}</div>
 				<div class="small text-muted customize-options small-bounce">
-					<span class="reset-customization" data-action="reset_dashboard_customization">
-						${__('Reset')}
-					</span> / <span class="save-customization" data-action="save_dashboard_customization">
-						${__('Save')}
-					</span> / <span class="discard-customization" data-action="discard_dashboard_customization">
-						${__('Discard')}
-					</span>
+					<span class="reset-customization customize-option" data-action="reset_dashboard_customization">${__('Reset')}</span>
+					<span> / </span>
+					<span class="save-customization customize-option" data-action="save_dashboard_customization">${__('Save')}</span>
+					<span> / </span>
+					<span class="discard-customization customize-option" data-action="discard_dashboard_customization">${__('Discard')}</span>
 				</div>
 			</div>`);
 

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -24,6 +24,7 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 		this.setup_dashboard_page();
 		this.setup_dashboard_customization();
 		this.make_dashboard();
+		this.setup_events();
 	}
 
 	setup_dashboard_customization() {
@@ -103,13 +104,11 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 		if (!this.charts.length && !this.number_cards.length) {
 			this.render_empty_state();
 		}
-
-		this.setup_events();
 	}
 
 	setup_events() {
-		$(document.body).on('toggleFullWidth', () => this.make_dashboard());
-		$(document.body).on('toggleListSidebar', () => this.make_dashboard());
+		$(document.body).on('toggleFullWidth', () => this.render_dashboard());
+		$(document.body).on('toggleListSidebar', () => this.render_dashboard());
 	}
 
 	fetch_dashboard_items(doctype, filters, obj_name) {

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -228,12 +228,14 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 	}
 
 	reset_dashboard_customization() {
-		this.dashboard_settings = null;
-		frappe.model.user_settings.save(
-			this.doctype, 'dashboard_settings', this.dashboard_settings
-		).then(() => this.make_dashboard());
+		frappe.confirm(__("Are you sure you want to reset all customizations?"), () => {
+			this.dashboard_settings = null;
+			frappe.model.user_settings.save(
+				this.doctype, 'dashboard_settings', this.dashboard_settings
+			).then(() => this.make_dashboard());
 
-		this.toggle_customize(false);
+			this.toggle_customize(false);
+		});
 	}
 
 	toggle_customize(show) {

--- a/frappe/public/less/dashboard_view.less
+++ b/frappe/public/less/dashboard_view.less
@@ -38,6 +38,10 @@
         .customize-options {
             display: none;
             cursor: pointer;
+
+            .customize-option:hover {
+                text-decoration: underline;
+            }
         }
     }
 }

--- a/frappe/public/less/desktop.less
+++ b/frappe/public/less/desktop.less
@@ -433,8 +433,9 @@
 				justify-content: space-between;
 
 				.number {
-					font-size: 25px;
-					line-height: 2em;
+					font-weight: 600;
+   				 	font-size: 26px;
+    				line-height: 1.8em;
 				}
 
 				.number-text {

--- a/frappe/public/less/desktop.less
+++ b/frappe/public/less/desktop.less
@@ -434,8 +434,8 @@
 
 				.number {
 					font-weight: 600;
-   				 	font-size: 26px;
-    				line-height: 1.8em;
+					font-size: 26px;
+					line-height: 1.8em;
 				}
 
 				.number-text {


### PR DESCRIPTION
- Underline customize options on hover

- Confirm before resetting customizations

- Increase font-weight of number to highlight it more:
<img width="1292" alt="Screenshot 2020-05-01 at 2 36 45 PM" src="https://user-images.githubusercontent.com/19775888/80795106-36092100-8bb9-11ea-8f30-1bd2eecbe7a7.png">

- change permlevel of `is_public` in Dashboard Chart to 0

- fix description of `is_public` field