### PR TITLE
fix: Date Range for Dashboard Charts

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -76,7 +76,7 @@ def get(chart_name = None, chart = None, no_cache = None, filters = None, from_d
 		if to_date and len(to_date):
 			to_date = get_datetime(to_date)
 		else:
-			to_date = chart.to_date
+			to_date = get_datetime(chart.to_date)
 
 	timegrain = time_interval or chart.time_interval
 	filters = frappe.parse_json(filters) or frappe.parse_json(chart.filters_json) or []


### PR DESCRIPTION
Dashboard charts with Timespan set as Select Date Range were not working
