### PR TITLE
feat: disable onboarding pop-up

### DIFF
--- a/frappe/change_log/v13/v13_0_0_beta_1.md
+++ b/frappe/change_log/v13/v13_0_0_beta_1.md
@@ -5,7 +5,6 @@
 - New Desk ([#9617](https://github.com/frappe/frappe/pull/9617))
 - Child table pagination ([#8786](https://github.com/frappe/frappe/pull/8786))
 - Events Streaming ([#8567](https://github.com/frappe/frappe/pull/8567))
-- Onboarding Wizard with configurable slides ([#8880](https://github.com/frappe/frappe/pull/8880))
 
 ### Dashboard Enhancements
 

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -96,10 +96,6 @@ frappe.Application = Class.extend({
 
 		this.show_notes();
 
-		if (frappe.boot.is_first_startup) {
-			this.setup_onboarding_wizard();
-		}
-
 		if (frappe.ui.startup_setup_dialog && !frappe.boot.setup_complete) {
 			frappe.ui.startup_setup_dialog.pre_show();
 			frappe.ui.startup_setup_dialog.show();


### PR DESCRIPTION
This PR disables onboarding pop on first start up

Current implementation is going to be replaced by https://github.com/frappe/frappe/pull/10194 and will be released in the next cycle