### PR TITLE
fix: '>' not supported between instances of 'int' and 'NoneType'

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -123,7 +123,7 @@ class Contact(Document):
 def get_default_contact(doctype, name):
 	'''Returns default contact for the given doctype, name'''
 	out = frappe.db.sql('''select parent,
-			(select is_primary_contact from tabContact c where c.name = dl.parent)
+			IFNULL((select is_primary_contact from tabContact c where c.name = dl.parent), 0)
 				as is_primary_contact
 		from
 			`tabDynamic Link` dl


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/__init__.py", line 1055, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/accounts/party.py", line 34, in get_party_details
    fetch_payment_terms_template, party_address, company_address, shipping_address, pos_profile)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/accounts/party.py", line 50, in _get_party_details
    set_contact_details(party_details, party, party_type)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/accounts/party.py", line 120, in set_contact_details
    party_details.contact_person = get_default_contact(party_type, party.name)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/contacts/doctype/contact/contact.py", line 134, in get_default_contact
    return sorted(out, key = functools.cmp_to_key(lambda x,y: cmp(y[1], x[1])))[0][0]
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/contacts/doctype/contact/contact.py", line 134, in 
    return sorted(out, key = functools.cmp_to_key(lambda x,y: cmp(y[1], x[1])))[0][0]
  File "/home/frappe/benches/bench-version-12-2020-04-23/env/lib/python3.6/site-packages/past/builtins/misc.py", line 33, in cmp
    return (x > y) - (x < y)
TypeError: '>' not supported between instances of 'int' and 'NoneType'
```