### PR TITLE
chore: Drop Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,6 @@ matrix:
     - bench --site test_site_producer execute frappe.utils.install.complete_setup_wizard
     script: bench --site test_site run-ui-tests frappe --headless
 
-  - name: "Python 2.7 MariaDB"
-    python: 2.7
-    env: DB=mariadb TYPE=server
-    script: bench --site test_site run-tests --coverage
-
 before_install:
   # install wkhtmltopdf
   - wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz


### PR DESCRIPTION
Drop Python2 support
https://discuss.erpnext.com/t/dropping-python-2-support-for-frappe-framework/61159