### PR TITLE
fix(patch): Do not set contribution_docname

### DIFF
--- a/frappe/patches/v13_0/migrate_translation_column_data.py
+++ b/frappe/patches/v13_0/migrate_translation_column_data.py
@@ -7,7 +7,6 @@ def execute():
 			SET
 				translated_text=target_name,
 				source_text=source_name,
-				contribution_docname=contributed_translation_doctype_name,
 				contribution_status=(CASE status
 					WHEN 'Deleted' THEN 'Rejected'
 					ELSE ''


### PR DESCRIPTION
Do not set contribution_docname because it will not exist in the new translation server

fixes: https://github.com/frappe/frappe/pull/9636#issuecomment-623352891
