### PR TITLE
perf: Add HTTP Link header for preload hints

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -7,8 +7,10 @@ from frappe import _
 import frappe.sessions
 from frappe.utils import cstr
 import os, mimetypes, json
+import re
 
 import six
+from bs4 import BeautifulSoup
 from six import iteritems
 from werkzeug.wrappers import Response
 from werkzeug.routing import Map, Rule, NotFound
@@ -128,11 +130,34 @@ def build_response(path, data, http_status_code, headers=None):
 	response.headers["X-Page-Name"] = path.encode("ascii", errors="xmlcharrefreplace")
 	response.headers["X-From-Cache"] = frappe.local.response.from_cache or False
 
+	add_preload_headers(response)
 	if headers:
 		for key, val in iteritems(headers):
 			response.headers[key] = val.encode("ascii", errors="xmlcharrefreplace")
 
 	return response
+
+
+def add_preload_headers(response):
+	try:
+		preload = []
+		soup = BeautifulSoup(response.data, "lxml")
+		for elem in soup.find_all('script', src=re.compile(".*")):
+			preload.append(("script", elem.get("src")))
+
+		for elem in soup.find_all('link', rel="stylesheet"):
+			preload.append(("style", elem.get("href")))
+
+		links = []
+		for type, link in preload:
+			links.append("</{}>; rel=preload; as={}".format(link.lstrip("/"), type))
+
+		if links:
+			response.headers["Link"] = ",".join(links)
+	except Exception:
+		import traceback
+		traceback.print_exc()
+
 
 def render_page_by_language(path):
 	translated_languages = frappe.get_hooks("translated_languages_for_website")


### PR DESCRIPTION
Parse rendered templates to find stylesheet and script files, add these files to the HTTP Link header.

In the case of HTTP 1.1 browser can fetch these resources before parsing the DOM.
In the case of HTTP 2.0 NGINX can use HTTP2 Server Push (`http2_push_preload on;`).

#### Before
**HTTP 1.1 without preload hints**
![http1 1-nopreload](https://user-images.githubusercontent.com/8528887/81038708-a3bc9200-8ec4-11ea-88f7-f007f14f00a3.png)

#### After
**HTTP 1.1 with preload hints**
![http1 1-preload](https://user-images.githubusercontent.com/8528887/81038714-a9b27300-8ec4-11ea-8b92-06cd5e8c56a1.png)

**HTTP 2 with preload hints with Server Push**
![http2-preload-push](https://user-images.githubusercontent.com/8528887/81038754-c9e23200-8ec4-11ea-9fd5-b1e985094558.png)


**Note:** Use `listen ssl http2;` and`http2_push_preload on;` to enable Server Push on NGINX.

**Note:** **Finish**, **DomContentLoaded** and **Load** times show significant variation on repeated runs. To replicate, use production setup.

Reference: https://www.w3.org/TR/preload/