### PR TITLE
fix: replace font tag with span in quill editor

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -54,6 +54,22 @@ Quill.register(FontStyle, true);
 Quill.register(AlignStyle, true);
 Quill.register(DirectionStyle, true);
 
+// replace font tag with span
+const Inline = Quill.import('blots/inline');
+
+class CustomColor extends Inline {
+	constructor(domNode, value) {
+		super(domNode, value);
+		this.domNode.style.color = this.domNode.color;
+		domNode.outerHTML = this.domNode.outerHTML.replace(/<font/g, '<span').replace(/<\/font>/g, '</span>');
+	}
+}
+
+CustomColor.blotName = "customColor";
+CustomColor.tagName = "font";
+
+Quill.register(CustomColor, true);
+
 frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 	make_wrapper() {
 		this._super();


### PR DESCRIPTION
The browser's spell check wraps a line with a misspelled word with a font tag. Quill doesn't recognise the font tag as a valid colour blot, so it deletes it, causing the issue.

**Before:**
![quill bug](https://user-images.githubusercontent.com/19775888/81040130-44f91780-8ec8-11ea-830d-1822075bce0f.gif)



**After:**
![quill fix](https://user-images.githubusercontent.com/19775888/81039852-b1bfe200-8ec7-11ea-8517-252722d24fa6.gif)
