### PR TITLE
fix(new-site): broken site if redis is not running

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -81,7 +81,7 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 	installing = touch_file(get_site_path('locks', 'installing.lock'))
 	atexit.register(_new_site_cleanup, site, mariadb_root_username, mariadb_root_password)
 
-	install_db(root_login=mariadb_root_username, root_password=mariadb_root_password, db_name=db_name, 
+	install_db(root_login=mariadb_root_username, root_password=mariadb_root_password, db_name=db_name,
 		admin_password=admin_password, verbose=verbose, source_sql=source_sql, force=force, reinstall=reinstall,
 		db_password=db_password, db_type=db_type, db_host=db_host, db_port=db_port, no_mariadb_socket=no_mariadb_socket)
 	apps_to_install = ['frappe'] + (frappe.conf.get("install_apps") or []) + (list(install_apps) or [])
@@ -101,7 +101,7 @@ def _new_site_cleanup(site, mariadb_root_username, mariadb_root_password):
 
 	if installing and os.path.exists(installing):
 		if mariadb_root_password:
-			_drop_site(site, mariadb_root_username, mariadb_root_password, force=True)
+			_drop_site(site, mariadb_root_username, mariadb_root_password, force=True, no_backup=True)
 		shutil.rmtree(site)
 
 	frappe.destroy()

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -102,7 +102,7 @@ class User(Document):
 			'frappe.core.doctype.user.user.create_contact',
 			user=self,
 			ignore_mandatory=True,
-			now=frappe.flags.in_test
+			now=frappe.flags.in_test or frappe.flags.in_install
 		)
 		if self.name not in ('Administrator', 'Guest') and not self.user_image:
 			frappe.enqueue('frappe.core.doctype.user.user.update_gravatar', name=self.name)


### PR DESCRIPTION
**Problem:** 

During development, if bench processes (rq, redis, socketio, etc....basically `bench start`) aren't running, 

- `new-site` fails as enqueued jobs can't run because ~RQ~ 
- failed site generation triggers drop-site which tries to take backups and our `atexit` hook breaks too

**Traceback:**

```
Traceback (most recent call last):
  File "/opt/python/2.7.17/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.7.17/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/commands/site.py", line 46, in new_site
    no_mariadb_socket=no_mariadb_socket, db_password=db_password, db_type=db_type, db_host=db_host, db_port=db_port)
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/commands/site.py", line 89, in _new_site
    _install_app(app, verbose=verbose, set_as_patched=not source_sql)
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/installer.py", line 93, in install_app
    frappe.get_attr(after_install)()
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/utils/install.py", line 19, in after_install
    install_basic_docs()
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/utils/install.py", line 77, in install_basic_docs
    frappe.get_doc(d).insert()
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/model/document.py", line 264, in insert
    self.run_post_save_methods()
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/model/document.py", line 949, in run_post_save_methods
    self.run_method("on_update")
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/model/document.py", line 816, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/model/document.py", line 1102, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/model/document.py", line 1085, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/model/document.py", line 810, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/core/doctype/user/user.py", line 105, in on_update
    now=frappe.flags.in_test
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/__init__.py", line 1533, in enqueue
    return frappe.utils.background_jobs.enqueue(*args, **kwargs)
  File "/home/travis/build/frappe/bench/test-bench/apps/frappe/frappe/utils/background_jobs.py", line 71, in enqueue
    kwargs=queue_args)
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/rq/queue.py", line 329, in enqueue_call
    job = self.enqueue_job(job, at_front=at_front)
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/rq/queue.py", line 435, in enqueue_job
    pipe.execute()
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/redis/client.py", line 4007, in execute
    self.shard_hint)
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/redis/connection.py", line 1182, in get_connection
    connection.connect()
  File "/home/travis/build/frappe/bench/test-bench/env/lib/python2.7/site-packages/redis/connection.py", line 554, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 111 connecting to localhost:11000. Connection refused.
Backed up files /home/travis/build/frappe/bench/test-bench/sites/install-app.test/private/backups/20200504_175711-install-app_test-files.tar
Backed up files /home/travis/build/frappe/bench/test-bench/sites/install-app.test/private/backups/20200504_175711-install-app_test-private-files.tar
```

**So, what?**

After this, no need to have `bench start` running in another terminal before creating a new-site (in development mode)