### PR TITLE
fix: Ignore energy point log perm on doc cancel

### DIFF
--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -52,8 +52,10 @@ class EnergyPointLog(Document):
 			reference_log.reverted = 0
 			reference_log.save()
 
-	def revert(self, reason):
-		frappe.only_for('System Manager')
+	def revert(self, reason, ignore_permissions=False):
+		if not ignore_permissions:
+			frappe.only_for('System Manager')
+
 		if self.type != 'Auto':
 			frappe.throw(_('This document cannot be reverted'))
 

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -110,7 +110,7 @@ def revert_points_for_cancelled_doc(doc):
 	})
 	for log in energy_point_logs:
 		reference_log = frappe.get_doc('Energy Point Log', log.name)
-		reference_log.revert(_('Reference document has been cancelled'))
+		reference_log.revert(_('Reference document has been cancelled'), ignore_permissions=True)
 
 
 def get_energy_point_doctypes():


### PR DESCRIPTION
User gets Permission Error on cancellation of any doc if `Energy Point Rule` is applied on it.
Ignored user permissions on cancellation of docs.