### PR TITLE
fix: default light blue color for charts

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -480,7 +480,7 @@ export default class ChartWidget extends Widget {
 				colors.push(field.color);
 			});
 		} else if (["Line", "Bar"].includes(this.chart_doc.type)) {
-			colors = [this.chart_doc.color || "light-blue"];
+			colors = [this.chart_doc.color || []];
 		}
 
 		if (!this.data || !this.data.labels.length || !Object.keys(this.data).length) {


### PR DESCRIPTION
"light-blue" as default color for line or bar graphs would render same color for different data points. This PR fixes that

### Before 

![Screenshot_2020-05-05 scam Dashboard(1)](https://user-images.githubusercontent.com/18097732/81094462-296e2b00-8f21-11ea-868f-c3692b1deb99.png)

### After

![Screenshot_2020-05-05 scam Dashboard](https://user-images.githubusercontent.com/18097732/81094474-2e32df00-8f21-11ea-89b2-2095a3a267b6.png)
