### PR TITLE
fix: dashboard sync issue

### DIFF
--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -87,7 +87,7 @@ def sync_dashboards(app=None):
 			if config:
 				frappe.flags.in_import = True
 				make_records(config.charts, "Dashboard Chart")
-				make_records(config.number_cards, "Number Cards")
+				make_records(config.number_cards, "Number Card")
 				make_records(config.dashboards, "Dashboard")
 				frappe.flags.in_import = False
 
@@ -95,10 +95,13 @@ def make_records(config, doctype):
 	if not config:
 		return
 
-	for item in config:
-		item["doctype"] = doctype
-		import_doc(item)
-		frappe.db.commit()
+	try:
+		for item in config:
+			item["doctype"] = doctype
+			import_doc(item)
+			frappe.db.commit()
+	except frappe.DuplicateEntryError:
+		pass
 
 def get_config(app, module):
 	try:


### PR DESCRIPTION
**Issue**

```
No module named number_cards.number_cards
```

During bench migrate getting below error
```
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/migrate.py", line 58, in migrate
    sync_dashboards()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/utils/dashboard.py", line 89, in sync_dashboards
    make_records(config.charts, "Dashboard Chart")
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/utils/dashboard.py", line 100, in make_records
    import_doc(item)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 143, in import_doc
    doc.insert()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 249, in insert
    raise e
frappe.exceptions.DuplicateEntryError: (u'Dashboard Chart', u'Work Order Analysis', IntegrityError(1062, u"Duplicate entry 'Work Order Analysis' for key 'PRIMARY'"))

```