### PR TITLE
perf(recorder): Don't store context (code) and frame locals

### DIFF
--- a/frappe/public/js/frappe/recorder/RequestDetail.vue
+++ b/frappe/public/js/frappe/recorder/RequestDetail.vue
@@ -126,26 +126,8 @@
 																									</thead>
 																									<tbody>
 																										<template v-for="(row, index) in call.stack">
-																											<tr :key="index" @click="showing_traceback = showing_traceback == index ? null : index">
+																											<tr :key="index">
 																												<td v-for="key in ['filename', 'lineno', 'function']" :key="key">{{ row[key] }}</td>
-																											</tr>
-																											<tr v-if="showing_traceback == index">
-																												<td colspan="4" v-html="row.context"></td>
-																											</tr>
-																											<tr v-if="showing_traceback == index">
-																												<td colspan="4">
-																													<table class="table table-striped">
-																														<thead>
-																															<tr><th>Variable</th><th>Value</th></tr>
-																														</thead>
-																														<tbody>
-																															<tr v-for="(variable, index) in Object.entries(JSON.parse(row.locals))" :key="index">
-																																<td>{{ variable[0] }}</td>
-																																<td>{{ variable[1] }}</td>
-																															</tr>
-																														</tbody>
-																													</table>
-																												</td>
 																											</tr>
 																										</template>
 																									</tbody>
@@ -244,7 +226,6 @@ export default {
 			},
 			group_duplicates: false,
 			showing: null,
-			showing_traceback: null,
 			request: {
 				calls: [],
 			},

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -9,12 +9,8 @@ import inspect
 import json
 import re
 import time
-import traceback
 import frappe
 import sqlparse
-from pygments import highlight
-from pygments.lexers import PythonLexer
-from pygments.formatters import HtmlFormatter
 
 from frappe import _
 
@@ -30,7 +26,7 @@ def sql(*args, **kwargs):
 
 	stack = list(get_current_stack_frames())
 
-	if frappe.db.db_type == 'postgres':
+	if frappe.db.db_type == "postgres":
 		query = frappe.db._cursor.query
 	else:
 		query = frappe.db._cursor._executed
@@ -80,7 +76,7 @@ def dump():
 			frappe.local._recorder.dump()
 
 
-class Recorder():
+class Recorder:
 	def __init__(self):
 		self.uuid = frappe.generate_hash(length=10)
 		self.time = datetime.datetime.now()
@@ -102,12 +98,18 @@ class Recorder():
 			"cmd": self.cmd,
 			"time": self.time,
 			"queries": len(self.calls),
-			"time_queries": float("{:0.3f}".format(sum(call["duration"] for call in self.calls))),
-			"duration": float("{:0.3f}".format((datetime.datetime.now() - self.time).total_seconds() * 1000)),
+			"time_queries": float(
+				"{:0.3f}".format(sum(call["duration"] for call in self.calls))
+			),
+			"duration": float(
+				"{:0.3f}".format((datetime.datetime.now() - self.time).total_seconds() * 1000)
+			),
 			"method": self.method,
 		}
 		frappe.cache().hset(RECORDER_REQUEST_SPARSE_HASH, self.uuid, request_data)
-		frappe.publish_realtime(event="recorder-dump-event", message=json.dumps(request_data, default=str))
+		frappe.publish_realtime(
+			event="recorder-dump-event", message=json.dumps(request_data, default=str)
+		)
 
 		self.mark_duplicates()
 
@@ -134,6 +136,7 @@ def do_not_record(function):
 			del frappe.local._recorder
 			frappe.db.sql = frappe.db._sql
 		return function(*args, **kwargs)
+
 	return wrapper
 
 
@@ -142,6 +145,7 @@ def administrator_only(function):
 		if frappe.session.user != "Administrator":
 			frappe.throw(_("Only Administrator is allowed to use Recorder"))
 		return function(*args, **kwargs)
+
 	return wrapper
 
 

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -65,9 +65,6 @@ def get_current_stack_frames():
 				"filename": re.sub(".*/apps/", "", filename),
 				"lineno": lineno,
 				"function": function,
-				"context": "".join(context),
-				"index": index,
-				"locals": json.dumps(frame.f_locals, skipkeys=True, default=str)
 			}
 
 
@@ -175,11 +172,6 @@ def stop(*args, **kwargs):
 def get(uuid=None, *args, **kwargs):
 	if uuid:
 		result = frappe.cache().hget(RECORDER_REQUEST_HASH, uuid)
-		lexer = PythonLexer(tabsize=4)
-		for call in result["calls"]:
-			for stack in call["stack"]:
-				formatter = HtmlFormatter(noclasses=True, hl_lines=[stack["index"] + 1])
-				stack["context"] = highlight(stack["context"], lexer, formatter)
 	else:
 		result = list(frappe.cache().hgetall(RECORDER_REQUEST_SPARSE_HASH).values())
 	return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ Pillow==6.2.2
 premailer==3.6.1
 psycopg2-binary==2.8.4
 pyasn1==0.4.8
-Pygments==2.5.2
 PyJWT==1.7.1
 PyMySQL==0.9.3
 pyOpenSSL==19.1.0


### PR DESCRIPTION
Removing context and frame locals from stored data reduces memory required per request (with a ~100 SQL queries) from ~15MB to ~256KB.

**Before**
![before-short](https://user-images.githubusercontent.com/8528887/81396851-d2946b80-9143-11ea-93dd-9807fde7ad38.gif)

**After** 
![after-short](https://user-images.githubusercontent.com/8528887/81396835-cad4c700-9143-11ea-93d8-d432a75bbbe7.gif)
After


Notice the page load time as well