### PR TITLE
fix(Document Link): Error when group is set in link

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -452,6 +452,7 @@ class Meta(Document):
 			for link in self.links:
 				link.added = False
 				for group in data.transactions:
+					group = frappe._dict(group)
 					# group found
 					if link.group and group.label == link.group:
 						if link.link_doctype not in group.get('items'):
@@ -460,7 +461,7 @@ class Meta(Document):
 
 				if not link.added:
 					# group not found, make a new group
-					data.transactions.append(frappe._dict(
+					data.transactions.append(dict(
 						label = link.group,
 						items = [link.link_doctype]
 					))


### PR DESCRIPTION
This error still occurs if group is set in the link:

<img width="1228" alt="Screenshot 2020-05-08 at 3 45 19 PM" src="https://user-images.githubusercontent.com/19775888/81396363-f1dec900-9142-11ea-9004-a8e392644f55.png">
