### PR TITLE
fix(Reports): set totals currency by field

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1020,7 +1020,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					name: __('Totals Row'),
 					content: totals[col.id],
 					format: value => {
-						return frappe.format(value, col.docfield, { always_show_decimals: true });
+						return frappe.format(value, col.docfield, { always_show_decimals: true }, data[0]);
 					}
 				}
 			})


### PR DESCRIPTION
The current implementation of the Totals row is currency agnostic, so we use the currency filter to calculate the totals individually. However, the currency format is set for the default company currency and not the field currency. So, this fix doesn't affect the "Grand Total (Company Currency)" field.

![Screenshot 2020-05-09 at 5 26 35 PM](https://user-images.githubusercontent.com/36654812/81473359-7ac93380-921b-11ea-9c70-470781bb08c2.png)

The last row is the Totals row

Before:
![Screenshot 2020-05-09 at 4 49 30 PM](https://user-images.githubusercontent.com/36654812/81473357-78ff7000-921b-11ea-8639-ee4cf5396036.png)

After:
![Screenshot 2020-05-09 at 5 26 35 PM 2](https://user-images.githubusercontent.com/36654812/81473358-7a309d00-921b-11ea-86ed-9e65fcb15f85.png)