### PR TITLE
fix: do not setup charts if not setup_complete

### DIFF
--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from functools import wraps
-from frappe.utils import add_to_date, get_link_to_form
+from frappe.utils import add_to_date, cint, get_link_to_form
 from frappe.modules.import_file import import_doc
 
 
@@ -75,6 +75,8 @@ def get_from_date_from_timespan(to_date, timespan):
 
 def sync_dashboards(app=None):
 	"""Import, overwrite fixtures from `[app]/fixtures`"""
+	if not cint(frappe.db.get_single_value('System Settings', 'setup_complete')):
+		return
 	if app:
 		apps = [app]
 	else:


### PR DESCRIPTION
extension to: frappe/erpnext#21670