### PR TITLE
feat: Show Notification in notifications dropdown

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.js
+++ b/frappe/desk/doctype/notification_log/notification_log.js
@@ -2,11 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Notification Log', {
-	refresh: function(frm) {
+	open_reference_document: function(frm) {
 		let dt = frm.doc.document_type;
 		let dn = frm.doc.document_name;
-		frm.fields_dict.document_name.$input_wrapper
-			.find('.control-value')
-			.wrapInner(`<a href='#Form/${dt}/${dn}'></a>`);
+		frappe.set_route('Form', dt, dn);
 	}
 });

--- a/frappe/desk/doctype/notification_log/notification_log.js
+++ b/frappe/desk/doctype/notification_log/notification_log.js
@@ -2,9 +2,44 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Notification Log', {
+	refresh: function(frm) {
+		if (frm.doc.attached_file) {
+			frm.trigger('set_attachment');
+		} else {
+			frm.get_field('attachment_link').$wrapper.empty();
+		}
+	},
+
 	open_reference_document: function(frm) {
-		let dt = frm.doc.document_type;
-		let dn = frm.doc.document_name;
+		const dt = frm.doc.document_type;
+		const dn = frm.doc.document_name;
 		frappe.set_route('Form', dt, dn);
+	},
+
+	set_attachment: function(frm) {
+		const attachment = JSON.parse(frm.doc.attached_file);
+
+		const $wrapper = frm.get_field('attachment_link').$wrapper;
+		$wrapper.html(`
+			<div class="attached-file text-medium">
+				<div class="ellipsis">
+					<i class="fa fa-paperclip"></i>
+					<a class="attached-file-link">${attachment.name}.pdf</a>
+				</div>
+			</div>
+		`);
+
+		$wrapper.find(".attached-file-link").click(() => {
+			const w = window.open(
+				frappe.urllib.get_full_url(`/api/method/frappe.utils.print_format.download_pdf?
+					doctype=${encodeURIComponent(attachment.doctype)}
+					&name=${encodeURIComponent(attachment.name)}
+					&format=${encodeURIComponent(attachment.print_format)}
+					&lang=${encodeURIComponent(attachment.lang)}`)
+			);
+			if (!w) {
+				frappe.msgprint(__("Please enable pop-ups"));
+			}
+		});
 	}
 });

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -117,9 +117,10 @@
    "show_seconds": 1
   }
  ],
+ "hide_toolbar": 1,
  "in_create": 1,
  "links": [],
- "modified": "2020-05-31 22:30:22.330366",
+ "modified": "2020-05-31 22:31:12.886950",
  "modified_by": "umair@erpnext.com",
  "module": "Desk",
  "name": "Notification Log",

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -9,7 +9,6 @@
   "for_user",
   "type",
   "email_content",
-  "column_break_4",
   "document_type",
   "read",
   "document_name",
@@ -26,6 +25,7 @@
   {
    "fieldname": "for_user",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "For User",
    "options": "User",
    "read_only": 1
@@ -33,6 +33,7 @@
   {
    "fieldname": "type",
    "fieldtype": "Select",
+   "hidden": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Type",
@@ -42,17 +43,14 @@
   },
   {
    "fieldname": "email_content",
-   "fieldtype": "Text",
-   "label": "Email Content",
+   "fieldtype": "Text Editor",
+   "label": "Message",
    "read_only": 1
-  },
-  {
-   "fieldname": "column_break_4",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "document_type",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Document Type",
    "options": "DocType",
    "read_only": 1,
@@ -61,13 +59,14 @@
   {
    "fieldname": "document_name",
    "fieldtype": "Data",
-   "label": "Document Name",
+   "label": "Document Link",
    "read_only": 1,
    "search_index": 1
   },
   {
    "fieldname": "from_user",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "From User",
    "options": "User",
    "read_only": 1,
@@ -84,8 +83,8 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-05-08 15:16:36.365285",
- "modified_by": "Administrator",
+ "modified": "2020-05-11 15:18:20.893718",
+ "modified_by": "umair@erpnext.com",
  "module": "Desk",
  "name": "Notification Log",
  "owner": "Administrator",

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2019-08-26 13:37:34.165254",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -35,7 +36,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Type",
-   "options": "Mention\nEnergy Point\nAssignment\nShare",
+   "options": "Mention\nEnergy Point\nAssignment\nShare\nAlert",
    "read_only": 1,
    "search_index": 1
   },
@@ -82,8 +83,9 @@
   }
  ],
  "in_create": 1,
- "modified": "2019-11-12 15:22:35.283678",
- "modified_by": "umair@erpnext.com",
+ "links": [],
+ "modified": "2020-05-08 15:16:36.365285",
+ "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Log",
  "owner": "Administrator",

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -12,6 +12,8 @@
   "document_type",
   "read",
   "document_name",
+  "attached_file",
+  "attachment_link",
   "open_reference_document",
   "from_user"
  ],
@@ -86,12 +88,24 @@
    "fieldname": "open_reference_document",
    "fieldtype": "Button",
    "label": "Open Reference Document"
+  },
+  {
+   "fieldname": "attached_file",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Attached File",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "attachment_link",
+   "fieldtype": "HTML",
+   "label": "Attachment Link"
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-05-11 19:19:58.578245",
- "modified_by": "umair@erpnext.com",
+ "modified": "2020-05-12 15:56:46.278677",
+ "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Log",
  "owner": "Administrator",

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -23,7 +23,8 @@
    "fieldtype": "Text",
    "in_list_view": 1,
    "label": "Subject",
-   "read_only": 1
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "for_user",
@@ -31,7 +32,8 @@
    "hidden": 1,
    "label": "For User",
    "options": "User",
-   "read_only": 1
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "type",
@@ -41,14 +43,16 @@
    "in_standard_filter": 1,
    "label": "Type",
    "options": "Mention\nEnergy Point\nAssignment\nShare\nAlert",
-   "read_only": 1,
-   "search_index": 1
+   "search_index": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "email_content",
    "fieldtype": "Text Editor",
    "label": "Message",
-   "read_only": 1
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "document_type",
@@ -56,16 +60,18 @@
    "hidden": 1,
    "label": "Document Type",
    "options": "DocType",
-   "read_only": 1,
-   "search_index": 1
+   "search_index": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "document_name",
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Document Link",
-   "read_only": 1,
-   "search_index": 1
+   "search_index": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "from_user",
@@ -73,8 +79,9 @@
    "hidden": 1,
    "label": "From User",
    "options": "User",
-   "read_only": 1,
-   "search_index": 1
+   "search_index": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
@@ -82,44 +89,50 @@
    "fieldtype": "Check",
    "hidden": 1,
    "ignore_user_permissions": 1,
-   "label": "Read"
+   "label": "Read",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "open_reference_document",
    "fieldtype": "Button",
-   "label": "Open Reference Document"
+   "label": "Open Reference Document",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "attached_file",
    "fieldtype": "Code",
    "hidden": 1,
    "label": "Attached File",
-   "options": "JSON"
+   "options": "JSON",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "attachment_link",
    "fieldtype": "HTML",
-   "label": "Attachment Link"
+   "label": "Attachment Link",
+   "show_days": 1,
+   "show_seconds": 1
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-05-12 15:56:46.278677",
- "modified_by": "Administrator",
+ "modified": "2020-05-31 22:30:22.330366",
+ "modified_by": "umair@erpnext.com",
  "module": "Desk",
  "name": "Notification Log",
  "owner": "Administrator",
  "permissions": [
   {
-   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "All",
-   "share": 1,
-   "write": 1
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -12,6 +12,7 @@
   "document_type",
   "read",
   "document_name",
+  "open_reference_document",
   "from_user"
  ],
  "fields": [
@@ -59,6 +60,7 @@
   {
    "fieldname": "document_name",
    "fieldtype": "Data",
+   "hidden": 1,
    "label": "Document Link",
    "read_only": 1,
    "search_index": 1
@@ -79,11 +81,16 @@
    "hidden": 1,
    "ignore_user_permissions": 1,
    "label": "Read"
+  },
+  {
+   "fieldname": "open_reference_document",
+   "fieldtype": "Button",
+   "label": "Open Reference Document"
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-05-11 15:18:20.893718",
+ "modified": "2020-05-11 19:19:58.578245",
  "modified_by": "umair@erpnext.com",
  "module": "Desk",
  "name": "Notification Log",

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -49,6 +49,7 @@ def enqueue_create_notification(users, doc):
 
 	if isinstance(users, frappe.string_types):
 		users = [user.strip() for user in users.split(',') if user.strip()]
+	users = list(set(users))
 
 	frappe.enqueue(
 		'frappe.desk.doctype.notification_log.notification_log.make_notification_logs',

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -61,10 +61,6 @@ def enqueue_create_notification(users, doc):
 def make_notification_logs(doc, users):
 	from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 
-	attachment = None
-	if doc.attachment:
-		attachment = doc.pop('attachment')
-
 	for user in users:
 		if frappe.db.exists('User', user):
 			if is_notifications_enabled(user):
@@ -76,8 +72,6 @@ def make_notification_logs(doc, users):
 				_doc.for_user = user
 				_doc.subject = _doc.subject.replace('<div>', '').replace('</div>', '')
 				if _doc.for_user != _doc.from_user or doc.type == 'Energy Point' or doc.type == 'Alert':
-					if attachment:
-						_doc.attached_file = json.dumps(attachment)
 					_doc.insert(ignore_permissions=True)
 
 def send_notification_email(doc):

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -65,11 +65,26 @@ def make_notification_logs(doc, users):
 					return
 
 				_doc = frappe.new_doc('Notification Log')
+
+				attachments = None
+				if doc.attachments:
+					attachments = doc.pop('attachments')
+
 				_doc.update(doc)
 				_doc.for_user = user
 				_doc.subject = _doc.subject.replace('<div>', '').replace('</div>', '')
 				if _doc.for_user != _doc.from_user or doc.type == 'Energy Point' or doc.type == 'Alert':
 					_doc.insert(ignore_permissions=True)
+					if attachments:
+						attach_file_to_doc(attachments, _doc.name)
+
+
+def attach_file_to_doc(attachments, docname):
+	from frappe.utils.file_manager import save_file
+	for attachment in attachments:
+		attachment.pop("print_format_attachment", None)
+		print_format_file = frappe._dict(frappe.attach_print(**attachment))
+		save_file(print_format_file.fname, print_format_file.fcontent, 'Notification Log', docname)
 
 def send_notification_email(doc):
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-import json
 from frappe.model.document import Document
 from frappe.desk.doctype.notification_settings.notification_settings import (is_notifications_enabled, is_email_notifications_enabled_for_type, set_seen_value)
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -68,7 +68,7 @@ def make_notification_logs(doc, users):
 				_doc.update(doc)
 				_doc.for_user = user
 				_doc.subject = _doc.subject.replace('<div>', '').replace('</div>', '')
-				if _doc.for_user != _doc.from_user or doc.type == 'Energy Point':
+				if _doc.for_user != _doc.from_user or doc.type == 'Energy Point' or doc.type == 'Alert':
 					_doc.insert(ignore_permissions=True)
 
 def send_notification_email(doc):

--- a/frappe/desk/doctype/notification_settings/notification_settings.json
+++ b/frappe/desk/doctype/notification_settings/notification_settings.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "Prompt",
  "creation": "2019-09-11 22:15:44.851526",
  "doctype": "DocType",
@@ -13,6 +14,7 @@
   "enable_email_assignment",
   "enable_email_energy_point",
   "enable_email_share",
+  "enable_email_alert",
   "user",
   "seen"
  ],
@@ -83,10 +85,18 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Seen"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_email_alert",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Alert"
   }
  ],
  "in_create": 1,
- "modified": "2019-11-19 12:57:59.356786",
+ "links": [],
+ "modified": "2020-05-08 15:15:53.925897",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Settings",

--- a/frappe/desk/doctype/notification_settings/notification_settings.json
+++ b/frappe/desk/doctype/notification_settings/notification_settings.json
@@ -14,7 +14,6 @@
   "enable_email_assignment",
   "enable_email_energy_point",
   "enable_email_share",
-  "enable_email_alert",
   "user",
   "seen"
  ],
@@ -23,52 +22,68 @@
    "default": "1",
    "fieldname": "enabled",
    "fieldtype": "Check",
-   "label": "Enabled"
+   "label": "Enabled",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "subscribed_documents",
    "fieldtype": "Table MultiSelect",
    "label": "Subscribed Documents",
-   "options": "Notification Subscribed Document"
+   "options": "Notification Subscribed Document",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "column_break_3",
    "fieldtype": "Section Break",
-   "label": "Email Settings"
+   "label": "Email Settings",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "1",
    "fieldname": "enable_email_notifications",
    "fieldtype": "Check",
-   "label": "Enable Email Notifications"
+   "label": "Enable Email Notifications",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "1",
    "depends_on": "enable_email_notifications",
    "fieldname": "enable_email_mention",
    "fieldtype": "Check",
-   "label": "Mentions"
+   "label": "Mentions",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "1",
    "depends_on": "enable_email_notifications",
    "fieldname": "enable_email_assignment",
    "fieldtype": "Check",
-   "label": "Assignments"
+   "label": "Assignments",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "1",
    "depends_on": "enable_email_notifications",
    "fieldname": "enable_email_energy_point",
    "fieldtype": "Check",
-   "label": "Energy Points"
+   "label": "Energy Points",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "1",
    "depends_on": "enable_email_notifications",
    "fieldname": "enable_email_share",
    "fieldtype": "Check",
-   "label": "Document Share"
+   "label": "Document Share",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "__user",
@@ -77,26 +92,23 @@
    "hidden": 1,
    "label": "User",
    "options": "User",
-   "read_only": 1
+   "read_only": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
    "fieldname": "seen",
    "fieldtype": "Check",
    "hidden": 1,
-   "label": "Seen"
-  },
-  {
-   "default": "0",
-   "fieldname": "enable_email_alert",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Alert"
+   "label": "Seen",
+   "show_days": 1,
+   "show_seconds": 1
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-05-08 15:15:53.925897",
+ "modified": "2020-05-31 22:16:40.798019",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Settings",

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -28,6 +28,9 @@ def is_email_notifications_enabled_for_type(user, notification_type):
 	if not is_email_notifications_enabled(user):
 		return False
 
+	if notification_type == 'Alert':
+		return False
+
 	fieldname = 'enable_email_' + frappe.scrub(notification_type)
 	enabled = frappe.db.get_value('Notification Settings', user, fieldname)
 	if enabled is None:

--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -80,7 +80,6 @@ frappe.ui.form.on("Notification", {
 		});
 	},
 	refresh: function(frm) {
-		frm.toggle_reqd("recipients", frm.doc.channel=="Email");
 		frappe.notification.setup_fieldname_select(frm);
 		frm.get_field("is_standard").toggle(frappe.boot.developer_mode);
 		frm.trigger('event');

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -23,9 +23,8 @@
   "days_in_advance",
   "value_changed",
   "sender",
+  "send_system_notification",
   "sender_email",
-  "show_in_notifications_dropdown",
-  "disable_channel",
   "section_break_9",
   "condition",
   "column_break_6",
@@ -49,11 +48,15 @@
    "default": "1",
    "fieldname": "enabled",
    "fieldtype": "Check",
-   "label": "Enabled"
+   "label": "Enabled",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "Email",
@@ -61,21 +64,27 @@
    "fieldname": "channel",
    "fieldtype": "Select",
    "label": "Channel",
-   "options": "Email\nSlack",
+   "options": "Email\nSlack\nSystem Notification",
    "reqd": 1,
-   "set_only_once": 1
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval:doc.channel=='Slack'",
    "fieldname": "slack_webhook_url",
    "fieldtype": "Link",
    "label": "Slack Channel",
-   "options": "Slack Webhook URL"
+   "mandatory_depends_on": "eval:doc.channel=='Slack'",
+   "options": "Slack Webhook URL",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "filters",
    "fieldtype": "Section Break",
-   "label": "Filters"
+   "label": "Filters",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "description": "To add dynamic subject, use jinja tags like\n\n<div><pre><code>{{ doc.name }} Delivered</code></pre></div>",
@@ -84,7 +93,9 @@
    "ignore_xss_filter": 1,
    "in_list_view": 1,
    "label": "Subject",
-   "reqd": 1
+   "reqd": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "document_type",
@@ -94,13 +105,17 @@
    "label": "Document Type",
    "options": "DocType",
    "reqd": 1,
-   "search_index": 1
+   "search_index": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
    "fieldname": "is_standard",
    "fieldtype": "Check",
-   "label": "Is Standard"
+   "label": "Is Standard",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "is_standard",
@@ -108,11 +123,15 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Module",
-   "options": "Module Def"
+   "options": "Module Def",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "col_break_1",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "event",
@@ -121,21 +140,27 @@
    "label": "Send Alert On",
    "options": "\nNew\nSave\nSubmit\nCancel\nDays After\nDays Before\nValue Change\nMethod\nCustom",
    "reqd": 1,
-   "search_index": 1
+   "search_index": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval:doc.event=='Method'",
    "description": "Trigger on valid methods like \"before_insert\", \"after_update\", etc (will depend on the DocType selected)",
    "fieldname": "method",
    "fieldtype": "Data",
-   "label": "Trigger Method"
+   "label": "Trigger Method",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval:doc.event==\"Days After\" || doc.event==\"Days Before\"",
    "description": "Send alert if date matches this field's value",
    "fieldname": "date_changed",
    "fieldtype": "Select",
-   "label": "Reference Date"
+   "label": "Reference Date",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
@@ -143,31 +168,41 @@
    "description": "Send days before or after the reference date",
    "fieldname": "days_in_advance",
    "fieldtype": "Int",
-   "label": "Days Before or After"
+   "label": "Days Before or After",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval:doc.event==\"Value Change\"",
    "description": "Send alert if this field's value changes",
    "fieldname": "value_changed",
    "fieldtype": "Select",
-   "label": "Value Changed"
+   "label": "Value Changed",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "sender",
    "fieldtype": "Link",
    "label": "Sender",
-   "options": "Email Account"
+   "options": "Email Account",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "sender_email",
    "fieldtype": "Data",
    "label": "Sender Email",
    "options": "Email",
-   "read_only": 1
+   "read_only": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "section_break_9",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "description": "Optional: The alert will be sent if this expression is true",
@@ -175,115 +210,143 @@
    "fieldtype": "Code",
    "ignore_xss_filter": 1,
    "in_list_view": 1,
-   "label": "Condition"
+   "label": "Condition",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "column_break_6",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "html_7",
    "fieldtype": "HTML",
-   "options": "<p><strong>Condition Examples:</strong></p>\n<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; 40000\n</pre>\n"
+   "options": "<p><strong>Condition Examples:</strong></p>\n<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; 40000\n</pre>\n",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "collapsible": 1,
    "fieldname": "property_section",
    "fieldtype": "Section Break",
-   "label": "Set Property After Alert"
+   "label": "Set Property After Alert",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "set_property_after_alert",
    "fieldtype": "Select",
-   "label": "Set Property After Alert"
+   "label": "Set Property After Alert",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "property_value",
    "fieldtype": "Data",
-   "label": "Value To Be Set"
+   "label": "Value To Be Set",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
-   "depends_on": "eval:doc.channel=='Email'",
+   "depends_on": "eval:doc.channel!=='Slack'",
    "fieldname": "column_break_5",
    "fieldtype": "Section Break",
-   "label": "Recipients"
+   "label": "Recipients",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "recipients",
    "fieldtype": "Table",
    "label": "Recipients",
-   "options": "Notification Recipient"
+   "mandatory_depends_on": "eval:doc.channel!=='Slack'",
+   "options": "Notification Recipient",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "message_sb",
    "fieldtype": "Section Break",
-   "label": "Message"
+   "label": "Message",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "Add your message here",
    "fieldname": "message",
    "fieldtype": "Code",
    "ignore_xss_filter": 1,
-   "label": "Message"
+   "label": "Message",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval:doc.channel=='Email'",
    "fieldname": "message_examples",
    "fieldtype": "HTML",
    "label": "Message Examples",
-   "options": "<h5>Message Example</h5>\n\n<pre>&lt;h3&gt;Order Overdue&lt;/h3&gt;\n\n&lt;p&gt;Transaction {{ doc.name }} has exceeded Due Date. Please take necessary action.&lt;/p&gt;\n\n&lt;!-- show last comment --&gt;\n{% if comments %}\nLast comment: {{ comments[-1].comment }} by {{ comments[-1].by }}\n{% endif %}\n\n&lt;h4&gt;Details&lt;/h4&gt;\n\n&lt;ul&gt;\n&lt;li&gt;Customer: {{ doc.customer }}\n&lt;li&gt;Amount: {{ doc.grand_total }}\n&lt;/ul&gt;\n</pre>"
+   "options": "<h5>Message Example</h5>\n\n<pre>&lt;h3&gt;Order Overdue&lt;/h3&gt;\n\n&lt;p&gt;Transaction {{ doc.name }} has exceeded Due Date. Please take necessary action.&lt;/p&gt;\n\n&lt;!-- show last comment --&gt;\n{% if comments %}\nLast comment: {{ comments[-1].comment }} by {{ comments[-1].by }}\n{% endif %}\n\n&lt;h4&gt;Details&lt;/h4&gt;\n\n&lt;ul&gt;\n&lt;li&gt;Customer: {{ doc.customer }}\n&lt;li&gt;Amount: {{ doc.grand_total }}\n&lt;/ul&gt;\n</pre>",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval:doc.channel=='Slack'",
    "fieldname": "slack_message_examples",
    "fieldtype": "HTML",
    "label": "Message Examples",
-   "options": "<h5>Message Example</h5>\n\n<pre>*Order Overdue*\n\nTransaction {{ doc.name }} has exceeded Due Date. Please take necessary action.\n\n<!-- show last comment -->\n{% if comments %}\nLast comment: {{ comments[-1].comment }} by {{ comments[-1].by }}\n{% endif %}\n\n*Details*\n\n\u2022 Customer: {{ doc.customer }}\n\u2022 Amount: {{ doc.grand_total }}\n</pre>"
+   "options": "<h5>Message Example</h5>\n\n<pre>*Order Overdue*\n\nTransaction {{ doc.name }} has exceeded Due Date. Please take necessary action.\n\n<!-- show last comment -->\n{% if comments %}\nLast comment: {{ comments[-1].comment }} by {{ comments[-1].by }}\n{% endif %}\n\n*Details*\n\n\u2022 Customer: {{ doc.customer }}\n\u2022 Amount: {{ doc.grand_total }}\n</pre>",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "view_properties",
    "fieldtype": "Button",
-   "label": "View Properties (via Customize Form)"
+   "label": "View Properties (via Customize Form)",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "collapsible": 1,
    "collapsible_depends_on": "attach_print",
    "fieldname": "column_break_25",
    "fieldtype": "Section Break",
-   "label": "Print Settings"
+   "label": "Print Settings",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
    "fieldname": "attach_print",
    "fieldtype": "Check",
-   "label": "Attach Print"
+   "label": "Attach Print",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "attach_print",
    "fieldname": "print_format",
    "fieldtype": "Link",
    "label": "Print Format",
-   "options": "Print Format"
+   "options": "Print Format",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.channel !== 'System Notification'",
    "description": "If enabled, the notification will show up in the notifications dropdown on the top right corner of the navigation bar.",
-   "fieldname": "show_in_notifications_dropdown",
+   "fieldname": "send_system_notification",
    "fieldtype": "Check",
-   "label": "Show in Notifications Dropdown"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.show_in_notifications_dropdown",
-   "description": "If enabled, the channel set for the Notification will be disabled. The Notification will only be received in the Notifications Dropdown.",
-   "fieldname": "disable_channel",
-   "fieldtype": "Check",
-   "label": "Disable Channel"
+   "label": "Send System Notification",
+   "show_days": 1,
+   "show_seconds": 1
   }
  ],
  "icon": "fa fa-envelope",
  "links": [],
- "modified": "2020-05-12 19:20:50.304928",
+ "modified": "2020-05-29 16:03:10.914526",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -57,6 +57,7 @@
   },
   {
    "default": "Email",
+   "depends_on": "eval: !doc.disable_channel",
    "fieldname": "channel",
    "fieldtype": "Select",
    "label": "Channel",
@@ -282,7 +283,7 @@
  ],
  "icon": "fa fa-envelope",
  "links": [],
- "modified": "2020-05-11 15:33:28.904019",
+ "modified": "2020-05-12 19:20:50.304928",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "Prompt",
  "creation": "2014-07-11 17:18:09.923399",
@@ -23,6 +24,7 @@
   "value_changed",
   "sender",
   "sender_email",
+  "show_in_notifications_dropdown",
   "section_break_9",
   "condition",
   "column_break_6",
@@ -260,10 +262,18 @@
    "fieldtype": "Link",
    "label": "Print Format",
    "options": "Print Format"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, the notification will also show up in the notifications dropdown on the top right corner of the navigation bar.",
+   "fieldname": "show_in_notifications_dropdown",
+   "fieldtype": "Check",
+   "label": "Show in Notifications Dropdown"
   }
  ],
  "icon": "fa fa-envelope",
- "modified": "2019-07-15 13:17:02.585013",
+ "links": [],
+ "modified": "2020-05-06 13:46:21.155535",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -25,6 +25,7 @@
   "sender",
   "sender_email",
   "show_in_notifications_dropdown",
+  "disable_channel",
   "section_break_9",
   "condition",
   "column_break_6",
@@ -265,15 +266,23 @@
   },
   {
    "default": "0",
-   "description": "If enabled, the notification will also show up in the notifications dropdown on the top right corner of the navigation bar.",
+   "description": "If enabled, the notification will show up in the notifications dropdown on the top right corner of the navigation bar.",
    "fieldname": "show_in_notifications_dropdown",
    "fieldtype": "Check",
    "label": "Show in Notifications Dropdown"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.show_in_notifications_dropdown",
+   "description": "If enabled, the channel set for the Notification will be disabled. The Notification will only be received in the Notifications Dropdown.",
+   "fieldname": "disable_channel",
+   "fieldtype": "Check",
+   "label": "Disable Channel"
   }
  ],
  "icon": "fa fa-envelope",
  "links": [],
- "modified": "2020-05-06 13:46:21.155535",
+ "modified": "2020-05-11 15:33:28.904019",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -252,7 +252,7 @@ def get_context(context):
 			# ignoring attachment as draft and cancelled documents are not allowed to print
 			status = "Draft" if doc.docstatus == 0 else "Cancelled"
 			frappe.throw(_("""Not allowed to attach {0} document,
-				please enable Allow Print For {0} in Print Settings""".format(status)),
+				please enable Allow Print For {0} in Print Settings""").format(status),
 				title=_("Error in Notification"))
 		else:
 			return [{

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -251,8 +251,7 @@ def get_context(context):
 
 			# ignoring attachment as draft and cancelled documents are not allowed to print
 			status = "Draft" if doc.docstatus == 0 else "Cancelled"
-			frappe.throw(_("""Not allowed to attach {0} document,
-				please enable Allow Print For {0} in Print Settings""").format(status),
+			frappe.throw(_("""Not allowed to attach {0} document, please enable Allow Print For {0} in Print Settings""").format(status),
 				title=_("Error in Notification"))
 		else:
 			return [{

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -120,15 +120,13 @@ def get_context(context):
 		if self.is_standard:
 			self.load_standard_properties(context)
 
-		channel_disabled = self.disable_channel
-
-		if self.channel == 'Email' and not channel_disabled:
+		if self.channel == 'Email':
 			self.send_an_email(doc, context)
 
-		if self.channel == 'Slack' and not channel_disabled:
+		if self.channel == 'Slack':
 			self.send_a_slack_msg(doc, context)
 
-		if self.show_in_notifications_dropdown:
+		if self.channel == 'System Notification' or self.send_system_notification:
 			self.create_drodown_notification(doc, context)
 
 		if self.set_property_after_alert:
@@ -164,7 +162,7 @@ def get_context(context):
 			'document_name': doc.name,
 			'subject': subject,
 			'email_content': frappe.render_template(self.message, context),
-			'attachment': attachments[0]
+			'attachment': attachments and attachments[0]
 		}
 		enqueue_create_notification(users, notification_doc)
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -164,7 +164,7 @@ def get_context(context):
 			'document_name': doc.name,
 			'subject': subject,
 			'email_content': frappe.render_template(self.message, context),
-			'attachments': attachments
+			'attachment': attachments[0]
 		}
 		enqueue_create_notification(recipients, notification_doc)
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -127,7 +127,7 @@ def get_context(context):
 			self.send_a_slack_msg(doc, context)
 
 		if self.channel == 'System Notification' or self.send_system_notification:
-			self.create_drodown_notification(doc, context)
+			self.create_system_notification(doc, context)
 
 		if self.set_property_after_alert:
 			allow_update = True
@@ -147,7 +147,7 @@ def get_context(context):
 			except Exception:
 				frappe.log_error(title='Document update failed', message=frappe.get_traceback())
 
-	def create_drodown_notification(self, doc, context):
+	def create_system_notification(self, doc, context):
 		subject = self.subject
 		if "{" in subject:
 			subject = frappe.render_template(self.subject, context)
@@ -162,7 +162,7 @@ def get_context(context):
 			'document_name': doc.name,
 			'subject': subject,
 			'email_content': frappe.render_template(self.message, context),
-			'attachment': attachments and attachments[0]
+			'attached_file': attachments and json.dumps(attachments[0])
 		}
 		enqueue_create_notification(users, notification_doc)
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -120,10 +120,12 @@ def get_context(context):
 		if self.is_standard:
 			self.load_standard_properties(context)
 
-		if self.channel == 'Email':
+		channel_disabled = self.disable_channel
+
+		if self.channel == 'Email' and not channel_disabled:
 			self.send_an_email(doc, context)
 
-		if self.channel == 'Slack':
+		if self.channel == 'Slack' and not channel_disabled:
 			self.send_a_slack_msg(doc, context)
 
 		if self.show_in_notifications_dropdown:

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -151,8 +151,8 @@ def get_context(context):
 		subject = self.subject
 		if "{" in subject:
 			subject = frappe.render_template(self.subject, context)
-		subject = '<b>[Alert] </b>' + subject
 
+		attachments = self.get_attachment(doc)
 		recipients, cc, bcc = self.get_list_of_recipients(doc, context)
 		users = recipients + cc + bcc
 
@@ -161,6 +161,8 @@ def get_context(context):
 			'document_type': doc.doctype,
 			'document_name': doc.name,
 			'subject': subject,
+			'email_content': frappe.render_template(self.message, context),
+			'attachments': attachments
 		}
 		enqueue_create_notification(recipients, notification_doc)
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -166,7 +166,7 @@ def get_context(context):
 			'email_content': frappe.render_template(self.message, context),
 			'attachment': attachments[0]
 		}
-		enqueue_create_notification(recipients, notification_doc)
+		enqueue_create_notification(users, notification_doc)
 
 	def send_an_email(self, doc, context):
 		from email.utils import formataddr

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -333,9 +333,11 @@ frappe.ui.Notifications = class Notifications {
 		return item_html;
 	}
 
-	get_item_link(field) {
-		const link_doctype = field.type == 'Alert'? 'Notification Log': field.document_type;
-		const link_docname = field.type == 'Alert'? field.name: field.document_name;
+	get_item_link(notification_doc) {
+		const link_doctype =
+			notification_doc.type == 'Alert' ? 'Notification Log': notification_doc.document_type;
+		const link_docname =
+			notification_doc.type == 'Alert' ? notification_doc.name: notification_doc.document_name;
 		return frappe.utils.get_form_link(
 			link_doctype,
 			link_docname

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -304,10 +304,7 @@ frappe.ui.Notifications = class Notifications {
 	}
 
 	get_dropdown_item_html(field) {
-		let doc_link = frappe.utils.get_form_link(
-			field.document_type,
-			field.document_name
-		);
+		let doc_link = this.get_item_link(field);
 		let read_class = field.read ? '' : 'unread';
 		let mark_read_action = field.read ? '': 'data-action="mark_as_read"';
 		let message = field.subject;
@@ -334,6 +331,15 @@ frappe.ui.Notifications = class Notifications {
 			</a>`;
 
 		return item_html;
+	}
+
+	get_item_link(field) {
+		const link_doctype = field.type == 'Alert'? 'Notification Log': field.document_type;
+		const link_docname = field.type == 'Alert'? field.name: field.document_name;
+		return frappe.utils.get_form_link(
+			link_doctype,
+			link_docname
+		);
 	}
 
 	render_dropdown_headers() {


### PR DESCRIPTION
Added option in **Notification** document type to show Notification in the notifications dropdown. If the option is enabled, the set channel can be disabled:
<img width="1211" alt="Screenshot 2020-05-11 at 7 55 55 PM" src="https://user-images.githubusercontent.com/19775888/81572921-7474bc00-93c1-11ea-91b6-94eaa902b82b.png">



The notification subject is rendered in the dropdown:
<img width="300" alt="Screenshot 2020-05-11 at 7 58 07 PM" src="https://user-images.githubusercontent.com/19775888/81573184-c1f12900-93c1-11ea-965b-04662e290710.png">


When clicked, it routes to the **Notification Log** document:
<img width="1207" alt="Screenshot 2020-05-12 at 4 30 34 PM" src="https://user-images.githubusercontent.com/19775888/81676797-00dcb880-946e-11ea-8b4a-ad4cd26793c4.png">

docs: https://github.com/frappe/erpnext_documentation/pull/84