### PR TITLE
fix(google-contact): remove parent kwarg from create contact

### DIFF
--- a/frappe/integrations/doctype/google_contacts/google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.py
@@ -218,7 +218,7 @@ def insert_contacts_to_google_contacts(doc, method=None):
 	emailAddresses = [{"value": email_id.email_id} for email_id in doc.email_ids]
 
 	try:
-		contact = google_contacts.people().createContact(parent='people/me', body={"names": [names],"phoneNumbers": phoneNumbers,
+		contact = google_contacts.people().createContact(body={"names": [names],"phoneNumbers": phoneNumbers,
 			"emailAddresses": emailAddresses}).execute()
 		frappe.db.set_value("Contact", doc.name, "google_contacts_id", contact.get("resourceName"))
 	except HttpError as err:


### PR DESCRIPTION
- Create contact doesn't need parent kwarg in the call anymore.
- Source(docs): https://googleapis.github.io/google-api-python-client/docs/dyn/people_v1.people.html#createContact