### PR TITLE
fix: Routing for doctypes having treeviews

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -268,6 +268,11 @@ $.extend(frappe.model, {
 		return frappe.boot.single_types.indexOf(doctype) != -1;
 	},
 
+	is_tree: function(doctype) {
+		if(!doctype) return false;
+		return frappe.boot.treeviews.indexOf(doctype) != -1;
+	},
+
 	can_import: function(doctype, frm) {
 		// system manager can always import
 		if(frappe.user_roles.includes("System Manager")) return true;

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -269,7 +269,7 @@ $.extend(frappe.model, {
 	},
 
 	is_tree: function(doctype) {
-		if(!doctype) return false;
+		if (!doctype) return false;
 		return frappe.boot.treeviews.indexOf(doctype) != -1;
 	},
 

--- a/frappe/public/js/frappe/widgets/utils.js
+++ b/frappe/public/js/frappe/widgets/utils.js
@@ -8,7 +8,10 @@ function generate_route(item) {
 		if (item.link) {
 			route = strip(item.link, "#");
 		} else if (type === "doctype") {
-			if (frappe.model.is_single(item.doctype)) {
+			if (frappe.model.is_tree(item.doctype)) {
+				route = "Tree/" + item.doctype;
+			}
+			else if (frappe.model.is_single(item.doctype)) {
 				route = "Form/" + item.doctype;
 			} else {
 				if (item.filters) {

--- a/frappe/public/js/frappe/widgets/utils.js
+++ b/frappe/public/js/frappe/widgets/utils.js
@@ -10,8 +10,7 @@ function generate_route(item) {
 		} else if (type === "doctype") {
 			if (frappe.model.is_tree(item.doctype)) {
 				route = "Tree/" + item.doctype;
-			}
-			else if (frappe.model.is_single(item.doctype)) {
+			} else if (frappe.model.is_single(item.doctype)) {
 				route = "Form/" + item.doctype;
 			} else {
 				if (item.filters) {


### PR DESCRIPTION
If a doctype in Desk Shortcut having treeview (For Eg: Account) is clicked it routes you to the list view instead of treeview

In the list view you can neither add new accounts nor proper hierarchy is visible, so routing to treeview instead of list view makes more sense. 