### PR TITLE
fix: fixed the reports print format

### DIFF
--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -145,6 +145,11 @@ table.no-border, table.no-border td {
 	margin: 3px 0px 3px;
 }
 
+.print-format table td pre {
+	white-space: normal;
+	word-break: normal;
+}
+
 table td div {
 	{% if not print_settings.allow_page_break_inside_tables %}
 	/* needed to avoid partial cutting of text between page break in wkhtmltopdf */


### PR DESCRIPTION
**Task:** Fix task reports format

**Description:** The print for the reports looked distorted. It's fixed.

**Screenshots:
Before:**
![before](https://user-images.githubusercontent.com/45919049/81693394-70a66f80-947d-11ea-8354-f87ce66387d6.png)

**After:**
![after](https://user-images.githubusercontent.com/45919049/81693400-7439f680-947d-11ea-8aee-b03bc7f03c24.png)
