### PR TITLE
fix: typo in Newsletter doctype

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.json
+++ b/frappe/email/doctype/newsletter/newsletter.json
@@ -17,7 +17,7 @@
   "subject",
   "message",
   "send_unsubscribe_link",
-  "send_attachements",
+  "send_attachments",
   "published",
   "route",
   "test_the_newsletter",
@@ -75,12 +75,6 @@
   },
   {
    "default": "0",
-   "fieldname": "send_attachements",
-   "fieldtype": "Check",
-   "label": "Send Attachements"
-  },
-  {
-   "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",
    "label": "Published"
@@ -127,6 +121,12 @@
   {
    "fieldname": "column_break_2",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "send_attachments",
+   "fieldtype": "Check",
+   "label": "Send Attachments"
   }
  ],
  "has_web_view": 1,
@@ -135,7 +135,7 @@
  "is_published_field": "published",
  "links": [],
  "max_attachments": 3,
- "modified": "2020-03-02 06:26:51.622521",
+ "modified": "2020-05-12 18:09:40.137138",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Newsletter",

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -67,7 +67,7 @@ class Newsletter(WebsiteGenerator):
 			frappe.db.auto_commit_on_many_writes = True
 
 		attachments = []
-		if self.send_attachements:
+		if self.send_attachments:
 			files = frappe.get_all("File", fields=["name"], filters={"attached_to_doctype": "Newsletter",
 				"attached_to_name": self.name}, order_by="creation desc")
 


### PR DESCRIPTION
Newsletter Doctype has typo:
"Send Attachements"
Fixed to:
"Send Attachments"

![new](https://user-images.githubusercontent.com/15175501/81693755-fc200080-947d-11ea-8f05-4a5b302536a4.png)

Also fixed fieldname in pythonfile.