### PR TITLE
fix: User Permission error 

### DIFF
--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -38,6 +38,7 @@ def create_notification_settings(user):
 	if not frappe.db.exists("Notification Settings", user):
 		_doc = frappe.new_doc('Notification Settings')
 		_doc.name = user
+		_doc.user = user
 		_doc.insert(ignore_permissions=True)
 		frappe.db.commit()
 


### PR DESCRIPTION
Add new User 
Add new User permission on User doctype with any value and set it in default
![FireShot Capture 017 - Report_ Notification Settings - 167 172 194 176](https://user-images.githubusercontent.com/2151684/81695824-d427a180-946b-11ea-88e1-ca1e5f256e73.png)
![FireShot Capture 016 - Task - 167 172 194 176](https://user-images.githubusercontent.com/2151684/81695888-e86b9e80-946b-11ea-8004-db487a3f95b9.png)

Notifications Setting always assigned to Administrator  
fix by add user to  value or make filed ignore permission 