### PR TITLE
fix: Rename 'View Website' desk dropdown option to 'View My Website' to reduce ambiguity.

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -34,7 +34,7 @@
 						<a href="" onclick="return frappe.ui.toolbar.clear_cache();">
 						{%= __("Reload") %}</a></li>
 					<li><a href="/index" target="_blank" rel="noopener noreferrer">
-						{%= __("View Website") %}</a></li>
+						{%= __("View My Website") %}</a></li>
 					<li class="navbar-toggle-full-width">
 						<a href="#" onclick="return false">{%= __("Toggle Full Width") %}</a>
 					</li>

--- a/frappe/website/doctype/website_settings/website_settings.js
+++ b/frappe/website/doctype/website_settings/website_settings.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Website Settings', {
 	refresh: function(frm) {
-		frm.add_custom_button(__('View Website'), () => {
+		frm.add_custom_button(__('View My Website'), () => {
 			window.open('/', '_blank');
 		});
 	},


### PR DESCRIPTION
'View Website' sounds ambiguous to users,
'View My Website' makes it clear that the website created in frappe will be shown.
Also changed button name in website settings.