### PR TITLE
perf: Make tests faster

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -345,7 +345,7 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None,
 			style="margin: 0;">{}</table>'''.format(table_rows)
 
 	if flags.print_messages and out.message:
-		print("Message: " + repr(out.message).encode("utf-8"))
+		print(f"Message: {repr(out.message).encode('utf-8')}")
 
 	if title:
 		out.title = title

--- a/frappe/desk/doctype/note/test_note.py
+++ b/frappe/desk/doctype/note/test_note.py
@@ -20,7 +20,7 @@ class TestNote(unittest.TestCase):
 		note = self.insert_note()
 		note.title = 'test note 1'
 		note.content = '1'
-		note.save()
+		note.save(ignore_version=False)
 
 		version = frappe.get_doc('Version', dict(docname=note.name))
 		data = version.get_data()
@@ -33,7 +33,7 @@ class TestNote(unittest.TestCase):
 
 		# test add
 		note.append('seen_by', {'user': 'Administrator'})
-		note.save()
+		note.save(ignore_version=False)
 
 		version = frappe.get_doc('Version', dict(docname=note.name))
 		data = version.get_data()
@@ -48,7 +48,7 @@ class TestNote(unittest.TestCase):
 
 		# test row change
 		note.seen_by[0].user = 'Guest'
-		note.save()
+		note.save(ignore_version=False)
 
 		version = frappe.get_doc('Version', dict(docname=note.name))
 		data = version.get_data()
@@ -62,7 +62,7 @@ class TestNote(unittest.TestCase):
 
 		# test remove
 		note.seen_by = []
-		note.save()
+		note.save(ignore_version=False)
 
 		version = frappe.get_doc('Version', dict(docname=note.name))
 		data = version.get_data()

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -14,7 +14,7 @@ class TestDocumentFollow(unittest.TestCase):
 		event_doc = get_event()
 
 		event_doc.description = "This is a test description for sending mail"
-		event_doc.save()
+		event_doc.save(ignore_version=False)
 
 		doc = document_follow.follow_document("Event", event_doc.name , user.name, force=True)
 		self.assertEquals(doc.user, user.name)
@@ -45,12 +45,12 @@ def get_event():
 	return doc
 
 def get_user():
-		doc = frappe.new_doc("User")
-		doc.email = "test@docsub.com"
-		doc.first_name = "Test"
-		doc.last_name = "User"
-		doc.send_welcome_email = 0
-		doc.document_follow_notify = 1
-		doc.document_follow_frequency = "Hourly"
-		doc.insert()
-		return doc
+	doc = frappe.new_doc("User")
+	doc.email = "test@docsub.com"
+	doc.first_name = "Test"
+	doc.last_name = "User"
+	doc.send_welcome_email = 0
+	doc.document_follow_notify = 1
+	doc.document_follow_frequency = "Hourly"
+	doc.insert()
+	return doc

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -297,8 +297,7 @@ class Document(BaseDocument):
 		if ignore_permissions!=None:
 			self.flags.ignore_permissions = ignore_permissions
 
-		if ignore_version!=None:
-			self.flags.ignore_version = ignore_version
+		self.flags.ignore_version = frappe.flags.in_test if ignore_version == None else ignore_version
 
 		if self.get("__islocal") or not self.get("name"):
 			self.insert()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -297,7 +297,7 @@ class Document(BaseDocument):
 		if ignore_permissions!=None:
 			self.flags.ignore_permissions = ignore_permissions
 
-		self.flags.ignore_version = frappe.flags.in_test if ignore_version == None else ignore_version
+		self.flags.ignore_version = frappe.flags.in_test if ignore_version is None else ignore_version
 
 		if self.get("__islocal") or not self.get("name"):
 			self.insert()

--- a/frappe/social/doctype/energy_point_settings/energy_point_settings.py
+++ b/frappe/social/doctype/energy_point_settings/energy_point_settings.py
@@ -12,7 +12,7 @@ class EnergyPointSettings(Document):
 	pass
 
 def is_energy_point_enabled():
-	return frappe.get_cached_value('Energy Point Settings', None, 'enabled')
+	return frappe.db.get_single_value('Energy Point Settings', 'enabled', True)
 
 def allocate_review_points():
 	settings = frappe.get_single('Energy Point Settings')


### PR DESCRIPTION
- Ignore doc versions in tests where it is not required.
- Properly cache `is_energy_points_enabled` function (`frappe.get_cached_value` does not cache single doctype's field value)

This fix might not show significant improvement for Frappe, But will improve ERPNext's test performance (~6mins faster)

Without fix:
<img width="1067" alt="Screenshot 2020-05-12 at 9 02 46 PM" src="https://user-images.githubusercontent.com/13928957/81714154-6348af80-9494-11ea-84f9-9038d15cca18.png">
https://travis-ci.com/github/frappe/erpnext/jobs/332484537

With Fix:
<img width="1082" alt="Screenshot 2020-05-12 at 9 02 59 PM" src="https://user-images.githubusercontent.com/13928957/81714134-5e83fb80-9494-11ea-945c-d5d2c978809c.png">
https://travis-ci.org/github/surajshetty3416/erpnext/builds/686154379

**Note:** 1 flaky test is failing in both cases.