### PR TITLE
chore: set python_requires to >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,6 @@ setup(
 	cmdclass = \
 	{
 		'clean': CleanCommand
-	}
+	},
+	python_requires='>=3.6'
 )


### PR DESCRIPTION
recent changes in `frappe/__init__.py`, as of #10307, make use of f-strings that are only available on python>=3.6

so explicitly stating that the required python needs to be >=3.6 will not allow frappe (develop) to be installed on a system with python<3.6, preventing errors from showing up.