### PR TITLE
feat: Allow custom desk pages

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -292,7 +292,6 @@ def get_desk_sidebar_items(flatten=False):
 	filters = {
 		'restrict_to_domain': ['in', frappe.get_active_domains()],
 		'extends_another_page': 0,
-		'is_standard': 1,
 		'for_user': '',
 		'module': ['not in', blocked_modules]
 	}

--- a/frappe/desk/doctype/desk_page/desk_page.js
+++ b/frappe/desk/doctype/desk_page/desk_page.js
@@ -2,10 +2,16 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Desk Page', {
-	setup: function(frm) {
+	refresh: function(frm) {
 		frm.get_field("is_standard").toggle(frappe.boot.developer_mode);
 		frm.get_field("extends_another_page").toggle(frappe.boot.developer_mode);
-		if (!frappe.boot.developer_mode || frm.doc.for_user) {
+		frm.get_field("developer_mode_only").toggle(frappe.boot.developer_mode);
+
+		if (frm.doc.for_user) {
+			frm.set_df_property("extends", "read_only", true);
+		}
+
+		if (frm.doc.for_user || frm.doc.is_standard) {
 			frm.trigger('disable_form');
 		}
 	},

--- a/frappe/desk/doctype/desk_page/desk_page.js
+++ b/frappe/desk/doctype/desk_page/desk_page.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('Desk Page', {
 	refresh: function(frm) {
+		frm.enable_save();
 		frm.get_field("is_standard").toggle(frappe.boot.developer_mode);
 		frm.get_field("extends_another_page").toggle(frappe.boot.developer_mode);
 		frm.get_field("developer_mode_only").toggle(frappe.boot.developer_mode);
@@ -17,7 +18,6 @@ frappe.ui.form.on('Desk Page', {
 	},
 
 	disable_form: function(frm) {
-		frm.set_read_only();
 		frm.fields
 			.filter(field => field.has_input)
 			.forEach(field => {

--- a/frappe/desk/doctype/desk_page/desk_page.json
+++ b/frappe/desk/doctype/desk_page/desk_page.json
@@ -8,8 +8,8 @@
  "engine": "InnoDB",
  "field_order": [
   "label",
-  "extends",
   "for_user",
+  "extends",
   "module",
   "category",
   "restrict_to_domain",
@@ -170,7 +170,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:doc.extends_another_page == 1",
+   "depends_on": "eval:doc.extends_another_page == 1 || doc.for_user",
    "fieldname": "extends",
    "fieldtype": "Link",
    "in_standard_filter": 1,
@@ -192,7 +192,7 @@
   }
  ],
  "links": [],
- "modified": "2020-05-12 16:12:20.708394",
+ "modified": "2020-05-13 19:01:42.041524",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desk Page",

--- a/frappe/desk/doctype/desk_shortcut/desk_shortcut.json
+++ b/frappe/desk/doctype/desk_shortcut/desk_shortcut.json
@@ -6,9 +6,9 @@
  "engine": "InnoDB",
  "field_order": [
   "type",
-  "label",
-  "column_break_4",
   "link_to",
+  "column_break_4",
+  "label",
   "icon",
   "restrict_to_domain",
   "section_break_5",
@@ -81,13 +81,14 @@
   {
    "fieldname": "label",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Label",
    "reqd": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-04-07 19:04:23.645198",
+ "modified": "2020-05-13 19:26:34.229669",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desk Shortcut",


### PR DESCRIPTION
## Allow users to create custom
This PR makes the following changes
1. Removes `is_standard` check from sidebar items query. The query will fetch all items that are standard and ones that don't extend another page.
1. Show and Hide specific fields in JS controller
1. Disable form if the page is standard or extends another page
1. Minor Layout Changes

> P.S. A page extends another page if it's a user customization with `for_user` field set, or if it adds it's shortucts, charts, etc to that page with `extends_another_page` checked. 

## Creating Pages
Simply fill all visible form details and the page will show up on desk. Users can customize it at will.

## Screenshots when Developer Mode is Disabled
### User Defined Custom Page
![image](https://user-images.githubusercontent.com/18097732/81821853-04487080-9550-11ea-991d-07e3fc0d3d97.png)


### Page added on Desk
<img width="1442" alt="image" src="https://user-images.githubusercontent.com/18097732/81821797-eb3fbf80-954f-11ea-93ac-084586574839.png">
