### PR TITLE
fix: Login redirect loop

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -180,6 +180,8 @@ def build(path):
 			return build_page(path)
 		else:
 			raise
+	except Exception:
+		raise
 
 def build_page(path):
 	if not getattr(frappe.local, "path", None):

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -20,7 +20,7 @@ def get_context(context):
 
 	if frappe.session.user != "Guest":
 		if not redirect_to:
-			redirect_to = "/" if frappe.session.data.user_type=="Website User" else "/desk"
+			redirect_to = "/me" if frappe.session.data.user_type=="Website User" else "/desk"
 		frappe.local.flags.redirect_location = redirect_to
 		raise frappe.Redirect
 


### PR DESCRIPTION
If you are logged in as a Website User, and try to visit `/` route, you will be redirected to `/login` if there is no default page, which in turn will redirect you to `/` because you are already logged in 🤷🏻‍♂️. This results in a timeout.

This PR changes the redirect to `/me` so we can be happy.