### PR TITLE
feat: hide dashboard widget if onboarding is present

### DIFF
--- a/frappe/desk/doctype/desk_page/desk_page.js
+++ b/frappe/desk/doctype/desk_page/desk_page.js
@@ -12,7 +12,7 @@ frappe.ui.form.on('Desk Page', {
 			frm.set_df_property("extends", "read_only", true);
 		}
 
-		if (frm.doc.for_user || frm.doc.is_standard) {
+		if (frm.doc.for_user || (frm.doc.is_standard && !frappe.boot.developer_mode)) {
 			frm.trigger('disable_form');
 		}
 	},

--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -294,7 +294,7 @@ class DesktopPage {
 
 	make_charts() {
 		return frappe.dashboard_utils.get_dashboard_settings().then(settings => {
-			let chart_config = settings.chart_config? JSON.parse(settings.chart_config): {};
+			let chart_config = settings.chart_config ? JSON.parse(settings.chart_config): {};
 			if (this.data.charts.items) {
 				this.data.charts.items.map(chart => {
 					chart.chart_settings = chart_config[chart.chart_name] || {};
@@ -306,6 +306,7 @@ class DesktopPage {
 				container: this.page,
 				type: "chart",
 				columns: 1,
+				hidden: Boolean(this.onboarding_widget),
 				options: {
 					allow_sorting: this.allow_customization,
 					allow_create: this.allow_customization,

--- a/frappe/public/js/frappe/widgets/widget_group.js
+++ b/frappe/public/js/frappe/widgets/widget_group.js
@@ -52,7 +52,7 @@ export default class WidgetGroup {
 				</div>
 			</div>`);
 		this.widget_area = widget_area;
-		if (this.hidden) this.widget_area.hide()
+		if (this.hidden) this.widget_area.hide();
 		this.title_area = widget_area.find(".widget-group-title");
 		this.control_area = widget_area.find(".widget-group-control");
 		this.body = widget_area.find(".widget-group-body");

--- a/frappe/public/js/frappe/widgets/widget_group.js
+++ b/frappe/public/js/frappe/widgets/widget_group.js
@@ -52,6 +52,7 @@ export default class WidgetGroup {
 				</div>
 			</div>`);
 		this.widget_area = widget_area;
+		if (this.hidden) this.widget_area.hide()
 		this.title_area = widget_area.find(".widget-group-title");
 		this.control_area = widget_area.find(".widget-group-control");
 		this.body = widget_area.find(".widget-group-body");
@@ -96,7 +97,7 @@ export default class WidgetGroup {
 	}
 
 	customize() {
-		this.widget_area.show();
+		if (!this.hidden) this.widget_area.show();
 		this.widgets_list.forEach((wid) => {
 			wid.customize(this.options);
 		});


### PR DESCRIPTION
This PR will hide dashboard widget if onboarding is present. The charts widget is created, but is hidden, this allows the customization to pick it up even when hidden.