### PR TITLE
feat: onboarding enhancements

### DIFF
--- a/frappe/desk/doctype/onboarding_step/onboarding_step.json
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.json
@@ -20,6 +20,9 @@
   "report_reference_doctype",
   "report_type",
   "report_description",
+  "path",
+  "callback_title",
+  "callback_message",
   "field",
   "value_to_validate",
   "video_url"
@@ -58,7 +61,7 @@
    "fieldname": "action",
    "fieldtype": "Select",
    "label": "Action",
-   "options": "Create Entry\nUpdate Settings\nShow Form Tour\nView Report\nWatch Video",
+   "options": "Create Entry\nUpdate Settings\nShow Form Tour\nView Report\nGo to Page\nWatch Video",
    "reqd": 1
   },
   {
@@ -136,10 +139,30 @@
    "fieldname": "is_single",
    "fieldtype": "Check",
    "label": "Is Single"
+  },
+  {
+   "depends_on": "eval:doc.action == \"Go to Page\"",
+   "description": "Example: #Tree/Account",
+   "fieldname": "path",
+   "fieldtype": "Data",
+   "label": "Path"
+  },
+  {
+   "depends_on": "eval:doc.action == \"Go to Page\"",
+   "fieldname": "callback_title",
+   "fieldtype": "Data",
+   "label": "Callback Title"
+  },
+  {
+   "depends_on": "eval:doc.action == \"Go to Page\"",
+   "description": "This will be shown in a modal after routing",
+   "fieldname": "callback_message",
+   "fieldtype": "Small Text",
+   "label": "Callback Message"
   }
  ],
  "links": [],
- "modified": "2020-05-11 13:24:05.457160",
+ "modified": "2020-05-14 13:53:11.977368",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Onboarding Step",

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.json
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.json
@@ -158,16 +158,14 @@
    "depends_on": "eval:doc.action == \"Go to Page\"",
    "fieldname": "callback_title",
    "fieldtype": "Data",
-   "label": "Callback Title",
-   "mandatory_depends_on": "eval:doc.action == \"Go to Page\""
+   "label": "Callback Title"
   },
   {
    "depends_on": "eval:doc.action == \"Go to Page\"",
    "description": "This will be shown in a modal after routing",
    "fieldname": "callback_message",
    "fieldtype": "Small Text",
-   "label": "Callback Message",
-   "mandatory_depends_on": "eval:doc.action == \"Go to Page\""
+   "label": "Callback Message"
   },
   {
    "default": "1",
@@ -186,7 +184,7 @@
   }
  ],
  "links": [],
- "modified": "2020-05-14 14:14:10.184240",
+ "modified": "2020-05-14 15:10:05.627706",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Onboarding Step",

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.json
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.json
@@ -15,6 +15,7 @@
   "action",
   "column_break_7",
   "reference_document",
+  "show_full_form",
   "is_single",
   "reference_report",
   "report_reference_doctype",
@@ -23,6 +24,7 @@
   "path",
   "callback_title",
   "callback_message",
+  "validate_action",
   "field",
   "value_to_validate",
   "video_url"
@@ -73,6 +75,7 @@
    "fieldname": "reference_document",
    "fieldtype": "Link",
    "label": "Reference Document",
+   "mandatory_depends_on": "eval:doc.action == \"Create Entry\" || doc.action == \"Update Settings\" || doc.action == \"Create Entry\" || doc.action == \"Show Form Tour\"",
    "options": "DocType"
   },
   {
@@ -87,7 +90,8 @@
    "depends_on": "eval:doc.action == \"Watch Video\"",
    "fieldname": "video_url",
    "fieldtype": "Data",
-   "label": "Video URL"
+   "label": "Video URL",
+   "mandatory_depends_on": "eval:doc.action == \"Watch Video\""
   },
   {
    "depends_on": "eval:doc.action == \"View Report\"",
@@ -105,17 +109,19 @@
    "label": "Is Skipped"
   },
   {
-   "depends_on": "eval:doc.action == \"Update Settings\"",
+   "depends_on": "eval:doc.action == \"Update Settings\" && doc.validate_action",
    "fieldname": "field",
    "fieldtype": "Select",
-   "label": "Field"
+   "label": "Field",
+   "mandatory_depends_on": "eval:doc.action == \"Update Settings\" && doc.validate_action"
   },
   {
-   "depends_on": "eval:doc.action == \"Update Settings\"",
+   "depends_on": "eval:doc.action == \"Update Settings\" && doc.validate_action",
    "description": "Use % for any non empty value.",
    "fieldname": "value_to_validate",
    "fieldtype": "Data",
-   "label": "Value to Validate"
+   "label": "Value to Validate",
+   "mandatory_depends_on": "eval:doc.action == \"Update Settings\" && doc.validate_action"
   },
   {
    "depends_on": "eval:doc.action == \"View Report\"",
@@ -145,24 +151,42 @@
    "description": "Example: #Tree/Account",
    "fieldname": "path",
    "fieldtype": "Data",
-   "label": "Path"
+   "label": "Path",
+   "mandatory_depends_on": "eval:doc.action == \"Go to Page\""
   },
   {
    "depends_on": "eval:doc.action == \"Go to Page\"",
    "fieldname": "callback_title",
    "fieldtype": "Data",
-   "label": "Callback Title"
+   "label": "Callback Title",
+   "mandatory_depends_on": "eval:doc.action == \"Go to Page\""
   },
   {
    "depends_on": "eval:doc.action == \"Go to Page\"",
    "description": "This will be shown in a modal after routing",
    "fieldname": "callback_message",
    "fieldtype": "Small Text",
-   "label": "Callback Message"
+   "label": "Callback Message",
+   "mandatory_depends_on": "eval:doc.action == \"Go to Page\""
+  },
+  {
+   "default": "1",
+   "depends_on": "eval:doc.action == \"Update Settings\"",
+   "fieldname": "validate_action",
+   "fieldtype": "Check",
+   "label": "Validate Field"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.action == \"Create Entry\"",
+   "description": "Show full form instead of a quick entry modal",
+   "fieldname": "show_full_form",
+   "fieldtype": "Check",
+   "label": "Show Full Form?"
   }
  ],
  "links": [],
- "modified": "2020-05-14 13:53:11.977368",
+ "modified": "2020-05-14 14:14:10.184240",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Onboarding Step",

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.py
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.py
@@ -10,3 +10,7 @@ class OnboardingStep(Document):
 	def before_export(self, doc):
 		doc.is_complete = 0
 		doc.is_skipped = 0
+
+	def validate(self):
+		if self.action == "Go to Page":
+			self.is_mandatory = 0

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -25,7 +25,7 @@ export default class OnboardingWidget extends Widget {
 
 		if (step.is_skipped) {
 			status = "skipped";
-			icon_class = "fa-times-circle-o";
+			icon_class = "fa-check-circle-o";
 		}
 
 		if (step.is_complete) {
@@ -324,7 +324,7 @@ export default class OnboardingWidget extends Widget {
 	update_step_status(step, status, value, callback) {
 		let icon_class = {
 			is_complete: "fa-check-circle-o",
-			is_skipped: "fa-times-circle-o",
+			is_skipped: "fa-check-circle-o",
 		};
 
 		frappe

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -238,7 +238,7 @@ export default class OnboardingWidget extends Widget {
 		frappe.route_hooks.after_save = () => {
 			frappe.msgprint({
 				message: __("You're doing great, let's take you back to the onboarding page."),
-				title: __("Good Work  🎉"),
+				title: __("Good Work 🎉"),
 				primary_action: {
 					action: () => {
 						frappe.set_route(current_route).then(() => {

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -173,6 +173,7 @@ export default class OnboardingWidget extends Widget {
 		frappe.route_hooks = {};
 		frappe.route_hooks.after_load = (frm) => {
 			frm.scroll_to_field(step.field);
+			frm.doc.__unsaved = true;
 		};
 
 		frappe.route_hooks.after_save = (frm) => {

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -76,8 +76,6 @@ export default class OnboardingWidget extends Widget {
 	}
 
 	go_to_page(step) {
-		let current_route = frappe.get_route();
-
 		frappe.set_route(step.path).then(() => {
 			if (step.callback_message) {
 				let msg_dialog = frappe.msgprint({

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -79,31 +79,19 @@ export default class OnboardingWidget extends Widget {
 		let current_route = frappe.get_route();
 
 		frappe.set_route(step.path).then(() => {
-			let msg_dialog = frappe.msgprint({
-				message: __(step.callback_message),
-				title: __(step.callback_title),
-				primary_action: {
-					action: () => {
-						frappe.set_route(current_route).then(() => {
-							this.mark_complete(step);
-						});
-						msg_dialog.hide();
+			if (step.callback_message) {
+				let msg_dialog = frappe.msgprint({
+					message: __(step.callback_message),
+					title: __(step.callback_title),
+					primary_action: {
+						action: () => {
+							msg_dialog.hide();
+						},
+						label: () => __("Continue"),
 					},
-					label: () => __("Continue"),
-				},
-				secondary_action: {
-					action: () => {
-						msg_dialog.hide();
-						frappe.set_route(current_route).then(() => {
-							this.mark_complete(step);
-						});
-					},
-					label: __("Go Back"),
-				},
-				wide: true,
-			});
-
-			frappe.msg_dialog.custom_onhide = () => this.mark_complete(step);
+					wide: true,
+				});
+			}
 		});
 	}
 

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -60,12 +60,45 @@ export default class OnboardingWidget extends Widget {
 			"Show Form Tour": () => this.show_form_tour(step),
 			"Update Settings": () => this.update_settings(step),
 			"View Report": () => this.open_report(step),
+			"Go to Page": () => this.go_to_page(step),
 		};
 
 		$step.find("#title").on("click", actions[step.action]);
 
 		$step.appendTo(this.body);
 		return $step;
+	}
+
+	go_to_page(step) {
+		let current_route = frappe.get_route();
+
+		frappe.set_route(step.path).then(() => {
+			let msg_dialog = frappe.msgprint({
+				message: __(step.callback_message),
+				title: __(step.callback_title),
+				primary_action: {
+					action: () => {
+						frappe.set_route(current_route).then(() => {
+							this.mark_complete(step);
+						});
+						msg_dialog.hide();
+					},
+					label: () => __("Continue"),
+				},
+				secondary_action: {
+					action: () => {
+						msg_dialog.hide();
+						frappe.set_route(current_route).then(() => {
+							this.mark_complete(step);
+						});
+					},
+					label: __("Go Back"),
+				},
+				wide: true,
+			});
+
+			frappe.msg_dialog.custom_onhide = () => this.mark_complete(step);
+		});
 	}
 
 	open_report(step) {


### PR DESCRIPTION
This PR adds two new options for Onboarding

1. Show Full Form for Create Entry
1. Allow navigation to any page

## Show Full Form for Create Entry
A checkbox `Show Full Form ?` is added, if it is checked the user will be redirected a new form page, and after save, the step is marked complete. In case it is not checked, a quick entry dialog will open

#### Demo
![Screen-Recording-2020-05-14-at-2](https://user-images.githubusercontent.com/18097732/81914684-3d83ed80-95ef-11ea-9b2c-893945cc08a1.gif)


#### Example Config
![Screenshot_2020-05-14 Create Blogger](https://user-images.githubusercontent.com/18097732/81914410-e67e1880-95ee-11ea-8365-77369f5fee4a.png)


## Allow navigation to any page
This is added as a new action type, using this you can route to any path, say `Tree/Account` or `From/Website Settings` and show a **wide** modal with some information about the page, see example for Accounts Tree below. This step does not get mark complete automatically.

This can be used to explain users on what that page/form/view is about. 

*Don't mark this step as mandatory*

#### Demo
![Screen-Recording-2020-05-14-at-2(1)](https://user-images.githubusercontent.com/18097732/81914881-7f149880-95ef-11ea-9e1e-adeb73ef5c36.gif)


#### Example Config
![Screenshot_2020-05-14 Go to Accounts Tree](https://user-images.githubusercontent.com/18097732/81914730-4c6aa000-95ef-11ea-99cb-c9bb04e02d96.png)

#### Success Dialog
This is shown after routing

![Screenshot_2020-05-14 Chart Of Accounts](https://user-images.githubusercontent.com/18097732/81914755-57253500-95ef-11ea-9fcf-792ef8587772.png)
