### PR TITLE
fix: set default values for report chart date filters

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -291,7 +291,7 @@ frappe.ui.form.on('Dashboard Chart', {
 					f.read_only = 1;
 				}
 				// Filter out date filters that have default values set
-				if (['Date', 'Date Range'].includes(f.fieldtype) && f.default) {
+				if (['Date', 'DateRange'].includes(f.fieldtype) && f.default) {
 					return false;
 				}
 				return f.fieldname;

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -290,7 +290,10 @@ frappe.ui.form.on('Dashboard Chart', {
 				if (f.get_query || f.get_data) {
 					f.read_only = 1;
 				}
-
+				// Filter out date filters that have default values set
+				if (['Date', 'Date Range'].includes(f.fieldtype) && f.default) {
+					return false;
+				}
 				return f.fieldname;
 			});
 

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -556,7 +556,7 @@ export default class ChartWidget extends Widget {
 		} else {
 			this.filters =
 				saved_filters || this.filters || chart_filters;
-				return Promise.resolve();
+			return Promise.resolve();
 		}
 	}
 

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -562,7 +562,7 @@ export default class ChartWidget extends Widget {
 
 	update_default_date_filters(report_filters, chart_filters) {
 		report_filters.map(f => {
-			if (['Date', 'Date Range'].includes(f.fieldtype) && f.default) {
+			if (['Date', 'DateRange'].includes(f.fieldtype) && f.default) {
 				if (chart_filters[f.fieldname]) {
 					chart_filters[f.fieldname] = f.default;
 				}


### PR DESCRIPTION
If a default value is set for a report's date type filter, the chart filter value will be set to that value.
The filters will still be shown in the filter dialog so that the chart can be manipulated, but the values won't be saved.