### PR TITLE
fix: set query report object for report type chart filters

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -283,17 +283,7 @@ frappe.ui.form.on('Dashboard Chart', {
 				});
 			}
 		} else if (frm.chart_filters.length) {
-			fields = frm.chart_filters.filter(f => {
-				if (f.on_change && !f.reqd) {
-					return false;
-				}
-				if (f.get_query || f.get_data) {
-					f.read_only = 1;
-				}
-
-				return f.fieldname;
-			});
-
+			fields = frm.chart_filters.filter(f => f.fieldname);
 			fields.map( f => {
 				if (filters[f.fieldname]) {
 					let condition = '=';
@@ -353,6 +343,8 @@ frappe.ui.form.on('Dashboard Chart', {
 			}
 
 			dialog.show();
+			//Set query report object so that it can be used while fetching filter values in the report
+			frappe.query_report = new frappe.views.QueryReport({'filters': dialog.fields_list});
 			dialog.set_values(filters);
 		});
 	},

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -332,15 +332,7 @@ export default class ChartWidget extends Widget {
 								}
 							];
 						} else {
-							fields = filters.filter(f => {
-								if (f.on_change && !f.reqd) {
-									return false;
-								}
-								if (f.get_query || f.get_data) {
-									f.read_only = 1;
-								}
-								return f.fieldname;
-							});
+							fields = filters.filter(f => f.fieldname);
 						}
 					} else {
 						fields = [
@@ -384,6 +376,8 @@ export default class ChartWidget extends Widget {
 		}
 
 		dialog.show();
+		//Set query report object so that it can be used while fetching filter values in the report
+		frappe.query_report = new frappe.views.QueryReport({'filters': dialog.fields_list});
 		dialog.set_values(this.filters);
 	}
 


### PR DESCRIPTION
Reports filters with functions like `get_query` use the query report object to get filter values.
