### PR TITLE
feat: allow submittable docs in onboarding step create entry

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -275,7 +275,7 @@ class Workspace:
 			step = doc.as_dict().copy()
 			step.label = _(doc.title)
 			if step.action == "Create Entry":
-				step.is_submittable = frappe.db.get_value("DocType", step.reference_document, 'is_submittable')
+				step.is_submittable = frappe.db.get_value("DocType", step.reference_document, 'is_submittable', cache=True)
 			steps.append(step)
 
 		return steps

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -518,5 +518,4 @@ def update_onboarding_step(name, field, value):
 	    value: Value to be updated
 
 	"""
-	return
 	frappe.db.set_value("Onboarding Step", name, field, value)

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -274,6 +274,8 @@ class Workspace:
 		for doc in self.onboarding_doc.get_steps():
 			step = doc.as_dict().copy()
 			step.label = _(doc.title)
+			if step.action == "Create Entry":
+				step.is_submittable = frappe.db.get_value("DocType", step.reference_document, 'is_submittable')
 			steps.append(step)
 
 		return steps
@@ -516,4 +518,5 @@ def update_onboarding_step(name, field, value):
 	    value: Value to be updated
 
 	"""
+	return
 	frappe.db.set_value("Onboarding Step", name, field, value)

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -651,6 +651,12 @@ frappe.ui.form.Form = class FrappeForm {
 							callback && callback();
 							me.script_manager.trigger("on_submit")
 								.then(() => resolve(me));
+							if (frappe.route_hooks.after_submit) {
+								let route_callback = frappe.route_hooks.after_submit;
+								delete frappe.route_hooks.after_submit;
+
+								route_callback(me);
+							}
 						}
 					}, btn, () => me.handle_save_fail(btn, on_error), resolve);
 				});

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -233,8 +233,7 @@ export default class OnboardingWidget extends Widget {
 		let current_route = frappe.get_route();
 
 		frappe.route_hooks = {};
-
-		frappe.route_hooks.after_save = () => {
+		let callback = () => {
 			frappe.msgprint({
 				message: __("You're doing great, let's take you back to the onboarding page."),
 				title: __("Good Work 🎉"),
@@ -252,6 +251,18 @@ export default class OnboardingWidget extends Widget {
 				this.mark_complete(step);
 			};
 		};
+
+		if (step.is_submittable) {
+			frappe.route_hooks.after_save = () => {
+				frappe.msgprint({
+					message: __("Submit this document to complete this step."),
+					title: __("Great")
+				});
+			};
+			frappe.route_hooks.after_submit = callback;
+		} else {
+			frappe.route_hooks.after_save = callback;
+		}
 
 		frappe.set_route(`Form/${step.reference_document}/New ${step.reference_document} 1`);
 	}
@@ -325,6 +336,8 @@ export default class OnboardingWidget extends Widget {
 			is_complete: "fa-check-circle-o",
 			is_skipped: "fa-check-circle-o",
 		};
+		//  Clear any hooks
+		frappe.route_hooks = {};
 
 		frappe
 			.call("frappe.desk.desktop.update_onboarding_step", {


### PR DESCRIPTION
This PR adds `after_submit` route hook, this is used in onboarding step for submittable document creation

### Demo
![Screen-Recording-2020-05-14-at-7](https://user-images.githubusercontent.com/18097732/81946509-104e3400-961d-11ea-90f4-0890f2309f9f.gif)
