### PR TITLE
feat: allow overriding filters in dashboards

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -361,7 +361,12 @@ export default class ChartWidget extends Widget {
 								}
 							];
 						} else {
-							fields = filters.filter(f => f.fieldname);
+							fields = filters
+								.filter(df => df.fieldname)
+								.map(df => {
+									Object.assign(df, df.dashboard_config || {});
+									return df;
+								});
 						}
 					} else {
 						fields = [


### PR DESCRIPTION
This PR allows adding custom settings for chart filters for filters dialog in dashboard.

To use the filters simply add a `dashboard_config` option in the filter config as follows
```javascript
frappe.query_reports["Awesome Report"] = {
	"filters": [
		{
			"fieldname": "project",
			"label": __("Project"),
			"fieldtype": "MultiSelectList",
			get_data: function(txt) {
				return frappe.db.get_link_options('Project', txt);
			},

		},
		{
			"fieldname": "include_default_book_entries",
			"label": __("Include Default Book Entries"),
			"fieldtype": "Check",
			"default": 1,
			"dashboard_config": {
				"read_only": 1, // Will make the check read only for dashboard
				"label": __("Include Default Entries")
			}
		}
	]
}
```