### PR TITLE
fix: Allow Custom Colors in Chart Widgets if specified.

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -562,8 +562,12 @@ export default class ChartWidget extends Widget {
 			this.chart_doc.y_axis.map(field => {
 				colors.push(field.color);
 			});
+		}
+		else if (this.chart_doc.custom_options){
+			let custom_options = JSON.parse(this.chart_doc.custom_options);
+			colors = custom_options.colors;
 		} else if (["Line", "Bar"].includes(this.chart_doc.type)) {
-			colors = [this.chart_doc.color || "light-blue"];
+			colors = [this.chart_doc.color || []];
 		}  else if (this.chart_doc.type == "Heatmap") {
 			colors = [];
 		}

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -558,13 +558,13 @@ export default class ChartWidget extends Widget {
 
 	get_chart_colors() {
 		let colors = [];
+		let custom_options = JSON.parse(this.chart_doc.custom_options || '{}');
+
 		if (this.chart_doc.y_axis.length) {
 			this.chart_doc.y_axis.map(field => {
 				colors.push(field.color);
 			});
-		}
-		else if (this.chart_doc.custom_options){
-			let custom_options = JSON.parse(this.chart_doc.custom_options);
+		} else if (custom_options.colors && custom_options.colors.length) {
 			colors = custom_options.colors;
 		} else if (["Line", "Bar"].includes(this.chart_doc.type)) {
 			colors = [this.chart_doc.color || []];


### PR DESCRIPTION
**Before:**
Config
![Screenshot 2020-05-14 at 11 46 24 PM](https://user-images.githubusercontent.com/25857446/81970322-f6244e00-963c-11ea-8a6d-4b9f25d4b40d.png)

Chart in dashboard
![Screenshot 2020-05-14 at 11 42 34 PM](https://user-images.githubusercontent.com/25857446/81970131-a6458700-963c-11ea-944c-353db6ae4f8d.png)


**After:**
![Screenshot 2020-05-14 at 11 38 28 PM](https://user-images.githubusercontent.com/25857446/81970146-a9d90e00-963c-11ea-86a8-8aeb4842ec2e.png)
