### PR TITLE
feat: show current site name on bench use <site>

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -326,6 +326,7 @@ def use(site, sites_path='.'):
 	if os.path.exists(os.path.join(sites_path, site)):
 		with open(os.path.join(sites_path,  "currentsite.txt"), "w") as sitefile:
 			sitefile.write(site)
+		print("Current Site set to {}".format(site))
 	else:
 		print("{} does not exist".format(site))
 


### PR DESCRIPTION
A confirmation message was missing when we use command bench use <site_name>. This change will help in achieving this.
![image](https://user-images.githubusercontent.com/44434910/82076479-888b2700-96fb-11ea-9cb3-371b00acb26c.png)
