### PR TITLE
fix: add missing chart types and don't make type mandatory

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -92,12 +92,6 @@ frappe.ui.form.on('Dashboard Chart', {
 				}
 			});
 		} else {
-			if (frm.doc.chart_type == 'Group By') {
-				frm.set_df_property('type', 'options', ['Line', 'Bar', 'Percentage', 'Pie', 'Donut']);
-			} else {
-				frm.set_df_property('type', 'options', ['Line', 'Bar', 'Heatmap']);
-			}
-
 			frm.set_value('document_type', '');
 		}
 	},

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -128,8 +128,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "Line\nBar\nHeatmap",
-   "reqd": 1
+   "options": "Line\nBar\nPercentage\nPie\nDonut\nHeatmap"
   },
   {
    "fieldname": "column_break_2",
@@ -219,7 +218,7 @@
    "options": "Dashboard Chart Field"
   },
   {
-   "description": "Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"] (the options set here will override the chart options set in the Dashboard)",
+   "description": "Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"]",
    "fieldname": "custom_options",
    "fieldtype": "Code",
    "label": "Custom Options"
@@ -239,7 +238,7 @@
   }
  ],
  "links": [],
- "modified": "2020-05-01 19:45:01.669384",
+ "modified": "2020-05-16 15:03:02.455395",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",


### PR DESCRIPTION
- Percentage, Pie and Donut chart types were removed in https://github.com/frappe/frappe/pull/10193

- Chart type doesn't need to be mandatory since Line is set as default