### PR TITLE
fix: Wrong parameter for letterhead when printing by server

### DIFF
--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -257,7 +257,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 							doctype: me.frm.doc.doctype,
 							name: me.frm.doc.name,
 							print_format:  me.selected_format(),
-							no_letterhead: (me.with_letterhead() ? "0" : "1")
+							no_letterhead: me.with_letterhead() ? "0" : "1"
 						},
 						callback: function (data) {
 						}

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -257,7 +257,7 @@ frappe.ui.form.PrintPreview = Class.extend({
 							doctype: me.frm.doc.doctype,
 							name: me.frm.doc.name,
 							print_format:  me.selected_format(),
-							no_letterhead: me.with_letterhead()
+							no_letterhead: (me.with_letterhead() ? "0" : "1")
 						},
 						callback: function (data) {
 						}


### PR DESCRIPTION
When using a print server to print documents (with PyCups), the setting for "print letterhead" was mixed up due to an incorrect parameter transfer.

Because of this, clicking print with letterhead option checked resulted in printing without letterhead and clicking print with letterhead option unchecked resulted in printing with letterhead.