### PR TITLE
feat: allow disabling custom cards in desk page

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -159,7 +159,10 @@ class Workspace:
 			}
 
 	def get_cards(self):
-		cards = self.doc.cards + get_custom_reports_and_doctypes(self.doc.module)
+		cards = self.doc.cards
+		if not self.doc.hide_custom:
+			cards = cards + get_custom_reports_and_doctypes(self.doc.module)
+
 		if len(self.extended_cards):
 			cards = cards + self.extended_cards
 		default_country = frappe.db.get_default("country")

--- a/frappe/desk/doctype/desk_page/desk_page.json
+++ b/frappe/desk/doctype/desk_page/desk_page.json
@@ -21,6 +21,7 @@
   "disable_user_customization",
   "pin_to_top",
   "pin_to_bottom",
+  "hide_custom",
   "section_break_2",
   "charts_label",
   "charts",
@@ -189,10 +190,17 @@
    "fieldtype": "Link",
    "label": "Onboarding",
    "options": "Module Onboarding"
+  },
+  {
+   "default": "0",
+   "description": "Checking this will hide custom doctypes and reports cards in Links section",
+   "fieldname": "hide_custom",
+   "fieldtype": "Check",
+   "label": "Hide Custom DocTypes and Reports"
   }
  ],
  "links": [],
- "modified": "2020-05-13 19:01:42.041524",
+ "modified": "2020-05-18 19:17:27.206646",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Desk Page",


### PR DESCRIPTION
Low Code Capability: For custom desk pages, user would like to hide custom documents and reports of the desk page. This PR adds that as an option in desk page doctype