### PR TITLE
fix: Type error when empty "Rich Text" or "HTML" content saved in Blog Post

### DIFF
--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -101,7 +101,7 @@ class BlogPost(WebsiteGenerator):
 				context.comment_text = _('{0} comments').format(len(context.comment_list))
 
 	def set_read_time(self):
-		content = self.content or self.content_html
+		content = (self.content or self.content_html) or ''
 		if self.content_type == "Markdown":
 			content = markdown(self.content_md)
 


### PR DESCRIPTION
When saving a blog post with no content and
Content Type set to "Rich Text/HTML", error is thrown.

Version: v12/develop

Error in Dialog:
`TypeError: expected string or bytes-like object`

Traceback in console:
```
Traceback (most recent call last):
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1086, in call
    return fn(*args, **newargs)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 281, in save
    return self._save(*args, **kwargs)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 316, in _save
    self.run_before_save_methods()
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 914, in run_before_save_methods
    self.run_method("validate")
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 815, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1101, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1084, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 809, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/website/doctype/blog_post/blog_post.py", line 47, in validate
    self.set_read_time()
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/website/doctype/blog_post/blog_post.py", line 108, in set_read_time
    total_words = len(strip_html_tags(content).split())
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/apps/frappe/frappe/utils/__init__.py", line 253, in strip_html_tags
    return re.sub("\<[^>]*\>", "", text)
  File "/Users/abhishekbalam/Dev/frappe/frappe-bench/env/lib/python3.7/re.py", line 192, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```

