### PR TITLE
fix: Console error in Blog Post when route is not set

### DIFF
--- a/frappe/website/doctype/blog_post/blog_post.js
+++ b/frappe/website/doctype/blog_post/blog_post.js
@@ -21,7 +21,7 @@ function generate_google_search_preview(frm) {
 	let seo_title = (frm.doc.title).slice(0, 60);
 	let seo_description =  (frm.doc.meta_description || frm.doc.blog_intro || "").slice(0, 160);
 	let date = frm.doc.published_on ? new frappe.datetime.datetime(frm.doc.published_on).moment.format('ll') + ' - ' : '';
-	let route_array = frm.doc.route.split('/');
+	let route_array = (frm.doc.route) ? frm.doc.route.split('/') : [];
 	route_array.pop();
 
 	google_preview.html(`

--- a/frappe/website/doctype/blog_post/blog_post.js
+++ b/frappe/website/doctype/blog_post/blog_post.js
@@ -21,7 +21,7 @@ function generate_google_search_preview(frm) {
 	let seo_title = (frm.doc.title).slice(0, 60);
 	let seo_description =  (frm.doc.meta_description || frm.doc.blog_intro || "").slice(0, 160);
 	let date = frm.doc.published_on ? new frappe.datetime.datetime(frm.doc.published_on).moment.format('ll') + ' - ' : '';
-	let route_array = (frm.doc.route) ? frm.doc.route.split('/') : [];
+	let route_array = frm.doc.route ? frm.doc.route.split('/') : [];
 	route_array.pop();
 
 	google_preview.html(`


### PR DESCRIPTION
When route is not set in Blog Post you see the following 
console error:

```
VM2249:28 Uncaught (in promise) TypeError: Cannot read property 'split' of undefined
    at generate_google_search_preview (eval at setup (form.min.js?ver=1589740826.0:15059), <anonymous>:28:34)
    at refresh (eval at setup (form.min.js?ver=1589740826.0:15059), <anonymous>:10:3)
    at runner (form.min.js?ver=1589740826.0:14996)
    at form.min.js?ver=1589740826.0:15014
```
Frappe version: v12
