### PR TITLE
fix: keyboard shortcut for toggle sidebar in report view

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1252,7 +1252,8 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			},
 			{
 				label: __('Toggle Sidebar'),
-				action: () => this.toggle_side_bar()
+				action: () => this.toggle_side_bar(),
+				shortcut: 'Ctrl+K',
 			},
 			{
 				label: __('Pick Columns'),


### PR DESCRIPTION
Keyboard shortcut **Cmd + K** wasn't set for Report View toggle sidebar