### PR TITLE
fix: remove markdown conversion

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -133,6 +133,11 @@ def get_comments(doctype, name):
 		reference_name = name
 	))
 
+	# convert to markdown (legacy ?)
+	for c in comments:
+		if c.comment_type == 'Comment':
+			c.content = frappe.utils.markdown(c.content)
+
 	return comments
 
 def get_point_logs(doctype, docname):

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -133,11 +133,6 @@ def get_comments(doctype, name):
 		reference_name = name
 	))
 
-	# convert to markdown (legacy ?)
-	for c in comments:
-		if c.comment_type == 'Comment':
-			c.content = frappe.utils.markdown(c.content)
-
 	return comments
 
 def get_point_logs(doctype, docname):

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -481,7 +481,7 @@ def watch(path, handler=None, debug=True):
 	observer.join()
 
 def markdown(text, sanitize=True, linkify=True):
-	html = frappe.utils.md_to_html(text)
+	html = text if is_html(text) else frappe.utils.md_to_html(text)
 
 	if sanitize:
 		html = html.replace("<!-- markdown -->", "")


### PR DESCRIPTION
Reason: markdown2 converts tags like `<this >` to `<this &gt;`

Markdown inputs from quill in comments output tags with trailing spaces. When passed through `sanitize_html`, characters `&gt;` are dropped.

Flow of execution:
```get_docinfo => get_comments => frappe.utils.markdown => frappe.utils.md_to_html + sanitize_html```

Comment Content:
```html
<div>Call with Baga boy</div><ul><li >Nice deal on new mobiles<ul><li  >Gada electronics is excited to become a  <strong>partner </strong></li></ul></li><li >Gada electronics is doing well post lockdown with the help of Jetha's brother in law</li><li >One crate of mangoes on each mobile bought. how nice</li><li ><strong>Ora Ora Ora </strong><ul><li  ><strong>Gibberish</strong></li><li  ><strong>Or not</strong></li></li><li >Gütenmorgen</li></ul>
```

**Before:**
![Screenshot 2020-05-20 at 12 05 35 PM](https://user-images.githubusercontent.com/36654812/82413256-a9080800-9a92-11ea-922b-a2d70aac4ff7.png)
**After:**
![Screenshot 2020-05-20 at 12 07 09 PM](https://user-images.githubusercontent.com/36654812/82413263-aa393500-9a92-11ea-8169-6584b7586035.png)
