### PR TITLE
fix: Report filters in Auto Email Report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('Auto Email Report', {
 	refresh: function(frm) {
+		console.log('refreshing')
 		if(frm.doc.report_type !== 'Report Builder') {
 			if(frm.script_setup_for !== frm.doc.report && !frm.doc.__islocal) {
 				frappe.call({
@@ -13,6 +14,7 @@ frappe.ui.form.on('Auto Email Report', {
 					callback: function(r) {
 						frappe.dom.eval(r.message.script || "");
 						frm.script_setup_for = frm.doc.report;
+						console.log(frappe.query_reports[frm.doc.report]);
 						frm.trigger('show_filters');
 					}
 				});
@@ -98,6 +100,7 @@ frappe.ui.form.on('Auto Email Report', {
 			});
 
 			table.on('click', function() {
+				console.log('clicked');
 				var dialog = new frappe.ui.Dialog({
 					fields: report_filters,
 					primary_action: function() {
@@ -110,6 +113,10 @@ frappe.ui.form.on('Auto Email Report', {
 					}
 				});
 				dialog.show();
+
+				//Set query report object so that it can be used while fetching filter values in the report
+				frappe.query_report = new frappe.views.QueryReport({'filters': dialog.fields_list});
+				frappe.query_reports[frm.doc.report].onload && frappe.query_reports[frm.doc.report].onload(frappe.query_report);
 				dialog.set_values(filters);
 			})
 

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -3,7 +3,6 @@
 
 frappe.ui.form.on('Auto Email Report', {
 	refresh: function(frm) {
-		console.log('refreshing')
 		if(frm.doc.report_type !== 'Report Builder') {
 			if(frm.script_setup_for !== frm.doc.report && !frm.doc.__islocal) {
 				frappe.call({
@@ -14,7 +13,6 @@ frappe.ui.form.on('Auto Email Report', {
 					callback: function(r) {
 						frappe.dom.eval(r.message.script || "");
 						frm.script_setup_for = frm.doc.report;
-						console.log(frappe.query_reports[frm.doc.report]);
 						frm.trigger('show_filters');
 					}
 				});
@@ -68,14 +66,16 @@ frappe.ui.form.on('Auto Email Report', {
 
 			var filters = JSON.parse(frm.doc.filters || '{}');
 
-			let report_filters;
+			let report_filters, report_name;
 
 			if (frm.doc.report_type === 'Custom Report'
 				&& frappe.query_reports[frm.doc.reference_report]
 				&& frappe.query_reports[frm.doc.reference_report].filters) {
 				report_filters = frappe.query_reports[frm.doc.reference_report].filters;
+				report_name = frm.doc.reference_report;
 			} else {
 				report_filters = frappe.query_reports[frm.doc.report].filters;
+				report_name = frm.doc.report;
 			}
 
 			if(report_filters && report_filters.length > 0) {
@@ -100,7 +100,6 @@ frappe.ui.form.on('Auto Email Report', {
 			});
 
 			table.on('click', function() {
-				console.log('clicked');
 				var dialog = new frappe.ui.Dialog({
 					fields: report_filters,
 					primary_action: function() {
@@ -116,7 +115,7 @@ frappe.ui.form.on('Auto Email Report', {
 
 				//Set query report object so that it can be used while fetching filter values in the report
 				frappe.query_report = new frappe.views.QueryReport({'filters': dialog.fields_list});
-				frappe.query_reports[frm.doc.report].onload && frappe.query_reports[frm.doc.report].onload(frappe.query_report);
+				frappe.query_reports[report_name].onload && frappe.query_reports[report_name].onload(frappe.query_report);
 				dialog.set_values(filters);
 			})
 


### PR DESCRIPTION
- Set query report object so that it can be used while fetching filter values in the report (ex: party name in general ledger)
- Call onload if defined

**Before:**
![auto email report filters bug](https://user-images.githubusercontent.com/19775888/82438486-c222b000-9ab6-11ea-870c-4f201b5b7f3e.gif)

**After:**
<img width="400" alt="Screenshot 2020-05-20 at 4 20 33 PM" src="https://user-images.githubusercontent.com/19775888/82438108-22652200-9ab6-11ea-857e-1d0d54899640.png">



**Before:**
![onload bug](https://user-images.githubusercontent.com/19775888/82438490-c5b63700-9ab6-11ea-8d5d-7e116d22ddd2.gif)

**After:**
<img width="400" alt="Screenshot 2020-05-20 at 4 06 48 PM" src="https://user-images.githubusercontent.com/19775888/82438094-1ed19b00-9ab6-11ea-81af-a9e7d97e2993.png">
