### PR TITLE
fix: set columns with hidden columns filtered out in datatable

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -467,7 +467,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.datatable.refresh(data, columns);
 		} else {
 			let datatable_options = {
-				columns: this.columns,
+				columns: columns,
 				data: data,
 				inlineFilters: true,
 				treeView: this.tree_report,


### PR DESCRIPTION
Set columns with hidden columns filtered out in datatable

Continuation of https://github.com/frappe/frappe/pull/10414
