### PR TITLE
test: fix flaky tests relative filter and control link

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,6 @@
   "baseUrl": "http://test_site_ui:8000",
   "projectId": "92odwv",
   "adminPassword": "admin",
-  "defaultCommandTimeout": 10000,
+  "defaultCommandTimeout": 20000,
   "pageLoadTimeout": 15000
 }

--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -34,7 +34,7 @@ context('Control Link', () => {
 
 		cy.get('.frappe-control[data-fieldname=link] input').focus().as('input');
 		cy.wait('@search_link');
-		cy.get('@input').type('todo for link');
+		cy.get('@input').type('todo for link', { delay: 200 });
 		cy.wait('@search_link');
 		cy.get('.frappe-control[data-fieldname=link] ul').should('be.visible');
 		cy.get('.frappe-control[data-fieldname=link] input').type('{enter}', { delay: 100 });

--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -10,7 +10,7 @@ context('Control Link', () => {
 			doctype: 'ToDo',
 			description: 'this is a test todo for link'
 		}).as('todos');
-	})
+	});
 
 	function get_dialog_with_link() {
 		return cy.dialog({

--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -1,12 +1,16 @@
 context('Control Link', () => {
-	beforeEach(() => {
+	before(() => {
 		cy.login();
+		cy.visit('/desk#workspace/Website');
+	});
+
+	beforeEach(() => {
 		cy.visit('/desk#workspace/Website');
 		cy.create_records({
 			doctype: 'ToDo',
 			description: 'this is a test todo for link'
 		}).as('todos');
-	});
+	})
 
 	function get_dialog_with_link() {
 		return cy.dialog({

--- a/cypress/integration/relative_filters.js
+++ b/cypress/integration/relative_filters.js
@@ -1,7 +1,6 @@
 context('Relative Timeframe', () => {
 	beforeEach(() => {
 		cy.login();
-		cy.visit('/desk#workspace/Website');
 	});
 	before(() => {
 		cy.login();


### PR DESCRIPTION
### Relative Filter

Relative filter test would route to home workspace before each of the test, which started with a route. The problem here is that the the second command visit would be issued right after the first one, in this, the first one gets resolved later and shows desk instead of Todo List


### Control Link
1. don't login before each test
1. added delay in typing 

### Default Command Timeout

Set this to 20 seconds, it makes a few tests like awesomeplete and awesomebar more reliable