### PR TITLE
fix: include docname in notification email

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -83,14 +83,13 @@ def send_notification_email(doc):
 	doc_link = get_url_to_form(doc.document_type, doc.document_name)
 	header = get_email_header(doc)
 	email_subject = strip_html(doc.subject)
-	body_content = get_email_body_content(doc)
 
 	frappe.sendmail(
 		recipients = doc.for_user,
 		subject = email_subject,
 		template = "new_notification",
 		args = {
-			'body_content': body_content,
+			'body_content': doc.subject,
 			'description': doc.email_content,
 			'document_type': doc.document_type,
 			'document_name': doc.document_name,
@@ -100,22 +99,17 @@ def send_notification_email(doc):
 		now=frappe.flags.in_test
 	)
 
-def get_email_body_content(doc):
-	#include document name in email content
-	title_html = get_title_html(get_title(doc.document_type, doc.document_name))
-	subject_parts = doc.subject.partition(title_html)
-	body_content = "{0}{1} ({2}){3}".format(subject_parts[0], subject_parts[1], doc.document_name, subject_parts[2])
-	return body_content
-
 def get_email_header(doc):
-	return {
+	docname = doc.document_name
+	header_map = {
 		'Default': _('New Notification'),
-		'Mention': _('New Mention'),
-		'Assignment': _('Assignment Update'),
-		'Share': _('New Document Shared'),
-		'Energy Point': _('Energy Point Update'),
-	}[doc.type or 'Default']
+		'Mention': _('New Mention on {0}').format(docname),
+		'Assignment': _('Assignment Update on {0}').format(docname),
+		'Share': _('New Document Shared {0}').format(docname),
+		'Energy Point': _('Energy Point Update on {0}').format(docname),
+	}
 
+	return header_map[doc.type or 'Default']
 
 @frappe.whitelist()
 def mark_all_as_read():

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -83,13 +83,14 @@ def send_notification_email(doc):
 	doc_link = get_url_to_form(doc.document_type, doc.document_name)
 	header = get_email_header(doc)
 	email_subject = strip_html(doc.subject)
+	body_content = get_email_body_content(doc)
 
 	frappe.sendmail(
 		recipients = doc.for_user,
 		subject = email_subject,
 		template = "new_notification",
 		args = {
-			'body_content': doc.subject,
+			'body_content': body_content,
 			'description': doc.email_content,
 			'document_type': doc.document_type,
 			'document_name': doc.document_name,
@@ -98,6 +99,13 @@ def send_notification_email(doc):
 		header = [header, 'orange'],
 		now=frappe.flags.in_test
 	)
+
+def get_email_body_content(doc):
+	#include document name in email content
+	title_html = get_title_html(get_title(doc.document_type, doc.document_name))
+	subject_parts = doc.subject.partition(title_html)
+	body_content = "{0}{1} ({2}){3}".format(subject_parts[0], subject_parts[1], doc.document_name, subject_parts[2])
+	return body_content
 
 def get_email_header(doc):
 	return {

--- a/frappe/templates/emails/new_notification.html
+++ b/frappe/templates/emails/new_notification.html
@@ -8,6 +8,5 @@
 </blockquote>
 {% endif %}
 <div class="more-info">
-	<a href="{{ doc_link }}">{{ _("Login and view in Browser") }}</a>
+	<a href="{{ doc_link }}">{{ _("Open Document") }}</a>
 </div>
-	


### PR DESCRIPTION
**Before:**
<img width="1107" alt="Screenshot 2020-05-21 at 12 31 43 PM" src="https://user-images.githubusercontent.com/19775888/82532527-33b63900-9b5f-11ea-86ba-ba902caa3a4c.png">



**After:**
<img width="1067" alt="Screenshot 2020-05-27 at 11 30 04 AM" src="https://user-images.githubusercontent.com/19775888/82983280-7075aa80-a00d-11ea-9308-24a04683ffb8.png">
