### PR TITLE
chore: Add release notes for v12.6.0

### DIFF
--- a/frappe/change_log/v12/v12_6_0.md
+++ b/frappe/change_log/v12/v12_6_0.md
@@ -1,0 +1,24 @@
+## Version 12.6.0 Release Notes
+
+### Bug Fixes
+
+- Fixed Calculation of dates and values for Dashboard Charts ([#9968](https://github.com/frappe/frappe/pull/9968))
+- Fixed and enhanced email thread system ([#10261](https://github.com/frappe/frappe/pull/10261))
+- Fixed invalid date parsing issue ([#10288](https://github.com/frappe/frappe/pull/10288))
+- Data Import Beta will now properly handle datetime imports ([#10077](https://github.com/frappe/frappe/pull/10077))
+- Fixed Auto Repeat schedule date calculation for Daily and Weekly frequencies ([#10237](https://github.com/frappe/frappe/pull/10237))
+- Fixed an issue of assignments getting reopened on close ([#10354](https://github.com/frappe/frappe/pull/10354))
+- Fixed permission issue while creating new private files ([#10115](https://github.com/frappe/frappe/pull/10115))
+- Fixed an issue where Print formats were not retaining customizations ([#10060](https://github.com/frappe/frappe/pull/10060))
+
+### UI/UX Enhancements
+
+- Introduced checkbox option to text editor's toolbar ([#9979](https://github.com/frappe/frappe/pull/9979))
+- Sidebar for Web Form items in mobile view ([#9942](https://github.com/frappe/frappe/pull/9942))
+- Arrow on select select is now clickable ([#10263](https://github.com/frappe/frappe/pull/10263))
+- Made website footer stick to bottom ([#9690](https://github.com/frappe/frappe/pull/9690))
+- Fixed the issue of Multi Select List field being rendered multiple times in dialog ([#10093](https://github.com/frappe/frappe/pull/10093))
+
+### Feature
+
+- Enabled 2FA for LDAP users ([#10002](https://github.com/frappe/frappe/pull/10002))


### PR DESCRIPTION
<img width="632" alt="Screenshot 2020-05-21 at 2 16 56 PM" src="https://user-images.githubusercontent.com/13928957/82541329-e8efed80-9b6d-11ea-810a-a4adfae46a02.png">
