### PR TITLE
chore: pin redis version to 3.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3.1
 rauth==0.7.3
-redis>=3.0
+redis==3.5.1
 requests-oauthlib==1.3.0
 requests==2.23.0
 RestrictedPython==5.0


### PR DESCRIPTION
redis version 3.5.2 released on May 15, 2020 is breaking