### PR TITLE
fix: customize hooks for override_doctype_dashboards get AttributeError

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -437,7 +437,7 @@ class Meta(Document):
 
 		if not self.custom:
 			for hook in frappe.get_hooks("override_doctype_dashboards", {}).get(self.name, []):
-				data = frappe.get_attr(hook)(data=data)
+				data = frappe._dict(frappe.get_attr(hook)(data=data))
 
 		return data
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

`frappe.get_attr(hook)(data=data)` return dict. But function `get_open_count` will access `fieldname` attribute in notifications.py.
 I will cause error `'dict' object has no attribute 'fieldname'`.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

Fix bug `'dict' object has no attribute 'fieldname'` if customize hooks for `override_doctype_dashboards`

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<img width="393" alt="呂昇達_-_SAL-ORD-2020-00007" src="https://user-images.githubusercontent.com/2996108/82551909-b953dc00-9b93-11ea-968a-ef5e68bd528d.png">

