### PR TITLE
fix: Website theme migration failure

### DIFF
--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -59,7 +59,7 @@ class WebsiteTheme(Document):
 
 		file_name = frappe.scrub(self.name) + '_' + frappe.generate_hash('Website Theme', 8) + '.css'
 		output_path = join_path(frappe.utils.get_bench_path(), 'sites', 'assets', 'css', file_name)
-		content = self.theme_scss
+		content = self.theme_scss or ''
 		content = content.replace('\n', '\\n')
 		command = ['node', 'generate_bootstrap_theme.js', output_path, content]
 


### PR DESCRIPTION
Fixes following theme generation failure while migration

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-05-21/apps/frappe/frappe/website/doctype/website_theme/website_theme.py", line 115, in generate_theme_files_if_not_exist
    doc.generate_theme_if_not_exist()
  File "/home/frappe/benches/bench-version-12-2020-05-21/apps/frappe/frappe/website/doctype/website_theme/website_theme.py", line 86, in generate_theme_if_not_exist
    self.generate_bootstrap_theme()
  File "/home/frappe/benches/bench-version-12-2020-05-21/apps/frappe/frappe/website/doctype/website_theme/website_theme.py", line 63, in generate_bootstrap_theme
    content = content.replace('\n', '\\n')
AttributeError: 'NoneType' object has no attribute 'replace'
```