### PR TITLE
fix: default return value for flt

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -348,7 +348,7 @@ def flt(s, precision=None):
 		if precision is not None:
 			num = rounded(num, precision)
 	except Exception:
-		num = 0
+		num = 0.0
 
 	return num
 


### PR DESCRIPTION
# Before

<img width="300" alt="Screenshot 2020-05-21 at 6 16 38 PM" src="https://user-images.githubusercontent.com/3784093/82561019-34b38e80-9b90-11ea-839a-c5e24db1c2fc.png">

# After

<img width="347" alt="Screenshot 2020-05-21 at 6 24 32 PM" src="https://user-images.githubusercontent.com/3784093/82561074-5a409800-9b90-11ea-96f0-242b468781c6.png">
