### PR TITLE
fix: Add backwards compatible verbose flag

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -12,7 +12,9 @@ import frappe
 from frappe import _, conf
 from frappe.utils import cstr, get_url, now_datetime
 
-_verbose = False
+# backup variable for backwards compatibility
+verbose = False
+_verbose = verbose
 
 
 class BackupGenerator:


### PR DESCRIPTION
Acceptable commands:
* `bench --verbose --site getanerp.site backup`
* `bench --site getanerp.site backup --verbose `

Bug introduced by https://github.com/frappe/frappe/pull/10423

**After #10423** 

![Screenshot 2020-05-22 at 12 21 06 PM](https://user-images.githubusercontent.com/36654812/82639679-d84f7e00-9c26-11ea-8c3d-92513e1a20b6.png)

**After #10455**
![Screenshot 2020-05-22 at 12 21 31 PM](https://user-images.githubusercontent.com/36654812/82639674-d685ba80-9c26-11ea-9776-512af7680600.png)

