### PR TITLE
fix: chart auto color

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -577,7 +577,7 @@ export default class ChartWidget extends Widget {
 				colors.push(field.color);
 			});
 		} else if (["Line", "Bar"].includes(this.chart_doc.type)) {
-			colors = [this.chart_doc.color || "light-blue"];
+			colors = [this.chart_doc.color || []];
 		}  else if (this.chart_doc.type == "Heatmap") {
 			colors = [];
 		}


### PR DESCRIPTION
Do not set default color for chart in chart_widget

### Before 
![Screenshot_2020-05-22 Desk](https://user-images.githubusercontent.com/18097732/82653961-9da51000-9c3d-11ea-9d66-ead595b69130.png)


### After
![Screenshot_2020-05-22 Desk(1)](https://user-images.githubusercontent.com/18097732/82653950-9b42b600-9c3d-11ea-9a80-7db0479dc383.png)
