### PR TITLE
feat: Date filter improvements

### DIFF
--- a/cypress/integration/relative_time_filters.js
+++ b/cypress/integration/relative_time_filters.js
@@ -9,14 +9,14 @@ context('Relative Timeframe', () => {
 			frappe.call("frappe.tests.ui_test_helpers.create_todo_records");
 		});
 	});
-	it('set relative filter for Previous and check list', () => {
+	it('sets relative timespan filter for last week and filters list', () => {
 		cy.visit('/desk#List/ToDo/List');
 		cy.get('.list-row:contains("this is fourth todo")').should('exist');
 		cy.get('.tag-filters-area .btn:contains("Add Filter")').click();
 		cy.get('.fieldname-select-area').should('exist');
 		cy.get('.fieldname-select-area input').type("Due Date{enter}", { delay: 100 });
-		cy.get('select.condition.form-control').select("Previous");
-		cy.get('.filter-field select.input-with-feedback.form-control').select("1 week");
+		cy.get('select.condition.form-control').select("Timespan");
+		cy.get('.filter-field select.input-with-feedback.form-control').select("last week");
 		cy.server();
 		cy.route('POST', '/api/method/frappe.desk.reportview.get').as('list_refresh');
 		cy.get('.filter-box .btn:contains("Apply")').click();
@@ -28,13 +28,13 @@ context('Relative Timeframe', () => {
 		cy.get('.remove-filter.btn').click();
 		cy.wait('@save_user_settings');
 	});
-	it('set relative filter for Next and check list', () => {
+	it('sets relative timespan filter for next week and filters list', () => {
 		cy.visit('/desk#List/ToDo/List');
 		cy.get('.list-row:contains("this is fourth todo")').should('exist');
 		cy.get('.tag-filters-area .btn:contains("Add Filter")').click();
 		cy.get('.fieldname-select-area input').type("Due Date{enter}", { delay: 100 });
-		cy.get('select.condition.form-control').select("Next");
-		cy.get('.filter-field select.input-with-feedback.form-control').select("1 week");
+		cy.get('select.condition.form-control').select("Timespan");
+		cy.get('.filter-field select.input-with-feedback.form-control').select("next week");
 		cy.server();
 		cy.route('POST', '/api/method/frappe.desk.reportview.get').as('list_refresh');
 		cy.get('.filter-box .btn:contains("Apply")').click();

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -85,7 +85,7 @@ def get_bootinfo():
 	bootinfo.points = get_energy_points(frappe.session.user)
 	bootinfo.frequently_visited_links = frequently_visited_links()
 	bootinfo.link_preview_doctypes = get_link_preview_doctypes()
-	bootinfo.additional_filters_config = get_additional_filters_config()
+	bootinfo.additional_filters_config = get_additional_filters_from_hooks()
 
 	return bootinfo
 
@@ -299,7 +299,7 @@ def get_link_preview_doctypes():
 
 	return link_preview_doctypes
 
-def get_additional_filters_config():
+def get_additional_filters_from_hooks():
 	filter_config = frappe._dict()
 	filter_hooks = frappe.get_hooks('filters_config')
 	for hook in filter_hooks:

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -85,7 +85,7 @@ def get_bootinfo():
 	bootinfo.points = get_energy_points(frappe.session.user)
 	bootinfo.frequently_visited_links = frequently_visited_links()
 	bootinfo.link_preview_doctypes = get_link_preview_doctypes()
-	bootinfo.filters_config = get_filters_config()
+	bootinfo.additional_filters_config = get_additional_filters_config()
 
 	return bootinfo
 
@@ -299,9 +299,10 @@ def get_link_preview_doctypes():
 
 	return link_preview_doctypes
 
-def get_filters_config():
+def get_additional_filters_config():
 	filter_config = frappe._dict()
 	filter_hooks = frappe.get_hooks('filters_config')
 	for hook in filter_hooks:
 		filter_config.update(frappe.get_attr(hook)())
+
 	return filter_config

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -85,6 +85,7 @@ def get_bootinfo():
 	bootinfo.points = get_energy_points(frappe.session.user)
 	bootinfo.frequently_visited_links = frequently_visited_links()
 	bootinfo.link_preview_doctypes = get_link_preview_doctypes()
+	bootinfo.filters_config = get_filters_config()
 
 	return bootinfo
 
@@ -297,3 +298,10 @@ def get_link_preview_doctypes():
 			link_preview_doctypes.append(custom.doc_type)
 
 	return link_preview_doctypes
+
+def get_filters_config():
+	filter_config = frappe._dict()
+	filter_hooks = frappe.get_hooks('filters_config')
+	for hook in filter_hooks:
+		filter_config.update(frappe.get_attr(hook)())
+	return filter_config

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -16,7 +16,8 @@ import frappe, json, copy, re
 from frappe.model import optional_fields
 from frappe.client import check_parent_permission
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
-from frappe.utils import flt, cint, get_time, make_filter_tuple, get_filter, add_to_date, cstr, nowdate
+from frappe.utils import flt, cint, get_time, make_filter_tuple, get_filter, add_to_date, cstr, nowdate,\
+	get_first_day, get_first_day_of_week, get_quarter_start, get_year_start
 from frappe.model.meta import get_table_columns
 
 class DatabaseQuery(object):
@@ -426,7 +427,7 @@ class DatabaseQuery(object):
 			if df and df.fieldtype in ("Check", "Float", "Int", "Currency", "Percent"):
 				can_be_null = False
 
-			if f.operator.lower() in ('previous', 'next'):
+			if f.operator.lower() in ('previous', 'next', 'current'):
 				if f.operator.lower() == "previous":
 					if f.value == "1 week":
 						date_range = [add_to_date(nowdate(), days=-7), nowdate()]
@@ -438,6 +439,15 @@ class DatabaseQuery(object):
 						date_range = [add_to_date(nowdate(), months=-6), nowdate()]
 					elif f.value == "1 year":
 						date_range = [add_to_date(nowdate(), years=-1), nowdate()]
+				elif f.operator.lower() == "current":
+					if f.value == "1 week":
+						date_range = [get_first_day_of_week(nowdate(), as_str=True), nowdate()]
+					elif f.value == "1 month":
+						date_range = [get_first_day(nowdate(), as_str=True), nowdate()]
+					elif f.value == "3 months":
+						date_range = [get_quarter_start(nowdate(), as_str=True), nowdate()]
+					elif f.value == "1 year":
+						date_range = [get_year_start(nowdate(), as_str=True), nowdate()]
 				elif f.operator.lower() == "next":
 					if f.value == "1 week":
 						date_range = [nowdate(), add_to_date(nowdate(), days=7)]

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -354,8 +354,8 @@ class DatabaseQuery(object):
 				ifnull(`tabDocType`.`fieldname`, fallback) operator "value"
 		"""
 
-		from frappe.boot import get_additional_filters_config
-		additional_filters_config = get_additional_filters_config()
+		from frappe.boot import get_additional_filters_from_hooks
+		additional_filters_config = get_additional_filters_from_hooks()
 		f = get_filter(self.doctype, f, additional_filters_config)
 
 		tname = ('`tab' + f.doctype + '`')

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -16,7 +16,7 @@ import frappe, json, copy, re
 from frappe.model import optional_fields
 from frappe.client import check_parent_permission
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
-from frappe.utils import flt, cint, get_time, make_filter_tuple, get_filter, add_to_date, cstr, nowdate, get_timespan_date_range
+from frappe.utils import flt, cint, get_time, make_filter_tuple, get_filter, add_to_date, cstr, get_timespan_date_range
 from frappe.model.meta import get_table_columns
 
 class DatabaseQuery(object):

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -431,10 +431,8 @@ class DatabaseQuery(object):
 			if df and df.fieldtype in ("Check", "Float", "Int", "Currency", "Percent"):
 				can_be_null = False
 
-			if f.operator.lower() == 'previous' or f.operator.lower() == 'next':
-				f = replace_old_date_filters(f)
-			if f.operator.lower() == 'timespan':
-				date_range = get_timespan_date_range(f.value)
+			if f.operator.lower() in ('previous', 'next', 'timespan'):
+				date_range = get_date_range(f.operator.lower(), f.value)
 				f.operator = "Between"
 				f.value = date_range
 				fallback = "'0001-01-01 00:00:00'"
@@ -841,7 +839,7 @@ def get_additional_filter_field(additional_filters_config, f, value):
 				f.value = option.query_value
 	return f
 
-def replace_old_date_filters(f):
+def get_date_range(operator, value):
 	timespan_map = {
 		'1 week': 'week',
 		'1 month': 'month',
@@ -849,13 +847,11 @@ def replace_old_date_filters(f):
 		'6 months': '6 months',
 		'1 year': 'year',
 	}
-
 	period_map = {
-		'Previous': 'last',
-		'Next': 'next'
+		'previous': 'last',
+		'next': 'next',
 	}
 
-	f.value = period_map[f.operator] + ' ' + timespan_map[f.value]
-	f.operator = 'Timespan'
+	timespan = period_map[operator] + ' ' + timespan_map[value] if operator != 'timespan' else value
 
-	return f
+	return get_timespan_date_range(timespan)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -354,8 +354,8 @@ class DatabaseQuery(object):
 				ifnull(`tabDocType`.`fieldname`, fallback) operator "value"
 		"""
 
-		from frappe.boot import get_filters_config
-		additional_filters_config = get_filters_config()
+		from frappe.boot import get_additional_filters_config
+		additional_filters_config = get_additional_filters_config()
 		f = get_filter(self.doctype, f, additional_filters_config)
 
 		tname = ('`tab' + f.doctype + '`')

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -16,8 +16,7 @@ import frappe, json, copy, re
 from frappe.model import optional_fields
 from frappe.client import check_parent_permission
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
-from frappe.utils import flt, cint, get_time, make_filter_tuple, get_filter, add_to_date, cstr, nowdate,\
-	get_first_day, get_first_day_of_week, get_quarter_start, get_year_start
+from frappe.utils import flt, cint, get_time, make_filter_tuple, get_filter, add_to_date, cstr, nowdate, get_timespan_date_range
 from frappe.model.meta import get_table_columns
 
 class DatabaseQuery(object):
@@ -374,6 +373,7 @@ class DatabaseQuery(object):
 		if f.operator.lower() in additional_filters_config:
 			f.update(get_additional_filter_field(additional_filters_config, f, f.value))
 
+		# prepare in condition
 		if f.operator.lower() in ('ancestors of', 'descendants of', 'not ancestors of', 'not descendants of'):
 			values = f.value or ''
 
@@ -838,35 +838,3 @@ def get_additional_filter_field(additional_filters_config, f, value):
 			if option.value == value:
 				f.value = option.query_value
 	return f
-
-def get_timespan_date_range(period):
-	if period == "last week":
-		date_range = [add_to_date(nowdate(), days=-7), nowdate()]
-	elif period == "last month":
-		date_range = [add_to_date(nowdate(), months=-1), nowdate()]
-	elif period == "last quarter":
-		date_range = [add_to_date(nowdate(), months=-3), nowdate()]
-	elif period == "last 6 months":
-		date_range = [add_to_date(nowdate(), months=-6), nowdate()]
-	elif period == "last year":
-		date_range = [add_to_date(nowdate(), years=-1), nowdate()]
-	elif period == "this week":
-		date_range = [get_first_day_of_week(nowdate(), as_str=True), nowdate()]
-	elif period == "this month":
-		date_range = [get_first_day(nowdate(), as_str=True), nowdate()]
-	elif period == "this quarter":
-		date_range = [get_quarter_start(nowdate(), as_str=True), nowdate()]
-	elif period == "this year":
-		date_range = [get_year_start(nowdate(), as_str=True), nowdate()]
-	elif period == "next week":
-		date_range = [nowdate(), add_to_date(nowdate(), days=7)]
-	elif period == "next month":
-		date_range = [nowdate(), add_to_date(nowdate(), months=1)]
-	elif period == "next quarter":
-		date_range = [nowdate(), add_to_date(nowdate(), months=3)]
-	elif period == "next 6 months":
-		date_range = [nowdate(), add_to_date(nowdate(), months=6)]
-	elif period == "next year":
-		date_range = [nowdate(), add_to_date(nowdate(), years=1)]
-
-	return date_range

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -431,6 +431,8 @@ class DatabaseQuery(object):
 			if df and df.fieldtype in ("Check", "Float", "Int", "Currency", "Percent"):
 				can_be_null = False
 
+			if f.operator.lower() == 'previous' or f.operator.lower() == 'next':
+				f = replace_old_date_filters(f)
 			if f.operator.lower() == 'timespan':
 				date_range = get_timespan_date_range(f.value)
 				f.operator = "Between"
@@ -837,4 +839,23 @@ def get_additional_filter_field(additional_filters_config, f, value):
 			option = frappe._dict(option)
 			if option.value == value:
 				f.value = option.query_value
+	return f
+
+def replace_old_date_filters(f):
+	timespan_map = {
+		'1 week': 'week',
+		'1 month': 'month',
+		'3 months': 'quarter',
+		'6 months': '6 months',
+		'1 year': 'year',
+	}
+
+	period_map = {
+		'Previous': 'last',
+		'Next': 'next'
+	}
+
+	f.value = period_map[f.operator] + ' ' + timespan_map[f.value]
+	f.operator = 'Timespan'
+
 	return f

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -431,38 +431,8 @@ class DatabaseQuery(object):
 			if df and df.fieldtype in ("Check", "Float", "Int", "Currency", "Percent"):
 				can_be_null = False
 
-			if f.operator.lower() in ('previous', 'next', 'current'):
-				if f.operator.lower() == "previous":
-					if f.value == "1 week":
-						date_range = [add_to_date(nowdate(), days=-7), nowdate()]
-					elif f.value == "1 month":
-						date_range = [add_to_date(nowdate(), months=-1), nowdate()]
-					elif f.value == "3 months":
-						date_range = [add_to_date(nowdate(), months=-3), nowdate()]
-					elif f.value == "6 months":
-						date_range = [add_to_date(nowdate(), months=-6), nowdate()]
-					elif f.value == "1 year":
-						date_range = [add_to_date(nowdate(), years=-1), nowdate()]
-				elif f.operator.lower() == "current":
-					if f.value == "1 week":
-						date_range = [get_first_day_of_week(nowdate(), as_str=True), nowdate()]
-					elif f.value == "1 month":
-						date_range = [get_first_day(nowdate(), as_str=True), nowdate()]
-					elif f.value == "3 months":
-						date_range = [get_quarter_start(nowdate(), as_str=True), nowdate()]
-					elif f.value == "1 year":
-						date_range = [get_year_start(nowdate(), as_str=True), nowdate()]
-				elif f.operator.lower() == "next":
-					if f.value == "1 week":
-						date_range = [nowdate(), add_to_date(nowdate(), days=7)]
-					elif f.value == "1 month":
-						date_range = [nowdate(), add_to_date(nowdate(), months=1)]
-					elif f.value == "3 months":
-						date_range = [nowdate(), add_to_date(nowdate(), months=3)]
-					elif f.value == "6 months":
-						date_range = [nowdate(), add_to_date(nowdate(), months=6)]
-					elif f.value == "1 year":
-						date_range = [nowdate(), add_to_date(nowdate(), years=1)]
+			if f.operator.lower() == 'timespan':
+				date_range = get_timespan_date_range(f.value)
 				f.operator = "Between"
 				f.value = date_range
 				fallback = "'0001-01-01 00:00:00'"
@@ -868,3 +838,35 @@ def get_additional_filter_field(additional_filters_config, f, value):
 			if option.value == value:
 				f.value = option.query_value
 	return f
+
+def get_timespan_date_range(period):
+	if period == "last week":
+		date_range = [add_to_date(nowdate(), days=-7), nowdate()]
+	elif period == "last month":
+		date_range = [add_to_date(nowdate(), months=-1), nowdate()]
+	elif period == "last quarter":
+		date_range = [add_to_date(nowdate(), months=-3), nowdate()]
+	elif period == "last 6 months":
+		date_range = [add_to_date(nowdate(), months=-6), nowdate()]
+	elif period == "last year":
+		date_range = [add_to_date(nowdate(), years=-1), nowdate()]
+	elif period == "this week":
+		date_range = [get_first_day_of_week(nowdate(), as_str=True), nowdate()]
+	elif period == "this month":
+		date_range = [get_first_day(nowdate(), as_str=True), nowdate()]
+	elif period == "this quarter":
+		date_range = [get_quarter_start(nowdate(), as_str=True), nowdate()]
+	elif period == "this year":
+		date_range = [get_year_start(nowdate(), as_str=True), nowdate()]
+	elif period == "next week":
+		date_range = [nowdate(), add_to_date(nowdate(), days=7)]
+	elif period == "next month":
+		date_range = [nowdate(), add_to_date(nowdate(), months=1)]
+	elif period == "next quarter":
+		date_range = [nowdate(), add_to_date(nowdate(), months=3)]
+	elif period == "next 6 months":
+		date_range = [nowdate(), add_to_date(nowdate(), months=6)]
+	elif period == "next year":
+		date_range = [nowdate(), add_to_date(nowdate(), years=1)]
+
+	return date_range

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -287,3 +287,4 @@ execute:frappe.delete_doc("Web Template", "Section with Left Image", force=1)
 execute:frappe.delete_doc("DocType", "Onboarding Slide")
 execute:frappe.delete_doc("DocType", "Onboarding Slide Field")
 execute:frappe.delete_doc("DocType", "Onboarding Slide Help Link")
+frappe.patches.v13_0.update_date_filters_in_user_settings

--- a/frappe/patches/v13_0/update_date_filters_in_user_settings.py
+++ b/frappe/patches/v13_0/update_date_filters_in_user_settings.py
@@ -1,0 +1,54 @@
+from __future__ import unicode_literals
+import frappe, json
+from frappe.model.utils.user_settings import update_user_settings, sync_user_settings
+
+def execute():
+	from frappe.model.utils.user_settings import update_user_settings, sync_user_settings
+	users = frappe.db.sql("select distinct(user) from `__UserSettings`", as_dict=True)
+
+	for user in users:
+		user_settings = frappe.db.sql('''
+			select
+				* from `__UserSettings`
+			where
+				user="{user}"
+		'''.format(user = user.user), as_dict=True)
+
+		for setting in user_settings:
+			data = frappe.parse_json(setting.get('data'))
+			if data:
+				for key in data:
+					update_user_setting_filters(data, key, setting)
+
+	sync_user_settings()
+
+
+def update_user_setting_filters(data, key, user_setting):
+	timespan_map = {
+		'1 week': 'week',
+		'1 month': 'month',
+		'3 months': 'quarter',
+		'6 months': '6 months',
+		'1 year': 'year',
+	}
+
+	period_map = {
+		'Previous': 'last',
+		'Next': 'next'
+	}
+
+	if data.get(key):
+		update = False
+		if isinstance(data.get(key), dict):
+			filters = data.get(key).get('filters')
+			for f in filters:
+				if f[2] == 'Next' or f[2] == 'Previous':
+					update = True
+					f[3] = period_map[f[2]] + ' ' + timespan_map[f[3]]
+					f[2] = 'Timespan'
+
+			if update:
+				data[key]['filters'] = filters
+				update_user_settings(user_setting['doctype'], json.dumps(data), for_update=True)
+
+

--- a/frappe/patches/v13_0/update_date_filters_in_user_settings.py
+++ b/frappe/patches/v13_0/update_date_filters_in_user_settings.py
@@ -3,7 +3,6 @@ import frappe, json
 from frappe.model.utils.user_settings import update_user_settings, sync_user_settings
 
 def execute():
-	from frappe.model.utils.user_settings import update_user_settings, sync_user_settings
 	users = frappe.db.sql("select distinct(user) from `__UserSettings`", as_dict=True)
 
 	for user in users:

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -339,8 +339,8 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	get_filter_value(fieldname) {
-		return this.get_filters_for_args().filter(f=> f[1] == fieldname)[0] &&
-			this.get_filters_for_args().filter(f=> f[1] == fieldname)[0][3];
+		return this.get_filters_for_args().filter(f => f[1] == fieldname)[0] &&
+			this.get_filters_for_args().filter(f => f[1] == fieldname)[0][3];
 	}
 
 	get_args() {

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -338,6 +338,11 @@ frappe.views.BaseList = class BaseList {
 			: [];
 	}
 
+	get_filter_value(fieldname) {
+		return this.get_filters_for_args().filter(f=> f[1] == fieldname)[0] &&
+			this.get_filters_for_args().filter(f=> f[1] == fieldname)[0][3];
+	}
+
 	get_args() {
 		return {
 			doctype: this.doctype,

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -223,7 +223,7 @@ frappe.ui.Filter = class {
 		this.fieldselect.selected_doctype = doctype;
 		this.fieldselect.selected_fieldname = fieldname;
 
-		if (this.filters_config[condition]
+		if (this.filters_config && this.filters_config[condition]
 				&& this.filters_config[condition].valid_for_fieldtypes.includes(df.fieldtype)) {
 			let args = {};
 			if (this.filters_config[condition].depends_on) {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -25,9 +25,7 @@ frappe.ui.Filter = class {
 			[">=", ">="],
 			["<=", "<="],
 			["Between", __("Between")],
-			["Previous", __("Previous")],
-			["Current", __("Current")],
-			["Next", __("Next")]
+			["Timespan", __("Timespan")],
 		];
 
 		this.nested_set_conditions = [
@@ -42,11 +40,11 @@ frappe.ui.Filter = class {
 		this.invalid_condition_map = {
 			Date: ['like', 'not like'],
 			Datetime: ['like', 'not like'],
-			Data: ['Between', 'Previous', 'Current', 'Next'],
-			Select: ['like', 'not like', 'Between', 'Previous', 'Current', 'Next'],
-			Link: ["Between", 'Previous', 'Current', 'Next', '>', '<', '>=', '<='],
-			Currency: ["Between", 'Previous', 'Current', 'Next'],
-			Color: ["Between", 'Previous', 'Current', 'Next'],
+			Data: ['Between', 'Timespan'],
+			Select: ['like', 'not like', 'Between', 'Timespan'],
+			Link: ["Between", 'Timespan', '>', '<', '>=', '<='],
+			Currency: ["Between", 'Timespan'],
+			Color: ["Between", 'Timespan'],
 			Check: this.conditions.map(c => c[0]).filter(c => c !== '=')
 		};
 	}
@@ -226,30 +224,9 @@ frappe.ui.Filter = class {
 		this.fieldselect.selected_doctype = doctype;
 		this.fieldselect.selected_fieldname = fieldname;
 
-		if(["Previous", "Current", "Next"].includes(condition) && ['Date', 'Datetime', 'DateRange', 'Select'].includes(this.field.df.fieldtype)) {
+		if(condition == 'Timespan' && ['Date', 'Datetime', 'DateRange', 'Select'].includes(this.field.df.fieldtype)) {
 			df.fieldtype = 'Select';
-			df.options = [
-				{
-					label: __('1 week'),
-					value: '1 week'
-				},
-				{
-					label: __('1 month'),
-					value: '1 month'
-				},
-				{
-					label: __('3 months'),
-					value: '3 months'
-				},
-				{
-					label: __('6 months'),
-					value: '6 months'
-				},
-				{
-					label: __('1 year'),
-					value: '1 year'
-				}
-			];
+			df.options = this.utils.get_timespan_options(['Last', 'This', 'Next']);c
 		}
 
 		if (this.filters_config[condition] && this.filters_config[condition].fieldtypes.includes(this.field.df.fieldtype)) {
@@ -485,5 +462,23 @@ frappe.ui.filter_utils = {
 				{ label: __('Not Set'), value: 'not set' },
 			];
 		}
+	},
+
+	get_timespan_options(periods) {
+		const period_map = {
+			'Last': ['Week', 'Month', 'Quarter', '6 months', 'Year'],
+			'This': ['Week', 'Month', 'Quarter', 'Year'],
+			'Next': ['Week', 'Month', 'Quarter', '6 months', 'Year']
+		}
+		let options = [];
+		periods.forEach(period => {
+			period_map[period].forEach(p => {
+				options.push({
+					label: __(`{0} {1}`, [period, p]),
+					value: `${period.toLowerCase()} ${p.toLowerCase()}`,
+				});
+			});
+		});
+		return options;
 	}
 };

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -223,13 +223,8 @@ frappe.ui.Filter = class {
 		this.fieldselect.selected_doctype = doctype;
 		this.fieldselect.selected_fieldname = fieldname;
 
-		if (condition == 'Timespan' && ['Date', 'Datetime', 'DateRange', 'Select'].includes(this.field.df.fieldtype)) {
-			df.fieldtype = 'Select';
-			df.options = this.utils.get_timespan_options(['Last', 'This', 'Next']);
-		}
-
 		if (this.filters_config[condition]
-				&& this.filters_config[condition].valid_for_fieldtypes.includes(this.field.df.fieldtype)) {
+				&& this.filters_config[condition].valid_for_fieldtypes.includes(df.fieldtype)) {
 			let args = {};
 			if (this.filters_config[condition].depends_on) {
 				const field_name = this.filters_config[condition].depends_on;
@@ -455,6 +450,10 @@ frappe.ui.filter_utils = {
 		if(condition == "Between" && (df.fieldtype == 'Date' || df.fieldtype == 'Datetime')){
 			df.fieldtype = 'DateRange';
 		}
+		if (condition == 'Timespan' && ['Date', 'Datetime', 'DateRange', 'Select'].includes(df.fieldtype)) {
+			df.fieldtype = 'Select';
+			df.options = this.get_timespan_options(['Last', 'This', 'Next']);
+		}
 		if (condition === 'is') {
 			df.fieldtype = 'Select';
 			df.options = [
@@ -462,6 +461,7 @@ frappe.ui.filter_utils = {
 				{ label: __('Not Set'), value: 'not set' },
 			];
 		}
+		return;
 	},
 
 	get_timespan_options(periods) {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -140,7 +140,6 @@ frappe.ui.Filter = class {
 	}
 
 	freeze() {
-		console.log('freeze here')
 		this.update_filter_tag();
 	}
 
@@ -224,9 +223,9 @@ frappe.ui.Filter = class {
 		this.fieldselect.selected_doctype = doctype;
 		this.fieldselect.selected_fieldname = fieldname;
 
-		if(condition == 'Timespan' && ['Date', 'Datetime', 'DateRange', 'Select'].includes(this.field.df.fieldtype)) {
+		if (condition == 'Timespan' && ['Date', 'Datetime', 'DateRange', 'Select'].includes(this.field.df.fieldtype)) {
 			df.fieldtype = 'Select';
-			df.options = this.utils.get_timespan_options(['Last', 'This', 'Next']);c
+			df.options = this.utils.get_timespan_options(['Last', 'This', 'Next']);
 		}
 
 		if (this.filters_config[condition] && this.filters_config[condition].fieldtypes.includes(this.field.df.fieldtype)) {
@@ -469,7 +468,7 @@ frappe.ui.filter_utils = {
 			'Last': ['Week', 'Month', 'Quarter', '6 months', 'Year'],
 			'This': ['Week', 'Month', 'Quarter', 'Year'],
 			'Next': ['Week', 'Month', 'Quarter', '6 months', 'Year']
-		}
+		};
 		let options = [];
 		periods.forEach(period => {
 			period_map[period].forEach(p => {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -50,13 +50,13 @@ frappe.ui.Filter = class {
 	}
 
 	set_conditions_from_config() {
-		if (frappe.boot.filters_config) {
-			this.filters_config = frappe.boot.filters_config;
+		if (frappe.boot.additional_filters_config) {
+			this.filters_config = frappe.boot.additional_filters_config;
 			for (let key of Object.keys(this.filters_config)) {
 				const filter = this.filters_config[key];
 				this.conditions.push([key, __(`{0}`, [filter.label])]);
 				for (let fieldtype of Object.keys(this.invalid_condition_map)) {
-					if (!filter.fieldtypes.includes(fieldtype)) {
+					if (!filter.valid_for_fieldtypes.includes(fieldtype)) {
 						this.invalid_condition_map[fieldtype].push(filter.label);
 					}
 				}
@@ -228,7 +228,8 @@ frappe.ui.Filter = class {
 			df.options = this.utils.get_timespan_options(['Last', 'This', 'Next']);
 		}
 
-		if (this.filters_config[condition] && this.filters_config[condition].fieldtypes.includes(this.field.df.fieldtype)) {
+		if (this.filters_config[condition]
+				&& this.filters_config[condition].valid_for_fieldtypes.includes(this.field.df.fieldtype)) {
 			let args = {};
 			if (this.filters_config[condition].depends_on) {
 				const field_name = this.filters_config[condition].depends_on;

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -20,6 +20,7 @@ frappe.ui.Filter = class {
 			["<=", "<="],
 			["Between", __("Between")],
 			["Previous", __("Previous")],
+			["Current", __("Current")],
 			["Next", __("Next")]
 		];
 
@@ -35,11 +36,11 @@ frappe.ui.Filter = class {
 		this.invalid_condition_map = {
 			Date: ['like', 'not like'],
 			Datetime: ['like', 'not like'],
-			Data: ['Between', 'Previous', 'Next'],
-			Select: ['like', 'not like', 'Between', 'Previous', 'Next'],
-			Link: ["Between", 'Previous', 'Next', '>', '<', '>=', '<='],
-			Currency: ["Between", 'Previous', 'Next'],
-			Color: ["Between", 'Previous', 'Next'],
+			Data: ['Between', 'Previous', 'Current', 'Next'],
+			Select: ['like', 'not like', 'Between', 'Previous', 'Current', 'Next'],
+			Link: ["Between", 'Previous', 'Current', 'Next', '>', '<', '>=', '<='],
+			Currency: ["Between", 'Previous', 'Current', 'Next'],
+			Color: ["Between", 'Previous', 'Current', 'Next'],
 			Check: this.conditions.map(c => c[0]).filter(c => c !== '=')
 		};
 		this.make();
@@ -203,7 +204,7 @@ frappe.ui.Filter = class {
 		this.fieldselect.selected_doctype = doctype;
 		this.fieldselect.selected_fieldname = fieldname;
 
-		if(["Previous", "Next"].includes(condition) && ['Date', 'Datetime', 'DateRange', 'Select'].includes(this.field.df.fieldtype)) {
+		if(["Previous", "Current", "Next"].includes(condition) && ['Date', 'Datetime', 'DateRange', 'Select'].includes(this.field.df.fieldtype)) {
 			df.fieldtype = 'Select';
 			df.options = [
 				{

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -452,7 +452,7 @@ frappe.ui.filter_utils = {
 		}
 		if (condition == 'Timespan' && ['Date', 'Datetime', 'DateRange', 'Select'].includes(df.fieldtype)) {
 			df.fieldtype = 'Select';
-			df.options = this.get_timespan_options(['Last', 'This', 'Next']);
+			df.options = this.get_timespan_options(['Last', 'Today', 'This', 'Next']);
 		}
 		if (condition === 'is') {
 			df.fieldtype = 'Select';
@@ -467,17 +467,25 @@ frappe.ui.filter_utils = {
 	get_timespan_options(periods) {
 		const period_map = {
 			'Last': ['Week', 'Month', 'Quarter', '6 months', 'Year'],
+			'Today': null,
 			'This': ['Week', 'Month', 'Quarter', 'Year'],
 			'Next': ['Week', 'Month', 'Quarter', '6 months', 'Year']
 		};
 		let options = [];
 		periods.forEach(period => {
-			period_map[period].forEach(p => {
-				options.push({
-					label: __(`{0} {1}`, [period, p]),
-					value: `${period.toLowerCase()} ${p.toLowerCase()}`,
+			if (period_map[period]) {
+				period_map[period].forEach(p => {
+					options.push({
+						label: __(`{0} {1}`, [period, p]),
+						value: `${period.toLowerCase()} ${p.toLowerCase()}`,
+					});
 				});
-			});
+			} else {
+				options.push({
+					label: __(`{0}`, [period]),
+					value: `${period.toLowerCase()}`,
+				});
+			}
 		});
 		return options;
 	}

--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -103,7 +103,8 @@ frappe.ui.FilterGroup = class {
 			},
 			filter_items: (doctype, fieldname) => {
 				return !this.filter_exists([doctype, fieldname]);
-			}
+			},
+			base_list: this.base_list
 		};
 		let filter = new frappe.ui.Filter(args);
 		this.filters.push(filter);
@@ -132,7 +133,7 @@ frappe.ui.FilterGroup = class {
 
 	get_filters() {
 		return this.filters.filter(f => f.field).map(f => {
-			f.freeze();
+			// f.freeze();
 			return f.get_value();
 		});
 		// {}: this.list.update_standard_filters(values);

--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -133,7 +133,6 @@ frappe.ui.FilterGroup = class {
 
 	get_filters() {
 		return this.filters.filter(f => f.field).map(f => {
-			// f.freeze();
 			return f.get_value();
 		});
 		// {}: this.list.update_standard_filters(values);

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1078,7 +1078,8 @@ def get_filter(doctype, f, filters_config=None):
 		f.operator = "="
 
 	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "is",
-		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of", "timespan")
+		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of",
+		"timespan", "previous", "next")
 
 	if filters_config:
 		additional_operators = []

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -392,6 +392,7 @@ def get_timespan_date_range(period):
 	}
 
 	return date_range_map.get("period");
+
 def global_date_format(date, format="long"):
 	"""returns localized date in the form of January 1, 2012"""
 	date = getdate(date)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -374,37 +374,24 @@ def get_weekday(datetime=None):
 	return weekdays[datetime.weekday()]
 
 def get_timespan_date_range(period):
-	if period == "last week":
-		date_range = [add_to_date(nowdate(), days=-7), nowdate()]
-	elif period == "last month":
-		date_range = [add_to_date(nowdate(), months=-1), nowdate()]
-	elif period == "last quarter":
-		date_range = [add_to_date(nowdate(), months=-3), nowdate()]
-	elif period == "last 6 months":
-		date_range = [add_to_date(nowdate(), months=-6), nowdate()]
-	elif period == "last year":
-		date_range = [add_to_date(nowdate(), years=-1), nowdate()]
-	elif period == "this week":
-		date_range = [get_first_day_of_week(nowdate(), as_str=True), nowdate()]
-	elif period == "this month":
-		date_range = [get_first_day(nowdate(), as_str=True), nowdate()]
-	elif period == "this quarter":
-		date_range = [get_quarter_start(nowdate(), as_str=True), nowdate()]
-	elif period == "this year":
-		date_range = [get_year_start(nowdate(), as_str=True), nowdate()]
-	elif period == "next week":
-		date_range = [nowdate(), add_to_date(nowdate(), days=7)]
-	elif period == "next month":
-		date_range = [nowdate(), add_to_date(nowdate(), months=1)]
-	elif period == "next quarter":
-		date_range = [nowdate(), add_to_date(nowdate(), months=3)]
-	elif period == "next 6 months":
-		date_range = [nowdate(), add_to_date(nowdate(), months=6)]
-	elif period == "next year":
-		date_range = [nowdate(), add_to_date(nowdate(), years=1)]
+	date_range_map = {
+		"last week": [add_to_date(nowdate(), days=-7), nowdate()],
+		"last month": [add_to_date(nowdate(), months=-1), nowdate()],
+		"last quarter": [add_to_date(nowdate(), months=-3), nowdate()],
+		"last 6 months": [add_to_date(nowdate(), months=-6), nowdate()],
+		"last year": [add_to_date(nowdate(), years=-1), nowdate()],
+		"this week": [get_first_day_of_week(nowdate(), as_str=True), nowdate()],
+		"this month": [get_first_day(nowdate(), as_str=True), nowdate()],
+		"this quarter": [get_quarter_start(nowdate(), as_str=True), nowdate()],
+		"this year": [get_year_start(nowdate(), as_str=True), nowdate()],
+		"next week": [nowdate(), add_to_date(nowdate(), days=7)],
+		"next month": [nowdate(), add_to_date(nowdate(), months=1)],
+		"next quarter": [nowdate(), add_to_date(nowdate(), months=3)],
+		"next 6 months": [nowdate(), add_to_date(nowdate(), months=6)],
+		"next year": [nowdate(), add_to_date(nowdate(), years=1)],
+	}
 
-	return date_range
-
+	return date_range_map.get("period");
 def global_date_format(date, format="long"):
 	"""returns localized date in the form of January 1, 2012"""
 	date = getdate(date)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1011,7 +1011,7 @@ def compare(val1, condition, val2):
 
 	return ret
 
-def get_filter(doctype, f):
+def get_filter(doctype, f, filters_config=None):
 	"""Returns a _dict like
 
 		{
@@ -1047,6 +1047,13 @@ def get_filter(doctype, f):
 
 	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "is",
 		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of", "previous", "current", "next")
+
+	if filters_config:
+		additional_operators = []
+		for key in filters_config:
+			additional_operators.append(key.lower())
+		valid_operators = tuple(set(valid_operators + tuple(additional_operators)))
+
 	if f.operator.lower() not in valid_operators:
 		frappe.throw(frappe._("Operator must be one of {0}").format(", ".join(valid_operators)))
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -380,6 +380,7 @@ def get_timespan_date_range(timespan):
 		"last quarter": [add_to_date(nowdate(), months=-3), nowdate()],
 		"last 6 months": [add_to_date(nowdate(), months=-6), nowdate()],
 		"last year": [add_to_date(nowdate(), years=-1), nowdate()],
+		"today": [nowdate(), nowdate()],
 		"this week": [get_first_day_of_week(nowdate(), as_str=True), nowdate()],
 		"this month": [get_first_day(nowdate(), as_str=True), nowdate()],
 		"this quarter": [get_quarter_start(nowdate(), as_str=True), nowdate()],

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1046,7 +1046,7 @@ def get_filter(doctype, f, filters_config=None):
 		f.operator = "="
 
 	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "is",
-		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of", "previous", "current", "next")
+		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of", "timespan")
 
 	if filters_config:
 		additional_operators = []

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -373,6 +373,38 @@ def get_weekday(datetime=None):
 	weekdays = get_weekdays()
 	return weekdays[datetime.weekday()]
 
+def get_timespan_date_range(period):
+	if period == "last week":
+		date_range = [add_to_date(nowdate(), days=-7), nowdate()]
+	elif period == "last month":
+		date_range = [add_to_date(nowdate(), months=-1), nowdate()]
+	elif period == "last quarter":
+		date_range = [add_to_date(nowdate(), months=-3), nowdate()]
+	elif period == "last 6 months":
+		date_range = [add_to_date(nowdate(), months=-6), nowdate()]
+	elif period == "last year":
+		date_range = [add_to_date(nowdate(), years=-1), nowdate()]
+	elif period == "this week":
+		date_range = [get_first_day_of_week(nowdate(), as_str=True), nowdate()]
+	elif period == "this month":
+		date_range = [get_first_day(nowdate(), as_str=True), nowdate()]
+	elif period == "this quarter":
+		date_range = [get_quarter_start(nowdate(), as_str=True), nowdate()]
+	elif period == "this year":
+		date_range = [get_year_start(nowdate(), as_str=True), nowdate()]
+	elif period == "next week":
+		date_range = [nowdate(), add_to_date(nowdate(), days=7)]
+	elif period == "next month":
+		date_range = [nowdate(), add_to_date(nowdate(), months=1)]
+	elif period == "next quarter":
+		date_range = [nowdate(), add_to_date(nowdate(), months=3)]
+	elif period == "next 6 months":
+		date_range = [nowdate(), add_to_date(nowdate(), months=6)]
+	elif period == "next year":
+		date_range = [nowdate(), add_to_date(nowdate(), years=1)]
+
+	return date_range
+
 def global_date_format(date, format="long"):
 	"""returns localized date in the form of January 1, 2012"""
 	date = getdate(date)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -373,7 +373,7 @@ def get_weekday(datetime=None):
 	weekdays = get_weekdays()
 	return weekdays[datetime.weekday()]
 
-def get_timespan_date_range(period):
+def get_timespan_date_range(timespan):
 	date_range_map = {
 		"last week": [add_to_date(nowdate(), days=-7), nowdate()],
 		"last month": [add_to_date(nowdate(), months=-1), nowdate()],
@@ -391,7 +391,7 @@ def get_timespan_date_range(period):
 		"next year": [nowdate(), add_to_date(nowdate(), years=1)],
 	}
 
-	return date_range_map.get("period");
+	return date_range_map.get(timespan)
 
 def global_date_format(date, format="long"):
 	"""returns localized date in the form of January 1, 2012"""

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -174,7 +174,7 @@ def nowtime():
 	"""return current time in hh:mm"""
 	return now_datetime().strftime(TIME_FORMAT)
 
-def get_first_day(dt, d_years=0, d_months=0):
+def get_first_day(dt, d_years=0, d_months=0, as_str=False):
 	"""
 	 Returns the first day of the month for the date specified by date object
 	 Also adds `d_years` and `d_months` if specified
@@ -185,10 +185,23 @@ def get_first_day(dt, d_years=0, d_months=0):
 	overflow_years, month = divmod(dt.month + d_months - 1, 12)
 	year = dt.year + d_years + overflow_years
 
-	return datetime.date(year, month + 1, 1)
+	return datetime.date(year, month + 1, 1).strftime(DATE_FORMAT) if as_str else datetime.date(year, month + 1, 1)
 
-def get_first_day_of_week(dt):
-	return dt - datetime.timedelta(days=dt.weekday())
+def get_quarter_start(dt, as_str=False):
+	date = getdate(dt)
+	quarter = (date.month - 1) // 3 + 1
+	first_date_of_quarter = datetime.date(date.year, ((quarter - 1) * 3) + 1, 1)
+	return first_date_of_quarter.strftime(DATE_FORMAT) if as_str else first_date_of_quarter
+
+def get_first_day_of_week(dt, as_str=False):
+	dt = getdate(dt)
+	date = dt - datetime.timedelta(days=dt.weekday())
+	return date.strftime(DATE_FORMAT) if as_str else date
+
+def get_year_start(dt, as_str=False):
+	dt = getdate(dt)
+	date = datetime.date(dt.year, 1, 1)
+	return date.strftime(DATE_FORMAT) if as_str else date
 
 def get_last_day_of_week(dt):
 	dt = get_first_day_of_week(dt)
@@ -1033,7 +1046,7 @@ def get_filter(doctype, f):
 		f.operator = "="
 
 	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "is",
-		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of", "previous", "next")
+		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of", "previous", "current", "next")
 	if f.operator.lower() not in valid_operators:
 		frappe.throw(frappe._("Operator must be one of {0}").format(", ".join(valid_operators)))
 


### PR DESCRIPTION
Changes:

- Added filter for current periods (this week, this month, this quarter, this year)

- Consolidated all period filters into a new condition - **Timespan**
<img width="1259" alt="Screenshot 2020-06-19 at 12 33 06 PM" src="https://user-images.githubusercontent.com/19775888/85105989-0e355180-b229-11ea-91e5-b031c6099143.png">



- API to add additional filters (Ex: Fiscal Year):
![fiscal year filter](https://user-images.githubusercontent.com/19775888/82658478-a816d800-9c44-11ea-9741-9a523e97bfbd.gif)

The filter configuration is saved as key value pairs where the key is the condition to be added:
```
filters_config: {
    "fiscal year": {
	     "label": "Fiscal Year",
	     "get_field": "erpnext.accounts.utils.get_fiscal_year_filter_field",
	     "fieldtypes": ["Date", "Datetime", "DateRange"],
	     "depends_on": "company",
     }
}
```
`fieldtypes` - valid field types for the filter
`depends_on` - if the filter options depend on a filter value, the field name can be set here (ex: fiscal year depends on company)
`get_field`- fetches the field config which looks like this
```
field: {
    "fieldtype": "Select", //filter fieldtype
     "options": [], //df options
     "operator": "Between",
     "query_value": True	
}
```
`query_value` can be set as True if the value in the query is different from the filter value and the value to be set can be set in options:
```
options: {
    "label": fiscal_year.name,
    "value": fiscal_year.name,
    "query_value": [fiscal_year.year_start_date.strftime("%Y-%m-%d"), fiscal_year.year_end_date.strftime("%Y-%m-%d")]
}
```

erpnext PR: https://github.com/frappe/erpnext/pull/21880