### PR TITLE
fix: Reopened assignments don't get reassigned

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -5,9 +5,9 @@ from __future__ import unicode_literals, absolute_import
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import validate_email_address, get_fullname, strip_html, cstr
+from frappe.utils import validate_email_address, get_fullname, strip_html, cstr, time_diff_in_seconds
 from frappe.core.doctype.communication.email import (validate_email,
-	notify, _notify, update_parent_mins_to_first_response)
+	notify, _notify)
 from frappe.core.utils import get_parent_doc
 from frappe.utils.bot import BotReply
 from frappe.utils import parse_addr
@@ -16,6 +16,7 @@ from email.utils import parseaddr
 from six.moves.urllib.parse import unquote
 from collections import Counter
 from frappe.contacts.doctype.contact.contact import get_contact_name
+from frappe.automation.doctype.assignment_rule.assignment_rule import apply as apply_assignment_rule
 
 exclude_from_linked_with = True
 
@@ -119,7 +120,7 @@ class Communication(Document):
 		update_comment_in_doc(self)
 
 		if self.comment_type != 'Updated':
-			update_parent_mins_to_first_response(self)
+			update_parent_document_on_communication(self)
 			self.bot_reply()
 
 	def on_trash(self):
@@ -423,3 +424,40 @@ def get_email_without_link(email):
 	email_host = email.split("@")[1]
 
 	return "{0}@{1}".format(email_id, email_host)
+
+def update_parent_document_on_communication(doc):
+	"""Update mins_to_first_communication of parent document based on who is replying."""
+
+	parent = get_parent_doc(doc)
+	if not parent:
+		return
+
+	# update parent mins_to_first_communication only if we create the Email communication
+	# ignore in case of only Comment is added
+	if doc.communication_type == "Comment":
+		return
+
+	status_field = parent.meta.get_field("status")
+	if status_field:
+		options = (status_field.options or '').splitlines()
+
+		# if status has a "Replied" option, then update the status for received communication
+		if ('Replied' in options) and doc.sent_or_received=="Received":
+			parent.db_set("status", "Open")
+			apply_assignment_rule(parent)
+		else:
+			# update the modified date for document
+			parent.update_modified()
+
+	update_mins_to_first_communication(parent, doc)
+	parent.run_method('notify_communication', doc)
+	parent.notify_update()
+
+def update_mins_to_first_communication(parent, communication):
+	if parent.meta.has_field('mins_to_first_response') and not parent.get('mins_to_first_response'):
+		if frappe.db.get_all('User', filters={'email': communication.sender,
+			'user_type': 'System User', 'enabled': 1}, limit=1):
+			first_responded_on = communication.creation
+			if parent.meta.has_field('first_responded_on') and communication.sent_or_received == "Sent":
+				parent.db_set('first_responded_on', first_responded_on)
+			parent.db_set('mins_to_first_response', round(time_diff_in_seconds(first_responded_on, parent.creation) / 60), 2)

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -2,19 +2,19 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals, absolute_import
+from collections import Counter
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import validate_email_address, get_fullname, strip_html, cstr, time_diff_in_seconds
-from frappe.core.doctype.communication.email import (validate_email,
-	notify, _notify)
+from frappe.utils import validate_email_address, strip_html, cstr, time_diff_in_seconds
+from frappe.core.doctype.communication.email import validate_email, notify, _notify
 from frappe.core.utils import get_parent_doc
 from frappe.utils.bot import BotReply
 from frappe.utils import parse_addr
 from frappe.core.doctype.comment.comment import update_comment_in_doc
 from email.utils import parseaddr
 from six.moves.urllib.parse import unquote
-from collections import Counter
+from frappe.utils.user import is_system_user
 from frappe.contacts.doctype.contact.contact import get_contact_name
 from frappe.automation.doctype.assignment_rule.assignment_rule import apply as apply_assignment_rule
 
@@ -455,8 +455,7 @@ def update_parent_document_on_communication(doc):
 
 def update_mins_to_first_communication(parent, communication):
 	if parent.meta.has_field('mins_to_first_response') and not parent.get('mins_to_first_response'):
-		if frappe.db.get_all('User', filters={'email': communication.sender,
-			'user_type': 'System User', 'enabled': 1}, limit=1):
+		if is_system_user(communication.sender):
 			first_responded_on = communication.creation
 			if parent.meta.has_field('first_responded_on') and communication.sent_or_received == "Sent":
 				parent.db_set('first_responded_on', first_responded_on)

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -9,7 +9,7 @@ import json
 from email.utils import formataddr
 from frappe.core.utils import get_parent_doc
 from frappe.utils import (get_url, get_formatted_email, cint,
-  validate_email_address, split_emails, time_diff_in_seconds, parse_addr, get_datetime)
+  validate_email_address, split_emails, parse_addr, get_datetime)
 from frappe.email.email_body import get_message_id
 import frappe.email.smtp
 import time
@@ -171,38 +171,6 @@ def _notify(doc, print_html=None, print_format=None, attachments=None,
 		is_notification=True if doc.sent_or_received =="Received" else False,
 		print_letterhead=frappe.flags.print_letterhead
 	)
-
-def update_parent_mins_to_first_response(doc):
-	"""Update mins_to_first_communication of parent document based on who is replying."""
-
-	parent = get_parent_doc(doc)
-	if not parent:
-		return
-
-	# update parent mins_to_first_communication only if we create the Email communication
-	# ignore in case of only Comment is added
-	if doc.communication_type == "Comment":
-		return
-
-	status_field = parent.meta.get_field("status")
-	if status_field:
-		options = (status_field.options or '').splitlines()
-
-		# if status has a "Replied" option, then update the status for received communication
-		if ('Replied' in options) and doc.sent_or_received=="Received":
-			update_document_status_on_received_communication(parent)
-		else:
-			# update the modified date for document
-			parent.update_modified()
-
-	update_mins_to_first_communication(parent, doc)
-	parent.run_method('notify_communication', doc)
-	parent.notify_update()
-
-def update_document_status_on_received_communication(doc):
-	from frappe.automation.doctype.assignment_rule.assignment_rule import apply
-	doc.db_set("status", "Open")
-	apply(doc)
 
 def get_recipients_cc_and_bcc(doc, recipients, cc, bcc, fetched_from_email_account=False):
 	doc.all_email_addresses = []
@@ -503,15 +471,6 @@ def sendmail(communication_name, print_html=None, print_format=None, attachments
 	except:
 		traceback = frappe.log_error("frappe.core.doctype.communication.email.sendmail")
 		raise
-
-def update_mins_to_first_communication(parent, communication):
-	if parent.meta.has_field('mins_to_first_response') and not parent.get('mins_to_first_response'):
-		if frappe.db.get_all('User', filters={'email': communication.sender,
-			'user_type': 'System User', 'enabled': 1}, limit=1):
-			first_responded_on = communication.creation
-			if parent.meta.has_field('first_responded_on') and communication.sent_or_received == "Sent":
-				parent.db_set('first_responded_on', first_responded_on)
-			parent.db_set('mins_to_first_response', round(time_diff_in_seconds(first_responded_on, parent.creation) / 60), 2)
 
 @frappe.whitelist(allow_guest=True)
 def mark_email_as_seen(name=None):

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -190,7 +190,7 @@ def update_parent_mins_to_first_response(doc):
 
 		# if status has a "Replied" option, then update the status for received communication
 		if ('Replied' in options) and doc.sent_or_received=="Received":
-			parent.db_set("status", "Open")
+			update_document_status_on_received_communication(parent)
 		else:
 			# update the modified date for document
 			parent.update_modified()
@@ -198,6 +198,11 @@ def update_parent_mins_to_first_response(doc):
 	update_mins_to_first_communication(parent, doc)
 	parent.run_method('notify_communication', doc)
 	parent.notify_update()
+
+def update_document_status_on_received_communication(doc):
+	from frappe.automation.doctype.assignment_rule.assignment_rule import apply
+	doc.db_set("status", "Open")
+	apply(doc)
 
 def get_recipients_cc_and_bcc(doc, recipients, cc, bcc, fetched_from_email_account=False):
 	doc.all_email_addresses = []

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -226,7 +226,7 @@ def get_assignments(dt, dn):
 			filters={
 				'reference_type': dt,
 				'reference_name': dn,
-				'status': ('!=', 'Cancelled'),
+				'status': ('not in', ['Closed', 'Cancelled']),
 			})
 
 	return cl

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -226,7 +226,7 @@ def get_assignments(dt, dn):
 			filters={
 				'reference_type': dt,
 				'reference_name': dn,
-				'status': ('not in', ['Closed', 'Cancelled']),
+				'status': ('!=', 'Cancelled'),
 			})
 
 	return cl


### PR DESCRIPTION
**Fixes:**

- `get_assignments` only fetched Cancelled ToDo docs so the assignment would show up on the form sidebar even if it was removed.

- Status is set as Open when an email is received - assignment rule should be applied in this case.