### PR TITLE
fix: Empty sidebar filter list html not updated

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -103,7 +103,11 @@ frappe.views.ListGroupBy = class ListGroupBy {
 					this.render_dropdown_items(field_count_list, fieldtype, dropdown);
 					frappe.utils.setup_search(dropdown, '.group-by-item', '.group-by-value', 'data-name');
 				} else {
-					dropdown.find('.group-by-loading').html(`${__("No filters found")}`);
+					dropdown.html(
+						`<div class="list-loading text-center group-by-empty text-muted">
+						${__("No filters found")}
+						</div>`
+					);
 				}
 			});
 		});


### PR DESCRIPTION
**Before:**

<img width="1200" alt="Screenshot 2020-05-25 at 5 52 06 PM" src="https://user-images.githubusercontent.com/19775888/82812377-7f931600-9eb0-11ea-8188-ef0dd815a16f.png">


**After:**
<img width="1231" alt="Screenshot 2020-05-25 at 5 49 20 PM" src="https://user-images.githubusercontent.com/19775888/82812399-89b51480-9eb0-11ea-988b-e4a4b672ac23.png">
