### PR TITLE
fix(dropbox): dropbox timeout for large files

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -90,7 +90,7 @@ def backup_to_dropbox(upload_db_backup=True):
 		dropbox_settings['access_token'] = access_token['oauth2_token']
 		set_dropbox_access_token(access_token['oauth2_token'])
 
-	dropbox_client = dropbox.Dropbox(dropbox_settings['access_token'])
+	dropbox_client = dropbox.Dropbox(dropbox_settings['access_token'], timeout=None)
 
 	if upload_db_backup:
 		if frappe.flags.create_new_backup:


### PR DESCRIPTION
fixing the following dropbox timeout error as per the [latest Dropboxer's recommendation](https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/socket-timeout-issue-even-with-session-upload/m-p/354432/highlight/true#M20244).

```
ReadTimeout: HTTPSConnectionPool(host='content.dropboxapi.com', port=443): Read timed out. (read timeout=30)
```
reference to other people having the same error: 
[discuss post 1](https://discuss.erpnext.com/t/v10-recently-getting-this-error-in-my-dropbox-backup/56359?u=karthikeyan5)
[discuss post 2](https://discuss.erpnext.com/t/dropbox-upload-failed/59999?u=karthikeyan5)

previous attempt to solve this: https://github.com/frappe/frappe/pull/7823


@Mergifyio backport version-13-beta-pre-release
@Mergifyio backport version-12-hotfix