### PR TITLE
fix (UX): set scrollbar to thin

### DIFF
--- a/frappe/public/less/frappe-datatable.less
+++ b/frappe/public/less/frappe-datatable.less
@@ -36,6 +36,7 @@
 .dt-scrollable {
 	max-height: calc(100vh - 250px);
 	min-height: 100px;
+	scrollbar-width: thin;
 }
 
 table td.dt-cell {


### PR DESCRIPTION
Set scrollbar width to thin for datatable. Fixes UX issue in reports where scrollbar would overlap the datatable.

reference: https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width
frappe: ISS-20-21-00884