### PR TITLE
fix: set default values for report chart date filters

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -304,15 +304,8 @@ frappe.ui.form.on('Dashboard Chart', {
 				});
 			}
 		} else if (frm.chart_filters.length) {
-			fields = frm.chart_filters.filter(f => {
-				// Set dynamic filters as read only
-				if (is_dynamic_filter(f)) {
-					f.read_only = 1;
-				}
-				if (f.fieldname) {
-					return true;
-				}
-			});
+			fields = frm.chart_filters.filter(f => f.fieldname);
+
 			fields.map( f => {
 				if (filters[f.fieldname]) {
 					let condition = '=';
@@ -339,7 +332,7 @@ frappe.ui.form.on('Dashboard Chart', {
 
 			let dialog = new frappe.ui.Dialog({
 				title: __('Set Filters'),
-				fields: fields,
+				fields: fields.filter(f => !is_dynamic_filter(f)),
 				primary_action: function() {
 					let values = this.get_values();
 					if (values) {
@@ -376,6 +369,7 @@ frappe.ui.form.on('Dashboard Chart', {
 			frappe.query_report = new frappe.views.QueryReport({'filters': dialog.fields_list});
 			frappe.query_reports[frm.doc.report_name].onload
 				&& frappe.query_reports[frm.doc.report_name].onload(frappe.query_report);
+
 			dialog.set_values(filters);
 		});
 	},

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -97,7 +97,6 @@ export default class ChartWidget extends Widget {
 				this.chart_settings = {};
 			}
 			this.setup_container();
-			this.prepare_chart_object();
 			if (!this.in_customize_mode) {
 				this.action_area.empty();
 				this.prepare_chart_actions();
@@ -110,7 +109,10 @@ export default class ChartWidget extends Widget {
 					this.render_time_series_filters();
 				}
 			}
-			this.fetch_and_update_chart();
+			frappe.run_serially([
+				() => this.prepare_chart_object(),
+				() => this.fetch_and_update_chart(),
+			]);
 		});
 	}
 
@@ -625,13 +627,41 @@ export default class ChartWidget extends Widget {
 	}
 
 	prepare_chart_object() {
-		let saved_filters = this.chart_settings.filters || null;
-		this.filters =
-			saved_filters || this.filters || JSON.parse(this.chart_doc.filters_json || "[]");
-
 		if (this.chart_doc.type == 'Heatmap' && !this.chart_doc.heatmap_year) {
 			this.chart_doc.heatmap_year = frappe.dashboard_utils.get_year(frappe.datetime.now_date());
 		}
+
+		return this.set_chart_filters();
+	}
+
+	set_chart_filters() {
+		let user_saved_filters = this.chart_settings.filters || null;
+		let chart_saved_filters = JSON.parse(this.chart_doc.filters_json || "null");
+
+		if (this.chart_doc.chart_type == 'Report') {
+			return frappe.dashboard_utils
+				.get_filters_for_chart_type(this.chart_doc).then(filters => {
+					chart_saved_filters = this.update_default_date_filters(filters, chart_saved_filters);
+					this.filters =
+						user_saved_filters || this.filters || chart_saved_filters;
+				});
+		} else {
+			this.filters =
+				user_saved_filters || this.filters || chart_saved_filters;
+			return Promise.resolve();
+		}
+	}
+
+	update_default_date_filters(report_filters, chart_filters) {
+		report_filters.map(f => {
+			if (['Date', 'DateRange'].includes(f.fieldtype) && f.default) {
+				if (chart_filters[f.fieldname]) {
+					chart_filters[f.fieldname] = f.default;
+				}
+			}
+		});
+
+		return chart_filters;
 	}
 
 	get_settings() {

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -655,7 +655,7 @@ export default class ChartWidget extends Widget {
 	update_default_date_filters(report_filters, chart_filters) {
 		report_filters.map(f => {
 			if (['Date', 'DateRange'].includes(f.fieldtype) && f.default) {
-				if (chart_filters[f.fieldname]) {
+				if (f.reqd || chart_filters[f.fieldname]) {
 					chart_filters[f.fieldname] = f.default;
 				}
 			}


### PR DESCRIPTION
If a default value is set for a report's date type filter, the chart filter value will be set to that value.

The filter is set as read only in the form so that the value cannot be saved:
<img width="400" alt="Screenshot 2020-05-27 at 5 14 17 PM" src="https://user-images.githubusercontent.com/19775888/83015093-8602c880-a03d-11ea-88ff-2099e1f575d4.png">

On the chart filter dialog, the value can be changed and saved. To reset the chart, the Reset Chart option in the dropdown can be used:
<img width="283" alt="Screenshot 2020-05-27 at 5 15 31 PM" src="https://user-images.githubusercontent.com/19775888/83015213-b5b1d080-a03d-11ea-9d53-ccb1c2b29517.png">



In a future PR, we can add an option in report filters, to identify dynamic filters:
               
```
{
        label: __("From Date"),
	fieldname:"from_date",
	fieldtype: "Date",
	default: frappe.datetime.add_months(frappe.datetime.get_today(), -12),
	reqd: 1,
	dashboard: {
		'dynamic': 1,
	}
}
```