### PR TITLE
chore: Add Release Notes for V13.0.0-beta.2

### DIFF
--- a/frappe/change_log/v13/v13_0_0-beta_2.md
+++ b/frappe/change_log/v13/v13_0_0-beta_2.md
@@ -1,0 +1,27 @@
+# Version 13.0.0 Beta 2 Release Notes
+
+## Features
+
+- Export and Import Customizations in Packages ([#9692](https://github.com/frappe/frappe/pull/9692))
+- Dashboard view for each DocTypes ([#10000](https://github.com/frappe/frappe/pull/10000))
+- Introduced HeatMap chart type option for Dashboard Charts ([#10193](https://github.com/frappe/frappe/pull/10193))
+- Translation Tool ([#9636](https://github.com/frappe/frappe/pull/9636))
+
+## Enhancements
+
+- Configure dependency mapping and default values for Event Streaming sync ([#9742](https://github.com/frappe/frappe/pull/9742))
+- Config for Section Break without border ([#10116](https://github.com/frappe/frappe/pull/10116))
+- Onboarding Enhancements ([#10356](https://github.com/frappe/frappe/pull/10356)) ([#10364](https://github.com/frappe/frappe/pull/10364))
+- Introduced Page Builder option in Web Page ([#10035](https://github.com/frappe/frappe/pull/10035)) ([#10154](https://github.com/frappe/frappe/pull/10154))
+- Module-wise onboarding via new desk ([#10194](https://github.com/frappe/frappe/pull/10194))
+- 2FA for LDAP users ([#10001](https://github.com/frappe/frappe/pull/10001))
+- Assign to multiple people at once ([#9957](https://github.com/frappe/frappe/pull/9957))
+- Desk page enhancements ([#10359](https://github.com/frappe/frappe/pull/10359)) ([#10384](https://github.com/frappe/frappe/pull/10384)) ([#10338](https://github.com/frappe/frappe/pull/10338))
+- Search in column picker and filter dialog ([#10111](https://github.com/frappe/frappe/pull/10111))
+
+## Performance Improvements
+
+- Application ([#10229](https://github.com/frappe/frappe/pull/10229)) ([#10147](https://github.com/frappe/frappe/pull/10147))
+- Recorder ([#10272](https://github.com/frappe/frappe/pull/10272))
+- Desk ([#9930](https://github.com/frappe/frappe/pull/9930))
+- Scheduler Job ([#9928](https://github.com/frappe/frappe/pull/9928))


### PR DESCRIPTION
<img width="632" alt="Screenshot 2020-05-28 at 9 34 50 AM" src="https://user-images.githubusercontent.com/13928957/83097748-7b404600-a0c6-11ea-8dc0-a71b76903500.png">
