### PR TITLE
fix: don't include review type energy points in chart

### DIFF
--- a/frappe/desk/page/user_profile/user_profile.js
+++ b/frappe/desk/page/user_profile/user_profile.js
@@ -110,7 +110,11 @@ class UserProfile {
 
 
 	render_line_chart() {
-		this.line_chart_filters = [['Energy Point Log', 'user', '=', this.user_id, false]];
+		this.line_chart_filters = [
+			['Energy Point Log', 'user', '=', this.user_id, false],
+			['Energy Point Log', 'type', '!=', 'Review', false]
+		];
+
 		this.line_chart_config = {
 			timespan: 'Last Month',
 			time_interval: 'Daily',
@@ -186,7 +190,10 @@ class UserProfile {
 				options: ['All', 'Auto', 'Criticism', 'Appreciation', 'Revert'],
 				action: (selected_item) => {
 					if (selected_item === 'All') {
-						if (this.line_chart_filters.length > 1) this.line_chart_filters.pop();
+						this.line_chart_filters = [
+							['Energy Point Log', 'user', '=', this.user_id, false],
+							['Energy Point Log', 'type', '!=', 'Review', false]
+						];
 					} else {
 						this.line_chart_filters[1] = ['Energy Point Log', 'type', '=', selected_item, false];
 					}


### PR DESCRIPTION
 Don't include 'Review' type energy points in the line chart on the User Profile page