### PR TITLE
fix(Email): include Text in fieldtypes to sanitize

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -693,7 +693,7 @@ class BaseDocument(object):
 			df = self.meta.get_field(fieldname)
 			sanitized_value = value
 
-			if df and df.get("fieldtype") in ("Data", "Code", "Small Text") and df.get("options")=="Email":
+			if df and df.get("fieldtype") in ("Data", "Code", "Small Text", "Text") and df.get("options")=="Email":
 				sanitized_value = sanitize_email(value)
 
 			elif df and (df.get("ignore_xss_filter")


### PR DESCRIPTION
To avoid escaped values in the field:
<img width="493" alt="Screenshot 2020-05-28 at 4 19 50 PM" src="https://user-images.githubusercontent.com/19775888/83132544-3258b380-a0ff-11ea-852a-96f3c5e8528b.png">
