### PR TITLE
Theme improvements

### DIFF
--- a/frappe/public/scss/base.scss
+++ b/frappe/public/scss/base.scss
@@ -18,6 +18,7 @@ h1 {
 	font-weight: 800;
 	line-height: 1.25;
 	letter-spacing: -0.025em;
+	margin-bottom: 1rem;
 
 	@include media-breakpoint-up(sm) {
 		line-height: 2.5rem;
@@ -32,6 +33,7 @@ h1 {
 h2 {
 	font-size: $font-size-xl;
 	font-weight: bold;
+	margin-bottom: 0.75rem;
 
 	@include media-breakpoint-up(sm) {
 		font-size: $font-size-2xl;

--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -104,7 +104,7 @@
 
 	&.card-sm {
 		.card-body {
-			padding: 1.25rem 1.5rem 1.5rem 1.5rem;
+			padding: 1.5rem;
 		}
 
 		.card-title {
@@ -118,7 +118,7 @@
 	}
 	&.card-md {
 		.card-body {
-			padding: 1.5rem 1.75rem 1.75rem 1.75rem;
+			padding: 1.75rem;
 		}
 
 		.card-title {
@@ -135,7 +135,7 @@
 	}
 	&.card-lg {
 		.card-body {
-			padding: 1.75rem 2rem 2rem 2rem;
+			padding: 2rem;
 		}
 
 		.card-title {

--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -88,6 +88,8 @@
 }
 
 .card {
+	transition: border-color 0.25s;
+
 	.card-title {
 		color: $black;
 	}

--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -92,6 +92,7 @@
 
 	.card-title {
 		color: $black;
+		line-height: 1;
 	}
 
 	.card-body {

--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -102,7 +102,7 @@
 
 	&.card-sm {
 		.card-body {
-			padding: 1.5rem;
+			padding: 1.25rem 1.5rem 1.5rem 1.5rem;
 		}
 
 		.card-title {
@@ -116,7 +116,7 @@
 	}
 	&.card-md {
 		.card-body {
-			padding: 1.75rem;
+			padding: 1.5rem 1.75rem 1.75rem 1.75rem;
 		}
 
 		.card-title {
@@ -133,7 +133,7 @@
 	}
 	&.card-lg {
 		.card-body {
-			padding: 2rem;
+			padding: 1.75rem 2rem 2rem 2rem;
 		}
 
 		.card-title {

--- a/frappe/public/scss/variables.scss
+++ b/frappe/public/scss/variables.scss
@@ -41,7 +41,7 @@ $btn-font-weight: 500 !default;
 $navbar-nav-link-padding-x: 1rem !default;
 $navbar-padding-y: 1rem;
 $card-border-radius: 0.75rem !default;
-$card-spacer-y: 1rem !default;
+$card-spacer-y: 0.5rem !default;
 
 $dropdown-font-size: $font-size-sm !default;
 $dropdown-border-radius: 0.375rem !default;


### PR DESCRIPTION
The PR has following changes

1. specific margin-bottom for h1 and h2
1. reduce line height for card title
1. reduce spacing between card body and card title
1. added 0.25s transition to border-color

> Note: The following screenshots are from vanilla theme without customizations

### Before
<img width="781" alt="Screenshot 2020-05-28 at 6 00 50 PM" src="https://user-images.githubusercontent.com/18097732/83141402-3c81ae80-a10d-11ea-8bb0-16ea1f443d8f.png">

### After
<img width="781" alt="Screenshot 2020-05-28 at 6 01 06 PM" src="https://user-images.githubusercontent.com/18097732/83141405-40adcc00-a10d-11ea-82e9-74e232488761.png">


