### PR TITLE
feat(migrate-to): switch Teams and restore existing Sites

### DIFF
--- a/frappe/integrations/frappe_providers/__init__.py
+++ b/frappe/integrations/frappe_providers/__init__.py
@@ -7,7 +7,6 @@ from frappe.integrations.frappe_providers.frappecloud import frappecloud_migrato
 
 def migrate_to(local_site, frappe_provider):
 	if frappe_provider in ("frappe.cloud", "frappecloud.com"):
-		frappe_provider = "frappecloud.com"
 		return frappecloud_migrator(local_site, frappe_provider)
 	else:
 		print("{} is not supported yet".format(frappe_provider))

--- a/frappe/integrations/frappe_providers/frappecloud.py
+++ b/frappe/integrations/frappe_providers/frappecloud.py
@@ -372,7 +372,7 @@ def frappecloud_migrator(local_site, frappecloud_site):
 	global login_url, upload_url, files_url, options_url, site_exists_url, restore_site_url, account_details_url, all_site_url
 	global session, migrator_actions, remote_site
 
-	remote_site = frappecloud_site
+	remote_site = frappe.conf.frappecloud_url or "frappecloud.com"
 
 	login_url = "https://{}/api/method/login".format(remote_site)
 	upload_url = "https://{}/api/method/press.api.site.new".format(remote_site)

--- a/frappe/integrations/frappe_providers/frappecloud.py
+++ b/frappe/integrations/frappe_providers/frappecloud.py
@@ -16,6 +16,107 @@ from frappe.utils import get_installed_apps_info
 from frappe.utils.commands import render_table, add_line_after, add_line_before
 
 
+# TODO: check upgrade compatibility
+
+
+def render_actions_table():
+	actions_table = [["#", "Action"]]
+	actions = []
+
+	for n, action in enumerate(migrator_actions):
+		actions_table.append([n+1, action["title"]])
+		actions.append(action["fn"])
+
+	render_table(actions_table)
+	return actions
+
+
+def render_site_table(sites_info):
+	sites_table = [["#", "Site Name", "Status"]]
+	available_sites = []
+
+	for n, site_data in enumerate(sites_info):
+		name, status = site_data["name"], site_data["status"]
+		if status not in ("Inactive", "Suspended"):
+			sites_table.append([n + 1, name, status])
+			available_sites.append(name)
+
+	render_table(sites_table)
+	return available_sites
+
+
+def render_teams_table(teams):
+	teams_table = [["#", "Team"]]
+
+	for n, team in enumerate(teams):
+		teams_table.append([n+1, team])
+
+	render_table(teams_table)
+
+
+def render_plan_table(plans_list):
+	plans_table = [["Plan", "CPU Time"]]
+	visible_headers = ["name", "cpu_time_per_day"]
+
+	for plan in plans_list:
+		plan, cpu_time = [plan[header] for header in visible_headers]
+		plans_table.append([plan, "{} hour{}/day".format(cpu_time, "" if cpu_time < 2 else "s")])
+
+	render_table(plans_table)
+
+
+def render_group_table(app_groups):
+	# title row
+	app_groups_table = [["#", "App Group", "Apps"]]
+
+	# all rows
+	for idx, app_group in enumerate(app_groups):
+		apps_list = ", ".join(["{}:{}".format(app["scrubbed"], app["branch"]) for app in app_group["apps"]])
+		row = [idx + 1, app_group["name"], apps_list]
+		app_groups_table.append(row)
+
+	render_table(app_groups_table)
+
+
+def handle_request_failure(request=None, message=None, traceback=True, exit_code=1):
+	message = message or "Request failed with error code {}".format(request.status_code)
+	response = html2text(request.text) if traceback else ""
+
+	print("{0}{1}".format(message, "\n" + response))
+	sys.exit(exit_code)
+
+
+@add_line_after
+def select_primary_action():
+	actions = render_actions_table()
+	idx = click.prompt("What do you want to do?", type=click.IntRange(1, len(actions))) - 1
+
+	return actions[idx]
+
+
+@add_line_after
+def select_site():
+	get_all_sites_request = session.post(all_site_url, headers={
+		"accept": "application/json",
+		"accept-encoding": "gzip, deflate, br",
+		"content-type": "application/json; charset=utf-8"
+	})
+
+	if get_all_sites_request.ok:
+		all_sites = get_all_sites_request.json()["message"]
+		available_sites = render_site_table(all_sites)
+
+		while True:
+			selected_site = click.prompt("Name of the site you want to restore to", type=str).strip()
+			if selected_site in available_sites:
+				return selected_site
+			else:
+				print("Site {} does not exist. Try again ❌".format(site))
+	else:
+		print("Couldn't retrive sites list...Try again later")
+		sys.exit(1)
+
+
 @add_line_before
 def select_team(session):
 	# get team options
@@ -65,21 +166,6 @@ def is_subdomain_available(subdomain):
 			print("Subdomain already exists! Try another one")
 
 		return available
-
-
-def render_plan_table(plans_list):
-	plans_table = []
-
-	# title row
-	visible_headers = ["name", "cpu_time_per_day"]
-	plans_table.append(["Plan", "CPU Time"])
-
-	# all rows
-	for plan in plans_list:
-		plan, cpu_time = [plan[header] for header in visible_headers]
-		plans_table.append([plan, "{} hour{}/day".format(cpu_time, "" if cpu_time < 2 else "s")])
-
-	render_table(plans_table)
 
 
 @add_line_after
@@ -132,19 +218,6 @@ def check_app_compat(available_group):
 	print(warning_message)
 
 	return is_compat, filtered_apps
-
-
-def render_group_table(app_groups):
-	# title row
-	app_groups_table = [["#", "App Group", "Apps"]]
-
-	# all rows
-	for idx, app_group in enumerate(app_groups):
-		apps_list = ", ".join(["{}:{}".format(app["scrubbed"], app["branch"]) for app in app_group["apps"]])
-		row = [idx + 1, app_group["name"], apps_list]
-		app_groups_table.append(row)
-
-	render_table(app_groups_table)
 
 
 @add_line_after
@@ -211,6 +284,68 @@ def upload_backup(local_site):
 	return files_uploaded
 
 
+def new_site(local_site):
+	# get new site options
+	site_options = get_new_site_options()
+
+	# set preferences from site options
+	subdomain = get_subdomain(site_options["domain"])
+	plan = choose_plan(site_options["plans"])
+
+	app_groups = site_options["groups"]
+	selected_group, filtered_apps = filter_apps(app_groups)
+	files_uploaded = upload_backup(local_site)
+
+	# push to frappe_cloud
+	payload = json.dumps({
+		"site": {
+			"apps": filtered_apps,
+			"files": files_uploaded,
+			"group": selected_group,
+			"name": subdomain,
+			"plan": plan
+		}
+	})
+
+	session.headers.update({"Content-Type": "application/json; charset=utf-8"})
+	site_creation_request = session.post(upload_url, payload)
+
+	if site_creation_request.ok:
+		site_url = site_creation_request.json()["message"]
+		print("Your site {} is being migrated ✨".format(local_site))
+		print("View your site dashboard at {}/dashboard/#/sites/{}".format(remote_site, site_url))
+		print("Your site URL: {}".format(site_url))
+	else:
+		handle_request_failure(site_creation_request)
+
+
+def restore_site(local_site):
+	# get list of existing sites they can restore
+	selected_site = select_site()
+
+	# TODO: check if they can restore it
+
+	click.confirm("This is an irreversible action. Are you sure you want to continue?", abort=True)
+
+	# backup site
+	files_uploaded = upload_backup(local_site)
+
+	# push to frappe_cloud
+	payload = json.dumps({
+		"name": selected_site,
+		"files": files_uploaded
+	})
+	headers = {"Content-Type": "application/json; charset=utf-8"}
+	site_restore_request = session.post(restore_site_url, payload, headers=headers)
+
+	if site_restore_request.ok:
+		print("Your site {0} is being restored on {1} ✨".format(local_site, selected_site))
+		print("View your site dashboard at {}/dashboard/#/sites/{}".format(remote_site, selected_site))
+		print("Your site URL: {}".format(selected_site))
+	else:
+		handle_request_failure(site_restore_request)
+
+
 @add_line_after
 def create_session():
 	print("Frappe Cloud credentials @ {}".format(remote_site))
@@ -231,3 +366,37 @@ def create_session():
 		return session
 	else:
 		handle_request_failure(message="Authorization Failed with Error Code {}".format(login_sc.status_code), traceback=False)
+
+
+def frappecloud_migrator(local_site, frappecloud_site):
+	global login_url, upload_url, files_url, options_url, site_exists_url, restore_site_url, account_details_url, all_site_url
+	global session, migrator_actions, remote_site
+
+	remote_site = frappecloud_site
+
+	login_url = "https://{}/api/method/login".format(remote_site)
+	upload_url = "https://{}/api/method/press.api.site.new".format(remote_site)
+	files_url = "https://{}/api/method/upload_file".format(remote_site)
+	options_url = "https://{}/api/method/press.api.site.options_for_new".format(remote_site)
+	site_exists_url = "https://{}/api/method/press.api.site.exists".format(remote_site)
+	account_details_url = "https://{}/api/method/press.api.account.get".format(remote_site)
+	all_site_url = "https://{}/api/method/press.api.site.all".format(remote_site)
+	restore_site_url = "https://{}/api/method/press.api.site.restore".format(remote_site)
+
+	migrator_actions = [
+		{ "title": "Create a new site", "fn": new_site },
+		{ "title": "Restore to an existing site", "fn": restore_site }
+	]
+
+	# get credentials + auth user + start session
+	session = create_session()
+
+	# available actions defined in migrator_actions
+	primary_action = select_primary_action()
+
+	frappe.init(site=local_site)
+	frappe.connect()
+
+	primary_action(local_site)
+
+	frappe.destroy()

--- a/frappe/integrations/frappe_providers/frappecloud.py
+++ b/frappe/integrations/frappe_providers/frappecloud.py
@@ -37,7 +37,7 @@ def render_site_table(sites_info):
 
 	for n, site_data in enumerate(sites_info):
 		name, status = site_data["name"], site_data["status"]
-		if status not in ("Inactive", "Suspended"):
+		if status in ("Active", "Broken"):
 			sites_table.append([n + 1, name, status])
 			available_sites.append(name)
 
@@ -372,7 +372,7 @@ def frappecloud_migrator(local_site, frappecloud_site):
 	global login_url, upload_url, files_url, options_url, site_exists_url, restore_site_url, account_details_url, all_site_url
 	global session, migrator_actions, remote_site
 
-	remote_site = frappecloud_site
+	remote_site = "staging.frappe.cloud" #frappecloud_site
 
 	login_url = "https://{}/api/method/login".format(remote_site)
 	upload_url = "https://{}/api/method/press.api.site.new".format(remote_site)

--- a/frappe/integrations/frappe_providers/frappecloud.py
+++ b/frappe/integrations/frappe_providers/frappecloud.py
@@ -111,7 +111,7 @@ def select_site():
 			if selected_site in available_sites:
 				return selected_site
 			else:
-				print("Site {} does not exist. Try again ❌".format(site))
+				print("Site {} does not exist. Try again ❌".format(selected_site))
 	else:
 		print("Couldn't retrive sites list...Try again later")
 		sys.exit(1)
@@ -372,7 +372,7 @@ def frappecloud_migrator(local_site, frappecloud_site):
 	global login_url, upload_url, files_url, options_url, site_exists_url, restore_site_url, account_details_url, all_site_url
 	global session, migrator_actions, remote_site
 
-	remote_site = "staging.frappe.cloud" #frappecloud_site
+	remote_site = frappecloud_site
 
 	login_url = "https://{}/api/method/login".format(remote_site)
 	upload_url = "https://{}/api/method/press.api.site.new".format(remote_site)

--- a/frappe/utils/commands.py
+++ b/frappe/utils/commands.py
@@ -27,6 +27,15 @@ def add_line_after(function):
 	return empty_line
 
 
+def add_line_before(function):
+	"""Adds an extra line to STDOUT before the execution of a function this decorates"""
+	def empty_line(*args, **kwargs):
+		print()
+		result = function(*args, **kwargs)
+		return result
+	return empty_line
+
+
 def log(message, colour=''):
 	"""Coloured log outputs to STDOUT"""
 	colours = {


### PR DESCRIPTION
**Updates:**

- If your account is a part of multiple teams, you'll be asked to choose which team you want to proceed with. If you are a part of only one team, it will be selected automatically.

- Want to restore an existing site on FC? You can do that too now! If your site's status is `Active` or `Broken`, you can restore it using your local site data

- Set `frappecloud_url` in `site_config.json` to override the frappecloud remote link

![Screenshot 2020-05-28 at 6 27 31 PM](https://user-images.githubusercontent.com/36654812/83144546-2118a280-a111-11ea-9e46-c89324b49575.png)

![Screenshot 2020-05-28 at 3 38 05 PM](https://user-images.githubusercontent.com/36654812/83146078-61792000-a113-11ea-840e-3091bd882fd0.png)


_* (The screenshot has all sites in the Site Table; With the latest commit here, only sites filtered by `Active` or `Broken` are visible)_