### PR TITLE
fix: Better logging if form script handler throws

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -16,12 +16,22 @@ frappe.ui.form.get_event_handler_list = function(doctype, fieldname) {
 frappe.ui.form.on = frappe.ui.form.on_change = function(doctype, fieldname, handler) {
 	var add_handler = function(fieldname, handler) {
 		var handler_list = frappe.ui.form.get_event_handler_list(doctype, fieldname);
-		handler_list.push(handler);
+
+		let _handler = (...args) => {
+			try {
+				handler(...args);
+			} catch (error) {
+				console.error(handler);
+				throw error;
+			}
+		}
+
+		handler_list.push(_handler);
 
 		// add last handler to events so it can be called as
 		// frm.events.handler(frm)
 		if(cur_frm && cur_frm.doctype===doctype) {
-			cur_frm.events[fieldname] = handler;
+			cur_frm.events[fieldname] = _handler;
 		}
 	}
 


### PR DESCRIPTION
When a Form Script handler (standard or custom) throws, the console has very less information to be able to find that function.

Here is what is shown in the console currently.

![image](https://user-images.githubusercontent.com/9355208/83233046-bf594680-a1ab-11ea-9ae9-d706583e4011.png)

It is very difficult to catch the stack trace from [eval executions](https://stackoverflow.com/questions/3526902/tracing-the-source-line-of-an-error-in-a-javascript-eval).

So I print the function that throws, which will be easier to debug.

![image](https://user-images.githubusercontent.com/9355208/83232986-a8b2ef80-a1ab-11ea-9bd9-308444f141ea.png)
