### PR TITLE
fix: shortcut routing and filters

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -31,9 +31,10 @@ export default class ShortcutWidget extends Widget {
 				is_query_report: this.is_query_report,
 				doctype: this.ref_doctype,
 			});
-			if (this.stats_filter) {
-				const get_filter = new Function(`return ${this.stats_filter}`);
-				frappe.route_options = get_filter();
+
+			let filters = this.get_doctype_filter();
+			if (this.type == "DocType" && filters) {
+				frappe.route_options = filters;
 			}
 			frappe.set_route(route);
 		});
@@ -43,14 +44,24 @@ export default class ShortcutWidget extends Widget {
 		if (this.in_customize_mode) return;
 
 		this.widget.addClass("shortcut-widget-box");
-		const get_filter = new Function(`return ${this.stats_filter}`);
-		if (this.type == "DocType" && this.stats_filter) {
+
+		let filters = this.get_doctype_filter();
+		if (this.type == "DocType" && filters) {
 			frappe.db
 				.count(this.link_to, {
-					filters: get_filter(),
+					filters: filters,
 				})
 				.then((count) => this.set_count(count));
 		}
+	}
+
+	get_doctype_filter() {
+		let count_filter = new Function(`return ${this.stats_filter}`)();
+		if (count_filter) {
+			return count_filter;
+		}
+
+		return null;
 	}
 
 	set_title() {

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -31,7 +31,10 @@ export default class ShortcutWidget extends Widget {
 				is_query_report: this.is_query_report,
 				doctype: this.ref_doctype
 			});
-
+			if (this.stats_filter) {
+				const get_filter = new Function(`return ${this.stats_filter}`);
+				frappe.route_options = get_filter();
+			}
 			frappe.set_route(route);
 		});
 	}

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -29,7 +29,7 @@ export default class ShortcutWidget extends Widget {
 				name: this.link_to,
 				type: this.type,
 				is_query_report: this.is_query_report,
-				doctype: this.ref_doctype
+				doctype: this.ref_doctype,
 			});
 			if (this.stats_filter) {
 				const get_filter = new Function(`return ${this.stats_filter}`);

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -241,11 +241,14 @@ class ShortcutDialog extends WidgetDialog {
 
 		if (this.dialog.get_value("type") == "DocType" && this.filter_group) {
 			let filters = this.filter_group.get_filters();
-			filters.forEach((arr) => {
-				stats_filter[arr[1]] = [arr[2], arr[3]];
-			});
 
-			data.stats_filter = JSON.stringify(stats_filter);
+			if (filters.length) {
+				filters.forEach((arr) => {
+					stats_filter[arr[1]] = [arr[2], arr[3]];
+				});
+
+				data.stats_filter = JSON.stringify(stats_filter);
+			}
 		}
 
 		data.label = data.label


### PR DESCRIPTION
This PR has the following changes

1. Set filter when routing to doctype list
1. Don't save empty filters when creating new shortcuts
1. Commonify get filters function