### PR TITLE
perf: We don't need to run Cypress tests for a README update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,20 +53,20 @@ before_install:
     ONLY_JS_CHANGES=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.js$' ; echo $?)
     ONLY_PY_CHANGES=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.py$' ; echo $?)
 
-    if [ $ONLY_DOCS_CHANGES == "1" ]; then
-      echo "Only docs were updated, stopping build process."
-      exit
+    if [[ $ONLY_DOCS_CHANGES == "1" ]]; then
+        echo "Only docs were updated, stopping build process.";
+        exit;
     fi
-    if [ $ONLY_JS_CHANGES == "1"  && $TYPE == "server" ]; then
-      echo "Only JavaScript code was updated; Stopping Python build process."
-      exit
+    if [[ $ONLY_JS_CHANGES == "1"  && $TYPE == "server" ]]; then
+        echo "Only JavaScript code was updated; Stopping Python build process.";
+        exit;
     fi
-    if [ $ONLY_PY_CHANGES == "1"  && $TYPE == "ui" ]; then
-      echo "Only Python code was updated, stopping Cypress build process."
-      exit
+    if [[ $ONLY_PY_CHANGES == "1"  && $TYPE == "ui" ]]; then
+        echo "Only Python code was updated, stopping Cypress build process.";
+        exit;
     fi
 
-  # install wkhtmltopdf
+ # install wkhtmltopdf
   - wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
   - tar -xf /tmp/wkhtmltox.tar.xz -C /tmp
   - sudo mv /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ cache:
     # https://docs.cypress.io/guides/guides/continuous-integration.html#Caching
     - ~/.cache
 
+
 matrix:
   include:
   - name: "Python 3.7 MariaDB"
@@ -46,6 +47,25 @@ matrix:
     script: bench --site test_site run-ui-tests frappe --headless
 
 before_install:
+    # do we really want to run travis?
+  - |
+    ONLY_DOCS_CHANGES=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.(md|png|jpg|jpeg)$|^.github|LICENSE' ; echo $?)
+    ONLY_JS_CHANGES=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.js$' ; echo $?)
+    ONLY_PY_CHANGES=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.py$' ; echo $?)
+
+    if [ $ONLY_DOCS_CHANGES == "1" ]; then
+      echo "Only docs were updated, stopping build process."
+      exit
+    fi
+    if [ $ONLY_JS_CHANGES == "1"  && $TYPE == "server" ]; then
+      echo "Only JavaScript code was updated; Stopping Python build process."
+      exit
+    fi
+    if [ $ONLY_PY_CHANGES == "1"  && $TYPE == "ui" ]; then
+      echo "Only Python code was updated, stopping Cypress build process."
+      exit
+    fi
+
   # install wkhtmltopdf
   - wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
   - tar -xf /tmp/wkhtmltox.tar.xz -C /tmp


### PR DESCRIPTION
## Changes

- Travis builds exit directly if changes exist only in docs; specifically `.md`, `.jpeg`, `.jpg`, files in the `.github` folder and `LICENSE`
- Python builds exit for PRs with only `.js` changes
- Cypress build exit for PRs with only `.py` changes

## Builds

### Before

- Any PR: https://github.com/frappe/frappe/pull/10545
https://travis-ci.com/github/frappe/frappe/builds/168758140

![Screenshot 2020-05-30 at 12 33 08 AM](https://user-images.githubusercontent.com/36654812/83295970-7b972900-a20d-11ea-8a77-553378e8a6d8.png)


### After

- Docs Update only: https://github.com/gavindsouza/frappe/pull/27 
https://travis-ci.org/github/gavindsouza/frappe/builds/692665649

![Screenshot 2020-05-30 at 12 26 55 AM](https://user-images.githubusercontent.com/36654812/83295304-5fdf5300-a20c-11ea-80c5-388ba7ca987b.png)


- Py Update only: https://github.com/gavindsouza/frappe/pull/28
https://travis-ci.org/github/gavindsouza/frappe/builds/692668414

![Screenshot 2020-05-30 at 12 27 03 AM](https://user-images.githubusercontent.com/36654812/83295343-6cfc4200-a20c-11ea-8bd1-e3ab524061fd.png)


- JS Update only: https://github.com/gavindsouza/frappe/pull/29
https://travis-ci.org/github/gavindsouza/frappe/builds/692670009

![Screenshot 2020-05-30 at 12 29 58 AM](https://user-images.githubusercontent.com/36654812/83295518-bb114580-a20c-11ea-8840-672414c4e8f6.png)


Co-authored-by @surajshetty3416 