### PR TITLE
fix: breadcrumb routing bug for desk pages

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -19,6 +19,7 @@ from frappe.email.inbox import get_email_accounts
 from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
 from frappe.social.doctype.energy_point_log.energy_point_log import get_energy_points
+from frappe.model.base_document import get_controller
 from frappe.social.doctype.post.post import frequently_visited_links
 
 def get_bootinfo():
@@ -106,6 +107,7 @@ def load_desktop_data(bootinfo):
 	from frappe.desk.desktop import get_desk_sidebar_items
 	bootinfo.allowed_modules = get_modules_from_all_apps_for_user()
 	bootinfo.allowed_workspaces = get_desk_sidebar_items(True)
+	bootinfo.module_page_map = get_controller("Desk Page").get_module_page_map()
 	bootinfo.dashboards = frappe.get_all("Dashboard")
 
 def get_allowed_pages(cache=False):

--- a/frappe/desk/doctype/desk_page/desk_page.py
+++ b/frappe/desk/doctype/desk_page/desk_page.py
@@ -20,6 +20,17 @@ class DeskPage(Document):
 		if frappe.conf.developer_mode and self.is_standard:
 			export_to_files(record_list=[['Desk Page', self.name]], record_module=self.module)
 
+	@staticmethod
+	def get_module_page_map():
+		filters = {
+			'extends_another_page': 0,
+			'for_user': '',
+		}
+
+		pages = frappe.get_all("Desk Page", fields=["name", "module"], filters=filters, as_list=1)
+
+		return { page[1]: page[0]  for page in pages }
+
 def disable_saving_as_standard():
 	return frappe.flags.in_install or \
 			frappe.flags.in_patch or \

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -89,16 +89,21 @@ frappe.breadcrumbs = {
 				breadcrumbs.module = frappe.breadcrumbs.module_map[breadcrumbs.module];
 			}
 
-			if(frappe.get_module(breadcrumbs.module)) {
+			let current_module = breadcrumbs.module
+			// Check if a desk page exists
+			if (frappe.boot.module_page_map[breadcrumbs.module]) {
+				breadcrumbs.module = frappe.boot.module_page_map[breadcrumbs.module];
+			}
+
+			if(frappe.get_module(current_module)) {
 				// if module access exists
-				var module_info = frappe.get_module(breadcrumbs.module),
+				var module_info = frappe.get_module(current_module),
 					icon = module_info && module_info.icon,
 					label = module_info ? module_info.label : breadcrumbs.module;
 
-
 				if(module_info && !module_info.blocked && frappe.visible_modules.includes(module_info.module_name)) {
 					$(repl('<li><a href="#workspace/%(module)s">%(label)s</a></li>',
-						{ module: breadcrumbs.module, label: __(label) }))
+						{ module: breadcrumbs.module, label: __(breadcrumbs.module) }))
 						.appendTo($breadcrumbs);
 				}
 			}


### PR DESCRIPTION
Breadcrumbs would route to module pages, this PR fixes that by adding a module page map to make route to pages correspond to the module