### PR TITLE
fix: translate label for open document counts

### DIFF
--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -153,12 +153,12 @@ frappe.ui.Notifications = class Notifications {
 		let title = target ? `title="${__('Your Target')}"` : '';
 		let $list_item = !target
 			? $(`<li><a class="badge-hover" data-action="route_to_document_type" data-doctype="${name}" ${title}>
-				${label}
+				${__(label)}
 				<span class="badge pull-right">${value}</span>
 			</a></li>`)
 			: $(`<li><a class="progress-small" data-action="route_to_document_type" ${title}
 				data-doctype="${doc_dt}" data-docname="${name}">
-					<span class="dropdown-item-label">${label}<span>
+					<span class="dropdown-item-label">${__(label)}<span>
 					<div class="progress-chart">
 						<div class="progress">
 							<div class="progress-bar" style="width: ${value}%"></div>


### PR DESCRIPTION
Added translation to open docs in notification dropdown
### Preview
![image](https://user-images.githubusercontent.com/18097732/83385343-ac8e7e00-a406-11ea-8bbd-f3a755e8c10c.png)
