### PR TITLE
fix: correct html entities escaped in menu links

### DIFF
--- a/frappe/public/js/frappe/views/components/ModuleLinkItem.vue
+++ b/frappe/public/js/frappe/views/components/ModuleLinkItem.vue
@@ -5,10 +5,8 @@
 	>
 		<span :class="['indicator', indicator_color]"></span>
 
-		<span v-if="disabled_dependent" class="link-content text-muted">{{ label || __(name) }}</span>
-		<a v-else class="link-content" :href="route" @click.prevent="handle_click">
-			{{ label || __(name) }}
-		</a>
+		<span v-if="disabled_dependent" class="link-content text-muted" v-html="label || __(name)"></span>
+		<a v-else class="link-content" :href="route" @click.prevent="handle_click" v-html="label || __(name)"></a>
 		<div v-if="disabled_dependent" v-show="popover_active"
 			@mouseover="popover_hover = true" @mouseleave="popover_hover = false"
 			class="module-link-popover popover fade top in" role="tooltip"


### PR DESCRIPTION
Vuejs with mustache syntax escape HTML entities.
Solution is to use v-html as explained here : [https://vuejs.org/v2/guide/syntax.html#Raw-HTML](https://vuejs.org/v2/guide/syntax.html#Raw-HTML)

Forum link : [here](https://discuss.erpnext.com/t/apostrophe-is-showed-as-39-is-not-interpreted/49954/4?u=jodeq)

example for "facture d&amp;#39;achat" :
![image](https://user-images.githubusercontent.com/7780466/83451531-6ad9f380-a457-11ea-971c-e8d401f7b7df.png)