### PR TITLE
fix: Init site before calling migrate_to

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -294,7 +294,10 @@ def migrate_to(context, frappe_provider):
 	"Migrates site to the specified provider"
 	from frappe.integrations.frappe_providers import migrate_to
 	for site in context.sites:
+		frappe.init(site=site)
+		frappe.connect()
 		migrate_to(site, frappe_provider)
+		frappe.destroy()
 	if not context.sites:
 		raise SiteNotSpecifiedError
 

--- a/frappe/integrations/frappe_providers/frappecloud.py
+++ b/frappe/integrations/frappe_providers/frappecloud.py
@@ -394,9 +394,4 @@ def frappecloud_migrator(local_site, frappecloud_site):
 	# available actions defined in migrator_actions
 	primary_action = select_primary_action()
 
-	frappe.init(site=local_site)
-	frappe.connect()
-
 	primary_action(local_site)
-
-	frappe.destroy()


### PR DESCRIPTION
Locals are not initialized otherwise which is required to access site_config