### PR TITLE
fix: show label for table fields

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -34,6 +34,7 @@
 		{%- if data -%}
 		{%- set visible_columns = get_visible_columns(doc.get(df.fieldname),
 			table_meta, df) -%}
+		<label>{{ _(df.label) }}</label>
 		<div {{ fieldmeta(df) }}>
 			<table class="table table-bordered table-condensed">
 				<thead>

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -34,8 +34,8 @@
 		{%- if data -%}
 		{%- set visible_columns = get_visible_columns(doc.get(df.fieldname),
 			table_meta, df) -%}
-		<label>{{ _(df.label) }}</label>
 		<div {{ fieldmeta(df) }}>
+			<label>{{ _(df.label) }}</label>
 			<table class="table table-bordered table-condensed">
 				<thead>
 					<tr>
@@ -96,7 +96,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {%- macro render_text_field(df, doc) -%}
 {%- if doc.get(df.fieldname) != None -%}
 <div style="padding: 10px 0px" {{ fieldmeta(df) }}>
-	{%- if df.fieldtype in ("Text", "Code", "Long Text") %}<label>{{ _(df.label) }}</label>{%- endif %}
+	{%- if df.fieldtype in ("Text", "Code", "Long Text", "Text Editor") %}<label>{{ _(df.label) }}</label>{%- endif %}
 	{%- if df.fieldtype=="Code" %}
 		<pre class="value">{{ doc.get(df.fieldname) }}</pre>
 	{% else -%}


### PR DESCRIPTION
All fields, except table ones, display their labels which is a natural thing to do.