### PR TITLE
fix: Number Card doesn't fetch data if country not India.

### DIFF
--- a/frappe/public/js/frappe/widgets/utils.js
+++ b/frappe/public/js/frappe/widgets/utils.js
@@ -128,7 +128,7 @@ function go_to_list_with_filters(doctype, filters) {
 }
 
 function shorten_number(number, country) {
-	country = country || '';
+	country = (country == 'India') ? country : '';
 	const number_system = get_number_system(country);
 	let x = Math.abs(Math.round(number));
 	for (const map of number_system) {


### PR DESCRIPTION
**Before**
![Screenshot 2020-06-02 at 7 48 49 PM](https://user-images.githubusercontent.com/25857446/83530935-04fa7400-a50a-11ea-8f62-99aa2c27bbd1.png)

**After**
![Screenshot 2020-06-02 at 7 49 53 PM](https://user-images.githubusercontent.com/25857446/83530910-fdd36600-a509-11ea-8084-1555436e4192.png)

**Issue:**
- If country is Sri Lanka it wont fetch anything from `get_number_system`

**Fix:**
- If not India set country to ' ', all countries except India are treated the same anyway.
- If undefined also it will be set to ' '.