### PR TITLE
fix: empty desk on does not exist error

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -313,21 +313,15 @@ def get_desktop_page(page):
 	Returns:
 		dict: dictionary of cards, charts and shortcuts to be displayed on website
 	"""
-	try:
-		wspace = Workspace(page)
-		wspace.build_workspace()
-		return {
-			'charts': wspace.charts,
-			'shortcuts': wspace.shortcuts,
-			'cards': wspace.cards,
-			'onboarding': wspace.onboarding,
-			'allow_customization': not wspace.doc.disable_user_customization
-		}
-
-	except DoesNotExistError:
-		if frappe.message_log:
-			frappe.message_log.pop()
-		return None
+	wspace = Workspace(page)
+	wspace.build_workspace()
+	return {
+		'charts': wspace.charts,
+		'shortcuts': wspace.shortcuts,
+		'cards': wspace.cards,
+		'onboarding': wspace.onboarding,
+		'allow_customization': not wspace.doc.disable_user_customization
+	}
 
 @frappe.whitelist()
 def get_desk_sidebar_items(flatten=False):


### PR DESCRIPTION
If any function in Workspace `build` would throw a does not exist error, an empty response would be sent. This means, the desk data will be empty and nothing will be rendered. 

This PR adds the try block to individual functions instead of entire desk by adding a decorator