### PR TITLE
refactor: set max height instead of height for footer logo

### DIFF
--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -143,7 +143,7 @@ a.card {
 
 .footer-logo {
 	width: 5rem;
-	height: 2rem;
+	max-height: 2rem;
 	object-fit: contain;
 }
 


### PR DESCRIPTION
Setting width explicitly would break the aspect ratio