### PR TITLE
fix: layout for onboarding step in multiple screen size

### DIFF
--- a/frappe/public/less/desktop.less
+++ b/frappe/public/less/desktop.less
@@ -390,6 +390,10 @@
 			margin-top: 20px;
 			padding-right: 200px;
 
+			@media (max-width: 970px) {
+				padding-right: 0;
+			}
+
 			&.grid {
 				display: grid;
 				grid-template-columns: 1fr 1fr;
@@ -409,6 +413,17 @@
 
 				&.grid-rows-5 {
 					grid-template-rows: repeat(5, 1fr);
+				}
+
+				@media (max-width: 768px) {
+					grid-template-columns: 1fr;
+					&.grid-rows-2,
+					&.grid-rows-3,
+					&.grid-rows-4,
+					&.grid-rows-5 {
+						grid-template-columns: 1fr;
+						grid-auto-flow: row;
+					}
 				}
 			}
 


### PR DESCRIPTION
## Changes

Layout fixes for onboarding step

## Mobile

![Screenshot_2020-06-04 Desk(2)](https://user-images.githubusercontent.com/18097732/83718459-b3a9cc00-a652-11ea-8a50-2a158351a623.png)

## Medium Screen

![Screenshot_2020-06-04 Desk(1)](https://user-images.githubusercontent.com/18097732/83718555-e784f180-a652-11ea-9ea3-492c00dd40a4.png)


## Large Screen
![Screenshot_2020-06-04 Desk](https://user-images.githubusercontent.com/18097732/83718475-b73d5300-a652-11ea-8ee2-c4eeda7990fa.png)
5af5.png)
