### PR TITLE
feat: Image grid web template

### DIFF
--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -292,7 +292,7 @@
 	margin-right: -2px;
 	margin-left: -2px;
 
-	.grid-image {
+	.image-container {
 		overflow: hidden;
 		border: 2px solid #fff;
 		border-radius: $border-radius;

--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -282,3 +282,40 @@
 .split-section-content {
 	margin-top: 2rem;
 }
+
+.image-grid {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+
+	// Offset for padding
+	margin-right: -2px;
+	margin-left: -2px;
+
+	.grid-image {
+		overflow: hidden;
+		height: 15rem;
+		border: 2px solid #fff;
+		border-radius: $border-radius;
+
+		&.wide {
+			max-width: 75%;
+			width: 75%;
+
+			img {
+				width: 100%;
+				object-fit: cover;
+			}
+		}
+
+		&.narrow {
+			max-width: 25%;
+			width: 25%;
+
+			img {
+				height: 100%;
+				object-fit: cover;
+			}
+		}
+	}
+}

--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -294,27 +294,40 @@
 
 	.grid-image {
 		overflow: hidden;
-		height: 15rem;
 		border: 2px solid #fff;
 		border-radius: $border-radius;
 
-		&.wide {
-			max-width: 75%;
-			width: 75%;
+		width: 100%;
+		max-height: 8rem;
 
-			img {
-				width: 100%;
-				object-fit: cover;
-			}
+		img {
+			width: 100%;
+			object-fit: cover;
 		}
 
-		&.narrow {
-			max-width: 25%;
-			width: 25%;
+		@include media-breakpoint-up(sm) {
+			&.wide {
+				max-width: 75%;
+				width: 75%;
+				max-height: 15rem;
+				height: 15rem;
 
-			img {
-				height: 100%;
-				object-fit: cover;
+				img {
+					width: 100%;
+					object-fit: cover;
+				}
+			}
+
+			&.narrow {
+				max-width: 25%;
+				width: 25%;
+				max-height: 15rem;
+				height: 15rem;
+
+				img {
+					height: 100%;
+					object-fit: cover;
+				}
 			}
 		}
 	}

--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -283,7 +283,7 @@
 	margin-top: 2rem;
 }
 
-.image-grid {
+.section-image-grid {
 	display: flex;
 	flex-wrap: wrap;
 	width: 100%;

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -771,6 +771,8 @@ def image_to_base64(image, extn):
 	from io import BytesIO
 
 	buffered = BytesIO()
+	if extn.lower() == 'jpg':
+		extn = 'JPEG'
 	image.save(buffered, extn)
 	img_str = base64.b64encode(buffered.getvalue())
 	return img_str

--- a/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
+++ b/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
@@ -7,7 +7,7 @@
 			{%- set image = values['image_' + index ] -%}
 			{%- set class = "narrow" if index in ['1', '4'] else "wide" -%}
 			{%- if image -%}
-				<div class="grid-image {{ class }}">
+				<div class="image-container {{ class }}">
 					{{ frappe.render_template('templates/includes/image_with_blur.html', {
 						"src": image
 					}) }}

--- a/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
+++ b/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
@@ -2,7 +2,7 @@
 	<h2 class="section-title">{{ title }}</h2>
 	<p class="section-description">{{ subtitle }}</p>
 
-	<div class="image-grid">
+	<div class="section-image-grid">
 		{%- for index in ['1', '2', '3', '4'] -%}
 			{%- set image = values['image_' + index ] -%}
 			{%- set class = "narrow" if index in ['1', '4'] else "wide" -%}

--- a/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
+++ b/frappe/website/web_template/section_with_image_grid/section_with_image_grid.html
@@ -1,0 +1,18 @@
+<div class="section-with-image-grid">
+	<h2 class="section-title">{{ title }}</h2>
+	<p class="section-description">{{ subtitle }}</p>
+
+	<div class="image-grid">
+		{%- for index in ['1', '2', '3', '4'] -%}
+			{%- set image = values['image_' + index ] -%}
+			{%- set class = "narrow" if index in ['1', '4'] else "wide" -%}
+			{%- if image -%}
+				<div class="grid-image {{ class }}">
+					{{ frappe.render_template('templates/includes/image_with_blur.html', {
+						"src": image
+					}) }}
+				</div>
+			{%- endif -%}
+		{%- endfor -%}
+	</div>
+</div>

--- a/frappe/website/web_template/section_with_image_grid/section_with_image_grid.json
+++ b/frappe/website/web_template/section_with_image_grid/section_with_image_grid.json
@@ -7,25 +7,25 @@
    "fieldname": "title",
    "fieldtype": "Data",
    "label": "Title",
-   "reqd": 0
+   "reqd": 1
   },
   {
    "fieldname": "subtitle",
    "fieldtype": "Data",
    "label": "Subtitle",
-   "reqd": 0
+   "reqd": 1
   },
   {
    "fieldname": "image_1",
    "fieldtype": "Attach Image",
    "label": "Image 1",
-   "reqd": 0
+   "reqd": 1
   },
   {
    "fieldname": "image_2",
    "fieldtype": "Attach Image",
    "label": "Image 2",
-   "reqd": 0
+   "reqd": 1
   },
   {
    "fieldname": "image_3",
@@ -41,7 +41,7 @@
   }
  ],
  "idx": 0,
- "modified": "2020-06-04 14:46:21.697200",
+ "modified": "2020-06-04 16:57:43.097550",
  "modified_by": "Administrator",
  "name": "Section with Image Grid",
  "owner": "Administrator",

--- a/frappe/website/web_template/section_with_image_grid/section_with_image_grid.json
+++ b/frappe/website/web_template/section_with_image_grid/section_with_image_grid.json
@@ -1,0 +1,50 @@
+{
+ "creation": "2020-06-04 14:43:39.753713",
+ "docstatus": 0,
+ "doctype": "Web Template",
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "reqd": 0
+  },
+  {
+   "fieldname": "subtitle",
+   "fieldtype": "Data",
+   "label": "Subtitle",
+   "reqd": 0
+  },
+  {
+   "fieldname": "image_1",
+   "fieldtype": "Attach Image",
+   "label": "Image 1",
+   "reqd": 0
+  },
+  {
+   "fieldname": "image_2",
+   "fieldtype": "Attach Image",
+   "label": "Image 2",
+   "reqd": 0
+  },
+  {
+   "fieldname": "image_3",
+   "fieldtype": "Attach Image",
+   "label": "Image 3",
+   "reqd": 0
+  },
+  {
+   "fieldname": "image_4",
+   "fieldtype": "Attach Image",
+   "label": "Image 4",
+   "reqd": 0
+  }
+ ],
+ "idx": 0,
+ "modified": "2020-06-04 14:46:21.697200",
+ "modified_by": "Administrator",
+ "name": "Section with Image Grid",
+ "owner": "Administrator",
+ "standard": 1,
+ "template": ""
+}


### PR DESCRIPTION
This PR adds section with image grid as a template and fixes a bug in image_to_base64

### Preview

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/18097732/83751327-46af2a00-a684-11ea-9869-3d0459ffec27.png">
