### PR TITLE
fix: DO NOT ever delete site folder

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -84,10 +84,6 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 
 	installing = touch_file(get_site_path('locks', 'installing.lock'))
 
-	if new_site:
-		# run cleanup only if new-site is called
-		atexit.register(_new_site_cleanup, site, mariadb_root_username, mariadb_root_password)
-
 	install_db(root_login=mariadb_root_username, root_password=mariadb_root_password, db_name=db_name,
 		admin_password=admin_password, verbose=verbose, source_sql=source_sql, force=force, reinstall=reinstall,
 		db_password=db_password, db_type=db_type, db_host=db_host, db_port=db_port, no_mariadb_socket=no_mariadb_socket)
@@ -103,18 +99,6 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 	scheduler_status = "disabled" if frappe.utils.scheduler.is_scheduler_disabled() else "enabled"
 	print("*** Scheduler is", scheduler_status, "***")
 
-def _new_site_cleanup(site, mariadb_root_username, mariadb_root_password):
-	try:
-		installing = get_site_path('locks', 'installing.lock')
-	except AttributeError:
-		installing = os.path.join(site, 'locks', 'installing.lock')
-
-	if installing and os.path.exists(installing):
-		if mariadb_root_password:
-			_drop_site(site, mariadb_root_username, mariadb_root_password, force=True)
-		shutil.rmtree(site)
-
-	frappe.destroy()
 
 @click.command('restore')
 @click.argument('sql-file-path')


### PR DESCRIPTION
this is very stupid, never delete folders that you do not know the importance of

all the site data is stored in the sites folder, and may it even be new-site, the data should not be deleted at any cost

please never add anything to the code that "deletes folders" on failure. this is highly risky, and it should never be a practice to delete anything without user confirmation.
