### PR TITLE
feat: Add canonical head link for SEO [v13]

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -20,6 +20,8 @@
 	>
 	{% endblock %}
 
+	<link rel="canonical" href="{{ canonical }}">
+
 	{%- block head -%}
 		{% if head_html is defined -%}
 		{{ head_html or "" }}

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -238,14 +238,13 @@ def add_metatags(context):
 
 		image = tags.get('image', context.image or None)
 		if image:
-			tags["og:image"] = tags["twitter:image:src"] = tags["image"] = frappe.utils.get_url(image)
+			tags["og:image"] = tags["twitter:image"] = tags["image"] = frappe.utils.get_url(image)
 			tags['twitter:card'] = "summary_large_image"
 
 		if context.author or tags.get('author'):
 			tags['author'] = context.author or tags.get('author')
 
-		if context.path:
-			tags['og:url'] = tags['url'] = frappe.utils.get_url(context.path)
+		tags['og:url'] = tags['url'] = frappe.utils.get_url(context.path)
 
 		if context.published_on:
 			tags['datePublished'] = context.published_on

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -20,11 +20,13 @@ def get_context(path, args=None):
 		# for <body data-path=""> (remove leading slash)
 		# path could be overriden in render.resolve_from_map
 		context["path"] = frappe.local.request.path.strip('/ ')
+		scheme = frappe.local.request.scheme
 	else:
 		context["path"] = path
+		scheme = 'http'
 
+	context.canonical = scheme + '://' + frappe.local.site + '/' + context.path
 	context.route = context.path
-
 	context = build_context(context)
 
 	# set using frappe.respond_as_web_page


### PR DESCRIPTION
Affects #10240

A canonical tag is important for SEO to avoid what search engines consider to be _duplicates_.
This implementation uses the scheme from the request, the bench/frappe site name (in case the site is aliased or proxied many times) and the context route

This implementation does not support port numbers. Not sure if that's important?
I will also submit to _version-12-hotfix_ if accepted

**Screenshot:**
![Screen Shot 2020-06-05 at 21 43 45](https://user-images.githubusercontent.com/64409021/83921164-b6e9a880-a775-11ea-85d2-810551bd84d0.png)

Changes below because [twitter documentation](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image) doesn't mention twitter:image:src
`if context.path:` will fail if the path is empty (homepage)
![Screen Shot 2020-06-08 at 10 47 45](https://user-images.githubusercontent.com/64409021/84016703-8d976b00-a975-11ea-9a26-4c85fad7e24f.png)
