### PR TITLE
feat: Add H1 tag to About and Contact pages for SEO [v13]

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -10,7 +10,7 @@
 		{% include "templates/includes/meta_block.html" %}
 	{% endblock %}
 
-	<title>{% block title %} {{ title | striptags }} {% endblock %}</title>
+	<title>{% block title %}{{ title | striptags }}{% endblock %}</title>
 
 	{% block favicon %}
 	<link

--- a/frappe/www/about.html
+++ b/frappe/www/about.html
@@ -1,6 +1,6 @@
 {% extends "templates/web.html" %}
 
-{% block title %}About Us{% endblock %}
+{% set title = "About Us" %}
 {% block header %}<h1>About Us</h1>{% endblock %}
 {% block page_sidebar %}
 {% include "templates/includes/web_sidebar.html" %}

--- a/frappe/www/about.html
+++ b/frappe/www/about.html
@@ -1,6 +1,7 @@
 {% extends "templates/web.html" %}
 
 {% block title %}About Us{% endblock %}
+{% block header %}<h1>About Us</h1>{% endblock %}
 {% block page_sidebar %}
 {% include "templates/includes/web_sidebar.html" %}
 {% endblock %}

--- a/frappe/www/contact.html
+++ b/frappe/www/contact.html
@@ -1,6 +1,7 @@
 {% extends "templates/web.html" %}
 
 {% block title %}{{ heading or "Contact Us"}}{% endblock %}
+{% block header %}<h1>{{ heading or "Contact Us"}}</h1>{% endblock %}
 
 {% block page_content %}
 <style>

--- a/frappe/www/contact.html
+++ b/frappe/www/contact.html
@@ -1,7 +1,7 @@
 {% extends "templates/web.html" %}
 
-{% block title %}{{ heading or "Contact Us"}}{% endblock %}
-{% block header %}<h1>{{ heading or "Contact Us"}}</h1>{% endblock %}
+{% set title = heading or "Contact Us" %}
+{% block header %}<h1>{{ heading or "Contact Us" }}</h1>{% endblock %}
 
 {% block page_content %}
 <style>


### PR DESCRIPTION
Affects: frappe/erpnext#21515

Search engines put a significant emphasis on a page H1 tag to figure out the main subject of the page. This adds an H1 to the two most prominent frappe web pages.

I will also submit to _version-12-hotfix_ if accepted