### PR TITLE
fix: Issue with breadcrumb on Contact Us page [v12]

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -10,7 +10,7 @@
 		{% include "templates/includes/meta_block.html" %}
 	{% endblock %}
 
-	<title>{% block title %} {{ title | striptags }} {% endblock %}</title>
+	<title>{% block title %}{{ title | striptags }}{% endblock %}</title>
 
 	{% block favicon %}
 	<link

--- a/frappe/www/about.html
+++ b/frappe/www/about.html
@@ -1,6 +1,6 @@
 {% extends "templates/web.html" %}
 
-{% block title %}About Us{% endblock %}
+{% set title = "About Us" %}
 {% block header %}<h1>About Us</h1>{% endblock %}
 {% block page_sidebar %}
 {% include "templates/includes/web_sidebar.html" %}

--- a/frappe/www/contact.html
+++ b/frappe/www/contact.html
@@ -1,7 +1,7 @@
 {% extends "templates/web.html" %}
 
-{% block title %}{{ heading or "Contact Us"}}{% endblock %}
-{% block header %}<h1>{{ heading or "Contact Us"}}</h1>{% endblock %}
+{% set title = heading or "Contact Us" %}
+{% block header %}<h1>{{ heading or "Contact Us" }}</h1>{% endblock %}
 
 {% block page_content %}
 <style>


### PR DESCRIPTION
Fixed pre-existing issue with About and Contact Us templates
Removed head title whitespace
Related: #10608 & #10605 