### PR TITLE
fix: Handle invalid date parsing

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 # IMPORTANT: only import safe functions as this module will be included in jinja environment
 import frappe
+from dateutil.parser._parser import ParserError
 import subprocess
 import operator
 import re, datetime, math, time
@@ -43,8 +44,12 @@ def getdate(string_date=None):
 
 	if is_invalid_date_string(string_date):
 		return None
-
-	return parser.parse(string_date).date()
+	try:
+		return parser.parse(string_date).date()
+	except ParserError:
+		frappe.throw(frappe._('{} is not a valid date string.').format(
+			frappe.bold(string_date)
+		), title=frappe._('Invalid Date'))
 
 def get_datetime(datetime_str=None):
 	if not datetime_str:


### PR DESCRIPTION
Handle invalid date parsing instead of throwing server error.

**Before:**
<img width="538" alt="Screenshot 2020-06-07 at 6 50 25 PM" src="https://user-images.githubusercontent.com/13928957/83969828-c5f46600-a8ef-11ea-81b6-0ba159c980ee.png">

**After:**
<img width="467" alt="Screenshot 2020-06-07 at 6 47 45 PM" src="https://user-images.githubusercontent.com/13928957/83969831-cab91a00-a8ef-11ea-8e38-2c12b24fb2c5.png">