### PR TITLE
fix: Make Delivery Status in Timeline Item translatable

### DIFF
--- a/frappe/public/js/frappe/form/templates/timeline_item.html
+++ b/frappe/public/js/frappe/form/templates/timeline_item.html
@@ -77,8 +77,8 @@
 							<span class="text-muted hidden-xs">&ndash;</span>
 							<span class="indicator-right {%= indicator_class %}
 								delivery-status-indicator"
-								title="{%= data.delivery_status %}"><span class="hidden-xs">
-								{%= data.delivery_status %}</span></span>
+								title="{%= __(data.delivery_status) %}"><span class="hidden-xs">
+								{%= __(data.delivery_status) %}</span></span>
 
 							{% } else { %}
 								{% if (frappe.model.can_read(\'Communication\')) { %}


### PR DESCRIPTION
The delivery status string in the timeline item of emails were not translatable. This fix adds back the translate function.