### PR TITLE
fix(web_form): web form file attachment link to specific doctype

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -138,6 +138,16 @@ export default class WebForm extends frappe.ui.FieldGroup {
 					this.handle_success(response.message);
 					frappe.web_form.events.trigger('after_save');
 					this.after_save && this.after_save();
+					// args doctype and docname added to link doctype in file manager
+					frappe.call({
+						type: 'POST',
+						method: "frappe.handler.upload_file",
+						args: {
+							file_url: response.message.attachment,
+							doctype: response.message.doctype,
+							docname: response.message.name
+						}
+					});
 				}
 			},
 			always: function() {


### PR DESCRIPTION
Problem: From Web Form it attach file into file manager but not linked to specific doctype
solve:
![Peek 2020-06-09 17-14](https://user-images.githubusercontent.com/6947417/84143768-c407df80-aa74-11ea-8bdf-06b3f1576c6a.gif)
