### PR TITLE
fix: colours missing from indicator.js

### DIFF
--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -41,6 +41,8 @@ frappe.get_indicator = function(doc, doctype) {
 					"Warning": "orange",
 					"Danger": "red",
 					"Primary": "blue",
+					"Inverse": "black",
+					"Info": "light-blue",
 				}[locals["Workflow State"][value].style];
 			}
 			if(!colour) colour = "darkgrey";


### PR DESCRIPTION
The indicator colours for workflow states are incomplete, and only provide the stated colour options for four of the named styles.
There are seven Workflow State color options, if you include the empty option, which currently displays as darkgrey.
On the Workflow State form, the styles are defined as:
"Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange"
In indicator.js, only four of these - Success, Warning, Danger and Primary are allocated to colours, despite the colours being available. Adding black for Inverse and light-blue for Info fixes this bug. Any non-matching colour will continue to be rendered in dark grey (which can be chosen by selecting the Empty option).

Currently looks like this:
![image](https://user-images.githubusercontent.com/4930097/84161018-b6e3f400-aa66-11ea-8d39-cad4ee4fe730.png)

Should look like this:
![image](https://user-images.githubusercontent.com/4930097/84161139-dd099400-aa66-11ea-8dc5-f271697e9d36.png)
