### PR TITLE
fix(web_form): set only_select property for link fields in child table

### DIFF
--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -95,6 +95,11 @@ frappe.ready(function() {
 					};
 
 					df.fields = form_data[df.fieldname];
+					$.each(df.fields || [], function(_i, field) {
+						if (field.fieldtype === "Link") {
+							field.only_select = true;
+						}
+					});
 
 					if (df.fieldtype === "Attach") {
 						df.is_private = true;


### PR DESCRIPTION
Set only_select property for Link fields in Child Table of Web Form

**Before:**

![web-form](https://user-images.githubusercontent.com/24353136/84160761-2d471d00-aa8c-11ea-8635-eff80c3ce91a.png)

**After:**
![link](https://user-images.githubusercontent.com/24353136/84161225-acd4ec00-aa8c-11ea-88b3-cee5945c4aee.png)

