### PR TITLE
fix(doctor): update broken command behaviour

### DIFF
--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -43,12 +43,14 @@ def pass_context(f):
 
 	return click.pass_context(_func)
 
-def get_site(context):
+def get_site(context, raise_err=True):
 	try:
 		site = context.sites[0]
 		return site
 	except (IndexError, TypeError):
-		raise frappe.SiteNotSpecifiedError
+		if raise_err:
+			raise frappe.SiteNotSpecifiedError
+		return None
 
 def popen(command, *args, **kwargs):
 	output    = kwargs.get('output', True)

--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -126,7 +126,7 @@ def doctor(context, site=None):
 	"Get diagnostic info about background workers"
 	from frappe.utils.doctor import doctor as _doctor
 	if not site:
-		site = get_site(context)
+		site = get_site(context, raise_err=False)
 	return _doctor(site=site)
 
 @click.command('show-pending-jobs')


### PR DESCRIPTION
**Bug:** Change in behaviour of command
**Command:** `bench doctor`
**PR:** https://github.com/frappe/frappe/pull/10382
**Why:** Unlike other commands, `doctor` doesn't follow the behavioural pattern of currentsite being set. If currentsite is set and `bench console`, `bench mariadb` is run, the command will start for the current site, else you'll get a `Please specify --site sitename` error message. However, `bench doctor` does not follow this. After the aforementioned PR, this behaviour was broken. This PR reverts back to past behaviour.

**Before specified PR:**

```
-----Checking scheduler status-----
Scheduler disabled for accounting
Scheduler inactive for accounting
Scheduler disabled for bench-manager.local
Scheduler inactive for bench-manager.local
Scheduler disabled for cloud
Scheduler inactive for cloud
Scheduler disabled for erpnext_com
Scheduler inactive for erpnext_com
Scheduler disabled for erpnext_tally
Scheduler inactive for erpnext_tally
Scheduler disabled for erpnext_tally_2
Scheduler inactive for erpnext_tally_2
Scheduler disabled for frappe_io
Scheduler inactive for frappe_io
Scheduler disabled for mumbaihackathon_in
Scheduler inactive for mumbaihackathon_in
Scheduler disabled for site1.local
Scheduler inactive for site1.local
Scheduler disabled for test_site_ui
Scheduler inactive for test_site_ui
Scheduler disabled for translator
Scheduler inactive for translator
Workers online: 3
-----None Jobs-----
```

**After specified PR:**

```
Please specify --site sitename
```

**After this PR:**
```
-----Checking scheduler status-----
Scheduler disabled for accounting
Scheduler inactive for accounting
Scheduler disabled for bench-manager.local
Scheduler inactive for bench-manager.local
Scheduler disabled for cloud
Scheduler inactive for cloud
Scheduler disabled for erpnext_com
Scheduler inactive for erpnext_com
Scheduler disabled for erpnext_tally
Scheduler inactive for erpnext_tally
Scheduler disabled for erpnext_tally_2
Scheduler inactive for erpnext_tally_2
Scheduler disabled for frappe_io
Scheduler inactive for frappe_io
Scheduler disabled for mumbaihackathon_in
Scheduler inactive for mumbaihackathon_in
Scheduler disabled for site1.local
Scheduler inactive for site1.local
Scheduler disabled for test_site_ui
Scheduler inactive for test_site_ui
Scheduler disabled for translator
Scheduler inactive for translator
Workers online: 3
-----None Jobs-----
```
