### PR TITLE
fix: catch exceptions when sending notification

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -119,15 +119,17 @@ def get_context(context):
 
 		if self.is_standard:
 			self.load_standard_properties(context)
+		try:
+			if self.channel == 'Email':
+				self.send_an_email(doc, context)
 
-		if self.channel == 'Email':
-			self.send_an_email(doc, context)
+			if self.channel == 'Slack':
+				self.send_a_slack_msg(doc, context)
 
-		if self.channel == 'Slack':
-			self.send_a_slack_msg(doc, context)
-
-		if self.channel == 'System Notification' or self.send_system_notification:
-			self.create_system_notification(doc, context)
+			if self.channel == 'System Notification' or self.send_system_notification:
+				self.create_system_notification(doc, context)
+		except:
+			frappe.log_error(title='Notificaiton Sending Failed', message=frappe.get_traceback())
 
 		if self.set_property_after_alert:
 			allow_update = True
@@ -167,6 +169,7 @@ def get_context(context):
 		enqueue_create_notification(users, notification_doc)
 
 	def send_an_email(self, doc, context):
+		frappe.throw("Cannot send this email. You have crossed the sending limit of 5000 emails for this month.")
 		from email.utils import formataddr
 		subject = self.subject
 		if "{" in subject:

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -169,7 +169,6 @@ def get_context(context):
 		enqueue_create_notification(users, notification_doc)
 
 	def send_an_email(self, doc, context):
-		frappe.throw("Cannot send this email. You have crossed the sending limit of 5000 emails for this month.")
 		from email.utils import formataddr
 		subject = self.subject
 		if "{" in subject:

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -129,7 +129,7 @@ def get_context(context):
 			if self.channel == 'System Notification' or self.send_system_notification:
 				self.create_system_notification(doc, context)
 		except:
-			frappe.log_error(title='Notificaiton Sending Failed', message=frappe.get_traceback())
+			frappe.log_error(title='Failed to send notification', message=frappe.get_traceback())
 
 		if self.set_property_after_alert:
 			allow_update = True


### PR DESCRIPTION
## Bug overview
For journeys where limits are checked, in case email limits are reached, and a notification is triggered a doctype event, an exception will be thrown. This exception cascades to the save function and the save function breaks

This PR fixes this by catching all exceptions and adding an error log

## Steps to reproduce

* Create a notification on Note to send an email to owner on creation
* Add a `frappe.throw` in the send function
* Try creating a Note

The note won't be saved

Reference Issue: ISS-20-21-01733