### PR TITLE
fix: show login dropdown if already logged on

### DIFF
--- a/frappe/templates/includes/navbar/navbar_login.html
+++ b/frappe/templates/includes/navbar/navbar_login.html
@@ -1,5 +1,5 @@
 <!-- post login tools -->
-{% if not only_static and not hide_login %}
+{% if not only_static %}
 
 	{% if frappe.session.user != 'Guest' %}
 	<li class="nav-item dropdown logged-in" id="website-post-login" data-label="website-post-login" style="display: none">


### PR DESCRIPTION
Hide Login (`hide_login`) was added to Website Settings, this would hide the login area all together, even if the user is logged in already.

This fixes that 