### PR TITLE
fix: set default template for list

### DIFF
--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -172,7 +172,7 @@ def get_list_context(context, doctype, web_form_name=None):
 		list_context.row_template = meta.get_row_template()
 
 	if not meta.custom and not list_context.list_template:
-		list_context.template = meta.get_list_template()
+		list_context.template = meta.get_list_template() or "www/list.html"
 
 	return list_context
 


### PR DESCRIPTION
Portal list views would not default to list template if template was not specified in controller.

Due to chagnes in `router.py` in `list.py` rendering the page, neither source, neither context was set. So html would not be genearted

### Traceback

```python
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/app.py", line 73, in application
    response = frappe.website.render.render()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/render.py", line 68, in render
    data = render_page(path)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/render.py", line 193, in render_page
    return build(path)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/render.py", line 200, in build
    return build_page(path)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/render.py", line 225, in build_page
    if '{index}' in html:
UnboundLocalError: local variable 'html' referenced before assignment
```