### PR TITLE
fix: Duplicate custom field check

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -31,6 +31,13 @@ class CustomField(Document):
 		# fieldnames should be lowercase
 		self.fieldname = self.fieldname.lower()
 
+	def before_insert(self):
+		meta = frappe.get_meta(self.dt, cached=False)
+		fieldnames = [df.fieldname for df in meta.get("fields")]
+
+		if self.fieldname in fieldnames:
+			frappe.throw(_("A field with the name '{}' already exists in doctype {}.").format(self.fieldname, self.dt))
+
 	def validate(self):
 		meta = frappe.get_meta(self.dt, cached=False)
 		fieldnames = [df.fieldname for df in meta.get("fields")]
@@ -45,9 +52,6 @@ class CustomField(Document):
 
 		if not self.fieldname:
 			frappe.throw(_("Fieldname not set for Custom Field"))
-
-		if self.fieldname in fieldnames:
-			frappe.throw(_("A field with the name '{}' already exists in doctype {}.").format(self.fieldname, self.dt))
 
 		if self.get('translatable', 0) and not supports_translation(self.fieldtype):
 			self.translatable = 0


### PR DESCRIPTION
Introduced in PR https://github.com/frappe/frappe/pull/10547

Duplicate field check should be done before inserting the field. Many times custom fields are updated in regional setup and in patches

The current fix breaks the patch and setup 