### PR TITLE
feat: prompt in case of site downgrades on restore

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -108,12 +108,14 @@ def _new_site(db_name, site, mariadb_root_username=None, mariadb_root_password=N
 @click.option('--install-app', multiple=True, help='Install app after installation')
 @click.option('--with-public-files', help='Restores the public files of the site, given path to its tar file')
 @click.option('--with-private-files', help='Restores the private files of the site, given path to its tar file')
+@click.option('--force', is_flag=True, default=False, help='Use a bit of force to get the job done')
 @pass_context
 def restore(context, sql_file_path, mariadb_root_username=None, mariadb_root_password=None, db_name=None, verbose=None, install_app=None, admin_password=None, force=None, with_public_files=None, with_private_files=None):
 	"Restore site database from an sql file"
-	from frappe.installer import extract_sql_gzip, extract_tar_files
-	# Extract the gzip file if user has passed *.sql.gz file instead of *.sql file
+	from frappe.installer import extract_sql_gzip, extract_tar_files, is_downgrade
+	force = context.force or force
 
+	# Extract the gzip file if user has passed *.sql.gz file instead of *.sql file
 	if not os.path.exists(sql_file_path):
 		base_path = '..'
 		sql_file_path = os.path.join(base_path, sql_file_path)
@@ -125,7 +127,6 @@ def restore(context, sql_file_path, mariadb_root_username=None, mariadb_root_pas
 	else:
 		base_path = '.'
 
-
 	if sql_file_path.endswith('sql.gz'):
 		decompressed_file_name = extract_sql_gzip(os.path.abspath(sql_file_path))
 	else:
@@ -133,6 +134,11 @@ def restore(context, sql_file_path, mariadb_root_username=None, mariadb_root_pas
 
 	site = get_site(context)
 	frappe.init(site=site)
+
+	# dont allow downgrading to older versions of frappe without force
+	if not force and is_downgrade(decompressed_file_name):
+		click.confirm("Downgrading sites may lead to a broken site. Do you wish to continue?", abort=True)
+
 	_new_site(frappe.conf.db_name, site, mariadb_root_username=mariadb_root_username,
 		mariadb_root_password=mariadb_root_password, admin_password=admin_password,
 		verbose=context.verbose, install_apps=install_app, source_sql=decompressed_file_name,

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -136,8 +136,9 @@ def restore(context, sql_file_path, mariadb_root_username=None, mariadb_root_pas
 	frappe.init(site=site)
 
 	# dont allow downgrading to older versions of frappe without force
-	if not force and is_downgrade(decompressed_file_name):
-		click.confirm("Downgrading sites may lead to a broken site. Do you wish to continue?", abort=True)
+	if not force and is_downgrade(decompressed_file_name, verbose=True):
+		warn_message = "This is not recommended and may lead to unexpected behaviour. Do you want to continue anyway?"
+		click.confirm(warn_message, abort=True)
 
 	_new_site(frappe.conf.db_name, site, mariadb_root_username=mariadb_root_username,
 		mariadb_root_password=mariadb_root_password, admin_password=admin_password,

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -330,7 +330,6 @@ def extract_tar_files(site_name, file_path, folder_name):
 def is_downgrade(sql_file_path):
 	"""checks if input db backup will get downgraded on current bench"""
 	from semantic_version import Version
-	from frappe.utils.change_log import get_app_branch
 	head = "INSERT INTO `tabInstalled Application` VALUES"
 
 	with open(sql_file_path) as f:
@@ -348,7 +347,7 @@ def is_downgrade(sql_file_path):
 					if app_name == "frappe":
 						try:
 							current_version = Version(frappe.__version__)
-							backup_version = Version(app_version[1:] if app_version[0] is "v" else app_version)
+							backup_version = Version(app_version[1:] if app_version[0] == "v" else app_version)
 						except ValueError:
 							return False
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -327,7 +327,7 @@ def extract_tar_files(site_name, file_path, folder_name):
 
 	return tar_path
 
-def is_downgrade(sql_file_path):
+def is_downgrade(sql_file_path, verbose=False):
 	"""checks if input db backup will get downgraded on current bench"""
 	from semantic_version import Version
 	head = "INSERT INTO `tabInstalled Application` VALUES"
@@ -335,9 +335,9 @@ def is_downgrade(sql_file_path):
 	with open(sql_file_path) as f:
 		for line in f:
 			if head in line:
-				# ('2056588823','2020-05-11 18:21:31.488367','2020-06-12 11:49:31.079506','Administrator','Administrator',0,'Installed Applications','installed_applications','Installed Applications',1,'frappe','v10.1.71-74 (3c50d5e) (v10.x.x)','v10.x.x'),('855c640b8e','2020-05-11 18:21:31.488367','2020-06-12 11:49:31.079506','Administrator','Administrator',0,'Installed Applications','installed_applications','Installed Applications',2,'press','0.0.1','master')
+				# 'line' (str) format: ('2056588823','2020-05-11 18:21:31.488367','2020-06-12 11:49:31.079506','Administrator','Administrator',0,'Installed Applications','installed_applications','Installed Applications',1,'frappe','v10.1.71-74 (3c50d5e) (v10.x.x)','v10.x.x'),('855c640b8e','2020-05-11 18:21:31.488367','2020-06-12 11:49:31.079506','Administrator','Administrator',0,'Installed Applications','installed_applications','Installed Applications',2,'your_custom_app','0.0.1','master')
 				line = line.strip().lstrip(head).rstrip(";").strip()
-				# [('frappe', '12.x.x-develop ()', 'develop'), ('press', '0.0.1', 'master')]
+				# 'all_apps' (list) format: [('frappe', '12.x.x-develop ()', 'develop'), ('your_custom_app', '0.0.1', 'master')]
 				all_apps = [ x[-3:] for x in frappe.safe_eval(line) ]
 
 				for app in all_apps:
@@ -351,4 +351,9 @@ def is_downgrade(sql_file_path):
 						except ValueError:
 							return False
 
-						return backup_version > current_version
+						downgrade = backup_version > current_version
+
+						if verbose and downgrade:
+							print("Your site will be downgraded from Frappe {0} to {1}".format(current_version, backup_version))
+
+						return downgrade


### PR DESCRIPTION
**Scenario:** Downgrading  site from v13-beta to a v12

**Why:** Downgrading isn't supported and may lead to a broken site or unexpected behavior and new site data corruption. 

The `is_downgrade` function checks if the DB file has a populated Installed Applications which compares frappe versions. If the DocType is not found or version tags are not readable, the prompt isn't triggered. The version tags extraction is tested with v10.x.x, v11, v12, and v13 versions. 

![Screenshot 2020-06-12 at 4 21 10 PM](https://user-images.githubusercontent.com/36654812/84495821-76d07b80-acc9-11ea-867e-383bba656ed9.png)

![Screenshot 2020-06-12 at 4 21 19 PM](https://user-images.githubusercontent.com/36654812/84495827-7932d580-acc9-11ea-9db8-454dd2d7eec8.png)

no-docs
<!-- no-docs -->