### PR TITLE
fix: Bypass ORM for removing apps from installed_apps list

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -113,7 +113,7 @@ def remove_from_installed_apps(app_name):
 	installed_apps = frappe.get_installed_apps()
 	if app_name in installed_apps:
 		installed_apps.remove(app_name)
-		frappe.db.set_global("installed_apps", json.dumps(installed_apps))
+		frappe.db.set_value("DefaultValue", {"defkey": "installed_apps"}, "defvalue", json.dumps(installed_apps))
 		frappe.db.commit()
 		if frappe.flags.in_install:
 			post_install()


### PR DESCRIPTION
**Scenario:**
a site (on older version) has a custom app xyz installed.
this site is to be restored on a new bench (without xyz) and migrated to recent version.

**Problem:**
`bench migrate` fails because xyz is not available.
`bench remove-from-installed-apps` might fail, because code is not compatible with the database.
