### PR TITLE
chore: update google-auth deps to avoid pinning indirect ones

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gitdb2==2.0.6;python_version<'3.4'
 google-api-python-client==1.7.11
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
-google-auth==1.7.1
+google-auth==1.17.1
 googlemaps==3.1.1
 gunicorn==19.10.0
 html2text==2016.9.19


### PR DESCRIPTION
Instead of https://github.com/frappe/frappe/pull/10660

https://github.com/googleapis/google-auth-library-python/blob/85c2bac0feca0c41d78c72be47f79491be836129/setup.py#L21-L29