### PR TITLE
fix: scrub script name while creating scheduler event

### DIFF
--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -42,7 +42,7 @@ class ServerScript(Document):
 
 @frappe.whitelist()
 def setup_scheduler_events(script_name, frequency):
-	method = frappe.scrub(script_name) + '_' + frequency.lower()
+	method = frappe.scrub('{0}-{1}'.format(script_name, frequency))
 	scheduled_script = frappe.db.get_value('Scheduled Job Type',
 		dict(method=method))
 


### PR DESCRIPTION
While creating a method from Server Script, there is a space between the method name which is not scrubbed because of which it doesn't run and gives the error.

![ofeyVqT](https://user-images.githubusercontent.com/3784093/84500113-894eb300-acd1-11ea-8cb7-903d23c5df1b.png)
