### PR TITLE
fix: rename web.log generated by frappe to frappe.web.log

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -99,7 +99,7 @@ def application(request):
 		frappe.monitor.stop(response)
 		frappe.recorder.dump()
 
-		frappe.logger("web").info({
+		frappe.logger("frappe.web").info({
 			"site": get_site_name(request.host),
 			"remote_addr": getattr(request, "remote_addr", "NOTFOUND"),
 			"base_url": getattr(request, "base_url", "NOTFOUND"),


### PR DESCRIPTION
redirect frappe weblogger output to `frappe.web.log` to avoid conflict with `web.log` file generated by gunicorn process in production.