### PR TITLE
fix: attribute error while handling email exception

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -10,7 +10,7 @@ import socket
 import time
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import validate_email_address, cint, get_datetime, DATE_FORMAT, strip, comma_or, sanitize_html, add_days
+from frappe.utils import validate_email_address, cint, cstr, get_datetime, DATE_FORMAT, strip, comma_or, sanitize_html, add_days
 from frappe.utils.user import is_system_user
 from frappe.utils.jinja import render_template
 from frappe.email.smtp import SMTPServer
@@ -169,19 +169,20 @@ class EmailAccount(Document):
 		try:
 			email_server.connect()
 		except (error_proto, imaplib.IMAP4.error) as e:
-			message = e.message.lower().replace(" ","")
-			if in_receive and any(map(lambda t: t in message, ['authenticationfail', 'loginviayourwebbrowser', #abbreviated to work with both failure and failed
+			e = cstr(e)
+			message = e.lower().replace(" ","")
+			if in_receive and any(map(lambda t: t in message, ['authenticationfailed', 'loginviayourwebbrowser', #abbreviated to work with both failure and failed
 				'loginfailed', 'err[auth]', 'errtemporaryerror'])): #temporary error to deal with godaddy
 				# if called via self.receive and it leads to authentication error, disable incoming
 				# and send email to system manager
 				self.handle_incoming_connect_error(
-					description=_('Authentication failed while receiving emails from Email Account {0}. Message from server: {1}').format(self.name, e.message)
+					description=_('Authentication failed while receiving emails from Email Account {0}. Message from server: {1}').format(self.name, e)
 				)
 
 				return None
 
 			else:
-				frappe.throw(e.message)
+				frappe.throw(e)
 
 		except socket.error:
 			if in_receive:


### PR DESCRIPTION
```
poplib.error_proto: b'-ERR [AUTH] Username and password not accepted.'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/__init__.py", line 1085, in call
    return fn(*args, **newargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 281, in save
    return self._save(*args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 316, in _save
    self.run_before_save_methods()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 914, in run_before_save_methods
    self.run_method("validate")
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 815, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 1105, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 1088, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 809, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 68, in validate
    self.get_incoming_server()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 172, in get_incoming_server
    message = e.message.lower().replace(" ","")
AttributeError: 'error_proto' object has no attribute 'message'
```