### PR TITLE
fix: permission query for dashboard chart and number card

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -26,15 +26,15 @@ def get_permission_query_conditions(user):
 	if "System Manager" in roles:
 		return None
 
-	allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())
-	allowed_reports = tuple([key if type(key) == str else key.encode('UTF8') for key in get_allowed_reports()])
+	allowed_doctypes = ['"%s"' % doctype for doctype in frappe.permissions.get_doctypes_with_read()]
+	allowed_reports = ['"%s"' % key if type(key) == str else key.encode('UTF8') for key in get_allowed_reports()]
 
 	return '''
-			`tabDashboard Chart`.`document_type` in {allowed_doctypes}
-			or `tabDashboard Chart`.`report_name` in {allowed_reports}
+			`tabDashboard Chart`.`document_type` in ({allowed_doctypes})
+			or `tabDashboard Chart`.`report_name` in ({allowed_reports})
 		'''.format(
-			allowed_doctypes=allowed_doctypes,
-			allowed_reports=allowed_reports
+			allowed_doctypes=','.join(allowed_doctypes),
+			allowed_reports=','.join(allowed_reports)
 		)
 
 

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -27,12 +27,12 @@ def get_permission_query_conditions(user=None):
 	if "System Manager" in roles:
 		return None
 
-	allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())
+	allowed_doctypes = ['"%s"' % doctype for doctype in frappe.permissions.get_doctypes_with_read()]
 
 	return '''
-			`tabNumber Card`.`document_type` in {allowed_doctypes}
+			`tabNumber Card`.`document_type` in ({allowed_doctypes})
 		'''.format(
-			allowed_doctypes=allowed_doctypes,
+			allowed_doctypes=','.join(allowed_doctypes)
 		)
 
 def has_permission(doc, ptype, user):


### PR DESCRIPTION
Syntax Error in permission query for dashboard chart and number card:

**Before:**

![permission-query](https://user-images.githubusercontent.com/24353136/84569367-9dfb7b80-ada3-11ea-9146-0f876898712c.png)

**After:**

![perm-query](https://user-images.githubusercontent.com/24353136/84569372-a2c02f80-ada3-11ea-9bfd-7040eeaf5a60.png)
