### PR TITLE
fix: Refactor report settings selection to avoid random failure

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -261,27 +261,25 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	get_report_settings() {
-		if (frappe.query_reports[this.report_name]) {
-			this.report_settings = this.get_local_report_settings();
-			return this._load_script;
-		}
-
-		this._load_script = (new Promise(resolve => frappe.call({
-			method: 'frappe.desk.query_report.get_script',
-			args: { report_name: this.report_name },
-			callback: resolve
-		}))).then(r => {
-			frappe.dom.eval(r.message.script || '');
-			return r;
-		}).then(r => {
-			return frappe.after_ajax(() => {
-				this.report_settings = this.get_local_report_settings();
-				this.report_settings.html_format = r.message.html_format;
-				this.report_settings.execution_time = r.message.execution_time || 0;
-			});
+		return new Promise((resolve, reject) => {
+			if (frappe.query_reports[this.report_name]) {
+				this.report_settings = frappe.query_reports[this.report_name];
+				resolve();
+			} else {
+				frappe.xcall('frappe.desk.query_report.get_script', {
+					report_name: this.report_name
+				}).then(r => {
+					frappe.dom.eval(r.message.script || '');
+					frappe.after_ajax(() => {
+						this.report_settings = this.get_local_report_settings();
+						this.report_settings.html_format = r.message.html_format;
+						this.report_settings.execution_time = r.message.execution_time || 0;
+						frappe.query_reports[this.report_name] = this.report_settings;
+						resolve();
+					});
+				}).catch(reject);
+			}
 		});
-
-		return this._load_script;
 	}
 
 	get_local_report_settings() {
@@ -454,6 +452,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if (query_params.prepared_report_name) {
 			filters.prepared_report_name = query_params.prepared_report_name;
 		}
+
+		let possible_filters = frappe.query_report[this.report_name].filters;
 
 		return new Promise(resolve => {
 			this.last_ajax = frappe.call({


### PR DESCRIPTION
Fixes random query report failures due to invalid filters

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/__init__.py", line 1086, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/__init__.py", line 546, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/desk/query_report.py", line 175, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/desk/query_report.py", line 59, in generate_report_result
    res = report.execute_script_report(filters)
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/core/doctype/report/report.py", line 116, in execute_script_report
    res = self.execute_module(filters)
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 32, in execute
    return ReceivablePayableReport(filters).run(args)
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 46, in run
    self.get_columns()
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 744, in get_columns
    self.setup_ageing_columns()
  File "/home/frappe/benches/bench-version-13-2020-06-04/apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 790, in setup_ageing_columns
    for i, label in enumerate(["0-{range1}".format(range1=self.filters["range1"]),
KeyError: 'range1'
```