### PR TITLE
refactor: use rich text instead of html in footer

### DIFF
--- a/frappe/printing/doctype/letter_head/letter_head.js
+++ b/frappe/printing/doctype/letter_head/letter_head.js
@@ -4,5 +4,20 @@
 frappe.ui.form.on('Letter Head', {
 	refresh: function(frm) {
 		frm.flag_public_attachments = true;
+		frm.fields_dict.add_image.onclick = () => {
+			let options = {
+				allow_multiple: false,
+				doctype: frm.doctype,
+				docname: frm.docname,
+				restrictions: {
+					allowed_file_types: ['image/*']
+				},
+				on_success: file => {
+					let footer_html = frm.fields_dict.footer.value || '';
+					frm.set_value('footer', footer_html + `<img src="${file.file_url}" alt="">`);
+				}
+			};
+			let file_uploader = new frappe.ui.FileUploader(options);
+		}
 	}
 });

--- a/frappe/printing/doctype/letter_head/letter_head.js
+++ b/frappe/printing/doctype/letter_head/letter_head.js
@@ -17,7 +17,7 @@ frappe.ui.form.on('Letter Head', {
 					frm.set_value('footer', footer_html + `<img src="${file.file_url}" alt="">`);
 				}
 			};
-			let file_uploader = new frappe.ui.FileUploader(options);
-		}
+			new frappe.ui.FileUploader(options);
+		};
 	}
 });

--- a/frappe/printing/doctype/letter_head/letter_head.js
+++ b/frappe/printing/doctype/letter_head/letter_head.js
@@ -4,20 +4,5 @@
 frappe.ui.form.on('Letter Head', {
 	refresh: function(frm) {
 		frm.flag_public_attachments = true;
-		frm.fields_dict.add_image.onclick = () => {
-			let options = {
-				allow_multiple: false,
-				doctype: frm.doctype,
-				docname: frm.docname,
-				restrictions: {
-					allowed_file_types: ['image/*']
-				},
-				on_success: file => {
-					let footer_html = frm.fields_dict.footer.value || '';
-					frm.set_value('footer', footer_html + `<img src="${file.file_url}" alt="">`);
-				}
-			};
-			new frappe.ui.FileUploader(options);
-		};
 	}
 });

--- a/frappe/printing/doctype/letter_head/letter_head.json
+++ b/frappe/printing/doctype/letter_head/letter_head.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "field:letter_head_name",
  "creation": "2012-11-22 17:45:46",
@@ -16,7 +17,8 @@
   "header_section",
   "content",
   "footer_section",
-  "footer"
+  "footer",
+  "add_image"
  ],
  "fields": [
   {
@@ -100,12 +102,18 @@
    "fieldname": "footer",
    "fieldtype": "HTML Editor",
    "label": "Footer HTML"
+  },
+  {
+   "fieldname": "add_image",
+   "fieldtype": "Button",
+   "label": "Add Image"
   }
  ],
  "icon": "fa fa-font",
  "idx": 1,
+ "links": [],
  "max_attachments": 3,
- "modified": "2019-11-11 18:46:43.375120",
+ "modified": "2020-06-15 13:03:08.074121",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Letter Head",

--- a/frappe/printing/doctype/letter_head/letter_head.json
+++ b/frappe/printing/doctype/letter_head/letter_head.json
@@ -17,8 +17,7 @@
   "header_section",
   "content",
   "footer_section",
-  "footer",
-  "add_image"
+  "footer"
  ],
  "fields": [
   {
@@ -100,20 +99,15 @@
    "depends_on": "eval:!doc.__islocal",
    "description": "Footer will display correctly only in PDF",
    "fieldname": "footer",
-   "fieldtype": "HTML Editor",
-   "label": "Footer HTML"
-  },
-  {
-   "fieldname": "add_image",
-   "fieldtype": "Button",
-   "label": "Add Image"
+   "fieldtype": "Text Editor",
+   "label": "Footer"
   }
  ],
  "icon": "fa fa-font",
  "idx": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2020-06-15 13:03:08.074121",
+ "modified": "2020-07-07 15:19:18.390464",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Letter Head",


### PR DESCRIPTION
Use rich text instead of html in footer

![image](https://user-images.githubusercontent.com/18097732/86764281-8db68380-c065-11ea-93e5-5258a0132e3e.png)
