### PR TITLE
fix: handle import error explicitly

### DIFF
--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -116,6 +116,8 @@ def get_config(app, module):
 		if hasattr(module_dashboards, 'get_data'):
 			return frappe._dict(module_dashboards.get_data())
 		return None
+	except ImportError:
+		return None
 	except Exception as e:
 		print(_("Failed to import dashboard fixtures for module {module}").format(module=module))
 		frappe.log_error(e, _("Dashboard Fixture Import Error"))


### PR DESCRIPTION
Fix unnecessary printing of log while importing dashboards

<img width="771" alt="Screenshot 2020-06-15 at 1 18 04 PM" src="https://user-images.githubusercontent.com/18097732/84631245-b1752680-af0a-11ea-8e02-505537c6c6ad.png">
