### PR TITLE
feat: add option for no backup in remove app

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -414,7 +414,7 @@ def remove_from_installed_apps(context, app):
 @click.argument('app')
 @click.option('--yes', '-y', help='To bypass confirmation prompt for uninstalling the app', is_flag=True, default=False, multiple=True)
 @click.option('--dry-run', help='List all doctypes that will be deleted', is_flag=True, default=False)
-@click.option('--no-backup', help='Do not backup the site DB', is_flag=True, default=False )
+@click.option('--no-backup', help='Do not backup the site', is_flag=True, default=False)
 @pass_context
 def uninstall(context, app, dry_run=False, yes=False, no_backup=False):
 	"Remove app and linked modules from site"

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -414,15 +414,16 @@ def remove_from_installed_apps(context, app):
 @click.argument('app')
 @click.option('--yes', '-y', help='To bypass confirmation prompt for uninstalling the app', is_flag=True, default=False, multiple=True)
 @click.option('--dry-run', help='List all doctypes that will be deleted', is_flag=True, default=False)
+@click.option('--no-backup', help='Do not backup the site DB', is_flag=True, default=False )
 @pass_context
-def uninstall(context, app, dry_run=False, yes=False):
+def uninstall(context, app, dry_run=False, yes=False, no_backup=False):
 	"Remove app and linked modules from site"
 	from frappe.installer import remove_app
 	for site in context.sites:
 		try:
 			frappe.init(site=site)
 			frappe.connect()
-			remove_app(app, dry_run, yes)
+			remove_app(app, dry_run, yes, no_backup)
 		finally:
 			frappe.destroy()
 	if not context.sites:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -118,7 +118,7 @@ def remove_from_installed_apps(app_name):
 		if frappe.flags.in_install:
 			post_install()
 
-def remove_app(app_name, dry_run=False, yes=False):
+def remove_app(app_name, dry_run=False, yes=False, no_backup=False):
 	"""Delete app and all linked to the app's module with the app."""
 
 	if not dry_run and not yes:
@@ -126,9 +126,10 @@ def remove_app(app_name, dry_run=False, yes=False):
 		if confirm!="y":
 			return
 
-	from frappe.utils.backups import scheduled_backup
-	print("Backing up...")
-	scheduled_backup(ignore_files=True)
+	if not no_backup:
+		from frappe.utils.backups import scheduled_backup
+		print("Backing up...")
+		scheduled_backup(ignore_files=True)
 
 	drop_doctypes = []
 


### PR DESCRIPTION
This PR adds option `--no-backup` to remove app. Default value is set to False, i.e. backup will be taken