### PR TITLE
fix: better message for removed assignment

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -103,7 +103,7 @@ def get_email_header(doc):
 	return {
 		'Default': _('New Notification'),
 		'Mention': _('New Mention'),
-		'Assignment': _('New Assignment'),
+		'Assignment': _('Assignment Update'),
 		'Share': _('New Document Shared'),
 		'Energy Point': _('Energy Point Update'),
 	}[doc.type or 'Default']

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -178,7 +178,7 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 	description_html =  "<div>{0}</div>".format(description) if description else None
 
 	if action=='CLOSE':
-		subject = _('Your assignment on {0} {1} has been removed by {2}')
+		subject = _('Your assignment on {0} {1} has been removed by {2}')\
 			.format(frappe.bold(doc_type), get_title_html(title), frappe.bold(user_name))
 	else:
 		user_name = frappe.bold(user_name)

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -178,7 +178,8 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 	description_html =  "<div>{0}</div>".format(description) if description else None
 
 	if action=='CLOSE':
-		subject = _('Your assignment on {0} {1} has been removed').format(frappe.bold(doc_type), get_title_html(title))
+		subject = _('Your assignment on {0} {1} has been removed by {2}')
+			.format(frappe.bold(doc_type), get_title_html(title), frappe.bold(user_name))
 	else:
 		user_name = frappe.bold(user_name)
 		document_type = frappe.bold(doc_type)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19775888/84667010-69bcc200-af3f-11ea-8912-9bd23b285bc6.png)


After:
<img width="651" alt="Screenshot 2020-06-12 at 1 51 20 PM" src="https://user-images.githubusercontent.com/19775888/84667091-86f19080-af3f-11ea-998e-20b6f224dfcf.png">
