### PR TITLE
feat: Add json as a non-static format 

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -91,10 +91,10 @@ def render(path=None, http_status_code=None):
 	return build_response(path, data, http_status_code or 200)
 
 def is_static_file(path):
-	if ('.' not in path):
+	if '.' not in path:
 		return False
 	extn = path.rsplit('.', 1)[-1]
-	if extn in ('html', 'md', 'js', 'xml', 'css', 'txt', 'py'):
+	if extn in ('html', 'md', 'js', 'xml', 'css', 'txt', 'py', 'json'):
 		return False
 
 	for app in frappe.get_installed_apps():


### PR DESCRIPTION
I'm working with Monogramm to develop a [PWA plugin](https://github.com/Monogramm/frappe_pwa). In our case necessary to render file `manifest.json` by `jinja2`. But server interpret this file as a static and we can't use `get_context` function.

#10655