### PR TITLE
refactor: get default desk page from allowed workspaces in boot

### DIFF
--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -134,11 +134,13 @@ export default class Desktop {
 	get_page_to_show() {
 		const default_page = this.desktop_settings
 			? this.desktop_settings["Modules"][0].name
-			: "Website";
+			: frappe.boot.allowed_workspaces[0].name;
+
 		let page =
 			frappe.get_route()[1] ||
 			localStorage.current_desk_page ||
 			default_page;
+
 		return page;
 	}
 


### PR DESCRIPTION
The desk space would default to "Website" this PR fetches the first allowed workspace from the bootinfo