### PR TITLE
fix: pass silent as an arg to frappe.call to avoid dialog if errors

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -101,6 +101,11 @@ frappe.call = function(opts) {
 		error_handlers: opts.error_handlers || {},
 		// show_spinner: !opts.no_spinner,
 		async: opts.async,
+		/*
+		this property is evaluated in frappe.request.cleanup, however there is not way to pass this argument, and it is very important
+		to avoid the msgprint dialog when you are calling and get an unknown exception, mostly when you are calling in batches
+        */
+		silent: opts.silent,
 		url,
 	});
 }

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -101,10 +101,6 @@ frappe.call = function(opts) {
 		error_handlers: opts.error_handlers || {},
 		// show_spinner: !opts.no_spinner,
 		async: opts.async,
-		/*
-		this property is evaluated in frappe.request.cleanup, however there is not way to pass this argument, and it is very important
-		to avoid the msgprint dialog when you are calling and get an unknown exception, mostly when you are calling in batches
-        */
 		silent: opts.silent,
 		url,
 	});


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

I was using `frappe.call`, however every time I got an exception, Frappe showed the exception dialog indicating about the problem. These calls were made from `.forEach()` (in batch) so it is terrible when you have dozens of items to add/update. I just wanted to catch every error and show it and the end, but not during the process.

Here, there is a property called `silent`, however, there is no way to pass from `frappe.call` to be used by this method everytime a request is made. So, this is my modification, allow to pass the `silent` property as an argument and avoid this "interruption" when you are making calls in batch and get exceptions on those.

https://github.com/frappe/frappe/blob/c1fb695ece8d5b9fb14a1be3b78b07d2b17aa8e2/frappe/public/js/frappe/request.js#L340-L347

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
