### PR TITLE
fix: fetch todos with status not equal to cancelled in assigned to sidebar filter

### DIFF
--- a/frappe/desk/listview.py
+++ b/frappe/desk/listview.py
@@ -36,7 +36,7 @@ def get_group_by_count(doctype, current_filters, field):
 			from
 				`tabToDo`, `tabUser`
 			where
-				`tabToDo`.status='Open' and
+				`tabToDo`.status!='Cancelled' and
 				`tabToDo`.owner = `tabUser`.name and
 				`tabUser`.user_type = 'System User'
 				{subquery_condition}


### PR DESCRIPTION
Show todos with Closed status also in "Assigned To" sidebar filter