### PR TITLE
fix: Doc layout fixes

### DIFF
--- a/frappe/public/scss/doc.scss
+++ b/frappe/public/scss/doc.scss
@@ -276,3 +276,13 @@ $navbar-height-lg: 4.5rem;
 	padding-top: 1rem;
 	text-align: right;
 }
+
+.doc-content .breadcrumb-container {
+	padding-left: 0;
+	padding-right: 0;
+	margin-top: 3rem;
+
+	.breadcrumb {
+		margin-bottom: 0;
+	}
+}

--- a/frappe/public/scss/markdown.scss
+++ b/frappe/public/scss/markdown.scss
@@ -122,6 +122,13 @@
 		border-radius: 0.375rem;
 	}
 
+	.screenshot + em {
+		text-align: center;
+		display: block;
+		margin-top: 0.5rem;
+		margin-bottom: 2rem;
+	}
+
 	code:not(.hljs) {
 		padding: 0 0.25rem;
 		background: $light;

--- a/frappe/public/scss/sidebar.scss
+++ b/frappe/public/scss/sidebar.scss
@@ -37,6 +37,7 @@
 	h6 {
 		font-size: $font-size-sm;
 		margin-bottom: 0.75rem;
+		line-height: 1.5;
 	}
 
 	> ul {

--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -311,3 +311,19 @@ h5.modal-title {
 .image-loaded {
 	filter: blur(0rem);
 }
+
+.embed-container {
+	position: relative;
+	padding-bottom: 56.25%;
+	height: 0;
+	overflow: hidden;
+	max-width: 100%;
+}
+
+.embed-container iframe {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}

--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -115,8 +115,8 @@
 }
 
 .breadcrumb {
-	padding-left: 0;
-	padding-right: 0;
+	padding: 0;
+	font-size: $font-size-sm;
 	background-color: white;
 }
 

--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -110,6 +110,10 @@
 	color: $light;
 }
 
+.breadcrumb-container {
+	margin-top: 1rem;
+}
+
 .breadcrumb {
 	padding-left: 0;
 	padding-right: 0;

--- a/frappe/templates/doc.html
+++ b/frappe/templates/doc.html
@@ -1,10 +1,6 @@
 {% extends "templates/base.html" %}
 {%- from "templates/includes/navbar/navbar_items.html" import render_item -%}
 
-{% macro page_content() %}
-{%- block page_content -%}{%- endblock -%}
-{% endmacro %}
-
 {%- block head_include %}
 <link rel="stylesheet" href="/assets/frappe/css/hljs-night-owl.css">
 {% endblock -%}
@@ -71,17 +67,6 @@
 
 {% block content %}
 
-{% macro main_content() %}
-<div class="page-content-wrapper">
-	{% block page_container %}
-	<main>
-		<div class="page_content page-content doc-content">
-			{{ page_content() }}
-		</div>
-	</main>
-	{% endblock %}
-</div>
-{% endmacro %}
 
 {% macro container_attributes() -%}
 id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
@@ -99,13 +84,28 @@ id="page-{{ name or route | e }}" data-path="{{ pathname | e }}"
 			</aside>
 		</div>
 		<div class="main-column doc-main col-12 col-lg-10 col-xl-8">
-			{{ main_content() }}
+			<div class="page-content-wrapper">
+				{% block page_container %}
+				<main>
+					<div class="page_content page-content doc-content">
+						{%- if add_breadcrumbs -%}
+						{% include "templates/includes/breadcrumbs.html" %}
+						{%- endif -%}
+						{%- block page_content -%}{%- endblock -%}
+					</div>
+				</main>
+				{% endblock %}
+			</div>
 		</div>
 		<div class="page-toc col-sm-2 d-none d-xl-block">
+			{% block page_toc %}
+			{% if page_toc_html %}
 			<div>
 				<h5>On this page</h5>
 				{{ page_toc_html }}
 			</div>
+			{% endif %}
+			{% endblock %}
 		</div>
 	</div>
 </div>

--- a/frappe/templates/includes/breadcrumbs.html
+++ b/frappe/templates/includes/breadcrumbs.html
@@ -1,5 +1,5 @@
 {%- if not no_breadcrumbs and parents -%}
-<div class="container mt-3">
+<div class="breadcrumb-container container">
 	<nav aria-label="breadcrumb">
 		<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 			{%- set parents = parents[-3:] %}

--- a/frappe/templates/web.html
+++ b/frappe/templates/web.html
@@ -1,10 +1,6 @@
 {% extends base_template_path %}
 {% block hero %}{% endblock %}
 
-{% macro page_content() %}
-{%- block page_content -%}{%- endblock -%}
-{% endmacro %}
-
 {% block content %}
 
 {% macro main_content() %}
@@ -31,7 +27,7 @@
 		</div>
 
 		<div class="page_content">
-			{{ page_content() }}
+			{%- block page_content -%}{%- endblock -%}
 		</div>
 
 		<div class="page-footer">


### PR DESCRIPTION

- Style breadcrumb container using class
- Styling for caption below image
- Add embed-container 16:9 box styling for embeddable content like videos
- Add breadcrumbs in doc layout
- Remove redundant macro in web.html

<img width="1440" alt="Screenshot 2020-06-18 at 12 44 04 PM" src="https://user-images.githubusercontent.com/9355208/84989504-67d24900-b161-11ea-8e0f-58bd3244ba74.png">