### PR TITLE
fix: Handle callback on msgprint primary action

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -167,6 +167,22 @@ frappe.msgprint = function(msg, title, is_minimizable) {
 					method: data.primary_action.server_action,
 					args: {
 						args: data.primary_action.args
+					},
+					freeze: true,
+					callback: (r) => {
+						frappe.run_serially([
+							() => {
+								if (data.primary_action.hide_on_success) {
+									frappe.hide_msgprint();
+								}
+							},
+							() => frappe.timeout(.1),
+							() => {
+								if (r && r.message) {
+									frappe.msgprint(r.message, title="Success");
+								}
+							}
+						]);
 					}
 				});
 			}

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -168,21 +168,10 @@ frappe.msgprint = function(msg, title, is_minimizable) {
 					args: {
 						args: data.primary_action.args
 					},
-					freeze: true,
-					callback: (r) => {
-						frappe.run_serially([
-							() => {
-								if (data.primary_action.hide_on_success) {
-									frappe.hide_msgprint();
-								}
-							},
-							() => frappe.timeout(.1),
-							() => {
-								if (r && r.message) {
-									frappe.msgprint(r.message, title="Success");
-								}
-							}
-						]);
+					callback() {
+						if (data.primary_action.hide_on_success) {
+							frappe.hide_msgprint();
+						}
 					}
 				});
 			}


### PR DESCRIPTION
hide msgprint in primary action