### PR TITLE
chore: Add release notes for v12.7.0

### DIFF
--- a/frappe/change_log/v12/v12_7_0.md
+++ b/frappe/change_log/v12/v12_7_0.md
@@ -1,0 +1,17 @@
+## Version 12.7.0 Release Notes
+
+### Bug Fixes
+
+- Show correct currency symbol in printed reports ([#10692](https://github.com/frappe/frappe/pull/10692))
+- Fixed order of columns in custom reports created from query reports ([#10435](https://github.com/frappe/frappe/pull/10435))
+- Correctly export reports in excel format ([#10599](https://github.com/frappe/frappe/pull/10599), [#10397](https://github.com/frappe/frappe/pull/10397))
+- Fixed dropbox timeout issue while backing up large files ([#10515](https://github.com/frappe/frappe/pull/10515))
+- Fixed api for user oauth validations ([#9676](https://github.com/frappe/frappe/pull/9676))
+- Fixed date parsing issue ([#10618](https://github.com/frappe/frappe/pull/10618))
+- Ensure that cancelled documents that are already amended cannot be amended again ([#10641](https://github.com/frappe/frappe/pull/10641))
+
+
+### Enhancements
+
+- Refactored Data Import Beta ([#10661](https://github.com/frappe/frappe/pull/10661))
+- List View UX enhancement ([#10676](https://github.com/frappe/frappe/pull/10676))


### PR DESCRIPTION
<img width="685" alt="Screenshot 2020-06-18 at 5 28 04 PM" src="https://user-images.githubusercontent.com/19775888/85017449-19d13b80-b189-11ea-8e79-2417062939df.png">
