### PR TITLE
refactor: route to list view once create entry is completed

### DIFF
--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -51,10 +51,14 @@ export default class OnboardingWidget extends Widget {
 		let actions = {
 			"Watch Video": () => this.show_video(step),
 			"Create Entry": () => {
-				if (step.show_full_form) {
-					this.create_entry(step);
+				if (step.is_complete) {
+					frappe.set_route(`#List/${step.reference_document}`);
 				} else {
-					this.show_quick_entry(step);
+					if (step.show_full_form) {
+						this.create_entry(step);
+					} else {
+						this.show_quick_entry(step);
+					}
 				}
 			},
 			"Show Form Tour": () => this.show_form_tour(step),


### PR DESCRIPTION
After the user creates the first entry (and click on the link again, we should take the user to the list, not the new employee)