### PR TITLE
feat: copy text docname on click of subtitle

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -36,6 +36,11 @@ frappe.ui.form.Toolbar = Class.extend({
 				this.page.set_title_sub("");
 			} else {
 				this.page.set_title_sub(this.frm.docname);
+				this.page.$sub_title_area.css("cursor", "copy");
+				this.page.$sub_title_area.on('click', (event) => {
+					event.stopImmediatePropagation();
+					frappe.utils.copy_to_clipboard(this.frm.docname);
+				});
 			}
 		} else {
 			var title = this.frm.docname;


### PR DESCRIPTION
The subtitle shows the actual docname, it's a pain to select and copy that tiny text. Let's fix that

<img width="384" alt="image" src="https://user-images.githubusercontent.com/18097732/85036145-91ab6000-b1a1-11ea-931d-b97e8699e5cf.png">
