### PR TITLE
fix: Comment link sent in email

### DIFF
--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -34,7 +34,7 @@ def add_comment(comment, comment_email, comment_by, reference_doctype, reference
 		clear_cache(route)
 
 	content = (comment.content
-		+ "<p><a href='{0}/desk/#Form/Comment/{1}' style='font-size: 80%'>{2}</a></p>".format(frappe.utils.get_request_site_address(),
+		+ "<p><a href='{0}/desk#Form/Comment/{1}' style='font-size: 80%'>{2}</a></p>".format(frappe.utils.get_request_site_address(),
 			comment.name,
 			_("View Comment")))
 


### PR DESCRIPTION
The comment link sent via email has a '/' wrongly appended:

![image](https://user-images.githubusercontent.com/33246109/85123518-07690780-b246-11ea-8ae3-1de520519e1b.png)

This PR fixes the same.