### PR TITLE
fix: check date string is exactly equal to None

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -52,7 +52,7 @@ def getdate(string_date=None):
 		), title=frappe._('Invalid Date'))
 
 def get_datetime(datetime_str=None):
-	if datetime_str == None:
+	if datetime_str is None:
 		return now_datetime()
 
 	if isinstance(datetime_str, (datetime.datetime, datetime.timedelta)):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -52,7 +52,7 @@ def getdate(string_date=None):
 		), title=frappe._('Invalid Date'))
 
 def get_datetime(datetime_str=None):
-	if not datetime_str:
+	if datetime_str == None:
 		return now_datetime()
 
 	if isinstance(datetime_str, (datetime.datetime, datetime.timedelta)):


### PR DESCRIPTION
While using the `get_datetime` function, if the `datetime_str` is like **"00:00:00"** which is not actually equal to **None** and is a valid time, it evaluates to True for the expression `not datetime_str` and then returns `now_datetime()`.

It should check whether the string is exactly equal to None instead