### PR TITLE
fix: Do not allow user to delete admin owned fields

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -74,8 +74,7 @@ class CustomField(Document):
 	def on_trash(self):
 		#check if Admin owned field
 		if self.owner == 'Administrator' and frappe.session.user != 'Administrator':
-			frappe.throw(_('''Custom Field {0} is created by Administrator.
-				Administrator owned custom fields can only be deleted by Administrator''').format(
+			frappe.throw(_("Custom Field {0} is created by the Administrator and can only be deleted through the Administrator account.").format(
 					frappe.bold(self.label)))
 
 		# delete property setter entries

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -72,6 +72,12 @@ class CustomField(Document):
 			frappe.db.updatedb(self.dt)
 
 	def on_trash(self):
+		#check if Admin owned field
+		if self.owner == 'Administrator' and frappe.session.user != 'Administrator':
+			frappe.throw(_('''Custom Field {0} is created by Administrator.
+				Administrator owned custom fields can only be deleted by Administrator''').format(
+					frappe.bold(self.label)))
+
 		# delete property setter entries
 		frappe.db.sql("""\
 			DELETE FROM `tabProperty Setter`


### PR DESCRIPTION
Many regional information and logic is captured using custom fields which is auto created during regional setup.

The same field is referenced many times in code. Intentionally or unintentionally user deletes those fields and something breaks.

Added a validation to only allow administrator to delete admin owned custom fields

<img width="1222" alt="Screenshot 2020-06-20 at 8 15 22 PM" src="https://user-images.githubusercontent.com/42651287/85204868-25f9fc00-b335-11ea-9ca8-638719f71432.png">
