### PR TITLE
fix: added back address and contact microtemplates to build json

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -250,6 +250,8 @@
 		"public/less/form_grid.less"
 	],
 	"js/form.min.js": [
+    	"public/js/frappe/form/templates/address_list.html",
+		"public/js/frappe/form/templates/contact_list.html",
 		"public/js/frappe/form/templates/print_layout.html",
 		"public/js/frappe/form/templates/users_in_sidebar.html",
 		"public/js/frappe/form/templates/set_sharing.html",

--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -1,0 +1,22 @@
+<div class="clearfix"></div>
+{% for(var i=0, l=addr_list.length; i<l; i++) { %}
+<div class="address-box">
+	<p class="h6">
+		{%= i+1 %}. {%= addr_list[i].address_title %}{% if(addr_list[i].address_type!="Other") { %}
+		<span class="text-muted">({%= __(addr_list[i].address_type) %})</span>{% } %}
+		{% if(addr_list[i].is_primary_address) { %}
+		<span class="text-muted">({%= __("Primary") %})</span>{% } %}
+		{% if(addr_list[i].is_shipping_address) { %}
+		<span class="text-muted">({%= __("Shipping") %})</span>{% } %}
+
+		<a href="#Form/Address/{%= encodeURIComponent(addr_list[i].name) %}" class="btn btn-default btn-xs pull-right"
+			style="margin-top:-3px; margin-right: -5px;">
+			{%= __("Edit") %}</a>
+	</p>
+	<p>{%= addr_list[i].display %}</p>
+</div>
+{% } %}
+{% if(!addr_list.length) { %}
+<p class="text-muted small">{%= __("No address added yet.") %}</p>
+{% } %}
+<p><button class="btn btn-xs btn-default btn-address">{{ __("New Address") }}</button></p>

--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -1,0 +1,54 @@
+<div class="clearfix"></div>
+{% for(var i=0, l=contact_list.length; i<l; i++) { %}
+	<div class="address-box">
+		<p class="h6">
+			{%= contact_list[i].first_name %} {%= contact_list[i].last_name %}
+			{% if(contact_list[i].is_primary_contact) { %}
+				<span class="text-muted">({%= __("Primary") %})</span>
+			{% } %}
+			{% if(contact_list[i].designation){ %}
+			 <span class="text-muted">&ndash; {%= contact_list[i].designation %}</span>
+			{% } %}
+			<a href="#Form/Contact/{%= encodeURIComponent(contact_list[i].name) %}"
+				class="btn btn-xs btn-default pull-right"
+				style="margin-top:-3px; margin-right: -5px;">
+				{%= __("Edit") %}</a>
+		</p>
+		{% if (contact_list[i].phones || contact_list[i].email_ids) { %}
+		<p>
+			{% if(contact_list[i].phone) { %}
+				{%= __("Phone") %}: {%= contact_list[i].phone %}<span class="text-muted"> ({%= __("Primary") %})</span><br>
+			{% endif %}
+			{% if(contact_list[i].mobile_no) { %}
+				{%= __("Mobile No") %}: {%= contact_list[i].mobile_no %}<span class="text-muted"> ({%= __("Primary") %})</span><br>
+			{% endif %}
+			{% if(contact_list[i].phone_nos) { %}
+				{% for(var j=0, k=contact_list[i].phone_nos.length; j<k; j++) { %}
+					{%= __("Phone") %}: {%= contact_list[i].phone_nos[j].phone %}<br>
+				{% } %}
+			{% endif %}
+		</p>
+		<p>
+			{% if(contact_list[i].email_id) { %}
+				{%= __("Email") %}: {%= contact_list[i].email_id %}<span class="text-muted"> ({%= __("Primary") %})</span><br>
+			{% endif %}
+			{% if(contact_list[i].email_ids) { %}
+				{% for(var j=0, k=contact_list[i].email_ids.length; j<k; j++) { %}
+					{%= __("Email") %}: {%= contact_list[i].email_ids[j].email_id %}<br>
+				{% } %}
+			{% endif %}
+		</p>
+		{% endif %}
+		<p>
+		{% if (contact_list[i].address) { %}
+			{%= __("Address") %}: {%= contact_list[i].address %}<br>
+		{% endif %}
+		</p>
+	</div>
+{% } %}
+{% if(!contact_list.length) { %}
+<p class="text-muted small">{%= __("No contacts added yet.") %}</p>
+{% } %}
+<p><button class="btn btn-xs btn-default btn-contact">
+	{{ __("New Contact") }}</button>
+</p>


### PR DESCRIPTION

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->



The address_list.html and contact_list.html templates were not loading on the customer DocType view for ERPNext. The templates were missing from the relevant folder and from the build.json file

