### PR TITLE
fix: Route on onboarding widget for new document

### DIFF
--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -136,7 +136,7 @@ export default class OnboardingWidget extends Widget {
 		if (step.is_single) {
 			route = `Form/${step.reference_document}`;
 		} else {
-			route = `Form/${step.reference_document}/__('New')+ ' ' + __(${step.reference_document})`;
+			route = `Form/${step.reference_document}/__('New')+ ' ' + ${step.reference_document}`;
 		}
 
 		let current_route = frappe.get_route();
@@ -262,7 +262,7 @@ export default class OnboardingWidget extends Widget {
 			frappe.route_hooks.after_save = callback;
 		}
 
-		frappe.set_route(`Form/${step.reference_document}/New ${step.reference_document} 1`);
+		frappe.set_route(`Form/${step.reference_document}/__('New')+ ' ' + ${step.reference_document}`);
 	}
 
 	show_quick_entry(step) {

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -136,7 +136,7 @@ export default class OnboardingWidget extends Widget {
 		if (step.is_single) {
 			route = `Form/${step.reference_document}`;
 		} else {
-			route = `Form/${step.reference_document}/New ${step.reference_document}`;
+			route = `Form/${step.reference_document}/__('New')+ ' ' + __(${step.reference_document})`;
 		}
 
 		let current_route = frappe.get_route();


### PR DESCRIPTION
fix: route on onboarding widget to new document work on different locales 

https://github.com/frappe/frappe/blob/a2caa8eb0459f580bc23277842633c7f2638c61d/frappe/public/js/frappe/model/create_new.js#L83



https://github.com/frappe/frappe/issues/10756

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
