### PR TITLE
fix: allow unversioned apps

### DIFF
--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -12,7 +12,7 @@ class InstalledApplications(Document):
 		for app in frappe.utils.get_installed_apps_info():
 			self.append("installed_applications", {
 				"app_name": app.get("app_name"),
-				"app_version": app.get("version"),
-				"git_branch": app.get("branch")
+				"app_version": app.get("version") or "UNVERSIONED",
+				"git_branch": app.get("branch") or "UNVERSIONED"
 			})
 		self.save()


### PR DESCRIPTION
On execution of `bench migrate`, after the migration process, the DocType Installed Applications updates the contents of the Frappe Apps installed on its site. In case the app doesn't have a git initialized, the branch gets an empty string and fails the mandatory check. Here, a fallback value `UNVERSIONED` is set instead.

![Screenshot 2020-06-23 at 2 05 49 PM](https://user-images.githubusercontent.com/36654812/85380973-25db4580-b55b-11ea-9f92-230f06b559e7.png)

Closes https://github.com/frappe/frappe/issues/10449