### PR TITLE
fix: hide form sidebar users

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -74,11 +74,11 @@
 	<li class="h6 shared-with-label">{%= __("Shared With") %}</li>
 	<li class="form-shared"></li>
 </ul>
-<ul class="list-unstyled sidebar-menu">
+<ul class="list-unstyled sidebar-menu hidden">
 	<li class="h6 viewers-label">{%= __("Currently Viewing") %}</li>
 	<li class="form-viewers"></li>
 </ul>
-<ul class="list-unstyled sidebar-menu">
+<ul class="list-unstyled sidebar-menu hidden">
 	<li class="h6 viewers-label">{%= __("Currently Replying") %}</li>
 	<li class="form-typers"></li>
 </ul>


### PR DESCRIPTION
Only show form sidebar users when a user is actually viewing a document, or composing an email.

Fixes:
<img width="316" alt="Screenshot 2020-06-23 at 3 35 00 PM" src="https://user-images.githubusercontent.com/19775888/85390943-24177f00-b567-11ea-9688-4d3cc999ffa1.png">
