### PR TITLE
fix: Create website theme file in public folder

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -273,7 +273,6 @@ setup_wizard_exception = [
 
 before_migrate = ['frappe.patches.v11_0.sync_user_permission_doctype_before_migrate.execute']
 after_migrate = [
-	'frappe.website.doctype.website_theme.website_theme.generate_theme_files_if_not_exist',
 	'frappe.modules.full_text_search.build_index_for_all_routes'
 ]
 


### PR DESCRIPTION
Earlier theme files were generated in assets folder, so if a site was moved to a different bench, theme files were not moved with the site.

Now, they will be generated in `/public/files/website_theme` folder so they move along with the site.