### PR TITLE
fix(sendmail): 'frappe' not defined

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -456,8 +456,8 @@ def sendmail(recipients=[], sender="", subject="No Subject", message="No Message
 	message = content or message
 
 	if as_markdown:
-        import frappe
-		message = frappe.utils.md_to_html(message)
+		from frappe.utils import md_to_html
+		message = md_to_html(message)
 
 	if not delayed:
 		now = True

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -456,6 +456,7 @@ def sendmail(recipients=[], sender="", subject="No Subject", message="No Message
 	message = content or message
 
 	if as_markdown:
+        import frappe
 		message = frappe.utils.md_to_html(message)
 
 	if not delayed:


### PR DESCRIPTION
I noticed, that inside function `sendmail`, in `as_markdown` condition somebody forgot import `frappe` library.
![image](https://user-images.githubusercontent.com/32329685/85524409-d0fa0680-b610-11ea-9668-e6ffdd10889e.png)
