### PR TITLE
fix: raise does not exist if controller module not found

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -380,7 +380,10 @@ def load_properties_from_source(page_info):
 def load_properties_from_controller(page_info):
 	if not page_info.controller: return
 
-	module = frappe.get_module(page_info.controller)
+	try:
+		module = frappe.get_module(page_info.controller)
+	except ModuleNotFoundError:
+		raise frappe.DoesNotExistError
 	if not module: return
 
 	for prop in ("base_template_path", "template", "no_cache",


### PR DESCRIPTION
When routing to a standard page say `/me`, the following piece of code fetches the controller from `www`.

https://github.com/frappe/frappe/blob/b0c3929a9e398b5ef3d1e901788e852d46066fb6/frappe/website/router.py#L380-L389

However, when the url requested is `/ME` in that case, the module that is fetched is `frappe.www.ME` which does not exist throwing a `ModuleNotFoundError`. 

We could either throw a 404 or route to /me instead. This PR implements a 404 assuming URLs are case sensitive.

> URLs in general are case-sensitive (with the exception of machine names). There may be URLs, or parts of URLs, where case doesn't matter, but identifying these may not be easy. Users should always consider that URLs are case-sensitive.
> 
> HTML and URLs - [w3.org](https://www.w3.org/TR/WD-html40-970708/htmlweb.html)