### PR TITLE
fix: Page primary action reset

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -380,10 +380,10 @@ frappe.ui.form.Toolbar = Class.extend({
 		var status = this.get_action_status();
 		if (status) {
 			// When moving from a page with status amend to another page with status amend
-			// We need to check if document is already amened specifcally and hide
+			// We need to check if document is already amend specifically and hide
 			// or clear the menu actions accordingly
 
-			if (status !== this.current_status || status === 'Amend') {
+			if (status !== this.current_status && status === 'Amend') {
 				let doc = this.frm.doc;
 				frappe.xcall('frappe.client.is_document_amended', {
 					'doctype': doc.doctype,
@@ -400,7 +400,7 @@ frappe.ui.form.Toolbar = Class.extend({
 			}
 		} else {
 			this.page.clear_actions();
-			this.current_status = null
+			this.current_status = null;
 		}
 	},
 	get_action_status: function() {


### PR DESCRIPTION
Check for is_document_ammended only if the status to be set is "Amend".

Fixes following issue:

Data import primary action was getting reset to "Submit" instead of "Start Import".

**Before:**
![data-import-primary-action](https://user-images.githubusercontent.com/13928957/85529786-0ca1ca00-b62b-11ea-87f4-ef09012029fd.gif)

**After:**
![data-import-primary-action-fix](https://user-images.githubusercontent.com/13928957/85530125-512d6580-b62b-11ea-993f-c4924a65f7fe.gif)





