### PR TITLE
fix: check for 2fa on password reset

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -564,7 +564,7 @@ def update_password(new_password, logout_all_sessions=0, key=None, old_password=
 
 	frappe.local.login_manager.user = user_doc.name
 	if should_run_2fa(user_doc.name):
-		authenticate_for_2factor(user.name)
+		authenticate_for_2factor(user_doc.name)
 		if not confirm_otp_token(frappe.local.login_manager):
 			return False
 


### PR DESCRIPTION
resetting password allowed users to bypass 2FA. this PR adds a check to prevent that from happening