### PR TITLE
fix: Custom ol padding removed in text editor

### DIFF
--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -137,7 +137,3 @@
 	margin-top: 0px;
 	margin-bottom: 0px;
 }
-
-.ql-editor ol {
-	padding-left: 2.5em;
-}


### PR DESCRIPTION
Following up on the recent change from PR:https://github.com/frappe/frappe/pull/10598

I think the custom `ol` padding should be removed too, it is not needed. Very minor difference.

With custom `ol` left padding:
<img width="257" alt="Screen Shot 2020-06-24 at 6 08 31 PM" src="https://user-images.githubusercontent.com/16913064/85557829-c6a62f80-b645-11ea-8c36-8980e9a0100f.png">


Without custom `ol` left padding:
<img width="245" alt="Screen Shot 2020-06-24 at 6 11 05 PM" src="https://user-images.githubusercontent.com/16913064/85558138-17b62380-b646-11ea-9588-e90308dec204.png">
