### PR TITLE
fix(prettyDate): Convert datetime to user's timezone first

### DIFF
--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -1,8 +1,10 @@
 function prettyDate(date, mini) {
 	if (!date) return '';
 
-	if (typeof (date) == "string")
+	if (typeof (date) == "string") {
+		date = frappe.datetime.convert_to_user_tz(date);
 		date = new Date((date || "").replace(/-/g, "/").replace(/[TZ]/g, " ").replace(/\.[0-9]*/, ""));
+	}
 
 	let diff = (((new Date()).getTime() - date.getTime()) / 1000);
 	let day_diff = Math.floor(diff / 86400);


### PR DESCRIPTION
Convert DateTime to the user's timezone first before showing rendering readable DateTime.

**Case:** A document created 21 minutes ago, but the user's timezone 
is different than that of system-wide timezone.

<img width="601" alt="Screenshot 2020-06-25 at 12 07 20 PM" src="https://user-images.githubusercontent.com/13928957/85668637-978ecd00-b6dc-11ea-84e7-98c8d01aa3bc.png">


The bug was introduced through https://github.com/frappe/frappe/pull/9802