### PR TITLE
fix: Escape user input before regex search

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -157,7 +157,7 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 				strict=False)
 
 			if doctype in UNTRANSLATED_DOCTYPES:
-				values = tuple([v for v in list(values) if re.search(txt+".*", (_(v.name) if as_dict else _(v[0])), re.IGNORECASE)])
+				values = tuple([v for v in list(values) if re.search(re.escape(txt)+".*", (_(v.name) if as_dict else _(v[0])), re.IGNORECASE)])
 
 			# remove _relevance from results
 			if as_dict:


### PR DESCRIPTION
Fixes following issue when search input is something like "**Random (**": 

```
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 1085, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/desk/search.py", line 53, in search_link
    search_widget(doctype, txt.strip(), query, searchfield=searchfield, page_length=page_length, filters=filters, reference_doctype=reference_doctype, ignore_user_permissions=ignore_user_permissions)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/desk/search.py", line 160, in search_widget
    values = tuple([v for v in list(values) if re.search(txt+".*", (_(v.name) if as_dict else _(v[0])), re.IGNORECASE)])
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/desk/search.py", line 160, in <listcomp>
    values = tuple([v for v in list(values) if re.search(txt+".*", (_(v.name) if as_dict else _(v[0])), re.IGNORECASE)])
  File "/home/frappe/frappe-io-bench/env/lib64/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
  File "/home/frappe/frappe-io-bench/env/lib64/python3.6/re.py", line 301, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/home/frappe/frappe-io-bench/env/lib64/python3.6/sre_compile.py", line 562, in compile
    p = sre_parse.parse(p, flags)
  File "/home/frappe/frappe-io-bench/env/lib64/python3.6/sre_parse.py", line 855, in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
  File "/home/frappe/frappe-io-bench/env/lib64/python3.6/sre_parse.py", line 416, in _parse_sub
    not nested and not items))
  File "/home/frappe/frappe-io-bench/env/lib64/python3.6/sre_parse.py", line 768, in _parse
    source.tell() - start)
sre_constants.error: missing ), unterminated subpattern at position 9
```