### PR TITLE
fix: handle dashboard sync get_config errors

### DIFF
--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -118,3 +118,7 @@ def get_config(app, module):
 		return None
 	except ImportError:
 		return None
+	except Exception as e:
+		print(_("Failed to import dashboard fixtures for module {module}").format(module=module))
+		frappe.log_error(e, _("Dashboard Fixture Import Error"))
+		return None


### PR DESCRIPTION
Handle all exceptions when fetching config from dashboard fixtures