### PR TITLE
feat: don't throw a already attached error, just upload it as duplicate

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -182,13 +182,7 @@ class File(Document):
 			if duplicate_file:
 				duplicate_file_doc = frappe.get_cached_doc('File', duplicate_file.name)
 				if duplicate_file_doc.exists_on_disk():
-					# if it is attached to a document then throw FileAlreadyAttachedException
-					if self.attached_to_doctype and self.attached_to_name:
-						self.duplicate_entry = duplicate_file.name
-						frappe.throw(_("Same file has already been attached to the record"),
-							frappe.FileAlreadyAttachedException)
-					# else just use the url, to avoid uploading a duplicate
-					else:
+						# just use the url, to avoid uploading a duplicate
 						self.file_url = duplicate_file.file_url
 
 	def set_file_name(self):


### PR DESCRIPTION
In a form with multiple attach fields, for example **Website Settings** (navbar and footer logo)
Attaching the same file would throw an error. 

This PR changes the behaviour by silently switching to the `file_url` of the duplicate file by default