### PR TITLE
fix: Link on onboarding widget for add new record (fix PR#10769)

### DIFF
--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -136,7 +136,7 @@ export default class OnboardingWidget extends Widget {
 		if (step.is_single) {
 			route = `Form/${step.reference_document}`;
 		} else {
-			route = __(`Form/${step.reference_document}/{0} {1}`, [__('New'), __(step.reference_document)]);
+			route = `Form/${step.reference_document}/{__('New')} {__(step.reference_document)}`;
 		}
 
 		let current_route = frappe.get_route();
@@ -262,7 +262,7 @@ export default class OnboardingWidget extends Widget {
 			frappe.route_hooks.after_save = callback;
 		}
 
-		frappe.set_route(__(`Form/${step.reference_document}/{0} {1}`, [__('New'), __(step.reference_document)]));
+		frappe.set_route(`Form/${step.reference_document}/{__('New')} {__(step.reference_document)}`);
 	}
 
 	show_quick_entry(step) {

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -136,7 +136,7 @@ export default class OnboardingWidget extends Widget {
 		if (step.is_single) {
 			route = `Form/${step.reference_document}`;
 		} else {
-			route = `Form/${step.reference_document}/{__('New')} {__(step.reference_document)}`;
+			route = `Form/${step.reference_document}/${__('New')} ${__(step.reference_document)}`;
 		}
 
 		let current_route = frappe.get_route();
@@ -262,7 +262,7 @@ export default class OnboardingWidget extends Widget {
 			frappe.route_hooks.after_save = callback;
 		}
 
-		frappe.set_route(`Form/${step.reference_document}/{__('New')} {__(step.reference_document)}`);
+		frappe.set_route(`Form/${step.reference_document}/${__('New')} ${__(step.reference_document)}`);
 	}
 
 	show_quick_entry(step) {

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -136,7 +136,7 @@ export default class OnboardingWidget extends Widget {
 		if (step.is_single) {
 			route = `Form/${step.reference_document}`;
 		} else {
-			route = __(`Form/${step.reference_document}/{0} {1}`,[__('New'),__(step.reference_document)]);
+			route = __(`Form/${step.reference_document}/{0} {1}`, [__('New'), __(step.reference_document)]);
 		}
 
 		let current_route = frappe.get_route();
@@ -262,7 +262,7 @@ export default class OnboardingWidget extends Widget {
 			frappe.route_hooks.after_save = callback;
 		}
 
-		frappe.set_route(__(`Form/${step.reference_document}/{0} {1}`,[__('New'),__(step.reference_document)]));
+		frappe.set_route(__(`Form/${step.reference_document}/{0} {1}`, [__('New'), __(step.reference_document)]));
 	}
 
 	show_quick_entry(step) {

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -136,7 +136,7 @@ export default class OnboardingWidget extends Widget {
 		if (step.is_single) {
 			route = `Form/${step.reference_document}`;
 		} else {
-			route = `Form/${step.reference_document}/__('New')+ ' ' + ${step.reference_document}`;
+			route = __(`Form/${step.reference_document}/{0} {1}`,[__('New'),__(step.reference_document)]);
 		}
 
 		let current_route = frappe.get_route();
@@ -262,7 +262,7 @@ export default class OnboardingWidget extends Widget {
 			frappe.route_hooks.after_save = callback;
 		}
 
-		frappe.set_route(`Form/${step.reference_document}/__('New')+ ' ' + ${step.reference_document}`);
+		frappe.set_route(__(`Form/${step.reference_document}/{0} {1}`,[__('New'),__(step.reference_document)]));
 	}
 
 	show_quick_entry(step) {


### PR DESCRIPTION
Fix broken link on onboarding widget for add new record

Fix pull request: https://github.com/frappe/frappe/pull/10769

This is working fine too, you consider is better?:

``Form/${step.reference_document}/${__('New')} ${__(step.reference_document)}``

Both New and the name of Doctype should be translated, please see this issue: https://github.com/frappe/frappe/issues/10756

This change is made as used on:
https://github.com/frappe/frappe/blob/a2caa8eb0459f580bc23277842633c7f2638c61d/frappe/public/js/frappe/views/treeview.js#L253

https://github.com/frappe/frappe/blob/a2caa8eb0459f580bc23277842633c7f2638c61d/frappe/public/js/frappe/views/reports/report_view.js#L1334