### PR TITLE
fix: Rename error in assignment rule

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -21,7 +21,7 @@ class AssignmentRule(Document):
 	def on_update(self): # pylint: disable=no-self-use
 		frappe.cache_manager.clear_doctype_map('Assignment Rule', self.name)
 
-	def after_rename(self): # pylint: disable=no-self-use
+	def after_rename(self, old, new, merge): # pylint: disable=no-self-use
 		frappe.cache_manager.clear_doctype_map('Assignment Rule', self.name)
 
 	def apply_unassign(self, doc, assignments):


### PR DESCRIPTION
**Steps**

1. Go to Assignment Rule
2. Rename it.

![image](https://user-images.githubusercontent.com/50285544/85939117-9524b100-b930-11ea-84ae-6159dedcf2ec.png)

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/model/rename_doc.py", line 20, in update_document_title
    docname = rename_doc(doctype=doctype, old=docname, new=new_name, merge=merge)
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/model/rename_doc.py", line 82, in rename_doc
    new_doc.run_method("after_rename", old, new, merge)
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/model/document.py", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/model/document.py", line 1071, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/model/document.py", line 1054, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-06-19/apps/frappe/frappe/model/document.py", line 791, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
TypeError: after_rename() takes 1 positional argument but 4 were given
```
