### PR TITLE
fix(permission): Show allowed rights on document for passed user

### DIFF
--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -5,23 +5,23 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _, throw
 import frappe.utils.user
-from frappe.permissions import check_admin_or_system_manager
+from frappe.permissions import check_admin_or_system_manager, rights
 from frappe.model import data_fieldtypes
 
 def execute(filters=None):
 	user, doctype, show_permissions = filters.get("user"), filters.get("doctype"), filters.get("show_permissions")
+
 	if not validate(user, doctype): return [], []
 
 	columns, fields = get_columns_and_fields(doctype)
 	data = frappe.get_list(doctype, fields=fields, as_list=True, user=user)
 
 	if show_permissions:
-		columns = columns + ["Read", "Write", "Create", "Delete", "Submit", "Cancel", "Amend", "Print", "Email",
-		                     "Report", "Import", "Export", "Share"]
+		columns = columns + [frappe.unscrub(right) + ':Check:80' for right in rights]
 		data = list(data)
-		for i,item in enumerate(data):
-			temp = frappe.permissions.get_doc_permissions(frappe.get_doc(doctype, item[0]), False,user)
-			data[i] = item+(temp.get("read"),temp.get("write"),temp.get("create"),temp.get("delete"),temp.get("submit"),temp.get("cancel"),temp.get("amend"),temp.get("print"),temp.get("email"),temp.get("report"),temp.get("import"),temp.get("export"),temp.get("share"),)
+		for i, doc in enumerate(data):
+			permission = frappe.permissions.get_doc_permissions(frappe.get_doc(doctype, doc[0]), user)
+			data[i] = doc + tuple(permission.get(right) for right in rights)
 
 	return columns, data
 


### PR DESCRIPTION
Previously, "Permitted Documents For User" used to show permissions based on session user instead of the user passed through the filter.

**Before:**
<img width="1173" alt="Screenshot 2020-06-30 at 12 04 55 PM" src="https://user-images.githubusercontent.com/13928957/86091690-f3d16280-bac9-11ea-809f-af60e40ac836.png">


**After:**
<img width="1167" alt="Screenshot 2020-06-30 at 12 00 04 PM" src="https://user-images.githubusercontent.com/13928957/86091360-68f06800-bac9-11ea-9dd5-fdd31a7828db.png">


**Note:** Above results are for the user with following role permissions.
<img width="1182" alt="Screenshot 2020-06-30 at 12 01 16 PM" src="https://user-images.githubusercontent.com/13928957/86091777-16fc1200-baca-11ea-91cc-b812e1fb0423.png">
