### PR TITLE
fix: Initialize email_sent_to_any_recipient outsite try block

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -347,7 +347,7 @@ def flush(from_test=False):
 			if not smtpserver:
 				smtpserver = SMTPServer()
 				smtpserver_dict[email.sender] = smtpserver
-				
+
 			if from_test:
 				send_one(email.name, smtpserver, auto_commit)
 			else:
@@ -390,12 +390,12 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False):
 		where
 			name=%s
 		for update''', email, as_dict=True)
-	
+
 	if len(email):
 		email = email[0]
 	else:
 		return
-	
+
 	recipients_list = frappe.db.sql('''select name, recipient, status from
 		`tabEmail Queue Recipient` where parent=%s''', email.name, as_dict=1)
 
@@ -416,6 +416,8 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False):
 
 	if email.communication:
 		frappe.get_doc('Communication', email.communication).set_delivery_status(commit=auto_commit)
+
+	email_sent_to_any_recipient = None
 
 	try:
 		message = None


### PR DESCRIPTION
fixes
```
Traceback (most recent call last):
  File "/home/frappe/develop/apps/frappe/frappe/email/queue.py", line 439, in send_one
    smtpserver.sess.sendmail(email.sender, recipient.recipient, message)
  File "/usr/lib/python3.6/smtplib.py", line 882, in sendmail
    (code, resp) = self.data(msg)
  File "/usr/lib/python3.6/smtplib.py", line 560, in data
    raise SMTPDataError(code, repl)
smtplib.SMTPDataError: (550, b'5.4.5 Daily user sending quota exceeded. j5sm483060pgi.42 - gsmtp')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/develop/apps/frappe/frappe/utils/background_jobs.py", line 100, in execute_job
    method(**kwargs)
  File "/home/frappe/develop/apps/frappe/frappe/email/queue.py", line 492, in send_one
    if email_sent_to_any_recipient:
UnboundLocalError: local variable 'email_sent_to_any_recipient' referenced before assignment
```