### PR TITLE
refactor(commands): uninstall-app to remove all app related data from site

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -415,15 +415,16 @@ def remove_from_installed_apps(context, app):
 @click.option('--yes', '-y', help='To bypass confirmation prompt for uninstalling the app', is_flag=True, default=False, multiple=True)
 @click.option('--dry-run', help='List all doctypes that will be deleted', is_flag=True, default=False)
 @click.option('--no-backup', help='Do not backup the site', is_flag=True, default=False)
+@click.option('--force', help='Force remove app from site', is_flag=True, default=False)
 @pass_context
-def uninstall(context, app, dry_run=False, yes=False, no_backup=False):
+def uninstall(context, app, dry_run, yes, no_backup, force):
 	"Remove app and linked modules from site"
 	from frappe.installer import remove_app
 	for site in context.sites:
 		try:
 			frappe.init(site=site)
 			frappe.connect()
-			remove_app(app, dry_run, yes, no_backup)
+			remove_app(app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force)
 		finally:
 			frappe.destroy()
 	if not context.sites:

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -42,6 +42,10 @@ class ModuleDef(Document):
 
 	def on_trash(self):
 		"""Delete module name from modules.txt"""
+
+		if frappe.flags.in_uninstall:
+			return
+
 		modules = None
 		if frappe.local.module_app.get(frappe.scrub(self.name)):
 			with open(frappe.get_app_path(self.app_name, "modules.txt"), "r") as f:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -157,10 +157,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 
 
 		linked_doctypes = frappe.get_all("DocField", filters={"fieldtype": "Link", "options": "Module Def"}, fields=['parent'])
-		ordered_doctypes = ["Desk Page", "Reports", "Pages", "Web Forms"]
+		ordered_doctypes = ["Desk Page", "Report", "Page", "Web Form"]
 		doctypes_with_linked_modules = ordered_doctypes + [doctype.parent for doctype in linked_doctypes if doctype.parent not in ordered_doctypes]
 
-		# remove desk page, reports, pages, web forms and chart sources
 		for doctype in doctypes_with_linked_modules:
 			for record in frappe.get_list(doctype, filters={"module": module_name}):
 				print("removing {0} {1}...".format(doctype, record.name))

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -146,8 +146,8 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False):
 				if not doctype.issingle:
 					drop_doctypes.append(doctype.name)
 
-		# remove reports, pages, web forms and chart sources
-		for doctype in ("Report", "Page", "Web Form", "Dashboard Chart Source"):
+		# remove desk page, reports, pages, web forms and chart sources
+		for doctype in ("Desk Page", "Report", "Page", "Web Form", "Dashboard Chart Source"):
 			for record in frappe.get_list(doctype, filters={"module": module_name}):
 				print("removing {0} {1}...".format(doctype, record.name))
 				if not dry_run:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -148,7 +148,8 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False):
 
 
 		linked_doctypes = frappe.get_all("DocField", filters={"fieldtype": "Link", "options": "Module Def"}, fields=['parent'])
-		doctypes_with_linked_modules = ["Desk Page", "Reports", "Pages", "Web Forms"] + [doctype.parent for doctype in linked_doctypes]
+		ordered_doctypes = ["Desk Page", "Reports", "Pages", "Web Forms"]
+		doctypes_with_linked_modules = ordered_doctypes + [doctype.parent for doctype in linked_doctypes if doctype.parent not in ordered_doctypes]
 
 		# remove desk page, reports, pages, web forms and chart sources
 		for doctype in doctypes_with_linked_modules:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -146,8 +146,12 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False):
 				if not doctype.issingle:
 					drop_doctypes.append(doctype.name)
 
+
+		linked_doctypes = frappe.get_all("DocField", filters={"fieldtype": "Link", "options": "Module Def"}, fields=['parent'])
+		doctypes_with_linked_modules = ["Desk Page", "Reports", "Pages", "Web Forms"] + [doctype.parent for doctype in linked_doctypes]
+
 		# remove desk page, reports, pages, web forms and chart sources
-		for doctype in ("Desk Page", "Report", "Page", "Web Form", "Dashboard Chart Source"):
+		for doctype in doctypes_with_linked_modules:
 			for record in frappe.get_list(doctype, filters={"module": module_name}):
 				print("removing {0} {1}...".format(doctype, record.name))
 				if not dry_run:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -146,8 +146,8 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False):
 				if not doctype.issingle:
 					drop_doctypes.append(doctype.name)
 
-		# remove reports, pages and web forms
-		for doctype in ("Report", "Page", "Web Form"):
+		# remove reports, pages, web forms and chart sources
+		for doctype in ("Report", "Page", "Web Form", "Dashboard Chart Source"):
 			for record in frappe.get_list(doctype, filters={"module": module_name}):
 				print("removing {0} {1}...".format(doctype, record.name))
 				if not dry_run:


### PR DESCRIPTION
**Updates:**

- Uninstalling apps should remove associated chart sources and desk pages
- Don't update `{app}/modules.txt` while deleting modules from site
- Added check to see if an app is installed before uninstalling
- Added verbosity

**Screenshots:**
![Screenshot 2020-06-30 at 2 04 06 PM](https://user-images.githubusercontent.com/36654812/86108143-6cdbb480-bae0-11ea-81c3-1f11b3e1e73c.png)


![Screenshot 2020-06-30 at 2 49 32 PM](https://user-images.githubusercontent.com/36654812/86108799-436f5880-bae1-11ea-9530-fe108cd20898.png)

Moved from https://github.com/frappe/frappe/pull/10863