### PR TITLE
chore: Add release notes for v13_0_0_beta_3

### DIFF
--- a/frappe/change_log/v13/v13_0_0-beta_3.md
+++ b/frappe/change_log/v13/v13_0_0-beta_3.md
@@ -1,0 +1,10 @@
+# Version 13.0.0 Beta 3 Release Notes
+
+## Fixes
+
+- Fixed circular linking while getting submitted linked doc ([#10425](https://github.com/frappe/frappe/pull/10425))
+- Fixed currency formatting in report print view ([#10584](https://github.com/frappe/frappe/pull/10584))
+- Now assignment filter in sidebar will also list closed assignments ([#10532](https://github.com/frappe/frappe/pull/10532)) ([#10714](https://github.com/frappe/frappe/pull/10714))
+- Fixed Data Import issues ([#10876](https://github.com/frappe/frappe/pull/10876))
+- Make delivery status in timeline item translatable ([#10616](https://github.com/frappe/frappe/pull/10616))
+- Website desk pages ([#10519](https://github.com/frappe/frappe/pull/10519))


### PR DESCRIPTION
<img width="807" alt="Screenshot 2020-06-30 at 5 57 01 PM" src="https://user-images.githubusercontent.com/13928957/86125976-2c3d6480-bafb-11ea-948f-633d0327eab4.png">
