### PR TITLE
fix(Print Format Builder): allow setting field label as empty

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -270,7 +270,7 @@ frappe.PrintFormatBuilder = Class.extend({
 				set_column();
 
 			} else if(!in_list(["Section Break", "Column Break", "Fold"], f.fieldtype)
-				&& f.label) {
+				&& (![undefined, null].includes(f.label))) {
 				if(!column) set_column();
 
 				if(f.fieldtype==="Table") {
@@ -477,7 +477,7 @@ frappe.PrintFormatBuilder = Class.extend({
 
 			d.set_primary_action(__("Update"), function() {
 				field.attr('data-align', d.get_value('align'));
-				field.attr('data-label', d.get_value('label'));
+				field.attr('data-label', d.get_value('label') || '');
 				field.find('.field-label').html(d.get_value('label'));
 				d.hide();
 			});
@@ -755,7 +755,7 @@ frappe.PrintFormatBuilder = Class.extend({
 						df.align = align;
 					}
 
-					if(label) {
+					if (![null, undefined].includes(label)) {
 						df.label = label;
 					}
 

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -443,6 +443,7 @@ frappe.PrintFormatBuilder = Class.extend({
 	setup_field_settings: function() {
 		this.page.main.find(".field-settings").on("click", e => {
 			const field = $(e.currentTarget).parent();
+			const is_table = field.attr('data-fieldtype') !== 'Table';
 			// new dialog
 			var d = new frappe.ui.Dialog({
 				title: "Set Properties",
@@ -456,7 +457,8 @@ frappe.PrintFormatBuilder = Class.extend({
 						label: __("Align Value"),
 						fieldname: "align",
 						fieldtype: "Select",
-						options: [{'label': __('Left'), 'value': 'left'}, {'label': __('Right'), 'value': 'right'}]
+						options: [{'label': __('Left'), 'value': 'left'}, {'label': __('Right'), 'value': 'right'}],
+						depends_on: `eval: ${is_table}`,
 					},
 					{
 						label: __("Remove Field"),

--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -25,9 +25,9 @@
 				data-custom-html-id={{ field.custom_html_id }}{% endif %}>
 			{{ field.options || me.get_no_content() }}</div>
 	{% } else { %}
-		<span class="field-label">{{ __(field.label) }}</span>
-		<span class="field-name text-muted">[{{ __(field.fieldname) }}]</span>
-		{% if(field.fieldtype==="Table") { %}
+		<span class="field-label">{{ __(field.label) }} </span>
+		<span class="field-name text-muted">{{ field.fieldname }}</span>
+		{% if (field.fieldtype === "Table") { %}
 			<span> ({%= __("Table") %})</span>
 			<a class="pull-right select-columns btn btn-default btn-xs">
 				{%= __("Select Columns") %}</a>

--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -1,36 +1,36 @@
 <div class="print-format-builder-field"
-    {% if(field.print_hide) { %}style="background-color: #F7FAFC; color: #8D99A6;"
-        title="{{ __("Hidden") }}"{% } %}
-    data-fieldname="{%= field.fieldname %}"
-    data-label="{{ __(field.label) }}"
+	{% if(field.print_hide) { %}style="background-color: #F7FAFC; color: #8D99A6;"
+		title="{{ __("Hidden") }}"{% } %}
+	data-fieldname="{%= field.fieldname %}"
+	data-label="{{ __(field.label) }}"
 
 	{% if field.align %}data-align="{{ field.align }}"{% endif %}
-    data-fieldtype="{%= field.fieldtype %}"
-    {% if(field.fieldtype==="Table") { %}
-        data-columns="{%= me.get_visible_columns_string(field) %}"
-        data-doctype="{%= field.options %}"
-    {% } %}>
+	data-fieldtype="{%= field.fieldtype %}"
+	{% if(field.fieldtype==="Table") { %}
+		data-columns="{%= me.get_visible_columns_string(field) %}"
+		data-doctype="{%= field.options %}"
+	{% } %}>
 	{% if !in_list(["HTML", "Custom HTML"], field.fieldtype) %}
-    <a class="field-settings pull-right
-        btn-default btn-xs" style="padding-top: 3px; margin-left: 5px;">
-        <span class="octicon octicon-gear text-muted"></span></a>
+	<a class="field-settings pull-right
+		btn-default btn-xs" style="padding-top: 3px; margin-left: 5px;">
+		<span class="octicon octicon-gear text-muted"></span></a>
 	{% endif %}
-    {% if(field.fieldtype==="Custom HTML") { %}
-        <div class="text-right">
-            <a class="edit-html btn btn-default btn-xs">
-                {%= __("Edit HTML") %}</a>
-        </div>
-        <div class="html-content"
+	{% if(field.fieldtype==="Custom HTML") { %}
+		<div class="text-right">
+			<a class="edit-html btn btn-default btn-xs">
+				{%= __("Edit HTML") %}</a>
+		</div>
+		<div class="html-content"
 			{% if field.custom_html_id!==undefined %}
 				data-custom-html-id={{ field.custom_html_id }}{% endif %}>
 			{{ field.options || me.get_no_content() }}</div>
-    {% } else { %}
-        <span class="field-label">{{ __(field.label) }}</span>
-        <span class="field-name text-muted">[{{ __(field.fieldname) }}]</span>
-        {% if(field.fieldtype==="Table") { %}
-            <span> ({%= __("Table") %})</span>
-            <a class="pull-right select-columns btn btn-default btn-xs">
-                {%= __("Select Columns") %}</a>
-        {% } %}
-    {% } %}
+	{% } else { %}
+		<span class="field-label">{{ __(field.label) }}</span>
+		<span class="field-name text-muted">[{{ __(field.fieldname) }}]</span>
+		{% if(field.fieldtype==="Table") { %}
+			<span> ({%= __("Table") %})</span>
+			<a class="pull-right select-columns btn btn-default btn-xs">
+				{%= __("Select Columns") %}</a>
+		{% } %}
+	{% } %}
 </div>

--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -10,9 +10,9 @@
         data-columns="{%= me.get_visible_columns_string(field) %}"
         data-doctype="{%= field.options %}"
     {% } %}>
-	{% if !in_list(["Table", "HTML", "Custom HTML"], field.fieldtype) %}
+	{% if !in_list(["HTML", "Custom HTML"], field.fieldtype) %}
     <a class="field-settings pull-right
-        btn-default btn-xs" style="padding-top: 3px">
+        btn-default btn-xs" style="padding-top: 3px; margin-left: 5px;">
         <span class="octicon octicon-gear text-muted"></span></a>
 	{% endif %}
     {% if(field.fieldtype==="Custom HTML") { %}
@@ -26,6 +26,7 @@
 			{{ field.options || me.get_no_content() }}</div>
     {% } else { %}
         <span class="field-label">{{ __(field.label) }}</span>
+        <span class="field-name text-muted">[{{ __(field.fieldname) }}]</span>
         {% if(field.fieldtype==="Table") { %}
             <span> ({%= __("Table") %})</span>
             <a class="pull-right select-columns btn btn-default btn-xs">

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -57,7 +57,7 @@
 						{% for tdf in visible_columns %}
 						{% if not d.flags.compact_item_print or tdf.fieldname in doc.get(df.fieldname)[0].flags.compact_item_fields %}
 							<td class="{{ get_align_class(tdf) }}" {{ fieldmeta(df) }}>
-                                <div class="value">{{ print_value(tdf, d, doc, visible_columns) }}</div></td>
+								<div class="value">{{ print_value(tdf, d, doc, visible_columns) }}</div></td>
 						{% endif %}
 						{% endfor %}
 					</tr>
@@ -113,7 +113,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 		{%- if df.fieldtype=="Text Editor" -%}<div class='ql-editor'>{%- endif -%}
 		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
 		{%- if df.fieldtype=="Text Editor" -%}</div>{%- endif -%}
-  {% endif -%}
+{% endif -%}
 </div>
 {%- endif -%}
 {%- endmacro -%}
@@ -131,9 +131,9 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {%- endmacro -%}
 
 {%- macro print_value(df, doc, parent_doc=None, visible_columns=None) -%}
-    {% if doc.print_templates and
+	{% if doc.print_templates and
 			doc.print_templates.get(df.fieldname) %}
-        {% include doc.print_templates[df.fieldname] %}
+		{% include doc.print_templates[df.fieldname] %}
 	{% elif df.fieldtype=="Check" %}
 		<i class="{{ 'fa fa-check' if doc[df.fieldname] }}"></i>
 	{% elif df.fieldtype=="Image" %}
@@ -173,25 +173,25 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% if letter_head and not no_letterhead %}
 		<div class="letter-head">{{ letter_head }}</div>
 	{% endif %}
-    {% if doc.print_heading_template %}
-        {{ frappe.render_template(doc.print_heading_template, {"doc":doc}) }}
-    {% else %}
-    <div class="print-heading">
+	{% if doc.print_heading_template %}
+		{{ frappe.render_template(doc.print_heading_template, {"doc":doc}) }}
+	{% else %}
+	<div class="print-heading">
 		<h2>{{ doc.select_print_heading or (doc.print_heading if doc.print_heading != None
 			else _(doc.doctype)) }}<br>
 			<small>{{ doc.sub_heading if doc.sub_heading != None
 				else doc.name }}</small>
-        </h2>
-    </div>
-    {% endif %}
+		</h2>
+	</div>
+	{% endif %}
 	{%- if doc.meta.is_submittable and doc.docstatus==0 and (print_settings==None or print_settings.add_draft_heading) -%}
 	<div class="text-center" document-status="draft">
 		<h4 style="margin: 0px;">{{ _("DRAFT") }}</h4>
-    </div>
+	</div>
 	{%- endif -%}
 	{%- if doc.meta.is_submittable and doc.docstatus==2-%}
 	<div class="text-center" document-status="cancelled">
 		<h4 style="margin: 0px;">{{ _("CANCELLED") }}</h4>
-    </div>
+	</div>
 	{%- endif -%}
 {%- endmacro -%}

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -35,7 +35,9 @@
 		{%- set visible_columns = get_visible_columns(doc.get(df.fieldname),
 			table_meta, df) -%}
 		<div {{ fieldmeta(df) }}>
+			{% if df.label != None %}
 			<label>{{ _(df.label) }}</label>
+			{% endif %}
 			<table class="table table-bordered table-condensed">
 				<thead>
 					<tr>
@@ -78,11 +80,15 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 
 				{% if df.fieldtype not in ("Image", "HTML", "Check") and
 					doc.get(df.fieldname) != None %}
-				<label>{{ _(df.label) }}</label>
+					{% if df.label != None %}
+					<label>{{ _(df.label) }}</label>
+					{% endif %}
 				{% endif %}
 				{% if df.fieldtype == "Check" and
 				doc.get(df.fieldname) != 0 %}
-				<label>{{ _(df.label) }}</label>
+					{% if df.label != None %}
+					<label>{{ _(df.label) }}</label>
+					{% endif %}
 				{% endif %}
 			</div>
 			<div class="col-xs-{{ "3" if df.fieldtype=="Check" else "7" }}
@@ -96,7 +102,11 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {%- macro render_text_field(df, doc) -%}
 {%- if doc.get(df.fieldname) != None -%}
 <div style="padding: 10px 0px" {{ fieldmeta(df) }}>
-	{%- if df.fieldtype in ("Text", "Code", "Long Text", "Text Editor") %}<label>{{ _(df.label) }}</label>{%- endif %}
+	{%- if df.fieldtype in ("Text", "Code", "Long Text", "Text Editor") %}
+		{% if df.label != None %}
+		<label>{{ _(df.label) }}</label>
+		{%- endif %}
+	{%- endif %}
 	{%- if df.fieldtype=="Code" %}
 		<pre class="value">{{ doc.get(df.fieldname) }}</pre>
 	{% else -%}


### PR DESCRIPTION
The label for print format fields was configurable through the field setting dialog in Print Format Builder, but we did not allow empty values to be set.

Changes in this PR:

- Allow the label to be set as empty

- Show field settings for Table fields too:
<img width="966" alt="Screenshot 2020-07-01 at 4 23 59 PM" src="https://user-images.githubusercontent.com/19775888/86236746-340f0e80-bbb8-11ea-9844-168354da719e.png">

- Also show field names on the builder layout (not sure about this, but we need to display something if the label is not set):
<img width="1212" alt="Screenshot 2020-07-01 at 4 31 50 PM" src="https://user-images.githubusercontent.com/19775888/86236858-63258000-bbb8-11ea-809f-91f85a1df25b.png">

