### PR TITLE
fix: whitelist auto repeat query function

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -372,7 +372,8 @@ def make_auto_repeat(doctype, docname, frequency = 'Daily', start_date = None, e
 	doc.save()
 	return doc
 
-#method for reference_doctype filter
+# method for reference_doctype filter
+@frappe.whitelist()
 def get_auto_repeat_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	res = frappe.db.get_all('Property Setter', {
 		'property': 'allow_auto_repeat',


### PR DESCRIPTION
Whitelist query function for getting auto-repeat doctypes

![perm](https://user-images.githubusercontent.com/24353136/86323747-0038f500-bc5b-11ea-8510-c00bb55f9eff.png)


