### PR TITLE
fix: add search queries to whitelist

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -146,6 +146,7 @@ def delete_contact_and_address(doctype, docname):
 			if len(doc.links)==1:
 				doc.delete()
 
+@frappe.whitelist()
 def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	if not txt: txt = ""
 

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -230,6 +230,7 @@ def get_company_address(company):
 
 	return ret
 
+@frappe.whitelist()
 def address_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -243,8 +243,7 @@ def address_query(doctype, txt, searchfield, start, page_len, filters):
 		if meta.get_field(fieldname) or fieldname in frappe.db.DEFAULT_COLUMNS:
 			condition += " and {field}={value}".format(
 				field=fieldname,
-				value=value
-			)
+				value=frappe.db.escape(value))
 
 	searchfields = meta.get_search_fields()
 

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -238,13 +238,14 @@ def address_query(doctype, txt, searchfield, start, page_len, filters):
 	link_name = filters.pop('link_name')
 
 	condition = ""
-	for fieldname, value in iteritems(filters):
-		condition += " and {field}={value}".format(
-			field=fieldname,
-			value=value
-		)
-
 	meta = frappe.get_meta("Address")
+	for fieldname, value in iteritems(filters):
+		if meta.get_field(fieldname) or fieldname in frappe.db.DEFAULT_COLUMNS:
+			condition += " and {field}={value}".format(
+				field=fieldname,
+				value=value
+			)
+
 	searchfields = meta.get_search_fields()
 
 	if searchfield:

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -248,7 +248,8 @@ def address_query(doctype, txt, searchfield, start, page_len, filters):
 
 	searchfields = meta.get_search_fields()
 
-	if searchfield:
+	if searchfield and (meta.get_field(searchfield)\
+				or searchfield in frappe.db.DEFAULT_COLUMNS):
 		searchfields.append(searchfield)
 
 	search_condition = ''

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -205,14 +205,14 @@ def contact_query(doctype, txt, searchfield, start, page_len, filters):
 			`tabDynamic Link`.parenttype = 'Contact' and
 			`tabDynamic Link`.link_doctype = %(link_doctype)s and
 			`tabDynamic Link`.link_name = %(link_name)s and
-			`tabContact`.`{key}` like %(txt)s
-			{mcond}
+			`tabContact`.`%(key)s` like %(txt)s
+			%(mcond)s
 		order by
 			if(locate(%(_txt)s, `tabContact`.name), locate(%(_txt)s, `tabContact`.name), 99999),
 			`tabContact`.idx desc, `tabContact`.name
-		limit %(start)s, %(page_len)s """.format(
-			mcond=get_match_cond(doctype),
-			key=searchfield), {
+		limit %(start)s, %(page_len)s """, {
+			'mcond': get_match_cond(doctype),
+			'key': searchfield,
 			'txt': '%' + txt + '%',
 			'_txt': txt.replace("%", ""),
 			'start': start,

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -193,13 +193,6 @@ def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	link_doctype = filters.pop('link_doctype')
 	link_name = filters.pop('link_name')
 
-	condition = ""
-	for fieldname, value in iteritems(filters):
-		condition += " and {field}={value}".format(
-			field=fieldname,
-			value=value
-		)
-
 	return frappe.db.sql("""select
 			`tabContact`.name, `tabContact`.first_name, `tabContact`.last_name
 		from

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -182,6 +182,7 @@ def update_contact(doc, method):
 		contact.flags.ignore_mandatory = True
 		contact.save(ignore_permissions=True)
 
+@frappe.whitelist()
 def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -186,7 +186,8 @@ def update_contact(doc, method):
 def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 
-	if not frappe.get_meta("Contact").get_field(searchfield):
+	if not frappe.get_meta("Contact").get_field(searchfield)\
+		or searchfield not in frappe.db.DEFAULT_COLUMNS:
 		return []
 
 	link_doctype = filters.pop('link_doctype')

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -187,7 +187,7 @@ def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 
 	if not frappe.get_meta("Contact").get_field(searchfield):
-		return {}
+		return []
 
 	link_doctype = filters.pop('link_doctype')
 	link_name = filters.pop('link_name')

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -186,6 +186,9 @@ def update_contact(doc, method):
 def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 
+	if not frappe.get_meta("Contact").get_field(searchfield):
+		return {}
+
 	link_doctype = filters.pop('link_doctype')
 	link_name = filters.pop('link_name')
 
@@ -205,14 +208,12 @@ def contact_query(doctype, txt, searchfield, start, page_len, filters):
 			`tabDynamic Link`.parenttype = 'Contact' and
 			`tabDynamic Link`.link_doctype = %(link_doctype)s and
 			`tabDynamic Link`.link_name = %(link_name)s and
-			`tabContact`.`%(key)s` like %(txt)s
-			%(mcond)s
+			`tabContact`.`{key}` like %(txt)s
+			{mcond}
 		order by
 			if(locate(%(_txt)s, `tabContact`.name), locate(%(_txt)s, `tabContact`.name), 99999),
 			`tabContact`.idx desc, `tabContact`.name
-		limit %(start)s, %(page_len)s """, {
-			'mcond': get_match_cond(doctype),
-			'key': searchfield,
+		limit %(start)s, %(page_len)s """.format(mcond=get_match_cond(doctype), key=searchfield), {
 			'txt': '%' + txt + '%',
 			'_txt': txt.replace("%", ""),
 			'start': start,


### PR DESCRIPTION
these functions are called through search widget and need to be whitelisted to work in link fields