### PR TITLE
fix: Duplicate Name Error Message on saving document

### DIFF
--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -18,11 +18,7 @@ def savedocs(doc, action):
 		if doc.docstatus==1:
 			doc.submit()
 		else:
-			try:
-				doc.save()
-			except frappe.NameError as e:
-				# Duplicate Error message already shown on db_insert
-				raise
+			doc.save()
 
 		# update recent documents
 		run_onload(doc)

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -21,8 +21,7 @@ def savedocs(doc, action):
 			try:
 				doc.save()
 			except frappe.NameError as e:
-				doctype, name, original_exception = e if isinstance(e, tuple) else (doc.doctype or "", doc.name or "", None)
-				frappe.msgprint(frappe._("{0} {1} already exists").format(doctype, name))
+				# Duplicate Error message already shown on db_insert
 				raise
 
 		# update recent documents

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -334,7 +334,7 @@ class BaseDocument(object):
 					self.db_insert()
 					return
 
-				frappe.msgprint(_("Duplicate name {0} {1}").format(self.doctype, self.name))
+				frappe.msgprint(_("{0} {1} already exists").format(self.doctype, frappe.bold(self.name)), title=_("Duplicate Name"), indicator="red")
 				raise frappe.DuplicateEntryError(self.doctype, self.name, e)
 
 			elif frappe.db.is_unique_key_violation(e):


### PR DESCRIPTION
## **Issue:**
<details><summary>Duplication Error Message two times</summary>
  
![image](https://user-images.githubusercontent.com/25857446/86450301-ec62c100-bd36-11ea-8991-1aaeb9e197b6.png)

</details>

## **Fix:**
- Remove try catch in `savedocs` as it only caught and re-raises NameError that handles itself everywhere
- Message and error raised on `db_insert` with styling fixes
  ![Screenshot 2020-07-03 at 2 08 25 PM](https://user-images.githubusercontent.com/25857446/86450745-a22e0f80-bd37-11ea-8a34-87c9bc05ea8f.png)
- Every invocation of `frappe.NameError` elsewhere is within `frappe.throw` i.e. for other name errors a message is raised. So removing the message in `savedocs` does no harm as far as i know