### PR TITLE
fix(Report): remove fields if they don't exist

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -109,9 +109,10 @@ frappe.views.BaseList = class BaseList {
 		this.fields = this.fields.uniqBy(f => f[0] + f[1]);
 	}
 
-	_add_field(fieldname) {
+	_add_field(fieldname, doctype) {
 		if (!fieldname) return;
-		let doctype = this.doctype;
+
+		if (!doctype) doctype = this.doctype;
 
 		if (typeof fieldname === 'object') {
 			// df is passed
@@ -119,6 +120,8 @@ frappe.views.BaseList = class BaseList {
 			fieldname = df.fieldname;
 			doctype = df.parent;
 		}
+
+		if (!this.fields) this.fields = [];
 
 		const is_valid_field = frappe.model.std_fields_list.includes(fieldname)
 			|| frappe.meta.has_field(doctype, fieldname)

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -641,21 +641,14 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	set_fields() {
-		// remove fields that don't exist any more
-		let remove_non_existent_fields = fields =>
-			fields.filter(f =>
-				frappe.model.std_fields_list.includes(f[0])
-				|| frappe.meta.has_field(f[1], f[0])
-			);
-
 		if (this.report_name && this.report_doc.json.fields) {
-			this.fields = this.report_doc.json.fields.slice();
-			this.fields = remove_non_existent_fields(this.fields);
+			let fields = this.report_doc.json.fields.slice();
+			fields.forEach(f => this._add_field(f[0], f[1]));
 			return;
 		} else if (this.view_user_settings.fields) {
 			// get from user_settings
-			this.fields = this.view_user_settings.fields;
-			this.fields = remove_non_existent_fields(this.fields);
+			let fields = this.view_user_settings.fields;
+			fields.forEach(f => this._add_field(f[0], f[1]));
 			return;
 		}
 

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -641,12 +641,21 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	set_fields() {
+		// remove fields that don't exist any more
+		let remove_non_existent_fields = fields =>
+			fields.filter(f =>
+				frappe.model.std_fields_list.includes(f[0])
+				|| frappe.meta.has_field(f[1], f[0])
+			);
+
 		if (this.report_name && this.report_doc.json.fields) {
 			this.fields = this.report_doc.json.fields.slice();
+			this.fields = remove_non_existent_fields(this.fields);
 			return;
 		} else if (this.view_user_settings.fields) {
 			// get from user_settings
 			this.fields = this.view_user_settings.fields;
+			this.fields = remove_non_existent_fields(this.fields);
 			return;
 		}
 


### PR DESCRIPTION
When fields are deleted they aren't removed from user settings, so we should check if the docfield exists while setting the report fields.

Fixes:
![image](https://user-images.githubusercontent.com/19775888/86467086-681e3700-bd52-11ea-8463-3f4bdc694c12.png)
