### PR TITLE
fix: Show reports in module view only if user has permission

### DIFF
--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -544,8 +544,8 @@ def get_last_modified(doctype):
 def get_report_list(module, is_standard="No"):
 	"""Returns list on new style reports for modules."""
 	try:
-		reports =  frappe.get_list("Report", fields=["name", "ref_doctype", "report_type"], filters=
-			{"is_standard": is_standard, "disabled": 0, "module": module},
+		reports = frappe.get_list("Report", fields=["name", "ref_doctype", "report_type"], 
+			filters={"is_standard": is_standard, "disabled": 0, "module": module},
 			order_by="name")
 	except frappe.PermissionError:
 		return

--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -235,8 +235,8 @@ def get_config(app, module):
 	sections = [s for s in config if s.get("condition", True)]
 
 	disabled_reports = get_disabled_reports()
-	has_report_permission = frappe.permissions.has_permission('Report', 'read', user=frappe.session.user,\
-		raise_exception=False)
+	has_report_permission = frappe.permissions.has_permission('Report', 'read',
+		user=frappe.session.user, raise_exception=False)
 
 	for section in sections:
 		items = []

--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -539,9 +539,12 @@ def get_last_modified(doctype):
 
 def get_report_list(module, is_standard="No"):
 	"""Returns list on new style reports for modules."""
-	reports =  frappe.get_list("Report", fields=["name", "ref_doctype", "report_type"], filters=
-		{"is_standard": is_standard, "disabled": 0, "module": module},
-		order_by="name")
+	try:
+		reports =  frappe.get_list("Report", fields=["name", "ref_doctype", "report_type"], filters=
+			{"is_standard": is_standard, "disabled": 0, "module": module},
+			order_by="name")
+	except frappe.PermissionError:
+		return
 
 	out = []
 	for r in reports:

--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -235,11 +235,15 @@ def get_config(app, module):
 	sections = [s for s in config if s.get("condition", True)]
 
 	disabled_reports = get_disabled_reports()
+	has_report_permission = frappe.permissions.has_permission('Report', 'read', user=frappe.session.user,\
+		raise_exception=False)
+
 	for section in sections:
 		items = []
 		for item in section["items"]:
-			if item["type"]=="report" and item["name"] in disabled_reports:
-				continue
+			if item["type"]=="report":
+				if item["name"] in disabled_reports or not has_report_permission:
+					continue
 			# some module links might not have name
 			if not item.get("name"):
 				item["name"] = item.get("label")


### PR DESCRIPTION
**Bug:**
If read permission for Report is removed, the module page cannot be viewed:
<img width="1432" alt="Screenshot 2020-07-03 at 5 42 17 PM" src="https://user-images.githubusercontent.com/19775888/86468212-8edd6d00-bd54-11ea-9769-ea37e47472a1.png">


**Fix:**
Don't show reports if user doesn't have read permission for Report.