### PR TITLE
refactor: use default dict methods for smaller stack [WIP]

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -34,6 +34,11 @@ class _dict(dict):
 
 	__setattr__ = dict.__setitem__
 
+	__setstate__ = dict.update
+
+	def __getstate__(self):
+		return self
+
 	def update(self, d):
 		"""update and return self -- the missing dict feature in python"""
 		super(_dict, self).update(d)

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -30,21 +30,15 @@ local = Local()
 
 class _dict(dict):
 	"""dict like object that exposes keys as attributes"""
-	def __getattr__(self, key):
-		ret = self.get(key)
-		if not ret and key.startswith("__"):
-			raise AttributeError()
-		return ret
-	def __setattr__(self, key, value):
-		self[key] = value
-	def __getstate__(self):
-		return self
-	def __setstate__(self, d):
-		self.update(d)
+	__getattr__ = dict.get
+
+	__setattr__ = dict.__setitem__
+
 	def update(self, d):
 		"""update and return self -- the missing dict feature in python"""
 		super(_dict, self).update(d)
 		return self
+
 	def copy(self):
 		return _dict(dict(self).copy())
 


### PR DESCRIPTION
Default dict methods are already present, and frappe._dict inherits the same. No need to re-implement them.