### PR TITLE
fix: Do not check for orphaned states in new workflows

### DIFF
--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -96,6 +96,7 @@ frappe.ui.form.on("Workflow", {
 		});
 	},
 	get_orphaned_states_and_count: function(frm) {
+		if (frm.is_new()) return;
 		let states_list = [];
 		frm.doc.states.map(state => states_list.push(state.state));
 		return frappe.xcall('frappe.workflow.doctype.workflow.workflow.get_workflow_state_count', {

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -119,7 +119,9 @@ def get_workflow_state_count(doctype, workflow_state_field, states):
 	result = frappe.get_all(
 		doctype,
 		fields=[workflow_state_field, 'count(*) as count', 'docstatus'],
-		filters = {'workflow_state': ['not in', states]},
+		filters = {
+			workflow_state_field: ['not in', states]
+		},
 		group_by = workflow_state_field
 	)
 	return [r for r in result if r[workflow_state_field]]


### PR DESCRIPTION
fixes the following issue while removing state row in new workflows.
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/workflow/doctype/workflow/workflow.py", line 123, in get_workflow_state_count
    group_by = workflow_state_field
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/__init__.py", line 1317, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/__init__.py", line 1290, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/model/db_query.py", line 96, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/model/db_query.py", line 130, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/database/database.py", line 171, in sql
    self._cursor.execute(query)
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2020-07-02/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column 'workflow_state' in 'field list'")
```
