### PR TITLE
fix(patch): patch to set _assign for docs with closed todos

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -264,6 +264,7 @@ frappe.patches.v11_0.make_all_prepared_report_attachments_private #2019-11-26
 frappe.patches.v12_0.setup_email_linking
 frappe.patches.v12_0.fix_home_settings_for_all_users
 frappe.patches.v12_0.change_existing_dashboard_chart_filters
+frappe.patches.v12_0.set_correct_assign_value_in_docs
 execute:frappe.delete_doc("Test Runner")
 execute:frappe.delete_doc_if_exists('DocType', 'Google Maps Settings')
 execute:frappe.db.set_default('desktop:home_page', 'workspace')

--- a/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
+++ b/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
@@ -1,0 +1,20 @@
+import frappe
+
+def execute():
+	frappe.reload_doc('desk', 'doctype', 'todo')
+
+	closed_todos = frappe.get_all(
+		'ToDo',
+		fields = ['name', 'reference_type', 'reference_name', 'owner'],
+		filters = {
+			'status': 'Closed'
+		}
+	)
+
+	for doc in closed_todos:
+		if doc.reference_type and doc.reference_name:
+			assignments = frappe.db.get_value(doc.reference_type, doc.reference_name, '_assign')
+			assignments = frappe.parse_json(assignments) or []
+			if isinstance(assignments, list) and doc.owner not in assignments:
+				assignments.append(doc.owner)
+				frappe.db.set_value(doc.reference_type, doc.reference_name, '_assign', frappe.as_json(assignments))

--- a/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
+++ b/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
@@ -9,7 +9,8 @@ def execute():
 		FROM
 			`tabTodo`
 		WHERE
-			not reference_type IS NULL and not reference_name IS NULL
+			COALESCE(reference_type, '') != '' and
+			COALESCE(reference_name, '') != ''
 		GROUP BY
 			reference_type, reference_name
 	'''
@@ -21,7 +22,6 @@ def execute():
 
 	for doc in assignments:
 		assignments = doc.assignees.split(',')
-		print('assignments', assignments)
 		frappe.db.set_value(
 			doc.reference_type,
 			doc.reference_name,

--- a/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
+++ b/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
@@ -3,18 +3,25 @@ import frappe
 def execute():
 	frappe.reload_doc('desk', 'doctype', 'todo')
 
-	closed_todos = frappe.get_all(
-		'ToDo',
-		fields = ['name', 'reference_type', 'reference_name', 'owner'],
-		filters = {
-			'status': 'Closed'
-		}
-	)
+	if frappe.db.db_type == 'mariadb':
+		fields = 'name, reference_type, reference_name, group_concat(distinct owner) as owner'
+	else:
+		fields = 'name, reference_type, reference_name, string_agg(distinct owner, ",") as owner'
+
+	closed_todos = frappe.db.sql('''
+		SELECT
+			{fields}
+		FROM
+			`tabTodo`
+		WHERE
+			reference_type != '' and reference_name != '' and
+			status = 'Closed'
+		GROUP BY
+			reference_type, reference_name
+	'''.format(fields=fields), as_dict=True)
 
 	for doc in closed_todos:
-		if doc.reference_type and doc.reference_name:
-			assignments = frappe.db.get_value(doc.reference_type, doc.reference_name, '_assign')
-			assignments = frappe.parse_json(assignments) or []
-			if isinstance(assignments, list) and doc.owner not in assignments:
-				assignments.append(doc.owner)
-				frappe.db.set_value(doc.reference_type, doc.reference_name, '_assign', frappe.as_json(assignments))
+		assignments = frappe.db.get_value(doc.reference_type, doc.reference_name, '_assign')
+		assignments = frappe.parse_json(assignments) or []
+		unique_assignments = list(set(doc.owner.split(',') + assignments))
+		frappe.db.set_value(doc.reference_type, doc.reference_name, '_assign', frappe.as_json(unique_assignments))

--- a/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
+++ b/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
@@ -3,25 +3,29 @@ import frappe
 def execute():
 	frappe.reload_doc('desk', 'doctype', 'todo')
 
-	if frappe.db.db_type == 'mariadb':
-		fields = 'name, reference_type, reference_name, group_concat(distinct owner) as owner'
-	else:
-		fields = 'name, reference_type, reference_name, string_agg(distinct owner, ",") as owner'
-
-	closed_todos = frappe.db.sql('''
+	query = '''
 		SELECT
-			{fields}
+			name, reference_type, reference_name, {} as assignees
 		FROM
 			`tabTodo`
 		WHERE
-			reference_type != '' and reference_name != '' and
-			status = 'Closed'
+			not reference_type IS NULL and not reference_name IS NULL
 		GROUP BY
 			reference_type, reference_name
-	'''.format(fields=fields), as_dict=True)
+	'''
 
-	for doc in closed_todos:
-		assignments = frappe.db.get_value(doc.reference_type, doc.reference_name, '_assign')
-		assignments = frappe.parse_json(assignments) or []
-		unique_assignments = list(set(doc.owner.split(',') + assignments))
-		frappe.db.set_value(doc.reference_type, doc.reference_name, '_assign', frappe.as_json(unique_assignments))
+	assignments = frappe.db.multisql({
+		'mariadb': query.format('GROUP_CONCAT(DISTINCT `owner`)'),
+		'postgres': query.format('STRING_AGG(DISTINCT "owner", ",")')
+	}, as_dict=True)
+
+	for doc in assignments:
+		assignments = doc.assignees.split(',')
+		print('assignments', assignments)
+		frappe.db.set_value(
+			doc.reference_type,
+			doc.reference_name,
+			'_assign',
+			frappe.as_json(assignments),
+			update_modified=False
+		)


### PR DESCRIPTION
After https://github.com/frappe/frappe/pull/10532 and https://github.com/frappe/frappe/pull/10714, we need a patch to set _assign for docs with closed Todos.