### PR TITLE
fix: Data Import fixes

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -957,7 +957,7 @@ class Column:
 
 		if self.df.fieldtype == 'Link':
 			# find all values that dont exist
-			values = list(set([v for v in self.column_values[1:] if v]))
+			values = list(set([cstr(v) for v in self.column_values[1:] if v]))
 			exists = [d.name for d in frappe.db.get_all(self.df.options, filters={'name': ('in', values)})]
 			not_exists = list(set(values) - set(exists))
 			if not_exists:

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1060,6 +1060,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 		# other fields
 		fields = get_standard_fields(doctype) + frappe.get_meta(doctype).fields
 		for df in fields:
+			label = (df.label or '').strip()
 			fieldtype = df.fieldtype or "Data"
 			parent = df.parent or parent_doctype
 			if fieldtype not in no_value_fields:
@@ -1068,12 +1069,12 @@ def build_fields_dict_for_column_matching(parent_doctype):
 					# Label
 					# label
 					# Label (label)
-					if not out.get(df.label):
+					if not out.get(label):
 						# if Label is already set, don't set it again
 						# in case of duplicate column headers
-						out[df.label] = df
+						out[label] = df
 					out[df.fieldname] = df
-					label_with_fieldname = "{0} ({1})".format(df.label, df.fieldname)
+					label_with_fieldname = "{0} ({1})".format(label, df.fieldname)
 					out[label_with_fieldname] = df
 				else:
 					# in case there are multiple table fields with the same doctype
@@ -1084,7 +1085,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 						"fields", {"fieldtype": ["in", table_fieldtypes], "options": parent}
 					)
 					for table_field in table_fields:
-						by_label = "{0} ({1})".format(df.label, table_field.label)
+						by_label = "{0} ({1})".format(label, table_field.label)
 						by_fieldname = "{0}.{1}".format(table_field.fieldname, df.fieldname)
 
 						# create a new df object to avoid mutation problems

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -191,7 +191,6 @@ def get_csv_content_from_google_sheets(url):
 		'Accept': 'text/csv'
 	}
 	response = requests.get(url, headers=headers)
-	response.raise_for_status()
 
 	if response.ok:
 		# if it returns html, it couldn't find the CSV content
@@ -202,6 +201,11 @@ def get_csv_content_from_google_sheets(url):
 				title=_("Invalid URL")
 			)
 		return response.content
+	elif response.status_code == 400:
+		frappe.throw(_('Google Sheets URL must end with "gid={number}". Copy and paste the URL from the browser address bar and try again.'),
+			title=_("Incorrect URL"))
+	else:
+		response.raise_for_status()
 
 def validate_google_sheets_url(url):
 	if "docs.google.com/spreadsheets" not in url:


### PR DESCRIPTION
### Cast name values to string for link checking
If values in Link column are numeric, they are parsed as numbers. It would break when checking for existence in the DB. This fix casts the values to string.

### Strip spaces from label for column matching
If there are trailing spaces in DocField Label, they are not matched correctly with the spreadsheet column. This fix will strip out the spaces.

### Show message if URL without gid is errored
Google Sheets can have multiple sheets. When you paste the URL, we try to get the first sheet by default and it is denoted by `gid=0` in the URL. But sometimes, the sheet number is different than `0`. 
For e.g., `https://docs.google.com/spreadsheets/d/1sQwTdYs5vgIR7v53SsEe3VVQKeUnFQ1hv5jpJkZCjto/edit#gid=929692877`. To always parse the Google Sheets correctly, User must ensure that `gid=number` is part of the URL.