### PR TITLE
fix: prevent rendering arbitrary html

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -228,7 +228,7 @@ frappe.search.AwesomeBar = Class.extend({
 		}
 
 		this.options.push({
-			label: __("Search for '{0}'", [txt.bold()]),
+			label: __("Search for '{0}'", [frappe.utils.xss_sanitise(txt).bold()]),
 			value: __("Search for '{0}'", [txt]),
 			match: txt,
 			index: 100,

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -25,7 +25,7 @@ def get_context(path, args=None):
 		context["path"] = path
 		scheme = 'http'
 
-	context.canonical = scheme + '://' + frappe.local.site + '/' + context.path
+	context.canonical = scheme + '://' + frappe.local.site + '/' + frappe.utils.escape_html(context.path)
 	context.route = context.path
 	context = build_context(context)
 


### PR DESCRIPTION
prevents xss inside:

* awesome bar
* base template

the base template rendering issue causes site-wide xss, which can be prevented by html-escaping the canonical url that is placed inside <head>

the base template includes a line:

https://github.com/frappe/frappe/blob/35b91889c6942edf93789a56d65a374f109a29e4/frappe/templates/base.html#L23

which renders to:

```html
<link rel="canonical" href="http://site/api/method/frappe.model.db_query.get_list'"--></style></script><script>alert(1)</script>">
```

which is an invalid html rendering, causing the script tag to render in the template. the same thing can be put to effect anywhere on the site, causing a site-wide xss.

html-escaping the canonical url makes it:

```html
<link rel="canonical" href="http://site/api/method/frappe.model.db_query.get_list&apos;&quot;--&gt;&lt;/style&gt;&lt;/script&gt;&lt;script&gt;alert(1)&lt;/script&gt;">
```

which has no effect on the frontend, but does not cause any XSS and also correctly renders the HTML