### PR TITLE
fix: whitelist address query

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -230,6 +230,7 @@ def get_company_address(company):
 
 	return ret
 
+@frappe.whitelist()
 def address_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 


### PR DESCRIPTION
Due to the fix introduced in https://github.com/frappe/frappe/pull/10893. All the queries called via search widget are required to be whitelisted