### PR TITLE
fix(File):  Update all file docs that point to the same file on url update

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -120,6 +120,7 @@ class File(Document):
 
 					self.file_url = "/private/files/{0}".format(self.file_name)
 
+				update_existing_file_docs(self)
 
 			# update documents image url with new file url
 			if self.attached_to_doctype and self.attached_to_name:
@@ -903,3 +904,20 @@ def get_files_in_folder(folder):
 		{ 'folder': folder },
 		['name', 'file_name', 'file_url', 'is_folder', 'modified']
 	)
+
+def update_existing_file_docs(doc):
+	# Update is private and file url of all file docs that point to the same file
+	frappe.db.sql("""
+		UPDATE `tabFile`
+		SET
+			`tabFile`.file_url = '{file_url}',
+			`tabFile`.is_private = {is_private}
+		WHERE
+			`tabFile`.content_hash = '{content_hash}'
+			and `tabFile`.name != '{file_name}'
+	""".format(
+		file_url=doc.file_url,
+		is_private=doc.is_private,
+		content_hash=doc.content_hash,
+		file_name=doc.name
+	))

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -108,17 +108,18 @@ class File(Document):
 				private_files = frappe.get_site_path('private', 'files')
 				public_files = frappe.get_site_path('public', 'files')
 
+				file_name = self.file_url.split('/')[-1]
 				if not self.is_private:
-					shutil.move(os.path.join(private_files, self.file_name),
-						os.path.join(public_files, self.file_name))
+					shutil.move(os.path.join(private_files, file_name),
+						os.path.join(public_files, file_name))
 
-					self.file_url = "/files/{0}".format(self.file_name)
+					self.file_url = "/files/{0}".format(file_name)
 
 				else:
-					shutil.move(os.path.join(public_files, self.file_name),
-						os.path.join(private_files, self.file_name))
+					shutil.move(os.path.join(public_files, file_name),
+						os.path.join(private_files, file_name))
 
-					self.file_url = "/private/files/{0}".format(self.file_name)
+					self.file_url = "/private/files/{0}".format(file_name)
 
 				update_existing_file_docs(self)
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -100,8 +100,6 @@ class File(Document):
 				self.validate_file()
 			self.generate_content_hash()
 
-		self.validate_url()
-
 		if frappe.db.exists('File', {'name': self.name, 'is_folder': 0}):
 			old_file_url = self.file_url
 			if not self.is_folder and (self.is_private != self.db_get('is_private')):
@@ -136,6 +134,8 @@ class File(Document):
 				if self.attached_to_field:
 					frappe.db.set_value(self.attached_to_doctype, self.attached_to_name,
 						self.attached_to_field, self.file_url)
+
+		self.validate_url()
 
 		if self.file_url and (self.is_private != self.file_url.startswith('/private')):
 			frappe.throw(_('Invalid file URL. Please contact System Administrator.'))

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -911,12 +911,12 @@ def update_existing_file_docs(doc):
 	frappe.db.sql("""
 		UPDATE `tabFile`
 		SET
-			`tabFile`.file_url = '{file_url}',
-			`tabFile`.is_private = {is_private}
+			file_url = %(file_url)s,
+			is_private = %(is_private)s
 		WHERE
-			`tabFile`.content_hash = '{content_hash}'
-			and `tabFile`.name != '{file_name}'
-	""".format(
+			content_hash = %(content_hash)s
+			and name != %(file_name)s
+	""", dict(
 		file_url=doc.file_url,
 		is_private=doc.is_private,
 		content_hash=doc.content_hash,

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -294,4 +294,37 @@ class TestFile(unittest.TestCase):
 		folder = frappe.get_doc("File", "Home/Test Folder 1/Test Folder 3")
 		self.assertRaises(frappe.ValidationError, folder.delete)
 
+	def test_same_file_url_update(self):
+		attached_to_doctype1, attached_to_docname1 = make_test_doc()
+		attached_to_doctype2, attached_to_docname2 = make_test_doc()
+
+		file1 = frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'file1.txt',
+			"attached_to_doctype": attached_to_doctype1,
+			"attached_to_name": attached_to_docname1,
+			"is_private": 1,
+			"content": test_content1}).insert()
+
+		file2 = frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'file2.txt',
+			"attached_to_doctype": attached_to_doctype2,
+			"attached_to_name": attached_to_docname2,
+			"is_private": 1,
+			"content": test_content1}).insert()
+
+		self.assertEqual(file1.is_private, file2.is_private, 1)
+		self.assertEqual(file1.file_url, file2.file_url)
+		self.assertTrue(os.path.exists(file1.get_full_path()))
+
+		file1.is_private = 0
+		file1.save()
+
+		file2 = frappe.get_doc('File', file2.name)
+
+		self.assertEqual(file1.is_private, file2.is_private, 0)
+		self.assertEqual(file1.file_url, file2.file_url)
+		self.assertTrue(os.path.exists(file2.get_full_path()))
+
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -273,6 +273,7 @@ execute:frappe.delete_doc_if_exists('DocType', 'GCalendar Account')
 execute:frappe.delete_doc_if_exists('DocType', 'GCalendar Settings')
 frappe.patches.v12_0.remove_parent_and_parenttype_from_print_formats
 execute:from frappe.desk.page.setup_wizard.install_fixtures import update_genders;update_genders()
+frappe.patches.v12_0.set_correct_url_in_files
 frappe.patches.v13_0.website_theme_custom_scss
 frappe.patches.v13_0.set_existing_dashboard_charts_as_public
 frappe.patches.v13_0.set_path_for_homepage_in_web_page_view

--- a/frappe/patches/v12_0/set_correct_url_in_files.py
+++ b/frappe/patches/v12_0/set_correct_url_in_files.py
@@ -1,0 +1,29 @@
+import frappe
+import os
+
+def execute():
+	files = frappe.get_all('File', filters={'is_folder': 0})
+	for file in files:
+		doc = frappe.get_doc('File', file.name)
+		file_name = doc.file_url.split('/')[-1]
+		private_file_path = frappe.get_site_path('private', 'files')
+		public_file_path = frappe.get_site_path('public', 'files')
+
+		file_path = doc.file_url or doc.file_name
+		if '/' not in file_path:
+			file_path = '/files/' + file_path
+
+		full_path = doc.get_full_path()
+
+		if not os.path.exists(full_path):
+			if file_path.startswith('/private/files/'):
+				public_file_url = os.path.join(public_file_path, file_name)
+				if os.path.exists(public_file_url):
+					frappe.db.set_value('File', doc.name, 'file_url', '/files/{0}'.format(file_name))
+					frappe.db.set_value('File', doc.name, 'is_private', 0)
+
+			elif file_path.startswith('/files/'):
+				private_file_url = os.path.join(private_file_path, file_name)
+				if os.path.exists(private_file_url):
+					frappe.db.set_value('File', doc.name, 'file_url', '/private/files/{0}'.format(file_name))
+					frappe.db.set_value('File', doc.name, 'is_private', 1)

--- a/frappe/patches/v12_0/set_correct_url_in_files.py
+++ b/frappe/patches/v12_0/set_correct_url_in_files.py
@@ -2,18 +2,25 @@ import frappe
 import os
 
 def execute():
-	files = frappe.get_all('File', filters={'is_folder': 0})
+	files = frappe.get_all(
+		'File',
+		fields = ['name', 'file_name', 'file_url'],
+		filters = {
+			'is_folder': 0,
+			'file_url': ['!=', '']
+		}
+	)
+
 	for file in files:
-		doc = frappe.get_doc('File', file.name)
-		file_name = doc.file_url.split('/')[-1]
+		file_name = file.file_url.split('/')[-1]
 		private_file_path = frappe.get_site_path('private', 'files')
 		public_file_path = frappe.get_site_path('public', 'files')
 
-		file_path = doc.file_url or doc.file_name
+		file_path = file.file_url or file.file_name
 		if '/' not in file_path:
 			file_path = '/files/' + file_path
 
-		full_path = doc.get_full_path()
+		full_path = get_full_path(file_path)
 
 		if not os.path.exists(full_path):
 			if file_path.startswith('/private/files/'):
@@ -21,7 +28,7 @@ def execute():
 				if os.path.exists(public_file_url):
 					frappe.db.set_value(
 						'File',
-						doc.name,
+						file.name,
 						{
 							'file_url': '/files/{0}'.format(file_name),
 							'is_private': 0
@@ -34,7 +41,7 @@ def execute():
 				if os.path.exists(private_file_url):
 					frappe.db.set_value(
 						'File',
-						doc.name,
+						file.name,
 						{
 							'file_url': '/private/files/{0}'.format(file_name),
 							'is_private': 1
@@ -42,3 +49,14 @@ def execute():
 						update_modified=False
 					)
 
+def get_full_path(file_path):
+	if file_path.startswith("/private/files/"):
+		file_path = frappe.utils.get_files_path(*file_path.split("/private/files/", 1)[1].split("/"), is_private=1)
+
+	elif file_path.startswith("/files/"):
+		file_path = frappe.utils.get_files_path(*file_path.split("/files/", 1)[1].split("/"))
+
+	else:
+		pass
+
+	return file_path

--- a/frappe/patches/v12_0/set_correct_url_in_files.py
+++ b/frappe/patches/v12_0/set_correct_url_in_files.py
@@ -19,11 +19,26 @@ def execute():
 			if file_path.startswith('/private/files/'):
 				public_file_url = os.path.join(public_file_path, file_name)
 				if os.path.exists(public_file_url):
-					frappe.db.set_value('File', doc.name, 'file_url', '/files/{0}'.format(file_name))
-					frappe.db.set_value('File', doc.name, 'is_private', 0)
+					frappe.db.set_value(
+						'File',
+						doc.name,
+						{
+							'file_url': '/files/{0}'.format(file_name),
+							'is_private': 0
+						},
+						update_modified=False
+					)
 
 			elif file_path.startswith('/files/'):
 				private_file_url = os.path.join(private_file_path, file_name)
 				if os.path.exists(private_file_url):
-					frappe.db.set_value('File', doc.name, 'file_url', '/private/files/{0}'.format(file_name))
-					frappe.db.set_value('File', doc.name, 'is_private', 1)
+					frappe.db.set_value(
+						'File',
+						doc.name,
+						{
+							'file_url': '/private/files/{0}'.format(file_name),
+							'is_private': 1
+						},
+						update_modified=False
+					)
+

--- a/frappe/patches/v12_0/set_correct_url_in_files.py
+++ b/frappe/patches/v12_0/set_correct_url_in_files.py
@@ -2,61 +2,38 @@ import frappe
 import os
 
 def execute():
-	files = frappe.get_all(
-		'File',
+	files = frappe.get_all('File',
 		fields = ['name', 'file_name', 'file_url'],
 		filters = {
 			'is_folder': 0,
-			'file_url': ['!=', '']
-		}
-	)
+			'file_url': ['!=', ''],
+		})
+
+	private_file_path = frappe.get_site_path('private', 'files')
+	public_file_path = frappe.get_site_path('public', 'files')
 
 	for file in files:
-		file_name = file.file_url.split('/')[-1]
-		private_file_path = frappe.get_site_path('private', 'files')
-		public_file_path = frappe.get_site_path('public', 'files')
+		file_path = file.file_url
+		file_name = file_path.split('/')[-1]
+		
+		if not file_path.startswith(('/private/', '/files/')):
+			continue
 
-		file_path = file.file_url or file.file_name
-		if '/' not in file_path:
-			file_path = '/files/' + file_path
-
-		full_path = get_full_path(file_path)
+		file_is_private = file_path.startswith('/private/files/')
+		full_path = frappe.utils.get_files_path(file_name, is_private=file_is_private)
 
 		if not os.path.exists(full_path):
-			if file_path.startswith('/private/files/'):
+			if file_is_private:
 				public_file_url = os.path.join(public_file_path, file_name)
 				if os.path.exists(public_file_url):
-					frappe.db.set_value(
-						'File',
-						file.name,
-						{
-							'file_url': '/files/{0}'.format(file_name),
-							'is_private': 0
-						},
-						update_modified=False
-					)
-
-			elif file_path.startswith('/files/'):
+					frappe.db.set_value('File', file.name, {
+						'file_url': '/files/{0}'.format(file_name),
+						'is_private': 0
+					})
+			else:
 				private_file_url = os.path.join(private_file_path, file_name)
 				if os.path.exists(private_file_url):
-					frappe.db.set_value(
-						'File',
-						file.name,
-						{
-							'file_url': '/private/files/{0}'.format(file_name),
-							'is_private': 1
-						},
-						update_modified=False
-					)
-
-def get_full_path(file_path):
-	if file_path.startswith("/private/files/"):
-		file_path = frappe.utils.get_files_path(*file_path.split("/private/files/", 1)[1].split("/"), is_private=1)
-
-	elif file_path.startswith("/files/"):
-		file_path = frappe.utils.get_files_path(*file_path.split("/files/", 1)[1].split("/"))
-
-	else:
-		pass
-
-	return file_path
+					frappe.db.set_value('File', file.name, {
+						'file_url': '/private/files/{0}'.format(file_name),
+						'is_private': 1
+					})


### PR DESCRIPTION
**Issue:**
If a file doc's `is_private` value is updated, the file is moved and the path is changed. Any other file docs (attached to different documents such as amended docs) that point to the same file cannot then be updated since the file won't exist at the path set for those docs, causing:
<img width="1218" alt="Screenshot 2020-06-28 at 12 59 34 PM" src="https://user-images.githubusercontent.com/19775888/85941225-3ca8e000-b93f-11ea-8c01-2516a852e48e.png">

**Fix:**
Update file url and `is_private` value of all file docs that point to the same file on `is_private` being updated.
Also, a patch is needed to set the correct url in all such existing file documents.

port-of: https://github.com/frappe/frappe/pull/10841