### PR TITLE
fix: Initialize git repository after creating app

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -98,7 +98,13 @@ def make_boilerplate(dest, app_name):
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "config", "docs.py"), "w") as f:
 		f.write(frappe.as_unicode(docs_template.format(**hooks)))
 
-	print("'{app}' created at {path}".format(app=app_name, path=os.path.join(dest, app_name)))
+	# initialize git
+	app_directory = os.path.join(dest, hooks.app_name)
+	frappe.commands.popen('git init', cwd=app_directory)
+	frappe.commands.popen('git add .', cwd=app_directory)
+	frappe.commands.popen('git commit -m "Initialize app"', cwd=app_directory)
+
+	print("'{app}' created at {path}".format(app=app_name, path=app_directory))
 
 
 manifest_template = """include MANIFEST.in

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals, print_function
 
 from six.moves import input
 
-import frappe, os, re
+import frappe, os, re, git
 from frappe.utils import touch_file, cstr
 
 def make_boilerplate(dest, app_name):
@@ -98,11 +98,11 @@ def make_boilerplate(dest, app_name):
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "config", "docs.py"), "w") as f:
 		f.write(frappe.as_unicode(docs_template.format(**hooks)))
 
-	# initialize git
+	# initialize git repository
 	app_directory = os.path.join(dest, hooks.app_name)
-	frappe.commands.popen('git init', cwd=app_directory)
-	frappe.commands.popen('git add .', cwd=app_directory)
-	frappe.commands.popen('git commit -m "Initialize app"', cwd=app_directory)
+	app_repo = git.Repo.init(app_directory)
+	app_repo.git.add(A=True)
+	app_repo.index.commit("feat: Initialize App")
 
 	print("'{app}' created at {path}".format(app=app_name, path=app_directory))
 


### PR DESCRIPTION
```bash
▶ bench new-app test
App Title (default: Test):
App Description: Test
App Publisher: Test
App Publisher: Test
App Email: Test
App Icon (default 'octicon octicon-file-directory'):
App Color (default 'grey'):
App License (default 'MIT'):
Initialized empty Git repository in /Users/farisansari/Projects/benches/frappe-bench/apps/test/.git/
[master (root-commit) 5d71761] Initialize app
 16 files changed, 221 insertions(+)
 create mode 100644 .gitignore
 create mode 100644 MANIFEST.in
 create mode 100644 README.md
 create mode 100644 license.txt
 create mode 100644 requirements.txt
 create mode 100644 setup.py
 create mode 100644 test/__init__.py
 create mode 100644 test/config/__init__.py
 create mode 100644 test/config/desktop.py
 create mode 100644 test/config/docs.py
 create mode 100644 test/hooks.py
 create mode 100644 test/modules.txt
 create mode 100644 test/patches.txt
 create mode 100644 test/templates/__init__.py
 create mode 100644 test/templates/pages/__init__.py
 create mode 100644 test/test/__init__.py
'test' created at /Users/farisansari/Projects/benches/frappe-bench/apps/test

Installing test
$ ./env/bin/pip install -q -U -e ./apps/test
$ bench build --app test
yarn run v1.22.4
$ node rollup/build.js --app test
Development mode
✔ Built js/moment-bundle.min.js
✔ Built js/libs.min.js
✨  Done in 0.95s.
```