### PR TITLE
fix: Datetime field description

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -20,8 +20,6 @@ frappe.ui.form.ControlDatetime = frappe.ui.form.ControlDate.extend({
 		if (!frappe.datetime.is_timezone_same()) {
 			if (!description) {
 				this.df.description = time_zone;
-			} else if (!description.includes(time_zone)) {
-				this.df.description += '<br>' + time_zone;
 			}
 		}
 		this._super();

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -17,9 +17,11 @@ frappe.ui.form.ControlDatetime = frappe.ui.form.ControlDate.extend({
 	set_description: function() {
 		const { description } = this.df;
 		const { time_zone } = frappe.sys_defaults;
-		if (!frappe.datetime.is_timezone_same()) {
+		if (!this.df.hide_timezone && !frappe.datetime.is_timezone_same()) {
 			if (!description) {
 				this.df.description = time_zone;
+			} else if (!description.includes(time_zone)) {
+				this.df.description += '<br>' + time_zone;
 			}
 		}
 		this._super();


### PR DESCRIPTION
Currently if User's timezone and System's Timezone is different than the System's Time Zone gets added in the description of the Datetime field and is impossible to remove or alter if the time that is displayed in the field is based on some other time than the System's Time and is misleading to the viewer.

This PR assumes that if the user is using the datetime field to display time based on other timezones than the system timezone, then it will be the users responsibility to update the description accordingly and leaves it at their discretion 