### PR TITLE
fix(patch): create new docs for customized standard dashboards

### DIFF
--- a/frappe/desk/doctype/dashboard/dashboard.json
+++ b/frappe/desk/doctype/dashboard/dashboard.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_rename": 1,
  "autoname": "field:dashboard_name",
  "creation": "2019-01-10 12:54:40.938705",
  "doctype": "DocType",
@@ -35,11 +36,11 @@
    "reqd": 1
   },
   {
-    "description": "Set Default Options for all charts on this Dashboard (Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"])",
-    "fieldname": "chart_options",
-    "fieldtype": "Code",
-    "label": "Chart Options",
-    "options": "JSON"
+   "description": "Set Default Options for all charts on this Dashboard (Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"])",
+   "fieldname": "chart_options",
+   "fieldtype": "Code",
+   "label": "Chart Options",
+   "options": "JSON"
   },
   {
    "fieldname": "cards",
@@ -49,8 +50,8 @@
   }
  ],
  "links": [],
- "modified": "2020-04-29 13:26:37.362482",
- "modified_by": "Administrator",
+ "modified": "2020-07-10 17:48:19.468813",
+ "modified_by": "umair@erpnext.com",
  "module": "Desk",
  "name": "Dashboard",
  "owner": "Administrator",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_rename": 1,
  "creation": "2020-04-15 18:06:39.444683",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -98,7 +99,7 @@
   }
  ],
  "links": [],
- "modified": "2020-05-06 19:47:57.753574",
+ "modified": "2020-07-10 17:55:35.873222",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -293,3 +293,4 @@ execute:frappe.delete_doc("DocType", "Onboarding Slide Help Link")
 frappe.patches.v13_0.update_date_filters_in_user_settings
 frappe.patches.v13_0.update_duration_options
 frappe.patches.v13_0.replace_old_data_import # 2020-06-24
+frappe.patches.v13_0.create_custom_dashboards_cards_and_charts

--- a/frappe/patches/v13_0/create_custom_dashboards_cards_and_charts.py
+++ b/frappe/patches/v13_0/create_custom_dashboards_cards_and_charts.py
@@ -1,5 +1,4 @@
 import frappe
-import json
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils.dashboard import get_dashboards_with_link
 
@@ -41,6 +40,6 @@ def rename_modified_doc(docname, doctype):
 	new_name = docname + ' Custom'
 	try:
 		frappe.rename_doc(doctype, docname, new_name)
-	except:
+	except frappe.ValidationError:
 		new_name = append_number_if_name_exists(doctype, new_name)
 		frappe.rename_doc(doctype, docname, new_name)

--- a/frappe/patches/v13_0/create_custom_dashboards_cards_and_charts.py
+++ b/frappe/patches/v13_0/create_custom_dashboards_cards_and_charts.py
@@ -1,0 +1,46 @@
+import frappe
+import json
+from frappe.model.naming import append_number_if_name_exists
+from frappe.utils.dashboard import get_dashboards_with_link
+
+def execute():
+	if not frappe.db.table_exists('Dashboard Chart')\
+		or not frappe.db.table_exists('Number Card')\
+		or not frappe.db.table_exists('Dashboard'):
+		return
+
+	frappe.reload_doc('desk', 'doctype', 'dashboard_chart')
+	frappe.reload_doc('desk', 'doctype', 'number_card')
+	frappe.reload_doc('desk', 'doctype', 'dashboard')
+
+	modified_charts = get_modified_docs('Dashboard Chart')
+	modified_cards = get_modified_docs('Number Card')
+	modified_dashboards = [doc.name for doc in get_modified_docs('Dashboard')]
+
+	for chart in modified_charts:
+		modified_dashboards += get_dashboards_with_link(chart.name, 'Dashboard Chart')
+		rename_modified_doc(chart.name, 'Dashboard Chart')
+
+	for card in modified_cards:
+		modified_dashboards += get_dashboards_with_link(card.name, 'Number Card')
+		rename_modified_doc(card.name, 'Number Card')
+
+	modified_dashboards = list(set(modified_dashboards))
+
+	for dashboard in modified_dashboards:
+		rename_modified_doc(dashboard, 'Dashboard')
+
+def get_modified_docs(doctype):
+	return frappe.get_all(doctype,
+		filters = {
+			'owner': 'Administrator',
+			'modified_by': ['!=', 'Administrator']
+		})
+
+def rename_modified_doc(docname, doctype):
+	new_name = docname + ' Custom'
+	try:
+		frappe.rename_doc(doctype, docname, new_name)
+	except:
+		new_name = append_number_if_name_exists(doctype, new_name)
+		frappe.rename_doc(doctype, docname, new_name)

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -74,6 +74,26 @@ def get_from_date_from_timespan(to_date, timespan):
 	return add_to_date(to_date, years=years, months=months, days=days,
 		as_datetime=True)
 
+def get_dashboards_with_link(docname, doctype):
+	dashboards = []
+	links = []
+
+	if doctype == 'Dashboard Chart':
+		links = frappe.get_all('Dashboard Chart Link',
+			fields = ['parent'],
+			filters = {
+				'chart': docname
+			})
+	elif doctype == 'Number Card':
+		links = frappe.get_all('Number Card Link',
+			fields = ['parent'],
+			filters = {
+				'card': docname
+			})
+
+	dashboards = [link.parent for link in links]
+	return dashboards
+
 def sync_dashboards(app=None):
 	"""Import, overwrite fixtures from `[app]/fixtures`"""
 	if not cint(frappe.db.get_single_value('System Settings', 'setup_complete')):


### PR DESCRIPTION
Patch to create new documents for dashboards, charts or number cards that have been edited, so that the changes can be preserved after the next migrate.

After #10585 documents set as standard will only be editable in developer mode.