### PR TITLE
fix(image-with-blur): Set width, height in CSS

### DIFF
--- a/frappe/templates/includes/image_with_blur.html
+++ b/frappe/templates/includes/image_with_blur.html
@@ -1,7 +1,9 @@
 {%- set res = frappe.utils.get_thumbnail_base64_for_image(src) if src else false -%}
 {%- if res and res['base64'].startswith('data:') -%}
 <img src="{{ res['base64'] }}" class="image-with-blur {{ resolve_class(class) }}"
-	alt="{{ alt or '' }}" width="{{ res['width'] }}" height="{{ res['height'] }}" data-src="{{ src or '' }}" />
+	data-src="{{ src or '' }}" alt="{{ alt or '' }}"
+	width="{{ res['width'] }}" height="{{ res['height'] }}"
+	style="width: {{ res['width'] }}px; height: {{ res['height'] }}px;" />
 {%- else -%}
 <img src="{{ src or '' }}" class="{{ resolve_class(class) }}" alt="{{ alt or '' }}" />
 {%- endif -%}


### PR DESCRIPTION
This will fix the issue in **Hero with Right Image** template, where the text jumps into place when the image is loaded.