### PR TITLE
fix: Properly retain whitespace sequence

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -199,6 +199,8 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 
 	get_input_value() {
 		let value = this.quill ? this.quill.root.innerHTML : '';
+		// hack to retain space sequence.
+		value = value.replace(/(\s)(\s)/g, ' &nbsp;');
 		return value;
 	},
 

--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -10,10 +10,6 @@
 }
 
 .ql-editor {
-	white-space: normal;
-}
-
-.ql-editor {
 	font-family: @font-stack;
 	line-height: 1.6;
 


### PR DESCRIPTION
fixes https://github.com/frappe/frappe/issues/10896

**Before:**
![space_sequence_bug](https://user-images.githubusercontent.com/13928957/87288751-62c2a880-c519-11ea-8978-0f238ae5227a.gif)


**After:**
![space_sequence_fix](https://user-images.githubusercontent.com/13928957/87288769-67875c80-c519-11ea-9d43-25594f2989f6.gif)


The issue was introduced via https://github.com/frappe/frappe/pull/10598
