### PR TITLE
fix: dont set '__unsaved' for single doctypes

### DIFF
--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -45,7 +45,9 @@ def make_new_doc(doctype):
 	doc = doc.get_valid_dict(sanitize=False)
 	doc["doctype"] = doctype
 	doc["__islocal"] = 1
-	doc["__unsaved"] = 1
+
+	if not frappe.model.meta.is_single(doctype):
+		doc["__unsaved"] = 1
 
 	return doc
 


### PR DESCRIPTION
**Before:**
![Screenshot 2020-07-13 at 5 44 32 PM](https://user-images.githubusercontent.com/36654812/87303510-eb007800-c530-11ea-822e-10126a4c393e.png)
![Screenshot 2020-07-13 at 5 44 41 PM](https://user-images.githubusercontent.com/36654812/87303512-ec31a500-c530-11ea-9ad1-3f305afaef31.png)

**After:**
![Screenshot 2020-07-13 at 5 47 58 PM](https://user-images.githubusercontent.com/36654812/87303563-03709280-c531-11ea-8367-7e6ff1a6495b.png)
![Screenshot 2020-07-13 at 5 43 29 PM](https://user-images.githubusercontent.com/36654812/87303498-e76cf100-c530-11ea-8152-7ed002387bcd.png)

