### PR TITLE
fix: Total Row in Reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -861,8 +861,19 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				if (column.isHeader && !data && this.data) {
 					// totalRow doesn't have a data object
 					// proxy it using the first data object
-					// this is needed only for currency formatting
-					data = this.data[0];
+					// applied to Float, Currency fields, needed only for currency formatting.
+					// make first data column have value 'Total'
+					let index = 1;
+					if (this.datatable && this.datatable.options.checkboxColumn) index = 2;
+
+					if (column.colIndex === index && !value) {
+						value = "Total";
+						column.fieldtype = "Data"; // avoid type issues for value if Date column
+					}
+					else if (in_list(["Currency", "Float"], column.fieldtype)) {
+						// proxy for currency and float
+						data = this.data[0];
+					}
 				}
 				return frappe.format(value, column,
 					{for_print: false, always_show_decimals: true}, data);

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -869,8 +869,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					if (column.colIndex === index && !value) {
 						value = "Total";
 						column.fieldtype = "Data"; // avoid type issues for value if Date column
-					}
-					else if (in_list(["Currency", "Float"], column.fieldtype)) {
+					} else if (in_list(["Currency", "Float"], column.fieldtype)) {
 						// proxy for currency and float
 						data = this.data[0];
 					}


### PR DESCRIPTION
## **Issue:**
- ![Screenshot 2020-07-13 at 7 32 33 PM](https://user-images.githubusercontent.com/25857446/87313247-3d489580-c53f-11ea-8bf5-23eb5c6b3258.png)
- While formatting cells in query_report.js, the first row is sent as proxy data object for the _total_ row , as it doesn't have it's own data object
- Due to this, Link fields with link_formatters and `null` value are assigned a value from the proxy object i.e. the first row 

## **Fix:**
- ![Screenshot 2020-07-13 at 7 23 57 PM](https://user-images.githubusercontent.com/25857446/87313666-d5df1580-c53f-11ea-8014-b391433d86bb.png)
- Send proxy object only for Currency and Float fieldtypes, since it was a hack for currency formatting (i checked, proxy is only used in Float and Currency in `formatters.js`)
- Make the first data column have the value **Total**. First data column Index for normal reports will be 1, but for reports with checkboxes in the rows its 2
- Line 871 is a small hack to avoid type issues as Date or Datetime columns perform date oriented formatting on **value**. **Data** wont give type issues

## **Impact:**
- In Report with checkbox column
  ![Screenshot 2020-07-13 at 7 53 02 PM](https://user-images.githubusercontent.com/25857446/87315910-a4b41480-c542-11ea-9baa-ecd4b756b37e.png)

- In currency formatting(for which the original hack was done)
 ![Screenshot 2020-07-13 at 7 55 04 PM](https://user-images.githubusercontent.com/25857446/87315918-a978c880-c542-11ea-8db8-3285a39b576b.png)
