### PR TITLE
fix(pdf): Use non-pretty version of HTML for pdf generation

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -137,7 +137,7 @@ def read_options_from_html(html):
 		except:
 			pass
 
-	return soup.prettify(), options
+	return str(soup), options
 
 
 def prepare_header_footer(soup):


### PR DESCRIPTION
Use non-pretty version of HTML for pdf generation.

For some reason, the prettified version of HTML results in weird PDF output.

BeautifulSoup's official documentation suggests avoiding `prettify` as it changes the meaning of an HTML document.

**ref:** 
https://www.crummy.com/software/BeautifulSoup/bs4/doc/#pretty-printing
https://www.crummy.com/software/BeautifulSoup/bs4/doc/#non-pretty-printing

---

**Print preview:**
<img width="1440" alt="Screenshot 2020-07-14 at 4 25 18 PM" src="https://user-images.githubusercontent.com/13928957/87419053-6ffe9680-c5f0-11ea-8f8b-b2853567c5b8.png">

**PDF (with `soup.prettify()`)**
<img width="1439" alt="Screenshot 2020-07-14 at 4 25 03 PM" src="https://user-images.githubusercontent.com/13928957/87419062-742ab400-c5f0-11ea-94f2-971f3954a35f.png">

**PDF (with `str(soup)`)**
<img width="1440" alt="Screenshot 2020-07-14 at 4 25 12 PM" src="https://user-images.githubusercontent.com/13928957/87419057-71c85a00-c5f0-11ea-8f22-d43f8d8232f5.png">