### PR TITLE
fix: redirect get_value to use get_list

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -85,7 +85,7 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 	if not filters:
 		filters = None
 
-	return frappe.db.get_value(doctype, filters, fieldname, as_dict=as_dict, debug=debug)
+	return frappe.db.get_value(doctype, filters, fieldname, as_dict=as_dict, debug=debug, ignore_permissions=False)
 
 @frappe.whitelist()
 def get_single_value(doctype, field):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -7,7 +7,6 @@
 from __future__ import unicode_literals
 
 import re
-import time
 import frappe
 import datetime
 import frappe.defaults
@@ -15,10 +14,9 @@ import frappe.model.meta
 
 from frappe import _
 from time import time
-from frappe.utils import now, getdate, cast_fieldtype, get_datetime
+from frappe.utils import now, getdate, cast_fieldtype, get_datetime, cint, cstr
 from frappe.utils.background_jobs import execute_job, get_queue
 from frappe.model.utils.link_count import flush_local_link_count
-from frappe.utils import cint, cstr
 
 # imports - compatibility imports
 from six import (

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -38,8 +38,12 @@ def get_controller(doctype):
 	global _classes
 
 	if not doctype in _classes:
-		module_name, custom = frappe.db.get_value("DocType", doctype, ("module", "custom"), cache=True) \
-			or ["Core", False]
+		module_name, custom = ["Core", False]
+		module_query = frappe.db.sql("""SELECT module, custom from `tabDocType`
+WHERE `name`=%(doctype)s""", {"doctype": doctype})
+
+		if module_query:
+			module_name, custom = module_query[0]
 
 		if custom:
 			if frappe.db.field_exists("DocType", "is_tree"):


### PR DESCRIPTION
* redirect get_value to the orm get_list
* use sql instead of orm to get meta, potentially giving a huge performance boost. this seems to be an optimal solution not just because raw sql is faster in this case, but also because currently `get_meta` calls get_value and get_value calls sql, but since replacing sql with `get_list`, there's an infinite recursion as `get_list` also calls `get_meta`. so not only does raw sql perform faster, it potentially reduces multiple calls that aren't really required. if you do not understand: code go brrrrrr.
* remove unused sql function