### PR TITLE
fix: set form perm only for standard reports

### DIFF
--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Report', {
 	refresh: function(frm) {
-		if(!frappe.boot.developer_mode && frappe.session.user !== 'Administrator') {
+		if (frm.doc.is_standard && !frappe.boot.developer_mode) {
 			// make the document read-only
 			frm.set_read_only();
 		}


### PR DESCRIPTION
Users were not allowed to create reports via the form even if permissions were given. This was because of bad conditions that set each report to read only. This PR fixes this by updating the condition that depends on server validation solely.

![image](https://user-images.githubusercontent.com/18097732/87446319-c5e63500-c616-11ea-98d0-2b5143c20e87.png)
