### PR TITLE
fix: don't allow users to remove ID column from report view

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -768,10 +768,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		const index = this.fields.findIndex(f => column.field === f[0]);
 		if (index === -1) return;
 		const field = this.fields[index];
-		if (field[0] === 'name' && this.group_by === null) {
+
+		if (field[0] === 'name') {
 			this.refresh();
 			frappe.throw(__('Cannot remove ID field'));
 		}
+
 		this.fields.splice(index, 1);
 		this.build_fields();
 		this.setup_columns();

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -852,7 +852,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			columns: 2,
 			options: columns[this.doctype]
 				.filter(df => {
-					return !df.hidden;
+					return !df.hidden && df.fieldname !== 'name';
 				})
 				.map(df => ({
 					label: __(df.label),


### PR DESCRIPTION
Removing ID column from datatable would break reference to name, causing set_value to break

### Steps to reproduce
In report builder, remove the ID column and try changing any value, for eg. Rate.
set_value()  does not get ID or name due to which it breaks.

![image](https://user-images.githubusercontent.com/18097732/87451316-5889d280-c61d-11ea-8e8c-307b1c39d611.png)
