### PR TITLE
fix: Strip HTML from notification subject

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -69,7 +69,6 @@ def make_notification_logs(doc, users):
 				_doc = frappe.new_doc('Notification Log')
 				_doc.update(doc)
 				_doc.for_user = user
-				_doc.subject = _doc.subject.replace('<div>', '').replace('</div>', '')
 				if _doc.for_user != _doc.from_user or doc.type == 'Energy Point' or doc.type == 'Alert':
 					_doc.insert(ignore_permissions=True)
 

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -309,7 +309,7 @@ frappe.ui.Notifications = class Notifications {
 		let mark_read_action = field.read ? '': 'data-action="mark_as_read"';
 		let message = field.subject;
 		let title = message.match(/<b class="subject-title">(.*?)<\/b>/);
-		message = title ? message.replace(title[1], frappe.ellipsis(title[1], 100)): message;
+		message = title ? message.replace(title[1], frappe.ellipsis(strip_html(title[1]), 100)) : message;
 		let message_html = `<div class="message">${message}</div>`;
 		let user = field.from_user;
 		let user_avatar = frappe.avatar(user, 'avatar-small user-avatar');


### PR DESCRIPTION
**Before:**
<img width="488" alt="Screenshot 2020-07-15 at 1 16 23 PM" src="https://user-images.githubusercontent.com/13928957/87518077-6d0daf80-c69d-11ea-99ab-1383f3affa36.png">

**After:**
<img width="478" alt="Screenshot 2020-07-15 at 1 16 36 PM" src="https://user-images.githubusercontent.com/13928957/87518094-739c2700-c69d-11ea-8988-d4c8f90a8e11.png">

