### PR TITLE
fix: Markdown content in Blog Post

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -9,7 +9,7 @@ import frappe
 
 from six import iteritems
 from past.builtins import cmp
-from frappe.utils import markdown
+from frappe.utils import md_to_html
 
 
 def delete_page_cache(path):
@@ -357,7 +357,7 @@ def get_html_content_based_on_type(doc, fieldname, content_type):
 		content = doc.get(fieldname)
 
 		if content_type == 'Markdown':
-			content = markdown(doc.get(fieldname + '_md'))
+			content = md_to_html(doc.get(fieldname + '_md'))
 		elif content_type == 'HTML':
 			content = doc.get(fieldname + '_html')
 


### PR DESCRIPTION
`markdown` checks if the content is html, if not, converts to markdown. This breaks when there are html tags in markdown. Instead we can use `md_to_html` directly.
