### PR TITLE
fix: Add share perm in set_read_only

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1400,10 +1400,13 @@ frappe.ui.form.Form = class FrappeForm {
 		var docperms = frappe.perm.get_perm(this.doc.doctype);
 		for (var i=0, l=docperms.length; i<l; i++) {
 			var p = docperms[i];
-			perm[p.permlevel || 0] = {read:1, print:1, cancel:1, email:1};
-			if (p.share) {
-				perm[p.permlevel || 0].share = 1;
-			}
+			perm[p.permlevel || 0] = {
+				read: p.read,
+				cancel: p.cancel,
+				share: p.share,
+				print: p.print,
+				email: p.email
+			};
 		}
 		this.perm = perm;
 	}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1401,6 +1401,9 @@ frappe.ui.form.Form = class FrappeForm {
 		for (var i=0, l=docperms.length; i<l; i++) {
 			var p = docperms[i];
 			perm[p.permlevel || 0] = {read:1, print:1, cancel:1, email:1};
+			if (p.share) {
+				perm[p.permlevel || 0].share = 1;
+			}
 		}
 		this.perm = perm;
 	}


### PR DESCRIPTION
Allow share permission in read only mode for workflow, if user has share permission.