### PR TITLE
fix: extend render_list in kanban view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1074,7 +1074,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					});
 					this.toggle_result_area();
 					this.render_list();
-					if (this.$checks.length) {
+					if (this.$checks && this.$checks.length) {
 						this.set_rows_as_checked();
 					}
 				});

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -73,6 +73,10 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		});
 	}
 
+	render_list() {
+
+	}
+
 	on_filter_change() {
 		if (JSON.stringify(this.board.filters_array) !== JSON.stringify(this.filter_area.get())) {
 			this.page.set_indicator(__('Not Saved'), 'orange');


### PR DESCRIPTION
Fixes:
<img width="1440" alt="Screenshot 2020-07-15 at 6 24 17 PM" src="https://user-images.githubusercontent.com/19775888/87547219-6b0d1600-c6c8-11ea-9e6c-c5aad03a1ea9.png">


Due to this, new cards couldn't be added to a Kanban.

fixes 
https://github.com/frappe/erpnext/issues/22737
https://github.com/frappe/frappe/issues/11046