### PR TITLE
feat(Desktop): Allow Desk Shortcuts for arbitrary routes

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -164,9 +164,7 @@ class Workspace:
 			return (name in self.allowed_pages and name in self.restricted_pages)
 		if item_type == "report":
 			return name in self.allowed_reports
-		if item_type == "help":
-			return True
-		if item_type == "dashboard":
+		if item_type in ["help", "dashboard", "route"]:
 			return True
 
 		return False
@@ -305,6 +303,8 @@ class Workspace:
 						new_item['is_query_report'] = 1
 					else:
 						new_item['ref_doctype'] = report.get('ref_doctype')
+				elif item.type == "Route":
+					new_item['route'] = frappe.db.get_value('Route', item.link_to, 'route')
 
 				# Translate label
 				new_item["label"] = _(item.label) if item.label else _(item.link_to)

--- a/frappe/desk/doctype/desk_shortcut/desk_shortcut.json
+++ b/frappe/desk/doctype/desk_shortcut/desk_shortcut.json
@@ -23,7 +23,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Type",
-   "options": "DocType\nReport\nPage\nDashboard",
+   "options": "DocType\nReport\nPage\nDashboard\nRoute",
    "reqd": 1
   },
   {

--- a/frappe/desk/doctype/route/route.json
+++ b/frappe/desk/doctype/route/route.json
@@ -1,0 +1,41 @@
+{
+ "autoname": "Prompt",
+ "creation": "2020-07-14 15:32:48.124721",
+ "description": "The Route DocType simply provides a way to name specific destinations in the web interface, primarily for use in Desk Shortcuts",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "route"
+ ],
+ "fields": [
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Route",
+   "reqd": 1
+  }
+ ],
+ "modified": "2020-07-14 19:27:16.334528",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Route",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/frappe/desk/doctype/route/route.py
+++ b/frappe/desk/doctype/route/route.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+from frappe.model.document import Document
+
+class Route(Document):
+	pass

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -294,3 +294,4 @@ frappe.patches.v13_0.update_date_filters_in_user_settings
 frappe.patches.v13_0.update_duration_options
 frappe.patches.v13_0.replace_old_data_import # 2020-06-24
 frappe.patches.v13_0.create_custom_dashboards_cards_and_charts
+frappe.patches.v13_0.add_route_shortcut

--- a/frappe/patches/v13_0/add_route_shortcut.py
+++ b/frappe/patches/v13_0/add_route_shortcut.py
@@ -1,0 +1,8 @@
+import frappe
+
+def execute():
+	frappe.reload_doc('core', 'doctype', 'DocField')
+
+	frappe.db.sql("""UPDATE tabDocField set options='DocType\nReport\nPage\nDashboard\nRoute' where parent LIKE 'Desk Shortcut' and fieldname LIKE 'type'""")
+
+	frappe.clear_cache(doctype='DocField')

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -145,7 +145,7 @@ class ShortcutDialog extends WidgetDialog {
 				fieldname: "type",
 				label: "Type",
 				reqd: 1,
-				options: "DocType\nReport\nPage\nDashboard",
+				options: "DocType\nReport\nPage\nDashboard\nRoute",
 				onchange: () => {
 					if (this.dialog.get_value("type") == "DocType") {
 						this.dialog.fields_dict.link_to.get_query = () => {


### PR DESCRIPTION
  Since we generally have new contractors for most projects, the first step
  in entering almost all invoices is the creation of a new supplier. Hence,
  it was critical for us to have a direct shortcut to the New Supplier form
  on the Buying desk page. However, none of the previously existing
  Desk Shortcut types would support this; a DocType shortcut to Supplier
  would require an extra click on the New button, and the Page, Dashboard,
  and Report shortcut types are not helpful for this. Hence, this commit
  adds a new fifth type of shortcut, Route, which simply specifies a
  specific route for the shortcut to proceed to. This makes creating a
  "New Supplier" or many other sorts of shortcuts very easy.

  The commit involves creating the Route doctype, adding the additional
  type of Desk Shortcut, and a modicum of additional logic to look up
  the route via the Route document linked to in the shortcut.

  The screenshots below show the creation of a named Route, and the addition of a new shortcut to the Buying desktop page,

![Creating_Route_Screenshot_2020-07-15_22-02-09](https://user-images.githubusercontent.com/3825429/87629168-58560980-c6e7-11ea-8047-7166850e7c89.png)

![Add_Route_Shortcut_Screenshot_2020-07-15_22-04-29](https://user-images.githubusercontent.com/3825429/87629166-57bd7300-c6e7-11ea-93c2-0ceeb0abd3ec.png)
