### PR TITLE
fix: Canonical URL

### DIFF
--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -20,12 +20,10 @@ def get_context(path, args=None):
 		# for <body data-path=""> (remove leading slash)
 		# path could be overriden in render.resolve_from_map
 		context["path"] = frappe.local.request.path.strip('/ ')
-		scheme = frappe.local.request.scheme
 	else:
 		context["path"] = path
-		scheme = 'http'
 
-	context.canonical = scheme + '://' + frappe.local.site + '/' + frappe.utils.escape_html(context.path)
+	context.canonical = frappe.utils.get_url(frappe.utils.escape_html(context.path))
 	context.route = context.path
 	context = build_context(context)
 


### PR DESCRIPTION
If sitename is different from the URL than it is usually accessed, the canonical URL will be wrong.

For e.g
If sitename is `tennismart` but the site is accessed by `mytennismart.com` then the canonical URL is incorrect.

This fix uses `frappe.utils.get_url()` that uses the hostname value from site_config.

Original PR that introduced this change: https://github.com/frappe/frappe/pull/10604