### PR TITLE
fix: Edit in full page broken link

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -403,7 +403,14 @@ class Document(BaseDocument):
 
 	def set_new_name(self, force=False, set_name=None, set_child_names=True):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""
+
 		if self.flags.name_set and not force:
+			return
+
+		# If autoname has set as Prompt (name)
+		if self.get("__newname"):
+			self.name = self.get("__newname")
+			self.flags.name_set = True
 			return
 
 		if set_name:

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -240,13 +240,8 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 		var me = this;
 		var data = this.dialog.get_values(true);
 		$.each(data, function(key, value) {
-			if(key==='__newname') {
-				me.dialog.doc.name = value;
-			}
-			else {
-				if(!is_null(value)) {
-					me.dialog.doc[key] = value;
-				}
+			if(!is_null(value)) {
+				me.dialog.doc[key] = value;
 			}
 		});
 		return this.dialog.doc;

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -240,7 +240,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 		var me = this;
 		var data = this.dialog.get_values(true);
 		$.each(data, function(key, value) {
-			if(!is_null(value)) {
+			if (!is_null(value)) {
 				me.dialog.doc[key] = value;
 			}
 		});

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -277,7 +277,7 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 			field.doctype = me.doc.doctype;
 			field.docname = me.doc.name;
 
-			if(!is_null(me.doc[fieldname])) {
+			if (!is_null(me.doc[fieldname])) {
 				field.set_input(me.doc[fieldname]);
 			}
 		});


### PR DESCRIPTION
**Issue**

If doctype has autoname as "Prompt" and quick entry has enabled

<img width="935" alt="Screenshot 2020-07-16 at 1 28 20 PM" src="https://user-images.githubusercontent.com/8780500/87645487-2dad9480-c76b-11ea-90a7-203ce916c965.png">

<img width="1011" alt="Screenshot 2020-07-16 at 1 28 34 PM" src="https://user-images.githubusercontent.com/8780500/87645546-44ec8200-c76b-11ea-96fc-2166dadd8f93.png">


**After Fix**
![broken_link_after_fix](https://user-images.githubusercontent.com/8780500/87650162-da3d4580-c76e-11ea-9012-aed50d0b4f8e.gif)
