### PR TITLE
feat: Custom and Report type Number Card

### DIFF
--- a/frappe/desk/doctype/dashboard/dashboard.js
+++ b/frappe/desk/doctype/dashboard/dashboard.js
@@ -13,7 +13,6 @@ frappe.ui.form.on('Dashboard', {
 			return {
 				filters: {
 					is_public: 1,
-					is_standard: 1,
 				}
 			};
 		});
@@ -22,7 +21,6 @@ frappe.ui.form.on('Dashboard', {
 			return {
 				filters: {
 					is_public: 1,
-					is_standard: 1,
 				}
 			};
 		});

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -193,7 +193,7 @@ frappe.ui.form.on('Dashboard Chart', {
 
 			if (!frm.doc.is_custom) {
 				if (data.result.length) {
-					frm.field_options = frappe.report_utils.get_possible_chart_options(data.columns, data);
+					frm.field_options = frappe.report_utils.get_field_options_from_report(data.columns, data);
 					frm.set_df_property('x_field', 'options', frm.field_options.non_numeric_fields);
 					if (!frm.field_options.numeric_fields.length) {
 						frappe.msgprint(__(`Report has no numeric fields, please change the Report Name`));
@@ -435,49 +435,10 @@ frappe.ui.form.on('Dashboard Chart', {
 		frm.trigger('set_dynamic_filters_in_table');
 
 		let filters = JSON.parse(frm.doc.filters_json || '[]');
-		let fields = [
-			{
-				fieldtype: 'HTML',
-				fieldname: 'description',
-				options:
-					`<div>
-						<p>Set dynamic filter values in JavaScript for the required fields here.
-						</p>
-						<p>Ex:
-							<code>frappe.defaults.get_user_default("Company")</code>
-						</p>
-					</div>`
-			}
-		];
 
-		if (is_document_type) {
-			if (frm.dynamic_filters) {
-				filters = [...filters, ...frm.dynamic_filters];
-			}
-			filters.forEach(f => {
-				for (let field of fields) {
-					if (field.fieldname == f[0] + ':' + f[1]) {
-						return;
-					}
-				}
-				if (f[2] == '=') {
-					fields.push({
-						label: `${f[1]} (${f[0]})`,
-						fieldname: f[0] + ':' + f[1],
-						fieldtype: 'Data',
-					});
-				}
-			});
-		} else {
-			filters = {...frm.dynamic_filters, ...filters};
-			for (let key of Object.keys(filters)) {
-				fields.push({
-					label: key,
-					fieldname: key,
-					fieldtype: 'Data',
-				});
-			}
-		}
+		let fields = frappe.dashboard_utils.get_fields_for_dynamic_filter_dialog(
+			is_document_type, filters, frm.dynamic_filters
+		);
 
 		frm.dynamic_filter_table.on('click', () => {
 			let dialog = new frappe.ui.Dialog({

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -175,6 +175,9 @@ frappe.ui.form.on('Dashboard Chart', {
 
 	set_chart_field_options: function(frm) {
 		let filters = frm.doc.filters_json.length > 2 ? JSON.parse(frm.doc.filters_json) : null;
+		if (frm.doc.dynamic_filters_json.length > 2) {
+			filters = {...filters, ...JSON.parse(frm.doc.dynamic_filters_json)};
+		}
 		frappe.xcall(
 			'frappe.desk.query_report.run',
 			{

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -347,7 +347,7 @@ frappe.ui.form.on('Number Card', {
 
 	render_dynamic_filters_table(frm) {
 		if (!frappe.boot.developer_mode || !frm.doc.is_standard || frm.doc.type == 'Custom') {
-			return
+			return;
 		}
 
 		frm.set_df_property("dynamic_filters_section", "hidden", 0);

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -24,6 +24,7 @@ frappe.ui.form.on('Number Card', {
 			}
 			frm.filters = eval(frm.doc.filters_config);
 			frm.trigger('set_filters_description');
+			frm.trigger('render_filters_table');
 		}
 		frm.trigger('create_add_to_dashboard_button');
 	},
@@ -278,7 +279,6 @@ frappe.ui.form.on('Number Card', {
 				filters_set = true;
 			}
 		} else if (frm.filters.length) {
-			filters_set = true;
 			fields = frm.filters.filter(f => f.fieldname);
 			fields.map(f => {
 				if (filters[f.fieldname]) {
@@ -289,8 +289,8 @@ frappe.ui.form.on('Number Card', {
 							<td>${condition}</td>
 							<td>${filters[f.fieldname] || ""}</td>
 						</tr>`);
-
 					table.find('tbody').append(filter_row);
+					if (!filters_set) filters_set = true;
 				}
 			});
 		}
@@ -346,7 +346,7 @@ frappe.ui.form.on('Number Card', {
 	},
 
 	render_dynamic_filters_table(frm) {
-		if (!frappe.boot.developer_mode || !frm.doc.is_standard) {
+		if (!frappe.boot.developer_mode || !frm.doc.is_standard || frm.doc.type == 'Custom') {
 			return
 		}
 

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -112,7 +112,6 @@ frappe.ui.form.on('Number Card', {
 	},
 
 	set_method_description: function(frm) {
-		console.log('called');
 		if (frm.doc.type == 'Custom') {
 			frm.fields_dict.method.set_description(`
 		Set the path to a whitelisted function that will return the number on the card in the format:
@@ -122,7 +121,7 @@ frappe.ui.form.on('Number Card', {
 	"value": value,
 	"fieldtype": "Currency"
 }
-</code></pre>`)
+</code></pre>`);
 		}
 	},
 

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -24,6 +24,7 @@ frappe.ui.form.on('Number Card', {
 			}
 			frm.filters = eval(frm.doc.filters_config);
 			frm.trigger('set_filters_description');
+			frm.trigger('set_method_description');
 			frm.trigger('render_filters_table');
 		}
 		frm.trigger('create_add_to_dashboard_button');
@@ -107,6 +108,21 @@ frappe.ui.form.on('Number Card', {
 	reqd: 1
 }]
 </code></pre>`);
+		}
+	},
+
+	set_method_description: function(frm) {
+		console.log('called');
+		if (frm.doc.type == 'Custom') {
+			frm.fields_dict.method.set_description(`
+		Set the path to a whitelisted function that will return the number on the card in the format:
+<pre class="small text-muted">
+<code>
+{
+	"value": value,
+	"fieldtype": "Currency"
+}
+</code></pre>`)
 		}
 	},
 

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -18,6 +18,7 @@
   "column_break_2",
   "document_type",
   "report_field",
+  "report_function",
   "is_public",
   "custom_configuration_section",
   "filters_config",
@@ -180,10 +181,18 @@
    "fieldtype": "Code",
    "label": "Filters Configuration",
    "options": "JSON"
+  },
+  {
+   "depends_on": "eval: doc.type == 'Report'",
+   "fieldname": "report_function",
+   "fieldtype": "Select",
+   "label": "Function",
+   "mandatory_depends_on": "eval: doc.type == 'Report'",
+   "options": "Sum\nAverage\nMinimum\nMaximum"
   }
  ],
  "links": [],
- "modified": "2020-07-16 02:03:09.175701",
+ "modified": "2020-07-16 13:04:03.470001",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "allow_workflow": 1,
  "creation": "2020-04-15 18:06:39.444683",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -9,10 +10,13 @@
   "is_standard",
   "module",
   "label",
+  "type",
+  "report_name",
   "function",
   "aggregate_function_based_on",
   "column_break_2",
   "document_type",
+  "report_field",
   "is_public",
   "stats_section",
   "show_percentage_stats",
@@ -26,20 +30,21 @@
  ],
  "fields": [
   {
+   "depends_on": "eval: doc.type == 'Document Type'",
    "fieldname": "document_type",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Document Type",
-   "options": "DocType",
-   "reqd": 1
+   "mandatory_depends_on": "eval: doc.type == 'Document Type'",
+   "options": "DocType"
   },
   {
-   "depends_on": "eval: doc.document_type",
+   "depends_on": "eval: doc.type == 'Document Type'",
    "fieldname": "function",
    "fieldtype": "Select",
    "label": "Function",
-   "options": "Count\nSum\nAverage\nMinimum\nMaximum",
-   "reqd": 1
+   "mandatory_depends_on": "eval: doc.type == 'Document Type'",
+   "options": "Count\nSum\nAverage\nMinimum\nMaximum"
   },
   {
    "depends_on": "eval: doc.function !== 'Count'",
@@ -98,6 +103,7 @@
    "options": "Daily\nWeekly\nMonthly\nYearly"
   },
   {
+   "depends_on": "eval: doc.type == 'Document Type'",
    "fieldname": "stats_section",
    "fieldtype": "Section Break",
    "label": "Stats"
@@ -114,34 +120,47 @@
    "fieldtype": "Link",
    "label": "Module",
    "mandatory_depends_on": "eval: doc.is_standard",
-   "options": "Module Def",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Module Def"
   },
   {
    "fieldname": "dynamic_filters_json",
    "fieldtype": "Code",
    "label": "Dynamic Filters JSON",
-   "options": "JSON",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "JSON"
   },
   {
    "fieldname": "section_break_16",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "dynamic_filters_section",
    "fieldtype": "Section Break",
-   "label": "Dynamic Filters Section",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Dynamic Filters Section"
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "Document Type\nReport"
+  },
+  {
+   "depends_on": "eval: doc.type == 'Report'",
+   "fieldname": "report_name",
+   "fieldtype": "Link",
+   "label": "Report Name",
+   "mandatory_depends_on": "eval: doc.type == 'Report'",
+   "options": "Report"
+  },
+  {
+   "depends_on": "eval: doc.type == 'Report'",
+   "fieldname": "report_field",
+   "fieldtype": "Select",
+   "label": "Field",
+   "mandatory_depends_on": "eval: doc.type == 'Report'"
   }
  ],
  "links": [],
- "modified": "2020-07-10 17:55:35.873222",
+ "modified": "2020-07-16 00:58:30.426929",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -164,7 +164,6 @@
   },
   {
    "depends_on": "eval: doc.type == 'Custom'",
-   "description": "This should contain the path to a whitelisted function that will return the number on the card",
    "fieldname": "method",
    "fieldtype": "Data",
    "label": "Method",
@@ -192,7 +191,7 @@
   }
  ],
  "links": [],
- "modified": "2020-07-16 13:04:03.470001",
+ "modified": "2020-07-17 18:04:00.814756",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -12,12 +12,15 @@
   "label",
   "type",
   "report_name",
+  "method",
   "function",
   "aggregate_function_based_on",
   "column_break_2",
   "document_type",
   "report_field",
   "is_public",
+  "custom_configuration_section",
+  "filters_config",
   "stats_section",
   "show_percentage_stats",
   "stats_time_interval",
@@ -141,7 +144,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "Document Type\nReport"
+   "options": "Document Type\nReport\nCustom"
   },
   {
    "depends_on": "eval: doc.type == 'Report'",
@@ -157,10 +160,30 @@
    "fieldtype": "Select",
    "label": "Field",
    "mandatory_depends_on": "eval: doc.type == 'Report'"
+  },
+  {
+   "depends_on": "eval: doc.type == 'Custom'",
+   "description": "This should contain the path to a whitelisted function that will return the number on the card",
+   "fieldname": "method",
+   "fieldtype": "Data",
+   "label": "Method",
+   "mandatory_depends_on": "eval: doc.type == 'Custom'"
+  },
+  {
+   "depends_on": "eval: doc.type == 'Custom'",
+   "fieldname": "custom_configuration_section",
+   "fieldtype": "Section Break",
+   "label": "Custom Configuration"
+  },
+  {
+   "fieldname": "filters_config",
+   "fieldtype": "Code",
+   "label": "Filters Configuration",
+   "options": "JSON"
   }
  ],
  "links": [],
- "modified": "2020-07-16 00:58:30.426929",
+ "modified": "2020-07-16 02:03:09.175701",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -157,6 +157,14 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 	), values)
 
 @frappe.whitelist()
+def create_report_number_card(args):
+	card = create_number_card(args)
+	args = frappe.parse_json(args)
+	args.name = card.name
+	if args.dashboard:
+		add_card_to_dashboard(frappe.as_json(args))
+
+@frappe.whitelist()
 def add_card_to_dashboard(args):
 	args = frappe.parse_json(args)
 

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -52,7 +52,7 @@ def has_permission(doc, ptype, user):
 	return False
 
 @frappe.whitelist()
-def get_result(doc, to_date=None):
+def get_result(doc, filters, to_date=None):
 	doc = frappe.parse_json(doc)
 	fields = []
 	sql_function_map = {
@@ -70,13 +70,13 @@ def get_result(doc, to_date=None):
 	else:
 		fields = ['{function}({based_on}) as result'.format(function=function, based_on=doc.aggregate_function_based_on)]
 
-	filters = frappe.parse_json(doc.filters_json)
+	filters = frappe.parse_json(filters)
 
 	if not filters:
 			filters = []
 
 	if to_date:
-		filters.append([doc.document_type, 'creation', '<', to_date, False])
+		filters.append([doc.document_type, 'creation', '<', to_date])
 
 	res = frappe.db.get_list(doc.document_type, fields=fields, filters=filters)
 	number = res[0]['result'] if res else 0
@@ -84,7 +84,7 @@ def get_result(doc, to_date=None):
 	return cint(number)
 
 @frappe.whitelist()
-def get_percentage_difference(doc, result):
+def get_percentage_difference(doc, filters, result):
 	doc = frappe.parse_json(doc)
 	result = frappe.parse_json(result)
 
@@ -93,13 +93,13 @@ def get_percentage_difference(doc, result):
 	if not doc.get('show_percentage_stats'):
 		return
 
-	previous_result = calculate_previous_result(doc)
+	previous_result = calculate_previous_result(doc, filters)
 	difference = (result - previous_result)/100.0
 
 	return difference
 
 
-def calculate_previous_result(doc):
+def calculate_previous_result(doc, filters):
 	from frappe.utils import add_to_date
 
 	current_date = frappe.utils.now()
@@ -112,7 +112,7 @@ def calculate_previous_result(doc):
 	else:
 		previous_date = add_to_date(current_date, years=-1)
 
-	number = get_result(doc, previous_date)
+	number = get_result(doc, filters, previous_date)
 	return number
 
 @frappe.whitelist()
@@ -155,3 +155,14 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 		search_conditions=search_conditions,
 		conditions=conditions
 	), values)
+
+@frappe.whitelist()
+def add_card_to_dashboard(args):
+	args = frappe.parse_json(args)
+
+	dashboard = frappe.get_doc('Dashboard', args.dashboard)
+	dashboard_link = frappe.new_doc('Number Card Link')
+	dashboard_link.card = args.name
+
+	dashboard.append('cards', dashboard_link)
+	dashboard.save()

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -167,6 +167,38 @@ frappe.dashboard_utils = {
 		}
 
 		return fields;
+	},
+
+	get_all_filters(doc) {
+		let filters = JSON.parse(doc.filters_json || "null");
+		let dynamic_filters = JSON.parse(doc.dynamic_filters_json || "null");
+
+		if (!dynamic_filters) {
+			return filters;
+		}
+
+		if ($.isArray(dynamic_filters)) {
+			dynamic_filters.forEach(f => {
+				try {
+					f[3] = eval(f[3]);
+				} catch (e) {
+					frappe.throw(__(`Invalid expression set in filter ${f[1]} (${f[0]})`));
+				}
+			});
+			filters = [...filters, ...dynamic_filters];
+		} else {
+			for (let key of Object.keys(dynamic_filters)) {
+				try {
+					const val = eval(dynamic_filters[key]);
+					dynamic_filters[key] = val;
+				} catch (e) {
+					frappe.throw(__(`Invalid expression set in filter ${key}`));
+				}
+			}
+			Object.assign(filters, dynamic_filters);
+		}
+
+		return filters;
 	}
 
 };

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -119,6 +119,54 @@ frappe.dashboard_utils = {
 		}
 
 		return static_filters;
+	},
+
+	get_fields_for_dynamic_filter_dialog(is_document_type, filters, dynamic_filters) {
+		let fields = [
+			{
+				fieldtype: 'HTML',
+				fieldname: 'description',
+				options:
+					`<div>
+						<p>Set dynamic filter values in JavaScript for the required fields here.
+						</p>
+						<p>Ex:
+							<code>frappe.defaults.get_user_default("Company")</code>
+						</p>
+					</div>`
+			}
+		];
+
+		if (is_document_type) {
+			if (dynamic_filters) {
+				filters = [...filters, ...dynamic_filters];
+			}
+			filters.forEach(f => {
+				for (let field of fields) {
+					if (field.fieldname == f[0] + ':' + f[1]) {
+						return;
+					}
+				}
+				if (f[2] == '=') {
+					fields.push({
+						label: `${f[1]} (${f[0]})`,
+						fieldname: f[0] + ':' + f[1],
+						fieldtype: 'Data',
+					});
+				}
+			});
+		} else {
+			filters = {...dynamic_filters, ...filters};
+			for (let key of Object.keys(filters)) {
+				fields.push({
+					label: key,
+					fieldname: key,
+					fieldtype: 'Data',
+				});
+			}
+		}
+
+		return fields;
 	}
 
 };

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -133,7 +133,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		]);
 	}
 
-	add_card_button_to_toolbar(show) {
+	add_card_button_to_toolbar() {
 		this.page.add_inner_button(__("Create Card"), () => {
 			this.add_card_to_dashboard();
 		});
@@ -609,12 +609,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				}
 				this.render_datatable();
 				this.add_chart_buttons_to_toolbar(true);
-				this.add_card_button_to_toolbar(true);
+				this.add_card_button_to_toolbar();
 			} else {
 				this.data = [];
 				this.toggle_nothing_to_show(true);
 				this.add_chart_buttons_to_toolbar(false);
-				this.add_card_button_to_toolbar(false);
 			}
 
 			this.show_footer_message();

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -129,11 +129,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.setup_page_head(),
 			() => this.refresh_report(),
 			() => this.add_chart_buttons_to_toolbar(true),
-			() => this.add_card_button_to_toolbar(),
+			() => this.add_card_button_to_toolbar(true),
 		]);
 	}
 
-	add_card_button_to_toolbar() {
+	add_card_button_to_toolbar(show) {
 		this.page.add_inner_button(__("Create Card"), () => {
 			this.add_card_to_dashboard();
 		});
@@ -609,10 +609,12 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				}
 				this.render_datatable();
 				this.add_chart_buttons_to_toolbar(true);
+				this.add_card_button_to_toolbar(true);
 			} else {
 				this.data = [];
 				this.toggle_nothing_to_show(true);
 				this.add_chart_buttons_to_toolbar(false);
+				this.add_card_button_to_toolbar(false);
 			}
 
 			this.show_footer_message();

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -128,8 +128,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.setup_progress_bar(),
 			() => this.setup_page_head(),
 			() => this.refresh_report(),
-			() => this.add_chart_buttons_to_toolbar(true)
+			() => this.add_chart_buttons_to_toolbar(true),
+			() => this.add_card_button_to_toolbar(),
 		]);
+	}
+
+	add_card_button_to_toolbar() {
+		this.page.add_inner_button(__("Create Card"), () => {
+			this.add_card_to_dashboard();
+		});
 	}
 
 	add_chart_buttons_to_toolbar(show) {
@@ -146,6 +153,62 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		} else {
 			this.page.clear_inner_toolbar();
 		}
+	}
+
+	add_card_to_dashboard() {
+		let field_options = frappe.report_utils.get_field_options_from_report(this.columns, this.raw_data);
+		const dialog = new frappe.ui.Dialog({
+			title: __('Create Card'),
+			fields: [
+				{
+					fieldname: 'report_field',
+					label: __('Field'),
+					fieldtype: 'Select',
+					options: field_options.numeric_fields,
+				},
+				{
+					fieldname: 'cb_1',
+					fieldtype: 'Column Break'
+				},
+				{
+					fieldname: 'report_function',
+					label: __('Function'),
+					options: ['Sum', 'Average', 'Minimum', 'Maximum'],
+					fieldtype: 'Select'
+				},
+				{
+					fieldname: 'sb_1',
+					label: __('Add to Dashboard'),
+					fieldtype: 'Section Break'
+				},
+				{
+					fieldname: 'dashboard',
+					label: __('Choose Dashboard'),
+					fieldtype: 'Link',
+					options: 'Dashboard',
+				},
+				{
+					fieldname: 'cb_2',
+					fieldtype: 'Column Break'
+				},
+				{
+					fieldname: 'label',
+					label: __('Card Label'),
+					fieldtype: 'Data',
+				}
+			],
+			primary_action_label: __('Add'),
+			primary_action: (values) => {
+				if (!values.label) {
+					values.label = `${values.report_function} of ${toTitle(values.report_field)}`;
+				}
+				this.create_number_card(values, values.dashboard, values.label);
+				dialog.hide();
+			}
+		});
+
+		dialog.show();
+
 	}
 
 	add_chart_to_dashboard() {
@@ -180,6 +243,24 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		} else {
 			frappe.msgprint(__('Please Set Chart'));
 		}
+	}
+
+	create_number_card(values, dashboard_name, card_name) {
+		let args = {
+			'dashboard': dashboard_name || null,
+			'type': 'Report',
+			'report_name': this.report_name,
+			'filters_json': JSON.stringify(this.get_filter_values()),
+		};
+		Object.assign(args, values);
+
+		this.add_to_dashboard(
+			'frappe.desk.doctype.number_card.number_card.create_report_number_card',
+			args,
+			dashboard_name,
+			card_name,
+			'Number Card'
+		);
 	}
 
 	create_dashboard_chart(chart_args, dashboard_name, chart_name) {
@@ -224,19 +305,29 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			);
 		}
 
-		frappe.xcall(
+		this.add_to_dashboard(
 			'frappe.desk.doctype.dashboard_chart.dashboard_chart.create_report_chart',
+			args,
+			dashboard_name,
+			chart_name,
+			'Dashboard Chart'
+		);
+	}
+
+	add_to_dashboard(method, args, dashboard_name, name, doctype) {
+		frappe.xcall(
+			method,
 			{args: args}
-		).then( () => {
+		).then(() => {
 			let message;
 			if (dashboard_name) {
 				let dashboard_route_html = `<a href = "#dashboard/${dashboard_name}">${dashboard_name}</a>`;
-				message = __(`New Dashboard Chart ${chart_name} added to Dashboard ` + dashboard_route_html);
+				message = __(`New {0} {1} added to Dashboard ` + dashboard_route_html, [doctype, name]);
 			} else {
-				message = __(`New chart ${chart_name} created`);
+				message = __(`New {0} {1} created`, [doctype, name]);
 			}
 
-			frappe.msgprint(message, __('New Chart Created'));
+			frappe.msgprint(message, __(`New {0} Created`, [doctype]));
 		});
 	}
 
@@ -700,7 +791,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	open_create_chart_dialog() {
 		const me = this;
-		let field_options = frappe.report_utils.get_possible_chart_options(this.columns, this.raw_data);
+		let field_options = frappe.report_utils.get_field_options_from_report(this.columns, this.raw_data);
 
 		function set_chart_values(values) {
 			values.y_fields = [];

--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -41,7 +41,7 @@ frappe.report_utils = {
 		}
 	},
 
-	get_possible_chart_options: function(columns, data) {
+	get_field_options_from_report: function(columns, data) {
 		const rows =  data.result.filter(value => Object.keys(value).length);
 		const first_row = Array.isArray(rows[0]) ? rows[0] : columns.map(col => rows[0][col.fieldname]);
 

--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -138,4 +138,14 @@ frappe.report_utils = {
 		return filter_values;
 	},
 
+	get_result_of_fn(fn, values) {
+		const get_result = {
+			'Minimum': values => values.reduce((min, val) => Math.min(min, val), values[0]),
+			'Maximum': values => values.reduce((min, val) => Math.max(min, val), values[0]),
+			'Average': values => values.reduce((a, b) => a + b, 0) / values.length,
+			'Sum': values => values.reduce((a, b) => a + b, 0)
+		};
+		return get_result[fn](values);
+	},
+
 };

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -639,7 +639,7 @@ export default class ChartWidget extends Widget {
 
 	set_chart_filters() {
 		let user_saved_filters = this.chart_settings.filters || null;
-		let chart_saved_filters = this.get_all_chart_filters();
+		let chart_saved_filters = frappe.dashboard_utils.get_all_filters(this.chart_doc);
 
 		if (this.chart_doc.chart_type == 'Report') {
 			return frappe.dashboard_utils
@@ -653,38 +653,6 @@ export default class ChartWidget extends Widget {
 				user_saved_filters || this.filters || chart_saved_filters;
 			return Promise.resolve();
 		}
-	}
-
-	get_all_chart_filters() {
-		let filters = JSON.parse(this.chart_doc.filters_json || "null");
-		let dynamic_filters = JSON.parse(this.chart_doc.dynamic_filters_json || "null");
-
-		if (!dynamic_filters) {
-			return filters;
-		}
-
-		if ($.isArray(dynamic_filters)) {
-			dynamic_filters.forEach(f => {
-				try {
-					f[3] = eval(f[3]);
-				} catch (e) {
-					frappe.throw(__(`Invalid expression set in filter ${f[1]} (${f[0]})`));
-				}
-			});
-			filters = [...filters, ...dynamic_filters];
-		} else {
-			for (let key of Object.keys(dynamic_filters)) {
-				try {
-					const val = eval(dynamic_filters[key]);
-					dynamic_filters[key] = val;
-				} catch (e) {
-					frappe.throw(__(`Invalid expression set in filter ${key}`));
-				}
-			}
-			Object.assign(filters, dynamic_filters);
-		}
-
-		return filters;
 	}
 
 	update_default_date_filters(report_filters, chart_filters) {

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -84,29 +84,36 @@ export default class NumberCardWidget extends Widget {
 	}
 
 	get_settings(type) {
+		this.filters = this.get_filters();
 		const settings_map = {
 			'Custom': {
 				method: this.card_doc.method,
 				args: {
-					filters: JSON.parse(this.card_doc.filters_json || '{}')
+					filters: this.filters
 				}
 			},
 			'Report': {
 				method: 'frappe.desk.query_report.run',
 				args: {
 					report_name: this.card_doc.report_name,
-					filters: JSON.parse(this.card_doc.filters_json || '{}'),
+					filters: this.filters,
 					ignore_prepared_report: 1
 				}
 			},
 			'Document Type': {
 				method: 'frappe.desk.doctype.number_card.number_card.get_result',
 				args: {
-					doc: this.card_doc
+					doc: this.card_doc,
+					filters: this.filters,
 				}
 			}
 		};
 		return settings_map[type];
+	}
+
+	get_filters() {
+		const filters = frappe.dashboard_utils.get_all_filters(this.card_doc);
+		return filters;
 	}
 
 	render_card() {
@@ -225,6 +232,7 @@ export default class NumberCardWidget extends Widget {
 	get_percentage_stats() {
 		return frappe.xcall('frappe.desk.doctype.number_card.number_card.get_percentage_difference', {
 			doc: this.card_doc,
+			filters: this.filters,
 			result: this.number
 		}).then(res => {
 			if (res !== undefined) {

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -83,9 +83,9 @@ export default class NumberCardWidget extends Widget {
 		if (is_document_type) {
 			const filters = JSON.parse(this.card_doc.filters_json);
 			frappe.route_options = filters.reduce((acc, filter) => {
-					return Object.assign(acc, {
-						[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]]
-					});
+				return Object.assign(acc, {
+					[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]]
+				});
 			}, {});
 		}
 

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -172,7 +172,7 @@ export default class NumberCardWidget extends Widget {
 						this.get_formatted_number(based_on_df);
 					});
 				} else {
-					this.number_html = res;
+					this.formatted_number = res;
 				}
 			}
 		});
@@ -197,13 +197,13 @@ export default class NumberCardWidget extends Widget {
 		const symbol = number_parts[1] || '';
 		const formatted_number = $(frappe.format(number_parts[0], df)).text();
 
-		this.number_html = formatted_number + ' ' + symbol;
+		this.formatted_number = formatted_number + ' ' + symbol;
 	}
 
 	render_number() {
 		return this.get_number().then(() => {
 			$(this.body).html(`<div class="widget-content">
-				<div class="number" style="color:${this.card_doc.color}">${this.number_html}</div>
+				<div class="number" style="color:${this.card_doc.color}">${this.formatted_number}</div>
 				</div>`);
 		});
 	}

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -163,6 +163,9 @@ export default class NumberCardWidget extends Widget {
 		return frappe.xcall(this.settings.method, this.settings.args).then(res => {
 			if (this.card_doc.type == 'Report') {
 				this.get_number_for_report(res);
+			} else if (this.card_doc.type == 'Custom') {
+				this.number = res.value;
+				this.get_formatted_number(res);
 			} else {
 				this.number = res;
 				if (this.card_doc.function !== 'Count') {
@@ -213,7 +216,7 @@ export default class NumberCardWidget extends Widget {
 			return;
 		}
 
-		let caret_html ='';
+		let caret_html = '';
 		let color_class = '';
 
 		return this.get_percentage_stats().then(() => {

--- a/frappe/public/js/frappe/widgets/utils.js
+++ b/frappe/public/js/frappe/widgets/utils.js
@@ -117,16 +117,6 @@ const build_summary_item = (summary) => {
 	</div>`);
 };
 
-function go_to_list_with_filters(doctype, filters) {
-	const route = `List/${doctype}/List`;
-	frappe.set_route(route).then(()=> {
-		let list_view = frappe.views.list_view[route];
-		let filter_area = list_view.filter_area;
-		filter_area.clear();
-		filter_area.filter_list.add_filters_to_filter_group(filters);
-	});
-}
-
 function shorten_number(number, country) {
 	country = (country == 'India') ? country : '';
 	const number_system = get_number_system(country);

--- a/frappe/public/js/frappe/widgets/utils.js
+++ b/frappe/public/js/frappe/widgets/utils.js
@@ -157,4 +157,4 @@ function get_number_system(country) {
 	return number_system_map[country];
 }
 
-export { generate_route, generate_grid, build_summary_item, go_to_list_with_filters, shorten_number };
+export { generate_route, generate_grid, build_summary_item, shorten_number };


### PR DESCRIPTION
- Create Custom Number Cards by setting method to the path of a whitelisted function and setting filters (only in developer mode):
<img width="1440" alt="Screenshot 2020-05-18 at 7 55 28 PM" src="https://user-images.githubusercontent.com/19775888/82224535-8fa37680-9941-11ea-9fa6-a9c370589d1d.png">

- Create Number Cards from reports:
![add card from report](https://user-images.githubusercontent.com/19775888/82225191-7fd86200-9942-11ea-8922-b5c68df00ed4.gif)

To Do:

- [ ] Stats for these cards (?)
