### PR TITLE
feat: Bench command to open ngrok tunnel

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -644,7 +644,7 @@ def start_ngrok(context):
 		'host_header': site
 	})
 	print(f'Public URL: {public_url}')
-	print(f'Inspect logs at http://localhost:4040')
+	print('Inspect logs at http://localhost:4040')
 
 	ngrok_process = ngrok.get_ngrok_process()
 	try:

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -631,6 +631,29 @@ def stop_recording(context):
 	if not context.sites:
 		raise SiteNotSpecifiedError
 
+@click.command('ngrok')
+@pass_context
+def start_ngrok(context):
+	from pyngrok import ngrok
+
+	site = get_site(context)
+	frappe.init(site=site)
+
+	port = frappe.conf.http_port or frappe.conf.webserver_port
+	public_url = ngrok.connect(port=port, options={
+		'host_header': site
+	})
+	print(f'Public URL: {public_url}')
+	print(f'Inspect logs at http://localhost:4040')
+
+	ngrok_process = ngrok.get_ngrok_process()
+	try:
+		# Block until CTRL-C or some other terminating event
+		ngrok_process.proc.wait()
+	except KeyboardInterrupt:
+		print("Shutting down server...")
+		frappe.destroy()
+		ngrok.kill()
 
 commands = [
 	add_system_manager,
@@ -656,5 +679,6 @@ commands = [
 	browse,
 	start_recording,
 	stop_recording,
-	add_to_hosts
+	add_to_hosts,
+	start_ngrok
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ dropbox==9.1.0
 email-reply-parser==0.5.9
 Faker==2.0.4
 future==0.18.2
-GitPython==2.1.15
 gitdb2==2.0.6;python_version<'3.4'
+GitPython==2.1.15
 google-api-python-client==1.9.3
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
@@ -40,6 +40,7 @@ psycopg2-binary==2.8.4
 pyasn1==0.4.8
 PyJWT==1.7.1
 PyMySQL==0.9.3
+pyngrok==4.1.6
 pyOpenSSL==19.1.0
 pyotp==2.3.0
 PyPDF2==1.26.0
@@ -48,7 +49,6 @@ PyQRCode==1.2.1
 python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3.1
-pyngrok==4.1.6
 rauth==0.7.3
 redis==3.5.1
 requests-oauthlib==1.3.0
@@ -65,6 +65,6 @@ unittest-xml-reporting==2.5.2
 urllib3==1.25.8
 watchdog==0.8.0
 Werkzeug==0.16.1
+Whoosh==2.7.4
 xlrd==1.2.0
 zxcvbn-python==4.4.24
-Whoosh==2.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ PyQRCode==1.2.1
 python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3.1
+pyngrok==4.1.6
 rauth==0.7.3
 redis==3.5.1
 requests-oauthlib==1.3.0


### PR DESCRIPTION
### Usage:

```sh
$ bench --site tennismart ngrok
Public URL: http://asdf1234.ngrok.io
Inspect logs at http://localhost:4040
```

### Why?

While building integrations with third-party services, I often needed to expose my local site on a public URL, for e.g., Testing Stripe Webhooks. `ngrok` is a great tool for doing just that. But every time, I had to install `ngrok` and look up the right command to execute.

This is also useful if you want to debug an issue on your local site with a colleague. You can create a temporary URL and share it with anyone, and they can access your local site in their browser.