### PR TITLE
fix: Make checkboxes navigatable via tab key

### DIFF
--- a/frappe/public/css/list.css
+++ b/frappe/public/css/list.css
@@ -172,6 +172,14 @@
 input.list-check-all,
 input.list-row-checkbox {
   margin-top: 0px;
+
+}
+.level-item .list-row-checkbox {
+	margin-right: 20px;
+}
+
+.level-left .list-check-all {
+	margin-right: 20px;
 }
 .filterable {
   cursor: pointer;

--- a/frappe/public/css/role_editor.css
+++ b/frappe/public/css/role_editor.css
@@ -6,6 +6,7 @@
 .role {
   padding-left: 5px;
   padding-top: 2px;
+  margin-left: 15px;
 }
 table.user-perm {
   border-collapse: collapse;

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -50,7 +50,7 @@ frappe.RoleEditor = Class.extend({
 		$.each(this.roles, function(i, role) {
 			$(me.wrapper).append(repl('<div class="user-role" \
 				data-user-role="%(role_value)s">\
-				<input type="checkbox" style="margin-top:0px;" class="box"> \
+				<input type="checkbox" style="margin-top:0px;" class="box checkbox"> \
 				<a href="#" class="grey role">%(role_display)s</a>\
 			</div>', {role_value: role,role_display:__(role)}));
 		});

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -784,7 +784,7 @@ li.user-progress {
 }
 
 .checkbox input[type=checkbox] {
-	margin-right: 5px;
+	margin-right: 20px;
 	margin-left: 0px;
 	position: relative;
 	height: 12px;
@@ -793,7 +793,8 @@ li.user-progress {
 // custom font awesome checkbox
 input[type="checkbox"] {
 	position: relative;
-	visibility: hidden;
+	width: 0px;
+	height: 0px;
 
 	&:before {
 		position: absolute;

--- a/frappe/public/less/list.less
+++ b/frappe/public/less/list.less
@@ -199,6 +199,13 @@ body.no-list-sidebar {
 input.list-check-all, input.list-row-checkbox {
 	margin-top: 0px;
 }
+.level-left .list-row-checkbox {
+	margin-right: 20px;
+}
+
+.level-left .list-check-all {
+	margin-right: 20px;
+}
 
 .filterable {
 	cursor: pointer;

--- a/frappe/public/less/role_editor.less
+++ b/frappe/public/less/role_editor.less
@@ -5,6 +5,7 @@
 }
 
 .role {
+	margin-left: 15px;
 	padding-left: 5px;
 	padding-top: 2px;
 }


### PR DESCRIPTION
There are three visibility states for any DOM element which decides whether element will be navigatable via keyboard or not 

![image](https://user-images.githubusercontent.com/42651287/87681816-b8f34e00-c79c-11ea-8d0a-a3f2eb8d0839.png)

We use custom checkboxes and hide the default checkboxes. Currently the default checkboxes are completely hidden and prohibits user from navigating through them via keyboard. In this PR I have made the default checkbox visually hidden which uses custom checkboxes for input and allows user to navigate through them via keyboard at the same time
