### PR TITLE
fix: remove example users email ids from notifications

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -267,6 +267,7 @@ execute:frappe.delete_doc_if_exists('DocType', 'GSuite Templates')
 execute:frappe.delete_doc_if_exists('DocType', 'GCalendar Account')
 execute:frappe.delete_doc_if_exists('DocType', 'GCalendar Settings')
 frappe.patches.v12_0.remove_parent_and_parenttype_from_print_formats
+frappe.patches.v12_0.remove_example_email_thread_notify
 execute:from frappe.desk.page.setup_wizard.install_fixtures import update_genders;update_genders()
 frappe.patches.v12_0.email_unsubscribe
 frappe.patches.v12_0.replace_old_data_import

--- a/frappe/patches/v12_0/remove_example_email_thread_notify.py
+++ b/frappe/patches/v12_0/remove_example_email_thread_notify.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	# remove all example.com email user accounts from notifications
+	frappe.db.sql("""UPDATE `tabUser`
+	SET thread_notify=0, send_me_a_copy=0
+	WHERE email like '%@example.com'""")

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -50,11 +50,13 @@ def install_basic_docs():
 	install_docs = [
 		{'doctype':'User', 'name':'Administrator', 'first_name':'Administrator',
 			'email':'admin@example.com', 'enabled':1, "is_admin": 1,
-			'roles': [{'role': 'Administrator'}]
+			'roles': [{'role': 'Administrator'}],
+			'thread_notify': 0, 'send_me_a_copy': 0
 		},
 		{'doctype':'User', 'name':'Guest', 'first_name':'Guest',
 			'email':'guest@example.com', 'enabled':1, "is_guest": 1,
-			'roles': [{'role': 'Guest'}]
+			'roles': [{'role': 'Guest'}],
+			'thread_notify': 0, 'send_me_a_copy': 0
 		},
 		{'doctype': "Role", "role_name": "Report Manager"},
 		{'doctype': "Role", "role_name": "Translator"},


### PR DESCRIPTION
currently the system tries sending emails to all users that have `thread_notify` enabled, including the default example emails that the Administrator and Guest accounts have. this patch disables email notifications for these accounts, and additionally tries to disable it for any other user accounts with example emails

port of: #11032 