### PR TITLE
feat: Ignore doctypes for cancel_all

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -443,7 +443,7 @@ class TestDocType(unittest.TestCase):
 		docs = get_submitted_linked_docs(link_doc.name, data_link_doc_1.name)
 		dump_docs = json.dumps(docs.get('docs'))
 
-		cancel_all_linked_docs(dump_docs, ignored_doctypes_on_cancel_all=["Test Doctype 2"])
+		cancel_all_linked_docs(dump_docs, ignore_doctypes_on_cancel_all=["Test Doctype 2"])
 
 		# checking that doc for Test Doctype 2 is not canceled
 		self.assertRaises(frappe.LinkExistsError, data_link_doc_1.cancel)

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -376,3 +376,96 @@ class TestDocType(unittest.TestCase):
 		link_doc.delete()
 		doc.delete()
 		frappe.db.commit()
+
+	def test_ignore_cancelation_of_linked_doctype_during_cancell(self):
+		import json
+		from frappe.desk.form.linked_with import get_submitted_linked_docs, cancel_all_linked_docs
+
+		#create linked doctype
+		link_doc = self.new_doctype('Test Linked Doctype 1')
+		link_doc.is_submittable = 1
+		for data in link_doc.get('permissions'):
+			data.submit = 1
+			data.cancel = 1
+		link_doc.insert()
+
+		#create first parent doctype
+		test_doc_1 = self.new_doctype('Test Doctype 1')
+		test_doc_1.is_submittable = 1
+
+		field_2 = test_doc_1.append('fields', {})
+		field_2.label = 'Test Linked Doctype 1'
+		field_2.fieldname  = 'test_linked_doctype_a'
+		field_2.fieldtype = 'Link'
+		field_2.options = 'Test Linked Doctype 1'
+
+		for data in test_doc_1.get('permissions'):
+			data.submit = 1
+			data.cancel = 1
+		test_doc_1.insert()
+
+		#crete second parent doctype
+		doc = self.new_doctype('Test Doctype 2')
+		doc.is_submittable = 1
+
+		field_2 = doc.append('fields', {})
+		field_2.label = 'Test Linked Doctype 1'
+		field_2.fieldname  = 'test_linked_doctype_a'
+		field_2.fieldtype = 'Link'
+		field_2.options = 'Test Linked Doctype 1'
+
+		for data in link_doc.get('permissions'):
+			data.submit = 1
+			data.cancel = 1
+		doc.insert()
+
+		# create doctype data
+		data_link_doc_1 = frappe.new_doc('Test Linked Doctype 1')
+		data_link_doc_1.some_fieldname = 'Data1'
+		data_link_doc_1.insert()
+		data_link_doc_1.save()
+		data_link_doc_1.submit()
+
+		data_doc_2 = frappe.new_doc('Test Doctype 1')
+		data_doc_2.some_fieldname = 'Data1'
+		data_doc_2.test_linked_doctype_a = data_link_doc_1.name
+		data_doc_2.insert()
+		data_doc_2.save()
+		data_doc_2.submit()
+
+		data_doc = frappe.new_doc('Test Doctype 2')
+		data_doc.some_fieldname = 'Data1'
+		data_doc.test_linked_doctype_a = data_link_doc_1.name
+		data_doc.insert()
+		data_doc.save()
+		data_doc.submit()
+
+		docs = get_submitted_linked_docs(link_doc.name, data_link_doc_1.name)
+		dump_docs = json.dumps(docs.get('docs'))
+
+		cancel_all_linked_docs(dump_docs, ignored_doctypes_on_cancel_all=["Test Doctype 2"])
+
+		# checking that doc for Test Doctype 2 is not canceled
+		self.assertRaises(frappe.LinkExistsError, data_link_doc_1.cancel)
+
+		data_doc.load_from_db()
+		data_doc_2.load_from_db()
+		self.assertEqual(data_link_doc_1.docstatus, 2)
+
+		#linked doc is canceled
+		self.assertEqual(data_doc_2.docstatus, 2)
+
+		#ignored doctype 2 during cancel
+		self.assertEqual(data_doc.docstatus, 1)
+
+		# delete doctype record
+		data_doc.cancel()
+		data_doc.delete()
+		data_doc_2.delete()
+		data_link_doc_1.delete()
+
+		# delete doctype
+		link_doc.delete()
+		doc.delete()
+		test_doc_1.delete()
+		frappe.db.commit()

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -78,7 +78,7 @@ def get_submitted_linked_docs(doctype, name, docs=None, visited=None):
 
 
 @frappe.whitelist()
-def cancel_all_linked_docs(docs):
+def cancel_all_linked_docs(docs, ignore_doctype_on_cancel_all=[]):
 	"""
 	Cancel all linked doctype
 
@@ -88,13 +88,13 @@ def cancel_all_linked_docs(docs):
 
 	docs = json.loads(docs)
 	for i, doc in enumerate(docs, 1):
-		if validate_linked_doc(doc) is True:
+		if validate_linked_doc(doc, ignore_doctype_on_cancel_all) is True:
 			frappe.publish_progress(percent=i * 100 / len(docs), title=_("Cancelling documents"))
 			linked_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
 			linked_doc.cancel()
 
 
-def validate_linked_doc(docinfo):
+def validate_linked_doc(docinfo, ignore_doctype_on_cancel_all=[]):
 	"""
 	Validate a document to be submitted and non-exempted from auto-cancel.
 
@@ -104,6 +104,10 @@ def validate_linked_doc(docinfo):
 	Returns:
 		bool: True if linked document passes all validations, else False
 	"""
+
+	#ignore doctype to cancel
+	if docinfo.get("doctype") in ignore_doctype_on_cancel_all:
+		return False
 
 	# skip non-submittable doctypes since they don't need to be cancelled
 	if not frappe.get_meta(docinfo.get('doctype')).is_submittable:

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -10,7 +10,6 @@ import frappe.desk.form.meta
 from frappe import _
 from frappe.model.meta import is_single
 from frappe.modules import load_doctype_module
-from six import string_types
 
 @frappe.whitelist()
 def get_submitted_linked_docs(doctype, name, docs=None, visited=None):

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -78,7 +78,7 @@ def get_submitted_linked_docs(doctype, name, docs=None, visited=None):
 
 
 @frappe.whitelist()
-def cancel_all_linked_docs(docs, ignore_doctype_on_cancel_all=[]):
+def cancel_all_linked_docs(docs, ignored_doctypes_on_cancel_all=[]):
 	"""
 	Cancel all linked doctype
 
@@ -87,14 +87,15 @@ def cancel_all_linked_docs(docs, ignore_doctype_on_cancel_all=[]):
 	"""
 
 	docs = json.loads(docs)
+	ignored_doctypes_on_cancel_all = json.loads(ignored_doctypes_on_cancel_all)
 	for i, doc in enumerate(docs, 1):
-		if validate_linked_doc(doc, ignore_doctype_on_cancel_all) is True:
-			frappe.publish_progress(percent=i * 100 / len(docs), title=_("Cancelling documents"))
+		if validate_linked_doc(doc, ignored_doctypes_on_cancel_all) is True:
+			frappe.publish_progress(percent=i * 100 / ((len(docs) - len(ignored_doctypes_on_cancel_all))), title=_("Cancelling documents"))
 			linked_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
 			linked_doc.cancel()
 
 
-def validate_linked_doc(docinfo, ignore_doctype_on_cancel_all=[]):
+def validate_linked_doc(docinfo, ignored_doctypes_on_cancel_all=[]):
 	"""
 	Validate a document to be submitted and non-exempted from auto-cancel.
 
@@ -106,7 +107,7 @@ def validate_linked_doc(docinfo, ignore_doctype_on_cancel_all=[]):
 	"""
 
 	#ignore doctype to cancel
-	if docinfo.get("doctype") in ignore_doctype_on_cancel_all:
+	if docinfo.get("doctype") in ignored_doctypes_on_cancel_all:
 		return False
 
 	# skip non-submittable doctypes since they don't need to be cancelled

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -77,7 +77,7 @@ def get_submitted_linked_docs(doctype, name, docs=None, visited=None):
 
 
 @frappe.whitelist()
-def cancel_all_linked_docs(docs, ignored_doctypes_on_cancel_all=[]):
+def cancel_all_linked_docs(docs, ignore_doctypes_on_cancel_all=[]):
 	"""
 	Cancel all linked doctype
 
@@ -86,16 +86,16 @@ def cancel_all_linked_docs(docs, ignored_doctypes_on_cancel_all=[]):
 	"""
 
 	docs = json.loads(docs)
-	if isinstance(ignored_doctypes_on_cancel_all, string_types):
-		ignored_doctypes_on_cancel_all = json.loads(ignored_doctypes_on_cancel_all)
+	if isinstance(ignore_doctypes_on_cancel_all, string_types):
+		ignore_doctypes_on_cancel_all = json.loads(ignore_doctypes_on_cancel_all)
 	for i, doc in enumerate(docs, 1):
-		if validate_linked_doc(doc, ignored_doctypes_on_cancel_all) is True:
-			frappe.publish_progress(percent=i * 100 / ((len(docs) - len(ignored_doctypes_on_cancel_all))), title=_("Cancelling documents"))
+		if validate_linked_doc(doc, ignore_doctypes_on_cancel_all) is True:
+			frappe.publish_progress(percent=i * 100 / ((len(docs) - len(ignore_doctypes_on_cancel_all))), title=_("Cancelling documents"))
 			linked_doc = frappe.get_doc(doc.get("doctype"), doc.get("name"))
 			linked_doc.cancel()
 
 
-def validate_linked_doc(docinfo, ignored_doctypes_on_cancel_all=[]):
+def validate_linked_doc(docinfo, ignore_doctypes_on_cancel_all=[]):
 	"""
 	Validate a document to be submitted and non-exempted from auto-cancel.
 
@@ -107,7 +107,7 @@ def validate_linked_doc(docinfo, ignored_doctypes_on_cancel_all=[]):
 	"""
 
 	#ignore doctype to cancel
-	if docinfo.get("doctype") in ignored_doctypes_on_cancel_all:
+	if docinfo.get("doctype") in ignore_doctypes_on_cancel_all:
 		return False
 
 	# skip non-submittable doctypes since they don't need to be cancelled

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -10,7 +10,7 @@ import frappe.desk.form.meta
 from frappe import _
 from frappe.model.meta import is_single
 from frappe.modules import load_doctype_module
-
+from six import string_types
 
 @frappe.whitelist()
 def get_submitted_linked_docs(doctype, name, docs=None, visited=None):
@@ -87,7 +87,8 @@ def cancel_all_linked_docs(docs, ignored_doctypes_on_cancel_all=[]):
 	"""
 
 	docs = json.loads(docs)
-	ignored_doctypes_on_cancel_all = json.loads(ignored_doctypes_on_cancel_all)
+	if isinstance(ignored_doctypes_on_cancel_all, string_types):
+		ignored_doctypes_on_cancel_all = json.loads(ignored_doctypes_on_cancel_all)
 	for i, doc in enumerate(docs, 1):
 		if validate_linked_doc(doc, ignored_doctypes_on_cancel_all) is True:
 			frappe.publish_progress(percent=i * 100 / ((len(docs) - len(ignored_doctypes_on_cancel_all))), title=_("Cancelling documents"))

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -667,22 +667,28 @@ frappe.ui.form.Form = class FrappeForm {
 	savecancel(btn, callback, on_error) {
 		const me = this;
 		this.validate_form_action('Cancel');
-
+		me.ignore_doctype_on_cancel_all = me.ignore_doctype_on_cancel_all || [];
 		frappe.call({
 			method: "frappe.desk.form.linked_with.get_submitted_linked_docs",
 			args: {
 				doctype: me.doc.doctype,
 				name: me.doc.name
 			},
-			freeze: true,
-			callback: (r) => {
-				if (!r.exc && r.message.count > 0) {
-					me._cancel_all(r, btn, callback, on_error);
-				} else {
-					me._cancel(btn, callback, on_error, false);
-				}
+			freeze: true
+		}).then(r => {
+			let all_doctypes_to_cancel = [];
+			r.message.docs.forEach(function(value) {
+				all_doctypes_to_cancel.push(value.doctype);
+			});
+
+			let check = JSON.stringify(all_doctypes_to_cancel.sort()) !=  JSON.stringify(me.ignore_doctype_on_cancel_all.sort());
+			if (!r.exc && r.message.count > 0 && check) {
+				me._cancel_all(r, btn, callback, on_error);
+			} else {
+				me._cancel(btn, callback, on_error, false);
 			}
-		});
+		}
+		);
 	}
 
 	_cancel_all(r, btn, callback, on_error) {
@@ -693,12 +699,16 @@ frappe.ui.form.Form = class FrappeForm {
 		let links = r.message.docs;
 		const doctypes = Array.from(new Set(links.map(link => link.doctype)));
 
+		me.ignore_doctype_on_cancel_all = me.ignore_doctype_on_cancel_all || [];
+
 		for (let doctype of doctypes) {
-			let docnames = links
-				.filter((link) => link.doctype == doctype)
-				.map((link) => frappe.utils.get_form_link(link.doctype, link.name, true))
-				.join(", ");
-			links_text += `<li><strong>${doctype}</strong>: ${docnames}</li>`;
+			if (!me.ignore_doctype_on_cancel_all.includes(doctype)) {
+				let docnames = links
+					.filter((link) => link.doctype == doctype)
+					.map((link) => frappe.utils.get_form_link(link.doctype, link.name, true))
+					.join(", ");
+				links_text += `<li><strong>${doctype}</strong>: ${docnames}</li>`;
+			}
 		}
 		links_text = `<ul>${links_text}</ul>`;
 
@@ -728,7 +738,8 @@ frappe.ui.form.Form = class FrappeForm {
 				frappe.call({
 					method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
 					args: {
-						docs: links
+						docs: links,
+						ignore_doctype_on_cancel_all: me.ignore_doctype_on_cancel_all || []
 					},
 					freeze: true,
 					callback: (resp) => {
@@ -742,7 +753,7 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 
 		d.show();
-	};
+	}
 
 	_cancel(btn, callback, on_error, skip_confirm) {
 		const me = this;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -667,7 +667,7 @@ frappe.ui.form.Form = class FrappeForm {
 	savecancel(btn, callback, on_error) {
 		const me = this;
 		this.validate_form_action('Cancel');
-		me.ignored_doctypes_on_cancel_all = me.ignored_doctypes_on_cancel_all || [];
+		me.ignore_doctypes_on_cancel_all = me.ignore_doctypes_on_cancel_all || [];
 		frappe.call({
 			method: "frappe.desk.form.linked_with.get_submitted_linked_docs",
 			args: {
@@ -680,7 +680,7 @@ frappe.ui.form.Form = class FrappeForm {
 				let doctypes_to_cancel = (r.message.docs || []).map(value => {
 					return value.doctype;
 				}).filter(value => {
-					return !me.ignored_doctypes_on_cancel_all.includes(value);
+					return !me.ignore_doctypes_on_cancel_all.includes(value);
 				});
 
 				if (doctypes_to_cancel.length) {
@@ -700,10 +700,10 @@ frappe.ui.form.Form = class FrappeForm {
 		let links = r.message.docs;
 		const doctypes = Array.from(new Set(links.map(link => link.doctype)));
 
-		me.ignored_doctypes_on_cancel_all = me.ignored_doctypes_on_cancel_all || [];
+		me.ignore_doctypes_on_cancel_all = me.ignore_doctypes_on_cancel_all || [];
 
 		for (let doctype of doctypes) {
-			if (!me.ignored_doctypes_on_cancel_all.includes(doctype)) {
+			if (!me.ignore_doctypes_on_cancel_all.includes(doctype)) {
 				let docnames = links
 					.filter((link) => link.doctype == doctype)
 					.map((link) => frappe.utils.get_form_link(link.doctype, link.name, true))
@@ -740,7 +740,7 @@ frappe.ui.form.Form = class FrappeForm {
 					method: "frappe.desk.form.linked_with.cancel_all_linked_docs",
 					args: {
 						docs: links,
-						ignored_doctypes_on_cancel_all: me.ignored_doctypes_on_cancel_all || []
+						ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all || []
 					},
 					freeze: true,
 					callback: (resp) => {


### PR DESCRIPTION
Ignore doctypes to be canceled on cancel all modal.
Use case: ledger entry is handled on cancel. We have to ignore ledger entry during all linked doctype's document. 

Docs Link: https://github.com/frappe/frappe_docs/pull/28