### PR TITLE
fix: Use SameSite=Lax instead of SameSite=Strict

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -337,7 +337,7 @@ class CookieManager:
 		if frappe.session.session_country:
 			self.set_cookie("country", frappe.session.session_country)
 
-	def set_cookie(self, key, value, expires=None, secure=False, httponly=False, samesite="Strict"):
+	def set_cookie(self, key, value, expires=None, secure=False, httponly=False, samesite="Lax"):
 		if not secure:
 			secure = frappe.local.request.scheme == "https"
 		self.cookies[key] = {


### PR DESCRIPTION
Introduced by: https://github.com/frappe/frappe/pull/10734

**Reference:** https://web.dev/samesite-cookies-explained/

### Scenario:
A user is logged in on a frappe instance. (with, say, `sid=abcd`)

In an OAuth like flow, a third party site, say, GitHub redirects the user to the frappe instance.

Now because `SameSite=Strict` is set, the browser can't send the cookies it has (`sid=abcd`) to the frappe server.

Once the frappe server receives this request without cookies, It assumes that this is an unauthenticated user, and sets cookies in response as `sid=Guest`.
**Reference:** https://github.com/frappe/frappe/blob/f3e14b4ac71135fae5d83bb371c665879be36600/frappe/sessions.py#L178

Once the browser receives these values in response (`sid=Guest`) it overwrites the existing cookie values(`sid=abcd`) and sets `sid=Guest`,

This effectively causes the user session to be terminated.

#### Before
Request Headers
```HTTP
GET /github/authorize HTTP/1.1
Host: frappe.io
```

Response Headers
```HTTP
HTTP/1.0 301 MOVED PERMANENTLY
Location: /authorized
Set-Cookie: sid=Guest; Expires=Mon, 20-Jul-2020 13:22:32 GMT; HttpOnly; Path=/; SameSite=Strict
Set-Cookie: system_user=yes; Path=/; SameSite=Strict
Set-Cookie: full_name=Guest; Path=/; SameSite=Strict
Set-Cookie: user_id=Guest; Path=/; SameSite=Strict
Set-Cookie: user_image=; Path=/; SameSite=Strict
```


#### After 
Request Headers
```HTTP
GET /github/authorize HTTP/1.1
Host: frappe.io
Cookie: system_user=yes; user_image=; sid=abcdef; full_name=Administrator; user_id=Administrator;
```

Response Headers
```HTTP
HTTP/1.0 301 MOVED PERMANENTLY
Location: /authorized
Set-Cookie: sid=abcdef; Expires=Mon, 20-Jul-2020 13:17:36 GMT; HttpOnly; Path=/; SameSite=Lax
Set-Cookie: system_user=yes; Path=/; SameSite=Lax
Set-Cookie: full_name=Administrator; Path=/; SameSite=Lax
Set-Cookie: user_id=Administrator; Path=/; SameSite=Lax
Set-Cookie: user_image=; Path=/; SameSite=Lax
```
