### PR TITLE
fix(Controls): 'Yes/No' instead of '1/0' in Filter Descriptions for 'Check' values

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -332,6 +332,12 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			let docfield = frappe.meta.get_docfield(doctype, fieldname);
 			let label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
 
+			if(docfield && docfield.fieldtype === "Check"){
+				filter[3] = filter[3] == 1
+					? "Yes"
+					: "No";
+			}
+
 			if (filter[3] && Array.isArray(filter[3]) && filter[3].length > 5) {
 				filter[3] = filter[3].slice(0, 5);
 				filter[3].push('...');

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -332,10 +332,8 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			let docfield = frappe.meta.get_docfield(doctype, fieldname);
 			let label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
 
-			if (docfield && docfield.fieldtype === "Check") {
-				filter[3] = filter[3] == 1
-					? "Yes"
-					: "No";
+			if (docfield && docfield.fieldtype === 'Check') {
+				filter[3] = filter[3] ? __('Yes'): __('No');
 			}
 
 			if (filter[3] && Array.isArray(filter[3]) && filter[3].length > 5) {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -332,7 +332,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			let docfield = frappe.meta.get_docfield(doctype, fieldname);
 			let label = docfield ? docfield.label : frappe.model.unscrub(fieldname);
 
-			if(docfield && docfield.fieldtype === "Check"){
+			if (docfield && docfield.fieldtype === "Check") {
 				filter[3] = filter[3] == 1
 					? "Yes"
 					: "No";


### PR DESCRIPTION
Changes Filter Description for only Checkbox values
From:
![image](https://user-images.githubusercontent.com/15175501/87837172-4378a200-c8b0-11ea-9e82-b3178d1a02a4.png)

To:
![image](https://user-images.githubusercontent.com/15175501/87837237-6f942300-c8b0-11ea-8466-ab98e0b303ef.png)

This is to improve UX as non-technical users might not understand
at first glance if 0 means No/False and 1 means Yes/True in 
filter descriptions.

Chose Yes/No over True/False as it is more easier to understand.
This is a non-breaking change, won't affect values anywhere.
