### PR TITLE
fix(Email): Check for Not Sending Autoreply on Initial Sync

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -95,6 +95,11 @@ frappe.ui.form.on("Email Account", {
 	enable_incoming: function(frm) {
 		frm.doc.no_remaining = null; //perform full sync
 		//frm.set_df_property("append_to", "reqd", frm.doc.enable_incoming);
+		frm.trigger("warn_autoreply_on_incoming");
+	},
+
+	enable_auto_reply: function(frm) {
+		frm.trigger("warn_autoreply_on_incoming");
 	},
 
 	notify_if_unreplied: function(frm) {
@@ -184,7 +189,18 @@ frappe.ui.form.on("Email Account", {
 				read as well as unread message from server. This may also cause the duplication\
 				of Communication (emails).");
 			frappe.confirm(msg, null, function() {
-				frm.set_value("email_sync_option", "ALL");
+				frm.set_value("email_sync_option", "UNSEEN");
+			});
+		}
+	},
+
+	warn_autoreply_on_incoming: function(frm) {
+		if (frm.doc.enable_incoming && frm.doc.enable_auto_reply && frm.doc.__islocal) {
+			var msg = __("Enabling auto reply on an incoming email account will send automated replies \
+				to all the synchronized emails. Do you wish to continue?");
+			frappe.confirm(msg, null, function() {
+				frm.set_value("enable_auto_reply", 0);
+				frappe.show_alert({message: __("Disabled Auto Reply"), indicator: "blue"});
 			});
 		}
 	}


### PR DESCRIPTION
When you sync the email account created with 
Auto Reply enabled ERPNext downloads all the
emails and sends a reply to each and every one 
of them.

This should not happen as it might send the 
autoreply email (with linked document urls) to
all email ids pulled.

Added a flag in the Email Account doctype
and a check before autoreply is sent from
the scheduler job.

This is a rough solution, please go through it,
let me know if it will work and let me know if there
is a better way.