### PR TITLE
fix(data-import): Do not exclude autoname field in exported template

### DIFF
--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -278,12 +278,6 @@ frappe.data_import.DataExporter = class DataExporter {
 			|| (df.reqd && this.exporting_for == 'Insert New Records');
 
 		return fields
-			.filter(df => {
-				if (autoname_field && df.fieldname === autoname_field.fieldname) {
-					return false;
-				}
-				return true;
-			})
 			.map(df => {
 				let label = __(df.label);
 				if (autoname_field && df.fieldname === 'name') {


### PR DESCRIPTION
### Scenario:

Child table `C` has field `A`
`C` has autoname set as `field:A`

e.g `Item` > `Barcodes` table > `Barcode` field

#### Before:
In Data Import exported template `A` can't be set, only `name` (ID) can be set.

**Fixes** [ISS-20-21-03493](https://frappe.io/desk#Form/Issue/ISS-20-21-03493)