### PR TITLE
fix: check if dynamic filters exists

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -176,7 +176,7 @@ frappe.ui.form.on('Dashboard Chart', {
 
 	set_chart_field_options: function(frm) {
 		let filters = frm.doc.filters_json.length > 2 ? JSON.parse(frm.doc.filters_json) : null;
-		if (frm.doc.dynamic_filters_json.length > 2) {
+		if (frm.doc.dynamic_filters_json && frm.doc.dynamic_filters_json.length > 2) {
 			filters = frappe.dashboard_utils.get_all_filters(frm.doc);
 		}
 		frappe.xcall(

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -215,7 +215,7 @@ frappe.ui.form.on('Number Card', {
 
 	set_report_field_options: function(frm) {
 		let filters = frm.doc.filters_json.length > 2 ? JSON.parse(frm.doc.filters_json) : null;
-		if (frm.doc.dynamic_filters_json.length > 2) {
+		if (frm.doc.dynamic_filters_json && frm.doc.dynamic_filters_json.length > 2) {
 			filters = frappe.dashboard_utils.get_all_filters(frm.doc);
 		}
 		frappe.xcall(


### PR DESCRIPTION
Check if dynamic filters exist before setting report filters for charts and number cards.