### PR TITLE
fix: Pattern matching backup files via get_recent_backup

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -104,11 +104,11 @@ class BackupGenerator:
 			this_file = cstr(this_file)
 			this_file_path = os.path.join(get_backup_path(), this_file)
 			if not is_file_old(this_file_path, older_than):
-				if "_private_files" in this_file_path:
+				if "-private-files" in this_file_path:
 					backup_path_private_files = this_file_path
-				elif "_files" in this_file_path:
+				elif "-files" in this_file_path:
 					backup_path_files = this_file_path
-				elif "_database" in this_file_path:
+				elif "-database" in this_file_path:
 					backup_path_db = this_file_path
 				elif "site_config" in this_file_path:
 					site_config_backup_path = this_file_path


### PR DESCRIPTION
**Issue:** Every call of `get_backup` and `get_recent_backup` would virtually ignore the `older_than` parameter as the file patterns never matched any existing files