### PR TITLE
fix: set page actions after setting read only

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1409,6 +1409,7 @@ frappe.ui.form.Form = class FrappeForm {
 			};
 		}
 		this.perm = perm;
+		this.toolbar.set_page_action();
 	}
 
 	trigger(event, doctype, docname) {


### PR DESCRIPTION
Set page action explicitly after setting read only. 
Ref: https://github.com/frappe/frappe/pull/10998