### PR TITLE
Add the name of a document as subject option

### DIFF
--- a/frappe/desk/doctype/calendar_view/calendar_view.js
+++ b/frappe/desk/doctype/calendar_view/calendar_view.js
@@ -22,6 +22,8 @@ frappe.ui.form.on('Calendar View', {
 				df => !frappe.model.no_value_type.includes(df.fieldtype)
 			).map(df => df.fieldname);
 
+			subject_options.push('name');
+			
 			const date_options = meta.fields.filter(
 				df => ['Date', 'Datetime'].includes(df.fieldtype)
 			).map(df => df.fieldname);


### PR DESCRIPTION
Add the name of a document as subject option for calendar view, as every DocType in Frappe has a name column.

![image](https://user-images.githubusercontent.com/8351245/88270457-f8a6c200-ccd5-11ea-996f-9fbadd655485.png)
