### PR TITLE
fix: Allowing to rename DocType Tag

### DIFF
--- a/frappe/desk/doctype/tag/tag.json
+++ b/frappe/desk/doctype/tag/tag.json
@@ -1,4 +1,5 @@
 {
+ "allow_rename": 1,
  "autoname": "Prompt",
  "creation": "2016-05-25 09:43:44.767581",
  "doctype": "DocType",


### PR DESCRIPTION
This is to be able to rename Tag when spelling mistakes happen. Also Tags are then mergable e.g. color & colour. This will increasve usability.
