### PR TITLE
feat: Fetch backups via API

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -176,8 +176,8 @@ def fetch_latest_backups(with_files=True, recent=3):
 	odb.get_backup(older_than=recent, ignore_files=not with_files)
 
 	return {
-		"database": odb.backup_path_files,
-		"public": odb.backup_path_db,
+		"database": odb.backup_path_db,
+		"public": odb.backup_path_files,
 		"private": odb.backup_path_private_files
 	}
 

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -158,6 +158,30 @@ def get_backup():
 	recipient_list = odb.send_email()
 	frappe.msgprint(_("Download link for your backup will be emailed on the following email address: {0}").format(', '.join(recipient_list)))
 
+
+@frappe.whitelist()
+def fetch_latest_backups(with_files=True, recent=3):
+	"""Takes backup on-demand if doesnt exist satisfying the `recent` parameter
+	Only for: System Managers
+
+	Args:
+		with_files (bool, optional): If set, files will backuped up. Defaults to True.
+		recent (int, optional): Won't take a new backup if backup exists within this paramter. Defaults to 3 hours
+
+	Returns:
+		dict: relative Backup Paths
+	"""
+	frappe.only_for("System Manager")
+	odb = BackupGenerator(frappe.conf.db_name, frappe.conf.db_name, frappe.conf.db_password, db_host=frappe.db.host)
+	odb.get_backup(older_than=recent, ignore_files=not with_files)
+
+	return {
+		"database": odb.backup_path_files,
+		"public": odb.backup_path_db,
+		"private": odb.backup_path_private_files
+	}
+
+
 def scheduled_backup(older_than=6, ignore_files=False, backup_path_db=None, backup_path_files=None, backup_path_private_files=None, force=False):
 	"""this function is called from scheduler
 		deletes backups older than 7 days


### PR DESCRIPTION
![Screenshot 2020-07-24 at 1 42 06 PM](https://user-images.githubusercontent.com/36654812/88372557-c4093800-cdb3-11ea-910e-b5ab8b9e66b8.png)

Port of #11086 

Changes:
- Removed `verbose`, `db_port`, `db_type` parameters which dont exist in v11