### PR TITLE
fix: Added AWS S3 missing regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ typings/
 # cypress
 cypress/screenshots
 cypress/videos
+
+# JetBrains IDEs
+.idea/

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
@@ -74,11 +74,11 @@
   },
   {
    "default": "us-east-1",
-   "description": "See https://docs.aws.amazon.com/de_de/general/latest/gr/rande.html#s3_region for details.",
+   "description": "See https://docs.aws.amazon.com/general/latest/gr/s3.html for details.",
    "fieldname": "region",
    "fieldtype": "Select",
    "label": "Region",
-   "options": "us-east-1\nus-east-2\nus-west-1\nus-west-2\nap-south-1\nap-southeast-1\nap-southeast-2\nap-northeast-1\nap-northeast-2\nap-northeast-3\nca-central-1\ncn-north-1\ncn-northwest-1\neu-central-1\neu-west-1\neu-west-2\neu-west-3\neu-north-1\nsa-east-1"
+   "options": "us-east-1\nus-east-2\nus-west-1\nus-west-2\naf-south-1\nap-east-1\nap-south-1\nap-southeast-1\nap-southeast-2\nap-northeast-1\nap-northeast-2\nap-northeast-3\nca-central-1\ncn-north-1\ncn-northwest-1\neu-central-1\neu-west-1\neu-west-2\neu-west-3\neu-south-1\neu-north-1\nme-south-1\nsa-east-1"
   },
   {
    "fieldname": "endpoint_url",
@@ -151,7 +151,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-04-13 20:57:24.432183",
+ "modified": "2020-07-27 17:27:21.400000",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "S3 Backup Settings",


### PR DESCRIPTION
Hi folks,
**have updated S3 regions because it was a long time that regions were untouched.**
Since the last two years, AWS opened new regions that are missing into S3 backup integration
I have also updated the link with region list for S3 with endpoints

Here below the link of regions if you want to have a look:
[https://docs.aws.amazon.com/general/latest/gr/s3.html](https://docs.aws.amazon.com/general/latest/gr/s3.html)

and here the link with all AWS regions in 2020:
[https://docs.aws.amazon.com/general/latest/gr/rande.html](https://docs.aws.amazon.com/general/latest/gr/rande.html)

**I think it should be useful to be ported also in version 12 and version 11** 

Last, I have added .idea/ folder to .gitignore, useful for whom using JetBrains IDEs like PyCharm or WebStorm


