### PR TITLE
fix: route to new doc 1 explicitly

### DIFF
--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -136,7 +136,7 @@ export default class OnboardingWidget extends Widget {
 		if (step.is_single) {
 			route = `Form/${step.reference_document}`;
 		} else {
-			route = `Form/${step.reference_document}/${__('New')} ${__(step.reference_document)}`;
+			route = `Form/${step.reference_document}/${__('New')} ${__(step.reference_document)} 1`;
 		}
 
 		let current_route = frappe.get_route();
@@ -262,7 +262,7 @@ export default class OnboardingWidget extends Widget {
 			frappe.route_hooks.after_save = callback;
 		}
 
-		frappe.set_route(`Form/${step.reference_document}/${__('New')} ${__(step.reference_document)}`);
+		frappe.set_route(`Form/${step.reference_document}/${__('New')} ${__(step.reference_document)} 1`);
 	}
 
 	show_quick_entry(step) {


### PR DESCRIPTION
Setting the route to "New Note" will take us to "New Note 1" however, navigating back from the browser would go back to "New Note" which will route to "New Note 2". This PR fixes this problem by explicitly routing to 1 in onboarding