### PR TITLE
fix: push fieldtype in invalid conditions map

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -57,7 +57,7 @@ frappe.ui.Filter = class {
 				this.conditions.push([key, __(`{0}`, [filter.label])]);
 				for (let fieldtype of Object.keys(this.invalid_condition_map)) {
 					if (!filter.valid_for_fieldtypes.includes(fieldtype)) {
-						this.invalid_condition_map[fieldtype].push(filter.label);
+						this.invalid_condition_map[fieldtype].push(key);
 					}
 				}
 			}


### PR DESCRIPTION
**Issue:**
Filter label was being pushed in `invalid_condition_map` instead of the fieldtype which was causing the Fiscal Year filter to show for all field types.

**Fix:**
Push fieldtype in `invalid_condition_map`.