### PR TITLE
fix: check for empty report filters while creating report type dashboard chart

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -615,9 +615,7 @@ export default class ChartWidget extends Widget {
 	}
 
 	update_last_synced() {
-		let last_synced_text = __("Last synced {0}", [
-			comment_when(this.chart_doc.last_synced_on)
-		]);
+		let last_synced_text = __("Last synced {0}", [comment_when(this.chart_doc.last_synced_on)]);
 		this.footer.html(last_synced_text);
 	}
 

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -656,14 +656,15 @@ export default class ChartWidget extends Widget {
 	}
 
 	update_default_date_filters(report_filters, chart_filters) {
-		report_filters.map(f => {
-			if (['Date', 'DateRange'].includes(f.fieldtype) && f.default) {
-				if (f.reqd || chart_filters[f.fieldname]) {
-					chart_filters[f.fieldname] = f.default;
+		if (report_filters) {
+			report_filters.map(f => {
+				if (['Date', 'DateRange'].includes(f.fieldtype) && f.default) {
+					if (f.reqd || chart_filters[f.fieldname]) {
+						chart_filters[f.fieldname] = f.default;
+					}
 				}
-			}
-		});
-
+			});
+		}
 		return chart_filters;
 	}
 


### PR DESCRIPTION
**Report type dashboard chart with empty filters breaking:**

![chart-widget-before](https://user-images.githubusercontent.com/24353136/88566160-3ea3b300-d053-11ea-9e31-7d5eba26691c.png)

**Dashboard Chart:**

![report-type-chart](https://user-images.githubusercontent.com/24353136/88566655-f46f0180-d053-11ea-9d59-dfa416d970d3.png)

**After fix:**

![after](https://user-images.githubusercontent.com/24353136/88566352-832f4e80-d053-11ea-854a-3d4cc5b9a6c8.png)
