### PR TITLE
feat: (minor) Set Default Email Template for DocType

### DIFF
--- a/frappe/email/doctype/email_template/email_template.js
+++ b/frappe/email/doctype/email_template/email_template.js
@@ -9,6 +9,6 @@ frappe.ui.form.on('Email Template', {
 					istable: 0
 				}
 			}
-		})
+		});
 	}
 });

--- a/frappe/email/doctype/email_template/email_template.js
+++ b/frappe/email/doctype/email_template/email_template.js
@@ -8,7 +8,7 @@ frappe.ui.form.on('Email Template', {
 				filters: {
 					istable: 0
 				}
-			}
+			};
 		});
 	}
 });

--- a/frappe/email/doctype/email_template/email_template.js
+++ b/frappe/email/doctype/email_template/email_template.js
@@ -2,7 +2,13 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Email Template', {
-	refresh: function() {
-
+	refresh: function(frm) {
+		frm.set_query("default_doctype", "defaults", () => {
+			return {
+				filters: {
+					istable: 0
+				}
+			}
+		})
 	}
 });

--- a/frappe/email/doctype/email_template/email_template.json
+++ b/frappe/email/doctype/email_template/email_template.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "Prompt",
@@ -10,6 +11,8 @@
   "subject",
   "response",
   "owner",
+  "section_break_3",
+  "defaults",
   "section_break_4",
   "email_reply_help"
  ],
@@ -45,10 +48,21 @@
    "fieldtype": "HTML",
    "label": "Email Reply Help",
    "options": "<h4>Email Reply Example</h4>\n\n<pre>Order Overdue\n\nTransaction {{ name }} has exceeded Due Date. Please take necessary action.\n\nDetails\n\n- Customer: {{ customer }}\n- Amount: {{ grand_total }}\n</pre>\n\n<h4>How to get fieldnames</h4>\n\n<p>The fieldnames you can use in your email template are the fields in the document from which you are sending the email. You can find out the fields of any documents via Setup &gt; Customize Form View and selecting the document type (e.g. Sales Invoice)</p>\n\n<h4>Templating</h4>\n\n<p>Templates are compiled using the Jinja Templating Language. To learn more about Jinja, <a class=\"strong\" href=\"http://jinja.pocoo.org/docs/dev/templates/\">read this documentation.</a></p>\n"
+  },
+  {
+   "fieldname": "section_break_3",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "defaults",
+   "fieldtype": "Table",
+   "label": "Defaults",
+   "options": "Email Template Default"
   }
  ],
  "icon": "fa fa-comment",
- "modified": "2019-10-30 14:15:00.956347",
+ "links": [],
+ "modified": "2020-07-28 23:04:18.823499",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Template",

--- a/frappe/email/doctype/email_template/email_template.py
+++ b/frappe/email/doctype/email_template/email_template.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe, json
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils.jinja import validate_template
 from six import string_types
@@ -10,6 +11,16 @@ from six import string_types
 class EmailTemplate(Document):
 	def validate(self):
 		validate_template(self.response)
+		self.validate_default_email_template()
+
+	def validate_default_email_template(self):
+		# check if a doctype already has a default template
+		for row in self.defaults:
+			default_template = get_default_email_template(row.default_doctype)
+			if default_template and default_template != self.name and row.is_default:
+				frappe.throw(_("Row #{0}: Document {1} already has a Default Email Template {2}")
+					.format(row.idx, frappe.bold(row.default_doctype), frappe.bold(default_template)),
+						title=_("Default Exists"))
 
 @frappe.whitelist()
 def get_email_template(template_name, doc):
@@ -20,3 +31,8 @@ def get_email_template(template_name, doc):
 	email_template = frappe.get_doc("Email Template", template_name)
 	return {"subject" : frappe.render_template(email_template.subject, doc),
 			"message" : frappe.render_template(email_template.response, doc)}
+
+@frappe.whitelist()
+def get_default_email_template(doctype):
+	'''Returns default email template of given doctype'''
+	return frappe.db.get_value("Email Template Default", {"is_default": 1, "default_doctype": doctype}, "parent")

--- a/frappe/email/doctype/email_template_default/email_template_default.json
+++ b/frappe/email/doctype/email_template_default/email_template_default.json
@@ -1,0 +1,45 @@
+{
+ "actions": [],
+ "creation": "2020-07-28 22:59:05.565389",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "default_doctype",
+  "col_break",
+  "is_default"
+ ],
+ "fields": [
+  {
+   "fieldname": "default_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Document Type",
+   "options": "DocType"
+  },
+  {
+   "columns": 2,
+   "default": "0",
+   "fieldname": "is_default",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Default"
+  },
+  {
+   "fieldname": "col_break",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2020-07-28 23:46:46.771614",
+ "modified_by": "Administrator",
+ "module": "Email",
+ "name": "Email Template Default",
+ "owner": "Administrator",
+ "permissions": [],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/email/doctype/email_template_default/email_template_default.py
+++ b/frappe/email/doctype/email_template_default/email_template_default.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class EmailTemplateDefault(Document):
+	pass

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -189,7 +189,7 @@ frappe.views.CommunicationComposer = Class.extend({
 				callback: function(r) {
 					if (r && r.message) email_template_field.set_value(r.message);
 				}
-			})
+			});
 		}
 
 		this.dialog.fields_dict["email_template"].df.onchange = () => {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -178,9 +178,22 @@ frappe.views.CommunicationComposer = Class.extend({
 
 	setup_email_template: function() {
 		var me = this;
+		var email_template_field = me.dialog.fields_dict.email_template;
+
+		if (!email_template_field.get_value()) {
+			frappe.call({
+				method: 'frappe.email.doctype.email_template.email_template.get_default_email_template',
+				args: {
+					doctype: me.frm.doctype
+				},
+				callback: function(r) {
+					if (r && r.message) email_template_field.set_value(r.message);
+				}
+			})
+		}
 
 		this.dialog.fields_dict["email_template"].df.onchange = () => {
-			var email_template = me.dialog.fields_dict.email_template.get_value();
+			var email_template = email_template_field.get_value();
 
 			var prepend_reply = function(reply) {
 				if(me.reply_added===email_template) {


### PR DESCRIPTION
- Added Defaults Table in Email Template to set DocType where Email Template will be applied by default
 ![Screenshot 2020-07-29 at 1 15 37 AM](https://user-images.githubusercontent.com/25857446/88713377-d7f8c500-d138-11ea-863c-e362c82919df.png)

- Validation to prevent a DocType from having two defaults
 ![Screenshot 2020-07-29 at 1 16 04 AM](https://user-images.githubusercontent.com/25857446/88713411-e34bf080-d138-11ea-84cc-b0c6d19cee5a.png)

- Auto-population of Default Template (if available) in Doctype
![default-email-template](https://user-images.githubusercontent.com/25857446/88713436-ecd55880-d138-11ea-96be-6aaccdb3e133.gif)
