### PR TITLE
fix(realtime): doc_update event handler fix behavior

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -55,7 +55,7 @@ $.extend(frappe.model, {
 				if(frappe.get_route()[0]==="Form" && cur_frm.doc.doctype===doc.doctype && cur_frm.doc.name===doc.name) {
 					if(!frappe.ui.form.is_saving && data.modified!=cur_frm.doc.modified) {
 						doc.__needs_refresh = true;
-						cur_frm.check_doctype_conflict();
+						cur_frm.show_conflict_message();
 					}
 				} else {
 					if(!doc.__unsaved) {


### PR DESCRIPTION
### Problem:
Form does not reload data when someone else modifies the document (when `doc_update` is received on the form you're on)

### Solution:
Use the correct function

### Related to another problem (not really)
https://github.com/frappe/bench/pull/982