### PR TITLE
refactor: refer to frappe.boot.single_types instead of db call

### DIFF
--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -174,18 +174,12 @@ class ShortcutDialog extends WidgetDialog {
 				onchange: () => {
 					if (this.dialog.get_value("type") == "DocType") {
 						let doctype = this.dialog.get_value("link_to");
-
-						doctype &&
-							frappe.db
-								.get_value("DocType", doctype, "issingle")
-								.then((res) => {
-									if (res.message && res.message.issingle) {
-										this.hide_filters();
-									} else {
-										this.setup_filter(doctype);
-										this.show_filters();
-									}
-								});
+						if (frappe.boot.single_types.includes("Stock Settings")) {
+							this.hide_filters();
+						} else {
+							this.setup_filter(doctype);
+							this.show_filters();
+						}
 					} else {
 						this.hide_filters();
 					}

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -174,7 +174,7 @@ class ShortcutDialog extends WidgetDialog {
 				onchange: () => {
 					if (this.dialog.get_value("type") == "DocType") {
 						let doctype = this.dialog.get_value("link_to");
-						if (frappe.boot.single_types.includes("Stock Settings")) {
+						if (frappe.boot.single_types.includes(doctype)) {
 							this.hide_filters();
 						} else {
 							this.setup_filter(doctype);


### PR DESCRIPTION
Previous implementation required a DB call to check if the DocType is a single type or not. However, if the user was not a System Manager, they couldn't directly read the DocType DocType causing a perm issue.
<img width="460" alt="Screenshot 2020-07-30 at 2 39 09 PM" src="https://user-images.githubusercontent.com/18097732/88904219-6f156800-d272-11ea-98a1-d6a479462694.png">

This PR fixes this by relying on boot info rather than DB call