### PR TITLE
fix: text in MultiSelectList doesn't get truncated

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -3,7 +3,7 @@ frappe.ui.form.ControlMultiSelectList = frappe.ui.form.ControlData.extend({
 		let template  = `
 			<div class="multiselect-list dropdown">
 				<div class="form-control cursor-pointer dropdown-toggle input-sm" data-toggle="dropdown" tabindex=0>
-					<span class="status-text ellipsis"></span>
+					<div class="status-text ellipsis"></div>
 				</div>
 				<ul class="dropdown-menu">
 					<li class="dropdown-input-wrapper">


### PR DESCRIPTION
Before:
<img width="1201" alt="Screenshot 2020-07-31 at 6 06 53 PM" src="https://user-images.githubusercontent.com/19775888/89035648-f3dab180-d358-11ea-9001-2e1aa120980c.png">

After:

<img width="1194" alt="Screenshot 2020-07-31 at 6 11 00 PM" src="https://user-images.githubusercontent.com/19775888/89035836-37352000-d359-11ea-91e8-9bb493c6baf8.png">
