### PR TITLE
fix(Link Card): refresh incomplete_dependencies as needed

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -221,6 +221,8 @@ class Workspace:
 				incomplete_dependencies = [d for d in item.dependencies if not _doctype_contains_a_record(d)]
 				if len(incomplete_dependencies):
 					item.incomplete_dependencies = incomplete_dependencies
+				else:
+					item.incomplete_dependencies = ""
 
 			if item.onboard:
 				# Mark Spotlights for initial


### PR DESCRIPTION
  When _prepare_item in Workspace.get_cards notices that the dependencies
  for an item have been completed, it should clear the incomplete_dependencies
  field in case a value has been saved in that attribute.

  Fixes #11168.
