### PR TITLE
fix(werkzeug): Avoid duplicate lines from werkzeug in bench start logs

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -256,9 +256,11 @@ def serve(port=8000, profile=False, no_reload=False, no_threading=False, site=No
 		'SERVER_NAME': 'localhost:8000'
 	}
 
+	log = logging.getLogger('werkzeug')
+	log.propagate = False
+
 	in_test_env = os.environ.get('CI')
 	if in_test_env:
-		log = logging.getLogger('werkzeug')
 		log.setLevel(logging.ERROR)
 
 	run_simple('0.0.0.0', int(port), application,


### PR DESCRIPTION
**Before**
```
19:55:49 web.1             | 127.0.0.1 - - [01/Aug/2020 19:55:49] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:49 web.1             | INFO:werkzeug:127.0.0.1 - - [01/Aug/2020 19:55:49] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:50 web.1             | 127.0.0.1 - - [01/Aug/2020 19:55:50] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:50 web.1             | INFO:werkzeug:127.0.0.1 - - [01/Aug/2020 19:55:50] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:50 web.1             | 127.0.0.1 - - [01/Aug/2020 19:55:50] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:50 web.1             | INFO:werkzeug:127.0.0.1 - - [01/Aug/2020 19:55:50] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:50 web.1             | 127.0.0.1 - - [01/Aug/2020 19:55:50] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:50 web.1             | INFO:werkzeug:127.0.0.1 - - [01/Aug/2020 19:55:50] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:51 web.1             | 127.0.0.1 - - [01/Aug/2020 19:55:51] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:55:51 web.1             | INFO:werkzeug:127.0.0.1 - - [01/Aug/2020 19:55:51] "GET /api/method/frappe.ping HTTP/1.1" 200 -
```
**After**
```
19:54:34 web.1             | 127.0.0.1 - - [01/Aug/2020 19:54:34] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:54:34 web.1             | 127.0.0.1 - - [01/Aug/2020 19:54:34] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:54:35 web.1             | 127.0.0.1 - - [01/Aug/2020 19:54:35] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:54:35 web.1             | 127.0.0.1 - - [01/Aug/2020 19:54:35] "GET /api/method/frappe.ping HTTP/1.1" 200 -
19:54:35 web.1             | 127.0.0.1 - - [01/Aug/2020 19:54:35] "GET /api/method/frappe.ping HTTP/1.1" 200 -
```