### PR TITLE
fix: check if is_standard is "Yes"

### DIFF
--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Report', {
 	refresh: function(frm) {
-		if (frm.doc.is_standard && !frappe.boot.developer_mode) {
+		if (frm.doc.is_standard === "Yes" && !frappe.boot.developer_mode) {
 			// make the document read-only
 			frm.set_read_only();
 		}


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/pull/11180

---

Users were not allowed to create reports via the form even if permissions were given. This was because the condition checked was `if (frm.doc.is_standard)`. `is_standard` is a select, so any value was considered truthy. This PR fixes this by explicitly checking for `Yes`