### PR TITLE
fix: Validate and sanitise whitelisted search methods using decorator

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -374,6 +374,7 @@ def make_auto_repeat(doctype, docname, frequency = 'Daily', start_date = None, e
 
 # method for reference_doctype filter
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def get_auto_repeat_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	res = frappe.db.get_all('Property Setter', {
 		'property': 'allow_auto_repeat',

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -374,7 +374,7 @@ def make_auto_repeat(doctype, docname, frequency = 'Daily', start_date = None, e
 
 # method for reference_doctype filter
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def get_auto_repeat_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	res = frappe.db.get_all('Property Setter', {
 		'property': 'allow_auto_repeat',

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -147,6 +147,7 @@ def delete_contact_and_address(doctype, docname):
 				doc.delete()
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	if not txt: txt = ""
 

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -147,7 +147,7 @@ def delete_contact_and_address(doctype, docname):
 				doc.delete()
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	if not txt: txt = ""
 

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -231,6 +231,7 @@ def get_company_address(company):
 	return ret
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def address_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -231,7 +231,7 @@ def get_company_address(company):
 	return ret
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def address_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -183,6 +183,7 @@ def update_contact(doc, method):
 		contact.save(ignore_permissions=True)
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -183,7 +183,7 @@ def update_contact(doc, method):
 		contact.save(ignore_permissions=True)
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -812,6 +812,7 @@ def reset_password(user):
 		return 'not found'
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def user_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -812,7 +812,7 @@ def reset_password(user):
 		return 'not found'
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def user_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -120,6 +120,7 @@ def user_permission_exists(user, allow, for_value, applicable_for=None):
 	return has_same_user_permission
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def get_applicable_for_doctype_list(doctype, txt, searchfield, start, page_len, filters):
 	linked_doctypes_map = get_linked_doctypes(doctype, True)
 

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -120,7 +120,7 @@ def user_permission_exists(user, allow, for_value, applicable_for=None):
 	return has_same_user_permission
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def get_applicable_for_doctype_list(doctype, txt, searchfield, start, page_len, filters):
 	linked_doctypes_map = get_linked_doctypes(doctype, True)
 

--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -42,6 +42,7 @@ def get_columns_and_fields(doctype):
 	return columns, fields
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def query_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	user = filters.get("user")
 	user_perms = frappe.utils.user.UserPermissions(user)

--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -42,7 +42,7 @@ def get_columns_and_fields(doctype):
 	return columns, fields
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def query_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	user = filters.get("user")
 	user_perms = frappe.utils.user.UserPermissions(user)

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -358,6 +358,7 @@ def get_year_ending(date):
 	return add_to_date(date, days=-1)
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def get_charts_for_user(doctype, txt, searchfield, start, page_len, filters):
 	or_filters = {'owner': frappe.session.user, 'is_public': 1}
 	return frappe.db.get_list('Dashboard Chart',

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -358,7 +358,7 @@ def get_year_ending(date):
 	return add_to_date(date, days=-1)
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def get_charts_for_user(doctype, txt, searchfield, start, page_len, filters):
 	or_filters = {'owner': frappe.session.user, 'is_public': 1}
 	return frappe.db.get_list('Dashboard Chart',

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -129,6 +129,7 @@ def create_number_card(args):
 	return doc
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 	meta = frappe.get_meta(doctype)
 	searchfields = meta.get_search_fields()

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -129,7 +129,7 @@ def create_number_card(args):
 	return doc
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 	meta = frappe.get_meta(doctype)
 	searchfields = meta.get_search_fields()

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -58,6 +58,7 @@ def relink(name, reference_doctype=None, reference_name=None):
 			name = %s""", (reference_doctype, reference_name, name))
 
 @frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs()
 def get_communication_doctype(doctype, txt, searchfield, start, page_len, filters):
 	user_perms = frappe.utils.user.UserPermissions(frappe.session.user)
 	user_perms.build_permissions()

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -58,7 +58,7 @@ def relink(name, reference_doctype=None, reference_name=None):
 			name = %s""", (reference_doctype, reference_name, name))
 
 @frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs()
+@frappe.validate_and_sanitize_search_inputs
 def get_communication_doctype(doctype, txt, searchfield, start, page_len, filters):
 	user_perms = frappe.utils.user.UserPermissions(frappe.session.user)
 	user_perms.build_permissions()


### PR DESCRIPTION
Validate and sanitize whitelisted search methods using the decorator

Requires: https://github.com/frappe/frappe/pull/11194