### PR TITLE
feat(minor): Allow web form to follow document permissions

### DIFF
--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -16,6 +16,7 @@
   "route_to_success_link",
   "allow_edit",
   "allow_multiple",
+  "apply_document_permissions",
   "show_in_grid",
   "allow_delete",
   "allow_print",
@@ -346,14 +347,20 @@
    "fieldname": "custom_css_section",
    "fieldtype": "Section Break",
    "label": "Custom CSS"
+  },
+  {
+   "default": "0",
+   "fieldname": "apply_document_permissions",
+   "fieldtype": "Check",
+   "label": "Apply Document Permissions"
   }
  ],
  "has_web_view": 1,
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2019-12-24 14:15:43.497431",
- "modified_by": "faris@erpnext.com",
+ "modified": "2020-06-30 21:49:18.237443",
+ "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",
  "owner": "Administrator",

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -134,7 +134,7 @@ def get_context(context):
 		if frappe.session.user == "Guest" and frappe.form_dict.name:
 			frappe.throw(_("You need to be logged in to access this {0}.").format(self.doc_type), frappe.PermissionError)
 
-		if frappe.form_dict.name and not has_web_form_permission(self.doc_type, frappe.form_dict.name):
+		if frappe.form_dict.name and not self.has_web_form_permission(self.doc_type, frappe.form_dict.name):
 			frappe.throw(_("You don't have the permissions to access this document"), frappe.PermissionError)
 
 		self.reset_field_parent()
@@ -347,6 +347,27 @@ def get_context(context):
 			frappe.throw(_('Mandatory Information missing:') + '<br><br>'
 				+ '<br>'.join(['{0} ({1})'.format(d.label, d.fieldtype) for d in missing]))
 
+	def has_web_form_permission(self, doctype, name, ptype='read'):
+		if frappe.session.user=="Guest":
+			return False
+
+		if self.apply_document_permissions:
+			return frappe.get_doc(doctype, name).has_permission()
+
+		# owner matches
+		elif frappe.db.get_value(doctype, name, "owner")==frappe.session.user:
+			return True
+
+		elif frappe.has_website_permission(name, ptype=ptype, doctype=doctype):
+			return True
+
+		elif check_webform_perm(doctype, name):
+			return True
+
+		else:
+			return False
+
+
 
 @frappe.whitelist(allow_guest=True)
 def accept(web_form, data, docname=None, for_payment=False):
@@ -395,7 +416,7 @@ def accept(web_form, data, docname=None, for_payment=False):
 		doc.run_method('validate_payment')
 
 	if doc.name:
-		if has_web_form_permission(doc.doctype, doc.name, "write"):
+		if web_form.has_web_form_permission(doc.doctype, doc.name, "write"):
 			doc.save(ignore_permissions=True)
 		else:
 			# only if permissions are present
@@ -482,24 +503,6 @@ def delete_multiple(web_form_name, docnames):
 		raise frappe.PermissionError("You do not have permisssion to delete " + ", ".join(restricted_docnames))
 
 
-def has_web_form_permission(doctype, name, ptype='read'):
-	if frappe.session.user=="Guest":
-		return False
-
-	# owner matches
-	elif frappe.db.get_value(doctype, name, "owner")==frappe.session.user:
-		return True
-
-	elif frappe.has_website_permission(name, ptype=ptype, doctype=doctype):
-		return True
-
-	elif check_webform_perm(doctype, name):
-		return True
-
-	else:
-		return False
-
-
 def check_webform_perm(doctype, name):
 	doc = frappe.get_doc(doctype, name)
 	if hasattr(doc, "has_webform_permission"):
@@ -536,7 +539,7 @@ def get_form_data(doctype, docname=None, web_form_name=None):
 
 	if docname:
 		doc = frappe.get_doc(doctype, docname)
-		if has_web_form_permission(doctype, docname, ptype='read'):
+		if web_form.has_web_form_permission(doctype, docname, ptype='read'):
 			out.doc = doc
 		else:
 			frappe.throw(_("Not permitted"), frappe.PermissionError)


### PR DESCRIPTION
In web form, the permissions where handled in an exceptional way. A simple model would be to allow the configured permissions to be applied. Add that as an option so that it does not break backward compatibility.

Also refactored so that permission check it is a class method.