### PR TITLE
fix: add a distinct identifier for public files backup

### DIFF
--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -53,7 +53,7 @@ def get_latest_backup_file(with_files=False):
 	latest_site_config = get_latest('*.json')
 
 	if with_files:
-		latest_public_file_bak = get_latest('*-files.tar')
+		latest_public_file_bak = get_latest('*-public-files.tar')
 		latest_private_file_bak = get_latest('*-private-files.tar')
 		return latest_file, latest_site_config, latest_public_file_bak, latest_private_file_bak
 

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -82,7 +82,7 @@ class BackupGenerator:
 	def set_backup_file_name(self):
 		#Generate a random name using today's date and a 8 digit random number
 		for_db = self.todays_date + "-" + self.site_slug + "-database.sql.gz"
-		for_public_files = self.todays_date + "-" + self.site_slug + "-files.tar"
+		for_public_files = self.todays_date + "-" + self.site_slug + "-public-files.tar"
 		for_private_files = self.todays_date + "-" + self.site_slug + "-private-files.tar"
 		backup_path = get_backup_path()
 


### PR DESCRIPTION
- get_latest_backup_file returns public files backup by searching for latest file ending with  *-files.tar. This sometimes returns private files backup, added an identifier to prevent this from happening.