### PR TITLE
fix: raise incorrect site path error instead of sys.exit

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -231,8 +231,7 @@ def get_site_config(sites_path=None, site_path=None):
 		if os.path.exists(site_config):
 			config.update(get_file_json(site_config))
 		elif local.site and not local.flags.new_site:
-			print("Site {0} does not exist".format(local.site))
-			sys.exit(1)
+			raise IncorrectSitePath("{0} does not exist".format(local.site))
 
 	return _dict(config)
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

If a request is made without host header and if your hostname is not the site name frappe terminates the request without any error, a proper error message should be raised instead of terminating the request without any error message 
eg:
```
curl -i  "http://localhost:8000/api/method/frappe.ping"
curl: (52) Empty reply from server
```

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?


If the request is made without passing host header frappe terminates the request without any proper error message

```
curl -i  "http://localhost:8000/api/method/frappe.ping"
curl: (52) Empty reply from server
```



<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs


fixes:

```
curl -i  "http://localhost:8000/api/method/frappe.ping"
HTTP/1.1 404 NOT FOUND
Server: gunicorn/20.0.4
Date: Wed, 05 Aug 2020 14:24:22 GMT
Connection: keep-alive
Content-Type: text/html
Content-Length: 141


<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>404 Not Found</title>
<h1>Not Found</h1>
<p>Site localhost does not exist</p>
```
<!-- Add images/recordings to better visualize the change: expected/current behviour -->
