### PR TITLE
fix: return handler in _handler

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -19,7 +19,7 @@ frappe.ui.form.on = frappe.ui.form.on_change = function(doctype, fieldname, hand
 
 		let _handler = (...args) => {
 			try {
-				handler(...args);
+				return handler(...args);
 			} catch (error) {
 				console.error(handler);
 				throw error;


### PR DESCRIPTION
`run_serially` doesn't run correctly if a Promise is returned in a form script handler.