### PR TITLE
fix(Data Import): Allow parent with differing child table lengths

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -465,6 +465,7 @@ class ImportFile:
 
 				if doctype != self.doctype and table_df:
 					child_doc = row.parse_doc(doctype, parent_doc, table_df)
+					if child_doc is None: continue
 					parent_doc[table_df.fieldname] = parent_doc.get(table_df.fieldname, [])
 					parent_doc[table_df.fieldname].append(child_doc)
 
@@ -589,16 +590,21 @@ class Row:
 		for key in frappe.model.default_fields + ("__islocal",):
 			doc.pop(key, None)
 
+		record_is_empty = True
 		for col, value in zip(columns, values):
 			df = col.df
 			if value in INVALID_VALUES:
 				value = None
 
 			if value is not None:
+				record_is_empty = False
 				value = self.validate_value(value, col)
 
 			if value is not None:
 				doc[df.fieldname] = self.parse_value(value, col)
+
+		if record_is_empty:
+			return None
 
 		is_table = frappe.get_meta(doctype).istable
 		is_update = self.import_type == UPDATE


### PR DESCRIPTION
  Prior to this commit, if a parent has multiple child tables and
  the child tables have different numbers of rows, then the
  data import will fail with an error when it detects missing
  mandatory fields in the (necessary) empty records in the
  shorter child table.

  This commit fixes the problem by ignoring child rows that have
  only INVALID_VALUES for fields relating to that child (e.g.,
  that are altogether empty in the fields for that child).

  Closes #11222.
