### PR TITLE
fix: cache all apps in local and switch to enable/disable frappe logger

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -153,6 +153,7 @@ def init(site, sites_path=None, new_site=False):
 	local.site = site
 	local.sites_path = sites_path
 	local.site_path = os.path.join(sites_path, site)
+	local.all_apps = None
 
 	local.request_ip = None
 	local.response = _dict({"docs":[]})
@@ -916,10 +917,13 @@ def get_installed_apps(sort=False, frappe_last=False):
 	if not db:
 		connect()
 
+	if not local.all_apps:
+		local.all_apps  = get_all_apps(True)
+
 	installed = json.loads(db.get_global("installed_apps") or "[]")
 
 	if sort:
-		installed = [app for app in get_all_apps(True) if app in installed]
+		installed = [app for app in local.all_apps if app in installed]
 
 	if frappe_last:
 		if 'frappe' in installed:

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -99,15 +99,16 @@ def application(request):
 		frappe.monitor.stop(response)
 		frappe.recorder.dump()
 
-		frappe.logger("frappe.web", allow_site=frappe.local.site).info({
-			"site": get_site_name(request.host),
-			"remote_addr": getattr(request, "remote_addr", "NOTFOUND"),
-			"base_url": getattr(request, "base_url", "NOTFOUND"),
-			"full_path": getattr(request, "full_path", "NOTFOUND"),
-			"method": getattr(request, "method", "NOTFOUND"),
-			"scheme": getattr(request, "scheme", "NOTFOUND"),
-			"http_status_code": getattr(response, "status_code", "NOTFOUND")
-		})
+		if hasattr(frappe.local, 'conf') and frappe.local.conf.enable_frappe_logger:
+			frappe.logger("frappe.web", allow_site=frappe.local.site).info({
+				"site": get_site_name(request.host),
+				"remote_addr": getattr(request, "remote_addr", "NOTFOUND"),
+				"base_url": getattr(request, "base_url", "NOTFOUND"),
+				"full_path": getattr(request, "full_path", "NOTFOUND"),
+				"method": getattr(request, "method", "NOTFOUND"),
+				"scheme": getattr(request, "scheme", "NOTFOUND"),
+				"http_status_code": getattr(response, "status_code", "NOTFOUND")
+			})
 
 		if response and hasattr(frappe.local, 'rate_limiter'):
 			response.headers.extend(frappe.local.rate_limiter.headers())


### PR DESCRIPTION
```

Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 191, in handle_request
    six.reraise(*sys.exc_info())
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/gunicorn/six.py", line 625, in reraise
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/werkzeug/local.py", line 231, in application
    return ClosingIterator(app(environ, start_response), self.cleanup)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/werkzeug/wrappers/base_request.py", line 237, in application
    resp = f(*args[:-2] + (request,))
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/app.py", line 102, in application
    frappe.logger("frappe.web", allow_site=frappe.local.site).info({
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/__init__.py", line 1565, in logger
    return get_logger(module=module, with_more_info=with_more_info, allow_site=allow_site, filter=filter, max_size=max_size, file_count=file_count)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/utils/logger.py", line 37, in get_logger
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/utils/__init__.py", line 448, in get_sites
OSError: [Errno 24] Too many open files: '.'
```