### PR TITLE
refactor: catch exceptions in formatters for text editor

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -201,9 +201,14 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 		// hack to retain space sequence.
 		value = value.replace(/(\s)(\s)/g, ' &nbsp;');
 
-		if (!$(value).find('.ql-editor').length) {
+		try {
+			if (!$(value).find('.ql-editor').length) {
+				value = `<div class="ql-editor read-mode">${value}</div>`;
+			}
+		} catch(e) {
 			value = `<div class="ql-editor read-mode">${value}</div>`;
 		}
+
 		return value;
 	},
 

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -230,9 +230,14 @@ frappe.form.formatters = {
 	TextEditor: function(value) {
 		let formatted_value = frappe.form.formatters.Text(value);
 		// to use ql-editor styles
-		if (!$(formatted_value).find('.ql-editor').length) {
+		try {
+			if (!$(formatted_value).find('.ql-editor').length) {
+				formatted_value = `<div class="ql-editor read-mode">${formatted_value}</div>`;
+			}
+		} catch(e) {
 			formatted_value = `<div class="ql-editor read-mode">${formatted_value}</div>`;
 		}
+
 		return formatted_value;
 	},
 	Code: function(value) {


### PR DESCRIPTION
When text editor receives values directly via the API the data may not always be something jQuery can consume directly.
Try this in your console

```javascript
$(`Hello, this is testing <p></p>`)
```

However the same string wrapped in a `div` will work fine

```javascript
$(`<div>Hello, this is testing <p></p></div>`)
```

The formatter for text editor tokenizes the DOM using jQuery and tries to find Quill Editor class, but fails and the exceptions cascade down breaking the form rendering.

The fix is to catch any exceptions and wrap the value in quill editor class annyway