### PR TITLE
chore: Update redis to avoid unexpected exception

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3.1
 rauth==0.7.3
-redis==3.5.1
+redis==3.5.3
 requests-oauthlib==1.3.0
 requests==2.23.0
 RestrictedPython==5.0


### PR DESCRIPTION
Fixes unexpected Redis exceptions.

```py
Exception ignored in: <function Connection.__del__ at 0x7f329b0b9830>
Traceback (most recent call last):
  File "/home/travis/frappe-bench/env/lib/python3.7/site-packages/redis/connection.py", line 537, in __del__
  File "/home/travis/frappe-bench/env/lib/python3.7/site-packages/redis/connection.py", line 667, in disconnect
TypeError: catching classes that do not inherit from BaseException is not allowed
```
<img width="916" alt="Screenshot 2020-08-11 at 9 21 40 PM" src="https://user-images.githubusercontent.com/13928957/89921994-1358c080-dc1c-11ea-9529-3350de0afbdf.png">

The issue was fixed in Redis-py 3.5.3
https://github.com/andymccurdy/redis-py/issues/1339
