### PR TITLE
fix(bug): pass correct fieldname to refresh_field

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -396,7 +396,7 @@ export default class GridRow {
 		var field_on_change_function = field.df.onchange;
 		field.df.onchange = function(e) {
 			field_on_change_function && field_on_change_function(e);
-			me.grid.grid_rows[this.doc.idx - 1].refresh_field(this.df.fieldname);
+			me.grid.grid_rows[this.doc.idx - 1].refresh_field(field.df.fieldname);
 		};
 		field.refresh();
 		if(field.$input) {


### PR DESCRIPTION
Pass correct fieldname to `refresh_field`