### PR TITLE
feat: encode subject using email.header.Header

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -212,7 +212,7 @@ class EMail:
 	def make(self):
 		"""build into msg_root"""
 		headers = {
-			"Subject":        strip(self.subject),
+			"Subject":        Header(strip(self.subject), "utf-8").encode(),
 			"From":           self.sender,
 			"To":             ', '.join(self.recipients) if self.expose_recipients=="header" else "<!--recipient-->",
 			"Date":           email.utils.formatdate(),


### PR DESCRIPTION
Fix encoding issues in subject for emails. This is to handle characters not in the ASCII range

ref: [email.header.Header](https://docs.python.org/3/library/email.header.html#email.header.Header)
related PR: https://github.com/frappe/frappe/pull/11037

Fixes: [ISS-20-21-04231](https://frappe.io/desk#Form/Issue/ISS-20-21-04231)
