### PR TITLE
fix(Controls): Added Option For Python in Code Fieldtype

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -59,7 +59,7 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 		const language = this.df.options;
 
 		const valid_languages = Object.keys(language_map);
-		if (!valid_languages.includes(language)) {
+		if (language && !valid_languages.includes(language)) {
 			// eslint-disable-next-line
 			console.warn(`Invalid language option provided for field "${this.df.label}". Valid options are ${valid_languages.join(', ')}.`);
 		}

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -46,6 +46,8 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 		const language_map = {
 			'Javascript': 'ace/mode/javascript',
 			'JS': 'ace/mode/javascript',
+			'Python': 'ace/mode/python',
+			'Py': 'ace/mode/python',
 			'HTML': 'ace/mode/html',
 			'CSS': 'ace/mode/css',
 			'Markdown': 'ace/mode/markdown',


### PR DESCRIPTION
For fields which evaluate in python, there is a console error:

![image](https://user-images.githubusercontent.com/15175501/90039497-51b9b280-dce4-11ea-810c-9128be0c1bbc.png)

Also I don't understand why Golang is needed here.
Should I remove?