### PR TITLE
feat: ignore add total when syncing fixtures

### DIFF
--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -9,7 +9,7 @@ from frappe.utils import get_datetime_str
 from frappe.model.base_document import get_controller
 
 ignore_values = {
-	"Report": ["disabled", "prepared_report"],
+	"Report": ["disabled", "prepared_report", "add_total_row"],
 	"Print Format": ["disabled"],
 	"Notification": ["enabled"],
 	"Print Style": ["disabled"],


### PR DESCRIPTION
"Add Total Row" would be reset on every migrate. Add to the ignore value in this PR

Solves: [ISS-20-21-02148](https://frappe.io/desk#Form/Issue/ISS-20-21-02148)