### PR TITLE
fix: Sanitise 2FA response

### DIFF
--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -152,6 +152,7 @@ def confirm_otp_token(login_manager, otp=None, tmp_id=None):
 def get_verification_obj(user, token, otp_secret):
 	otp_issuer = frappe.db.get_value('System Settings', 'System Settings', 'otp_issuer_name')
 	verification_method = get_verification_method()
+
 	verification_obj = None
 	if verification_method == 'SMS':
 		verification_obj = process_2fa_for_sms(user, token, otp_secret)
@@ -187,9 +188,7 @@ def process_2fa_for_otp_app(user, otp_secret, otp_issuer):
 		otp_setup_completed = False
 
 	verification_obj = {
-		'totp_uri': totp_uri,
 		'method': 'OTP App',
-		'qrcode': get_qr_svg_code(totp_uri),
 		'setup': otp_setup_completed
 	}
 	return verification_obj
@@ -200,6 +199,7 @@ def process_2fa_for_email(user, token, otp_secret, otp_issuer, method='Email'):
 	message = None
 	status = True
 	prompt = ''
+
 	if method == 'OTP App' and not frappe.db.get_default(user + '_otplogin'):
 		'''Sending one-time email for OTP App'''
 		totp_uri = pyotp.TOTP(otp_secret).provisioning_uri(user, issuer_name=otp_issuer)


### PR DESCRIPTION
Description:

In frappe/frappe/twofactor.py in Frappe 12,

In two-factor authentication, the system also sending 2fa secret key in response, which enables an intruder to breach the 2fa security.

ISS-20-21-03714