### PR TITLE
fix: Remove scroll to top in form on save

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -568,9 +568,6 @@ frappe.ui.form.Form = class FrappeForm {
 		if(!save_action) save_action = "Save";
 		this.validate_form_action(save_action, resolve);
 
-		if((!this.meta.in_dialog || this.in_form) && !this.meta.istable) {
-			frappe.utils.scroll_to(0);
-		}
 		var after_save = function(r) {
 			if(!r.exc) {
 				if (["Save", "Update", "Amend"].indexOf(save_action)!==-1) {


### PR DESCRIPTION
When you edit a field and save a form, all sections are collapsed and the page scrolls to top. This behavior becomes very annoying when you try to change an attached image because a Save is triggered when removing the image and another when you attach the image.

I am not sure why the scroll to top on Save was implemented in the first place. This is open to discussion before merging.

If this is approved, I have another proposal to keep sections open that were opened by user on save. Will further make the experience less annoying.