### PR TITLE
feat: Add validate_and_sanitize_search_inputs decorator

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1650,23 +1650,6 @@ def mock(type, size = 1, locale = 'en'):
 	from frappe.chat.util import squashify
 	return squashify(results)
 
-def validate_and_sanitize_search_inputs(doctype=None):
-	def inner_fn(fn):
-		def wrapper_fn(*args, **kwargs):
-			# update kwargs with args
-			kwargs.update(dict(zip(fn.__code__.co_varnames, args)))
-			if not frappe.db.has_column(doctype or kwargs.get('doctype'), kwargs.get('searchfield')):
-				kwargs['searchfield'] = 'name'
-			else:
-				sanitize_searchfield(kwargs['searchfield'])
-
-			kwargs['txt'] = frappe.db.escape(kwargs['txt'])
-			kwargs['start'] = cint(kwargs['start'])
-			kwargs['page_len'] = cint(kwargs['page_len'])
-
-			if kwargs['doctype'] and not frappe.db.exists('DocType', kwargs['doctype']):
-				return []
-
-			return fn(**kwargs)
-		return wrapper_fn
-	return inner_fn
+def validate_and_sanitize_search_inputs(fn):
+	from frappe.desk.search import validate_and_sanitize_search_inputs as func
+	return func(fn)

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1648,7 +1648,25 @@ def mock(type, size = 1, locale = 'en'):
 			results.append(data)
 
 	from frappe.chat.util import squashify
+	return squashify(results)
 
-	results = squashify(results)
+def validate_and_sanitize_search_inputs(doctype=None):
+	def inner_fn(fn):
+		def wrapper_fn(*args, **kwargs):
+			# update kwargs with args
+			kwargs.update(dict(zip(fn.__code__.co_varnames, args)))
+			if not frappe.db.has_column(doctype or kwargs.get('doctype'), kwargs.get('searchfield')):
+				kwargs['searchfield'] = 'name'
+			else:
+				sanitize_searchfield(kwargs['searchfield'])
 
-	return results
+			kwargs['txt'] = frappe.db.escape(kwargs['txt'])
+			kwargs['start'] = cint(kwargs['start'])
+			kwargs['page_len'] = cint(kwargs['page_len'])
+
+			if kwargs['doctype'] and not frappe.db.exists('DocType', kwargs['doctype']):
+				return []
+
+			return fn(**kwargs)
+		return wrapper_fn
+	return inner_fn

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -206,24 +206,3 @@ def scrub_custom_query(query, key, txt):
 	if '%s' in query:
 		query = query.replace('%s', ((txt or '') + '%'))
 	return query
-
-def validate_and_sanitize_search_inputs(doctype=None):
-	def inner_fn(fn):
-		def wrapper_fn(*args, **kwargs):
-			# update kwargs with args
-			kwargs.update(dict(zip(fn.__code__.co_varnames, args)))
-			if not frappe.db.has_column(doctype or kwargs.get('doctype'), kwargs.get('searchfield')):
-				kwargs['searchfield'] = 'name'
-			else:
-				sanitize_searchfield(kwargs['searchfield'])
-
-			kwargs['txt'] = frappe.db.escape(kwargs['txt'])
-			kwargs['start'] = cint(kwargs['start'])
-			kwargs['page_len'] = cint(kwargs['page_len'])
-
-			if kwargs['doctype'] and not frappe.db.exists('DocType', kwargs['doctype']):
-				return []
-
-			return fn(**kwargs)
-		return wrapper_fn
-	return inner_fn

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -10,7 +10,7 @@ from frappe.handler import is_whitelisted
 from frappe import _
 from six import string_types
 import re
-from functools import wraps
+import wrapt
 
 UNTRANSLATED_DOCTYPES = ["DocType", "Role"]
 
@@ -208,17 +208,14 @@ def scrub_custom_query(query, key, txt):
 		query = query.replace('%s', ((txt or '') + '%'))
 	return query
 
-def validate_and_sanitize_search_inputs(fn):
-	@wraps(fn)
-	def inner_fn(*args, **kwargs):
-		# update kwargs with args
-		kwargs.update(dict(zip(fn.__code__.co_varnames, args)))
-		sanitize_searchfield(kwargs['searchfield'])
-		kwargs['start'] = cint(kwargs['start'])
-		kwargs['page_len'] = cint(kwargs['page_len'])
+@wrapt.decorator
+def validate_and_sanitize_search_inputs(fn, instance, args, kwargs):
+	kwargs.update(dict(zip(fn.__code__.co_varnames, args)))
+	sanitize_searchfield(kwargs['searchfield'])
+	kwargs['start'] = cint(kwargs['start'])
+	kwargs['page_len'] = cint(kwargs['page_len'])
 
-		if kwargs['doctype'] and not frappe.db.exists('DocType', kwargs['doctype']):
-			return []
+	if kwargs['doctype'] and not frappe.db.exists('DocType', kwargs['doctype']):
+		return []
 
-		return fn(**kwargs)
-	return inner_fn
+	return fn(**kwargs)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -52,9 +52,6 @@ class TestSearch(unittest.TestCase):
 		frappe.local.lang = 'en'
 
 	def test_validate_and_sanitize_search_inputs(self):
-		@frappe.validate_and_sanitize_search_inputs
-		def get_data(doctype, txt, searchfield, start, page_len, filters):
-			return [doctype, txt, searchfield, start, page_len, filters]
 
 		# should raise error if searchfield is injectable
 		self.assertRaises(frappe.DataError,
@@ -72,3 +69,12 @@ class TestSearch(unittest.TestCase):
 
 		# return empty string if passed doctype is invalid
 		self.assertListEqual(get_data("Random DocType", 'Random', 'email', '2', '10', dict()), [])
+
+		# should not fail if function is called via frappe.call with extra arguments
+		args = ("Random DocType", 'Random', 'email', '2', '10', dict())
+		kwargs = {'as_dict': False}
+		self.assertListEqual(frappe.call('frappe.tests.test_search.get_data', *args, **kwargs), [])
+
+@frappe.validate_and_sanitize_search_inputs
+def get_data(doctype, txt, searchfield, start, page_len, filters):
+	return [doctype, txt, searchfield, start, page_len, filters]

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -50,3 +50,25 @@ class TestSearch(unittest.TestCase):
 
 	def tearDown(self):
 		frappe.local.lang = 'en'
+
+	def test_validate_and_sanitize_search_inputs(self):
+		@frappe.validate_and_sanitize_search_inputs
+		def get_data(doctype, txt, searchfield, start, page_len, filters):
+			return [doctype, txt, searchfield, start, page_len, filters]
+
+		# should raise error if searchfield is injectable
+		self.assertRaises(frappe.DataError,
+			get_data, *('User', 'Random', 'select * from tabSessions) --', '1', '10', dict()))
+
+		# page_len and start should be converted to int
+		self.assertListEqual(get_data('User', 'Random', 'email', 'name or (select * from tabSessions)', '10', dict()),
+			['User', 'Random', 'email', 0, 10, {}])
+		self.assertListEqual(get_data('User', 'Random', 'email', page_len='2', start='10', filters=dict()),
+			['User', 'Random', 'email', 10, 2, {}])
+
+		# DocType can be passed as None which should be accepted
+		self.assertListEqual(get_data(None, 'Random', 'email', '2', '10', dict()),
+			[None, 'Random', 'email', 2, 10, {}])
+
+		# return empty string if passed doctype is invalid
+		self.assertListEqual(get_data("Random DocType", 'Random', 'email', '2', '10', dict()), [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,3 +67,4 @@ watchdog==0.8.0
 Werkzeug==0.16.1
 xlrd==1.2.0
 zxcvbn-python==4.4.24
+wrapt==1.10.11


### PR DESCRIPTION
Decorator to validate and sanitize input to the search queries.

Docs Link: https://github.com/frappe/frappe_docs/pull/20

port-of: https://github.com/frappe/frappe/pull/11194