### PR TITLE
fix: google auth version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gitdb2==2.0.6;python_version<'3.4'
 google-api-python-client==1.9.3
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
-google-auth==1.18.0
+google-auth==1.19.1
 googlemaps==3.1.1
 gunicorn==19.10.0
 html2text==2016.9.19


### PR DESCRIPTION
fix: pip warning that after October, 2020 the way to resolve might be different.
google api core need minimum google auth 1.19.1