### PR TITLE
fix: DocPerm duplication

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -989,7 +989,8 @@ def clear_permissions_cache(doctype):
 			`tabHas Role`,
 			`tabDocPerm`
 		WHERE `tabDocPerm`.`parent` = %s
-		AND `tabDocPerm`.`role` = `tabHas Role`.`role`
+			AND `tabDocPerm`.`role` = `tabHas Role`.`role`
+			AND `tabHas Role`.`parenttype` = 'User'
 		""", doctype):
 		frappe.clear_cache(user=user)
 

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -376,8 +376,7 @@ frappe.PermissionEngine = Class.extend({
 							options:me.options.roles, reqd:1,fieldname:"role"},
 						{fieldtype:"Select", label:__("Permission Level"),
 							options:[0,1,2,3,4,5,6,7,8,9], reqd:1, fieldname: "permlevel",
-							description: __("Level 0 is for document level permissions, \
-								higher levels for field level permissions.")}
+							description: __("Level 0 is for document level permissions, higher levels for field level permissions.")}
 					]
 				});
 				if(me.get_doctype()) {

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -334,6 +334,7 @@ frappe.PermissionEngine = Class.extend({
 		});
 
 		this.body.on("click", "input[type='checkbox']", function() {
+			frappe.dom.freeze();
 			var chk = $(this);
 			var args = {
 				role: chk.attr("data-role"),
@@ -348,6 +349,7 @@ frappe.PermissionEngine = Class.extend({
 				method: "update",
 				args: args,
 				callback: function(r) {
+					frappe.dom.unfreeze();
 					if(r.exc) {
 						// exception: reverse
 						chk.prop("checked", !chk.prop("checked"));


### PR DESCRIPTION
In the permission manager page, when a perm value is changed, a request is immediately sent to the server, for a fresh instance a copy of the initial perms are created and the permission is updated onto it. This request would take some time to finish and commit the copied perms (2-4 seconds). 

During this, the user is allowed to click and change other permissions. This means a new request gets initiated, since the previous changes are not committed, the new request would generate a new copy of custom perms, leading to duplication.

Two problems can be pointed out here

1. **Users can initiate simultaneous requests, causing duplication**
	Fixed by freezing the DOM on request creation, and unfreezing it when done
1. **The request is slow**
	A query on `Has Role` would scan all its parents, these parents could be anything, adding a where clause to filter only for users significantly reduces the amount of time taken. Clear notification is heavy, but for smaller systems the request is instantaneous, for larger systems (tested on 130 users), it takes about a second to process

Solves: [ISS-20-21-04336](https://frappe.io/desk#Form/Issue/ISS-20-21-04336)