### PR TITLE
fix: blog title and intro not shown

### DIFF
--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -99,7 +99,7 @@ def get_list_context(context=None):
 		hide_filters = True,
 		children = get_children(),
 		# show_search = True,
-		title = _('Blog')
+		title = frappe.db.get_single_value("Blog Settings", "blog_title"),
 	)
 
 	category = sanitize_html(frappe.local.form_dict.blog_category or frappe.local.form_dict.category)
@@ -115,6 +115,9 @@ def get_list_context(context=None):
 
 	elif frappe.local.form_dict.txt:
 		list_context.sub_title = _('Filtered by "{0}"').format(sanitize_html(frappe.local.form_dict.txt))
+
+	else:
+		list_context.introduction = frappe.db.get_single_value("Blog Settings", "blog_introduction")
 
 	if list_context.sub_title:
 		list_context.parents = [{"name": _("Home"), "route": "/"},

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -17,9 +17,9 @@ def get_context(context, **dict_params):
 	doctype = frappe.local.form_dict.doctype
 	context.parents = [{"route":"me", "title":_("My Account")}]
 	context.meta = frappe.get_meta(doctype)
+	context.title = context.doctype
 	context.update(get_list_context(context, doctype) or {})
 	context.doctype = doctype
-	context.title = context.doctype
 	context.txt = frappe.local.form_dict.txt
 	context.update(get(**frappe.local.form_dict))
 


### PR DESCRIPTION
The Blog Settings configuration would not reflect on v12. This was because the list view context was not set correctly and the context was overridden in `list.py`
