### PR TITLE
fix(minor): use get_list in client.get_value for tighter checks

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -75,17 +75,23 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 	filters = get_safe_filters(filters)
 
 	try:
-		fieldname = json.loads(fieldname)
+		fields = json.loads(fieldname)
 	except (TypeError, ValueError):
 		# name passed, not json
-		pass
+		fields = [fieldname]
 
 	# check whether the used filters were really parseable and usable
 	# and did not just result in an empty string or dict
 	if not filters:
 		filters = None
 
-	return frappe.db.get_value(doctype, filters, fieldname, as_dict=as_dict, debug=debug)
+	value = frappe.get_list(doctype, filters=filters, fields=fields, debug=debug, limit=1)
+	if as_dict:
+		value = value[0] if value else {}
+	else:
+		value = value[0].fieldname
+
+	return value
 
 @frappe.whitelist()
 def get_single_value(doctype, field):

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -11,7 +11,11 @@ import requests
 import base64
 
 class TestAPI(unittest.TestCase):
-	def insert_docs(self):
+	def test_insert_many(self):
+		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		frappe.db.sql("delete from `tabNote` where title in ('Sing','a','song','of','sixpence')")
+		frappe.db.commit()
+
 		server.insert_many([
 			{"doctype": "Note", "public": True, "title": "Sing"},
 			{"doctype": "Note", "public": True, "title": "a"},
@@ -19,13 +23,6 @@ class TestAPI(unittest.TestCase):
 			{"doctype": "Note", "public": True, "title": "of"},
 			{"doctype": "Note", "public": True, "title": "sixpence"},
 		])
-
-	def test_insert_many(self, server):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabNote` where title in ('Sing','a','song','of','sixpence')")
-		frappe.db.commit()
-
-		self.insert_docs(server)
 
 		self.assertTrue(frappe.db.get_value('Note', {'title': 'Sing'}))
 		self.assertTrue(frappe.db.get_value('Note', {'title': 'a'}))
@@ -44,8 +41,6 @@ class TestAPI(unittest.TestCase):
 
 	def test_list_docs(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		self.insert_docs(server)
-
 		doc_list = server.get_list("Note")
 
 		self.assertTrue(len(doc_list))


### PR DESCRIPTION
Alternate fix for: https://github.com/frappe/frappe/pull/10996

@revant @Thunderbottom 