### PR TITLE
fix: Create backups folder if doesn't exist

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -62,7 +62,7 @@ class BackupGenerator:
 		else:
 			for file_path in [self.backup_path_files, self.backup_path_db, self.backup_path_private_files]:
 				dir = os.path.dirname(file_path)
-				os.makedirs(dir)
+				os.makedirs(dir, exist_ok=True)
 
 
 	def get_backup(self, older_than=24, ignore_files=False, force=False):

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -48,9 +48,22 @@ class BackupGenerator:
 
 		site = frappe.local.site or frappe.generate_hash(length=8)
 		self.site_slug = site.replace('.', '_')
-
 		self.verbose = verbose
+		self.setup_backup_directory()
 		_verbose = verbose
+
+	def setup_backup_directory(self):
+		specified = self.backup_path_db or self.backup_path_files or self.backup_path_private_files
+
+		if not specified:
+			backups_folder = get_backup_path()
+			if not os.path.exists(backups_folder):
+				os.makedirs(backups_folder)
+		else:
+			for file_path in [self.backup_path_files, self.backup_path_db, self.backup_path_private_files]:
+				dir = os.path.dirname(file_path)
+				os.makedirs(dir)
+
 
 	def get_backup(self, older_than=24, ignore_files=False, force=False):
 		"""


### PR DESCRIPTION
Backups fail silently if the default `backups` folder doesn't exist under private or by the ones set by those using the function