### PR TITLE
fix: website generator

### DIFF
--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -154,7 +154,7 @@ class WebsiteGenerator(Document):
 		# Check if the route is changed
 		if old_doc and old_doc.route != self.route:
 			# Remove the route from index if the route has changed
-			remove_document_from_index("web_routes", old_doc.route)
+			remove_document_from_index(old_doc.route)
 
 	def update_website_search_index(self):
 		"""
@@ -169,4 +169,4 @@ class WebsiteGenerator(Document):
 			frappe.enqueue(update_index_for_path, path=self.route)
 		elif self.route:
 			# If the website is not published
-			remove_document_from_index("web_routes", self.route)
+			remove_document_from_index(self.route)


### PR DESCRIPTION
### Error

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1093, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 307, in _save
    self.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 268, in insert
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 982, in run_post_save_methods
    self.run_method('on_change')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 831, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1116, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1099, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 825, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/website_generator.py", line 92, in on_change
    self.update_website_search_index()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/website_generator.py", line 172, in update_website_search_index
    remove_document_from_index("web_routes", self.route)
TypeError: remove_document_from_index() takes 1 positional argument but 2 were given
```

### Fix

`remove_document_from_index`takes only one argument, the path / route:

https://github.com/frappe/frappe/blob/b83e0b9abd63014cd9c3b331518c79885381547d/frappe/search/website_search.py#L111-L113
