### PR TITLE
fix: Re-connect to database in case connection is closed

### DIFF
--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -92,6 +92,8 @@ def bootstrap_database(db_name, verbose, source_sql=None):
 		sys.exit(1)
 
 	import_db_from_sql(source_sql, verbose)
+
+	frappe.connect(db_name=db_name)
 	if not 'tabDefaultValue' in frappe.db.get_tables():
 		print('''Database not installed, this can due to lack of permission, or that the database name exists.
 			Check your mysql root password, or use --force to reinstall''')


### PR DESCRIPTION
Bootstrapping a large database may take very long. In this case, Frappe's connection to the database gets closed before the check `'tabDefaultValue' in frappe.db.get_tables()` can be run.

Error message: 2006, MySQL server has gone away

Why does this happen?

frappe process loses connection due to inactivity as it starts another process to restore the database and must reconnect after a long restore.