### PR TITLE
refactor: Rounding

### DIFF
--- a/frappe/tests/test_data.py
+++ b/frappe/tests/test_data.py
@@ -1,0 +1,24 @@
+#  -*- coding: utf-8 -*-
+
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import unittest
+import frappe
+
+class TestData(unittest.TestCase):
+	def test_rounded_using_flt(self):
+		# Test if rounding result is on par with mysql rounding
+		# using Round Halfs to nearest Even
+		from frappe.utils import flt
+
+		dataset = [(34.5, 0), (-34.5, 0),
+			(3.45, 1), (-3.45, 1),
+			(0.345, 2), (-0.345, 2),
+			(0.0345, 3), (-0.0345, 3)]
+
+		for data in dataset:
+			py_rounding = flt(data[0], data[1])
+			db_rounding = frappe.db.sql("""select ROUND(CONVERT({0}, DOUBLE),{1})""".format(data[0], data[1]))[0][0]
+			self.assertEqual(py_rounding, db_rounding)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -488,25 +488,10 @@ def cstr(s, encoding='utf-8'):
 	return frappe.as_unicode(s, encoding)
 
 def rounded(num, precision=0):
-	"""round method for round halfs to nearest even algorithm aka banker's rounding - compatible with python3"""
-	precision = cint(precision)
-	multiplier = 10 ** precision
-
-	# avoid rounding errors
-	num = round(num * multiplier if precision else num, 8)
-
-	floor_num = math.floor(num)
-	decimal_part = num - floor_num
-
-	if not precision and decimal_part == 0.5:
-		num = floor_num if (floor_num % 2 == 0) else floor_num + 1
-	else:
-		if decimal_part == 0.5:
-			num = floor_num + 1
-		else:
-			num = round(num)
-
-	return (num / multiplier) if precision else num
+	"""round method for round halfs to nearest even"""
+	from decimal import Decimal
+	number = Decimal(str(num))
+	return float(round(number, precision))
 
 def remainder(numerator, denominator, precision=2):
 	precision = cint(precision)


### PR DESCRIPTION
## **Problem:**
There's inconsistency between our Python implemented rounding and that of MySQL

![Screenshot 2020-08-14 at 1 12 44 PM](https://user-images.githubusercontent.com/25857446/90668624-fe101180-e26d-11ea-931d-1d89a31d1ab8.png)

The aim here is make sure rounding through either methods must give us the same result

## **Fix:**

**Python:**
- Before getting into what was done, we need to understand that not all floating point numbers have accurate binary representations. 
- **0.1** is a good example of floating point number that has an infinite representation in binary making it very hard to round it ([here](https://www.exploringbinary.com/why-0-point-1-does-not-exist-in-floating-point/) is a great break down)
- Similarly with 0.2. Thus we get  **0.1 + 0.2 = 0.30000000000000004** , while we were expecting 0.3
- Almost all platforms map python floats to IEEE 745 floating-point arithmetic which stores floats with best approximate double precision it can get. The implication of the same is what we discussed above.
- Another result of this implication is : **0.1 * 6 = 0.6000000000000001**
- Python usually rounds and returns such floats upto 16 / 17 (older versions) digits which introduces inaccuracy when rounding on our end. We need a way to store all these digits after the decimal point (not just 16 places) and round them thereafter to get better accuracy.
- The [decimal](https://docs.python.org/3/library/decimal.html) module in python handles this well. It can stores approx 55 digits after the decimal.
- Why we use `Decimal(str(number))` over `Decimal(number)` is visible below. For most of our operations when we mean 0.1 * 0.2 we want 0.02 not 0.02000000000000000222044604925
![Screenshot 2020-08-20 at 10 05 15 PM](https://user-images.githubusercontent.com/25857446/90799765-52c89080-e331-11ea-8531-e1f5bed68688.png)
- What you see is what you get 
![Screenshot 2020-08-20 at 10 11 33 PM](https://user-images.githubusercontent.com/25857446/90799821-64aa3380-e331-11ea-9d4d-ca6a26837864.png)

- The default rounding method it uses is [ROUND_HALF_EVEN ](https://docs.python.org/3/library/decimal.html#decimal.ROUND_HALF_EVEN)

**MySQL:**
- MySQL has some [absurd](https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round) 
  rounding rules (which we cannot change). We need it to behave exactly like Round Half Even.
  According to Here's what `select round(0.0345, 3)` gives us:
  ![Screenshot 2020-08-20 at 10 17 43 PM](https://user-images.githubusercontent.com/25857446/90800448-5577b580-e332-11ea-8ce5-4ec2c6520604.png)

- Instead of `select round(0.0345, 3)`, we use `select round(convert(0.0345,double), 3)` for better accuracy in the values after the decimal. **Double** will store more digits after the decimal which brings us to the closest approximation of the number as  compared to float as well.

More details regarding _why convert to double?_

```
MariaDB> SELECT ROUND(CONVERT('3.45', FLOAT), 1);
+----------------------------------+
| ROUND(CONVERT('3.45', FLOAT), 1) |
+----------------------------------+
|                              3.5 |
+----------------------------------+
1 row in set (0.000 sec)

MariaDB> SELECT ROUND(CONVERT(3.45, DOUBLE), 1);
+---------------------------------+
| ROUND(CONVERT(3.45, DOUBLE), 1) |
+---------------------------------+
|                             3.4 |
+---------------------------------+
```

- Result with `flt` using the new rounded function and query tweak:
![Screenshot 2020-08-19 at 10 53 57 PM](https://user-images.githubusercontent.com/25857446/90668790-39124500-e26e-11ea-8301-e02f74debdeb.png)

**Note:** A lot of trial and error was involved. Comparisons were made between different rounding methods for the decimal module, and the default came the closest with MySQL's behaviour