### PR TITLE
fix(scheduler): Sync Jobs when hooks change

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -125,9 +125,9 @@ def run_scheduled_job(job_type):
 		print(frappe.get_traceback())
 
 
-def sync_jobs():
+def sync_jobs(hooks=None):
 	frappe.reload_doc("core", "doctype", "scheduled_job_type")
-	scheduler_events = frappe.get_hooks("scheduler_events")
+	scheduler_events = hooks or frappe.get_hooks("scheduler_events")
 	all_events = insert_events(scheduler_events)
 	clear_events(all_events)
 

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -164,14 +164,19 @@ def insert_event_jobs(events, event_type):
 
 def insert_single_event(frequency, event, cron_format=None):
 	cron_expr = {"cron_format": cron_format} if cron_format else {}
+	doc = frappe.get_doc({
+		"doctype": "Scheduled Job Type",
+		"method": event,
+		"cron_format": cron_format,
+		"frequency": frequency
+	})
 
 	if not frappe.db.exists("Scheduled Job Type", {"method": event, "frequency": frequency, **cron_expr }):
-		frappe.get_doc({
-			"doctype": "Scheduled Job Type",
-			"method": event,
-			"cron_format": cron_format,
-			"frequency": frequency
-		}).insert()
+		try:
+			doc.insert()
+		except frappe.DuplicateEntryError:
+			doc.delete()
+			doc.insert()
 
 
 def clear_events(all_events):

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -109,11 +109,13 @@ class ScheduledJobType(Document):
 	def on_trash(self):
 		frappe.db.sql('delete from `tabScheduled Job Log` where scheduled_job_type=%s', self.name)
 
+
 @frappe.whitelist()
 def execute_event(doc):
 	frappe.only_for('System Manager')
 	doc = json.loads(doc)
 	frappe.get_doc('Scheduled Job Type', doc.get('name')).enqueue()
+
 
 def run_scheduled_job(job_type):
 	'''This is a wrapper function that runs a hooks.scheduler_events method'''
@@ -122,11 +124,13 @@ def run_scheduled_job(job_type):
 	except Exception:
 		print(frappe.get_traceback())
 
+
 def sync_jobs():
-	frappe.reload_doc('core', 'doctype', 'scheduled_job_type')
-	scheduler_events = frappe.get_hooks('scheduler_events')
+	frappe.reload_doc("core", "doctype", "scheduled_job_type")
+	scheduler_events = frappe.get_hooks("scheduler_events")
 	all_events = insert_events(scheduler_events)
 	clear_events(all_events)
+
 
 def insert_events(scheduler_events):
 	cron_jobs, event_jobs = [], []
@@ -139,13 +143,15 @@ def insert_events(scheduler_events):
 			event_jobs += insert_event_jobs(events, event_type)
 	return cron_jobs + event_jobs
 
+
 def insert_cron_jobs(events):
 	cron_jobs = []
 	for cron_format in events:
 		for event in events.get(cron_format):
 			cron_jobs.append(event)
-			insert_single_event('Cron', event, cron_format)
+			insert_single_event("Cron", event, cron_format)
 	return cron_jobs
+
 
 def insert_event_jobs(events, event_type):
 	event_jobs = []
@@ -155,18 +161,20 @@ def insert_event_jobs(events, event_type):
 		insert_single_event(frequency, event)
 	return event_jobs
 
-def insert_single_event(frequency, event, cron_format=None):
-	cron_expr = {'cron_format': cron_format} if cron_format else {}
 
-	if not frappe.db.exists('Scheduled Job Type', {'method': event, 'frequency': frequency, **cron_expr }):
+def insert_single_event(frequency, event, cron_format=None):
+	cron_expr = {"cron_format": cron_format} if cron_format else {}
+
+	if not frappe.db.exists("Scheduled Job Type", {"method": event, "frequency": frequency, **cron_expr }):
 		frappe.get_doc({
-			'doctype': 'Scheduled Job Type',
-			'method': event,
-			'cron_format': cron_format,
-			'frequency': frequency
+			"doctype": "Scheduled Job Type",
+			"method": event,
+			"cron_format": cron_format,
+			"frequency": frequency
 		}).insert()
 
+
 def clear_events(all_events):
-	for event in frappe.get_all('Scheduled Job Type', ('name', 'method')):
+	for event in frappe.get_all("Scheduled Job Type", ("name", "method")):
 		if event.method not in all_events:
-			frappe.delete_doc('Scheduled Job Type', event.name)
+			frappe.delete_doc("Scheduled Job Type", event.name)

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -44,7 +44,7 @@ class TestScheduledJobType(unittest.TestCase):
 		sync_jobs(updated_scheduler_events)
 		frappe.db.commit()
 		updated_scheduled_job = frappe.get_doc("Scheduled Job Type", {"method": "frappe.email.queue.flush"})
-		self.assertEqual(scheduled_job.frequency, "Hourly")
+		self.assertEqual(updated_scheduled_job.frequency, "Hourly")
 
 	def test_daily_job(self):
 		job = frappe.get_doc('Scheduled Job Type', dict(method = 'frappe.email.queue.clear_outbox'))

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -11,11 +11,10 @@ from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
 
 class TestScheduledJobType(unittest.TestCase):
 	def setUp(self):
-		if not frappe.get_all('Scheduled Job Type', limit=1):
-			frappe.db.rollback()
-			frappe.db.sql('truncate `tabScheduled Job Type`')
-			sync_jobs()
-			frappe.db.commit()
+		frappe.db.rollback()
+		frappe.db.sql('truncate `tabScheduled Job Type`')
+		sync_jobs()
+		frappe.db.commit()
 
 	def test_sync_jobs(self):
 		all_job = frappe.get_doc('Scheduled Job Type',
@@ -35,7 +34,6 @@ class TestScheduledJobType(unittest.TestCase):
 		# check if jobs are synced after change in hooks
 		updated_scheduler_events = { "hourly": ["frappe.email.queue.flush"] }
 		sync_jobs(updated_scheduler_events)
-		frappe.db.commit()
 		updated_scheduled_job = frappe.get_doc("Scheduled Job Type", {"method": "frappe.email.queue.flush"})
 		self.assertEqual(updated_scheduled_job.frequency, "Hourly")
 

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -33,13 +33,6 @@ class TestScheduledJobType(unittest.TestCase):
 		self.assertEqual(cron_job.cron_format, '0/15 * * * *')
 
 		# check if jobs are synced after change in hooks
-		scheduler_events = { "cron": { "0/15 * * * *": ["frappe.email.queue.flush"] } }
-		sync_jobs(scheduler_events)
-		frappe.db.commit()
-		scheduled_job = frappe.get_doc("Scheduled Job Type", {"method": "frappe.email.queue.flush"})
-		self.assertEqual(scheduled_job.frequency, "Cron")
-		self.assertEqual(scheduled_job.cron_format, "0/15 * * * *")
-
 		updated_scheduler_events = { "hourly": ["frappe.email.queue.flush"] }
 		sync_jobs(updated_scheduler_events)
 		frappe.db.commit()


### PR DESCRIPTION
**Issue:** If the frequency of jobs would change, it would not update be updated in the corresponding Schedule Job Type documents, which causes the events to get triggered on basis of the old schedules. 

