### PR TITLE
feat(server script): Allow frappe.db.sql for read

### DIFF
--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-import unittest
+import unittest, frappe
 from frappe.utils.safe_exec import safe_exec
 
 class TestSafeExec(unittest.TestCase):
@@ -8,3 +8,10 @@ class TestSafeExec(unittest.TestCase):
 
 	def test_internal_attributes(self):
 		self.assertRaises(SyntaxError, safe_exec, '().__class__.__call__')
+
+	def test_sql(self):
+		_locals = dict(out=None)
+		safe_exec('''out = frappe.db.sql("select name from tabDocType where name='DocType'")''', None, _locals)
+		self.assertEqual(_locals['out'][0][0], 'DocType')
+
+		self.assertRaises(frappe.PermissionError, safe_exec, 'frappe.db.sql("update tabToDo set description=NULL")')

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -114,6 +114,7 @@ def get_safe_globals():
 			get_single_value = frappe.db.get_single_value,
 			get_default = frappe.db.get_default,
 			escape = frappe.db.escape,
+			sql = read_sql
 		)
 
 	if frappe.response:
@@ -131,6 +132,13 @@ def get_safe_globals():
 	out.sorted = sorted
 
 	return out
+
+def read_sql(query, *args, **kwargs):
+	'''a wrapper for frappe.db.sql to allow reads'''
+	if query.strip().split(None, 1)[0].lower() == 'select':
+		return frappe.db.sql(query, *args, **kwargs)
+	else:
+		raise frappe.PermissionError('Only SELECT SQL allowed in scripting')
 
 def _getitem(obj, key):
 	# guard function for RestrictedPython


### PR DESCRIPTION
Allow `frappe.db.sql` for `SELECT` queries in safe scripting to allow for join queries