### PR TITLE
fix: Image shown as broken in comment

### DIFF
--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -406,6 +406,10 @@ def extract_images_from_html(doc, content):
 		doctype = doc.parenttype if doc.parent else doc.doctype
 		name = doc.parent or doc.name
 
+		if doc.doctype == "Comment":
+			doctype = doc.reference_doctype
+			name = doc.reference_name
+
 		# TODO fix this
 		file_url = save_file(filename, content, doctype, name, decode=True).get("file_url")
 		if not frappe.flags.has_dataurl:


### PR DESCRIPTION
Problem is that when the image is attached to the Comment. It appears broken to the other users, only the creator can see it.

<img width="624" alt="Screen Shot 2020-08-21 at 6 04 06 PM" src="https://user-images.githubusercontent.com/16913064/90891047-bb1e7d00-e3d8-11ea-97ec-951d90a3395a.png">

It is being caused because of the absence reference name in File. Since no reference name, the permissions fail hence broken image.
<img width="464" alt="Screen Shot 2020-08-21 at 6 07 12 PM" src="https://user-images.githubusercontent.com/16913064/90891418-46980e00-e3d9-11ea-87da-e576ce932b85.png">


The solution for this is that reference doctype and reference name should be the Document it is being commented on.

<img width="926" alt="Screen Shot 2020-08-21 at 6 06 18 PM" src="https://user-images.githubusercontent.com/16913064/90891305-1ea8aa80-e3d9-11ea-8b06-13626a94e90b.png">
