### PR TITLE
[WIP] feat: GraphQL support for Frappe

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -17,6 +17,7 @@ import frappe
 import frappe.handler
 import frappe.auth
 import frappe.api
+import frappe.graphql
 import frappe.utils.response
 import frappe.website.render
 from frappe.utils import get_site_name, sanitize_html
@@ -60,6 +61,9 @@ def application(request):
 
 		elif frappe.request.path.startswith("/api/"):
 			response = frappe.api.handle()
+
+		elif frappe.request.path.startswith("/graphql"):
+			response = frappe.graphql.handle()
 
 		elif frappe.request.path.startswith('/backups'):
 			response = frappe.utils.response.download_backup(request.path)

--- a/frappe/graphql/__init__.py
+++ b/frappe/graphql/__init__.py
@@ -1,0 +1,55 @@
+import frappe
+
+from frappe import _
+from frappe.api import validate_oauth
+from frappe.api import validate_auth_via_api_keys
+from frappe.handler import get_attr
+from frappe.utils.response import build_response
+
+
+def handle():
+    validate_oauth()
+    validate_auth_via_api_keys()
+
+    parts = frappe.request.path[1:].split('/')
+
+    if len(parts) > 1:
+        frappe.DoesNotExistError
+
+    return execute()
+
+
+def execute():
+    if frappe.session['user'] == 'Guest':
+        frappe.msgprint(_('Not permitted'))
+        raise frappe.PermissionError(
+            'Guest not allowed'
+        )
+
+    # execute command directly will cause error
+    # RuntimeError("no object bound to %s" % self.__name__)
+    method = get_attr('frappe.graphql.schema.execute')
+    result = frappe.call(method)
+
+    frappe.response['data'] = result.data
+    if result.errors:
+        error_response = []
+        for e in result.errors:
+
+            error_locations = []
+            for loc in e.locations:
+                error_locations.append({
+                    'line': loc.line,
+                    'column': loc.column,
+                })
+
+            error_response.append(
+                {
+                    'message': e.message,
+                    'locations': error_locations,
+                    'path': e.path,
+                }
+            )
+        frappe.response['errors'] = error_response
+
+    return build_response('json')

--- a/frappe/graphql/schema.py
+++ b/frappe/graphql/schema.py
@@ -1,0 +1,44 @@
+import frappe
+import graphene
+
+from frappe.graphql.types import FrappeObjectType
+
+
+class Blogger(FrappeObjectType):
+    class Meta:
+        doctype = 'Blogger'
+
+
+class BlogPost(graphene.ObjectType):
+    name = graphene.String(required=True)
+    blog_category = graphene.String()
+    route = graphene.String()
+    blogger = graphene.Field(Blogger, name=graphene.String())
+
+    def resolve_blogger(root, info, **kwargs):
+        name = root.blogger
+        doc = frappe.get_doc('Blogger', name).as_dict()
+        return Blogger(**doc)
+
+
+class RootQuery(graphene.ObjectType):
+    blog_post = graphene.Field(BlogPost, docname=graphene.String())
+
+    def resolve_blog_post(root, info, **kwargs):
+        docname = kwargs.get('docname')
+        doc = frappe.get_doc('Blog Post', docname).as_dict()
+        return BlogPost(
+            name=doc.get('name'),
+            blog_category=doc.get('blog_category'),
+            blogger=doc.get('blogger'),
+        )
+
+
+schema = graphene.Schema(RootQuery)
+
+
+def execute():
+    query = frappe.form_dict.get('query')
+    result = schema.execute(query)
+
+    return result

--- a/frappe/graphql/types.py
+++ b/frappe/graphql/types.py
@@ -1,0 +1,74 @@
+import graphene
+
+from frappe.graphql.utils import make_object_field
+from frappe.graphql.utils import make_object_resolver
+
+from graphene.types.objecttype import ObjectType, ObjectTypeOptions
+
+
+frappe_graphene = {
+    'Currency': graphene.Decimal,
+    'Int': graphene.Int,
+    'Long Int': graphene.Int,
+    'Float': graphene.Float,
+    'Percent': graphene.Float,
+    'Check': graphene.Boolean,
+    'Small Text': graphene.String,
+    'Long Text': graphene.String,
+    'Code': graphene.String,
+    'Text Editor': graphene.String,
+    'Markdown Editor': graphene.String,
+    'HTML Editor': graphene.String,
+    'Date': graphene.Date,
+    'Datetime': graphene.DateTime,
+    'Time': graphene.Time,
+    'Text': graphene.String,
+    'Data': graphene.String,
+    'Link': graphene.Field,
+    'Dynamic Link': graphene.String,
+    'Select': graphene.String,
+    'Rating': graphene.Float,
+    'Read Only': graphene.String,
+    'Signature': graphene.String,
+    'Color': graphene.String,
+    'Barcode': graphene.String,
+    'Geolocation': graphene.String,
+}
+frappe_not_include = [
+    'Password',
+    'Attach',
+    'Attach Image',
+]
+
+
+class FrappeObjectType(graphene.ObjectType):
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        doctype=None,
+        interfaces=(),
+        possible_types=(),
+        default_resolver=None,
+        _meta=None,
+        **options
+    ):
+        fields = make_object_field(doctype)
+        make_object_resolver(cls, doctype)
+
+        # create _meta object
+        if not _meta:
+            _meta = ObjectTypeOptions(cls)
+
+        if _meta.fields:
+            _meta.fields.update(fields)
+        else:
+            _meta.fields = fields
+
+        if not _meta.interfaces:
+            _meta.interfaces = interfaces
+        _meta.possible_types = possible_types
+        _meta.default_resolver = default_resolver
+
+        super(ObjectType, cls).__init_subclass_with_meta__(
+            _meta=_meta, **options
+        )

--- a/frappe/graphql/utils.py
+++ b/frappe/graphql/utils.py
@@ -1,0 +1,72 @@
+import graphene
+import frappe
+
+from frappe.model import no_value_fields
+from frappe.model import default_fields
+
+from graphene.types.field import Field
+from graphene.types.utils import yank_fields_from_attrs
+from collections import OrderedDict
+
+
+def make_object_field(doctype):
+    docfields = frappe.get_all(
+        'DocField',
+        fields=[
+            'fieldname',
+            'fieldtype',
+        ],
+        filters={'parent': doctype}
+    )
+    customfield = frappe.get_all(
+        'Custom Field',
+        fields=[
+            'fieldname',
+            'fieldtype'
+        ],
+        filters={'dt': doctype}
+    )
+    docfields.extend(customfield)
+
+    frappe_fields = {}
+    for field in docfields:
+        frappe_fields[field.get('fieldname')] = graphene.String()
+
+    for field in default_fields:
+        frappe_fields[field] = graphene.String()
+
+    fields = OrderedDict()
+    fields = yank_fields_from_attrs(
+        frappe_fields,
+        _as=Field,
+    )
+    return fields
+
+
+def make_object_resolver(cls, doctype):
+    docfields = frappe.get_all(
+        'DocField',
+        fields=[
+            'fieldname',
+            'fieldtype',
+        ],
+        filters={'parent': doctype}
+    )
+    customfield = frappe.get_all(
+        'Custom Field',
+        fields=[
+            'fieldname',
+            'fieldtype'
+        ],
+        filters={'dt': doctype}
+    )
+    docfields.extend(customfield)
+
+    for field in docfields:
+        def resolver(self, info):
+            return 'abcd'
+        resolver_name = 'resolve_{}'.format(field.get('fieldname'))
+
+        setattr(cls, resolver_name, resolver)
+
+    return cls


### PR DESCRIPTION
# Adding GraphQL support for Frappe

Adding GraphQL to Frappe using [Graphene](https://graphene-python.org/) GraphQL libary in Python

Since GraphQL is strong typing, we won't try to add some check box to DocType to enable GraphQL , instead we will aim to create object such as [FrappeObjectType](https://github.com/pipech/frappe/blob/0b958bba423a1ab0c01c621f6710a04dcb400ff1/frappe/graphql/types.py) to fetch frappe doctype and convert to Graphene object.

Developer will have to create manually create FrappeObjectType to enable GraphQL for each Doctype.

Schema should be create at server start (or some sort), it should fetch all Graphene object from each installed apps and then add it to Root schema.

## Todo list

- [ ] Mapped Frappe Type with [Graphene types](https://docs.graphene-python.org/en/latest/types/)
- [ ] Add resolver to get FrappeObjectType for link field
- [ ] Fetch all Graphene object from each installed apps and then add it to Root schema
- [ ] Solve n+1 problem
    * https://apirobot.me/posts/django-graphql-solving-n-1-problem-using-dataloaders
    * https://docs.graphene-python.org/en/latest/execution/dataloader/
