### PR TITLE
fix: group dashboard cards based on label

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -203,7 +203,7 @@ class Workspace:
 			cards = cards + get_custom_reports_and_doctypes(self.doc.module)
 
 		if len(self.extended_cards):
-			cards = cards + self.extended_cards
+			cards = merge_cards_based_on_label(cards + self.extended_cards)
 		default_country = frappe.db.get_default("country")
 
 		def _doctype_contains_a_record(name):
@@ -579,3 +579,16 @@ def update_onboarding_step(name, field, value):
 
 	"""
 	frappe.db.set_value("Onboarding Step", name, field, value)
+
+def merge_cards_based_on_label(cards):
+	"""Merge cards with common label."""
+	cards_dict = {}
+	for card in cards:
+		if card.label in cards_dict:
+			links = loads(cards_dict[card.label].links) + loads(card.links)
+			cards_dict[card.label].update(dict(links=dumps(links)))
+			cards_dict[card.label] = cards_dict.pop(card.label)
+		else:
+			cards_dict[card.label] = card
+
+	return list(cards_dict.values())


### PR DESCRIPTION
- **Issue:** Dashboard cards were not getting grouped by their labels for extended pages
- **Fix:** Group them based on their label and maintained the order defined in the extended page.
- Before
![Screenshot 2020-08-23 at 8 18 44 PM](https://user-images.githubusercontent.com/14824451/90986506-13a07680-e5a1-11ea-97c4-58aba8b981fd.png)
- After
![Screenshot 2020-08-23 at 8 32 57 PM](https://user-images.githubusercontent.com/14824451/90986508-14d1a380-e5a1-11ea-8214-6c7e489a534d.png)
