### PR TITLE
fix: Bundle minified version of vue in libs.min.js

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -128,7 +128,7 @@
 		"public/js/lib/Sortable.min.js",
 		"public/js/lib/jquery/jquery.hotkeys.js",
 		"public/js/lib/bootstrap.min.js",
-		"node_modules/vue/dist/vue.js",
+		"node_modules/vue/dist/vue.min.js",
 		"node_modules/moment/min/moment-with-locales.min.js",
 		"node_modules/moment-timezone/builds/moment-timezone-with-data.min.js",
 		"public/js/lib/socket.io.min.js",


### PR DESCRIPTION
Alternate solution for https://github.com/frappe/frappe/pull/11271

All libraries in `libs.min.js` are minified. So, `vue` should be bundled minified too for obvious performance reasons.

```
# Before this change
~/Projects/benches/frappe-bench
❯ ll sites/assets/js/libs.min.js
-rw-r--r--@ 1 farisansari  staff   1.2M Aug 21 16:34 sites/assets/js/libs.min.js


# After this change
~/Projects/benches/frappe-bench                                                                    ⍉
❯ ll sites/assets/js/libs.min.js
-rw-r--r--@ 1 farisansari  staff   1.0M Aug 24 22:17 sites/assets/js/libs.min.js

```