### PR TITLE
fix: use this.doc if this.frm is not available

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -525,7 +525,7 @@ frappe.ui.form.Layout = Class.extend({
 			return;
 		}
 
-		var parent = this.frm ? this.frm.doc : null;
+		var parent = this.frm ? this.frm.doc : this.doc || null;
 
 		if(typeof(expression) === 'boolean') {
 			out = expression;


### PR DESCRIPTION
`Webform` extends `Layout`, it does not have a `frm` object. When evaluating `depends_on` conditions, doc object is available to both form and web forms. However, if a condition like `eval:parent.show_items` the `parent` object was earlier referenced from the `frm` object. Causing the condition to break

![image](https://user-images.githubusercontent.com/18097732/91177473-64c77c00-e701-11ea-9f21-e8f2cbec2778.png)

This PR adds a fallback to `this.doc` instead.