### PR TITLE
fix: load theme after web_include_css

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -27,15 +27,18 @@
 		{{ head_html or "" }}
 		{%- endif %}
 
-		{%- if theme.name != 'Standard' -%}
-		<link type="text/css" rel="stylesheet" href="{{ theme.theme_url }}">
-		{%- else -%}
+		{%- if theme.name == 'Standard' -%}
 		<link type="text/css" rel="stylesheet" href="/assets/css/frappe-web-b4.css">
 		{%- endif -%}
 
 		{%- for link in web_include_css %}
 		<link type="text/css" rel="stylesheet" href="{{ link|abs_url }}">
 		{%- endfor -%}
+
+		{%- if theme.name != 'Standard' -%}
+		<link type="text/css" rel="stylesheet" href="{{ theme.theme_url }}">
+		{%- endif -%}
+
 	{%- endblock -%}
 
 	{%- block head_include %}


### PR DESCRIPTION
## Problem

Suppose I create a custom app that uses `web_include_css` in `hooks.py` to set the primary color to black (`$primary: #000;`). Because **Website Theme** is loaded before `web_include_css`, from the user's perspective there is no way to overwrite this.

## Possible Solution

User configuration should always have the highest priority. Therefore, load the **Website Theme** after `web_include_css`.

## Considerations

On the downside, the **Website Theme** overwrites the styles from the custom app. Is there a way to include only the user modifications as the last thing? Or, the other way round, is it possible to use the variables defined in **Website Theme** in a custom app?