### PR TITLE
fix(backups): Allow naming conf file via BackupGenerator

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -27,7 +27,7 @@ class BackupGenerator:
 		To initialize, specify (db_name, user, password, db_file_name=None, db_host="localhost")
 		If specifying db_file_name, also append ".sql.gz"
 	"""
-	def __init__(self, db_name, user, password, backup_path_db=None, backup_path_files=None,
+	def __init__(self, db_name, user, password, backup_path_conf=None, backup_path_db=None, backup_path_files=None,
 		backup_path_private_files=None, db_host="localhost", db_port=None, verbose=False,
 		db_type='mariadb'):
 		global _verbose
@@ -37,8 +37,9 @@ class BackupGenerator:
 		self.db_type = db_type
 		self.user = user
 		self.password = password
-		self.backup_path_files = backup_path_files
+		self.backup_path_conf = backup_path_conf
 		self.backup_path_db = backup_path_db
+		self.backup_path_files = backup_path_files
 		self.backup_path_private_files = backup_path_private_files
 
 		if not self.db_port and self.db_type == 'mariadb':
@@ -83,11 +84,14 @@ class BackupGenerator:
 
 	def set_backup_file_name(self):
 		#Generate a random name using today's date and a 8 digit random number
+		for_conf = self.todays_date + "-" + self.site_slug + "-site_config_backup.json"
 		for_db = self.todays_date + "-" + self.site_slug + "-database.sql.gz"
 		for_public_files = self.todays_date + "-" + self.site_slug + "-files.tar"
 		for_private_files = self.todays_date + "-" + self.site_slug + "-private-files.tar"
 		backup_path = get_backup_path()
 
+		if not self.backup_path_conf:
+			self.backup_path_conf = os.path.join(backup_path, for_conf)
 		if not self.backup_path_db:
 			self.backup_path_db = os.path.join(backup_path, for_db)
 		if not self.backup_path_files:
@@ -150,19 +154,11 @@ class BackupGenerator:
 				print('Backed up files', os.path.abspath(backup_path))
 
 	def copy_site_config(self):
-		site_config_backup_path = os.path.join(
-			get_backup_path(),
-			"{time_stamp}-{site_slug}-site_config_backup.json".format(
-				time_stamp=self.todays_date,
-				site_slug=self.site_slug))
+		site_config_backup_path = self.backup_path_conf
 		site_config_path = os.path.join(frappe.get_site_path(), "site_config.json")
-		site_config = {}
-		if os.path.exists(site_config_path):
-			site_config.update(frappe.get_file_json(site_config_path))
+
 		with open(site_config_backup_path, "w") as f:
-			f.write(json.dumps(site_config, indent=2))
-			f.flush()
-		self.site_config_backup_path = site_config_backup_path
+			json.dump(frappe.get_file_json(site_config_path), f, indent=2)
 
 	def take_dump(self):
 		import frappe.utils

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -27,9 +27,9 @@ class BackupGenerator:
 		To initialize, specify (db_name, user, password, db_file_name=None, db_host="localhost")
 		If specifying db_file_name, also append ".sql.gz"
 	"""
-	def __init__(self, db_name, user, password, backup_path_conf=None, backup_path_db=None, backup_path_files=None,
+	def __init__(self, db_name, user, password, backup_path_db=None, backup_path_files=None,
 		backup_path_private_files=None, db_host="localhost", db_port=None, verbose=False,
-		db_type='mariadb'):
+		db_type='mariadb', backup_path_conf=None):
 		global _verbose
 		self.db_host = db_host
 		self.db_port = db_port

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -157,8 +157,8 @@ class BackupGenerator:
 		site_config_backup_path = self.backup_path_conf
 		site_config_path = os.path.join(frappe.get_site_path(), "site_config.json")
 
-		with open(site_config_backup_path, "w") as f:
-			json.dump(frappe.get_file_json(site_config_path), f, indent=2)
+		with open(site_config_backup_path, "w") as n, open(site_config_path) as c:
+			n.write(c.read())
 
 	def take_dump(self):
 		import frappe.utils


### PR DESCRIPTION
- Allow passing config backup name as a parameter in `BackupGenerator`
- Don't unnecessarily parse the site config file, just copy the contents
- Set config file backup name while setting the name for the rest of the files
- Changed `BackupGenerator` attribute from `site_config_backup_path` to `backup_path_conf`