### PR TITLE
fix: contact not showing in form

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -188,7 +188,7 @@ def contact_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 
 	if not frappe.get_meta("Contact").get_field(searchfield)\
-		or searchfield not in frappe.db.DEFAULT_COLUMNS:
+		and searchfield not in frappe.db.DEFAULT_COLUMNS:
 		return []
 
 	link_doctype = filters.pop('link_doctype')


### PR DESCRIPTION
Before if you remove the contact person in quotation to change it the filter didn't use to works:
![Screenshot 2020-08-26 at 4 25 48 PM](https://user-images.githubusercontent.com/33727827/91334369-7e91bd80-e7ec-11ea-87f2-39217f4158ae.png)

After the change, the values get fetch correctly:
![Screenshot 2020-08-26 at 4 24 40 PM](https://user-images.githubusercontent.com/33727827/91334401-8baeac80-e7ec-11ea-8794-02ff877d2047.png)
