### PR TITLE
fix: don't override column

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1041,7 +1041,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 					if (column.colIndex === index && !value) {
 						value = "Total";
-						column.fieldtype = "Data"; // avoid type issues for value if Date column
+						column = { fieldtype: "Data" }; // avoid type issues for value if Date column
 					} else if (in_list(["Currency", "Float"], column.fieldtype)) {
 						// proxy for currency and float
 						data = this.data[0];


### PR DESCRIPTION
A previous PR https://github.com/frappe/frappe/pull/10987 allowed add the "Total" in totals row in reports. It essentially used the first item of the column as reference, overriding the fieldtype to Data and value to "Total"

Overriding column would remove the link formatting for the column for future renders, and the link would be broken across reports in case the filter is applied. This PR fixes that, by declaring a new column for it and not changing values of the original column object.

![image](https://user-images.githubusercontent.com/18097732/91532293-bb180300-e92b-11ea-8b2b-38c495b1de21.png)
