### PR TITLE
feat: Show Status Section in Query Report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -592,6 +592,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				this.render_summary(data.report_summary);
 			}
 
+			if(data.message && !data.prepared_report) this.show_status(data.message);
+
 			this.toggle_message(false);
 			if (data.result && data.result.length) {
 				this.prepare_report_data(data);

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -592,7 +592,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				this.render_summary(data.report_summary);
 			}
 
-			if(data.message && !data.prepared_report) this.show_status(data.message);
+			if (data.message && !data.prepared_report) this.show_status(data.message);
 
 			this.toggle_message(false);
 			if (data.result && data.result.length) {


### PR DESCRIPTION
- Along with `data, columns, chart, report_summary` , `message` is also passed along with the report data
- The same isn't used for display anywhere in `query_report.js`
- This PR adds provision to return `message` as a string and display it in the `status` section (right under the filters) if the report is not a Prepared Report
 ![Screenshot 2020-08-31 at 7 59 16 PM](https://user-images.githubusercontent.com/25857446/91731566-97bbb500-ebc4-11ea-9b0e-5cd3463757f0.png)
