### PR TITLE
fix: Set blog route if title and category are set

### DIFF
--- a/frappe/website/doctype/blog_post/blog_post.js
+++ b/frappe/website/doctype/blog_post/blog_post.js
@@ -11,16 +11,29 @@ frappe.ui.form.on('Blog Post', {
 	},
 	title: function(frm) {
 		generate_google_search_preview(frm);
+		frm.trigger('set_route');
 	},
 	meta_description: function(frm) {
 		generate_google_search_preview(frm);
 	},
 	blog_intro: function(frm) {
 		generate_google_search_preview(frm);
+	},
+	blog_category(frm) {
+		frm.trigger('set_route');
+	},
+	set_route(frm) {
+		if (frm.doc.route) return;
+		if (frm.doc.title && frm.doc.blog_category) {
+			frm.call('make_route').then(r => {
+				frm.set_value('route', r.message);
+			});
+		}
 	}
 });
 
 function generate_google_search_preview(frm) {
+	if (!frm.doc.title) return;
 	let google_preview = frm.get_field("google_preview");
 	let seo_title = (frm.doc.title).slice(0, 60);
 	let seo_description =  (frm.doc.meta_description || frm.doc.blog_intro || "").slice(0, 160);


### PR DESCRIPTION
Set blog route on client side as soon as title and category are selected. This behavior is in line with Web Page, where the route is set as soon as the title is entered.

This will ensure blog routes are consistent and contain category as the part of the route. The user can change the route ofcourse, but this behavior is the most common expectation.


![blog-route-fix](https://user-images.githubusercontent.com/9355208/91733105-c63a8f80-ebc6-11ea-99d0-e15473c7e11f.gif)


