### PR TITLE
fix: Refresh datatable when sidebar is toggled

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -48,10 +48,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	setup_view() {
 		this.setup_columns();
 		super.setup_new_doc_event();
+	}
+
+	toggle_side_bar() {
+		super.toggle_side_bar();
 		// refresh datatable when sidebar is toggled to accomodate extra space
-		$(document.body)
-			.off('toggleListSidebar.report_view')
-			.on('toggleListSidebar.report_view', () => this.render(true));
+		this.render(true);
 	}
 
 	setup_result_area() {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -48,6 +48,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	setup_view() {
 		this.setup_columns();
 		super.setup_new_doc_event();
+		// refresh datatable when sidebar is toggled to accomodate extra space
+		$(document.body)
+			.off('toggleListSidebar.report_view')
+			.on('toggleListSidebar.report_view', () => this.render(true));
 	}
 
 	setup_result_area() {


### PR DESCRIPTION
![datatable-sidebar-toggle](https://user-images.githubusercontent.com/9355208/91736829-e91b7280-ebcb-11ea-8616-3c11d2fb8d31.gif)
