### PR TITLE
fix: set perm in set_read_only only if object is not empty

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1261,8 +1261,8 @@ frappe.ui.form.Form = class FrappeForm {
 		var docperms = frappe.perm.get_perm(this.doc.doctype);
 		for (var i=0, l=docperms.length; i<l; i++) {
 			var p = docperms[i];
-			if (Object.keys(p).length !== 0) {
-				perm[p.permlevel || 0] = {
+			if (Number.isInteger(p.permlevel)) {
+				perm[p.permlevel] = {
 					read: p.read,
 					cancel: p.cancel,
 					share: p.share,

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1261,13 +1261,16 @@ frappe.ui.form.Form = class FrappeForm {
 		var docperms = frappe.perm.get_perm(this.doc.doctype);
 		for (var i=0, l=docperms.length; i<l; i++) {
 			var p = docperms[i];
-			perm[p.permlevel || 0] = {
-				read: p.read,
-				cancel: p.cancel,
-				share: p.share,
-				print: p.print,
-				email: p.email
-			};
+			if (Object.keys(p).length !== 0) {
+				perm[p.permlevel || 0] = {
+					read: p.read,
+					cancel: p.cancel,
+					share: p.share,
+					print: p.print,
+					email: p.email
+				};
+			}
+
 		}
 		this.perm = perm;
 	}


### PR DESCRIPTION
Fixes issue introduced in https://github.com/frappe/frappe/pull/11014.

If no permissions for a perm level are defined, all keys (including read) in `perm[0]` are set as `undefined`. This leads to a user not having permission for all fields in a document with a particular `docstatus`, if he does not have the role set in **Allow Edit For** for that `docstatus`.