### PR TITLE
fix: Also check if name is set, since empty object is truthy

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -61,7 +61,7 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 						// check if name exists
 						frappe.db.get_value(this.doctype, this.$input.val(),
 							'name', (val) => {
-								if (val) {
+								if (val && val.name) {
 									this.set_description(__('{0} already exists. Select another name', [val.name]));
 								}
 							},


### PR DESCRIPTION
When checking for existence of a record when entering the "Name" for a new record, it would falsely show the message because empty object is truthy in JavaScript.