### PR TITLE
fix: Handle exception while setting In-Reply-To in email header

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -207,7 +207,11 @@ class EMail:
 
 	def set_in_reply_to(self, in_reply_to):
 		"""Used to send the Message-Id of a received email back as In-Reply-To"""
-		self.msg_root["In-Reply-To"] = in_reply_to
+		try:
+			self.msg_root["In-Reply-To"] = in_reply_to
+		except ValueError:
+			# in_reply_to may contain line feed characters, so ignore in that case
+			pass
 
 	def make(self):
 		"""build into msg_root"""


### PR DESCRIPTION
Fixes:

`line 228, in set_in_reply_to\n    self.msg_root[\"In-Reply-To\"] = in_reply_to\n  File \"/usr/lib64/python3.6/email/message.py\", line 409, in __setitem__\n    self._headers.append(self.policy.header_store_parse(name, val))\n  File \"/usr/lib64/python3.6/email/policy.py\", line 145, in header_store_parse\n    raise ValueError(\"Header values may not contain linefeed \"\nValueError: Header values may not contain linefeed or carriage return characters\n"`