### PR TITLE
fix(Event Streaming): remove in_test flag from Event Consumer

### DIFF
--- a/frappe/event_streaming/doctype/event_consumer/event_consumer.json
+++ b/frappe/event_streaming/doctype/event_consumer/event_consumer.json
@@ -13,8 +13,7 @@
   "api_secret",
   "column_break_6",
   "user",
-  "incoming_change",
-  "in_test"
+  "incoming_change"
  ],
  "fields": [
   {
@@ -61,14 +60,6 @@
    "read_only": 1
   },
   {
-   "default": "0",
-   "fieldname": "in_test",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "In Test",
-   "read_only": 1
-  },
-  {
    "fieldname": "consumer_doctypes",
    "fieldtype": "Table",
    "label": "Event Consumer Document Types",
@@ -78,7 +69,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2019-12-30 11:52:16.276047",
+ "modified": "2020-09-06 15:42:00.746493",
  "modified_by": "Administrator",
  "module": "Event Streaming",
  "name": "Event Consumer",

--- a/frappe/event_streaming/doctype/event_producer/event_producer.py
+++ b/frappe/event_streaming/doctype/event_producer/event_producer.py
@@ -75,8 +75,7 @@ class EventProducer(Document):
 		return {
 			'event_consumer': get_url(),
 			'consumer_doctypes': json.dumps(consumer_doctypes),
-			'user': self.user,
-			'in_test': frappe.flags.in_test
+			'user': self.user
 		}
 
 	def create_custom_fields(self):
@@ -110,8 +109,6 @@ class EventProducer(Document):
 						'status': get_approval_status(config, ref_doctype),
 						'unsubscribed': entry.unsubscribe
 					})
-				if frappe.flags.in_test:
-					event_consumer.in_test = True
 				event_consumer.user = self.user
 				event_consumer.incoming_change = True
 				producer_site.update(event_consumer)


### PR DESCRIPTION
`in_test` flag was being passed to the producer site for approving subscribed doctypes since the tests are running on consumer's site and `frappe.flags.in_test` will not return true for the other site. Instead check for `os.environ.get('CI')` to be True 