### PR TITLE
fix: Permission check on adding custom columns in query reports

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -463,7 +463,7 @@ def add_total_row(result, columns, meta = None):
 def get_data_for_custom_field(doctype, field):
 
 	if not frappe.has_permission(doctype, "read"):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 
 	value_map = frappe._dict(frappe.get_all(doctype,
 		fields=["name", field],

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -462,6 +462,9 @@ def add_total_row(result, columns, meta = None):
 @frappe.whitelist()
 def get_data_for_custom_field(doctype, field):
 
+	if not frappe.has_permission(doctype, "read"):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
 	value_map = frappe._dict(frappe.get_all(doctype,
 		fields=["name", field],
 		as_list=1))


### PR DESCRIPTION
**Issue:**
Add Column option in query reports will allow user to add custom columns even though they don't have the rights to view those fields

**Solution:**
Check for permission before adding custom column in query reports