### PR TITLE
fix(Newsletter): default content type while getting message

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -85,12 +85,12 @@ class Newsletter(WebsiteGenerator):
 			self.db_set("scheduled_to_send", len(self.recipients))
 
 	def get_message(self):
-		
+
 		return {
 			'Rich Text': self.message,
 			'Markdown': markdown(self.message_md),
 			'HTML': self.message_html
-		}[self.content_type]
+		}[self.content_type or 'Rich Text']
 
 	def get_recipients(self):
 		"""Get recipients from Email Group"""


### PR DESCRIPTION
Set default type content as Rich Text in Newsletter while getting message.