### PR TITLE
fix(Email): replace newline characters in In-Reply-To in email header

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -225,11 +225,7 @@ class EMail:
 
 	def set_in_reply_to(self, in_reply_to):
 		"""Used to send the Message-Id of a received email back as In-Reply-To"""
-		try:
-			self.msg_root["In-Reply-To"] = in_reply_to
-		except ValueError:
-			# in_reply_to may contain line feed characters, so ignore in that case
-			pass
+		self.msg_root["In-Reply-To"] = in_reply_to.replace("\r", "").replace("\n", "")
 
 	def make(self):
 		"""build into msg_root"""


### PR DESCRIPTION
Fixes:
  
```
File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/email/email_body.py", line 228, in set_in_reply_to
    try:
  File "/usr/lib64/python3.6/email/message.py", line 409, in __setitem__
    self._headers.append(self.policy.header_store_parse(name, val))
  File "/usr/lib64/python3.6/email/policy.py", line 145, in header_store_parse
    raise ValueError("Header values may not contain linefeed "
ValueError: Header values may not contain linefeed or carriage return characters
```