### PR TITLE
fix(db_query): Reject `user` argument in whitelisted methods

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -36,6 +36,7 @@ def get_form_params():
 	data.pop('data', None)
 	data.pop('ignore_permissions', None)
 	data.pop('view', None)
+	data.pop('user', None)
 
 	if "csrf_token" in data:
 		del data["csrf_token"]

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -769,6 +769,7 @@ def get_list(doctype, *args, **kwargs):
 	kwargs.pop('ignore_permissions', None)
 	kwargs.pop('data', None)
 	kwargs.pop('strict', None)
+	kwargs.pop('user', None)
 
 	# If doctype is child table
 	if frappe.is_table(doctype):


### PR DESCRIPTION
Reject `user` argument in whitelisted methods