### PR TITLE
fix(security): Remove ignore_permissions flag from API request

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1110,6 +1110,7 @@ def get_newargs(fn, kwargs):
 		if (a in fnargs) or varkw:
 			newargs[a] = kwargs.get(a)
 
+	newargs.pop('ignore_permissions', None)
 	if "flags" in newargs:
 		del newargs["flags"]
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1110,9 +1110,8 @@ def get_newargs(fn, kwargs):
 		if (a in fnargs) or varkw:
 			newargs[a] = kwargs.get(a)
 
-	newargs.pop('ignore_permissions', None)
-	if "flags" in newargs:
-		del newargs["flags"]
+	newargs.pop("ignore_permissions", None)
+	newargs.pop("flags", None)
 
 	return newargs
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -25,7 +25,6 @@ def update_document_title(doctype, docname, title_field=None, old_title=None, ne
 
 	return docname
 
-@frappe.whitelist()
 def rename_doc(doctype, old, new, force=False, merge=False, ignore_permissions=False, ignore_if_exists=False, show_alert=True):
 	"""
 		Renames a doc(dt, old) to doc(dt, new) and


### PR DESCRIPTION
- Remove ignore_permissions flag from API request
- Remove unnecessary whitelisting of `frappe.model.rename_doc.rename_doc` method