### PR TITLE
fix: Handle None value

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -938,7 +938,7 @@ def attach_files_to_document(doc, event):
 		# we dont want the update to fail if file cannot be attached for some reason
 		try:
 			value = doc.get(df.fieldname)
-			if not value.startswith(("/files", "/private/files")):
+			if not (value or '').startswith(("/files", "/private/files")):
 				return
 
 			if frappe.db.exists("File", {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 941, in attach_files_to_document
    if not value.startswith(("/files", "/private/files")):
AttributeError: 'NoneType' object has no attribute 'startswith'

```