### PR TITLE
fix: total row in report print template

### DIFF
--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -37,16 +37,20 @@
 
 					<td {% if row.bold == 1 %} style="font-weight: bold" {% endif %}>
 						<span {% if col._index == 0 %} style="padding-left: {%= cint(row.indent) * 2 %}em" {% endif %}>
-							{% format_data = row.is_total_row ? data[0] : row %}
-							{{
-								col.formatter
-									? col.formatter(row._index, col._index, value, col, format_data, true)
-									: col.format
-										? col.format(value, row, col, format_data)
-										: col.docfield
-											? frappe.format(value, col.docfield)
-											: value
-							}}
+							{% format_data = row.is_total_row && ["Currency", "Float"].includes(col.fieldtype) ? data[0] : row %}
+							{% if (row.is_total_row && col._index == 0) { %}
+								{{ __("Total") }}
+							{% } else { %}
+								{{
+									col.formatter
+										? col.formatter(row._index, col._index, value, col, format_data, true)
+										: col.format
+											? col.format(value, row, col, format_data)
+											: col.docfield
+												? frappe.format(value, col.docfield)
+												: value
+								}}
+							{% } %}
 						</span>
 					</td>
 				{% endif %}
@@ -55,4 +59,3 @@
 		{% endfor %}
 	</tbody>
 </table>
-


### PR DESCRIPTION
**Fixes:**

- Use `data[0]` only for Float and Currency fields in Total Row

- Set Value as Total for 0th index column in Total Row

**Before:**
<img width="1129" alt="Screenshot 2020-09-08 at 8 58 40 PM" src="https://user-images.githubusercontent.com/19775888/92496758-2dcf8b00-f216-11ea-987d-ff8a3b721693.png">


**After:**
<img width="1148" alt="Screenshot 2020-09-08 at 8 58 20 PM" src="https://user-images.githubusercontent.com/19775888/92496695-18f2f780-f216-11ea-9bf9-1a53a915be5e.png">
