### PR TITLE
fix(Email): replace CR and LF characters with empty string in case of exception

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -225,7 +225,7 @@ class EMail:
 
 	def set_in_reply_to(self, in_reply_to):
 		"""Used to send the Message-Id of a received email back as In-Reply-To"""
-		self.msg_root["In-Reply-To"] = in_reply_to.replace("\r", "").replace("\n", "")
+		self.set_header('In-Reply-To', in_reply_to)
 
 	def make(self):
 		"""build into msg_root"""
@@ -252,7 +252,10 @@ class EMail:
 		if key in self.msg_root:
 			del self.msg_root[key]
 
-		self.msg_root[key] = value
+		try:
+			self.msg_root[key] = value
+		except ValueError:
+			self.msg_root[key] = sanitize_email_header(value)
 
 	def as_string(self):
 		"""validate, build message and convert to string"""
@@ -478,3 +481,6 @@ def get_header(header=None):
 	})
 
 	return email_header
+
+def sanitize_email_header(str):
+	return str.replace('\r', '').replace('\n', '')


### PR DESCRIPTION
"\r" and "\n" in email headers seems to break for certain mail systems such as Outlook, causing:

<img width="885" alt="Screenshot 2020-09-08 at 11 09 12 AM" src="https://user-images.githubusercontent.com/19775888/92498016-b8fd5080-f217-11ea-8f18-f8d57cf96934.png">

So in case of a ValueError exception we can replace them with an empty string which should fix the issue.