### PR TITLE
fix(recorder): Fix Cypress Tests

### DIFF
--- a/cypress/integration/recorder.js
+++ b/cypress/integration/recorder.js
@@ -61,10 +61,10 @@ context('Recorder', () => {
 
 		cy.visit('/desk#recorder');
 
-		cy.get('.list-row-container span').contains('frappe.desk.reportview.get').click();
+		cy.get('.list-row-container span').contains('/api/method/frappe').click();
 
 		cy.location('hash').should('contain', '#recorder/request/');
-		cy.get('form').should('contain', 'frappe.desk.reportview.get');
+		cy.get('form').should('contain', '/api/method/frappe');
 
 		cy.get('#page-recorder .primary-action').should('contain', 'Stop').click();
 		cy.get('#page-recorder .btn-secondary').should('contain', 'Clear').click();


### PR DESCRIPTION
This particular recorder test seems to be flaky.

**Before:**
Test Description: Find a list item with the label containing `frappe.desk.reportview.get` and click on it when the form opens expect `frappe.desk.reportview.get` inside as well.

But once in a while (couldn't replicate locally, tried increasing/reducing the number of CPU cores and increasing/reducing the clock speed and adding programmatic delays) it opens the form for `frappe.model.db_query.get_list` (cypress says it clicked on the correct label though).

**After:**
Test Description: Find a list item with the label containing `/api/method/frappe` and click on it to open the form and expect `/api/method/frappe` inside as well.