### PR TITLE
fix(Data Import): don't set child doc values if all values are empty

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -465,8 +465,9 @@ class ImportFile:
 
 				if doctype != self.doctype and table_df:
 					child_doc = row.parse_doc(doctype, parent_doc, table_df)
-					parent_doc[table_df.fieldname] = parent_doc.get(table_df.fieldname, [])
-					parent_doc[table_df.fieldname].append(child_doc)
+					if child_doc:
+						parent_doc[table_df.fieldname] = parent_doc.get(table_df.fieldname, [])
+						parent_doc[table_df.fieldname].append(child_doc)
 
 		doc = parent_doc
 
@@ -570,6 +571,10 @@ class Row:
 	def parse_doc(self, doctype, parent_doc=None, table_df=None):
 		col_indexes = self.header.get_column_indexes(doctype, table_df)
 		values = self.get_values(col_indexes)
+
+		if values.count(None) == len(values):
+			return None
+
 		columns = self.header.get_columns(col_indexes)
 		doc = self._parse_doc(doctype, columns, values, parent_doc, table_df)
 		return doc


### PR DESCRIPTION
All child tables don't need to have the same number of rows, so if all values for the table are empty in a row then don't set the values in the doc.

Fixes:
<img width="1103" alt="Screenshot 2020-09-09 at 1 56 10 PM" src="https://user-images.githubusercontent.com/19775888/92574061-3d95b080-f2a4-11ea-940f-0942a6420c67.png">
