### PR TITLE
fix: set overflow auto for report builder wrapper

### DIFF
--- a/frappe/public/less/report.less
+++ b/frappe/public/less/report.less
@@ -72,7 +72,7 @@
 	margin-bottom: 10px;
 }
 
-.report-wrapper {
+.report-wrapper, .datatable-wrapper {
 	overflow: auto;
 }
 


### PR DESCRIPTION
Fixes the border disappearing issue while scrolling in Report view.