### PR TITLE
fix(pdf): Restrict cookies to the host domain

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -52,6 +52,8 @@ def get_pdf(html, options=None, output=None):
 				output.appendPagesFromReader(reader)
 		else:
 			raise
+	finally:
+		cleanup(options)
 
 	if "password" in options:
 		password = options["password"]
@@ -184,10 +186,7 @@ def prepare_header_footer(soup):
 	return options
 
 
-def cleanup(fname, options):
-	if os.path.exists(fname):
-		os.remove(fname)
-
+def cleanup(options):
 	for key in ("header-html", "footer-html"):
 		if options.get(key) and os.path.exists(options[key]):
 			os.remove(options[key])


### PR DESCRIPTION
Use wkhtmltopdf's cookie-jar options to set the domain
**Reference:** https://github.com/wkhtmltopdf/wkhtmltopdf/blob/7952b0f3e754588a3fcdaf5000a4cd99448292de/src/lib/multipageloader.cc#L532-L536
**Cookie format Reference:** https://doc.qt.io/qt-5/qnetworkcookie.html#parseCookies

Also, werkzeug 0.16.x shows the port in the host attribute. 
https://werkzeug.palletsprojects.com/en/0.16.x/wrappers/#werkzeug.wrappers.BaseRequest.host
