### PR TITLE
fix: boot if module is not present in desk

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -40,7 +40,7 @@ class Workspace:
 
 		self.doc = self.get_page_for_user()
 
-		if self.doc.module not in self.allowed_modules:
+		if self.doc.module and self.doc.module not in self.allowed_modules:
 			raise frappe.PermissionError
 
 		self.can_read = self.get_cached('user_perm_can_read', self.get_can_read_items)

--- a/frappe/desk/doctype/desk_page/desk_page.py
+++ b/frappe/desk/doctype/desk_page/desk_page.py
@@ -38,7 +38,7 @@ class DeskPage(Document):
 
 		pages = frappe.get_all("Desk Page", fields=["name", "module"], filters=filters, as_list=1)
 
-		return { page[1]: page[0]  for page in pages }
+		return { page[1]: page[0] for page in pages if page[1] }
 
 def disable_saving_as_standard():
 	return frappe.flags.in_install or \


### PR DESCRIPTION
Boot would break if boot dict has `None` value in it. When creating desk page without module, `get_module_page_map` would return `None`, this would break in `www/desk.py` at `boot_json = frappe.as_json(boot)`

This PR fixes that