### PR TITLE
fix(About Us): Padding in About Us page sections

### DIFF
--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -355,3 +355,9 @@ h5.modal-title {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }
+.about-section {
+	padding-top: 1rem;
+}
+.about-footer {
+	padding-top: 1rem;
+}

--- a/frappe/www/about.html
+++ b/frappe/www/about.html
@@ -17,6 +17,7 @@
 			list of key team members in Website > About Us Settings</p>""" }}
 
 	{% if doc.get({"doctype":"Company History"}) %}
+	<div class="about-section">
 	<h3>{{ doc.company_history_heading or "Company History" }}</h3>
 	{% for d in doc.get({"doctype":"Company History"}) %}
 	<div class="row">
@@ -24,9 +25,11 @@
 		<span class="col-md-10"><p>{{ d.highlight }}</p></span>
 	</div>
 	{% endfor %}
+	</div>
 	{% endif %}
 
 	{% if doc.get({"doctype":"About Us Team Member"}) %}
+	<div class="about-section">
 	<h3>{{ doc.team_members_heading or "Team Members" }}</h3>
 	{% for d in doc.get({"doctype":"About Us Team Member"}) %}
 	<div class="row" itemscope itemtype="http://schema.org/Person">
@@ -40,7 +43,10 @@
 		</span>
 	</div>
 	{% endfor %}
+	</div>
 	{% endif %}
+	<div class="about-footer">
 	{{ doc.footer or "" }}
+	</div>
 </article>
 {% endblock %}


### PR DESCRIPTION
**Problem:**

<img width="685" alt="Screen Shot 2020-09-10 at 4 07 11 PM" src="https://user-images.githubusercontent.com/16913064/92722696-97ba7280-f385-11ea-9c10-8c6abc7bb5a7.png">

**Added classes and paddings to various sections of About Us.**

<img width="555" alt="Screen Shot 2020-09-10 at 4 36 34 PM" src="https://user-images.githubusercontent.com/16913064/92722720-a2750780-f385-11ea-8bd9-083280691cef.png">
