### PR TITLE
fix: create JS sourcemaps only in developer environment

### DIFF
--- a/rollup/config.js
+++ b/rollup/config.js
@@ -102,7 +102,7 @@ function get_rollup_options_for_js(output_file, input_files) {
 			globals: {
 				'jquery': 'window.jQuery'
 			},
-			sourcemap: true
+			sourcemap: !production
 		}
 	};
 }


### PR DESCRIPTION
Tested locally:
- manually removed source maps from `assets/js` to ensure they build again as expected for developer environment.

Screenshot:

![Screenshot from 2020-09-14 13-21-42](https://user-images.githubusercontent.com/16315650/93058950-ace91700-f68d-11ea-840f-b737d1114c2d.png)
