### PR TITLE
fix: TypeError occuring due to modification of modified function

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -393,11 +393,16 @@ export default class GridRow {
 		// sync get_query
 		field.get_query = this.grid.get_field(df.fieldname).get_query;
 
-		var field_on_change_function = field.df.onchange;
-		field.df.onchange = function(e) {
-			field_on_change_function && field_on_change_function(e);
-			me.grid.grid_rows[this.doc.idx - 1].refresh_field(field.df.fieldname);
-		};
+		if (!field.df.onchange_modified) {
+			var field_on_change_function = field.df.onchange;
+			field.df.onchange = function(e) {
+				field_on_change_function && field_on_change_function(e);
+				me.grid.grid_rows[this.doc.idx - 1].refresh_field(this.df.fieldname);
+			};
+
+			field.df.onchange_modified = true;
+		}
+
 		field.refresh();
 		if(field.$input) {
 			field.$input


### PR DESCRIPTION
The error:
```
grid_row.js:399 Uncaught (in promise) TypeError: Cannot read property 'doc' of undefined
    at field.df.onchange (grid_row.js:399)
    at SubClass.field.df.onchange (grid_row.js:398)
    at base_control.js:158
```
The reason:
Previously, the second time this code would run, it would modify the already modified function. As a result the `field_on_change_function` call would fail because it would not get `this`. To prevent this from happening, a new flag has been introduced to not modify the function if already modified.

Tested locally.