### PR TITLE
fix: rewrite sort_fields to ensure proper ordering of custom fields

### DIFF
--- a/frappe/custom/doctype/custom_field/test_custom_field.py
+++ b/frappe/custom/doctype/custom_field/test_custom_field.py
@@ -8,7 +8,31 @@ from __future__ import unicode_literals
 import frappe
 import unittest
 
-test_records = frappe.get_test_records('Custom Field')
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 class TestCustomField(unittest.TestCase):
-	pass
+	def test_custom_field_sorting(self):
+		custom_fields = {
+			'ToDo': [
+				{
+					'fieldname': 'test_field_0',
+					'fieldtype': 'Data',
+					'insert_after': 'description'
+				},
+				{
+					'fieldname': 'test_field_1',
+					'fieldtype': 'Data',
+					'insert_after': 'not_a_real_reference'
+				}
+			]
+		}
+
+		create_custom_fields(custom_fields, ignore_validate=True)
+		meta = frappe.get_meta('ToDo')
+
+		for i, df in enumerate(meta.fields):
+			if df.fieldname == 'test_field_0':
+				self.assertEqual(meta.fields[i - 1].fieldname, 'description')
+				break
+
+		self.assertEqual(meta.fields[-1].fieldname, 'test_field_1')

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -351,6 +351,10 @@ class Meta(Document):
 			else:
 				newlist.append(df)
 
+		# custom fields not found
+		if newlist == self.fields:
+			return
+
 		newlist_fieldnames = [df.fieldname for df in newlist]
 
 		changed = True

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -343,6 +343,7 @@ class Meta(Document):
 		for df in self.fields:
 			if df.get('is_custom_field'):
 				if not df.insert_after:
+					# custom field without insert_after, should go first
 					newlist.insert(0, df)
 				else:
 					# reverse sorted, looped in reverse later
@@ -352,10 +353,10 @@ class Meta(Document):
 
 		newlist_fieldnames = [df.fieldname for df in newlist]
 
-		while True:
-			current_index = len(custom_fields) - 1
+		changed = True
+		while changed:
 			changed = False
-			while current_index >= 0:
+			for current_index in range(len(custom_fields) - 1, -1, -1):
 				df = custom_fields[current_index]
 				if df.insert_after in newlist_fieldnames:
 					# add to new list
@@ -367,13 +368,9 @@ class Meta(Document):
 					del custom_fields[current_index]
 					changed = True
 
-				current_index -= 1
-
-			if not changed:
-				# avoid recursion, add remaining custom fields to end of new list
-				if custom_fields:
-					newlist += custom_fields
-				break
+		# these fields probably have an invalid insert_after reference
+		if custom_fields:
+			newlist += custom_fields
 
 		# renum idx
 		for i, f in enumerate(newlist):


### PR DESCRIPTION
**Before:**

![Screenshot from 2020-09-14 14-46-47](https://user-images.githubusercontent.com/16315650/93075101-f2640f00-f6a2-11ea-9640-045c60b3d2da.png)

**After:**

![Screenshot from 2020-09-14 14-48-08](https://user-images.githubusercontent.com/16315650/93075131-fee86780-f6a2-11ea-84d4-949099253db9.png)


Custom fields created using backend ([example](https://github.com/frappe/erpnext/blob/develop/erpnext/regional/india/setup.py#L110)) sometimes go to end of the doctype instead of the field they're supposed to be inserted after. This is because fields were previously sorted by `idx` which is not a field in the `Custom Field` doctype. To solve this issue, the logic has been rewritten to loop as long as `insert_after` is found in `newlist` and break when the list of custom fields stops reducing.

Originally created #11484 