### PR TITLE
feat: Allow sending emails via Server Script

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -66,6 +66,7 @@ def get_safe_globals():
 			get_url = frappe.utils.get_url,
 			render_template = frappe.render_template,
 			msgprint = frappe.msgprint,
+			sendmail = frappe.sendmail,
 
 			user = user,
 			get_fullname = frappe.utils.get_fullname,


### PR DESCRIPTION
Whitelist `sendemail` function in server scripts

Docs Link: https://github.com/frappe/erpnext_documentation/pull/122

port-of: https://github.com/frappe/frappe/pull/11162