### PR TITLE
fix: Clear sitemap cache along with website cache

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -309,7 +309,7 @@ def clear_cache(path=None):
 
 	:param path: (optional) for the given path'''
 	for key in ('website_generator_routes', 'website_pages',
-		'website_full_index'):
+		'website_full_index', 'sitemap_routes'):
 		frappe.cache().delete_value(key)
 
 	frappe.cache().delete_value("website_404")


### PR DESCRIPTION
Clear sitemap cache along with website cache

Before this change, if you published/unpublished a Web Page it would not reflect in the sitemap.xml immediately.