### PR TITLE
fix: Deprecate site_config_backup_path in BackupGenerator

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -97,7 +97,7 @@ def backup_to_dropbox(upload_db_backup=True):
 		if frappe.flags.create_new_backup:
 			backup = new_backup(ignore_files=True)
 			filename = os.path.join(get_backups_path(), os.path.basename(backup.backup_path_db))
-			site_config = os.path.join(get_backups_path(), os.path.basename(backup.site_config_backup_path))
+			site_config = os.path.join(get_backups_path(), os.path.basename(backup.backup_path_conf))
 		else:
 			filename, site_config = get_latest_backup_file()
 

--- a/frappe/integrations/doctype/google_drive/google_drive.py
+++ b/frappe/integrations/doctype/google_drive/google_drive.py
@@ -191,7 +191,7 @@ def upload_system_backup_to_google_drive():
 		backup = new_backup()
 		file_urls = []
 		file_urls.append(backup.backup_path_db)
-		file_urls.append(backup.site_config_backup_path)
+		file_urls.append(backup.backup_path_conf)
 
 		if account.file_backup:
 			file_urls.append(backup.backup_path_files)

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -118,7 +118,7 @@ def backup_to_s3():
 		backup = new_backup(ignore_files=False, backup_path_db=None,
 						backup_path_files=None, backup_path_private_files=None, force=True)
 		db_filename = os.path.join(get_backups_path(), os.path.basename(backup.backup_path_db))
-		site_config = os.path.join(get_backups_path(), os.path.basename(backup.site_config_backup_path))
+		site_config = os.path.join(get_backups_path(), os.path.basename(backup.backup_path_conf))
 		if backup_files:
 			files_filename = os.path.join(get_backups_path(), os.path.basename(backup.backup_path_files))
 			private_files = os.path.join(get_backups_path(), os.path.basename(backup.backup_path_private_files))

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -80,6 +80,11 @@ class BackupGenerator:
 			last_db, last_file, last_private_file, site_config_backup_path = self.get_recent_backup(older_than)
 		else:
 			last_db, last_file, last_private_file, site_config_backup_path = False, False, False, False
+		print(last_db)
+		print(last_file)
+		print(last_private_file)
+		print(site_config_backup_path)
+
 
 		self.todays_date = now_datetime().strftime('%Y%m%d_%H%M%S')
 
@@ -93,6 +98,7 @@ class BackupGenerator:
 				self.zip_files()
 
 		else:
+			print('inside')
 			self.backup_path_files = last_file
 			self.backup_path_db = last_db
 			self.backup_path_private_files = last_private_file
@@ -175,6 +181,8 @@ class BackupGenerator:
 
 		with open(site_config_backup_path, "w") as n, open(site_config_path) as c:
 			n.write(c.read())
+
+		self.site_config_backup_path = site_config_backup_path
 
 	def take_dump(self):
 		import frappe.utils

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -80,11 +80,6 @@ class BackupGenerator:
 			last_db, last_file, last_private_file, site_config_backup_path = self.get_recent_backup(older_than)
 		else:
 			last_db, last_file, last_private_file, site_config_backup_path = False, False, False, False
-		print(last_db)
-		print(last_file)
-		print(last_private_file)
-		print(site_config_backup_path)
-
 
 		self.todays_date = now_datetime().strftime('%Y%m%d_%H%M%S')
 
@@ -98,7 +93,6 @@ class BackupGenerator:
 				self.zip_files()
 
 		else:
-			print('inside')
 			self.backup_path_files = last_file
 			self.backup_path_db = last_db
 			self.backup_path_private_files = last_private_file

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -68,6 +68,12 @@ class BackupGenerator:
 				dir = os.path.dirname(file_path)
 				os.makedirs(dir, exist_ok=True)
 
+	@property
+	def site_config_backup_path(self):
+		# For backwards compatibility
+		import click
+		click.secho("BackupGenerator.site_config_backup_path has been deprecated in favour of BackupGenerator.backup_path_conf", fg="yellow")
+		return getattr(self, "backup_path_conf", None)
 
 	def get_backup(self, older_than=24, ignore_files=False, force=False):
 		"""
@@ -96,7 +102,7 @@ class BackupGenerator:
 			self.backup_path_files = last_file
 			self.backup_path_db = last_db
 			self.backup_path_private_files = last_private_file
-			self.site_config_backup_path = site_config_backup_path
+			self.backup_path_conf = site_config_backup_path
 
 	def set_backup_file_name(self):
 		#Generate a random name using today's date and a 8 digit random number
@@ -175,8 +181,6 @@ class BackupGenerator:
 
 		with open(site_config_backup_path, "w") as n, open(site_config_path) as c:
 			n.write(c.read())
-
-		self.site_config_backup_path = site_config_backup_path
 
 	def take_dump(self):
 		import frappe.utils


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/11358 was incomplete when it was merged. This PR is an attempt to fix that.

- Deprecate`site_config_backup_path`
- Use `backup_path_conf` across frappe


![Screenshot 2020-09-15 at 6 03 06 PM](https://user-images.githubusercontent.com/36654812/93210735-bfdb1480-f77d-11ea-8f03-5940b729cac4.png)
