### PR TITLE
fix(web_form): Removed buggy code at webform save

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -139,16 +139,6 @@ export default class WebForm extends frappe.ui.FieldGroup {
 					this.handle_success(response.message);
 					frappe.web_form.events.trigger('after_save');
 					this.after_save && this.after_save();
-					// args doctype and docname added to link doctype in file manager
-					frappe.call({
-						type: 'POST',
-						method: "frappe.handler.upload_file",
-						args: {
-							file_url: response.message.attachment,
-							doctype: response.message.doctype,
-							docname: response.message.name
-						}
-					});
 				}
 			},
 			always: function() {


### PR DESCRIPTION
The removed lines produce a bug when saving an arbitrary web form that does not have the field "attachment". They should allow the upload of attachments in webforms but

A. There aren't checks about whether there are attachments or not (if there is the "attachment" field)
B. There aren't any handlers for multiple attachments

[Even the original fork of these lines updated their code to meet requirement A. ](https://github.com/DigiThinkIT/frappe/blob/8d84aafa0644af20e21f8c31d6f3345c5ce933af/frappe/public/js/frappe/web_form/web_form.js#L145)

Original PR: https://github.com/frappe/frappe/pull/10628