### PR TITLE
fix(Dashboard Chart): refresh data on individual chart refresh

### DIFF
--- a/frappe/core/page/dashboard/dashboard.js
+++ b/frappe/core/page/dashboard/dashboard.js
@@ -173,7 +173,7 @@ class DashboardChart {
 				label: __("Refresh"),
 				action: 'action-refresh',
 				handler: () => {
-					this.refresh();
+					this.refresh(true);
 				}
 			},
 			{


### PR DESCRIPTION
Pass `refresh_data` as `true` for chart refresh action.