### PR TITLE
fix: Validation for naming_series field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -234,6 +234,8 @@ class DocType(Document):
 
 		if not autoname and self.get("fields", {"fieldname":"naming_series"}):
 			self.autoname = "naming_series:"
+		elif self.autoname == "naming_series:" and not self.get("fields", {"fieldname":"naming_series"}):
+			frappe.throw(_("Invalid fieldname '{0}' in autoname").format(self.autoname))
 
 		# validate field name if autoname field:fieldname is used
 		# Create unique index on autoname field automatically.


### PR DESCRIPTION
**Issue:** `naming_series:` is allowed to be added in `autoname` field even though `naming_series` field is not present in the  doctype fields

This causes an issue later while saving the document. Add a validation to avoid this.