### PR TITLE
fix: Define chunk size based on backup file size to avoid timeout issues

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -9,7 +9,7 @@ import frappe
 import os
 from frappe import _
 from frappe.model.document import Document
-from frappe.integrations.offsite_backup_utils import get_latest_backup_file, send_email, validate_file_size
+from frappe.integrations.offsite_backup_utils import get_latest_backup_file, send_email, validate_file_size, get_chunk_site
 from frappe.integrations.utils import make_post_request
 from frappe.utils import (cint, get_request_site_address,
 	get_files_path, get_backups_path, get_url, encode)
@@ -165,8 +165,9 @@ def upload_file_to_dropbox(filename, folder, dropbox_client):
 		return
 
 	create_folder_if_not_exists(folder, dropbox_client)
-	chunk_size = 15 * 1024 * 1024
 	file_size = os.path.getsize(encode(filename))
+	chunk_size = get_chunk_site(file_size)
+
 	mode = (dropbox.files.WriteMode.overwrite)
 
 	f = open(encode(filename), 'rb')

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import glob
 import os
-from frappe.utils import split_emails, now_datetime, get_backups_path, cint
+from frappe.utils import split_emails, now_datetime, cint
 
 
 def send_email(success, service_name, doctype, email_field, error_status=None):

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -87,16 +87,17 @@ def get_chunk_site(file_size):
 
 	file_size_in_gb = cint(file_size/1024/1024)
 
+	MB = 1024 * 1024
 	if file_size_in_gb > 5000:
-		return 200*1024*1024 #200 mb
-	elif file_size_in_gb < 5000 and file_size_in_gb >= 3000:
-		return 150*1024*1024 #150 mb
-	elif file_size_in_gb < 3000 and file_size_in_gb >= 1000:
-		return 100*1024*1024 #100 mb
-	elif file_size_in_gb < 1000 and file_size_in_gb >= 500:
-		return 50*1024*1024 #50 mb
+		return 200 * MB
+	elif file_size_in_gb >= 3000:
+		return 150 * MB
+	elif file_size_in_gb >= 1000:
+		return 100 * MB
+	elif file_size_in_gb >= 500:
+		return 50 * MB
 	else:
-		return 15*1024*1024 #15 mb
+		return 15 * MB
 
 def validate_file_size():
 	frappe.flags.create_new_backup = True

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import glob
 import os
-from frappe.utils import split_emails, get_backups_path
+from frappe.utils import split_emails, get_backups_path, cint
 
 
 def send_email(success, service_name, doctype, email_field, error_status=None):
@@ -82,6 +82,21 @@ def get_file_size(file_path, unit):
 
 	return file_size
 
+def get_chunk_site(file_size):
+	''' this function will return chunk size in megabytes based on file size '''
+
+	file_size_in_gb = cint(file_size/1024/1024)
+
+	if file_size_in_gb > 5000:
+		return 200*1024*1024 #200 mb
+	elif file_size_in_gb < 5000 and file_size_in_gb >= 3000:
+		return 150*1024*1024 #150 mb
+	elif file_size_in_gb < 3000 and file_size_in_gb >= 1000:
+		return 100*1024*1024 #100 mb
+	elif file_size_in_gb < 1000 and file_size_in_gb >= 500:
+		return 50*1024*1024 #50 mb
+	else:
+		return 15*1024*1024 #15 mb
 
 def validate_file_size():
 	frappe.flags.create_new_backup = True


### PR DESCRIPTION
The system uses a chunk size of 15 MB while uploading a file to Dropbox. But some database backup files have a size larger than few GB's. 

In such cases, the offsite backup is breaking with a timeout error,  due to a small chunk size(15 MB).

This fix will define a chunk size, based on file size