### PR TITLE
feat: Ability to override doctype classes from hooks

### DIFF
--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 import unittest
 import frappe
+from frappe.desk.doctype.todo.todo import ToDo
 
 class TestHooks(unittest.TestCase):
 	def test_hooks(self):
@@ -14,3 +15,23 @@ class TestHooks(unittest.TestCase):
 		self.assertTrue(isinstance(hooks.get("doc_events").get("*"), dict))
 		self.assertTrue("frappe.desk.notifications.clear_doctype_notifications" in
 			hooks.get("doc_events").get("*").get("on_update"))
+
+	def test_override_doctype_class(self):
+		# mock get_hooks
+		original = frappe.get_hooks
+		def get_hooks(hook=None, default=None, app_name=None):
+			if hook == 'override_doctype_class':
+				return {
+					'ToDo': ['frappe.tests.test_hooks.CustomToDo']
+				}
+			return original(hook, default, app_name)
+		frappe.get_hooks = get_hooks
+
+		todo = frappe.get_doc(doctype='ToDo', description='asdf')
+		self.assertTrue(isinstance(todo, CustomToDo))
+
+		# restore
+		frappe.get_hooks = original
+
+class CustomToDo(ToDo):
+	pass

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -211,6 +211,14 @@ app_license = "{app_license}"
 # 	"Event": "frappe.desk.doctype.event.event.has_permission",
 # }}
 
+# DocType Class
+# ---------------
+# Override standard doctype classes
+
+# override_doctype_class = {{
+# 	"ToDo": "custom_app.overrides.CustomToDo"
+# }}
+
 # Document Events
 # ---------------
 # Hook on document methods and events


### PR DESCRIPTION
Currently there is no way to override standard methods of DocType class.

There are a [lot of discussions](https://discuss.erpnext.com/search?q=override%20doctype%20method) on this topic. And the suggested solution is this one:
https://discuss.erpnext.com/t/how-to-override-method-in-frappe/28786/4

This overrides the method directly by setting the method on the class object. If this line is not called in a method, then the method will stay after the request is complete, so if there are other sites that don't have that app installed, they will be affected by the custom method behavior.


You can now override a standard DocType class via hooks.

**test_app/hooks.py**
```py
override_doctype_class = {
	'ToDo': 'test_app.overrides.CustomToDo'
}
```

**test_app/overrides.py**
```py
import frappe
from frappe.desk.doctype.todo.todo import ToDo


class CustomToDo(ToDo):
	def on_update(self):
		self.my_custom_code()
		super(ToDo, self).on_update()

	def my_custom_code(self):
		pass
```

- [x] [Docs Link](https://github.com/frappe/frappe_docs/pull/45): https://github.com/frappe/frappe_docs/pull/45/files#diff-059ec755822aab5a151ab63bb8792c10R388
- [x] Test