### PR TITLE
fix(List): include tab in special characters to match to encode url 

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -705,7 +705,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return this.settings.get_form_link(doc);
 		}
 
-		const docname = doc.name.match(/[%'"]/)
+		const docname = doc.name.match(/[\t%'"]/)
 			? encodeURIComponent(doc.name)
 			: doc.name;
 


### PR DESCRIPTION
Tab character in a document name breaks the routing in list view.