### PR TITLE
fix: reload doc before blog patch

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -306,6 +306,7 @@ frappe.patches.v13_0.add_toggle_width_in_navbar_settings
 frappe.patches.v13_0.rename_notification_fields
 frappe.patches.v13_0.remove_duplicate_navbar_items
 frappe.patches.v12_0.set_default_password_reset_limit
+execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True)
 frappe.patches.v13_0.set_route_for_blog_category
 frappe.patches.v13_0.enable_custom_script
 frappe.patches.v13_0.update_newsletter_content_type


### PR DESCRIPTION
Reload DocType before executing blog category patch

```
doc.save()
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/model/document.py", line 337, in _save
    self.run_post_save_methods()
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/model/document.py", line 982, in run_post_save_methods
    self.run_method('on_change')
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/model/document.py", line 831, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/model/document.py", line 1116, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/model/document.py", line 1099, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/model/document.py", line 825, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/website/website_generator.py", line 92, in on_change
    self.update_website_search_index()
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/website/website_generator.py", line 165, in update_website_search_index
    if not self.allow_website_search_indexing() or frappe.flags.in_test:
  File "/home/frappe/benches/bench-nightly-f1-43/apps/frappe/frappe/website/website_generator.py", line 147, in allow_website_search_indexing
    return self.meta.index_web_pages_for_search
AttributeError: 'Meta' object has no attribute 'index_web_pages_for_search'
```