### PR TITLE
Revert "fix: ignore no_copy for auto repeat document creation (bp #10917)"

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -146,7 +146,7 @@ class AutoRepeat(Document):
 
 	def make_new_document(self):
 		reference_doc = frappe.get_doc(self.reference_doctype, self.reference_document)
-		new_doc = frappe.copy_doc(reference_doc)
+		new_doc = frappe.copy_doc(reference_doc, ignore_no_copy = False)
 		self.update_doc(new_doc, reference_doc)
 		new_doc.insert(ignore_permissions = True)
 


### PR DESCRIPTION
Reverts frappe/frappe#10919

`no_copy` is set on purpose for fields as there exists code to set values for such fields so `ignore_no_copy` should ideally be False while creating auto-repeat documents. The Purchase Invoice scenario has been fixed in https://github.com/frappe/erpnext/pull/23367