### PR TITLE
feat(Data Import): Handle import of DocTypes with tree structure

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 import os
+import traceback
 import frappe
 from frappe.model.document import Document
 
@@ -104,6 +105,14 @@ def start_import(data_import):
 	except Exception:
 		frappe.db.rollback()
 		data_import.db_set("status", "Error")
+		# Not clear whether it is reasonable to print the traceback.
+		# However, I couldn't find any other way to capture it;
+		# the utils/error "make_error_snapshot" function did not appear
+		# to leave anything behind in the database, even if called
+		# after the rollback above. Please feel free to replace this
+		# with any better mechanism for capturing the error report,
+		# which is critical for debugging Data Import/Importer.
+		traceback.print_exc()
 		frappe.log_error(title=data_import.name)
 	finally:
 		frappe.flags.in_import = False

--- a/frappe/core/doctype/data_import/fixtures/sample_import_file_for_tree.csv
+++ b/frappe/core/doctype/data_import/fixtures/sample_import_file_for_tree.csv
@@ -1,0 +1,5 @@
+Title,Description,Is Group,Parent DocType for Import
+alpha,leader,1,
+beta,first follower,0,leader
+gamma,subleader,1,leader
+delta,lowly follower,0,subleader

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1042,7 +1042,8 @@ class Column:
 		self.skip_import = skip_import
 		if not skip_import:
 			self.value_occurs = {self.column_values[i]:i
-					     for i in range(len(self.column_values)-1,0,-1)}
+				for i in range(len(self.column_values)-1,0,-1)
+				if self.column_values[i]}
 
 	def guess_date_format_for_column(self):
 		"""Guesses date format for a column by parsing all the values in the column,

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -634,7 +634,6 @@ class Row:
 				value = None
 
 			if value is not None:
-				record_is_empty = False
 				value = self.validate_value(value, col, prior)
 
 			if value is not None:

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -98,6 +98,26 @@ class TestImporter(unittest.TestCase):
 		self.assertEqual(updated_doc.table_field_1[0].child_description, 'child description')
 		self.assertEqual(updated_doc.table_field_1_again[0].child_title, 'child title again')
 
+	def test_data_import_tree(self):
+		import_file = get_import_file('sample_import_file_for_tree')
+		data_import = self.get_importer(doctype_name, import_file)
+		data_import.start_import()
+
+		doca = frappe.get_doc(doctype_name, 'alpha')
+		docb = frappe.get_doc(doctype_name, 'beta')
+		docc = frappe.get_doc(doctype_name, 'gamma')
+		docd = frappe.get_doc(doctype_name, 'delta')
+
+		self.assertEqual(doca.description, 'leader')
+		self.assertEqual(doca.is_group, 1)
+		self.assertEqual(docb.description, 'first follower')
+		self.assertEqual(docb.parent_doctype_for_import, 'alpha')
+		self.assertEqual(docc.title, 'gamma')
+		self.assertEqual(docc.is_group, 1)
+		self.assertEqual(docc.parent_doctype_for_import, 'alpha')
+		self.assertEqual(docd.title, 'delta')
+		self.assertEqual(docd.parent_doctype_for_import, 'gamma')
+
 	def get_importer(self, doctype, import_file, update=False):
 		data_import = frappe.new_doc('Data Import')
 		data_import.import_type = 'Insert New Records' if not update else 'Update Existing Records'
@@ -168,6 +188,7 @@ def create_doctype_if_not_exists(doctype_name, force=False):
 			{'label': 'Table Field 2', 'fieldname': 'table_field_2', 'fieldtype': 'Table', 'options': table_2_name},
 			{'label': 'Table Field 1 Again', 'fieldname': 'table_field_1_again', 'fieldtype': 'Table', 'options': table_1_name},
 		],
+		'is_tree': 1,
 		'permissions': [
 			{'role': 'System Manager'}
 		]

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -175,6 +175,9 @@ def parse_naming_series(parts, doctype='', doc=''):
 			part = doc.get(e)
 		elif doc and doc.get(e):
 			part = doc.get(e)
+                        # Make sure we can include numbers and such in the name
+			if part is not None:
+				part = cstr(part)
 		else:
 			part = e
 


### PR DESCRIPTION
      Prior to this PR, it is impossible to use Data Import to insert
      new records with tree structure, because the parent field may reference
      nodes (of the same DocType) that do not yet exist prior to the import.
      This PR improves this situation in two major ways:
    
      (1) in "insert" type imports, allow references to docs previously created
          during this same import in Link fields of the same doctype as is being
          imported. These references by name work as long as it is possible to
          determine the name of new docs from the fields specified in the import
          file; those names need to be manually entered in the import file where
          the reference is desired, and the reference needs to come after the
          row that creates the document being referred to.
    
      (2) if in a Link field of the same doctype, one uses the value of any other
          field of this same doctype that matches the value for that field in
          an earlier document in the import file, and there is a unique field
          for which that is true, then the import process will look up references
          to this same doctype via that field value.
    
      Note that references of types (1) and (2) can be mixed in the same import
      file, and that it continues to work to use the name of documents of this
      same doctype that existed prior to the start of this import.
    
      In addition, this PR allows numeric and other fields to occur in
      the format: type of autoname, so that a naming scheme like that of
      Account and Cost Center can be used for custom doctypes. Prior to this,
      a reference to a numeric field would yield the empty string in the doc
      name.

Note that this PR is a further development of PR #10956, which it is intended to replace (I will close the other PR momentarily). The additional feature of referring to earlier records via the values of another (unambiguous) field in addition to by the "name" of earlier records (which might not be known in advance, depending on the naming scheme), was added in response to the discussion of PR #10956. In particular, the Task import attempted by the reviewer of that prior PR should now work if one simply replaces the "TASK000200" values in the "Parent Task" column with "Home Interior Project". I hope that seems natural and convenient.