### PR TITLE
fix: Validate whether file type is CSV in Grid Upload

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -673,6 +673,10 @@ export default class Grid {
 					as_dataurl: true,
 					allow_multiple: false,
 					on_success(file) {
+						if (file.file_obj.type !== "text/csv") {
+							let msg = __(`Your file could not be processed. It should be a standard CSV file.`);
+							frappe.throw(msg);
+						}
 						var data = frappe.utils.csv_to_array(frappe.utils.get_decoded_string(file.dataurl));
 						// row #2 contains fieldnames;
 						var fieldnames = data[2];


### PR DESCRIPTION
**Before:**

![grid-upload-before](https://user-images.githubusercontent.com/24353136/93862354-8e170000-fcdf-11ea-9f0f-d7c1c17c920f.gif)

**After:**

![grid-upload-after](https://user-images.githubusercontent.com/24353136/93861902-e568a080-fcde-11ea-94d6-8084e551edc1.gif)
