### PR TITLE
fix: Remove unused import

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 import frappe, json
-import frappe.defaults
 from frappe.model.document import Document
 from frappe.desk.notifications import (delete_notification_count_for,
 	clear_notifications)


### PR DESCRIPTION
This is a circular import between `cache_manager.py` and `defaults.py`. There was no change in these files for a long time but it was breaking on migrate for some reason. Removing the unused import fixes this.

```
Traceback (most recent call last):
  File "/Users/farisansari/.pyenv/versions/3.7.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/farisansari/.pyenv/versions/3.7.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 99, in <module>
    main()
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/farisansari/Projects/benches/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/farisansari/Projects/benches/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/farisansari/Projects/benches/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/farisansari/Projects/benches/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/farisansari/Projects/benches/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/farisansari/Projects/benches/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/farisansari/Projects/benches/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/commands/site.py", line 280, in migrate
    from frappe.migrate import migrate
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/migrate.py", line 16, in <module>
    from frappe.cache_manager import clear_global_cache
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/cache_manager.py", line 7, in <module>
    import frappe.defaults
  File "/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/defaults.py", line 7, in <module>
    from frappe.cache_manager import clear_defaults_cache, common_default_keys
ImportError: cannot import name 'clear_defaults_cache' from 'frappe.cache_manager' (/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/frappe/cache_manager.py)
```