### PR TITLE
fix: Pluck syntax for get_all and friends

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -37,7 +37,8 @@ class DatabaseQuery(object):
 		ignore_permissions=False, user=None, with_comment_count=False,
 		join='left join', distinct=False, start=None, page_length=None, limit=None,
 		ignore_ifnull=False, save_user_settings=False, save_user_settings_fields=False,
-		update=None, add_total_row=None, user_settings=None, reference_doctype=None, return_query=False, strict=True):
+		update=None, add_total_row=None, user_settings=None, reference_doctype=None,
+		return_query=False, strict=True, pluck=None):
 		if not ignore_permissions and not frappe.has_permission(self.doctype, "read", user=user):
 			frappe.flags.error_message = _('Insufficient Permission for {0}').format(frappe.bold(self.doctype))
 			raise frappe.PermissionError(self.doctype)
@@ -103,6 +104,9 @@ class DatabaseQuery(object):
 		if save_user_settings:
 			self.save_user_settings_fields = save_user_settings_fields
 			self.update_user_settings()
+
+		if pluck:
+			return [d[pluck] for d in result]
 
 		return result
 


### PR DESCRIPTION
```py
# Instead of 
docnames = [d.name for d in frappe.db.get_all('ToDo')]

# You can now do
docnames = frappe.db.get_all('ToDo', pluck='name')
```

<details>
<summary>Lots of usage in code:</summary>

<img width="815" alt="image" src="https://user-images.githubusercontent.com/9355208/93980867-d21c0a80-fd9c-11ea-8084-acd9fcac53ab.png">


</details>