### PR TITLE
fix: Copy incoming_port from Email Domain to Email Account

### DIFF
--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -69,7 +69,7 @@ class EmailDomain(Document):
 		for email_account in frappe.get_all("Email Account", filters={"domain": self.name}):
 			try:
 				email_account = frappe.get_doc("Email Account", email_account.name)
-				for attr in ["email_server", "use_imap", "use_ssl", "use_tls", "attachment_limit", "smtp_server", "smtp_port", "use_ssl_for_outgoing", "append_emails_to_sent_folder"]:
+				for attr in ["email_server", "use_imap", "use_ssl", "use_tls", "attachment_limit", "smtp_server", "smtp_port", "use_ssl_for_outgoing", "append_emails_to_sent_folder", "incoming_port"]:
 					email_account.set(attr, self.get(attr, default=0))
 				email_account.save()
 

--- a/frappe/email/doctype/email_domain/test_email_domain.py
+++ b/frappe/email/doctype/email_domain/test_email_domain.py
@@ -5,8 +5,35 @@ from __future__ import unicode_literals
 
 import frappe
 import unittest
+from frappe.test_runner import make_test_objects
 
-# test_records = frappe.get_test_records('Domain')
+test_records = frappe.get_test_records('Email Domain')
 
 class TestDomain(unittest.TestCase):
-	pass
+
+	def setUp(self):
+		make_test_objects('Email Domain', reset=True)
+
+	def tearDown(self):
+		frappe.delete_doc("Email Account", "Test")
+		frappe.delete_doc("Email Domain", "test.com")
+
+	def test_on_update(self):
+		mail_domain = frappe.get_doc("Email Domain", "test.com")
+		mail_account = frappe.get_doc("Email Account", "Test")
+
+		# Initially, incoming_port is different in domain and account
+		self.assertNotEqual(mail_account.incoming_port, mail_domain.incoming_port)
+		# Trigger update of accounts using this domain
+		mail_domain.on_update()
+		mail_account = frappe.get_doc("Email Account", "Test")
+		# After update, incoming_port in account should match the domain
+		self.assertEqual(mail_account.incoming_port, mail_domain.incoming_port)
+
+		# Also make sure that the other attributes match
+		self.assertEqual(mail_account.use_imap, mail_domain.use_imap)
+		self.assertEqual(mail_account.use_ssl, mail_domain.use_ssl)
+		self.assertEqual(mail_account.use_tls, mail_domain.use_tls)
+		self.assertEqual(mail_account.attachment_limit, mail_domain.attachment_limit)
+		self.assertEqual(mail_account.smtp_server, mail_domain.smtp_server)
+		self.assertEqual(mail_account.smtp_port, mail_domain.smtp_port)

--- a/frappe/email/doctype/email_domain/test_records.json
+++ b/frappe/email/doctype/email_domain/test_records.json
@@ -1,0 +1,30 @@
+[
+ {
+  "doctype": "Email Domain",
+  "domain_name": "test.com",
+  "email_id": "_test@test.com",
+  "email_server": "imap.test.com",
+  "use_imap": "imap.test.com",
+  "use_ssl": 1,
+  "use_tls": 1,
+  "incoming_port": "993",
+  "attachment_limit": "1",
+  "smtp_server": "smtp.test.com",
+  "smtp_port": "587"
+ },
+ {
+  "doctype": "Email Account",
+  "name": "_Test Email Account 1",
+  "enable_incoming": 1,
+  "email_id": "_test@test.com",
+  "domain": "test.com",
+  "email_server": "imap.test.com",
+  "use_imap": 1,
+  "use_ssl": 0,
+  "use_tls": 1,
+  "incoming_port": "143",
+  "attachment_limit": "1",
+  "smtp_server": "smtp.test.com",
+  "smtp_port": "587"
+ }
+]


### PR DESCRIPTION
When changing an Email Domain, the configuration fields are copied
to all Email Accounts using this domain. This happens in the method
`on_update`

- Include `incoming_port` when copying fields
- Add test case for `on_update`

closes #11556