### PR TITLE
fix(DocType): Change label to "Linked Documents"

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -490,7 +490,7 @@
    "collapsible_depends_on": "links",
    "fieldname": "links_section",
    "fieldtype": "Section Break",
-   "label": "Dashboard Links"
+   "label": "Linked Documents"
   },
   {
    "fieldname": "links",
@@ -609,7 +609,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2020-09-24 13:02:09.975230",
+ "modified": "2020-09-24 13:13:58.227153",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -490,7 +490,7 @@
    "collapsible_depends_on": "links",
    "fieldname": "links_section",
    "fieldtype": "Section Break",
-   "label": "Links Section"
+   "label": "Dashboard Links"
   },
   {
    "fieldname": "links",
@@ -609,7 +609,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2020-08-06 12:59:32.369095",
+ "modified": "2020-09-24 13:02:09.975230",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",


### PR DESCRIPTION
Changed the label of the section "Links Section" to "Linked Document".

Before:

![image](https://user-images.githubusercontent.com/50285544/94114931-a1a0a300-fe66-11ea-99a7-554e66bbf28b.png)


After:

![image](https://user-images.githubusercontent.com/50285544/94116290-79b23f00-fe68-11ea-9c28-f39ac5bbc2e6.png)

