### PR TITLE
refactor: Web Template

### DIFF
--- a/frappe/website/doctype/web_template/web_template.json
+++ b/frappe/website/doctype/web_template/web_template.json
@@ -52,8 +52,13 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2020-09-18 13:54:12.667877",
+ "links": [
+  {
+   "link_doctype": "Web Page",
+   "link_fieldname": "web_template"
+  }
+ ],
+ "modified": "2020-09-25 00:48:57.902292",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Template",

--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -37,7 +37,8 @@ class WebTemplate(Document):
 				self.create_template_file()
 
 			# standard to custom
-			if self.get_doc_before_save().standard and not self.standard:
+			was_standard = (self.get_doc_before_save() or {}).get("standard")
+			if was_standard and not self.standard:
 				self.template = self.get_template(standard=True)
 				rmtree(self.get_template_folder())
 

--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -83,6 +83,7 @@ class WebTemplate(Document):
 
 	def render(self, values="{}"):
 		values = frappe.parse_json(values)
+		values.update({"values": values})
 		template = self.get_template(self.standard)
 
 		return frappe.render_template(template, values)

--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -3,13 +3,15 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-import frappe
+
 import os
+from shutil import rmtree
+
+import frappe
 from frappe.model.document import Document
 from frappe import _
 from frappe.modules.export_file import (
 	export_to_files,
-	create_folder,
 	get_module_path,
 	scrub_dt_dn,
 )
@@ -28,35 +30,58 @@ class WebTemplate(Document):
 			frappe.throw(_("Please select which module this Web Template belongs to."))
 
 	def on_update(self):
-		if self.standard and frappe.conf.developer_mode:
-			export_to_files(record_list=[["Web Template", self.name]], create_init=True)
-			self.create_template_file()
+		if frappe.conf.developer_mode:
+			# custom to standard
+			if self.standard:
+				export_to_files(record_list=[["Web Template", self.name]], create_init=True)
+				self.create_template_file()
+
+			# standard to custom
+			if self.get_doc_before_save().standard and not self.standard:
+				self.template = self.get_template(standard=True)
+				rmtree(self.get_template_folder())
 
 	def create_template_file(self):
 		"""Touch a HTML file for the Web Template and add existing content, if any."""
 		if self.standard:
-			module = self.module or "Website" # required for smooth migration
-			folder = create_folder(module, self.doctype, self.name, False)
-			path = os.path.join(folder, frappe.scrub(self.name) + ".html")
+			path = self.get_template_path()
 			if not os.path.exists(path):
 				with open(path, "w") as template_file:
 					if self.template:
 						template_file.write(self.template)
 
-	def render(self, values):
-		values = values or "{}"
-		values = frappe.parse_json(values)
+	def get_template_folder(self):
+		"""Return the absolute path to the template's folder."""
+		module = self.module or "Website"
+		module_path = get_module_path(module)
+		doctype, docname = scrub_dt_dn(self.doctype, self.name)
 
-		if self.standard:
-			module_path = get_module_path(self.module or "Website")
-			dt, dn = scrub_dt_dn("Web Template", self.name)
-			scrubbed = frappe.scrub(self.name)
-			full_path = os.path.join("frappe", module_path, dt, dn, scrubbed + ".html")
-			root_app_path = os.path.abspath(os.path.join(frappe.get_app_path("frappe"), ".."))
-			template = os.path.relpath(full_path, root_app_path)
+		return os.path.join(module_path, doctype, docname)
+
+	def get_template_path(self):
+		"""Return the absolute path to the template's HTML file."""
+		folder = self.get_template_folder()
+		file_name = frappe.scrub(self.name) + ".html"
+
+		return os.path.join(folder, file_name)
+
+	def get_template(self, standard=False):
+		"""Get the jinja template string.
+
+		Params:
+		standard - if True, look on the disk instead of in the database.
+		"""
+		if standard:
+			template = self.get_template_path()
+			with open(template, "r") as template_file:
+				template = template_file.read()
 		else:
 			template = self.template
 
-		context = values or {}
-		context.update({"values": values})
-		return frappe.render_template(template, context)
+		return template
+
+	def render(self, values="{}"):
+		values = frappe.parse_json(values)
+		template = self.get_template(self.standard)
+
+		return frappe.render_template(template, values)


### PR DESCRIPTION
### Refactor

Extract methods to get the location of a standard **Web Template**. They get used in multiple places and should not be implemented twice and in two different ways.

### Feature

If a standard **Web Template** becomes non-standard, read it from the disk, store it in the database and delete it from the disk. This way it's fast and convenient for developers to switch between the two. Only works in developer mode.

### Fix

Reading a standard **Web Template** from other apps than frappe wasn't implemented properly (stupid me).