### PR TITLE
Fix(Google Drive): Take file backup if Size>1Gb and Google Drive "File Backup" is enabled

### DIFF
--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -88,5 +88,5 @@ def validate_file_size():
 	latest_file, site_config = get_latest_backup_file()
 	file_size = get_file_size(latest_file, unit="GB")
 
-	if file_size > 1:
+	if file_size > 1 and not frappe.db.get_value('Google Drive', None, 'file_backup'):
 		frappe.flags.create_new_backup = False


### PR DESCRIPTION
When file backup size is greater than 1gb, it is not taken.
This prevents backup to gdrive too.

This fix allows file backup to be taken if Google Drive "File Backup" is enabled
when the size is greater than 1GB.