### PR TITLE
feat: as_raw update to display content inline not always download as attachment

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -71,7 +71,7 @@ def as_txt():
 def as_raw():
 	response = Response()
 	response.mimetype = frappe.response.get("content_type") or mimetypes.guess_type(frappe.response['filename'])[0] or "application/unknown"
-	response.headers["Content-Disposition"] = (f"{frappe.response.get('display_content_as') or 'attachment'}; filename=\"%s\"" % frappe.response['filename'].replace(' ', '_')).encode("utf-8")
+	response.headers["Content-Disposition"] = (f"{frappe.response.get('display_content_as','attachment')}; filename={frappe.response['filename'].replace(' ', '_')}").encode("utf-8")
 	response.data = frappe.response['filecontent']
 	return response
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -71,7 +71,7 @@ def as_txt():
 def as_raw():
 	response = Response()
 	response.mimetype = frappe.response.get("content_type") or mimetypes.guess_type(frappe.response['filename'])[0] or "application/unknown"
-	response.headers["Content-Disposition"] = (f"{frappe.response.get('display_content_as','attachment')}; filename={frappe.response['filename'].replace(' ', '_')}").encode("utf-8")
+	response.headers["Content-Disposition"] = (f'{frappe.response.get("display_content_as","attachment")}; filename="{frappe.response["filename"].replace(" ", "_")}"').encode("utf-8")
 	response.data = frappe.response['filecontent']
 	return response
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -71,7 +71,7 @@ def as_txt():
 def as_raw():
 	response = Response()
 	response.mimetype = frappe.response.get("content_type") or mimetypes.guess_type(frappe.response['filename'])[0] or "application/unknown"
-	response.headers["Content-Disposition"] = ("attachment; filename=\"%s\"" % frappe.response['filename'].replace(' ', '_')).encode("utf-8")
+	response.headers["Content-Disposition"] = (f"{frappe.response.get('display_content_as') or 'attachment'}; filename=\"%s\"" % frappe.response['filename'].replace(' ', '_')).encode("utf-8")
 	response.data = frappe.response['filecontent']
 	return response
 


### PR DESCRIPTION
If I want to display some response in my webpage through API call this will help
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

If I hit my API call in the browser which is returning Image or PDF it will show directly in the browser instead of downloading if we set
frappe.local.response.display_content_as = 'inline'
in the API

You can test for any existing PDF creation API
Tested for Image creation and PDF creation API's

Docs: https://github.com/frappe/frappe_docs/pull/62

How to implement: https://frappeframework.com/docs/user/en/python-api/response