### PR TITLE
fix(UX): Freeze buttons during request

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.js
+++ b/frappe/email/doctype/email_queue/email_queue.js
@@ -4,12 +4,13 @@
 frappe.ui.form.on("Email Queue", {
 	refresh: function(frm) {
 		if (["Not Sent","Partially Sent"].indexOf(frm.doc.status)!=-1) {
-			frm.add_custom_button("Send Now", function() {
+			let button = frm.add_custom_button("Send Now", function() {
 				frappe.call({
 					method: 'frappe.email.doctype.email_queue.email_queue.send_now',
 					args: {
 						name: frm.doc.name
 					},
+					btn: button,
 					callback: function() {
 						frm.reload_doc();
 					}
@@ -18,12 +19,13 @@ frappe.ui.form.on("Email Queue", {
 		}
 
 		if (["Error","Partially Errored"].indexOf(frm.doc.status)!=-1) {
-			frm.add_custom_button("Retry Sending", function() {
+			let button = frm.add_custom_button("Retry Sending", function() {
 				frm.call({
 					method: "retry_sending",
 					args: {
 						name: frm.doc.name
 					},
+					btn: button,
 					callback: function(r) {
 						if (!r.exc) {
 							frm.set_value("status", "Not Sent");


### PR DESCRIPTION
Freeze buttons "Send Now" and "Retry Sending" in Email Queue until the request is complete.