### PR TITLE
fix: frappe.utils.formatdate not working in the jinja

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -192,7 +192,7 @@ VALID_UTILS = (
 "get_time_str",
 "get_user_date_format",
 "get_user_time_format",
-"format_date",
+"formatdate",
 "format_time",
 "format_datetime",
 "format_duration",


### PR DESCRIPTION
**Issue**

frappe.utils.formatdate is not working in the print format and gives below error. This is because `formatdate` is not available, in v12, the safe_exec PR was backported from v13 without handling the function name change. 

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/handler.py", line 64, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/__init__.py", line 1064, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/www/printview.py", line 189, in get_html_and_style
    no_letterhead=no_letterhead, trigger_print=trigger_print)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/www/printview.py", line 159, in get_rendered_template
    html = template.render(args, filters={"len": len})
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/./templates/print_formats/standard.html", line 7, in top-level template code
    {{ add_header(loop.index, layout|len, doc, letter_head, no_letterhead, footer, print_settings) }}
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/sandbox.py", line 440, in call
    return __context.call(__obj, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/runtime.py", line 574, in _invoke
    rv = self._func(*arguments)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/./templates/print_formats/standard_macros.html", line 166, in template
    {{ frappe.render_template(doc.print_heading_template, {"doc":doc}) }}
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/sandbox.py", line 440, in call
    return __context.call(__obj, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/utils/jinja.py", line 80, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 17, in top-level template code
  File "/home/frappe/benches/bench-version-12-2020-09-25/env/lib/python3.6/site-packages/jinja2/sandbox.py", line 440, in call
    return __context.call(__obj, *args, **kwargs)
TypeError: 'NoneType' object is not callable
```