### PR TITLE
refactor: report name is mandatory while saving report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1258,6 +1258,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							{
 								fieldtype: 'Data',
 								fieldname: 'report_name',
+								reqd: true,
 								label: __("Report Name"),
 								default: this.report_doc.is_standard == 'No' ? this.report_name : "",
 							}


### PR DESCRIPTION
**Issue**

1. Goto report Stock balance

1. Click on save

1. Don't put report name and hit submit button, throws below error

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/handler.py", line 64, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-09-25/apps/frappe/frappe/__init__.py", line 1064, in call
    return fn(*args, **newargs)
TypeError: save_report() missing 1 required positional argument: 'report_name'
```

**Solution**

Report Name must be mandatory
<img width="821" alt="Screenshot 2020-09-25 at 7 35 12 PM" src="https://user-images.githubusercontent.com/8780500/94276779-5077d880-ff66-11ea-9fda-29923349dc17.png">
