### PR TITLE
feat: Ability to define path for whitelisted methods

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -532,7 +532,7 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None, path=None):
 
 	:param allow_guest: Allow non logged-in user to access this method.
 	:param methods: Allowed http method to access the method.
-	:param alias: Alias the path to method with an alternative string
+	:param path: Full path that can be used to trigger this method
 
 	Use as:
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -520,12 +520,12 @@ def sendmail(recipients=[], sender="", subject="No Subject", message="No Message
 		inline_images=inline_images, header=header, print_letterhead=print_letterhead)
 
 whitelisted = []
-whitelisted_alias = {}
+whitelisted_paths = {}
 guest_methods = []
 xss_safe_methods = []
 allowed_http_methods_for_whitelisted_func = {}
 
-def whitelist(allow_guest=False, xss_safe=False, methods=None, alias=None):
+def whitelist(allow_guest=False, xss_safe=False, methods=None, path=None):
 	"""
 	Decorator for whitelisting a function and making it accessible via HTTP.
 	Standard request will be `/api/method/[path.to.method]`
@@ -545,14 +545,11 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None, alias=None):
 		methods = ['GET', 'POST', 'PUT', 'DELETE']
 
 	def innerfn(fn):
-		global whitelisted, guest_methods, xss_safe_methods, allowed_http_methods_for_whitelisted_func, whitelisted_alias
+		global whitelisted, guest_methods, xss_safe_methods, allowed_http_methods_for_whitelisted_func, whitelisted_paths
 		whitelisted.append(fn)
 
-		if alias:
-			if whitelisted_alias.get(alias):
-				throw('Whitelisted method alias already exists for ' + alias)
-			else:
-				whitelisted_alias[alias] = fn
+		if path:
+			whitelisted_paths[path] = fn
 
 		allowed_http_methods_for_whitelisted_func[fn] = methods
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -520,12 +520,11 @@ def sendmail(recipients=[], sender="", subject="No Subject", message="No Message
 		inline_images=inline_images, header=header, print_letterhead=print_letterhead)
 
 whitelisted = []
-whitelisted_paths = {}
 guest_methods = []
 xss_safe_methods = []
 allowed_http_methods_for_whitelisted_func = {}
 
-def whitelist(allow_guest=False, xss_safe=False, methods=None, path=None):
+def whitelist(allow_guest=False, xss_safe=False, methods=None):
 	"""
 	Decorator for whitelisting a function and making it accessible via HTTP.
 	Standard request will be `/api/method/[path.to.method]`
@@ -547,9 +546,6 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None, path=None):
 	def innerfn(fn):
 		global whitelisted, guest_methods, xss_safe_methods, allowed_http_methods_for_whitelisted_func, whitelisted_paths
 		whitelisted.append(fn)
-
-		if path:
-			whitelisted_paths[path] = fn
 
 		allowed_http_methods_for_whitelisted_func[fn] = methods
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -520,17 +520,19 @@ def sendmail(recipients=[], sender="", subject="No Subject", message="No Message
 		inline_images=inline_images, header=header, print_letterhead=print_letterhead)
 
 whitelisted = []
+whitelisted_alias = {}
 guest_methods = []
 xss_safe_methods = []
 allowed_http_methods_for_whitelisted_func = {}
 
-def whitelist(allow_guest=False, xss_safe=False, methods=None):
+def whitelist(allow_guest=False, xss_safe=False, methods=None, alias=None):
 	"""
 	Decorator for whitelisting a function and making it accessible via HTTP.
 	Standard request will be `/api/method/[path.to.method]`
 
 	:param allow_guest: Allow non logged-in user to access this method.
 	:param methods: Allowed http method to access the method.
+	:param alias: Alias the path to method with an alternative string
 
 	Use as:
 
@@ -543,8 +545,14 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None):
 		methods = ['GET', 'POST', 'PUT', 'DELETE']
 
 	def innerfn(fn):
-		global whitelisted, guest_methods, xss_safe_methods, allowed_http_methods_for_whitelisted_func
+		global whitelisted, guest_methods, xss_safe_methods, allowed_http_methods_for_whitelisted_func, whitelisted_alias
 		whitelisted.append(fn)
+
+		if alias:
+			if whitelisted_alias.get(alias):
+				throw('Whitelisted method alias already exists for ' + alias)
+			else:
+				whitelisted_alias[alias] = fn
 
 		allowed_http_methods_for_whitelisted_func[fn] = methods
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -60,6 +60,9 @@ def application(request):
 		if frappe.local.form_dict.cmd:
 			response = frappe.handler.handle()
 
+		elif frappe.request.path in frappe.whitelisted_paths:
+			response = frappe.handler.handle_whitelisted_path()
+
 		elif frappe.request.path.startswith("/api/"):
 			response = frappe.api.handle()
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -60,7 +60,7 @@ def application(request):
 		if frappe.local.form_dict.cmd:
 			response = frappe.handler.handle()
 
-		elif frappe.request.path in frappe.whitelisted_paths:
+		elif frappe.request.path in frappe.get_hooks('whitelisted_paths'):
 			response = frappe.handler.handle_whitelisted_path()
 
 		elif frappe.request.path.startswith("/api/"):

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -46,7 +46,18 @@ def handle_whitelisted_path():
 	validate_auth()
 	path = frappe.request.path
 
-	method = frappe.whitelisted_paths.get(path)
+	whitelisted_paths = frappe.get_hooks('whitelisted_paths', {})
+
+	handler = whitelisted_paths.get(path)
+	if len(handler) == 2:
+		# [doctype, method] format
+		doctype, method = handler
+		doctype_module = frappe.modules.utils.load_doctype_module(doctype)
+		method = getattr(doctype_module, method)
+	else:
+		# dotted path format
+		method = handler[-1]
+
 	data = execute_whitelisted_method(method)
 
 	if data is not None:

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -51,15 +51,18 @@ def execute_cmd(cmd, from_async=False):
 	if run_server_script_api(cmd):
 		return None
 
-	try:
-		method = get_attr(cmd)
-	except Exception as e:
-		if frappe.local.conf.developer_mode:
-			raise e
-		else:
-			frappe.respond_as_web_page(title='Invalid Method', html='Method not found',
-			indicator_color='red', http_status_code=404)
-		return
+	if cmd in frappe.whitelisted_alias.keys():
+		method = frappe.whitelisted_alias.get(cmd)
+	else:
+		try:
+			method = get_attr(cmd)
+		except Exception as e:
+			if frappe.local.conf.developer_mode:
+				raise e
+			else:
+				frappe.respond_as_web_page(title='Invalid Method', html='Method not found',
+				indicator_color='red', http_status_code=404)
+			return
 
 	if from_async:
 		method = method.queue
@@ -224,4 +227,6 @@ def get_attr(cmd):
 
 @frappe.whitelist(allow_guest = True)
 def ping():
+	import time
+	time.sleep(5)
 	return "pong"


### PR DESCRIPTION
## What?
This PR adds the ability to add whitelisted methods that respond to a defined path.


**app/app/doctype/page/page.py**
```py
@frappe.whitelist(path='/new-page', methods=['POST'])
def new_page(title, content):
	doc = frappe.new_doc('Page')
	doc.title = title
	doc.content = content
	doc.insert()
	return doc.name
```

```js
let response = await fetch('/new-page', {
	method: 'POST',
	body: JSON.stringify({
		title: 'Test',
		content: 'Test content'
	})
})

let data = await response.json();
// { message: 'page1234' }
```


## Why?
Let's say you have a whitelisted method in your frappe app:

**app/app/doctype/page/page.py**
```py
@frappe.whitelist()
def new_page(title, content):
	doc = frappe.new_doc('Page')
	doc.title = title
	doc.content = content
	doc.insert()
```

To use this method, you have to write the full path to the method.
```js
request('/api/method/app.app.doctype.page.page.new_page', {
	title: 'Test',
	content: 'Test content'
})
```

This may not be desirable if you don't want to expose the file structure of your app, or if you want to have clean URLs for your REST API or both.

After this change, you can now add an alternative path to your whitelisted method like so:

**app/app/doctype/page/page.py**
```py
@frappe.whitelist(path='/new-page')
def new_page(title, content):
	doc = frappe.new_doc('Page')
	doc.title = title
	doc.content = content
	doc.insert()
	return doc.name
```

Now, to use this method:
```js
fetch('/new-page', {
	method: 'POST',
	body: JSON.stringify({
		title: 'Test',
		content: 'Test content'
	})
})
```

## Overriding Caveats

If an app adds a path that is already assigned to a method, the method that comes later will override the older one. I am not sure if this should be the desired behavior.

Edit: Earlier this was implemented in the name of method aliases which would allow you to alias the dotted path to method but the `/api/method` remained the same. I changed it to allow the developer to define any path they want. I believe this is more powerful and should be provided by the framework.

---

- [ ] Tests
- [ ] Docs

