### PR TITLE
fix: Support single file builds in build.json

### DIFF
--- a/rollup/config.js
+++ b/rollup/config.js
@@ -198,7 +198,11 @@ function get_options_for(app) {
 		.map(output_file => {
 			if (output_file.startsWith('concat:')) return null;
 
-			const input_files = build_json[output_file]
+			let files = build_json[output_file];
+			if (typeof files === 'string') {
+				files = [files];
+			}
+			const input_files = files
 				.map(input_file => {
 					let prefix = get_app_path(app);
 					if (input_file.startsWith('node_modules/')) {


### PR DESCRIPTION
`build.json` entries would only support an array of file paths, if this PR is merged, they will support a single file path too.

**build.json**

```
{
  "css/test.css": "public/css/test.scss"
}
```