### PR TITLE
fix: Website enhancements

### DIFF
--- a/frappe/public/scss/variables.scss
+++ b/frappe/public/scss/variables.scss
@@ -19,6 +19,25 @@ $text-muted: $gray-600 !default;
 $border-color: $gray-300 !default;
 $headings-color: $gray-900 !default;
 
+$font-sizes: (
+	"xs": 0.75rem,
+	"sm": 0.875rem,
+	"base": 1rem,
+	"lg": 1.125rem,
+	"xl": 1.25rem,
+	"2xl": 1.5rem,
+	"3xl": 1.875rem,
+	"4xl": 2.25rem,
+	"5xl": 3rem,
+	"6xl": 4rem
+);
+
+@each $size, $value in $font-sizes {
+	.font-size-#{$size} {
+		font-size: $value;
+	}
+}
+
 $font-size-xs: 0.75rem !default;
 $font-size-sm: 0.875rem !default;
 $font-size-base: 1rem !default;

--- a/frappe/public/scss/variables.scss
+++ b/frappe/public/scss/variables.scss
@@ -79,12 +79,12 @@ $input-border-radius: 0.375rem;
 $custom-control-indicator-bg: white;
 
 $grid-breakpoints: (
-  xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1200px,
-  2xl: 1440px
+	xs: 0,
+	sm: 576px,
+	md: 768px,
+	lg: 992px,
+	xl: 1200px,
+	2xl: 1440px
 ) !default;
 
 $spacers: (
@@ -112,11 +112,11 @@ $spacers: (
 	48: 12rem,
 	52: 13rem,
 	56: 14rem,
-	64: 16rem,
+	64: 16rem
 );
 
-@import '~bootstrap/scss/functions';
-@import '~bootstrap/scss/variables';
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 
 $code-color: $purple;

--- a/frappe/website/doctype/website_sidebar/website_sidebar.py
+++ b/frappe/website/doctype/website_sidebar/website_sidebar.py
@@ -11,8 +11,8 @@ class WebsiteSidebar(Document):
 	def get_items(self):
 		items = frappe.get_all(
 			"Website Sidebar Item",
-			filters=dict(parent=self.name),
-			fields=["title", "route", "`group`"],
+			filters={'parent': self.name},
+			fields=["title", "route", "group"],
 			order_by="idx asc",
 		)
 
@@ -20,8 +20,7 @@ class WebsiteSidebar(Document):
 		items_without_group = []
 		for item in items:
 			if item.group:
-				items_by_group[item.group] = items_by_group.get(item.group, [])
-				items_by_group[item.group].append(item)
+				items_by_group.setdefault(item.group, []).append(item)
 			else:
 				items_without_group.append(item)
 

--- a/frappe/website/doctype/website_sidebar/website_sidebar.py
+++ b/frappe/website/doctype/website_sidebar/website_sidebar.py
@@ -6,5 +6,28 @@ from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
 
+
 class WebsiteSidebar(Document):
-	pass
+	def get_items(self):
+		items = frappe.get_all(
+			"Website Sidebar Item",
+			filters=dict(parent=self.name),
+			fields=["title", "route", "`group`"],
+			order_by="idx asc",
+		)
+
+		items_by_group = {}
+		items_without_group = []
+		for item in items:
+			if item.group:
+				items_by_group[item.group] = items_by_group.get(item.group, [])
+				items_by_group[item.group].append(item)
+			else:
+				items_without_group.append(item)
+
+		out = []
+		for group, items in items_by_group.items():
+			out.append({"group_title": group, "group_items": items})
+
+		out += items_without_group
+		return out

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -411,6 +411,9 @@ frappe.setup_search = function (target, search_scope) {
 	let offsetIndex = 0;
 
 	$(document).on('keypress', e => {
+		if ($(e.target).is('textarea, input, select')) {
+			return;
+		}
 		if (e.key === '/') {
 			e.preventDefault();
 			$input.focus();


### PR DESCRIPTION
1. Add font size utility classes that can be used as:

```html
<div class="font-size-sm">Lorem ipsum</div>
```

2. Ignore `/` key capture when typing in input elements in doc page.

3. get_items() utility method in Website Sidebar to build a sidebar dict that is renderable by `web_sidebar.html`