### PR TITLE
fix(Google Drive): Take file backup before uploading

### DIFF
--- a/frappe/integrations/doctype/google_drive/google_drive.py
+++ b/frappe/integrations/doctype/google_drive/google_drive.py
@@ -19,7 +19,7 @@ from apiclient.http import MediaFileUpload
 from frappe.utils import get_backups_path, get_bench_path
 from frappe.utils.backups import new_backup
 from frappe.integrations.doctype.google_settings.google_settings import get_auth_url
-from frappe.integrations.offsite_backup_utils import get_latest_backup_file, send_email, validate_file_size
+from frappe.integrations.offsite_backup_utils import get_latest_backup_file, send_email, validate_file_size, take_files_backup
 
 SCOPES = "https://www.googleapis.com/auth/drive"
 
@@ -197,6 +197,7 @@ def upload_system_backup_to_google_drive():
 			file_urls.append(backup.backup_path_files)
 			file_urls.append(backup.backup_path_private_files)
 	else:
+		take_files_backup()
 		file_urls = get_latest_backup_file(with_files=account.file_backup)
 
 	for fileurl in file_urls:

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -8,7 +8,7 @@ import os.path
 import frappe
 import boto3
 from frappe import _
-from frappe.integrations.offsite_backup_utils import get_latest_backup_file, send_email, validate_file_size, generate_files_backup
+from frappe.integrations.offsite_backup_utils import get_latest_backup_file, send_email, validate_file_size, take_files_backup
 from frappe.model.document import Document
 from frappe.utils import cint
 from frappe.utils.background_jobs import enqueue
@@ -127,7 +127,7 @@ def backup_to_s3():
 			db_filename, site_config, files_filename, private_files = get_latest_backup_file(with_files=backup_files)
 
 			if not files_filename or not private_files:
-				generate_files_backup()
+				take_files_backup()
 				db_filename, site_config, files_filename, private_files = get_latest_backup_file(with_files=backup_files)
 
 		else:

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import glob
 import os
-from frappe.utils import split_emails, get_backups_path
+from frappe.utils import split_emails, get_backups_path, now_datetime
 
 
 def send_email(success, service_name, doctype, email_field, error_status=None):
@@ -67,7 +67,23 @@ def get_latest_backup_file(with_files=False):
 
 	return database, config
 
+def take_files_backup():
+	"""Only zips and places public and private files in backup folder"""
+	from frappe.utils.backups import BackupGenerator
 
+	odb = BackupGenerator(
+		frappe.conf.db_name,
+		frappe.conf.db_name,
+		frappe.conf.db_password,
+		db_host=frappe.db.host,
+		db_type=frappe.conf.db_type,
+		db_port=frappe.conf.db_port,
+	)
+
+	odb.todays_date = now_datetime().strftime('%Y%m%d_%H%M%S')
+	odb.set_backup_file_name()
+	odb.zip_files()
+	
 def get_file_size(file_path, unit):
 	if not unit:
 		unit = "MB"

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import glob
 import os
-from frappe.utils import split_emails, get_backups_path, now_datetime
+from frappe.utils import split_emails, now_datetime
 
 
 def send_email(success, service_name, doctype, email_field, error_status=None):

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import glob
 import os
-from frappe.utils import split_emails, now_datetime
+from frappe.utils import split_emails
 
 
 def send_email(success, service_name, doctype, email_field, error_status=None):
@@ -80,9 +80,8 @@ def take_files_backup():
 		db_port=frappe.conf.db_port,
 	)
 
-	odb.todays_date = now_datetime().strftime('%Y%m%d_%H%M%S')
 	odb.set_backup_file_name()
-	odb.zip_files()
+	odb.backup_files()
 	
 def get_file_size(file_path, unit):
 	if not unit:
@@ -106,13 +105,3 @@ def validate_file_size():
 
 	if file_size > 1:
 		frappe.flags.create_new_backup = False
-
-def generate_files_backup():
-	from frappe.utils.backups import BackupGenerator
-
-	backup = BackupGenerator(frappe.conf.db_name, frappe.conf.db_name,
-		frappe.conf.db_password, db_host = frappe.db.host,
-		db_type=frappe.conf.db_type, db_port=frappe.conf.db_port)
-
-	backup.set_backup_file_name()
-	backup.zip_files()

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -87,8 +87,6 @@ class BackupGenerator:
 		else:
 			last_db, last_file, last_private_file, site_config_backup_path = False, False, False, False
 
-		self.todays_date = now_datetime().strftime('%Y%m%d_%H%M%S')
-
 		if not (self.backup_path_files and self.backup_path_db and self.backup_path_private_files):
 			self.set_backup_file_name()
 
@@ -106,10 +104,12 @@ class BackupGenerator:
 
 	def set_backup_file_name(self):
 		#Generate a random name using today's date and a 8 digit random number
-		for_conf = self.todays_date + "-" + self.site_slug + "-site_config_backup.json"
-		for_db = self.todays_date + "-" + self.site_slug + "-database.sql.gz"
-		for_public_files = self.todays_date + "-" + self.site_slug + "-files.tar"
-		for_private_files = self.todays_date + "-" + self.site_slug + "-private-files.tar"
+		todays_date = now_datetime().strftime('%Y%m%d_%H%M%S')
+		
+		for_conf = todays_date + "-" + self.site_slug + "-site_config_backup.json"
+		for_db = todays_date + "-" + self.site_slug + "-database.sql.gz"
+		for_public_files = todays_date + "-" + self.site_slug + "-files.tar"
+		for_private_files = todays_date + "-" + self.site_slug + "-private-files.tar"
 		backup_path = get_backup_path()
 
 		if not self.backup_path_conf:


### PR DESCRIPTION
When db backup size is greater than 1GB, private/public files are not uploaded to drive as they are not taken in daily backups.

