### PR TITLE
feat: option to anonymize ip for google analytics

### DIFF
--- a/frappe/data/sample_site_config.json
+++ b/frappe/data/sample_site_config.json
@@ -22,6 +22,9 @@
  "use_ssl": 0,
  "auto_email_id": "hello@example.com",
 
+ "google_analytics_id": "google_analytics_id",
+ "google_analytics_anonymize_ip": 1,
+
  "google_login": {
 	 "client_id": "google_client_id",
 	 "client_secret": "google_client_secret"

--- a/frappe/templates/includes/app_analytics/google_analytics.html
+++ b/frappe/templates/includes/app_analytics/google_analytics.html
@@ -6,6 +6,9 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{ google_analytics_id }}', 'auto');
+  {% if google_analytics_anonymize_ip %}
+  ga('set', 'anonymizeIp', true);
+  {% endif %}
 
   $(document).on("mousedown", function(event) {
     if(!frappe && !frappe.get_route) return;

--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -52,6 +52,7 @@
   "indexing_authorization_code",
   "column_break_17",
   "google_analytics_id",
+  "google_analytics_anonymize_ip",
   "misc_section",
   "subdomain",
   "disable_signup",
@@ -206,7 +207,6 @@
    "label": "Integrations"
   },
   {
-   "description": "Add Google Analytics ID: eg. UA-89XXX57-1. Please search help on Google Analytics for more information.",
    "fieldname": "google_analytics_id",
    "fieldtype": "Data",
    "label": "Google Analytics ID"
@@ -401,6 +401,12 @@
    "fieldname": "edit_footer_template_values",
    "fieldtype": "Button",
    "label": "Edit Values"
+  },
+  {
+   "default": "1",
+   "fieldname": "google_analytics_anonymize_ip",
+   "fieldtype": "Check",
+   "label": "Google Analytics Anonymize IP"
   }
  ],
  "icon": "fa fa-cog",
@@ -409,7 +415,7 @@
  "issingle": 1,
  "links": [],
  "max_attachments": 10,
- "modified": "2020-08-21 14:02:55.168829",
+ "modified": "2020-09-28 18:47:18.506700",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -43,6 +43,7 @@ def get_context(context):
 		"boot": boot if context.get("for_mobile") else boot_json,
 		"csrf_token": csrf_token,
 		"google_analytics_id": frappe.conf.get("google_analytics_id"),
+		"google_analytics_anonymize_ip": frappe.conf.get("google_analytics_anonymize_ip"),
 		"mixpanel_id": frappe.conf.get("mixpanel_id")
 	})
 

--- a/frappe/www/website_script.js
+++ b/frappe/www/website_script.js
@@ -9,6 +9,9 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 ga('create', '{{ google_analytics_id }}', 'auto');
+{% if google_analytics_anonymize_ip %}
+ga('set', 'anonymizeIp', true);
+{% endif %}
 ga('send', 'pageview');
 // End Google Analytics
 {%- endif %}

--- a/frappe/www/website_script.py
+++ b/frappe/www/website_script.py
@@ -18,5 +18,11 @@ def get_context(context):
 		context.javascript += "\n" + js
 
 	if not frappe.conf.developer_mode:
-		context["google_analytics_id"] = (frappe.db.get_single_value("Website Settings", "google_analytics_id")
-			or frappe.conf.get("google_analytics_id"))
+		context['google_analytics_id'] = get_setting('google_analytics_id')
+		context['google_analytics_anonymize_ip'] = get_setting('google_analytics_anonymize_ip')
+
+def get_setting(field_name):
+	"""Return value of field_name frok Website Settings or Site Config."""
+	website_settings = frappe.db.get_single_value('Website Settings', field_name)
+	conf = frappe.conf.get(field_name)
+	return website_settings or conf


### PR DESCRIPTION
From the General Data Protection Regulation (GDPR) of the European Union follows that companies using Google Analytics on  European users have to set the "Anonymize IP" flag, like this:

```js
ga('set', 'anonymizeIp', true);
```

More info on the effect of this setting can be found [here](https://support.google.com/analytics/answer/2763052).

This PR introduces a setting, named `google_analytics_anonymize_ip`, in **Website Settings** and site config. If it is true, the templates for google analytics will include above line.

Docs: https://github.com/frappe/erpnext_documentation/pull/176