### PR TITLE
fix: Remove dead option "rebuild-website" in migrate

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -271,11 +271,10 @@ def disable_user(context, email):
 
 
 @click.command('migrate')
-@click.option('--rebuild-website', help="Rebuild webpages after migration")
 @click.option('--skip-failing', is_flag=True, help="Skip patches that fail to run")
 @click.option('--skip-search-index', is_flag=True, help="Skip search indexing for web documents")
 @pass_context
-def migrate(context, rebuild_website=False, skip_failing=False, skip_search_index=False):
+def migrate(context, skip_failing=False, skip_search_index=False):
 	"Run patches, sync schema and rebuild files/translations"
 	from frappe.migrate import migrate
 
@@ -286,7 +285,6 @@ def migrate(context, rebuild_website=False, skip_failing=False, skip_search_inde
 		try:
 			migrate(
 				context.verbose,
-				rebuild_website=rebuild_website,
 				skip_failing=skip_failing,
 				skip_search_index=skip_search_index
 			)

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -22,7 +22,7 @@ from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
 from frappe.search.website_search import build_index_for_all_routes
 
 
-def migrate(verbose=True, rebuild_website=False, skip_failing=False, skip_search_index=False):
+def migrate(verbose=True, skip_failing=False, skip_search_index=False):
 	'''Migrate all apps to the current version, will:
 	- run before migrate hooks
 	- run patches


### PR DESCRIPTION
Noticed there's a redundant `--rebuild-website` option in bench migrate. It does nothing.