### PR TITLE
fix(Login): Autofocus on first field in Login/Forgot/Signup form

### DIFF
--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -106,21 +106,25 @@ login.reset_sections = function(hide) {
 login.login = function() {
 	login.reset_sections();
 	$(".for-login").toggle(true);
+	$("#login_email").focus();
 }
 
 login.steptwo = function() {
 	login.reset_sections();
 	$(".for-login").toggle(true);
+	$("#login_email").focus();
 }
 
 login.forgot = function() {
 	login.reset_sections();
 	$(".for-forgot").toggle(true);
+	$("#forgot_email").focus();
 }
 
 login.signup = function() {
 	login.reset_sections();
 	$(".for-signup").toggle(true);
+	$("#signup_fullname").focus();
 }
 
 


### PR DESCRIPTION
First fields:
- login: #login-email
- forgot email: #forgot_email
- sign up: #signup_fullname 

Related to #11127 

[Link to video](https://i.imgur.com/l0a8KmK.mp4)