### PR TITLE
fix: improve ux of standard web templates

### DIFF
--- a/frappe/website/doctype/web_template/web_template.js
+++ b/frappe/website/doctype/web_template/web_template.js
@@ -8,14 +8,14 @@ frappe.ui.form.on('Web Template', {
 		}
 
 		frm.toggle_display('standard', frappe.boot.developer_mode);
-		frm.toggle_display('template', !frm.doc.standard);
 	},
 	standard: function(frm) {
-		if (!frm.doc.standard) {
+		if (!frm.doc.standard && !frm.is_new()) {
 			// If standard changes from true to false, hide template until
 			// the next save. Changes will get overwritten from the backend
 			// on save and should not be possible in the UI.
 			frm.toggle_display('template', false);
+			frm.dashboard.clear_headline();
 			frm.dashboard.set_headline(__('Please save to edit the template.'));
 		}
 	}

--- a/frappe/website/doctype/web_template/web_template.js
+++ b/frappe/website/doctype/web_template/web_template.js
@@ -2,11 +2,21 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Web Template', {
-	refresh(frm) {
+	refresh: function(frm) {
 		if (!frappe.boot.developer_mode && frm.doc.standard) {
 			frm.disable_form();
 		}
 
 		frm.toggle_display('standard', frappe.boot.developer_mode);
+		frm.toggle_display('template', !frm.doc.standard);
+	},
+	standard: function(frm) {
+		if (!frm.doc.standard) {
+			// If standard changes from true to false, hide template until
+			// the next save. Changes will get overwritten from the backend
+			// on save and should not be possible in the UI.
+			frm.toggle_display('template', false);
+			frm.save();
+		}
 	}
 });

--- a/frappe/website/doctype/web_template/web_template.js
+++ b/frappe/website/doctype/web_template/web_template.js
@@ -16,7 +16,7 @@ frappe.ui.form.on('Web Template', {
 			// the next save. Changes will get overwritten from the backend
 			// on save and should not be possible in the UI.
 			frm.toggle_display('template', false);
-			frm.save();
+			frm.dashboard.set_headline(__('Please save to edit the template.'));
 		}
 	}
 });

--- a/frappe/website/doctype/web_template/web_template.json
+++ b/frappe/website/doctype/web_template/web_template.json
@@ -48,6 +48,7 @@
    "fieldname": "module",
    "fieldtype": "Link",
    "label": "Module",
+   "mandatory_depends_on": "standard",
    "options": "Module Def"
   }
  ],
@@ -58,7 +59,7 @@
    "link_fieldname": "web_template"
   }
  ],
- "modified": "2020-09-25 00:48:57.902292",
+ "modified": "2020-10-20 15:08:57.027962",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Template",

--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -35,6 +35,7 @@ class WebTemplate(Document):
 			if self.standard:
 				export_to_files(record_list=[["Web Template", self.name]], create_init=True)
 				self.create_template_file()
+				self.template = ""
 
 			# standard to custom
 			was_standard = (self.get_doc_before_save() or {}).get("standard")

--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -26,9 +26,6 @@ class WebTemplate(Document):
 			if not field.fieldname:
 				field.fieldname = frappe.scrub(field.label)
 
-		if self.standard and not self.module:
-			frappe.throw(_("Please select which module this Web Template belongs to."))
-
 	def on_update(self):
 		if frappe.conf.developer_mode:
 			# custom to standard


### PR DESCRIPTION
- If **Web Template** is written to disk, remove it from the database
- If a standard **Web Template** becomes non-standard:

  1. Frontend continues to hide the template field and shows headline "Please save to edit template"
  2. [Users saves]
  3. Backend loads template from file into db
  4. Frontend shows template
