### PR TITLE
fix(Query Report): set df options for custom column

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1484,7 +1484,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								insert_after_index: insert_after_index,
 								link_field: this.doctype_field_map[values.doctype],
 								doctype: values.doctype,
-								options: df.fieldtype === "Link" ? df.options : undefined,
+								options: df.options,
 								width: 100
 							});
 


### PR DESCRIPTION
Since options wasn't set for currency fields in custom columns, the value wouldn't get formatted correctly.

In this example the Total field (1st column) is a custom column fetched from Purchase Invoice. The correct currency that should have been set in this case is USD.

**Before:**
<img width="1186" alt="Screenshot 2020-09-30 at 6 27 13 PM" src="https://user-images.githubusercontent.com/19775888/94687968-98be3e80-034a-11eb-8851-c88d8c403bb6.png">


**After:**
<img width="1219" alt="Screenshot 2020-09-30 at 6 09 42 PM" src="https://user-images.githubusercontent.com/19775888/94687749-4f6def00-034a-11eb-8769-5ecf5ba4cd2c.png">




Note: Not sure if there was a specific reason for setting options only for Link fields
