### PR TITLE
fix: footer link targets

### DIFF
--- a/frappe/templates/includes/footer/footer_links.html
+++ b/frappe/templates/includes/footer/footer_links.html
@@ -1,5 +1,5 @@
 {% macro footer_link(item) %}
-<a href="{{ item.url | abs_url }}" class="footer-link">
+<a href="{{ item.url | abs_url }}" {{ item.target }} class="footer-link">
 	{%- if item.icon -%}
 	<img src="{{ item.icon }}" alt="{{ item.label }}">
 	{%- else -%}


### PR DESCRIPTION
Footer link target is not set in the template, this PR fixes that.

The possible values for target is either blank or `target: "_blank"`

<img width="337" alt="Screen Shot 2020-09-30 at 6 37 48 PM" src="https://user-images.githubusercontent.com/18097732/94689076-0b7be980-034c-11eb-8447-13d4fd757782.png">
