### PR TITLE
fix: show unique users during viewing/typing notify

### DIFF
--- a/socketio.js
+++ b/socketio.js
@@ -407,6 +407,6 @@ function send_users(args, action) {
 	io.to(open_doc_room).emit(emit_event, {
 		doctype: args.doctype,
 		docname: args.docname,
-		users: users
+		users: Array.from(new Set(users))
 	});
 }


### PR DESCRIPTION
Fixes #11598 

An alternative would have been to check for dupes while constructing the `users` list here - 
https://github.com/frappe/frappe/blob/d5f1df14544375d6cd1109ba39b8d046a10ef046/socketio.js#L398-L401

However, I felt this change to be the least intrusive.

