### PR TITLE
fix(Translation): Change file open write mode in get-untranslated command

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -620,7 +620,7 @@ def get_untranslated(lang, untranslated_file, get_all=False):
 
 	if get_all:
 		print(str(len(messages)) + " messages")
-		with open(untranslated_file, "w") as f:
+		with open(untranslated_file, "wb") as f:
 			for m in messages:
 				# replace \n with ||| so that internal linebreaks don't get split
 				f.write((escape_newlines(m[1]) + os.linesep).encode("utf-8"))
@@ -633,10 +633,10 @@ def get_untranslated(lang, untranslated_file, get_all=False):
 
 		if untranslated:
 			print(str(len(untranslated)) + " missing translations of " + str(len(messages)))
-			with open(untranslated_file, "w") as f:
+			with open(untranslated_file, "wb") as f:
 				for m in untranslated:
 					# replace \n with ||| so that internal linebreaks don't get split
-					f.write(cstr(frappe.safe_encode(escape_newlines(m) + os.linesep)))
+					f.write((escape_newlines(m) + os.linesep).encode("utf-8"))
 		else:
 			print("all translated!")
 


### PR DESCRIPTION
This is in reference to https://github.com/frappe/frappe/issues/7508

The issue arises due to a mismatch in file open() mode and input type of write(), which is [enforced](https://docs.python.org/2/howto/pyporting.html#text-versus-binary-data) in python3 but would otherwise work without issues in python2.