### PR TITLE
fix(notification): Set integer value if fieldtype is one of numeric_fieldtypes

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -155,7 +155,12 @@ def get_context(context):
 				allow_update = False
 			try:
 				if allow_update and not doc.flags.in_notification_update:
-					doc.set(self.set_property_after_alert, self.property_value)
+					fieldname = self.set_property_after_alert
+					value = self.property_value
+					if doc.meta.get_field(fieldname).fieldtype in frappe.model.numeric_fieldtypes:
+						value = frappe.utils.cint(value)
+
+					doc.set(fieldname, value)
 					doc.flags.updater_reference = {
 						'doctype': self.doctype,
 						'docname': self.name,
@@ -177,7 +182,7 @@ def get_context(context):
 		recipients, cc, bcc = self.get_list_of_recipients(doc, context)
 
 		users = recipients + cc + bcc
-		
+
 		if not users:
 			return
 


### PR DESCRIPTION
To avoid 
<img width="326" alt="Screenshot 2020-10-04 at 9 23 24 PM" src="https://user-images.githubusercontent.com/13928957/95021196-21abe180-068d-11eb-8996-5c77408d04b1.png">

Such issues might cause failure in checks eg. `if doc.auto_close == 1` would fail if the value set is not integer.

**Note:** fieldtype of auto_close is 'Check'
