### PR TITLE
fix: Clearing attachment from web form causes error on save.

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -457,7 +457,7 @@ def accept(web_form, data, docname=None, for_payment=False):
 	if files_to_delete:
 		for f in files_to_delete:
 			if f:
-				remove_file_by_url(doc.get(fieldname), doctype=doc.doctype, name=doc.name)
+				remove_file_by_url(f, doctype=doc.doctype, name=doc.name)
 
 
 	frappe.flags.web_form_doc = doc


### PR DESCRIPTION
Solves an error thrown when clearing an attachment from a web form, also fixes the deletion of the file from the private/public file store.

closes #11636