### PR TITLE
fix: web template field doctype not reloaded

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -312,4 +312,4 @@ frappe.patches.v13_0.enable_custom_script
 frappe.patches.v13_0.update_newsletter_content_type
 execute:frappe.db.set_value('Website Settings', 'Website Settings', {'navbar_template': 'Standard Navbar', 'footer_template': 'Standard Footer'})
 frappe.patches.v13_0.delete_event_producer_and_consumer_keys
-frappe.patches.v13_0.web_template_set_module
+frappe.patches.v13_0.web_template_set_module #2020-10-05

--- a/frappe/patches/v13_0/web_template_set_module.py
+++ b/frappe/patches/v13_0/web_template_set_module.py
@@ -6,7 +6,8 @@ import frappe
 
 def execute():
 	"""Set default module for standard Web Template, if none."""
-	frappe.reload_doc('website', 'doctype', 'Web Template')
+	frappe.reload_doctype('Web Template')
+	frappe.reload_doctype('Web Template Field')
 	standard_templates = frappe.get_list('Web Template', {'standard': 1})
 	for template in standard_templates:
 		doc = frappe.get_doc('Web Template', template.name)


### PR DESCRIPTION
A new fieldtype `Table Break` is introduced in `Web Template Field`. Additionally, a patch was added to add module value to the Web Templates. Now, Web Template Field was not properly loaded, causing the migration to break on Select Field validation.

```
frappe.exceptions.ValidationError: Row #4: Fieldtype cannot be "Table Break". It should be one of "Attach Image", "Check", "Data", "Int", "Select", "Small Text", "Text", "Markdown Editor", "Section Break", "Column Break"
```

This PR fixes that by reloading the `Web Template Field`