### PR TITLE
fix(report): Always add name & docstatus field to avoid permission error

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -651,6 +651,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	set_fields() {
+		// default fields
+		['name', 'docstatus'].map(this._add_field);
+
 		if (this.report_name && this.report_doc.json.fields) {
 			let fields = this.report_doc.json.fields.slice();
 			fields.forEach(f => this._add_field(f[0], f[1]));
@@ -672,7 +675,6 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 		// default fields
 		[
-			'name', 'docstatus',
 			this.meta.title_field,
 			this.meta.image_field
 		].map(add_field);

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -670,7 +670,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	set_default_fields() {
 		// get fields from meta
-		this.fields = [];
+		this.fields = this.fields || [];
 		const add_field = f => this._add_field(f);
 
 		// default fields

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -652,7 +652,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	set_fields() {
 		// default fields
-		['name', 'docstatus'].map(this._add_field);
+		['name', 'docstatus'].map((f) => this._add_field(f));
 
 		if (this.report_name && this.report_doc.json.fields) {
 			let fields = this.report_doc.json.fields.slice();


### PR DESCRIPTION
Previously, since the value of **docstatus** was missing in each row, the system used to incorrectly throw the following error while doing bulk printing.

![image](https://user-images.githubusercontent.com/13928957/95078076-30989f80-0732-11eb-8b36-90a608f7add6.png)


**After fix:**
![report-print](https://user-images.githubusercontent.com/13928957/95078406-b9afd680-0732-11eb-88e6-c48f83f8e4cd.gif)



