### PR TITLE
fix: Website context enhancements

### DIFF
--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -234,6 +234,7 @@ def add_metatags(context):
 	title = tags.get("name") or tags.get("title")
 	if title:
 		tags["og:title"] = tags["twitter:title"] = title
+		tags["twitter:card"] = "summary"
 
 	if "description" not in tags and context.description:
 		tags["description"] = context.description

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -124,6 +124,13 @@ def build_context(context):
 	if context.title_prefix and context.title and not context.title.startswith(context.title_prefix):
 		context.title = '{0} - {1}'.format(context.title_prefix, context.title)
 
+	# apply context from hooks
+	update_website_context = frappe.get_hooks('update_website_context')
+	for method in update_website_context:
+		values = frappe.get_attr(method)(context)
+		if values:
+			context.update(values)
+
 	return context
 
 def load_sidebar(context, sidebar_json_path):

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -225,33 +225,44 @@ def add_sidebar_data(context):
 def add_metatags(context):
 	tags = frappe._dict(context.get("metatags") or {})
 
-	if tags:
-		if "og:type" not in tags:
-			tags["og:type"] = "article"
+	if "og:type" not in tags:
+		tags["og:type"] = "article"
 
-		name = tags.get('name') or tags.get('title')
-		if name:
-			tags["og:title"] = tags["twitter:title"] = name
+	if "title" not in tags and context.title:
+		tags["title"] = context.title
 
-		description = tags.get("description") or context.description
-		if description:
-			tags['description'] = tags["og:description"] = tags["twitter:description"] = description
+	title = tags.get("name") or tags.get("title")
+	if title:
+		tags["og:title"] = tags["twitter:title"] = title
 
-		image = tags.get('image', context.image or None)
-		if image:
-			tags["og:image"] = tags["twitter:image"] = tags["image"] = frappe.utils.get_url(image)
-			tags['twitter:card'] = "summary_large_image"
+	if "description" not in tags and context.description:
+		tags["description"] = context.description
 
-		if context.author or tags.get('author'):
-			tags['author'] = context.author or tags.get('author')
+	description = tags.get("description")
+	if description:
+		tags["og:description"] = tags["twitter:description"] = description
 
-		tags['og:url'] = tags['url'] = frappe.utils.get_url(context.path)
+	if "image" not in tags and context.image:
+		tags["image"] = context.image
 
-		if context.published_on:
-			tags['datePublished'] = context.published_on
+	image = tags.get("image")
+	if image:
+		tags["og:image"] = tags["twitter:image"] = tags["image"] = frappe.utils.get_url(image)
+		tags['twitter:card'] = "summary_large_image"
 
+	if "author" not in tags and context.author:
+		tags["author"] = context.author
 
-		tags['language'] = frappe.local.lang or 'en'
+	tags["og:url"] = tags["url"] = frappe.utils.get_url(context.path)
+
+	if "published_on" not in tags and context.published_on:
+		tags["published_on"] = context.published_on
+
+	if "published_on" in tags:
+		tags["datePublished"] = tags["published_on"]
+		del tags["published_on"]
+
+	tags["language"] = frappe.local.lang or "en"
 
 	# Get meta tags from Website Route meta
 	# they can override the defaults set above

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -136,9 +136,6 @@ def get_website_settings(context=None):
 
 	context.encoded_title = quote(encode(context.title or ""), str(""))
 
-	for update_website_context in hooks.update_website_context or []:
-		frappe.get_attr(update_website_context)(context)
-
 	context.web_include_js = hooks.web_include_js or []
 
 	context.web_include_css = hooks.web_include_css or []


### PR DESCRIPTION
**1. Better fallback for metatags**

   Earlier if `context.title` was set, it would not set `context.metatags.title` and as a result it would not render the `title` meta tag. These changes will allow a better fallback logic for `title, description, image, published_on` values that are set in `context`.

**2. Apply context from hooks at the end of `build_context`**

   This will allow apps to override values of `context` set by the framework and not the other way round.