### PR TITLE
fix: Allow creation of Energy Point Log 

### DIFF
--- a/frappe/social/doctype/energy_point_log/energy_point_log.json
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2018-06-21 14:58:55.913619",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -109,8 +110,9 @@
    "label": "Seen"
   }
  ],
- "in_create": 1,
- "modified": "2019-08-21 15:51:05.288886",
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2020-10-06 17:25:40.477044",
  "modified_by": "Administrator",
  "module": "Social",
  "name": "Energy Point Log",

--- a/frappe/social/doctype/energy_point_log/energy_point_log.json
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.json
@@ -110,6 +110,7 @@
    "label": "Seen"
   }
  ],
+ "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
  "modified": "2020-10-06 17:25:40.477044",

--- a/frappe/social/doctype/energy_point_log/energy_point_log.json
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.json
@@ -110,7 +110,6 @@
    "label": "Seen"
   }
  ],
- "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
  "modified": "2020-10-06 17:25:40.477044",


### PR DESCRIPTION
**Issue:** Cannot see "Delete" option in Role Permissions Manager because the creation of Energy Point log is not allowed. 

**Before:**

![image](https://user-images.githubusercontent.com/50285544/95199178-0e6a5480-07fa-11eb-9d82-e68a265f1b51.png)


**After:**

![image](https://user-images.githubusercontent.com/50285544/95199333-4d98a580-07fa-11eb-921f-a7ff542a9ca4.png)
