### PR TITLE
fix(db_query): Allow plucking a field without having to add it to the fields list

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -58,7 +58,10 @@ class DatabaseQuery(object):
 		if fields:
 			self.fields = fields
 		else:
-			self.fields =  ["`tab{0}`.`name`".format(self.doctype)]
+			if pluck:
+				self.fields =  ["`tab{0}`.`{1}`".format(self.doctype, pluck)]
+			else:
+				self.fields =  ["`tab{0}`.`name`".format(self.doctype)]
 
 		if start: limit_start = start
 		if page_length: limit_page_length = page_length

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -347,6 +347,14 @@ class TestReportview(unittest.TestCase):
 			limit=50,
 		)
 
+	def test_pluck_name(self):
+		names = DatabaseQuery("DocType").execute(filters={"name": "DocType"}, pluck="name")
+		self.assertEqual(names, ["DocType"])
+
+	def test_pluck_any_field(self):
+		owners = DatabaseQuery("DocType").execute(filters={"name": "DocType"}, pluck="owner")
+		self.assertEqual(owners, ["Administrator"])
+
 def create_event(subject="_Test Event", starts_on=None):
 	""" create a test event """
 


### PR DESCRIPTION

e.g.
```python
frappe.get_all("ToDo", pluck="owner")
```
Didn't work before, instead
```python
frappe.get_all("ToDo", fields=["owner"], pluck="owner")
```
was needed