### PR TITLE
fix(scheduler): Don't enqueue a job if it is being executed

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -36,7 +36,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.queue==='All'",
+   "depends_on": "eval:doc.frequency==='All'",
    "fieldname": "create_log",
    "fieldtype": "Check",
    "label": "Create Log"
@@ -49,7 +49,7 @@
   },
   {
    "allow_in_quick_entry": 1,
-   "depends_on": "eval:doc.queue==='Cron'",
+   "depends_on": "eval:doc.frequency==='Cron'",
    "fieldname": "cron_format",
    "fieldtype": "Data",
    "label": "Cron Format",
@@ -81,7 +81,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2020-04-05 17:27:33.480562",
+ "modified": "2020-10-07 10:39:24.519460",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -20,9 +20,9 @@ class ScheduledJobType(Document):
 			# force logging for all events other than continuous ones (ALL)
 			self.create_log = 1
 
-	def enqueue(self):
+	def enqueue(self, force=False):
 		# enqueue event if last execution is done
-		if self.is_event_due():
+		if self.is_event_due() or force:
 			if frappe.flags.enqueued_jobs:
 				frappe.flags.enqueued_jobs.append(self.method)
 
@@ -114,7 +114,7 @@ class ScheduledJobType(Document):
 def execute_event(doc):
 	frappe.only_for('System Manager')
 	doc = json.loads(doc)
-	frappe.get_doc('Scheduled Job Type', doc.get('name')).enqueue()
+	frappe.get_doc('Scheduled Job Type', doc.get('name')).enqueue(force=True)
 
 
 def run_scheduled_job(job_type):

--- a/frappe/tests/test_scheduler.py
+++ b/frappe/tests/test_scheduler.py
@@ -42,12 +42,7 @@ class TestScheduler(TestCase):
 		job.db_set('last_execution', '2010-01-01 00:00:00')
 		frappe.db.commit()
 
-		# 1 job in queue
-		self.assertTrue(job.enqueue())
-		job.db_set('last_execution', '2010-01-01 00:00:00')
-		frappe.db.commit()
-
-		# 2nd job not loaded
+		# 1st job is in the queue (or running), don't enqueue it again
 		self.assertFalse(job.enqueue())
 		frappe.db.sql('DELETE FROM `tabScheduled Job Log` WHERE `scheduled_job_type`=%s', job.name)
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -178,8 +178,8 @@ def get_jobs(site=None, queue=None, key='method'):
 
 	for queue in get_queue_list(queue):
 		q = get_queue(queue)
-
-		for job in q.jobs:
+		jobs = q.jobs + get_running_jobs_in_queue(q)
+		for job in jobs:
 			if job.kwargs.get('site'):
 				if site is None:
 					add_to_dict(job)
@@ -206,6 +206,20 @@ def get_queue_list(queue_list=None):
 
 	else:
 		return default_queue_list
+
+def get_workers(queue):
+	'''Returns a list of Worker objects tied to a queue object'''
+	return Worker.all(queue=queue)
+
+def get_running_jobs_in_queue(queue):
+	'''Returns a list of Jobs objects that are tied to a queue object and are currently running'''
+	jobs = []
+	workers = get_workers(queue)
+	for worker in workers:
+		current_job = worker.get_current_job()
+		if current_job:
+			jobs.append(current_job)
+	return jobs
 
 def get_queue(queue, is_async=True):
 	'''Returns a Queue object tied to a redis connection'''


### PR DESCRIPTION
1. The current behavior of queue peeking ignores a job that is already being executed. 

	This allows a job to be executed simultaneously by multiple workers. (When the number of job workers is more than 1 of course)


2. Execute button on Scheduled Job Type doesn't do anything (since the event is not due when the button is clicked. And when the event is due, the scheduler will enqueue it anyway)