### PR TITLE
fix: Provision for 'distinct' keyword in prepare_args

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -175,7 +175,7 @@ class DatabaseQuery(object):
 			if (field.strip().startswith(("`", "*")) or "(" in field):
 				fields.append(field)
 			elif "as" in field.lower().split(" "):
-				col, _, new = field.split()
+				col, _, new = field.split()[-3:]
 				fields.append("`{0}` as {1}".format(col, new))
 			else:
 				fields.append("`{0}`".format(field))

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -133,6 +133,8 @@ class TestDB(unittest.TestCase):
 		self.assertEqual(list(frappe.get_all("ToDo", fields=[random_field], limit=1)[0])[0], random_field)
 		self.assertEqual(list(frappe.get_all("ToDo", fields=["{0} as total".format(random_field)], limit=1)[0])[0], "total")
 
+		# Testing read for distinct keyword - Check if result contains total field
+		self.assertEqual(list(frappe.get_all("ToDo", fields=["distinct {0} as total".format(random_field)], limit=1)[0])[0], "total")
 
 		# Testing update
 		frappe.db.set_value(test_doctype, random_doc, random_field, random_value)


### PR DESCRIPTION
- If a column is selected of the form `distinct a as b` , there were too many values to unpack
- This PR fixes that. Only the last 3 values of a column selection criteria will be considered (`a as b`)
- Added a test for the same