### PR TITLE
fix(Address): Set default user Company in links table when "Is Your Company Address" is set

### DIFF
--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -57,5 +57,26 @@ frappe.ui.form.on("Address", {
 				}
 			}
 		]);
+	},
+	is_your_company_address: function(frm) {
+		if(frm.doc.is_your_company_address){
+			frm.add_child('links', {
+				link_doctype: 'Company',
+				link_name: frappe.defaults.get_user_default('Company')
+			});
+			frm.fields_dict.links.grid.get_field('link_doctype').get_query = function() {
+				return {
+					filters: {
+						name: 'Company'
+					}
+				}
+			}
+			frm.refresh_field('links');
+		}
+		else{
+			frm.fields_dict.links.grid.get_field('link_doctype').get_query = null;
+			frm.clear_table('links');
+		}
+		frm.refresh_field('links');
 	}
 });


### PR DESCRIPTION
The "Is Your Company Address" checkbox does not do anything on selection.

In this PR, when the checkbox is selected it does 2 things:
- Gets user's default company and adds it to the links list
- Adds a filter to the "link_doctype" field in child table to only allow "Company" doctype to be set
And on disabling the checkbox:
- Removes the filter in "link_doctype" in child table
- Clears child table so if there are any existing empty rows, the filter won't remain.

Gif:
![gif](http://frappe-gifs.surge.sh/gifs/address.gif)