### PR TITLE
fix(database): Show numeric values as integer for single doctypes in get_value() instead of string

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -502,8 +502,15 @@ class Database(object):
 			r = self.sql("""select field, value
 				from `tabSingles` where field in (%s) and doctype=%s"""
 					% (', '.join(['%s'] * len(fields)), '%s'),
-					tuple(fields) + (doctype,), as_dict=False, debug=debug)
-
+					tuple(fields) + (doctype,), as_dict=False, debug=debug, as_list=True)
+			
+			for field in r:
+				fieldtype = self.sql("""
+					select fieldtype from `tabDocfield` 
+					where parent=%s and fieldname=%s """, (doctype, field[0]))[0][0]
+				if fieldtype in frappe.model.numeric_fieldtypes:
+					field[1] = cint(field[1])
+			
 			if as_dict:
 				if r:
 					r = frappe._dict(r)


### PR DESCRIPTION
frappe.db.get_value() when used with single doctypes was returning string values for numeric fieldtypes:
![image](https://user-images.githubusercontent.com/15175501/95474921-4a8ce900-09a3-11eb-9fb2-548319e1f9cb.png)

Now:
![image](https://user-images.githubusercontent.com/15175501/95475097-83c55900-09a3-11eb-8ce4-d373d672ee8b.png)

frappe.db.get_single_value() works because it uses frappe.get_meta() to get the fieldtype which we cant do as frappe.get_meta itself uses frappe.get_value() indirectly resulting in recursion depth errors. Hence used a query.