### PR TITLE
feat(Assignment Rule): Option to set custom due_date for assignments

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Assignment Rule', {
+	onload: (frm) => {
+		frm.trigger('set_due_date_field_options');
+	},
 	refresh: function(frm) {
 		// refresh description
 		frm.events.rule(frm);
@@ -12,5 +15,34 @@ frappe.ui.form.on('Assignment Rule', {
 		} else {
 			frm.get_field('rule').set_description(__('Assign to the one who has the least assignments'));
 		}
+	},
+	document_type: (frm) => {
+		frm.trigger('set_due_date_field_options');
+	},
+	set_due_date_field_options: (frm) => {
+		let doctype = frm.doc.document_type;
+		let datetime_fields = [];
+		if (doctype) {
+			frappe.model.with_doctype(doctype, () => {
+				frappe.get_meta(doctype).fields.map((df) => {
+					if (['Date', 'Datetime'].includes(df.fieldtype)) {
+						datetime_fields.push({ label: df.label, value: df.fieldname });
+					}
+				});
+				if (datetime_fields) {
+					frm.set_df_property('due_date_based_on', 'options', datetime_fields);
+				}
+				frm.set_df_property('due_date_based_on', 'hidden', !datetime_fields.length);
+			});
+		}
+	},
+	due_date_based_on(frm) {
+		let due_date_based_on = frm.doc.due_date_based_on;
+		let doctype = frm.doc.document_type;
+		let fetch_from = null;
+		if (doctype && due_date_based_on) {
+			fetch_from = `${doctype}.${due_date_based_on}`;
+		}
+		frm.set_df_property('due_date_based_on', 'fetch_from', fetch_from);
 	}
 });

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -35,14 +35,5 @@ frappe.ui.form.on('Assignment Rule', {
 				frm.set_df_property('due_date_based_on', 'hidden', !datetime_fields.length);
 			});
 		}
-	},
-	due_date_based_on(frm) {
-		let due_date_based_on = frm.doc.due_date_based_on;
-		let doctype = frm.doc.document_type;
-		let fetch_from = null;
-		if (doctype && due_date_based_on) {
-			fetch_from = `${doctype}.${due_date_based_on}`;
-		}
-		frm.set_df_property('due_date_based_on', 'fetch_from', fetch_from);
 	}
 });

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.json
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_rename": 1,
  "autoname": "Prompt",
  "creation": "2019-02-28 17:12:18.815830",
@@ -8,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "document_type",
+  "due_date_based_on",
   "priority",
   "disabled",
   "column_break_4",
@@ -129,9 +131,17 @@
    "label": "Assignment Days",
    "options": "Assignment Rule Day",
    "reqd": 1
+  },
+  {
+   "depends_on": "document_type",
+   "fieldname": "due_date_based_on",
+   "fieldtype": "Select",
+   "label": "Due Date Based On"
   }
  ],
- "modified": "2019-09-25 14:52:12.214514",
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2020-10-08 06:48:54.019735",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Assignment Rule",

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -189,7 +189,7 @@ def apply(doc, method=None, doctype=None, name=None):
 
 	# multiple auto assigns
 	for d in assignment_rules:
-		assignment_rule_docs.append(frappe.get_doc('Assignment Rule', d.get('name')))
+		assignment_rule_docs.append(frappe.get_cached_doc('Assignment Rule', d.get('name')))
 
 	if not assignment_rule_docs:
 		return

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -19,14 +19,14 @@ class AssignmentRule(Document):
 			repeated_days = get_repeated(assignment_days)
 			frappe.throw(_("Assignment Day {0} has been repeated.").format(frappe.bold(repeated_days)))
 
-	def on_update(self): # pylint: disable=no-self-use
-		frappe.cache_manager.clear_doctype_map('Assignment Rule', self.document_type)
+	def on_update(self):
+		clear_assignment_rule_cache(self)
 
-	def after_rename(self, old, new, merge): # pylint: disable=no-self-use
-		frappe.cache_manager.clear_doctype_map('Assignment Rule', self.document_type)
+	def after_rename(self, old, new, merge):
+		clear_assignment_rule_cache(self)
 
-	def on_trash(self): # pylint: disable=no-self-use
-		frappe.cache_manager.clear_doctype_map('Assignment Rule', self.document_type)
+	def on_trash(self):
+		clear_assignment_rule_cache(self)
 
 	def apply_unassign(self, doc, assignments):
 		if (self.unassign_condition and
@@ -53,7 +53,8 @@ class AssignmentRule(Document):
 			name = doc.get('name'),
 			description = frappe.render_template(self.description, doc),
 			assignment_rule = self.name,
-			notify = True
+			notify = True,
+			date = doc.get(self.due_date_based_on) if self.due_date_based_on else None
 		))
 
 		# set for reference in round robin
@@ -237,6 +238,32 @@ def apply(doc, method=None, doctype=None, name=None):
 						break
 			assignment_rule.close_assignments(doc)
 
+def update_due_date(doc, state=None):
+	# called from hook
+	assignment_rules = frappe.cache_manager.get_doctype_map('Assignment Rule', 'due_date_rules_for_' + doc.doctype, dict(
+		document_type = doc.doctype,
+		disabled = 0,
+		due_date_based_on = ['is', 'set']
+	))
+	for rule in assignment_rules:
+		rule_doc = frappe.get_cached_doc('Assignment Rule', rule.get('name'))
+		due_date_field = rule_doc.due_date_based_on
+		if doc.meta.has_field(due_date_field) and \
+			doc.has_value_changed(due_date_field) and rule.get('name'):
+			assignment_todos = frappe.get_all('ToDo', {
+				'assignment_rule': rule.get('name'),
+				'status': 'Open'
+			})
+			for todo in assignment_todos:
+				todo_doc = frappe.get_doc('ToDo', todo.name)
+				todo_doc.date = doc.get(due_date_field)
+				todo_doc.flags.updater_reference = {
+					'doctype': 'Assignment Rule',
+					'docname': rule.get('name'),
+					'label': _('via Assignment Rule')
+				}
+				todo_doc.save(ignore_permissions=True)
+
 def get_assignment_rules():
 	return [d.document_type for d in frappe.db.get_all('Assignment Rule', fields=['document_type'], filters=dict(disabled = 0))]
 
@@ -250,3 +277,7 @@ def get_repeated(values):
 			if value not in diff:
 				diff.append(str(value))
 	return " ".join(diff)
+
+def clear_assignment_rule_cache(rule):
+	frappe.cache_manager.clear_doctype_map('Assignment Rule', rule.document_type)
+	frappe.cache_manager.clear_doctype_map('Assignment Rule', 'due_date_rules_for_' + rule.document_type)

--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -20,6 +20,7 @@ class TestAutoAssign(unittest.TestCase):
 			dict(day = 'Friday'),
 			dict(day = 'Saturday'),
 		]
+		self.days = days
 		self.assignment_rule = get_assignment_rule([days, days])
 		clear_assignments()
 
@@ -179,6 +180,45 @@ class TestAutoAssign(unittest.TestCase):
 			reference_name = note.name,
 			status = 'Open'
 		), 'owner'), ['test3@example.com'])
+
+	def test_assignment_rule_condition(self):
+		frappe.db.sql("DELETE FROM `tabAssignment Rule`")
+
+		# Add expiry_date custom field
+		from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+		df = dict(fieldname='expiry_date', label='Expiry Date', fieldtype='Date')
+		create_custom_field('Note', df)
+
+		assignment_rule = frappe.get_doc(dict(
+			name = 'Assignment with Due Date',
+			doctype = 'Assignment Rule',
+			document_type = 'Note',
+			assign_condition = 'public == 0',
+			due_date_based_on = 'expiry_date',
+			assignment_days = self.days,
+			users = [
+				dict(user = 'test@example.com'),
+			]
+		)).insert()
+
+		expiry_date = frappe.utils.add_days(frappe.utils.nowdate(), 2)
+		note = make_note({'expiry_date': expiry_date})
+
+		todo = frappe.get_all('ToDo', filters=dict(
+			reference_type = 'Note',
+			reference_name = note.name,
+			status = 'Open'
+		))[0]
+
+		todo = frappe.get_doc('ToDo', todo.name)
+		self.assertEqual(frappe.utils.get_date_str(todo.date), expiry_date)
+
+		# due date should be updated if the reference doc's date is updated.
+		note.expiry_date = frappe.utils.add_days(expiry_date, 2)
+		note.save()
+		todo.reload()
+		self.assertEqual(frappe.utils.get_date_str(todo.date), note.expiry_date)
+
 
 def clear_assignments():
 	frappe.db.sql("delete from tabToDo where reference_type = 'Note'")

--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -189,7 +189,7 @@ class TestAutoAssign(unittest.TestCase):
 		df = dict(fieldname='expiry_date', label='Expiry Date', fieldtype='Date')
 		create_custom_field('Note', df)
 
-		assignment_rule = frappe.get_doc(dict(
+		frappe.get_doc(dict(
 			name = 'Assignment with Due Date',
 			doctype = 'Assignment Rule',
 			document_type = 'Note',

--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -189,7 +189,7 @@ class TestAutoAssign(unittest.TestCase):
 		df = dict(fieldname='expiry_date', label='Expiry Date', fieldtype='Date')
 		create_custom_field('Note', df)
 
-		frappe.get_doc(dict(
+		assignment_rule = frappe.get_doc(dict(
 			name = 'Assignment with Due Date',
 			doctype = 'Assignment Rule',
 			document_type = 'Note',
@@ -218,7 +218,7 @@ class TestAutoAssign(unittest.TestCase):
 		note.save()
 		todo.reload()
 		self.assertEqual(frappe.utils.get_date_str(todo.date), note.expiry_date)
-
+		assignment_rule.delete()
 
 def clear_assignments():
 	frappe.db.sql("delete from tabToDo where reference_type = 'Note'")

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -143,6 +143,7 @@ doc_events = {
 			"frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone",
 			"frappe.core.doctype.file.file.attach_files_to_document",
 			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 		],
 		"after_rename": "frappe.desk.notifications.clear_doctype_notifications",
 		"on_cancel": [


### PR DESCRIPTION
Previously, `due dates` of all the assignments(todos) created by assignment rule used to have today's date i.e., the date when on which the assignment was made.

Now, we can optionally set the due date based on some date field value in the reference document.

<img width="1183" alt="Screenshot 2020-10-09 at 11 03 53 AM" src="https://user-images.githubusercontent.com/13928957/95546829-2f5fbf00-0a1f-11eb-8f91-0324ba18f624.png">


**Use case:**
To set the due date of an assignment based on the SLA fulfillment date.

- [x] Test
- [x] Documentation: https://github.com/frappe/erpnext_documentation/pull/167