### PR TITLE
fix: customizations saved twice

### DIFF
--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -70,9 +70,9 @@ export default class Desktop {
 	}
 
 	make_sidebar() {
-		const get_sidebar_item = function(item) {
+		const get_sidebar_item = function (item) {
 			return $(`<a href="${"desk#workspace/" + item.name}"
-					class="sidebar-item 
+					class="sidebar-item
 						${item.selected ? " selected" : ""}
 						${item.hidden ? "hidden" : ""}
 					">
@@ -87,7 +87,7 @@ export default class Desktop {
 			}
 			let $item = get_sidebar_item(item);
 			let $mobile_item = $item.clone();
-			
+
 			$item.appendTo(this.sidebar);
 			this.sidebar_items[item.name] = $item;
 
@@ -128,7 +128,7 @@ export default class Desktop {
 		if (this.sidebar_items && this.sidebar_items[this.current_page]) {
 			this.sidebar_items[this.current_page].removeClass("selected");
 			this.mobile_sidebar_items[this.current_page].removeClass("selected");
-			
+
 			this.sidebar_items[page].addClass("selected");
 			this.mobile_sidebar_items[page].addClass("selected");
 		}
@@ -326,7 +326,7 @@ class DesktopPage {
 
 	make_charts() {
 		return frappe.dashboard_utils.get_dashboard_settings().then(settings => {
-			let chart_config = settings.chart_config ? JSON.parse(settings.chart_config): {};
+			let chart_config = settings.chart_config ? JSON.parse(settings.chart_config) : {};
 			if (this.data.charts.items) {
 				this.data.charts.items.map(chart => {
 					chart.chart_settings = chart_config[chart.chart_name] || {};

--- a/frappe/public/js/frappe/views/desktop/desktop.js
+++ b/frappe/public/js/frappe/views/desktop/desktop.js
@@ -282,6 +282,7 @@ class DesktopPage {
 	}
 
 	save_customization() {
+		frappe.dom.freeze();
 		const config = {};
 
 		if (this.sections.charts) config.charts = this.sections.charts.get_widget_config();
@@ -292,14 +293,15 @@ class DesktopPage {
 			page: this.page_name,
 			config: config
 		}).then(res => {
+			frappe.dom.unfreeze();
 			if (res.message) {
-				frappe.msgprint({ message: __("Customizations Saved Successfully"), title: __("Success")});
+				frappe.msgprint({ message: __("Customizations Saved Successfully"), title: __("Success") });
 				this.reload();
 			} else {
-				frappe.throw({message: __("Something went wrong while saving customizations"), title: __("Failed")});
+				frappe.throw({ message: __("Something went wrong while saving customizations"), title: __("Failed") });
 				this.reload();
 			}
-		});
+		})
 	}
 
 	make_onboarding() {


### PR DESCRIPTION
Freeze DOM when saving customization. To prevent double clicks triggering a call twice

![image](https://user-images.githubusercontent.com/18097732/95553395-1c072080-0a2c-11eb-925b-16b6a7c4efde.png)
