### PR TITLE
fix: set fieldname before insert in customize form

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -32,6 +32,7 @@ class CustomField(Document):
 		self.fieldname = self.fieldname.lower()
 
 	def before_insert(self):
+		self.set_fieldname()
 		meta = frappe.get_meta(self.dt, cached=False)
 		fieldnames = [df.fieldname for df in meta.get("fields")]
 


### PR DESCRIPTION
`fieldname` check would not work when inserting new field in customize form.

### Steps to replicate

1. Go to Customize Form for **Note**
1. Add a field that already exists, for example `Title`.
1. Update the form

The form will stay as is without any message. This is fine for smaller forms, but not for large forms.
	
### How does this work
The `fieldname` is a read only field. The value is not set when creating a **Custom Field**, it is made during `autoname()`. The validation if the field is already present or not runs before insert. The problem is that the `fieldname` is `None` when this happens, so the validation never fails.

This PR fixes this behavior by making `fieldname` before insert.

Frappe Issue: FR-ISS-223809


