### PR TITLE
fix: int validation

### DIFF
--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -19,7 +19,10 @@ frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
 				return false;
 			});
 	},
-	eval_expression: function(value) {
+	validate: function (value) {
+		return this.parse(value);
+	},
+	eval_expression: function (value) {
 		if (typeof value === 'string') {
 			if (value.match(/^[0-9+\-/* ]+$/)) {
 				// If it is a string containing operators

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -1,17 +1,17 @@
 frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
-	make: function() {
+	make: function () {
 		this._super();
 		// $(this.label_area).addClass('pull-right');
 		// $(this.disp_area).addClass('text-right');
 	},
-	make_input: function() {
+	make_input: function () {
 		var me = this;
 		this._super();
 		this.$input
 			// .addClass("text-right")
-			.on("focus", function() {
-				setTimeout(function() {
-					if(!document.activeElement) return;
+			.on("focus", function () {
+				setTimeout(function () {
+					if (!document.activeElement) return;
 					document.activeElement.value
 						= me.validate(document.activeElement.value);
 					document.activeElement.select();
@@ -36,7 +36,7 @@ frappe.ui.form.ControlInt = frappe.ui.form.ControlData.extend({
 		}
 		return value;
 	},
-	parse: function(value) {
+	parse: function (value) {
 		return cint(this.eval_expression(value), null);
 	}
 });


### PR DESCRIPTION
`ControlInt` extends from `ControlData` and reuses it's validate method. However, the validation does not work for Numbers because of the following condition 

https://github.com/frappe/frappe/blob/f4aa4bb9ae59e5e3f6e61b2c344c21a9e2519f82/frappe/public/js/frappe/form/controls/data.js#L109-L111

This caused an issue when entering `0` as a value in forms and filters.

### Broken Filter
![broken filter](https://user-images.githubusercontent.com/18097732/95564486-80ca7700-0a3c-11eb-8a67-395f83262588.gif)
![broken form](https://user-images.githubusercontent.com/18097732/95564492-858f2b00-0a3c-11eb-9295-5edee8385ccb.gif)

The fix was to override the `validate` method, it reuses the `parse` method already present in the control class. 

### Working filters
![working filter](https://user-images.githubusercontent.com/18097732/95564521-9049c000-0a3c-11eb-9861-25c0eec8ce0c.gif)

![working form](https://user-images.githubusercontent.com/18097732/95564662-c129f500-0a3c-11eb-81ad-bcda1536ec53.gif)


Frappe Issue: [FR-ISS-217825](https://frappe.io/desk#Form/Internal%20Issue/FR-ISS-217825)