### PR TITLE
fix: Add provision for quotes in DatabaseQuery.prepare_args

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -172,7 +172,7 @@ class DatabaseQuery(object):
 		fields = []
 
 		for field in self.fields:
-			if (field.strip().startswith(("`", "*")) or "(" in field):
+			if field.strip().startswith(("`", "*", '"', "'")) or "(" in field:
 				fields.append(field)
 			elif "as" in field.lower().split(" "):
 				col, _, new = field.split()[-3:]


### PR DESCRIPTION
Added provision for " and ' as a replacement fix for https://github.com/frappe/frappe/pull/11678

<details><summary>Replaced PR Description
</summary>
<p>

This is a critical error causing **Boot Failed** issue.

![Screenshot from 2020-10-09 19-49-44](https://user-images.githubusercontent.com/16315650/95594503-a66d7580-0a68-11eb-9aa7-4ae45f7327a4.png)


Generated Query:
```
19:16:56 web.1            | select `'doctype'` as type, `name`, `description`, `document_type`, `custom`, `issingle`
19:16:56 web.1            | 			from `tabDocType`
19:16:56 web.1            | 			where `tabDocType`.module = 'filtersource' and `tabDocType`.istable = 0.0 and (ifnull(restrict_to_domain, '') = '' or ifnull(`tabDocType`.restrict_to_domain, '') in ('Distribution', ''))
19:16:56 web.1            | 			
19:16:56 web.1            | 			 order by custom asc, document_type desc, name asc
```

Error:
```
19:16:56 web.1            | Traceback (most recent call last):
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/www/desk.py", line 22, in get_context
19:16:56 web.1            |     boot = frappe.sessions.get()
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/sessions.py", line 133, in get
19:16:56 web.1            |     bootinfo = get_bootinfo()
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/boot.py", line 47, in get_bootinfo
19:16:56 web.1            |     load_desktop_data(bootinfo)
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/boot.py", line 111, in load_desktop_data
19:16:56 web.1            |     bootinfo.allowed_modules = get_modules_from_all_apps_for_user()
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/config/__init__.py", line 28, in get_modules_from_all_apps_for_user
19:16:56 web.1            |     module["links"] =  get_onboard_items(module["app"], frappe.scrub(module_name))[:5]
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/desk/moduleview.py", line 291, in get_onboard_items
19:16:56 web.1            |     doctype_info = get_doctype_info(module)
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/desk/moduleview.py", line 164, in get_doctype_info
19:16:56 web.1            |     doctype_info = frappe.get_all("DocType", filters={
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/__init__.py", line 1374, in get_all
19:16:56 web.1            |     return get_list(doctype, *args, **kwargs)
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/__init__.py", line 1347, in get_list
19:16:56 web.1            |     return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/model/db_query.py", line 100, in execute
19:16:56 web.1            |     result = self.build_and_run()
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/model/db_query.py", line 138, in build_and_run
19:16:56 web.1            |     return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
19:16:56 web.1            |   File "/home/snv/Work/v13/apps/frappe/frappe/database/database.py", line 153, in sql
19:16:56 web.1            |     self._cursor.execute(query)
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/cursors.py", line 170, in execute
19:16:56 web.1            |     result = self._query(query)
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/cursors.py", line 328, in _query
19:16:56 web.1            |     conn.query(q)
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/connections.py", line 517, in query
19:16:56 web.1            |     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/connections.py", line 732, in _read_query_result
19:16:56 web.1            |     result.read()
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/connections.py", line 1075, in read
19:16:56 web.1            |     first_packet = self.connection._read_packet()
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/connections.py", line 684, in _read_packet
19:16:56 web.1            |     packet.check_error()
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/protocol.py", line 220, in check_error
19:16:56 web.1            |     err.raise_mysql_exception(self._data)
19:16:56 web.1            |   File "/home/snv/Work/v13/env/lib/python3.8/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
19:16:56 web.1            |     raise errorclass(errno, errval)
19:16:56 web.1            | pymysql.err.InternalError: (1054, "Unknown column ' 'doctype' ' in 'field list'")
```
</p>
</details>
