### PR TITLE
fix: First Response Time not getting set when sender is Administrator

### DIFF
--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -292,7 +292,7 @@ def is_website_user():
 	return frappe.db.get_value('User', frappe.session.user, 'user_type') == "Website User"
 
 def is_system_user(username):
-	return frappe.db.get_value("User", {"name": username, "enabled": 1, "user_type": "System User"})
+	return frappe.db.get_value("User", {"email": username, "enabled": 1, "user_type": "System User"})
 
 def get_users():
 	from frappe.core.doctype.user.user import get_system_users


### PR DESCRIPTION
First Response Time not getting set for communications where Sender is the Administrator. Check for `email` as a filter instead of `name` in the `is_system_user` function.

**Before:**
![before](https://user-images.githubusercontent.com/24353136/95722707-e95e6180-0c91-11eb-95c4-68beed460e3f.png)

**After:**
![after](https://user-images.githubusercontent.com/24353136/95722721-eb282500-0c91-11eb-932a-4156369e6803.png)
