### PR TITLE
fix: query to handle user value having special characters

### DIFF
--- a/frappe/desk/page/user_profile/user_profile.py
+++ b/frappe/desk/page/user_profile/user_profile.py
@@ -1,17 +1,23 @@
 import frappe
 from datetime import datetime
+from frappe.utils import getdate
 
 @frappe.whitelist()
 def get_energy_points_heatmap_data(user, date):
+	try:
+		date = getdate(date)
+	except Exception:
+		date = getdate()
+
 	return dict(frappe.db.sql("""select unix_timestamp(date(creation)), sum(points)
 		from `tabEnergy Point Log`
 		where
 			date(creation) > subdate('{date}', interval 1 year) and
 			date(creation) < subdate('{date}', interval -1 year) and
-			user = '{user}' and
+			user = %s and
 			type != 'Review'
 		group by date(creation)
-		order by creation asc""".format(user = user, date = date)))
+		order by creation asc""".format(date = date), user))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
```
17:11:01 web.1            | select unix_timestamp(date(creation)), sum(points)
17:11:01 web.1            | 		from `tabEnergy Point Log`
17:11:01 web.1            | 		where
17:11:01 web.1            | 			date(creation) > subdate('2020-01-01', interval 1 year) and
17:11:01 web.1            | 			date(creation) < subdate('2020-01-01', interval -1 year) and
17:11:01 web.1            | 			user = 'da'' and
17:11:01 web.1            | 			type != 'Review'
17:11:01 web.1            | 		group by date(creation)
17:11:01 web.1            | 		order by creation asc
17:11:01 web.1            | Traceback (most recent call last):
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/apps/frappe/frappe/app.py", line 64, in application
17:11:01 web.1            |     response = frappe.api.handle()
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/apps/frappe/frappe/api.py", line 58, in handle
17:11:01 web.1            |     return frappe.handler.handle()
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/apps/frappe/frappe/handler.py", line 30, in handle
17:11:01 web.1            |     data = execute_cmd(cmd)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/apps/frappe/frappe/handler.py", line 70, in execute_cmd
17:11:01 web.1            |     return frappe.call(method, **frappe.form_dict)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/apps/frappe/frappe/__init__.py", line 1111, in call
17:11:01 web.1            |     return fn(*args, **newargs)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/apps/frappe/frappe/desk/page/user_profile/user_profile.py", line 14, in get_energy_points_heatmap_data
17:11:01 web.1            |     order by creation asc""".format(user = user, date = date)))
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/apps/frappe/frappe/database/database.py", line 153, in sql
17:11:01 web.1            |     self._cursor.execute(query)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 170, in execute
17:11:01 web.1            |     result = self._query(query)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 328, in _query
17:11:01 web.1            |     conn.query(q)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 517, in query
17:11:01 web.1            |     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
17:11:01 web.1            |     result.read()
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 1075, in read
17:11:01 web.1            |     first_packet = self.connection._read_packet()
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 684, in _read_packet
17:11:01 web.1            |     packet.check_error()
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/protocol.py", line 220, in check_error
17:11:01 web.1            |     err.raise_mysql_exception(self._data)
17:11:01 web.1            |   File "/Users/saurabh/project/dev-py3-bench/env/lib/python3.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
17:11:01 web.1            |     raise errorclass(errno, errval)
17:11:01 web.1            | pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Review'\n\t\tgroup by date(creation)\n\t\torder by creation asc' at line 6")
```

<img width="430" alt="Screenshot 2020-10-12 at 5 12 09 PM" src="https://user-images.githubusercontent.com/3784093/95742737-16b90880-0cae-11eb-9228-81c37b1c6779.png">
