### PR TITLE
chore: Check words in translation lint

### DIFF
--- a/.github/helper/translation.py
+++ b/.github/helper/translation.py
@@ -3,17 +3,25 @@ import sys
 
 errors_encounter = 0
 pattern = re.compile(r"_\(([\"']{,3})(?P<message>((?!\1).)*)\1(\s*,\s*context\s*=\s*([\"'])(?P<py_context>((?!\5).)*)\5)*(\s*,\s*(.)*?\s*(,\s*([\"'])(?P<js_context>((?!\11).)*)\11)*)*\)")
-start_pattern = re.compile(r"_{1,2}\([\"'`]{1,3}.*?[a-zA-Z]")
+words_pattern = re.compile(r"_{1,2}\([\"'`]{1,3}.*?[a-zA-Z]")
+start_pattern = re.compile(r"_{1,2}\([f\"'`]{1,3}")
+f_string_pattern = re.compile(r"_\(f[\"']")
+starts_with_f_pattern = re.compile(r"_\(f")
 
 # _('this is valid')
 # _('{0} {1}')
 # _("{0} {1}")
+# _(f"invalid")
+# _(fieldname)
 # _("{0} valid")
+# _('asdf asdf')
 # _("valid {0}")
 
 # skip first argument
 files = sys.argv[1:]
 files_to_scan = [_file for _file in files if _file.endswith(('.py', '.js'))]
+
+files_to_scan = ['/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/.github/helper/translation.py']
 
 for _file in files_to_scan:
 	with open(_file, 'r') as f:
@@ -21,8 +29,21 @@ for _file in files_to_scan:
 		file_lines = f.readlines()
 		for line_number, line in enumerate(file_lines, 1):
 			start_matches = start_pattern.search(line)
-			if start_matches:
+			if start_matches and not '# frappe-lint: disable-translate' in line:
+				starts_with_f = starts_with_f_pattern.search(line)
+
+				if starts_with_f:
+					has_f_string = f_string_pattern.search(line)
+					if has_f_string:
+						errors_encounter += 1
+						print(f'\nF-strings are not supported for translations at line number {line_number + 1}\n{line.strip()[:100]}')
+						continue
+					else:
+						continue
+
 				match = pattern.search(line)
+				error_found = False
+
 				if not match and line.endswith(',\n'):
 					# concat remaining text to validate multiline pattern
 					line = "".join(file_lines[line_number - 1:])
@@ -30,11 +51,18 @@ for _file in files_to_scan:
 					match = pattern.match(line)
 
 				if not match:
+					error_found = True
+					print(f'\nTranslation syntax error at line number {line_number + 1}\n{line.strip()[:100]}')
+
+				if not error_found and not words_pattern.search(line):
+					error_found = True
+					print(f'\nTranslation is useless because it has no words at line number {line_number + 1}\n{line.strip()[:100]}')
+
+				if error_found:
 					errors_encounter += 1
-					print(f'\nTranslation syntax error at line number: {line_number + 1}\n{line.strip()[:100]}')
 
 if errors_encounter > 0:
-	print('\nYou can visit "https://frappeframework.com/docs/user/en/translations" to resolve this error.')
+	print('\nVisit "https://frappeframework.com/docs/user/en/translations" to learn about valid translation strings.')
 	sys.exit(1)
 else:
 	print('\nGood To Go!')

--- a/.github/helper/translation.py
+++ b/.github/helper/translation.py
@@ -3,7 +3,7 @@ import sys
 
 errors_encounter = 0
 pattern = re.compile(r"_\(([\"']{,3})(?P<message>((?!\1).)*)\1(\s*,\s*context\s*=\s*([\"'])(?P<py_context>((?!\5).)*)\5)*(\s*,\s*(.)*?\s*(,\s*([\"'])(?P<js_context>((?!\11).)*)\11)*)*\)")
-start_pattern = re.compile(r"_{1,2}\([\"'`]{1,3}")
+start_pattern = re.compile(r"_{1,2}\([\"'`]{1,3}.*[a-zA-Z]")
 
 # skip first argument
 files = sys.argv[1:]

--- a/.github/helper/translation.py
+++ b/.github/helper/translation.py
@@ -3,7 +3,7 @@ import sys
 
 errors_encounter = 0
 pattern = re.compile(r"_\(([\"']{,3})(?P<message>((?!\1).)*)\1(\s*,\s*context\s*=\s*([\"'])(?P<py_context>((?!\5).)*)\5)*(\s*,\s*(.)*?\s*(,\s*([\"'])(?P<js_context>((?!\11).)*)\11)*)*\)")
-start_pattern = re.compile(r"_{1,2}\([\"'`]{1,3}.*[a-zA-Z]")
+start_pattern = re.compile(r"_{1,2}\([\"'`]{1,3}.*?[a-zA-Z]")
 
 # _('this is valid')
 # _('{0} {1}')

--- a/.github/helper/translation.py
+++ b/.github/helper/translation.py
@@ -5,6 +5,12 @@ errors_encounter = 0
 pattern = re.compile(r"_\(([\"']{,3})(?P<message>((?!\1).)*)\1(\s*,\s*context\s*=\s*([\"'])(?P<py_context>((?!\5).)*)\5)*(\s*,\s*(.)*?\s*(,\s*([\"'])(?P<js_context>((?!\11).)*)\11)*)*\)")
 start_pattern = re.compile(r"_{1,2}\([\"'`]{1,3}.*[a-zA-Z]")
 
+# _('this is valid')
+# _('{0} {1}')
+# _("{0} {1}")
+# _("{0} valid")
+# _("valid {0}")
+
 # skip first argument
 files = sys.argv[1:]
 files_to_scan = [_file for _file in files if _file.endswith(('.py', '.js'))]

--- a/.github/helper/translation.py
+++ b/.github/helper/translation.py
@@ -21,8 +21,6 @@ starts_with_f_pattern = re.compile(r"_\(f")
 files = sys.argv[1:]
 files_to_scan = [_file for _file in files if _file.endswith(('.py', '.js'))]
 
-files_to_scan = ['/Users/farisansari/Projects/benches/frappe-bench/apps/frappe/.github/helper/translation.py']
-
 for _file in files_to_scan:
 	with open(_file, 'r') as f:
 		print(f'Checking: {_file}')

--- a/.github/helper/translation.py
+++ b/.github/helper/translation.py
@@ -8,15 +8,6 @@ start_pattern = re.compile(r"_{1,2}\([f\"'`]{1,3}")
 f_string_pattern = re.compile(r"_\(f[\"']")
 starts_with_f_pattern = re.compile(r"_\(f")
 
-# _('this is valid')
-# _('{0} {1}')
-# _("{0} {1}")
-# _(f"invalid")
-# _(fieldname)
-# _("{0} valid")
-# _('asdf asdf')
-# _("valid {0}")
-
 # skip first argument
 files = sys.argv[1:]
 files_to_scan = [_file for _file in files if _file.endswith(('.py', '.js'))]
@@ -26,8 +17,11 @@ for _file in files_to_scan:
 		print(f'Checking: {_file}')
 		file_lines = f.readlines()
 		for line_number, line in enumerate(file_lines, 1):
+			if 'frappe-lint: disable-translate' in line:
+				continue
+
 			start_matches = start_pattern.search(line)
-			if start_matches and not '# frappe-lint: disable-translate' in line:
+			if start_matches:
 				starts_with_f = starts_with_f_pattern.search(line)
 
 				if starts_with_f:


### PR DESCRIPTION
Translation strings with no words are not valid

```
_("{0} test") # this is valid
_("{0} {1}") # this is not
```