### PR TITLE
fix: patch travis

### DIFF
--- a/frappe/patches/v13_0/generate_theme_files_in_public_folder.py
+++ b/frappe/patches/v13_0/generate_theme_files_in_public_folder.py
@@ -6,6 +6,7 @@ import frappe
 
 
 def execute():
+	frappe.reload_doc("website", "doctype", "website_theme_ignore_app")
 	themes = frappe.db.get_all(
 		"Website Theme", filters={"theme_url": ("not like", "/files/website_theme/%")}
 	)

--- a/frappe/patches/v13_0/web_template_set_module.py
+++ b/frappe/patches/v13_0/web_template_set_module.py
@@ -6,8 +6,9 @@ import frappe
 
 def execute():
 	"""Set default module for standard Web Template, if none."""
-	frappe.reload_doctype('Web Template')
-	frappe.reload_doctype('Web Template Field')
+	frappe.reload_doc('website', 'doctype', 'Web Template Field')
+	frappe.reload_doc('website', 'doctype', 'web_template')
+
 	standard_templates = frappe.get_list('Web Template', {'standard': 1})
 	for template in standard_templates:
 		doc = frappe.get_doc('Web Template', template.name)


### PR DESCRIPTION
**Issue**

```
Executing frappe.patches.v13_0.web_template_set_module #2020-10-05 in test_site (test_frappe)
Traceback (most recent call last):
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 99, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 287, in migrate
    skip_search_index=skip_search_index
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v13_0/web_template_set_module.py", line 9, in execute
    frappe.reload_doctype('Web Template')
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 846, in reload_doctype
    reload_doc(scrub(db.get_value("DocType", doctype, "module")), "doctype", scrub(doctype),
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 880, in scrub
    return txt.replace(' ', '_').replace('-', '_').lower()
AttributeError: 'NoneType' object has no attribute 'replace'
```

```
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v13_0/generate_theme_files_in_public_folder.py", line 16, in execute
    doc.save()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 318, in _save
    self.validate_higher_perm_levels()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 614, in validate_higher_perm_levels
    high_permlevel_fields = frappe.get_meta(df.options).get_high_permlevel_fields()
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 819, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/meta.py", line 37, in get_meta
    meta = Meta(doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/meta.py", line 83, in __init__
    super(Meta, self).__init__("DocType", doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 113, in __init__
    self.load_from_db()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/meta.py", line 88, in load_from_db
    super(Meta, self).load_from_db()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 156, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 413, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 392, in msgprint
    _raise_exception()
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 340, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType Website Theme Ignore App not found
```