### PR TITLE
fix: Skip using cookie-jar to set cookies if via tests

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -112,7 +112,8 @@ def prepare_options(html, options):
 	options.update(html_options or {})
 
 	# cookies
-	options.update(get_cookie_options())
+	if not frappe.flags.in_test:
+		options.update(get_cookie_options())
 
 	# page size
 	if not options.get("page-size"):


### PR DESCRIPTION
While running tests locally :
```
   File "/Users/marica/Desktop/bench-v-12/apps/erpnext/erpnext/payroll/doctype/salary_slip/salary_slip.py", line 1004, in email_salary_slip
    "attachments": [frappe.attach_print(self.doctype, self.name, file_name=self.name, password=password)],
  File "/Users/marica/Desktop/bench-v-12/apps/frappe/frappe/__init__.py", line 1486, in attach_print
    content = get_print(doctype, name, **kwargs)
  File "/Users/marica/Desktop/bench-v-12/apps/frappe/frappe/__init__.py", line 1452, in get_print
    return get_pdf(html, output = output, options = options)
  File "/Users/marica/Desktop/bench-v-12/apps/frappe/frappe/utils/pdf.py", line 27, in get_pdf
    html, options = prepare_options(html, options)
  File "/Users/marica/Desktop/bench-v-12/apps/frappe/frappe/utils/pdf.py", line 115, in prepare_options
    options.update(get_cookie_options())
  File "/Users/marica/Desktop/bench-v-12/apps/frappe/frappe/utils/pdf.py", line 132, in get_cookie_options
    domain = frappe.local.request.host.split(":", 1)[0]
  File "/Users/marica/Desktop/bench-v-12/env/lib/python3.7/site-packages/werkzeug/local.py", line 74, in __getattr__
    raise AttributeError(name)
AttributeError: request
```