### PR TITLE
perf(form): use get_list with limit instead of count

### DIFF
--- a/frappe/public/js/frappe/form/success_action.js
+++ b/frappe/public/js/frappe/form/success_action.js
@@ -28,8 +28,9 @@ frappe.ui.form.SuccessAction = class SuccessAction {
 	}
 
 	show_alert() {
-		frappe.db.count(this.form.doctype)
-			.then(count => {
+		frappe.db.get_list(this.form.doctype, {limit: 2})
+			.then(result => {
+				const count = result.length;
 				const setting = this.setting;
 				let message = count === 1 ?
 					setting.first_success_message :


### PR DESCRIPTION
Resolves: #11553, #11377

**Before:**
Used to scan the whole table to count the number of entries.

**After:**
Gets a limited list of maximum 2 entries so that `count  === 1` can be checked.

**Locally Tested**