### PR TITLE
 fix: Update due date of reference doc's ToDo only

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.json
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -136,12 +136,13 @@
    "depends_on": "document_type",
    "fieldname": "due_date_based_on",
    "fieldtype": "Select",
-   "label": "Due Date Based On"
+   "label": "Due Date Based On",
+   "description": "Value from this field will be set as the due date in the ToDo"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-08 06:48:54.019735",
+ "modified": "2020-10-13 06:48:54.019735",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Assignment Rule",

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -252,7 +252,9 @@ def update_due_date(doc, state=None):
 			doc.has_value_changed(due_date_field) and rule.get('name'):
 			assignment_todos = frappe.get_all('ToDo', {
 				'assignment_rule': rule.get('name'),
-				'status': 'Open'
+				'status': 'Open',
+				'reference_type': doc.doctype,
+				'reference_name': doc.name
 			})
 			for todo in assignment_todos:
 				todo_doc = frappe.get_doc('ToDo', todo.name)

--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -202,22 +202,32 @@ class TestAutoAssign(unittest.TestCase):
 		)).insert()
 
 		expiry_date = frappe.utils.add_days(frappe.utils.nowdate(), 2)
-		note = make_note({'expiry_date': expiry_date})
+		note1 = make_note({'expiry_date': expiry_date})
+		note2 = make_note({'expiry_date': expiry_date})
 
-		todo = frappe.get_all('ToDo', filters=dict(
+		note1_todo = frappe.get_all('ToDo', filters=dict(
 			reference_type = 'Note',
-			reference_name = note.name,
+			reference_name = note1.name,
 			status = 'Open'
 		))[0]
 
-		todo = frappe.get_doc('ToDo', todo.name)
-		self.assertEqual(frappe.utils.get_date_str(todo.date), expiry_date)
+		note1_todo_doc = frappe.get_doc('ToDo', note1_todo.name)
+		self.assertEqual(frappe.utils.get_date_str(note1_todo_doc.date), expiry_date)
 
 		# due date should be updated if the reference doc's date is updated.
-		note.expiry_date = frappe.utils.add_days(expiry_date, 2)
-		note.save()
-		todo.reload()
-		self.assertEqual(frappe.utils.get_date_str(todo.date), note.expiry_date)
+		note1.expiry_date = frappe.utils.add_days(expiry_date, 2)
+		note1.save()
+		note1_todo_doc.reload()
+		self.assertEqual(frappe.utils.get_date_str(note1_todo_doc.date), note1.expiry_date)
+
+		# saving one note's expiry should not update other note todo's due date
+		note2_todo = frappe.get_all('ToDo', filters=dict(
+			reference_type = 'Note',
+			reference_name = note2.name,
+			status = 'Open'
+		), fields=['name', 'date'])[0]
+		self.assertNotEqual(frappe.utils.get_date_str(note2_todo.date), note1.expiry_date)
+		self.assertEqual(frappe.utils.get_date_str(note2_todo.date), expiry_date)
 		assignment_rule.delete()
 
 def clear_assignments():


### PR DESCRIPTION
- Previously, the system used to set due_date for all ToDos/assignments related to assignment rule. Fixed it to set only for the todos of reference document.
- Updated test case to avoid this.
- Added description for due_date_based_on field

Fixes issue introduced through: https://github.com/frappe/frappe/pull/11669