### PR TITLE
fix: Restore assets during bench init

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -112,17 +112,20 @@ def download_frappe_assets(verbose=True):
 
 			if assets_archive:
 				import tarfile
+				directories_created = set()
 
 				click.secho("\nExtracting assets...\n", fg="yellow")
 				with tarfile.open(assets_archive) as tar:
 					for file in tar:
 						if not file.isdir():
 							dest = "." + file.name.replace("./frappe-bench/sites", "")
+							asset_directory = os.path.dirname(dest)
 							show = dest.replace("./assets/", "")
 
-							dirname = os.path.dirname(dest)
-							if not os.path.exists(dirname):
-								os.makedirs(dirname, exist_ok=True)
+							if asset_directory not in directories_created:
+								if not os.path.exists(asset_directory):
+									os.makedirs(asset_directory, exist_ok=True)
+								directories_created.add(asset_directory)
 
 							tar.makefile(file, dest)
 							print("{0} Restored {1}".format(green('✔'), show))

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -40,6 +40,7 @@ def build_missing_files():
 	# check which files dont exist yet from the build.json and tell build.js to build only those!
 	missing_assets = []
 	current_asset_files = []
+	frappe_build = os.path.join("..", "apps", "frappe", "frappe", "public", "build.json")
 
 	for type in ["css", "js"]:
 		current_asset_files.extend(
@@ -49,7 +50,7 @@ def build_missing_files():
 			]
 		)
 
-	with open(os.path.join(sites_path, "assets", "frappe", "build.json")) as f:
+	with open(frappe_build) as f:
 		all_asset_files = json.load(f).keys()
 
 	for asset in all_asset_files:
@@ -118,6 +119,11 @@ def download_frappe_assets(verbose=True):
 						if not file.isdir():
 							dest = "." + file.name.replace("./frappe-bench/sites", "")
 							show = dest.replace("./assets/", "")
+
+							dirname = os.path.dirname(dest)
+							if not os.path.exists(dirname):
+								os.makedirs(dirname, exist_ok=True)
+
 							tar.makefile(file, dest)
 							print("{0} Restored {1}".format(green('✔'), show))
 


### PR DESCRIPTION
During `bench init`, an error would occur at the build stage, and instead of restoring assets from assets.frappeframework.com, it would start building the assets manually. These errors only come up due to a mid setup bench and don't occur if you run `bench build` after the bench initialization is complete. 

**Fixes:**
1. Access build.json for frappe from the apps directory
2. Create the assets directory if doesn't exist 