### PR TITLE
feat: Add as_list parameter to msgprint

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -347,26 +347,10 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, 
 		return
 
 	if as_table and type(msg) in (list, tuple):
-
-		table_rows = ''
-		for row in msg:
-			table_row_data = ''
-			for data in row:
-				table_row_data += '<td>{}</td>'.format(data)
-			table_rows += '<tr>{}</tr>'.format(table_row_data)
-
-		out.message = '''<table class="table table-bordered"
-			style="margin: 0;">{}</table>'''.format(table_rows)
+		out.as_table = 1
 	
-	if as_list and type(msg) in (list, tuple):
-		if len(msg) > 1:
-			list_rows = ''
-			for row in msg:
-				list_rows += '<li>{}</li>'.format(row)
-
-			out.message = '''<ul style="padding-left: 20px">{}</ul>'''.format(list_rows)
-		elif len(msg) == 1:
-			out.message = msg[0]
+	if as_list and type(msg) in (list, tuple) and len(msg) > 1:
+		out.as_list = 1
 
 	if flags.print_messages and out.message:
 		print(f"Message: {repr(out.message).encode('utf-8')}")

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -416,12 +416,12 @@ def clear_last_message():
 	if len(local.message_log) > 0:
 		local.message_log = local.message_log[:-1]
 
-def throw(msg, exc=ValidationError, title=None, is_minimizable=None, wide=None):
+def throw(msg, exc=ValidationError, title=None, is_minimizable=None, wide=None, **kwargs):
 	"""Throw execption and show message (`msgprint`).
 
 	:param msg: Message.
 	:param exc: Exception class. Default `frappe.ValidationError`"""
-	msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide)
+	msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, **kwargs)
 
 def emit_js(js, user=False, **kwargs):
 	if user == False:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -312,7 +312,7 @@ def log(msg):
 
 	debug_log.append(as_unicode(msg))
 
-def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None, alert=False, primary_action=None, is_minimizable=None, wide=None):
+def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, indicator=None, alert=False, primary_action=None, is_minimizable=None, wide=None):
 	"""Print a message to the user (via HTTP response).
 	Messages are sent in the `__server_messages` property in the
 	response JSON and shown in a pop-up / modal.
@@ -321,6 +321,7 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None,
 	:param title: [optional] Message title.
 	:param raise_exception: [optional] Raise given exception and show message.
 	:param as_table: [optional] If `msg` is a list of lists, render as HTML table.
+	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
 	:param primary_action: [optional] Bind a primary server/client side action.
 	:param is_minimizable: [optional] Allow users to minimize the modal
 	:param wide: [optional] Show wide modal
@@ -356,6 +357,16 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, indicator=None,
 
 		out.message = '''<table class="table table-bordered"
 			style="margin: 0;">{}</table>'''.format(table_rows)
+	
+	if as_list and type(msg) in (list, tuple):
+		if len(msg) > 1:
+			list_rows = ''
+			for row in msg:
+				list_rows += '<li>{}</li>'.format(row)
+
+			out.message = '''<ul style="padding-left: 20px">{}</ul>'''.format(list_rows)
+		elif len(msg) == 1:
+			out.message = msg[0]
 
 	if flags.print_messages and out.message:
 		print(f"Message: {repr(out.message).encode('utf-8')}")

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -400,12 +400,12 @@ def clear_last_message():
 	if len(local.message_log) > 0:
 		local.message_log = local.message_log[:-1]
 
-def throw(msg, exc=ValidationError, title=None, is_minimizable=None, wide=None, **kwargs):
+def throw(msg, exc=ValidationError, title=None, is_minimizable=None, wide=None, as_list=False):
 	"""Throw execption and show message (`msgprint`).
 
 	:param msg: Message.
 	:param exc: Exception class. Default `frappe.ValidationError`"""
-	msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, **kwargs)
+	msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
 
 def emit_js(js, user=False, **kwargs):
 	if user == False:

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -128,6 +128,19 @@ frappe.msgprint = function(msg, title, is_minimizable) {
 		data.indicator = 'blue';
 	}
 
+	if (data.as_list) {
+		const list_rows = data.message.map(m => `<li>${m}</li>`).join('');
+		data.message = `<ul style="padding-left: 20px">${list_rows}</ul>`;
+	}
+
+	if (data.as_table) {
+		const rows = data.message.map(row => {
+			const cols = row.map(col => `<td>${col}</td>`).join('');
+			return `<tr>${cols}</tr>`
+		}).join('');
+		data.message = `<table class="table table-bordered" style="margin: 0;">${rows}</table>`;
+	}
+
 	if(data.message instanceof Array) {
 		data.message.forEach(function(m) {
 			frappe.msgprint(m);

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -136,7 +136,7 @@ frappe.msgprint = function(msg, title, is_minimizable) {
 	if (data.as_table) {
 		const rows = data.message.map(row => {
 			const cols = row.map(col => `<td>${col}</td>`).join('');
-			return `<tr>${cols}</tr>`
+			return `<tr>${cols}</tr>`;
 		}).join('');
 		data.message = `<table class="table table-bordered" style="margin: 0;">${rows}</table>`;
 	}


### PR DESCRIPTION
Pass a list of error messages to display them as an unordered list. Useful when validating child table fields to display errors/warnings from every row

<img width="448" alt="Screenshot 2020-10-14 at 4 02 11 PM" src="https://user-images.githubusercontent.com/25369014/95977542-a25da100-0e36-11eb-9598-bdb47dc6a644.png">

Docs: https://github.com/frappe/frappe_docs/pull/58