### PR TITLE
fix: handle FileAlreadyAttachedException while pulling email

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -540,6 +540,8 @@ class Email:
 			except MaxFileSizeReachedError:
 				# WARNING: bypass max file size exception
 				pass
+			except frappe.FileAlreadyAttachedException:
+				pass
 			except frappe.DuplicateEntryError:
 				# same file attached twice??
 				pass


### PR DESCRIPTION
Handle `FileAlreadyAttachedException` while pulling email.