### PR TITLE
fix(Request): Sanitize Error Report Email Message

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -55,7 +55,7 @@ def make(doctype=None, name=None, content=None, subject=None, sent_or_received =
 	comm = frappe.get_doc({
 		"doctype":"Communication",
 		"subject": subject,
-		"content": content,
+		"content": frappe.utils.sanitize_html(content),
 		"sender": sender,
 		"sender_full_name":sender_full_name,
 		"recipients": recipients,

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -443,7 +443,7 @@ frappe.request.report_error = function(xhr, request_opts) {
 		var communication_composer = new frappe.views.CommunicationComposer({
 			subject: 'Error Report [' + frappe.datetime.nowdate() + ']',
 			recipients: error_report_email,
-			message: error_report_message,
+			message: frappe.utils.xss_sanitise(error_report_message),
 			doc: {
 				doctype: "User",
 				name: frappe.session.user


### PR DESCRIPTION
We can run and execute js in the message field.
Just ran frappe.utils.xss_sanitise() before creating communication.