### PR TITLE
fix(UX): special characters like "/" now work in tags, other fixes

### DIFF
--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -147,7 +147,6 @@ def update_tags(doc, tags):
 			delete_tag_for_document(doc.doctype, doc.name, tag)
 
 def get_deleted_tags(new_tags, existing_tags):
-
 	return list(set(existing_tags) - set(new_tags))
 
 def delete_tag_for_document(dt, dn, tag):

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -313,3 +313,4 @@ frappe.patches.v13_0.update_newsletter_content_type
 execute:frappe.db.set_value('Website Settings', 'Website Settings', {'navbar_template': 'Standard Navbar', 'footer_template': 'Standard Footer'})
 frappe.patches.v13_0.delete_event_producer_and_consumer_keys
 frappe.patches.v13_0.web_template_set_module #2020-10-05
+frappe.patches.v13_0.fix_tag_naming

--- a/frappe/patches/v13_0/fix_tag_naming.py
+++ b/frappe/patches/v13_0/fix_tag_naming.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+
+import re
+import frappe
+
+
+def execute():
+	to_replace = ["&lt", "&gt", "&quot", "&#x27", "&#x2F"]
+
+	or_filters = [["Tag", "name", "like", "%{}%".format(entity)] for entity in to_replace]
+	tags = frappe.get_all("Tag", or_filters=or_filters)
+
+	if not tags:
+		return
+
+	regex_rules = [re.compile("({});?".format(entity)) for entity in to_replace]
+
+	for tag in tags:
+		new_name = tag.name
+		for rule in regex_rules:
+			new_name = re.sub(rule, r"\1;", new_name)
+
+		if tag.name != new_name:
+			frappe.rename_doc("Tag", tag.name, new_name, force=True)

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -152,10 +152,7 @@ frappe.ui.form.Sidebar = class {
 
 		this.frm.tags = new frappe.ui.TagEditor({
 			parent: this.sidebar.find(".tag-area"),
-			frm: this.frm,
-			on_change: function(user_tags) {
-				this.frm.tags && this.frm.tags.refresh(user_tags);
-			}
+			frm: this.frm
 		});
 	}
 

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -96,18 +96,16 @@ frappe.ui.form.Sidebar = class {
 			this.sidebar
 				.find(".modified-by")
 				.html(
-					__("{0} edited this {1}", [
-						frappe.user.full_name(this.frm.doc.modified_by).bold(),
-						"<br>" + comment_when(this.frm.doc.modified),
-					])
+					`${frappe.user.full_name(this.frm.doc.modified_by).bold()} ${
+						__("edited this")
+					}<br>${comment_when(this.frm.doc.modified)}`
 				);
 			this.sidebar
 				.find(".created-by")
 				.html(
-					__("{0} created this {1}", [
-						frappe.user.full_name(this.frm.doc.owner).bold(),
-						"<br>" + comment_when(this.frm.doc.creation),
-					])
+					`${frappe.user.full_name(this.frm.doc.owner).bold()} ${
+						__("created this")
+					}<br>${comment_when(this.frm.doc.creation)}`
 				);
 
 			this.refresh_like();

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -210,7 +210,7 @@ frappe.views.ListSidebar = class ListSidebar {
 			let email_account = (account.email_id == "All Accounts") ? "All Accounts" : account.email_account;
 			let route = ["List", "Communication", "Inbox", email_account].join('/');
 			let display_name = ["All Accounts", "Sent Mail", "Spam", "Trash"].includes(account.email_id) ? __(account.email_id) : account.email_id;
-			
+
 			if (!divider) {
 				this.get_divider().appendTo($dropdown);
 				divider = true;
@@ -317,7 +317,10 @@ frappe.views.ListSidebar = class ListSidebar {
 				if (label == "No Tags") {
 					label = "%,%";
 					condition = "not like";
+				} else {
+					label = frappe.utils.xss_sanitise(label);
 				}
+
 				me.list_view.filter_area.filter_list.add_filter(me.list_view.doctype, fieldname, condition, label)
 					.then(function() {
 						me.list_view.refresh();

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -507,7 +507,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			</div>`).appendTo($list_rows.get(i));
 
 			// add tags
-			let tag_editor = new frappe.ui.TagEditor({
+			new frappe.ui.TagEditor({
 				parent: tag_html.find('.list-tag'),
 				frm: {
 					doctype: this.doctype,
@@ -518,11 +518,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				on_change: (user_tags) => {
 					d._user_tags = user_tags;
 				}
-			});
-
-			tag_editor.wrapper.on('click', '.tagit-label', (e) => {
-				const $this = $(e.currentTarget);
-				this.filter_area.add(this.doctype, '_user_tags', '=', $this.text());
 			});
 		});
 	}
@@ -781,11 +776,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return this.settings.get_form_link(doc);
 		}
 
-		const docname = doc.name.match(/[%'"]/)
-			? encodeURIComponent(doc.name)
-			: doc.name;
-
-		return '#Form/' + this.doctype + '/' + docname;
+		return '#Form/' + this.doctype + '/' + encodeURIComponent(doc.name);
 	}
 
 	get_seen_class(doc) {

--- a/frappe/public/js/frappe/ui/tag_editor.js
+++ b/frappe/public/js/frappe/ui/tag_editor.js
@@ -39,7 +39,7 @@ frappe.ui.TagEditor = Class.extend({
 						args: me.get_args(tag),
 						callback: function(r) {
 							var user_tags = me.user_tags ? me.user_tags.split(",") : [];
-							user_tags.push(tag)
+							user_tags.push(tag);
 							me.user_tags = user_tags.join(",");
 							me.on_change && me.on_change(me.user_tags);
 							frappe.tags.utils.fetch_tags();

--- a/frappe/public/js/frappe/ui/tags.js
+++ b/frappe/public/js/frappe/ui/tags.js
@@ -37,7 +37,15 @@ frappe.ui.Tags = class {
 		const me = this;
 		const select_tag = function() {
 			const tagValue = frappe.utils.xss_sanitise(me.$input.val());
-			me.addTag(tagValue);
+
+			if (tagValue.includes(",")) {
+				const tagValues = tagValue.split(",");
+				tagValues.forEach(tagValue => { me.addTag(tagValue) });
+			}
+			else {
+				me.addTag(tagValue);
+			}
+
 			me.$input.val('');
 		}
 
@@ -92,12 +100,12 @@ frappe.ui.Tags = class {
 	}
 
 	clearTags() {
-		this.$ul.find('.frappe-tag').remove();
+		this.$ul.find('.frappe-tag').parent('.tags-list-item').remove();
 		this.tagsList = [];
 	}
 
 	getListElement($element, className) {
-		let $li = $(`<li class="tags-list-item ${className}"></li>`);
+		let $li = $(`<li class="tags-list-item ${className || ""}"></li>`);
 		$element.appendTo($li);
 		return $li;
 	}
@@ -105,7 +113,7 @@ frappe.ui.Tags = class {
 	getTag(label) {
 		let $tag = $(`<div class="frappe-tag btn-group" data-tag-label="${label}">
 			<button class="btn btn-default btn-xs toggle-tag"
-				title="${ __("toggle Tag") }"
+				title="${ __("Toggle Tag") }"
 				data-tag-label="${label}">#${label}
 			</button>
 			<button class="btn btn-default btn-xs remove-tag"
@@ -118,7 +126,8 @@ frappe.ui.Tags = class {
 		let $removeTag = $tag.find(".remove-tag");
 
 		$searchTag.on("click", () => {
-			frappe.searchdialog.search.init_search("#".concat($searchTag.attr('data-tag-label')), "tags");
+			const tagLabel = frappe.utils.xss_sanitise($searchTag.attr('data-tag-label'));
+			frappe.searchdialog.search.init_search("#".concat(tagLabel), "tags");
 		});
 
 		$removeTag.on("click", () => {

--- a/frappe/public/js/frappe/ui/tags.js
+++ b/frappe/public/js/frappe/ui/tags.js
@@ -40,9 +40,8 @@ frappe.ui.Tags = class {
 
 			if (tagValue.includes(",")) {
 				const tagValues = tagValue.split(",");
-				tagValues.forEach(tagValue => { me.addTag(tagValue) });
-			}
-			else {
+				tagValues.forEach(tagValue => me.addTag(tagValue));
+			} else {
 				me.addTag(tagValue);
 			}
 

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -248,7 +248,7 @@ frappe.utils.xss_sanitise = function (string, options) {
 		for (let char in HTML_ESCAPE_MAP) {
 			const escape = HTML_ESCAPE_MAP[char];
 			const regex = new RegExp(char, "g");
-			sanitised = sanitised.replace(regex, escape);
+			sanitised = sanitised.replace(regex, escape + ";");
 		}
 	}
 


### PR DESCRIPTION
Resolves #9757

**tags.js**
- While creating a new tag, if the value contains a comma, the same is broken into multiple tags now

![image](https://user-images.githubusercontent.com/38958184/96141103-4f5f1900-0f1e-11eb-9e9f-1190080249a4.png)

- `tags.clearTags` previously left a parent element which causes extra whitespace at the beginning of tag editor, fixed

**Before:**

![Screenshot from 2020-10-15 19-16-51](https://user-images.githubusercontent.com/38958184/96141175-6271e900-0f1e-11eb-9a9f-075eb4c439e6.png) 

**After:**

![image](https://user-images.githubusercontent.com/38958184/96142546-db257500-0f1f-11eb-8706-59213d7771c1.png)


- fixed `getListElement` to use `className` only when it exists

![image](https://user-images.githubusercontent.com/38958184/96141505-b67ccd80-0f1e-11eb-8862-3896e9bd3125.png)

- proper case for button title "Toggle Tag"
- XSS sanitize tag label before performing a global search for it

**Other changes**
- `frappe.utils.xss_sanitise` was previously mistakenly changing user input. For example: `a/b` became `a˻` because the HTML entity `&#x2Fb` points to another character (`˻`). Fixed by adding a semicolon at end of HTML entity. Added monkey patch to fix existing broken tag names (tested locally).

**Before:**

 ![image](https://user-images.githubusercontent.com/38958184/96141674-de6c3100-0f1e-11eb-807e-e8d21b21839e.png)  

**After:**

![image](https://user-images.githubusercontent.com/38958184/96142202-723dfd00-0f1f-11eb-9260-7454d9db82f9.png)


- XSS sanitize tag label before filtering a list

![image](https://user-images.githubusercontent.com/38958184/96141911-18d5ce00-0f1f-11eb-8b38-19645d31b528.png)

- List View links: encode all values of `doc.name`, not just those that contain specific characters. Helps with accessing tags from the `Tag List`
- `on_change` not really needed when creating a tag editor for the form sidebar, since the refresh method of the tag editor has no additional effect
- fixed unrelated issue with translation in `form_sidebar.js` (because frappe linter was complaining)
- removed click listener for `.tagit-label`, no element with this class exists
- removed extra whitespace