### PR TITLE
fix: broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Full-stack web application framework that uses Python and MariaDB on the server 
 
 ## Contributing
 
-1. [Pull Request Requirements](https://github.com/frappe/erpnext/wiki/Pull-Request-Guidelines)
+1. [Contribution Guidelines](https://github.com/frappe/erpnext/wiki/Contribution-Guidelines)
 1. [Translations](https://translate.erpnext.com)
 
 ### Website


### PR DESCRIPTION
Current link redirects to a new wiki page.
To validate, note that same link has been added to the [Contributing section in ERPNext's README](https://github.com/frappe/erpnext#contributing).