### PR TITLE
fix: validate email id before passing to formataddr

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -66,9 +66,14 @@ def get_email_address(user=None):
 def get_formatted_email(user, mail=None):
 	"""get Email Address of user formatted as: `John Doe <johndoe@example.com>`"""
 	fullname = get_fullname(user)
+
 	if not mail:
-		mail = get_email_address(user)
-	return cstr(make_header(decode_header(formataddr((fullname, mail)))))
+		mail = get_email_address(user) or validate_email_address(user)
+
+	if not mail:
+		return ''
+	else:
+		return cstr(make_header(decode_header(formataddr((fullname, mail)))))
 
 def extract_email_id(email):
 	"""fetch only the email part of the Email Address"""

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -10,7 +10,7 @@ import functools
 from .html_utils import sanitize_html
 import frappe
 from frappe.utils.identicon import Identicon
-from email.utils import parseaddr, formataddr, cstr
+from email.utils import parseaddr, formataddr
 from email.header import decode_header, make_header
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -10,7 +10,7 @@ import functools
 from .html_utils import sanitize_html
 import frappe
 from frappe.utils.identicon import Identicon
-from email.utils import parseaddr, formataddr
+from email.utils import parseaddr, formataddr, cstr
 from email.header import decode_header, make_header
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/background_jobs.py", line 100, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 793, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 309, in receive
    communication.notify(attachments=attachments, fetched_from_email_account=True)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/core/doctype/communication/communication.py", line 205, in notify
    fetched_from_email_account)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 126, in notify
    fetched_from_email_account=fetched_from_email_account)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 184, in get_recipients_cc_and_bcc
    cc = get_cc(doc, recipients, fetched_from_email_account=fetched_from_email_account)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 314, in get_cc
    cc.append(get_owner_email(doc))
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 417, in get_owner_email
    return get_formatted_email(owner) or owner
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/__init__.py", line 71, in get_formatted_email
    return cstr(make_header(decode_header(formataddr((fullname, mail)))))
  File "/usr/lib64/python3.6/email/utils.py", line 91, in formataddr
    address.encode('ascii')
AttributeError: 'NoneType' object has no attribute 'encode'
```