### PR TITLE
fix: patch breaks if reference doctype doesn't exist

### DIFF
--- a/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
+++ b/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
@@ -23,10 +23,14 @@ def execute():
 
 	for doc in assignments:
 		assignments = doc.assignees.split(',')
-		frappe.db.set_value(
-			doc.reference_type,
-			doc.reference_name,
-			'_assign',
-			frappe.as_json(assignments),
-			update_modified=False
-		)
+		try:
+			frappe.db.set_value(
+				doc.reference_type,
+				doc.reference_name,
+				'_assign',
+				frappe.as_json(assignments),
+				update_modified=False
+			)
+
+		except frappe.db.ProgrammingError:
+			pass


### PR DESCRIPTION
`set_correct_assign_value_in_docs` fails if the reference doctype does not exist.