### PR TITLE
fix: use configured postgres port in setup_db

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -20,8 +20,9 @@ def setup_database(force, source_sql=None, verbose=False):
 		source_sql = os.path.join(os.path.dirname(__file__), 'framework_postgres.sql')
 
 	subprocess.check_output([
-		'psql', frappe.conf.db_name, '-h', frappe.conf.db_host or 'localhost', '-U',
-		frappe.conf.db_name, '-f', source_sql
+		'psql', frappe.conf.db_name, '-h', frappe.conf.db_host or 'localhost', 
+		'-p', str(frappe.conf.db_port or '5432'), '-U', frappe.conf.db_name,
+		'-f', source_sql
 	], env=subprocess_env)
 
 	frappe.connect()

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -20,8 +20,10 @@ def setup_database(force, source_sql=None, verbose=False):
 		source_sql = os.path.join(os.path.dirname(__file__), 'framework_postgres.sql')
 
 	subprocess.check_output([
-		'psql', frappe.conf.db_name, '-h', frappe.conf.db_host or 'localhost', 
-		'-p', str(frappe.conf.db_port or '5432'), '-U', frappe.conf.db_name,
+		'psql', frappe.conf.db_name,
+		'-h', frappe.conf.db_host or 'localhost',
+		'-p', str(frappe.conf.db_port or '5432'),
+		'-U', frappe.conf.db_name,
 		'-f', source_sql
 	], env=subprocess_env)
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

When a non-standard port is used for PostgreSQL, the `bench new-site` command fails when
calling out to `psql` because no argument is given to psql to specify the port.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This PR adds an argument to specify the port for `psql` in `frappe/database/postgres/setup_db.py`.