### PR TITLE
fix: Link Preview not working for Link fields with indicator formatters

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1517,11 +1517,12 @@ frappe.ui.form.Form = class FrappeForm {
 
 					const escaped_name = encodeURIComponent(value);
 
-					return repl('<a class="indicator %(color)s" href="#Form/%(doctype)s/%(name)s">%(label)s</a>', {
+					return repl('<a class="indicator %(color)s" href="#Form/%(doctype)s/%(escaped_name)s" data-doctype="%(doctype)s" data-name="%(name)s">%(label)s</a>', {
 						color: get_color(doc || {}),
 						doctype: df.options,
-						name: escaped_name,
-						label: label
+						escaped_name: escaped_name,
+						label: label,
+						name: value
 					});
 				} else {
 					return '';


### PR DESCRIPTION
**Before:**

![link-preview-before](https://user-images.githubusercontent.com/24353136/96372111-0eb40980-1183-11eb-81a8-ad5abf2bd1d0.gif)


**After:**

The data attributes for doctype and name are not set in the `set_indicator_formatter` function and link preview checks for these link classes. Hence the popover was not working for link fields with indicator formatters.

![link-preview-after](https://user-images.githubusercontent.com/24353136/96372000-62722300-1182-11eb-92a4-8e8e738f5976.gif)
