### PR TITLE
fix: Trim long names in website navbar by adding ellipsis

### DIFF
--- a/frappe/public/scss/website.scss
+++ b/frappe/public/scss/website.scss
@@ -160,3 +160,16 @@ h5.modal-title {
 .pull-right {
 	float: right;
 }
+
+.ellipsis {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 100%;
+	vertical-align: middle;
+}
+
+.logged-in > .nav-link {
+	max-width: 200px;
+	@extend .ellipsis;
+}


### PR DESCRIPTION
**Before:**
<img width="1142" alt="Screenshot 2020-10-19 at 9 34 22 AM" src="https://user-images.githubusercontent.com/13928957/96400579-bb77a080-11ee-11eb-844e-8a1e814db50b.png">

**After:**
<img width="1160" alt="Screenshot 2020-10-19 at 9 35 05 AM" src="https://user-images.githubusercontent.com/13928957/96400576-b87cb000-11ee-11eb-964b-e6d4444f9be1.png">


