### PR TITLE
fix(Email Account): Auto contact creation

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -260,10 +260,8 @@ class Communication(Document):
 	# Timeline Links
 	def set_timeline_links(self):
 		contacts = []
-		if (self.email_account and frappe.db.get_value("Email Account", self.email_account, "create_contact")) or \
-			frappe.flags.in_test:
-
-			contacts = get_contacts([self.sender, self.recipients, self.cc, self.bcc])
+		create_contact_enabled = self.email_account and frappe.db.get_value("Email Account", self.email_account, "create_contact")
+		contacts = get_contacts([self.sender, self.recipients, self.cc, self.bcc], auto_create_contact=create_contact_enabled)
 
 		for contact_name in contacts:
 			self.add_link('Contact', contact_name)
@@ -342,7 +340,7 @@ def get_permission_query_conditions_for_communication(user):
 		return """`tabCommunication`.email_account in ({email_accounts})"""\
 			.format(email_accounts=','.join(email_accounts))
 
-def get_contacts(email_strings):
+def get_contacts(email_strings, auto_create_contact=False):
 	email_addrs = []
 
 	for email_string in email_strings:
@@ -357,7 +355,7 @@ def get_contacts(email_strings):
 		email = get_email_without_link(email)
 		contact_name = get_contact_name(email)
 
-		if not contact_name and email:
+		if not contact_name and email and auto_create_contact:
 			email_parts = email.split("@")
 			first_name = frappe.unscrub(email_parts[0])
 


### PR DESCRIPTION
#10256 added a check to auto create contact only if Email Account has Create Contact checked.

This was supposed to stop auto creation of contacts, however it prevented adding timeline links if no email account was set in the communication document which breaks [email aggregation](https://docs.erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document#1-email-aggregation-for-customer-and-supplier)