### PR TITLE
fix: TypeError on saving web form and other fixes

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -933,6 +933,9 @@ def attach_files_to_document(doc, event):
 	the file url to the document if it is not already attached.
 	"""
 
+	if frappe.flags.in_web_form:
+		return
+
 	attach_fields = doc.meta.get(
 		"fields", {"fieldtype": ["in", ["Attach", "Attach Image"]]}
 	)

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -69,6 +69,11 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 			options.fieldname = this.df.fieldname;
 		}
 
+		if (frappe.web_form && frappe.web_form.doc && frappe.web_form.doc.name) {
+			options.doctype = frappe.web_form.doc.doctype;
+			options.docname = frappe.web_form.doc.name;
+		}
+
 		if (this.df.options) {
 			Object.assign(options, this.df.options);
 		}
@@ -103,6 +108,11 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 			this.frm.attachments.update_attachment(attachment);
 			this.frm.doc.docstatus == 1 ? this.frm.save('Update') : this.frm.save();
 		}
+
+		if (frappe.web_form) {
+			frappe.web_form.files.push(attachment);
+		}
+
 		this.set_value(attachment.file_url);
 	},
 

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -7,14 +7,15 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		super();
 		Object.assign(this, opts);
 		frappe.web_form = this;
-		frappe.web_form.events = {};
-		Object.assign(frappe.web_form.events, EventEmitterMixin);
+
+		this.events = Object.assign({}, EventEmitterMixin);
 	}
 
 	prepare(web_form_doc, doc) {
 		Object.assign(this, web_form_doc);
 		this.fields = web_form_doc.web_form_fields;
 		this.doc = doc;
+		this.files = [];
 	}
 
 	make() {
@@ -130,6 +131,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 				data: this.doc,
 				web_form: this.name,
 				docname: this.doc.name,
+				files: this.files,
 				for_payment
 			},
 			callback: response => {
@@ -174,6 +176,8 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		if (this.accept_payment && !this.doc.paid) {
 			window.location.href = data;
 		}
+
+		this.files.length = 0;
 
 		const success_dialog = new frappe.ui.Dialog({
 			title: __("Saved Successfully"),

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -17,6 +17,7 @@ class TestWebForm(unittest.TestCase):
 
 	def tearDown(self):
 		frappe.conf.disable_website_cache = False
+		frappe.flags.in_web_form = False
 		frappe.local.path = None
 
 	def test_accept(self):

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -368,12 +368,14 @@ def get_context(context):
 
 
 @frappe.whitelist(allow_guest=True)
-def accept(web_form, data, docname=None, for_payment=False):
+def accept(web_form, data, docname=None, files=None, for_payment=False):
 	'''Save the web form'''
 	data = frappe._dict(json.loads(data))
+	files = json.loads(files) if files else []
 	for_payment = frappe.parse_json(for_payment)
 
-	files = []
+	base64_files = []
+	files_to_keep = []
 	files_to_delete = []
 
 	web_form = frappe.get_doc("Web Form", web_form)
@@ -407,6 +409,9 @@ def accept(web_form, data, docname=None, for_payment=False):
 			elif not value and doc.get(fieldname):
 				files_to_delete.append(doc.get(fieldname))
 
+			elif value:
+				files_to_keep.append(value)
+
 		doc.set(fieldname, value)
 
 	if for_payment:
@@ -425,39 +430,51 @@ def accept(web_form, data, docname=None, for_payment=False):
 		if web_form.login_required and frappe.session.user=="Guest":
 			frappe.throw(_("You must login to submit this form"))
 
-		ignore_mandatory = True if files else False
+		ignore_mandatory = True if base64_files else False
 
 		doc.insert(ignore_permissions = True, ignore_mandatory = ignore_mandatory)
 
-	# add files
-	if files:
-		for f in files:
-			fieldname, filedata = f
+	# add base64 files
+	for f in base64_files:
+		fieldname, filedata = f
 
-			# remove earlier attached file (if exists)
-			if doc.get(fieldname):
-				remove_file_by_url(doc.get(fieldname), doctype=doc.doctype, name=doc.name)
+		# remove earlier attached file (if exists)
+		if doc.get(fieldname):
+			remove_file_by_url(doc.get(fieldname), doctype=doc.doctype, name=doc.name)
 
-			# save new file
-			filename, dataurl = filedata.split(',', 1)
-			_file = frappe.get_doc({
-				"doctype": "File",
-				"file_name": filename,
-				"attached_to_doctype": doc.doctype,
-				"attached_to_name": doc.name,
-				"content": dataurl,
-				"decode": True})
-			_file.save()
+		# save new file
+		filename, dataurl = filedata.split(',', 1)
+		_file = frappe.get_doc({
+			"doctype": "File",
+			"file_name": filename,
+			"attached_to_doctype": doc.doctype,
+			"attached_to_name": doc.name,
+			"content": dataurl,
+			"decode": True})
+		_file.save()
 
-			# update values
-			doc.set(fieldname, _file.file_url)
-
+		# update values
+		doc.set(fieldname, _file.file_url)
 		doc.save(ignore_permissions = True)
 
-	if files_to_delete:
-		for f in files_to_delete:
-			if f:
-				remove_file_by_url(f, doctype=doc.doctype, name=doc.name)
+	for f in files:
+		f = frappe._dict(f)
+		if f.file_url not in files_to_keep:
+			frappe.delete_doc('File', f.name, ignore_permissions=True)
+			continue
+
+		_file = frappe.get_doc('File', f.name)
+		if _file.attached_to_doctype and _file.attached_to_name:
+			# already attached to a document, do nothing
+			continue
+
+		_file.attached_to_doctype = doc.doctype
+		_file.attached_to_name = doc.name
+		_file.save(ignore_permissions=True)
+
+
+	for f in files_to_delete:
+		remove_file_by_url(f, doctype=doc.doctype, name=doc.name)
 
 
 	frappe.flags.web_form_doc = doc

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -183,7 +183,7 @@ def get_list(doctype, txt, filters, limit_start, limit_page_length=20, ignore_pe
 		filters = []
 
 	if not fields:
-		fields = "distinct *"
+		fields = "*"
 
 	or_filters = []
 
@@ -201,5 +201,5 @@ def get_list(doctype, txt, filters, limit_start, limit_page_length=20, ignore_pe
 	return frappe.get_list(doctype, fields = fields,
 		filters=filters, or_filters=or_filters, limit_start=limit_start,
 		limit_page_length = limit_page_length, ignore_permissions=ignore_permissions,
-		order_by=order_by)
+		order_by=order_by, distinct=True)
 


### PR DESCRIPTION
Continued from #11677
- Fixed issue by returning from `attach_files_to_document` if in web form. (and related broken test)
- All changes now in one commit