### PR TITLE
fix: don't allow user to delete standard report

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -49,6 +49,8 @@ class Report(Document):
 		self.export_doc()
 
 	def on_trash(self):
+		if self.is_standard == 'Yes' and not cint(getattr(frappe.local.conf, 'developer_mode',0)):
+			frappe.throw(_("Can't Delete Standard Report"))
 		delete_custom_role('report', self.name)
 
 	def get_columns(self):

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -50,7 +50,7 @@ class Report(Document):
 
 	def on_trash(self):
 		if self.is_standard == 'Yes' and not cint(getattr(frappe.local.conf, 'developer_mode',0)):
-			frappe.throw(_("Can't Delete Standard Report"))
+			frappe.throw(_("You are not allowed to delete Standard Report"))
 		delete_custom_role('report', self.name)
 
 	def get_columns(self):


### PR DESCRIPTION
**Issue -** User can delete standard-reports even after developer mode is disabled.