### PR TITLE
refactor: Login Code Size too Small on Mobile

### DIFF
--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -225,7 +225,11 @@ def get_email_subject_for_2fa(kwargs_dict):
 
 def get_email_body_for_2fa(kwargs_dict):
 	'''Get email body for 2fa.'''
-	body_template = 'Enter this code to complete your login:<br><br> <span style="font-size:18px;font-weight:bold;">{{otp}}</span>'
+	body_template = """
+		Enter this code to complete your login:
+		<br><br>
+		<b style="font-size: 18px;">{{ otp }}</b>
+	"""
 	body = frappe.render_template(body_template, kwargs_dict)
 	return body
 

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -225,7 +225,7 @@ def get_email_subject_for_2fa(kwargs_dict):
 
 def get_email_body_for_2fa(kwargs_dict):
 	'''Get email body for 2fa.'''
-	body_template = 'Enter this code to complete your login:<br><br> <b>{{otp}}</b>'
+	body_template = 'Enter this code to complete your login:<br><br> <span style="font-size:18px;font-weight:bold;">{{otp}}</span>'
 	body = frappe.render_template(body_template, kwargs_dict)
 	return body
 


### PR DESCRIPTION
**Problem:**
Currently, when a Login Code is received on a phone, it is tiny and is very hard to copy. The login code should be a little bigger than other text by design too.

![hb8IfyR](https://user-images.githubusercontent.com/16913064/96602523-bc085800-1310-11eb-9806-3adf7f360c05.png)

**Solution:**
Increased the size from default 14 px to 18 px.

