### PR TITLE
chore: git url format for air-datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://frappeframework.com",
   "dependencies": {
     "ace-builds": "^1.4.8",
-    "air-datepicker": "git+https://github.com/frappe/air-datepicker.git",
+    "air-datepicker": "github:frappe/air-datepicker",
     "autoprefixer": "^9.8.6",
     "awesomplete": "^1.1.5",
     "bootstrap": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://frappeframework.com",
   "dependencies": {
     "ace-builds": "^1.4.8",
-    "air-datepicker": "http://github.com/frappe/air-datepicker",
+    "air-datepicker": "git+https://github.com/frappe/air-datepicker.git",
     "autoprefixer": "^9.8.6",
     "awesomplete": "^1.1.5",
     "bootstrap": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,9 +348,9 @@ agent-base@~4.2.1:
   dependencies:
     es6-promisify "^5.0.0"
 
-"air-datepicker@git+https://github.com/frappe/air-datepicker.git":
+"air-datepicker@github:frappe/air-datepicker":
   version "2.2.3"
-  resolved "git+https://github.com/frappe/air-datepicker.git#ed37b94d95c68d8544357e330be0c89d044a3eea"
+  resolved "https://codeload.github.com/frappe/air-datepicker/tar.gz/ed37b94d95c68d8544357e330be0c89d044a3eea"
   dependencies:
     jquery ">=2.0.0 <4.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,9 +348,9 @@ agent-base@~4.2.1:
   dependencies:
     es6-promisify "^5.0.0"
 
-"air-datepicker@http://github.com/frappe/air-datepicker":
+"air-datepicker@git+https://github.com/frappe/air-datepicker.git":
   version "2.2.3"
-  resolved "http://github.com/frappe/air-datepicker#ed37b94d95c68d8544357e330be0c89d044a3eea"
+  resolved "git+https://github.com/frappe/air-datepicker.git#ed37b94d95c68d8544357e330be0c89d044a3eea"
   dependencies:
     jquery ">=2.0.0 <4.0.0"
 


### PR DESCRIPTION
The npm documentation explains a different format for dependencies from github: https://docs.npmjs.com/files/package.json#git-urls-as-dependencies

I had issues because `npm install` tried to do some stuff over ssh, which couldn't be done without configuring ssh, which is why I guess `bench build` failed. Whatever the reason for npms behaviour was, this seems to work and not cause this.