### PR TITLE
fix: Webform file permission

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -30,6 +30,7 @@ import frappe
 from frappe import _, conf
 from frappe.model.document import Document
 from frappe.utils import call_hook_method, cint, cstr, encode, get_files_path, get_hook_method, random_string, strip
+from frappe.permissions import has_web_form_permission
 
 
 class MaxFileSizeReachedError(frappe.ValidationError):
@@ -730,7 +731,7 @@ def has_permission(doc, ptype=None, user=None):
 			ref_doc = frappe.get_doc(attached_to_doctype, attached_to_name)
 
 			if ptype in ['write', 'create', 'delete']:
-				has_access = ref_doc.has_permission('write')
+				has_access = ref_doc.has_permission('write') or has_web_form_permission(attached_to_doctype, attached_to_name, ptype='write')
 
 				if ptype == 'delete' and not has_access:
 					frappe.throw(_("Cannot delete file as it belongs to {0} {1} for which you do not have permissions").format(

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -352,4 +352,26 @@ class TestFile(unittest.TestCase):
 		self.assertEqual(file1.file_url, file2.file_url)
 		self.assertTrue(os.path.exists(file2.get_full_path()))
 
-
+	def test_website_user_file_permission(self):
+		# Website User should be able to attach a file
+		# if they have write access to a document
+		from frappe.core.doctype.file.file import File
+		user = frappe.get_doc(dict(
+			doctype='User',
+			email='test-file-perm@example.com',
+			first_name='Tester'
+		))
+		user.insert(ignore_if_duplicate=True)
+		frappe.set_user('test-file-perm@example.com')
+		txt_file = frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'file3.txt',
+			"attached_to_doctype": 'User',
+			"attached_to_name": user.name,
+			"content": test_content1
+		})
+		txt_file.insert()
+		# creation of file should not fail
+		# because user gets permission via has_web_form_permission
+		self.assertIsInstance(txt_file, File)
+		frappe.set_user('Administrator')

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -549,3 +549,26 @@ def filter_allowed_docs_for_doctype(user_permissions, doctype, with_default_doc=
 def push_perm_check_log(log):
 	if frappe.flags.get('has_permission_check_logs') == None: return
 	frappe.flags.get('has_permission_check_logs').append(_(log))
+
+def has_web_form_permission(doctype, name, ptype='read'):
+	if frappe.session.user=="Guest":
+		return False
+
+	# owner matches
+	elif frappe.db.get_value(doctype, name, "owner")==frappe.session.user:
+		return True
+
+	elif frappe.has_website_permission(name, ptype=ptype, doctype=doctype):
+		return True
+
+	elif check_webform_perm(doctype, name):
+		return True
+
+	else:
+		return False
+
+def check_webform_perm(doctype, name):
+	doc = frappe.get_doc(doctype, name)
+	if hasattr(doc, "has_webform_permission"):
+		if doc.has_webform_permission():
+			return True

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -551,11 +551,12 @@ def push_perm_check_log(log):
 	frappe.flags.get('has_permission_check_logs').append(_(log))
 
 def has_web_form_permission(doctype, name, ptype='read'):
-	if frappe.session.user=="Guest":
+	user = frappe.session.user
+	if user == "Guest":
 		return False
 
 	# owner matches
-	elif frappe.db.get_value(doctype, name, "owner")==frappe.session.user:
+	elif user == frappe.get_cached_value(doctype, name, "owner"):
 		return True
 
 	elif frappe.has_website_permission(name, ptype=ptype, doctype=doctype):

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -68,6 +68,11 @@ frappe.ui.form.ControlAttach = frappe.ui.form.ControlData.extend({
 			options.docname = this.frm.docname;
 		}
 
+		if (this.doc) {
+			options.doctype = this.doc.doctype;
+			options.docname = this.doc.name;
+		}
+
 		if (this.df.options) {
 			Object.assign(options, this.df.options);
 		}

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -138,16 +138,6 @@ export default class WebForm extends frappe.ui.FieldGroup {
 					this.handle_success(response.message);
 					frappe.web_form.events.trigger('after_save');
 					this.after_save && this.after_save();
-					// args doctype and docname added to link doctype in file manager
-					frappe.call({
-						type: 'POST',
-						method: "frappe.handler.upload_file",
-						args: {
-							file_url: response.message.attachment,
-							doctype: response.message.doctype,
-							docname: response.message.name
-						}
-					});
 				}
 			},
 			always: function() {

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -14,6 +14,7 @@ from frappe.modules.utils import export_module_json, get_doc_module
 from six.moves.urllib.parse import urlencode
 from frappe.integrations.utils import get_payment_gateway_controller
 from six import iteritems
+from frappe.permissions import has_web_form_permission
 
 
 class WebForm(WebsiteGenerator):
@@ -460,31 +461,6 @@ def delete_multiple(web_form_name, docnames):
 
 	if restricted_docnames:
 		raise frappe.PermissionError("You do not have permisssion to delete " + ", ".join(restricted_docnames))
-
-
-def has_web_form_permission(doctype, name, ptype='read'):
-	if frappe.session.user=="Guest":
-		return False
-
-	# owner matches
-	elif frappe.db.get_value(doctype, name, "owner")==frappe.session.user:
-		return True
-
-	elif frappe.has_website_permission(name, ptype=ptype, doctype=doctype):
-		return True
-
-	elif check_webform_perm(doctype, name):
-		return True
-
-	else:
-		return False
-
-
-def check_webform_perm(doctype, name):
-	doc = frappe.get_doc(doctype, name)
-	if hasattr(doc, "has_webform_permission"):
-		if doc.has_webform_permission():
-			return True
 
 @frappe.whitelist(allow_guest=True)
 def get_web_form_filters(web_form_name):


### PR DESCRIPTION
All files uploaded via webform should be properly linked to the actual document.

Previously, [we used to re-attach file](https://github.com/surajshetty3416/frappe/blob/version-12-hotfix/frappe/public/js/frappe/web_form/web_form.js#L142) after successfully saving the document. Now it is no more required because we can pass `doctype` & `docname` while uploading the file.

It also avoids the following issue while saving the user profile.
<img width="826" alt="Screenshot 2020-10-21 at 1 50 09 PM" src="https://user-images.githubusercontent.com/13928957/96693001-5bc2f600-13a4-11eb-9953-708bbd59ce82.png">

