### PR TITLE
fix(Website): Add noreferrer policy to footer links

### DIFF
--- a/frappe/templates/includes/footer/footer_grouped_links.html
+++ b/frappe/templates/includes/footer/footer_grouped_links.html
@@ -15,7 +15,7 @@
 				<ul class="footer-group-links list-unstyled">
 					{%- for child in group.child_items -%}
 					<li class="footer-child-item" data-label="{{ child.label }}">
-						<a href="{{ child.url | abs_url }}" {% if child.target %} target="_blank" {% endif %}>
+						<a href="{{ child.url | abs_url }}" {% if child.target %} target="_blank" {% endif %} rel="noreferrer">
 							{%- if child.icon -%}
 							<img src="{{ child.icon }}" alt="{{ child.label }}">
 							{%- else -%}

--- a/frappe/templates/includes/footer/footer_links.html
+++ b/frappe/templates/includes/footer/footer_links.html
@@ -1,5 +1,5 @@
 {% macro footer_link(item) %}
-<a href="{{ item.url | abs_url }}" {{ item.target }} class="footer-link">
+<a href="{{ item.url | abs_url }}" {{ item.target }} class="footer-link"  rel="noreferrer">
 	{%- if item.icon -%}
 	<img src="{{ item.icon }}" alt="{{ item.label }}">
 	{%- else -%}


### PR DESCRIPTION
When a reset password link is opened there is a token in the URL as a get parameter
`/update-password?key=x` where x is a 32 character hash.

Now when you click on social media links in the footer on this page this token is sent in the referrer header to the target website.

![image](https://user-images.githubusercontent.com/15175501/96703861-faedea80-13b0-11eb-9a41-c85fd82a29a3.png)

This token can be abused to take over accounts.

Using the ["noreferrer" value for "rel"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) attribute to prevent sending that header.