### PR TITLE
refactor: Set label as State/Province in Address instead of just State

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -75,7 +75,7 @@
   {
    "fieldname": "state",
    "fieldtype": "Data",
-   "label": "State"
+   "label": "State/Province"
   },
   {
    "fieldname": "country",
@@ -148,7 +148,7 @@
  "icon": "fa fa-map-marker",
  "idx": 5,
  "links": [],
- "modified": "2020-10-14 17:38:08.971776",
+ "modified": "2020-10-21 16:14:37.284830",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",


### PR DESCRIPTION
Using only "State" for geography cannot be translated, because at other times this refers to the status kind of state, which breaks sentences outside of the Address doctype