### PR TITLE
fix: Allow report deletion during migration

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -50,8 +50,8 @@ class Report(Document):
 
 	def on_trash(self):
 		if (self.is_standard == 'Yes' 
-		    and not cint(getattr(frappe.local.conf, 'developer_mode', 0)) 
-		    and not frappe.flags.in_patch):
+			and not cint(getattr(frappe.local.conf, 'developer_mode', 0)) 
+			and not frappe.flags.in_patch):
 			frappe.throw(_("You are not allowed to delete Standard Report"))
 		delete_custom_role('report', self.name)
 

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -49,8 +49,9 @@ class Report(Document):
 		self.export_doc()
 
 	def on_trash(self):
-		if (self.is_standard == 'Yes' and
-			not cint(getattr(frappe.local.conf, 'developer_mode',0)) and not frappe.flags.in_patch):
+		if (self.is_standard == 'Yes' 
+		    and not cint(getattr(frappe.local.conf, 'developer_mode', 0)) 
+		    and not frappe.flags.in_patch):
 			frappe.throw(_("You are not allowed to delete Standard Report"))
 		delete_custom_role('report', self.name)
 

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -49,7 +49,8 @@ class Report(Document):
 		self.export_doc()
 
 	def on_trash(self):
-		if self.is_standard == 'Yes' and not cint(getattr(frappe.local.conf, 'developer_mode',0)):
+		if (self.is_standard == 'Yes' and
+			not cint(getattr(frappe.local.conf, 'developer_mode',0)) and not frappe.flags.in_patch):
 			frappe.throw(_("You are not allowed to delete Standard Report"))
 		delete_custom_role('report', self.name)
 


### PR DESCRIPTION
**Issue**

While executing the patch erpnext.patches.v8_1.delete_deprecated_reports, getting below error

```
Executing erpnext.patches.v8_1.delete_deprecated_reports in test_site (test_frappe)
Traceback (most recent call last):
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 99, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 287, in migrate
    skip_search_index=skip_search_index
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/patches/v8_1/delete_deprecated_reports.py", line 20, in execute
    frappe.delete_doc("Report", report, ignore_permissions=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 837, in delete_doc
    ignore_permissions, flags, ignore_on_trash, ignore_missing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 94, in delete_doc
    doc.run_method("on_trash")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 831, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1116, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1099, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 825, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 53, in on_trash
    frappe.throw(_("You are not allowed to delete Standard Report"))
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 413, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 392, in msgprint
    _raise_exception()
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 340, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: You are not allowed to delete Standard Report
```