### PR TITLE
fix: Allow standard report deletion from PATCH without enabling developer mode

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -49,7 +49,8 @@ class Report(Document):
 		self.export_doc()
 
 	def on_trash(self):
-		if self.is_standard == 'Yes' and not cint(getattr(frappe.local.conf, 'developer_mode',0)):
+		if self.is_standard == 'Yes' and not frappe.flags.in_patch \
+				and not cint(getattr(frappe.local.conf, 'developer_mode',0)):
 			frappe.throw(_("You are not allowed to delete Standard Report"))
 		delete_custom_role('report', self.name)
 


### PR DESCRIPTION
```
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/patches/v8_1/delete_deprecated_reports.py", line 20, in execute
    frappe.delete_doc("Report", report, ignore_permissions=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 805, in delete_doc
    ignore_permissions, flags, ignore_on_trash, ignore_missing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 95, in delete_doc
    doc.run_method("on_trash")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 791, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 53, in on_trash
    frappe.throw(_("You are not allowed to delete Standard Report"))
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 377, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 356, in msgprint
    _raise_exception()
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 316, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: You are not allowed to delete Standard Report
```