### PR TITLE
chore: Added change log

### DIFF
--- a/frappe/change_log/v12/v12_11_0.md
+++ b/frappe/change_log/v12/v12_11_0.md
@@ -1,0 +1,21 @@
+## Version 12.11.0 Release Notes
+
+### Fixes & Enhancements
+
+- Ability to rename and merge tags ([#11503](https://github.com/frappe/frappe/pull/11503))
+- Check for get_data function in get_modal_data ([#11516](https://github.com/frappe/frappe/pull/11516))
+- Include tab in special characters to match to encode url  ([#11531](https://github.com/frappe/frappe/pull/11531))
+- frappe.utils.formatdate not working in the jinja ([#11571](https://github.com/frappe/frappe/pull/11571))
+- Check indicator value only if indicator exists ([#11529](https://github.com/frappe/frappe/pull/11529))
+- Refresh data on individual chart refresh ([#11511](https://github.com/frappe/frappe/pull/11511))
+- S3 success email sent even when checkbox not selected ([#11606](https://github.com/frappe/frappe/pull/11606))
+- Newsletter email validation ([#11431](https://github.com/frappe/frappe/pull/11431))
+- Always add name & docstatus field to avoid permission error in report ([#11644](https://github.com/frappe/frappe/pull/11644))
+- Report name is mandatory while saving report ([#11573](https://github.com/frappe/frappe/pull/11573))
+- Validate whether file type is CSV in Grid Upload ([#11548](https://github.com/frappe/frappe/pull/11548))
+
+### Features
+
+- Allow sending emails via Server Script ([#11493](https://github.com/frappe/frappe/pull/11493))
+- Generate and attach assets to releases ([#11517](https://github.com/frappe/frappe/pull/11517))
+- Take file backup before uploading to Google Drive ([#11601](https://github.com/frappe/frappe/pull/11601))


### PR DESCRIPTION
## Version 12.11.0 Release Notes

### Fixes & Enhancements

- Ability to rename and merge tags ([#11503](https://github.com/frappe/frappe/pull/11503))
- Check for get_data function in get_modal_data ([#11516](https://github.com/frappe/frappe/pull/11516))
- Include tab in special characters to match to encode url  ([#11531](https://github.com/frappe/frappe/pull/11531))
- frappe.utils.formatdate not working in the jinja ([#11571](https://github.com/frappe/frappe/pull/11571))
- Check indicator value only if indicator exists ([#11529](https://github.com/frappe/frappe/pull/11529))
- Refresh data on individual chart refresh ([#11511](https://github.com/frappe/frappe/pull/11511))
- S3 success email sent even when checkbox not selected ([#11606](https://github.com/frappe/frappe/pull/11606))
- Newsletter email validation ([#11431](https://github.com/frappe/frappe/pull/11431))
- Always add name & docstatus field to avoid permission error in report ([#11644](https://github.com/frappe/frappe/pull/11644))
- Report name is mandatory while saving report ([#11573](https://github.com/frappe/frappe/pull/11573))
- Validate whether file type is CSV in Grid Upload ([#11548](https://github.com/frappe/frappe/pull/11548))

### Features

- Allow sending emails via Server Script ([#11493](https://github.com/frappe/frappe/pull/11493))
- Generate and attach assets to releases ([#11517](https://github.com/frappe/frappe/pull/11517))
- Take file backup before uploading to Google Drive ([#11601](https://github.com/frappe/frappe/pull/11601))
