### PR TITLE
fix: excluded disabled users from getting emails and notifications

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -61,7 +61,7 @@ def make_notification_logs(doc, users):
 	from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 
 	for user in users:
-		if frappe.db.exists('User', user):
+		if frappe.db.exists('User', {"name": user, "enabled": 1}):
 			if is_notifications_enabled(user):
 				if doc.type == 'Energy Point' and not is_energy_point_enabled():
 					return

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -168,8 +168,8 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 	"""
 	if not (assigned_by and owner and doc_type and doc_name): return
 
-	# self assignment / closing - no message
-	if assigned_by==owner:
+	# return if self assigned or user disabled
+	if assigned_by == owner or not frappe.db.get_value('User', owner, 'enabled'):
 		return
 
 	# Search for email address in description -- i.e. assignee
@@ -177,7 +177,7 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 	title = get_title(doc_type, doc_name)
 	description_html =  "<div>{0}</div>".format(description) if description else None
 
-	if action=='CLOSE':
+	if action == 'CLOSE':
 		subject = _('Your assignment on {0} {1} has been removed by {2}')\
 			.format(frappe.bold(doc_type), get_title_html(title), frappe.bold(user_name))
 	else:


### PR DESCRIPTION
Resolves : #11625 

- Added case to check if user is enabled or not
- Added a filter to check if user is enabled along with checking if user exists