### PR TITLE
fix(translations): Always apply user translations

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -128,8 +128,7 @@ def get_dict(fortype, name=None):
 
 	translation_map = translation_assets[asset_key]
 
-	if fortype == "boot":
-		translation_map.update(get_user_translations(frappe.local.lang))
+	translation_map.update(get_user_translations(frappe.local.lang))
 
 	return translation_map
 


### PR DESCRIPTION
- Always apply user translations while returning translation dict or else user translations are not applied for some specific page or views.


User translation is applied in global search (since it picks up from boot translations)
<img width="1196" alt="Screenshot 2020-10-24 at 10 59 08 AM" src="https://user-images.githubusercontent.com/13928957/97068735-fa8b6480-15e7-11eb-9336-bd731aa76393.png">

In the case of doctype specific translation, user translations were not getting applied.
<img width="1172" alt="Screenshot 2020-10-24 at 11 06 57 AM" src="https://user-images.githubusercontent.com/13928957/97068876-1ba08500-15e9-11eb-8a05-ae162534ff85.png">


**Note:**

User Translation: 
Shopify Settings -> Shopify-Einstellungen

Default Translation: 
Shopify Settings -> Einstellungen bearbeiten