### PR TITLE
fix: Build cookie jar only if request object is present

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -124,7 +124,7 @@ def prepare_options(html, options):
 
 def get_cookie_options():
 	options = {}
-	if frappe.session and frappe.session.sid:
+	if frappe.session and frappe.session.sid and hasattr(frappe.local, "request"):
 		# Use wkhtmltopdf's cookie-jar feature to set cookies and restrict them to host domain
 		cookiejar = "/tmp/{}.jar".format(frappe.generate_hash())
 


### PR DESCRIPTION
Fixes following random failure 

```
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 72, in __getattr__
    return self.__storage__[self.__ident_func__()][name]
KeyError: 'request'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/background_jobs.py", line 100, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py", line 197, in send_workflow_action_email
    common_args = get_common_email_args(doc)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/workflow/doctype/workflow_action/workflow_action.py", line 293, in get_common_email_args
    'attachments': [frappe.attach_print(doctype, docname , file_name=docname)],
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 1486, in attach_print
    content = get_print(doctype, name, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 1452, in get_print
    return get_pdf(html, output = output, options = options)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/pdf.py", line 27, in get_pdf
    html, options = prepare_options(html, options)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/pdf.py", line 116, in prepare_options
    options.update(get_cookie_options())
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/pdf.py", line 133, in get_cookie_options
    domain = frappe.local.request.host.split(":", 1)[0]
  File "/home/frappe/frappe-io-bench/env/lib/python3.6/site-packages/werkzeug/local.py", line 74, in __getattr__
    raise AttributeError(name)
AttributeError: request
```