### PR TITLE
fix: customize options in desk page rtl layout

### DIFF
--- a/frappe/public/less/desktop.less
+++ b/frappe/public/less/desktop.less
@@ -147,6 +147,12 @@
 	.desk-body {
 		padding-left: 0px;
 		padding-right: calc(20rem + 15px);
+
+		.desk-page.allow-customization {
+			.customize-options {
+				text-align: left;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
**Before:** (Words merged)
<img width="1218" alt="Screenshot 2020-10-24 at 3 23 15 PM" src="https://user-images.githubusercontent.com/19775888/97078872-f0c82800-160c-11eb-8051-b651609d4b44.png">


**After:**
<img width="1235" alt="Screenshot 2020-10-24 at 3 22 38 PM" src="https://user-images.githubusercontent.com/19775888/97078874-faea2680-160c-11eb-91d8-02d428813ffc.png">
