### PR TITLE
fix: disabled dashboard chart form fixes

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -21,8 +21,10 @@ frappe.ui.form.on('Dashboard Chart', {
 
 	refresh: function(frm) {
 		frm.chart_filters = null;
+		frm.is_disabled = !frappe.boot.developer_mode && frm.doc.is_standard;
 
-		if (!frappe.boot.developer_mode && frm.doc.is_standard) {
+		if (!frm.is_disabled) {
+			!frm.doc.custom_options && frm.set_df_property('chart_options_section', 'hidden', 1);
 			frm.disable_form();
 		}
 
@@ -333,6 +335,7 @@ frappe.ui.form.on('Dashboard Chart', {
 		}
 
 		table.on('click', () => {
+			frm.is_disabled && frappe.throw(__('Cannot edit filters for standard charts'));
 
 			let dialog = new frappe.ui.Dialog({
 				title: __('Set Filters'),


### PR DESCRIPTION
- Don't allow filters to be edited for standard charts

- Don't show empty Chart Options section:
<img width="1191" alt="Screenshot 2020-10-24 at 4 11 18 PM" src="https://user-images.githubusercontent.com/19775888/97079671-9383a500-1613-11eb-9dbc-38175d0fe5ef.png">

