### PR TITLE
fix(ui.Page): prevent duplicate fields so fields aren't "lost" from fields_dict

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -607,6 +607,11 @@ frappe.ui.Page = Class.extend({
 			df.placeholder = df.label;
 		}
 
+		var key = df.fieldname || df.label;
+		if (df.fieldtype != 'HTML' && this.fields_dict[key]) {
+			frappe.throw(`Attempt to add duplicate field ${key} to page.`);
+		}
+
 		var f = frappe.ui.form.make_control({
 			df: df,
 			parent: this.page_form,
@@ -639,11 +644,12 @@ frappe.ui.Page = Class.extend({
 
 		if(df["default"])
 			f.set_input(df["default"])
-		this.fields_dict[df.fieldname || df.label] = f;
+		this.fields_dict[key] = f;
 		return f;
 	},
 	clear_fields: function() {
 		this.page_form.empty();
+		this.fields_dict = {};
 	},
 	show_form: function() {
 		this.page_form.removeClass("hide");


### PR DESCRIPTION
  Prior to this change, you could add two fields with the same field name to
  a ui.Page object. This could cause multiple redundant fields to accumulate,
  for example in a Bank Reconciliation page if you selected "Reconcile
  this Account" multiple times. Worse, only one of the fields could be
  registered in the fields_dict directory for the Page, so only one of the
  fields would actually affect the user interface. If this happened, operation
  of the page could become inconsistent and confusing, especially if the two
  fields had inconsistent onchange actions.

  This change ensures that there can be at most one field on a Page with a
  given fieldname. It institutes a system of "importance" for deciding which
  field to keep when there is a conflict. It makes a tie in "importance" an
  error so that ambiguous cases will be caught and dealt with. Finally, it
  clears the fields_dict when the fields are cleared, so that there won't
  remain spurious references to fields that no longer exist.

Note that I do not recommend merging this PR until after the related ERPNext pull request (https://github.com/frappe/erpnext/pull/23721) or something along its lines has been merged. That's because without that change to ERPNext, the Bank Reconciliation screen does add multiple instances of the same fields (company and bank_account) to the same page, which would result in an error with the code in this PR.

Concerning that error: this PR as it stands makes it an error to attempt to add two identical fields to the same Page without specifying (by the "importance") attribute which should take precedence and be the only instance of that field on the page. This seemed the most conservative approach, as it is likely at least an oversight if not an outright problem. On the other hand, it is possible that there are other instances of duplicate fields sitting out there in ERPNext (or other Frappe applications, if there are any) and then this code would make those instances into errors.  So if the developers prefer, I would be happy to change this PR so that a second attempt to put the same field into a Page is not an error -- but if so, please let me know which is the desired behavior: the pre-existing field should remain, or the new field should replace it (I do think the existing behavior of keeping both fields should be abandoned, since only one can remain in the fields_dict, and so the other one is basically "lost" at that point -- its values will not be reported by "get_form_values," for example. Basically, the existence of duplicate fields was what was causing Bank Reconciliation of one account to show unreconciled transactions of a different account. So duplicate fields should be disallowed.