### PR TITLE
feat: Add module field in get_desk_sidebar_items

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -375,7 +375,7 @@ def get_desk_sidebar_items(flatten=False, cache=True):
 
 		# pages sorted based on pinned to top and then by name
 		order_by = "pin_to_top desc, pin_to_bottom asc, name asc"
-		all_pages = frappe.get_all("Desk Page", fields=["name", "category"], filters=filters, order_by=order_by, ignore_permissions=True)
+		all_pages = frappe.get_all("Desk Page", fields=["name", "category", "module"], filters=filters, order_by=order_by, ignore_permissions=True)
 		pages = []
 
 		# Filter Page based on Permission


### PR DESCRIPTION
`module` field required to filter selected modules from list of all modules due to `label` being different from `module` in some cases

> no-docs