### PR TITLE
fix: URI encode in case white spaces exist in docname

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -781,7 +781,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return this.settings.get_form_link(doc);
 		}
 
-		const docname = doc.name.match(/[%'"]/)
+		const docname = doc.name.match(/[%'"\s]/)
 			? encodeURIComponent(doc.name)
 			: doc.name;
 


### PR DESCRIPTION
Instead of writing a patch to fix all existing entries, why not make them accessible via `/desk` too?

> Correctness is important, but at what cost?

Alternative fix for https://github.com/frappe/frappe/pull/11666 to accommodate existing documents with trailing and/or leading whitespaces.