### PR TITLE
fix: Bug when running bench update-translations

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -588,13 +588,13 @@ def write_csv_file(path, app_messages, lang_dict):
 	"""
 	app_messages.sort(key = lambda x: x[1])
 	from csv import writer
-	with open(path, 'wb') as msgfile:
+	with open(path, 'w') as msgfile:
 		w = writer(msgfile, lineterminator='\n')
 		for p, m in app_messages:
 			t = lang_dict.get(m, '')
 			# strip whitespaces
 			t = re.sub('{\s?([0-9]+)\s?}', "{\g<1>}", t)
-			w.writerow([p.encode('utf-8') if p else '', m.encode('utf-8'), t.encode('utf-8')])
+			w.writerow([p if p else '', m, t])
 
 def get_untranslated(lang, untranslated_file, get_all=False):
 	"""Returns all untranslated strings for a language and writes in a file

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -588,7 +588,7 @@ def write_csv_file(path, app_messages, lang_dict):
 	"""
 	app_messages.sort(key = lambda x: x[1])
 	from csv import writer
-	with open(path, 'w') as msgfile:
+	with open(path, 'w', newline='') as msgfile:
 		w = writer(msgfile, lineterminator='\n')
 		for p, m in app_messages:
 			t = lang_dict.get(m, '')


### PR DESCRIPTION
This fixes the issue in https://github.com/frappe/frappe/issues/11738 in which type mismatch caused issues when running `bench update-translations`. This PR fixes the function `write_csv_file` by changing the open mode and removing the encoding step since this is handled by `csv.writer`. The method implemented was from over 5 years ago (python 2) when CSV had a different API:

1. http://python3porting.com/problems.html#csv-api-changes
2. https://docs.python.org/3/library/csv.html#id3

**This can be backported to version-12**

Closes: https://github.com/frappe/frappe/issues/11738