### PR TITLE
fix(UI): treats the scrollbar as an overlay

### DIFF
--- a/frappe/public/css/mobile.css
+++ b/frappe/public/css/mobile.css
@@ -10,6 +10,7 @@ body {
 html,
 body {
   overflow-x: hidden;
+  overflow-y: overlay;
 }
 @media (max-width: 991px) {
   .intro-area,

--- a/frappe/public/less/mobile.less
+++ b/frappe/public/less/mobile.less
@@ -15,6 +15,7 @@ body {
 html,
 body {
 	overflow-x: hidden;  //Prevent scroll on narrow devices
+	overflow-y: overlay;  
 }
 
 @media(max-width: 991px) {


### PR DESCRIPTION
Resolves #10625

- Treats the scrollbar as an overlay and hence doesn't deduct scrollbar width from overall body width calculation, thus keeps Desk page and header width consistent while switching between modules.

`overflow-y: overlay` is currently supported only by limited browsers which include Chrome and Safari.  

![image](https://user-images.githubusercontent.com/38958184/97390917-f458f900-1903-11eb-93ee-91e8720d0248.png)

See [here for the discussion](https://github.com/w3c/csswg-drafts/issues/92).

Tested locally for chrome; works as expected.

*Note: The `scrollbar-gutter` would be a good alternative but as per [this](https://www.chromestatus.com/feature/5746559209701376), the feature is still in development.

**Before:**
- Refer [this](https://github.com/frappe/frappe/issues/10625#issuecomment-643256896).

**After:**

![Peek 2020-10-27 15-44](https://user-images.githubusercontent.com/38958184/97288088-5e718f80-186b-11eb-8047-438601dd9942.gif)
