### PR TITLE
fix(pdf): PDF generation shouldn't fail in background jobs and tests

### DIFF
--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -47,3 +47,8 @@ class TestPdf(unittest.TestCase):
 		if six.PY2:
 			password = frappe.safe_encode(password)
 		self.assertTrue(reader.decrypt(password))
+
+	def test_pdf_generation_as_a_user(self):
+		frappe.set_user("Administrator")
+		pdf = pdfgen.get_pdf(self.html)
+		self.assertTrue(pdf)

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -112,8 +112,7 @@ def prepare_options(html, options):
 	options.update(html_options or {})
 
 	# cookies
-	if not frappe.flags.in_test:
-		options.update(get_cookie_options())
+	options.update(get_cookie_options())
 
 	# page size
 	if not options.get("page-size"):

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -129,7 +129,7 @@ def get_cookie_options():
 
 		# Remove port from request.host
 		# https://werkzeug.palletsprojects.com/en/0.16.x/wrappers/#werkzeug.wrappers.BaseRequest.host
-		domain = frappe.local.request.host.split(":", 1)[0]
+		domain = frappe.utils.get_host_name().split(":", 1)[0]
 		with open(cookiejar, "w") as f:
 			f.write("sid={}; Domain={};\n".format(frappe.session.sid, domain))
 


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/11469 relies on `frappe.local.request` to get host name during PDF generation, assuming `frappe.session` and `frappe.session.sid` won't be set in background jobs and tests (This was a bad assumption).

The tests pass if frappe.session is not set. This was caught in https://github.com/frappe/frappe/pull/11700 (and an incomplete fix was applied).

Note: Have added a PDF generation test with `frappe.set_user("Administrator")`

```python-traceback
Traceback (most recent call last):
  File "/home/aditya/Frappe/benches/press/env/lib/python3.7/site-packages/werkzeug/local.py", line 72, in __getattr__
    return self.__storage__[self.__ident_func__()][name]
KeyError: 'request'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/utils/pdf.py", line 27, in get_pdf
    html, options = prepare_options(html, options)
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/utils/pdf.py", line 115, in prepare_options
    options.update(get_cookie_options())
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/utils/pdf.py", line 133, in get_cookie_options
    domain = frappe.local.request.host.split(":", 1)[0]
  File "/home/aditya/Frappe/benches/press/env/lib/python3.7/site-packages/werkzeug/local.py", line 74, in __getattr__
    raise AttributeError(name)
AttributeError: request
```