### PR TITLE
fix: Milestone not created for fields updated after submission

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -140,7 +140,6 @@ doc_events = {
 			"frappe.core.doctype.activity_log.feed.update_feed",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
-			"frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone",
 			"frappe.core.doctype.file.file.attach_files_to_document",
 			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
@@ -156,7 +155,8 @@ doc_events = {
 			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers"
 		],
 		"on_change": [
-			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points"
+			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",
+			"frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone"
 		]
 	},
 	"Event": {


### PR DESCRIPTION
**Steps to Replicate:**
1. Create a new Milestone Tracker for a field that has **_Allow on Submit_** enabled.
2. Update the field after submission. Milestone documents will be created before submission but not when the field is updated after submission.

    ![milestone-tracker](https://user-images.githubusercontent.com/24353136/97283668-20be3800-1866-11eb-9d87-4aad2d449039.png)

**Before:**

![milestone-tracker-before](https://user-images.githubusercontent.com/24353136/97283859-5e22c580-1866-11eb-8700-5d9963c66649.gif)


**After:** Evaluate Milestones on `on_change` instead of `on_update` 

![milestone-tracker-after](https://user-images.githubusercontent.com/24353136/97283875-63801000-1866-11eb-857a-5e27868a2379.gif)

