### PR TITLE
style: formatted a few files

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -3,25 +3,26 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
+import json
+
 import frappe
 import frappe.utils
-import json
 from frappe import _
 from frappe.utils.jinja import validate_template
-
 from frappe.model.document import Document
+
 
 class PrintFormat(Document):
 	def validate(self):
-		if (self.standard=="Yes"
+		if (
+			self.standard == "Yes"
 			and not frappe.local.conf.get("developer_mode")
-			and not (frappe.flags.in_import or frappe.flags.in_test)):
-
+			and not (frappe.flags.in_import or frappe.flags.in_test)
+		):
 			frappe.throw(frappe._("Standard Print Format cannot be updated"))
 
 		# old_doc_type is required for clearing item cache
-		self.old_doc_type = frappe.db.get_value('Print Format',
-				self.name, 'doc_type')
+		self.old_doc_type = frappe.db.get_value('Print Format', self.name, 'doc_type')
 
 		self.extract_images()
 
@@ -32,17 +33,23 @@ class PrintFormat(Document):
 			validate_template(self.html)
 
 		if self.custom_format and self.raw_printing and not self.raw_commands:
-			frappe.throw(_('{0} are required').format(frappe.bold(_('Raw Commands'))), frappe.MandatoryError)
+			frappe.throw(_('{0} are required').format(
+				frappe.bold(_('Raw Commands'))),
+				frappe.MandatoryError
+			)
 
 		if self.custom_format and not self.html and not self.raw_printing:
-			frappe.throw(_('{0} is required').format(frappe.bold(_('HTML'))), frappe.MandatoryError)
+			frappe.throw(_('{0} is required').format(
+				frappe.bold(_('HTML'))),
+				frappe.MandatoryError
+			)
 
 	def extract_images(self):
 		from frappe.core.doctype.file.file import extract_images_from_html
 		if self.format_data:
 			data = json.loads(self.format_data)
 			for df in data:
-				if df.get('fieldtype') and df['fieldtype'] in ('HTML', 'Custom HTML') and df.get('options'):
+				if df.get('fieldtype') in ('HTML', 'Custom HTML') and df.get('options'):
 					df['options'] = extract_images_from_html(self, df['options'])
 			self.format_data = json.dumps(data)
 
@@ -63,6 +70,7 @@ class PrintFormat(Document):
 		if self.doc_type:
 			frappe.clear_cache(doctype=self.doc_type)
 
+
 @frappe.whitelist()
 def make_default(name):
 	"""Set print format as default"""
@@ -70,7 +78,7 @@ def make_default(name):
 
 	print_format = frappe.get_doc("Print Format", name)
 
-	if (frappe.conf.get('developer_mode') or 0) == 1:
+	if frappe.conf.get('developer_mode'):
 		# developer mode, set it default in doctype
 		doctype = frappe.get_doc("DocType", print_format.doc_type)
 		doctype.default_print_format = name

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1129,7 +1129,7 @@ def get_link_to_report(name, label=None, report_type=None, doctype=None, filters
 				for value in v:
 					conditions.append(f'{k}=["{value[0]}","{value[1]}"])')
 			else:
-				conditions.append(str(k)+"="+str(v))
+				conditions.append(f'{k}={v}')
 
 		filters = "&".join(conditions)
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -328,7 +328,6 @@ def format_date(string_date=None, format_string=None):
 	* mm-dd-yyyy
 	* dd/mm/yyyy
 	"""
-
 	if not string_date:
 		return ''
 
@@ -339,7 +338,8 @@ def format_date(string_date=None, format_string=None):
 	try:
 		formatted_date = babel.dates.format_date(
 			date, format_string,
-			locale=(frappe.local.lang or "").replace("-", "_"))
+			locale=(frappe.local.lang or "").replace("-", "_")
+		)
 	except UnknownLocaleError:
 		format_string = format_string.replace("MM", "%m").replace("dd", "%d").replace("yyyy", "%Y")
 		formatted_date = date.strftime(format_string)

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -2,9 +2,11 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals, print_function
+import os
 
-import frappe, os
+import frappe
 from frappe.core.doctype.data_import.data_import import import_doc, export_json
+
 
 def sync_fixtures(app=None):
 	"""Import, overwrite fixtures from `[app]/fixtures`"""
@@ -29,6 +31,7 @@ def sync_fixtures(app=None):
 
 	frappe.db.commit()
 
+
 def import_custom_scripts(app):
 	"""Import custom scripts from `[app]/fixtures/custom_scripts`"""
 	if os.path.exists(frappe.get_app_path(app, "fixtures", "custom_scripts")):
@@ -49,6 +52,7 @@ def import_custom_scripts(app):
 							"script": script
 						}).insert()
 
+
 def export_fixtures(app=None):
 	"""Export fixtures as JSON to `[app]/fixtures`"""
 	if app:
@@ -59,13 +63,23 @@ def export_fixtures(app=None):
 		for fixture in frappe.get_hooks("fixtures", app_name=app):
 			filters = None
 			or_filters = None
+
 			if isinstance(fixture, dict):
 				filters = fixture.get("filters")
 				or_filters = fixture.get("or_filters")
 				fixture = fixture.get("doctype") or fixture.get("dt")
-			print("Exporting {0} app {1} filters {2}".format(fixture, app, (filters if filters else or_filters)))
+
+			print("Exporting {0} app {1} filters {2}".format(
+				fixture, app, (filters if filters else or_filters)
+			))
+
 			if not os.path.exists(frappe.get_app_path(app, "fixtures")):
 				os.mkdir(frappe.get_app_path(app, "fixtures"))
 
-			export_json(fixture, frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"),
-				filters=filters, or_filters=or_filters, order_by="idx asc, creation asc")
+			export_json(
+				fixture,
+				frappe.get_app_path(app, "fixtures", frappe.scrub(fixture) + ".json"),
+				filters=filters,
+				or_filters=or_filters,
+				order_by="idx asc, creation asc"
+			)

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -73,9 +73,9 @@ def get_safe_globals():
 			render_template=frappe.render_template,
 			msgprint=frappe.msgprint,
 			throw=frappe.throw,
-			sendmail = frappe.sendmail,
-			get_print = frappe.get_print,
-			attach_print = frappe.attach_print,
+			sendmail=frappe.sendmail,
+			get_print=frappe.get_print,
+			attach_print=frappe.attach_print,
 
 			user=user,
 			get_fullname=frappe.utils.get_fullname,
@@ -86,8 +86,8 @@ def get_safe_globals():
 				user=user,
 				csrf_token=frappe.local.session.data.csrf_token if getattr(frappe.local, "session", None) else ''
 			),
-			make_get_request = frappe.integrations.utils.make_get_request,
-			make_post_request = frappe.integrations.utils.make_post_request,
+			make_get_request=frappe.integrations.utils.make_get_request,
+			make_post_request=frappe.integrations.utils.make_post_request,
 			socketio_port=frappe.conf.socketio_port,
 			get_hooks=frappe.get_hooks,
 			sanitize_html=frappe.utils.sanitize_html


### PR DESCRIPTION
- Shortened lines above 100 characters, pep default would be 79.
- Added an extra required newline above many functions
- using """ in docstrings instead of ''', starting them uppercase, being imperative and ending with a dot in a single summary line.
- format strings instead of concatenation
- readable indents for stuff that is nested a lot (can quickly get quite messy when .format is involved)
- ordering of imports: 1. python standard library, 2. external libraries, 3. frappe stuff