### PR TITLE
perf(render): Don't set context.no_cache

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -394,7 +394,6 @@ def load_properties_from_source(page_info):
 		and "</body>" not in page_info.source):
 		page_info.source = '''{{% extends "{0}" %}}
 			{{% block page_content %}}{1}{{% endblock %}}'''.format(page_info.base_template, page_info.source)
-		page_info.no_cache = 1
 
 	if "<!-- no-breadcrumbs -->" in page_info.source:
 		page_info.no_breadcrumbs = 1


### PR DESCRIPTION
#### TL; DR 
Page rendering can be performed ~6 times faster by (surprise!) not rendering at all

**Note:** There doesn't seem to be any obvious explanation for `no_cache = 1`, Don't merge unless you are certain that there are no bad side effects.

**Before** 
```shell
$ wrk -d 10s -t 1 -c 1 http://docs.local/docs/user/manual/en/manufacturing
Running 10s test @ http://docs.local/docs/user/manual/en/manufacturing
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   342.87ms   12.29ms 382.71ms   82.76%
    Req/Sec     2.55      0.51     3.00     55.17%
  29 requests in 10.02s, 473.03KB read
Requests/sec:      2.90
Transfer/sec:     47.22KB
```
**After**
```shell
$ wrk -d 10s -t 1 -c 1 http://docs.local/docs/user/manual/en/manufacturing
Running 10s test @ http://docs.local/docs/user/manual/en/manufacturing
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    51.98ms    6.69ms  95.79ms   93.19%
    Req/Sec    19.10      3.21    30.00     89.00%
  191 requests in 10.01s, 3.04MB read
Requests/sec:     19.08
Transfer/sec:    311.20KB
```