### PR TITLE
fix(recorder): Error page rendering shouldn't fail when recorder is active

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -615,8 +615,10 @@ def browse(context, site):
 @click.command('start-recording')
 @pass_context
 def start_recording(context):
+	import frappe.recorder
 	for site in context.sites:
 		frappe.init(site=site)
+		frappe.set_user("Administrator")
 		frappe.recorder.start()
 	if not context.sites:
 		raise SiteNotSpecifiedError
@@ -625,8 +627,10 @@ def start_recording(context):
 @click.command('stop-recording')
 @pass_context
 def stop_recording(context):
+	import frappe.recorder
 	for site in context.sites:
 		frappe.init(site=site)
+		frappe.set_user("Administrator")
 		frappe.recorder.stop()
 	if not context.sites:
 		raise SiteNotSpecifiedError

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -53,16 +53,18 @@ def sql(*args, **kwargs):
 
 
 def get_current_stack_frames():
-	current = inspect.currentframe()
-	frames = inspect.getouterframes(current, context=10)
-	for frame, filename, lineno, function, context, index in list(reversed(frames))[:-2]:
-		if "/apps/" in filename:
-			yield {
-				"filename": re.sub(".*/apps/", "", filename),
-				"lineno": lineno,
-				"function": function,
-			}
-
+	try:
+		current = inspect.currentframe()
+		frames = inspect.getouterframes(current, context=10)
+		for frame, filename, lineno, function, context, index in list(reversed(frames))[:-2]:
+			if "/apps/" in filename:
+				yield {
+					"filename": re.sub(".*/apps/", "", filename),
+					"lineno": lineno,
+					"function": function,
+				}
+	except Exception:
+		pass
 
 def record():
 	if __debug__:

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -10,6 +10,7 @@ from glob import glob
 # imports - module imports
 import frappe
 from frappe.utils.backups import fetch_latest_backups
+import frappe.recorder
 
 
 def clean(value):
@@ -119,3 +120,15 @@ class TestCommands(BaseTestCommands):
 		# test 6: take a backup with --verbose
 		self.execute("bench --site {site} backup --verbose")
 		self.assertEquals(self.returncode, 0)
+
+
+	def test_recorder(self):
+		frappe.recorder.stop()
+
+		self.execute("bench --site {site} start-recording")
+		frappe.local.cache = {}
+		self.assertEqual(frappe.recorder.status(), True)
+
+		self.execute("bench --site {site} stop-recording")
+		frappe.local.cache = {}
+		self.assertEqual(frappe.recorder.status(), False)

--- a/frappe/tests/test_recorder.py
+++ b/frappe/tests/test_recorder.py
@@ -8,6 +8,7 @@ import unittest
 import frappe
 import frappe.recorder
 from frappe.utils import set_request
+from frappe.website.render import render_page
 
 import sqlparse
 
@@ -119,3 +120,7 @@ class TestRecorder(unittest.TestCase):
 
 		for query, call in zip(queries, request['calls']):
 			self.assertEqual(call['exact_copies'], query[1])
+
+	def test_error_page_rendering(self):
+		content = render_page("error")
+		self.assertIn("Error", content)


### PR DESCRIPTION
1. Error page rendering used to fail when recorder is active with.
```python-traceback
Traceback (most recent call last):
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/website/render.py", line 50, in render
    data = render_page_by_language(path)
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/website/render.py", line 177, in render_page_by_language
    return render_page(path)
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/website/render.py", line 193, in render_page
    return build(path)
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/website/render.py", line 200, in build
    return build_page(path)
...
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/database/database.py", line 458, in get_values
    out = self._get_values_from_table(fields, filters, doctype, as_dict, debug, order_by, update, for_update=for_update)
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/database/database.py", line 611, in _get_values_from_table
    values, as_dict=as_dict, debug=debug, update=update)
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/recorder.py", line 27, in sql
    stack = list(get_current_stack_frames())
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/recorder.py", line 57, in get_current_stack_frames
    frames = inspect.getouterframes(current, context=10)
  File "/home/aditya/.pyenv/versions/3.7.6/lib/python3.7/inspect.py", line 1490, in getouterframes
    frameinfo = (frame,) + getframeinfo(frame, context)
  File "/home/aditya/.pyenv/versions/3.7.6/lib/python3.7/inspect.py", line 1464, in getframeinfo
    lines, lnum = findsource(frame)
  File "/home/aditya/.pyenv/versions/3.7.6/lib/python3.7/inspect.py", line 828, in findsource
    if pat.match(lines[lnum]): break
IndexError: list index out of range
```
![image](https://user-images.githubusercontent.com/8528887/97390001-d094b380-1901-11eb-8464-cc105df24307.png)

2. `bench start-recoding` and `bench stop-recording` commands used to fail with

```python-traceback
Traceback (most recent call last):
...
  File "/home/aditya/Frappe/benches/press/apps/frappe/frappe/commands/site.py", line 620, in start_recording
    frappe.recorder.start()
AttributeError: module 'frappe' has no attribute 'recorder'
```


