### PR TITLE
fix: Max slices for aggregate charts

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -547,6 +547,7 @@ export default class ChartWidget extends Widget {
 			type: chart_type_map[this.chart_doc.type],
 			colors: colors,
 			height: this.height,
+			maxSlices: ['Pie', 'Donut'].includes(this.chart_doc.type) ? 6 : 9,
 			axisOptions: {
 				xIsSeries: this.chart_doc.timeseries,
 				shortenYAxisNumbers: 1


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/19775888/97403433-69372d80-191a-11eb-8099-0d6122fb6fb9.png)
