### PR TITLE
fix: Show total text with value if first column is numeric

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1058,15 +1058,30 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					name: __('Totals Row'),
 					content: totals[col.id],
 					format: value => {
-						return frappe.format(value, col.docfield, { always_show_decimals: true }, data[0]);
+						let formatted_value = frappe.format(value, col.docfield, {
+							always_show_decimals: true
+						}, data[0]);
+						if (i === 0) {
+							return this.format_total_cell(formatted_value, col);
+						}
+						return formatted_value;
 					}
-				}
-			})
+				};
+			});
 
-			totals_row[0].content = __('Totals').bold();
 			out.push(totals_row);
 		}
 		return out;
+	}
+
+	format_total_cell(formatted_value, df) {
+		let cell_value = __('Totals').bold();
+		if (frappe.model.is_numeric_field(df.docfield)) {
+			cell_value = `<span class="flex justify-between">
+				${cell_value} ${$(formatted_value).text()}
+			</span>`;
+		}
+		return cell_value;
 	}
 
 	build_row(d) {
@@ -1249,8 +1264,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				label: __('Show Totals'),
 				action: () => {
 					this.add_totals_row = !this.add_totals_row;
-					this.save_view_user_settings(
-						{ add_totals_row: this.add_totals_row });
+					this.save_view_user_settings({
+						add_totals_row: this.add_totals_row
+					});
 					this.datatable.refresh(this.get_data(this.data));
 				}
 			},


### PR DESCRIPTION
Previously, after applying the group filter in the Report View, the first cell of the total row used to show `0` value if the first column was numeric.

**Before:**
<img width="667" alt="Screenshot 2020-10-28 at 11 37 46 PM" src="https://user-images.githubusercontent.com/13928957/97478425-f019f380-1976-11eb-9411-03df6069a1d2.png">

**Now:**
<img width="664" alt="Screenshot 2020-10-28 at 11 30 32 PM" src="https://user-images.githubusercontent.com/13928957/97478771-6585c400-1977-11eb-8b38-f768406d1e00.png">


If the first column is not numeric.
<img width="668" alt="Screenshot 2020-10-28 at 11 30 08 PM" src="https://user-images.githubusercontent.com/13928957/97478779-69b1e180-1977-11eb-873d-3173f3d2b033.png">
