### PR TITLE
fix: updated fields of child table gets overwritten by old doc

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -616,7 +616,9 @@ class Row:
 			id_field = get_id_field(doctype)
 			id_value = doc.get(id_field.fieldname)
 			if id_value and frappe.db.exists(doctype, id_value):
-				doc = frappe.get_doc(doctype, id_value)
+				existing_doc = frappe.get_doc(doctype, id_value)
+				existing_doc.update(doc)
+				doc = existing_doc
 			else:
 				# for table rows being inserted in update
 				# create a new doc with defaults set


### PR DESCRIPTION
**Cannot update child table fields if child table doc exists.**

Existing Item and Reorder Level
<img width="1221" alt="Screenshot 2020-10-29 at 6 32 38 PM" src="https://user-images.githubusercontent.com/25369014/97577472-7e44b700-1a15-11eb-91c3-301449849c30.png">

Updating the same row by exporting template and editing value
<img width="1221" alt="Screenshot 2020-10-29 at 6 33 59 PM" src="https://user-images.githubusercontent.com/25369014/97577366-581f1700-1a15-11eb-900e-8eb41887e9fb.png">
