### PR TITLE
fix: Navbar logo height and width

### DIFF
--- a/frappe/public/less/navbar.less
+++ b/frappe/public/less/navbar.less
@@ -266,6 +266,8 @@
 
 .navbar-brand > img {
 	display: inline-block;
+	height: 24px;
+	max-width: 150px;
 }
 
 .toggle-sidebar {


### PR DESCRIPTION
Added Desk navbar logo height and max-width to avoid overflow of images