### PR TITLE
fix: create auto_repeat field only if docfield/custom field does not exist

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -570,7 +570,8 @@ class DocType(Document):
 	def make_repeatable(self):
 		"""If allow_auto_repeat is set, add auto_repeat custom field."""
 		if self.allow_auto_repeat:
-			if not frappe.db.exists('Custom Field', {'fieldname': 'auto_repeat', 'dt': self.name}):
+			if not frappe.db.exists('Custom Field', {'fieldname': 'auto_repeat', 'dt': self.name}) and \
+				not frappe.db.exists('DocField', {'fieldname': 'auto_repeat', 'parent': self.name}):
 				insert_after = self.fields[len(self.fields) - 1].fieldname
 				df = dict(fieldname='auto_repeat', label='Auto Repeat', fieldtype='Link', options='Auto Repeat', insert_after=insert_after, read_only=1, no_copy=1, print_hide=1)
 				create_custom_field(self.name, df)

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -76,8 +76,8 @@ class CustomizeForm(Document):
 
 	def create_auto_repeat_custom_field_if_requried(self, meta):
 		if self.allow_auto_repeat:
-			if not frappe.db.exists('Custom Field', {'fieldname': 'auto_repeat',
-				'dt': self.doc_type}):
+			if not frappe.db.exists('Custom Field', {'fieldname': 'auto_repeat', 'dt': self.doc_type}) and \
+				not frappe.db.exists('DocField', {'fieldname': 'auto_repeat', 'parent': self.name}):
 				insert_after = self.fields[len(self.fields) - 1].fieldname
 				df = dict(
 					fieldname='auto_repeat',


### PR DESCRIPTION
Some Standard DocTypes already have an `auto_repeat` standard field. Checking **Allow Auto Repeat** breaks here, since it tries to create a custom field when a standard docfield already exists.

![photo_2020-10-30 14 07 18](https://user-images.githubusercontent.com/24353136/97678118-5575fd80-1ab9-11eb-8c5f-ea460fe98494.jpeg)

**Fix:** Create custom field only if standard docfield / custom field is not already present. This property is now enabled for such doctypes in https://github.com/frappe/erpnext/pull/23776
