### PR TITLE
fix: Make route and action readonly for standard navbar items

### DIFF
--- a/frappe/core/doctype/navbar_item/navbar_item.json
+++ b/frappe/core/doctype/navbar_item/navbar_item.json
@@ -2,7 +2,6 @@
  "actions": [],
  "creation": "2020-08-01 23:38:41.783206",
  "doctype": "DocType",
- "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "item_label",
@@ -30,6 +29,7 @@
    "in_list_view": 1,
    "label": "Item Type",
    "options": "Route\nAction\nSeparator",
+   "read_only_depends_on": "eval:doc.is_standard",
    "show_days": 1,
    "show_seconds": 1
   },
@@ -59,6 +59,7 @@
    "in_list_view": 1,
    "label": "Route",
    "mandatory_depends_on": "eval:doc.item_type == 'Route'",
+   "read_only_depends_on": "eval:doc.is_standard",
    "show_days": 1,
    "show_seconds": 1
   },
@@ -68,13 +69,14 @@
    "fieldtype": "Data",
    "label": "Action",
    "mandatory_depends_on": "eval:doc.item_type == 'Action'",
+   "read_only_depends_on": "eval:doc.is_standard",
    "show_days": 1,
    "show_seconds": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-08-06 16:32:49.597060",
+ "modified": "2020-11-02 10:57:37.709262",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Navbar Item",


### PR DESCRIPTION
Users were able to edit route and actions for standard navbar items.
This PR makes them read only