### PR TITLE
fix: Throw exception if template not found

### DIFF
--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -82,8 +82,8 @@ frappe.render_template = function(name, data) {
 	if(data===undefined) {
 		data = {};
 	}
-	if(template === undefined){
-		frappe.throw("Template " + name + " not found")
+	if (template === undefined) {
+		frappe.throw("Template " + name + " not found");
 	}
 	return frappe.render(template, data, name);
 }

--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -82,6 +82,9 @@ frappe.render_template = function(name, data) {
 	if(data===undefined) {
 		data = {};
 	}
+	if(template === undefined){
+		frappe.throw("Template " + name + " not found")
+	}
 	return frappe.render(template, data, name);
 }
 frappe.render_grid = function(opts) {

--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -82,8 +82,8 @@ frappe.render_template = function(name, data) {
 	if(data===undefined) {
 		data = {};
 	}
-	if (template === undefined) {
-		frappe.throw("Template " + name + " not found");
+	if (!template) {
+		frappe.throw(`Template <b>${name}</b> not found.`);
 	}
 	return frappe.render(template, data, name);
 }


### PR DESCRIPTION
If the microtemplate is called with a template name that does not exists, it throws this exception
![image](https://user-images.githubusercontent.com/28212972/97860210-c3bff780-1d27-11eb-8a4d-ebe37019620d.png)

This exception is misleading as it does not direct towards the actual issue.
Added a check and a exception
![image](https://user-images.githubusercontent.com/28212972/97860062-878c9700-1d27-11eb-92db-dd7d54b81df7.png)
