### PR TITLE
fix: disable chart form condition

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -23,7 +23,7 @@ frappe.ui.form.on('Dashboard Chart', {
 		frm.chart_filters = null;
 		frm.is_disabled = !frappe.boot.developer_mode && frm.doc.is_standard;
 
-		if (!frm.is_disabled) {
+		if (frm.is_disabled) {
 			!frm.doc.custom_options && frm.set_df_property('chart_options_section', 'hidden', 1);
 			frm.disable_form();
 		}


### PR DESCRIPTION
Disabled Dashboard Chart form if chart is standard and developer mode is not enabled.