### PR TITLE
fix: shorten number card percentage stat

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -268,7 +268,7 @@ export default class NumberCardWidget extends Widget {
 			result: this.number
 		}).then(res => {
 			if (res !== undefined) {
-				this.percentage_stat = +res.toFixed(2);
+				this.percentage_stat = shorten_number(res);
 			}
 		});
 	}

--- a/frappe/public/js/frappe/widgets/utils.js
+++ b/frappe/public/js/frappe/widgets/utils.js
@@ -154,7 +154,7 @@ function shorten_number(number, country) {
 			return (number/map.divisor).toFixed(2) + ' ' + map.symbol;
 		}
 	}
-	return number.toFixed();
+	return number.toFixed(2);
 }
 
 function get_number_system(country) {


### PR DESCRIPTION
Shorten percentage stat number on Number Card, to prevent:
![image](https://user-images.githubusercontent.com/19775888/97865741-aba0a600-1d30-11eb-9a3d-8e83e2f793ef.png)
