### PR TITLE
fix: Doctype query in create new shortcut

### DIFF
--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -47,7 +47,7 @@ def query_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	user = filters.get("user")
 	user_perms = frappe.utils.user.UserPermissions(user)
 	user_perms.build_permissions()
-	can_read = user_perms.can_read
+	can_read = user_perms.can_read # Does not include child tables
 
 	single_doctypes = [d[0] for d in frappe.db.get_values("DocType", {"issingle": 1})]
 

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -150,7 +150,13 @@ class ShortcutDialog extends WidgetDialog {
 				onchange: () => {
 					if (this.dialog.get_value("type") == "DocType") {
 						this.dialog.fields_dict.link_to.get_query = () => {
-							return { filters: { istable: false } };
+							return {
+								query: "frappe.core.report.permitted_documents_for_user.permitted_documents_for_user.query_doctypes",
+								filters: {
+									istable: false,
+									user: frappe.session.user
+								}
+							};
 						};
 					} else {
 						this.dialog.fields_dict.link_to.get_query = null;

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -153,7 +153,6 @@ class ShortcutDialog extends WidgetDialog {
 							return {
 								query: "frappe.core.report.permitted_documents_for_user.permitted_documents_for_user.query_doctypes",
 								filters: {
-									istable: false,
 									user: frappe.session.user
 								}
 							};


### PR DESCRIPTION
While creating a desk shortcut, users were able to see the list of all doctypes. This would allow them to create the shortcut, however it won't be visible on the desk because of permission filetering while building desk.

![image](https://user-images.githubusercontent.com/18097732/98086223-76b56000-1ea4-11eb-8721-24a480f24de6.png)

This PR fixes this by using custom query for doctype from `permitted_documents_for_user.py`

<img width="627" alt="Screen Shot 2020-11-04 at 1 42 43 PM" src="https://user-images.githubusercontent.com/18097732/98086283-892f9980-1ea4-11eb-93cc-0084715eafac.png">


