### PR TITLE
fix: don't throw if filter is invalid

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -67,7 +67,11 @@ frappe.ui.FilterGroup = class {
 			&& !frappe.meta.has_field(doctype, fieldname)
 			&& !frappe.model.std_fields_list.includes(fieldname)) {
 
-			frappe.throw(__("Invalid filter: {0}", [fieldname.bold()]));
+			frappe.msgprint({
+				message: __('Invalid filter: {0}', [fieldname.bold()]),
+				indicator: 'red',
+			});
+
 			return false;
 		}
 		return true;


### PR DESCRIPTION
`validate_args` doesn't need to throw if a filter is invalid. It should continue execution so that the invalid filter can be removed.