### PR TITLE
fix: enable disable save when navigating between docs

### DIFF
--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -2,7 +2,9 @@ frappe.ui.form.on('Report', {
 	refresh: function(frm) {
 		if (frm.doc.is_standard === "Yes" && !frappe.boot.developer_mode) {
 			// make the document read-only
-			frm.set_read_only();
+			frm.disable_form();
+		} else {
+			frm.enable_save();
 		}
 
 		let doc = frm.doc;
@@ -32,8 +34,6 @@ frappe.ui.form.on('Report', {
 				});
 			}, doc.disabled ? "fa fa-check" : "fa fa-off");
 		}
-
-		frm.events.report_type(frm);
 	},
 
 	ref_doctype: function(frm) {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -275,6 +275,10 @@ frappe.ui.form.Form = class FrappeForm {
 			this.read_only = frappe.workflow.is_read_only(this.doctype, this.docname);
 			if (this.read_only) this.set_read_only(true);
 
+			if (this.save_disabled && !this.read_only) {
+				this.enable_save()
+			}
+
 			// check if doctype is already open
 			if (!this.opendocs[this.docname]) {
 				this.check_doctype_conflict(this.docname);

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -276,7 +276,7 @@ frappe.ui.form.Form = class FrappeForm {
 			if (this.read_only) this.set_read_only(true);
 
 			if (this.save_disabled && !this.read_only) {
-				this.enable_save()
+				this.enable_save();
 			}
 
 			// check if doctype is already open

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -261,7 +261,7 @@ frappe.ui.form.Form = class FrappeForm {
 		cur_frm = this;
 
 		if(this.docname) { // document to show
-
+			this.save_disabled = false;
 			// set the doc
 			this.doc = frappe.get_doc(this.doctype, this.docname);
 
@@ -274,10 +274,6 @@ frappe.ui.form.Form = class FrappeForm {
 			// read only (workflow)
 			this.read_only = frappe.workflow.is_read_only(this.doctype, this.docname);
 			if (this.read_only) this.set_read_only(true);
-
-			if (this.save_disabled && !this.read_only) {
-				this.enable_save();
-			}
 
 			// check if doctype is already open
 			if (!this.opendocs[this.docname]) {


### PR DESCRIPTION
This PR Has two Changes

1. Explicitly enable and disable save in reports
1. Moving between a read-only and non-read-only doc, the form save status would not be updated, this PR fixes it.

Fixed GIF:

**This is navigating between the docs without explicitly calling `enable_save` in report.js `refresh`**

![gif](https://user-images.githubusercontent.com/18097732/98094326-22fc4400-1eaf-11eb-9c58-ce5f90e4feb4.gif)


[Internal Test Link](https://frappe.io/desk#Form/Pre%20Release%20Test/PRT-25-10-20-228474)