### PR TITLE
feat: Added filters and order_by fields in frappe.get_last_doc API

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -348,7 +348,7 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, 
 
 	if as_table and type(msg) in (list, tuple):
 		out.as_table = 1
-	
+
 	if as_list and type(msg) in (list, tuple) and len(msg) > 1:
 		out.as_list = 1
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -796,11 +796,17 @@ def get_doc(*args, **kwargs):
 
 	return doc
 
-def get_last_doc(doctype, **kwargs):
+def get_last_doc(doctype, filters=None, order_by="creation desc"):
 	"""Get last created document of this type."""
-	d = get_all(doctype, ["name"], order_by="creation desc", limit_page_length=1, **kwargs)
+	d = get_all(
+		doctype,
+		filters=filters,
+		limit_page_length=1,
+		order_by=order_by,
+		pluck="name"
+	)
 	if d:
-		return get_doc(doctype, d[0].name)
+		return get_doc(doctype, d[0])
 	else:
 		raise DoesNotExistError
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -796,9 +796,9 @@ def get_doc(*args, **kwargs):
 
 	return doc
 
-def get_last_doc(doctype):
+def get_last_doc(doctype, **kwargs):
 	"""Get last created document of this type."""
-	d = get_all(doctype, ["name"], order_by="creation desc", limit_page_length=1)
+	d = get_all(doctype, ["name"], order_by="creation desc", limit_page_length=1, **kwargs)
 	if d:
 		return get_doc(doctype, d[0].name)
 	else:


### PR DESCRIPTION
## Why?

So, we can do things like

```python
credit_report = frappe.get_last_doc("Site Credit Report", filters={"site": "bagel.frappeframework.com"})
```
to retrieve the last `Site Credit Report` document created for the site `bagel.frappeframework.com`

Currently, to do the same we'd have to do something like

```python
d = frappe.get_all("Site Credit Report", ["name"], order_by="creation desc", limit_page_length=1, filters={"site": "bagel.frappeframework.com"})
credit_report = frappe.get_doc("Site Credit Report", d[0].name)
```

which is already what `frappe.get_last_doc` does.

Docs: https://github.com/frappe/frappe_docs/pull/64