### PR TITLE
fix: Total Row in Checkbox Column Reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1043,7 +1043,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					// applied to Float, Currency fields, needed only for currency formatting.
 					// make first data column have value 'Total'
 					let index = 1;
-					if (this.datatable && this.datatable.options.checkboxColumn) index = 2;
+					let datatable = this.report_settings.get_datatable_options({});
+					if (datatable && datatable.checkboxColumn) index = 2;
 
 					if (column.colIndex === index && !value) {
 						value = "Total";

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1043,8 +1043,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					// applied to Float, Currency fields, needed only for currency formatting.
 					// make first data column have value 'Total'
 					let index = 1;
-					let datatable = this.report_settings.get_datatable_options({});
-					if (datatable && datatable.checkboxColumn) index = 2;
+
+					if (this.report_settings.get_datatable_options) {
+						let datatable = this.report_settings.get_datatable_options({});
+						if (datatable && datatable.checkboxColumn) index = 2;
+					}
 
 					if (column.colIndex === index && !value) {
 						value = "Total";


### PR DESCRIPTION
**Issue:**
- Datatable is rendered **after** columns are prepared. 
- So in `prepare_columns` the check added to see if it is a checkboxcolumn report , always had the value of `this.datatable=null`.  Thus **Total** was not visible on the first report load in such a report.
 ![Screenshot 2020-11-04 at 11 25 40 PM](https://user-images.githubusercontent.com/25857446/98150945-709b9f80-1ef5-11eb-86cd-5ad746f9d51c.png)

- If you change a filter value however, the report gets refreshed. This time since the old datatable value (that was previously rendered) exists, **Total** is visible.

**Fix:**
- Since `this.datatable` is not initialised yet, fetch the datatable config from the report settings, which will always be present from the very beginning

Here's a GIF showing **Total** on a hard refresh as well as on changing filter values
  ![total-row](https://user-images.githubusercontent.com/25857446/98151158-c2dcc080-1ef5-11eb-8d65-20d4bc729b3d.gif)
