### PR TITLE
chore: Add Release Notes for v13-beta-6

### DIFF
--- a/frappe/change_log/v13/v13_0_0-beta_6.md
+++ b/frappe/change_log/v13/v13_0_0-beta_6.md
@@ -1,0 +1,47 @@
+# Version 13.0.0 Beta 6 Release Notes
+
+## Fixes and Enhancements
+
+- Fixed back navigation on user-profile ([#11627](https://github.com/frappe/frappe/pull/11627))
+- Multiple fixes related to reports ([#11593](https://github.com/frappe/frappe/pull/11593)) ([#10959](https://github.com/frappe/frappe/pull/10959)) ([#11533](https://github.com/frappe/frappe/pull/11533)) ([#11459](https://github.com/frappe/frappe/pull/11459)) ([#10987](https://github.com/frappe/frappe/pull/10987)) ([#11612](https://github.com/frappe/frappe/pull/11612)) ([#11468](https://github.com/frappe/frappe/pull/11468)) ([#11593](https://github.com/frappe/frappe/pull/11593))
+- Fixed breaking of website theme on updating site ([#11663](https://github.com/frappe/frappe/pull/11663))
+- Fixed `@` character failure in link field search ([#11851](https://github.com/frappe/frappe/pull/11851))
+- Freeze buttons during request in Form view ([#11570](https://github.com/frappe/frappe/pull/11570))
+- Fixed images shown as broken in comment ([#11337](https://github.com/frappe/frappe/pull/11337))
+- Mute badges in desk shortcut if the count is zero ([#11515](https://github.com/frappe/frappe/pull/11515))
+- Now system will use hostname config in sitemap.xml ([#11160](https://github.com/frappe/frappe/pull/11160))
+- Enhancements in notifications ([#11398](https://github.com/frappe/frappe/pull/11398)) ([#11409](https://github.com/frappe/frappe/pull/11409))
+- Fixed "undefined" value on Number Card ([#11117](https://github.com/frappe/frappe/pull/11117))
+- Dashboard fixes ([#11074](https://github.com/frappe/frappe/pull/11074)) ([#11186](https://github.com/frappe/frappe/pull/11186)) ([#11773](https://github.com/frappe/frappe/pull/11773))  ([#11340](https://github.com/frappe/frappe/pull/11340)) ([#11277](https://github.com/frappe/frappe/pull/11277))
+- Data Import fixes ([#11083](https://github.com/frappe/frappe/pull/11083)) ([#11159](https://github.com/frappe/frappe/pull/11159))
+- Newsletter fixes ([#11401](https://github.com/frappe/frappe/pull/11401)) ([#11321](https://github.com/frappe/frappe/pull/11321))
+- Website Enhancements ([#11285](https://github.com/frappe/frappe/pull/11285)) ([#11584](https://github.com/frappe/frappe/pull/11584)) ([#11646](https://github.com/frappe/frappe/pull/11646)) ([#11315](https://github.com/frappe/frappe/pull/11315))
+- Cleaned up layout of DocType, User, Role and added home_page to Portal Settings & Role ([#11225](https://github.com/frappe/frappe/pull/11225))
+
+## Features
+
+- Added ability to override doctype classes from hooks ([#11527](https://github.com/frappe/frappe/pull/11527))
+- Introduced Razorpay client ([#11418](https://github.com/frappe/frappe/pull/11418))
+- Introduced option to configurable navbar logo and dropdowns ([#11213](https://github.com/frappe/frappe/pull/11213))
+- Added Paytm integration ([#9955](https://github.com/frappe/frappe/pull/9955))
+- Introduced Log Settings ([#11699](https://github.com/frappe/frappe/pull/11699))
+- Added option to set custom due_date for assignments in Assignment Rule ([#11669](https://github.com/frappe/frappe/pull/11669))
+- Added option to anonymize IP for Google Analytics ([#11594](https://github.com/frappe/frappe/pull/11594))
+- Introduced System Settings to automatically delete old Prepared Reports ([#9751](https://github.com/frappe/frappe/pull/9751))
+- Added option to assign based on field value ([#11619](https://github.com/frappe/frappe/pull/11619))
+- Rule based naming of documents ([#11439](https://github.com/frappe/frappe/pull/11439))
+- Added WhatsApp/SMS channels for Notification ([#9623](https://github.com/frappe/frappe/pull/9623))
+- Added option to resize images in text editor ([#10820](https://github.com/frappe/frappe/pull/10820))
+- Now usage of `get_print`, `attach_print` and `send_mail` is allowed in Server Scripts ([#11260](https://github.com/frappe/frappe/pull/11260)) ([#11162](https://github.com/frappe/frappe/pull/11162))
+- Introduced option to disable custom script ([#11342](https://github.com/frappe/frappe/pull/11342))
+- Option to show child table row index number in report builder ([#11246](https://github.com/frappe/frappe/pull/11246))
+
+## Performance
+
+- Used get_list with limit instead of count for faster form load ([#11701](https://github.com/frappe/frappe/pull/11701))
+
+## Security
+
+- Removed `ignore_permissions` flag from API request to avoid unauthorized data access ([#11452](https://github.com/frappe/frappe/pull/11452))
+- Added noreferrer policy to footer links to avoid token key abuse ([#11747](https://github.com/frappe/frappe/pull/11747))
+- Restricted cookies to the host domain ([#11469](https://github.com/frappe/frappe/pull/11469)) ([#11231](https://github.com/frappe/frappe/pull/11231))

--- a/frappe/change_log/v13/v13_0_0-beta_6.md
+++ b/frappe/change_log/v13/v13_0_0-beta_6.md
@@ -28,7 +28,7 @@
 - Added option to set custom due_date for assignments in Assignment Rule ([#11669](https://github.com/frappe/frappe/pull/11669))
 - Added option to anonymize IP for Google Analytics ([#11594](https://github.com/frappe/frappe/pull/11594))
 - Introduced System Settings to automatically delete old Prepared Reports ([#9751](https://github.com/frappe/frappe/pull/9751))
-- Added option to assign based on field value ([#11619](https://github.com/frappe/frappe/pull/11619))
+- Added option in assignment rule to assign based on field value ([#11619](https://github.com/frappe/frappe/pull/11619))
 - Rule based naming of documents ([#11439](https://github.com/frappe/frappe/pull/11439))
 - Added WhatsApp/SMS channels for Notification ([#9623](https://github.com/frappe/frappe/pull/9623))
 - Added option to resize images in text editor ([#10820](https://github.com/frappe/frappe/pull/10820))


### PR DESCRIPTION
<img width="567" alt="Screenshot 2020-11-05 at 6 50 36 PM" src="https://user-images.githubusercontent.com/13928957/98246072-ccb70000-1f97-11eb-970f-92d482447af9.png">
