### PR TITLE
fix: validate links table data

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -662,7 +662,7 @@ class DocType(Document):
 		"""Validate fieldnames in Links table"""
 		if frappe.flags.in_patch: return
 		if frappe.flags.in_fixtures: return
-		if not len(self.links): return
+		if not self.links: return
 
 		for index, link in enumerate(self.links):
 			meta = frappe.get_meta(link.link_doctype)

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -451,6 +451,33 @@ class TestDocType(unittest.TestCase):
 		test_doc_1.delete()
 		frappe.db.commit()
 
+	def test_links_table_fieldname_validation(self):
+		doc = new_doctype("Test Links Table Validation")
+
+		# check valid data
+		doc.append("links", {
+			'link_doctype': "User",
+			'link_fieldname': "first_name"
+		})
+		doc.validate_links_table_fieldnames() # no error
+		doc.links = [] # reset links table
+
+		# check invalid doctype
+		doc.append("links", {
+			'link_doctype': "User2",
+			'link_fieldname': "first_name"
+		})
+		self.assertRaises(frappe.DoesNotExistError, doc.validate_links_table_fieldnames)
+		doc.links = [] # reset links table
+
+		# check invalid fieldname
+		doc.append("links", {
+			'link_doctype': "User",
+			'link_fieldname': "a_field_that_does_not_exists"
+		})
+		self.assertRaises(InvalidFieldNameError, doc.validate_links_table_fieldnames)
+
+
 def new_doctype(name, unique=0, depends_on='', fields=None):
 	doc = frappe.get_doc({
 		"doctype": "DocType",


### PR DESCRIPTION
DocType links table is used to add links to the form dashboard. However there is no validation for it. So a user can add any fieldname and it goes through. But when opening the form for that doctype, the query is executed looking for that fieldname which does not exists, an error occurs.

```python
...
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column 'tabQuotation.quotation' in 'where clause'")
```

This PR adds validation and test for that validation.

## Error Message

<img width="1184" alt="Screen Shot 2020-11-06 at 12 44 05 PM" src="https://user-images.githubusercontent.com/18097732/98338922-ed7f6400-2030-11eb-95dc-c50e6cb96cfe.png">


[Frappe Issue Link](https://frappe.io/desk#Form/Issue/ISS-20-21-06700)