### PR TITLE
fix: form dashboard perm

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -113,7 +113,7 @@ frappe.ui.form.Layout = Class.extend({
 			label: __('Dashboard'),
 			cssClass: 'form-dashboard',
 			collapsible: 1,
-			//hidden: 1
+			hidden: 1
 		});
 	},
 

--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -57,6 +57,10 @@ def get_monthly_goal_graph_data(title, doctype, docname, goal_value_field, goal_
 	from frappe.utils.formatters import format_value
 	import json
 
+	# should have atleast read perm
+	if not frappe.has_permission(goal_doctype):
+		return None
+
 	meta = frappe.get_meta(doctype)
 	doc = frappe.get_doc(doctype, docname)
 


### PR DESCRIPTION
The whitelisted method `get_monthly_goal_graph_data` in goals.py would not check if the user had read permission on the doctype or not.

This PR adds a perm check for the same.

## Result
### Administrator View
<img width="1242" alt="Screen Shot 2020-11-06 at 2 03 54 PM" src="https://user-images.githubusercontent.com/18097732/98344512-5e2a7e80-2039-11eb-81c1-00c8c31f4d8f.png">


### User without permission for Sales Invoice
Note: Previously the user could see the Sales Invoice chart even if they had no read permission
<img width="1197" alt="Screen Shot 2020-11-06 at 2 03 43 PM" src="https://user-images.githubusercontent.com/18097732/98344525-61be0580-2039-11eb-8bc8-ee5fcf35a05a.png">
