### PR TITLE
fix: Remove scrolling on focusout event for touchscreen devices

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -133,18 +133,6 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 			me.parse_validate_and_set_in_model(me.get_input_value(), e);
 		});
 	},
-	bind_focusout: function() {
-		// on touchscreen devices, scroll to top
-		// so that static navbar and page head don't overlap the input
-		if (frappe.dom.is_touchscreen()) {
-			var me = this;
-			this.$input && this.$input.on("focusout", function() {
-				if (frappe.dom.is_touchscreen()) {
-					frappe.utils.scroll_to(me.$wrapper);
-				}
-			});
-		}
-	},
 	set_label: function(label) {
 		if(label) this.df.label = label;
 

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -21,7 +21,6 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 		this.input = this.$input.get(0);
 		this.has_input = true;
 		this.bind_change_event();
-		this.bind_focusout();
 		this.setup_autoname_check();
 		if (this.df.options == 'Phone') {
 			this.setup_phone();


### PR DESCRIPTION
**Before:**

On the `focusout` event of any input field, the page scrolls to the wrapper, users lose context of what field they were filling. GIF below shows such instances:

![scrolling-issue-1](https://user-images.githubusercontent.com/24353136/98346763-72bc4600-203c-11eb-9fc1-c12f7c5be2a3.gif)

![scrolling-issue-2](https://user-images.githubusercontent.com/24353136/98347108-fbd37d00-203c-11eb-9a89-898b56e2fded.gif)


**After:**

Removed the function

![scrolling-issue-fixed](https://user-images.githubusercontent.com/24353136/98348488-d6e00980-203e-11eb-8e31-03e0994d7533.gif)
