### PR TITLE
fix(quick entry): make sure init_callback is always called

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -35,14 +35,15 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 				if (this.is_quick_entry() || this.force) {
 					this.render_dialog();
 					resolve(this);
-				} else { // No quick entry, use full Form
-					// but still give callback a shot at the doc
-					if (this.init_callback) {
-						this.init_callback(this.doc);
-					}
+				} else {
+					// no quick entry, open full form
 					frappe.quick_entry = null;
 					frappe.set_route('Form', this.doctype, this.doc.name)
 						.then(() => resolve(this));
+					// call init_callback for consistency
+					if (this.init_callback) {
+						this.init_callback(this.doc);
+					}
 				}
 			});
 		});

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -35,7 +35,11 @@ frappe.ui.form.QuickEntryForm = Class.extend({
 				if (this.is_quick_entry() || this.force) {
 					this.render_dialog();
 					resolve(this);
-				} else {
+				} else { // No quick entry, use full Form
+					// but still give callback a shot at the doc
+					if (this.init_callback) {
+						this.init_callback(this.doc);
+					}
 					frappe.quick_entry = null;
 					frappe.set_route('Form', this.doctype, this.doc.name)
 						.then(() => resolve(this));


### PR DESCRIPTION
  Prior to this PR, as noted in issue #7638, it is not possible with
  frappe.new_doc to initialize certain fields of the new document, such as the
  description of a Task or the posting_date of a Journal Entry (in ERPNext).
  The reason this occurs is that currently the route_options which can be set
  in the second argument to frappe.new_doc() are only allowed to set certain
  field types of a document (namely, Link, Select, Data, and Dynamic Link).

  Although it turns out that it would not work to allow any field type to
  be set in the route options (in particular, attempting to allow one to set
  Table field types in this way is non-functional), it would be reasonable
  simply to try setting other fields that cannot be set in the route_options
  via the callback allowed as the third argument of frappe.new_doc. And
  indeed, this approach works for those DocTypes that have a Quick Entry Form.
  For those DocTypes that do not, however, the callback is never called.

  This PR modifies frappe.ui.form.make_quick_entry() -- which frappe.new_doc
  calls to do most of its work -- so that the callback is called regardless
  of whether the DocType has a Quick Entry Form or not. The only slight
  awkwardness in this is that if there is a Quick Entry, the callback is
  passed the dialog object of that Quick Entry, whereas if there is no
  Quick Entry, the callback is only passed the doc object that is about to be
  edited in the standard Form interface for a new document.

  Nevertheless, in any case, it is now possible to write a callback which
  will initialize any field in the new document being created.

  Resolves #7638.