### PR TITLE
fix(query-report): Show scrollbar for datatable

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -813,6 +813,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			data.splice(-1, 1);
 		}
 
+		this.$report.show();
 		if (this.datatable && this.datatable.options
 			&& (this.datatable.options.showTotalRow ===this.raw_data.add_total_row)) {
 			this.datatable.options.treeView = this.tree_report;
@@ -844,7 +845,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if (this.report_settings.after_datatable_render) {
 			this.report_settings.after_datatable_render(this.datatable);
 		}
-		this.$report.show();
 	}
 
 	get_chart_options(data) {


### PR DESCRIPTION
Vertical Scrollbar was not being shown for datatable in query report.


**Before**

![Before](https://user-images.githubusercontent.com/8528887/98655576-a1e8f500-2365-11eb-8df5-a2a55edbe890.gif)



**After**

![After](https://user-images.githubusercontent.com/8528887/98655598-a6ada900-2365-11eb-9422-ba902a646c14.gif)



