### PR TITLE
fix: Uninstall app enhancements

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -135,7 +135,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 		if not confirm:
 			return
 
-	if not no_backup:
+	if not (dry_run or no_backup):
 		from frappe.utils.backups import scheduled_backup
 		print("Backing up...")
 		scheduled_backup(ignore_files=True)
@@ -173,13 +173,15 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 	if not dry_run:
 		remove_from_installed_apps(app_name)
 
-		for doctype in set(drop_doctypes):
-			print("* dropping Table for '{0}'...".format(doctype))
+	for doctype in set(drop_doctypes):
+		print("* dropping Table for '{0}'...".format(doctype))
+		if not dry_run:
 			frappe.db.sql_ddl("drop table `tab{0}`".format(doctype))
 
+	if not dry_run:
 		frappe.db.commit()
-		click.secho("Uninstalled App {0} from Site {1}".format(app_name, frappe.local.site), fg="green")
 
+	click.secho("Uninstalled App {0} from Site {1}".format(app_name, frappe.local.site), fg="green")
 	frappe.flags.in_uninstall = False
 
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -147,7 +147,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 	for module_name in modules:
 		print("Deleting Module '{0}'".format(module_name))
 
-		for doctype in frappe.get_list("DocType", filters={"module": module_name}, fields=["name", "issingle"]):
+		for doctype in frappe.get_all("DocType", filters={"module": module_name}, fields=["name", "issingle"]):
 			print("* removing DocType '{0}'...".format(doctype.name))
 
 			if not dry_run:
@@ -161,7 +161,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 		doctypes_with_linked_modules = ordered_doctypes + [doctype.parent for doctype in linked_doctypes if doctype.parent not in ordered_doctypes]
 
 		for doctype in doctypes_with_linked_modules:
-			for record in frappe.get_list(doctype, filters={"module": module_name}):
+			for record in frappe.get_all(doctype, filters={"module": module_name}):
 				print("* removing {0} '{1}'...".format(doctype, record.name))
 				if not dry_run:
 					frappe.delete_doc(doctype, record.name)

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -121,34 +121,41 @@ def remove_from_installed_apps(app_name):
 def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False):
 	"""Remove app and all linked to the app's module with the app from a site."""
 	import click
+	site = frappe.local.site
 
 	# dont allow uninstall app if not installed unless forced
 	if not force:
 		if app_name not in frappe.get_installed_apps():
-			click.secho("App {0} not installed on Site {1}".format(app_name, frappe.local.site), fg="yellow")
+			click.secho(f"App {app_name} not installed on Site {site}", fg="yellow")
 			return
 
-	print("Uninstalling App {0} from Site {1}...".format(app_name, frappe.local.site))
+	print(f"Uninstalling App {app_name} from Site {site}...")
 
 	if not dry_run and not yes:
-		confirm = click.confirm("All doctypes (including custom), modules related to this app will be deleted. Are you sure you want to continue?")
+		confirm = click.confirm(
+			"All doctypes (including custom), modules related to this app will be"
+			" deleted. Are you sure you want to continue?"
+		)
 		if not confirm:
 			return
 
 	if not (dry_run or no_backup):
 		from frappe.utils.backups import scheduled_backup
+
 		print("Backing up...")
 		scheduled_backup(ignore_files=True)
 
 	frappe.flags.in_uninstall = True
 	drop_doctypes = []
 
-	modules = (x.name for x in frappe.get_all("Module Def", filters={"app_name": app_name}))
+	modules = frappe.get_all("Module Def", filters={"app_name": app_name}, pluck="name")
 	for module_name in modules:
-		print("Deleting Module '{0}'".format(module_name))
+		print(f"Deleting Module '{module_name}'")
 
-		for doctype in frappe.get_all("DocType", filters={"module": module_name}, fields=["name", "issingle"]):
-			print("* removing DocType '{0}'...".format(doctype.name))
+		for doctype in frappe.get_all(
+			"DocType", filters={"module": module_name}, fields=["name", "issingle"]
+		):
+			print(f"* removing DocType '{doctype.name}'...")
 
 			if not dry_run:
 				frappe.delete_doc("DocType", doctype.name)
@@ -156,17 +163,25 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 				if not doctype.issingle:
 					drop_doctypes.append(doctype.name)
 
-		linked_doctypes = frappe.get_all("DocField", filters={"fieldtype": "Link", "options": "Module Def"}, fields=['parent'])
+		linked_doctypes = frappe.get_all(
+			"DocField", filters={"fieldtype": "Link", "options": "Module Def"}, fields=["parent"]
+		)
 		ordered_doctypes = ["Desk Page", "Report", "Page", "Web Form"]
-		doctypes_with_linked_modules = ordered_doctypes + [doctype.parent for doctype in linked_doctypes if doctype.parent not in ordered_doctypes]
-
+		all_doctypes_with_linked_modules = ordered_doctypes + [
+			doctype.parent
+			for doctype in linked_doctypes
+			if doctype.parent not in ordered_doctypes
+		]
+		doctypes_with_linked_modules = [
+			x for x in all_doctypes_with_linked_modules if frappe.db.exists("DocType", x)
+		]
 		for doctype in doctypes_with_linked_modules:
-			for record in frappe.get_all(doctype, filters={"module": module_name}):
-				print("* removing {0} '{1}'...".format(doctype, record.name))
+			for record in frappe.get_all(doctype, filters={"module": module_name}, pluck="name"):
+				print(f"* removing {doctype} '{record}'...")
 				if not dry_run:
-					frappe.delete_doc(doctype, record.name)
+					frappe.delete_doc(doctype, record)
 
-		print("* removing Module Def '{0}'...".format(module_name))
+		print(f"* removing Module Def '{module_name}'...")
 		if not dry_run:
 			frappe.delete_doc("Module Def", module_name)
 
@@ -174,14 +189,14 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 		remove_from_installed_apps(app_name)
 
 	for doctype in set(drop_doctypes):
-		print("* dropping Table for '{0}'...".format(doctype))
+		print(f"* dropping Table for '{doctype}'...")
 		if not dry_run:
-			frappe.db.sql_ddl("drop table `tab{0}`".format(doctype))
+			frappe.db.sql_ddl(f"drop table `tab{doctype}`")
 
 	if not dry_run:
 		frappe.db.commit()
 
-	click.secho("Uninstalled App {0} from Site {1}".format(app_name, frappe.local.site), fg="green")
+	click.secho(f"Uninstalled App {app_name} from Site {site}", fg="green")
 	frappe.flags.in_uninstall = False
 
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -121,6 +121,7 @@ def remove_from_installed_apps(app_name):
 def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False):
 	"""Remove app and all linked to the app's module with the app from a site."""
 	import click
+
 	site = frappe.local.site
 
 	# dont allow uninstall app if not installed unless forced
@@ -158,7 +159,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 			print(f"* removing DocType '{doctype.name}'...")
 
 			if not dry_run:
-				frappe.delete_doc("DocType", doctype.name)
+				frappe.delete_doc("DocType", doctype.name, ignore_on_trash=True)
 
 				if not doctype.issingle:
 					drop_doctypes.append(doctype.name)
@@ -179,14 +180,11 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 			for record in frappe.get_all(doctype, filters={"module": module_name}, pluck="name"):
 				print(f"* removing {doctype} '{record}'...")
 				if not dry_run:
-					frappe.delete_doc(doctype, record)
+					frappe.delete_doc(doctype, record, ignore_on_trash=True)
 
 		print(f"* removing Module Def '{module_name}'...")
 		if not dry_run:
-			frappe.delete_doc("Module Def", module_name)
-
-	if not dry_run:
-		remove_from_installed_apps(app_name)
+			frappe.delete_doc("Module Def", module_name, ignore_on_trash=True)
 
 	for doctype in set(drop_doctypes):
 		print(f"* dropping Table for '{doctype}'...")
@@ -194,6 +192,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 			frappe.db.sql_ddl(f"drop table `tab{doctype}`")
 
 	if not dry_run:
+		remove_from_installed_apps(app_name)
 		frappe.db.commit()
 
 	click.secho(f"Uninstalled App {app_name} from Site {site}", fg="green")

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -335,18 +335,24 @@ def clear_timeline_references(link_doctype, link_name):
 		WHERE `tabCommunication Link`.link_doctype=%s AND `tabCommunication Link`.link_name=%s""", (link_doctype, link_name))
 
 def insert_feed(doc):
-	from frappe.utils import get_fullname
-
-	if frappe.flags.in_install or frappe.flags.in_import or getattr(doc, "no_feed_on_delete", False):
+	if (
+		frappe.flags.in_install
+		or frappe.flags.in_uninstall
+		or frappe.flags.in_import
+		or getattr(doc, "no_feed_on_delete", False)
+	):
 		return
+
+	from frappe.utils import get_fullname
 
 	frappe.get_doc({
 		"doctype": "Comment",
 		"comment_type": "Deleted",
 		"reference_doctype": doc.doctype,
 		"subject": "{0} {1}".format(_(doc.doctype), doc.name),
-		"full_name": get_fullname(doc.owner)
+		"full_name": get_fullname(doc.owner),
 	}).insert(ignore_permissions=True)
+
 
 def delete_controllers(doctype, module):
 	"""


### PR DESCRIPTION
* Don't take database backup in `--dry-run`
* Run `frappe.delete_doc` with `ignore_on_trash=True` to bypass errors while uninstalling from sites with older Frappe versions.
*  Don't add comment on doctype via `insert_feed` in [delete_doc.py](https://github.com/frappe/frappe/blob/d28fb7ff5e7c74a516a9c2bf5ac44fb1535165cc/frappe/model/delete_doc.py#L128)
* Re-arrange and optimize code blocks to maintain dry run verbosity 
* Replaced `.format` with `f-strings`
* style: Black-ish

