### PR TITLE
fix: Read-only table has read-only form fields.

### DIFF
--- a/cypress/integration/depends_on.js
+++ b/cypress/integration/depends_on.js
@@ -3,7 +3,31 @@ context('Depends On', () => {
 		cy.login();
 		cy.visit('/desk#workspace/Website');
 		return cy.window().its('frappe').then(frappe => {
-			return frappe.call('frappe.tests.ui_test_helpers.create_doctype', {
+			return frappe.xcall('frappe.tests.ui_test_helpers.create_child_doctype', {
+				name: 'Child Test Depends On',
+				fields: [
+					{
+						"label": "Child Test Field",
+						"fieldname": "child_test_field",
+						"fieldtype": "Data",
+						"in_list_view": 1,
+					},
+					{
+						"label": "Child Dependant Field",
+						"fieldname": "child_dependant_field",
+						"fieldtype": "Data",
+						"in_list_view": 1,
+					},
+					{
+						"label": "Child Display Dependant Field",
+						"fieldname": "child_display_dependant_field",
+						"fieldtype": "Data",
+						"in_list_view": 1,
+					},
+				]
+			});
+		}).then(frappe => {
+			return frappe.xcall('frappe.tests.ui_test_helpers.create_doctype', {
 				name: 'Test Depends On',
 				fields: [
 					{
@@ -23,6 +47,13 @@ context('Depends On', () => {
 						"fieldname": "display_dependant_field",
 						"fieldtype": "Data",
 						'depends_on': "eval:doc.test_field=='Value'"
+					},
+					{
+						"label": "Child Test Depends On Field",
+						"fieldname": "child_test_depends_on_field",
+						"fieldtype": "Table",
+						'read_only_depends_on': "eval:doc.test_field=='Some Other Value'",
+						'options': "Child Test Depends On"
 					},
 				]
 			});
@@ -47,6 +78,30 @@ context('Depends On', () => {
 		cy.fill_field('test_field', 'Random Value');
 		cy.get('body').click();
 		cy.get('.control-input [data-fieldname="dependant_field"]').should('not.be.disabled');
+	});
+	it('should set the table and its fields as read only depending on other fields value', () => {
+		cy.new_form('Test Depends On');
+		cy.fill_field('dependant_field', 'Some Value');
+		//cy.fill_field('test_field', 'Some Other Value');
+		cy.get('.frappe-control[data-fieldname="child_test_depends_on_field"]').as('table');
+		cy.get('@table').find('button.grid-add-row').click();
+		cy.get('@table').find('[data-idx="1"]').as('row1');
+		cy.get('@row1').find('.btn-open-row').click();
+		cy.get('@row1').find('.form-in-grid').as('row1-form_in_grid');
+		//cy.get('@row1-form_in_grid').find('')
+		cy.fill_table_field('child_test_depends_on_field', '1', 'child_test_field', 'Some Value');
+		cy.fill_table_field('child_test_depends_on_field', '1', 'child_dependant_field', 'Some Other Value');
+
+		cy.get('@row1-form_in_grid').find('.octicon-triangle-up').click();
+
+		// set the table to read-only
+		cy.fill_field('test_field', 'Some Other Value');
+
+		// grid row form fields should be read-only
+		cy.get('@row1').find('.btn-open-row').click();
+
+		cy.get('@row1-form_in_grid').find('.control-input [data-fieldname="child_test_field"]').should('be.disabled');
+		cy.get('@row1-form_in_grid').find('.control-input [data-fieldname="child_dependant_field"]').should('be.disabled');
 	});
 	it('should display the field depending on other fields value', () => {
 		cy.new_form('Test Depends On');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -160,7 +160,7 @@ Cypress.Commands.add('remove_doc', (doctype, name) => {
 
 Cypress.Commands.add('create_records', doc => {
 	return cy
-		.call('frappe.tests.ui_test_helpers.create_if_not_exists', { doc })
+		.call('frappe.tests.ui_test_helpers.create_if_not_exists', {doc})
 		.then(r => r.message);
 });
 
@@ -186,7 +186,7 @@ Cypress.Commands.add('fill_field', (fieldname, value, fieldtype = 'Data') => {
 	if (fieldtype === 'Select') {
 		cy.get('@input').select(value);
 	} else {
-		cy.get('@input').type(value, { waitForAnimations: false, force: true });
+		cy.get('@input').type(value, {waitForAnimations: false, force: true});
 	}
 	return cy.get('@input');
 });
@@ -204,8 +204,43 @@ Cypress.Commands.add('get_field', (fieldname, fieldtype = 'Data') => {
 	return cy.get(selector);
 });
 
+Cypress.Commands.add('fill_table_field', (tablefieldname, row_idx, fieldname, value, fieldtype = 'Data') => {
+	cy.get_table_field(tablefieldname, row_idx, fieldname, fieldtype).as('input');
+
+	if (['Date', 'Time', 'Datetime'].includes(fieldtype)) {
+		cy.get('@input').click().wait(200);
+		cy.get('.datepickers-container .datepicker.active').should('exist');
+	}
+	if (fieldtype === 'Time') {
+		cy.get('@input').clear().wait(200);
+	}
+
+	if (fieldtype === 'Select') {
+		cy.get('@input').select(value);
+	} else {
+		cy.get('@input').type(value, {waitForAnimations: false, force: true});
+	}
+	return cy.get('@input');
+});
+
+Cypress.Commands.add('get_table_field', (tablefieldname, row_idx, fieldname, fieldtype = 'Data') => {
+	let selector = `.frappe-control[data-fieldname="${tablefieldname}"]`;
+	selector += ` [data-idx="${row_idx}"]`;
+	selector += ` .form-in-grid`;
+
+	if (fieldtype === 'Text Editor') {
+		selector += ` [data-fieldname="${fieldname}"] .ql-editor[contenteditable=true]`;
+	} else if (fieldtype === 'Code') {
+		selector += ` [data-fieldname="${fieldname}"] .ace_text-input`;
+	} else {
+		selector += ` .form-control[data-fieldname="${fieldname}"]`;
+	}
+
+	return cy.get(selector);
+});
+
 Cypress.Commands.add('awesomebar', text => {
-	cy.get('#navbar-search').type(`${text}{downarrow}{enter}`, { delay: 100 });
+	cy.get('#navbar-search').type(`${text}{downarrow}{enter}`, {delay: 100});
 });
 
 Cypress.Commands.add('new_form', doctype => {

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -40,23 +40,31 @@ frappe.ui.form.Control = Class.extend({
 			return this.df.get_status(this);
 		}
 
-		if((!this.doctype && !this.docname) || this.df.parenttype === 'Web Form') {
+		if ((!this.doctype && !this.docname) || this.df.parenttype === 'Web Form' || this.df.is_web_form) {
 			// like in case of a dialog box
 			if (cint(this.df.hidden)) {
 				// eslint-disable-next-line
-				if(explain) console.log("By Hidden: None");
+				if (explain) console.log("By Hidden: None"); // eslint-disable-line no-console
 				return "None";
 
 			} else if (cint(this.df.hidden_due_to_dependency)) {
 				// eslint-disable-next-line
-				if(explain) console.log("By Hidden Dependency: None");
+				if(explain) console.log("By Hidden Dependency: None"); // eslint-disable-line no-console
 				return "None";
 
 			} else if (cint(this.df.read_only)) {
 				// eslint-disable-next-line
-				if(explain) console.log("By Read Only: Read");
+				if (explain) console.log("By Read Only: Read"); // eslint-disable-line no-console
 				return "Read";
 
+			} else if ((this.grid &&
+						this.grid.display_status == 'Read') ||
+						(this.layout &&
+						this.layout.grid &&
+						this.layout.grid.display_status == 'Read')) {
+				// parent grid is read
+				if (explain) console.log("By Parent Grid Read-only: Read"); // eslint-disable-line no-console
+				return "Read";
 			}
 
 			return "Write";
@@ -65,13 +73,22 @@ frappe.ui.form.Control = Class.extend({
 		var status = frappe.perm.get_field_display_status(this.df,
 			frappe.model.get_doc(this.doctype, this.docname), this.perm || (this.frm && this.frm.perm), explain);
 
+		// Match parent grid controls read only status
+		if (status === 'Write' && (this.grid || (this.layout && this.layout.grid))) {
+			var grid = this.grid || this.layout.grid;
+			if (grid.display_status == 'Read') {
+				status = 'Read';
+				if (explain) console.log("By Parent Grid Read-only: Read"); // eslint-disable-line no-console
+			}
+		}
+
 		// hide if no value
 		if (this.doctype && status==="Read" && !this.only_input
 			&& is_null(frappe.model.get_value(this.doctype, this.docname, this.df.fieldname))
 			&& !in_list(["HTML", "Image", "Button"], this.df.fieldtype)) {
 
 			// eslint-disable-next-line
-			if(explain) console.log("By Hide Read-only, null fields: None");
+			if (explain) console.log("By Hide Read-only, null fields: None"); // eslint-disable-line no-console
 			status = "None";
 		}
 

--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -9,7 +9,8 @@ frappe.ui.form.ControlTable = frappe.ui.form.Control.extend({
 			frm: this.frm,
 			df: this.df,
 			perm: this.perm || (this.frm && this.frm.perm) || this.df.perm,
-			parent: this.wrapper
+			parent: this.wrapper,
+			control: this
 		});
 		if(this.frm) {
 			this.frm.grids[this.frm.grids.length] = this;

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -264,6 +264,8 @@ export default class Grid {
 		if (this.frm) {
 			this.display_status = frappe.perm.get_field_display_status(this.df, this.frm.doc,
 				this.perm);
+		} else if (this.df.is_web_form && this.control) {
+			this.display_status = this.control.get_status();
 		} else {
 			// not in form
 			this.display_status = 'Write';

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -16,6 +16,9 @@ export default class GridRowForm {
 			body: this.form_area,
 			no_submit_on_enter: true,
 			frm: this.row.frm,
+			grid: this.row.grid,
+			grid_row: this.row,
+			grid_row_form: this,
 		});
 		this.layout.make();
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -1,7 +1,7 @@
 import '../class';
 
 frappe.ui.form.Layout = Class.extend({
-	init: function(opts) {
+	init: function (opts) {
 		this.views = {};
 		this.pages = [];
 		this.sections = [];
@@ -10,24 +10,24 @@ frappe.ui.form.Layout = Class.extend({
 
 		$.extend(this, opts);
 	},
-	make: function() {
-		if(!this.parent && this.body) {
+	make: function () {
+		if (!this.parent && this.body) {
 			this.parent = this.body;
 		}
 		this.wrapper = $('<div class="form-layout">').appendTo(this.parent);
 		this.message = $('<div class="form-message text-muted small hidden"></div>').appendTo(this.wrapper);
-		if(!this.fields) {
+		if (!this.fields) {
 			this.fields = this.get_doctype_fields();
 		}
 		this.setup_tabbing();
 		this.render();
 	},
-	show_empty_form_message: function() {
-		if(!(this.wrapper.find(".frappe-control:visible").length || this.wrapper.find(".section-head.collapsed").length)) {
+	show_empty_form_message: function () {
+		if (!(this.wrapper.find(".frappe-control:visible").length || this.wrapper.find(".section-head.collapsed").length)) {
 			this.show_message(__("This form does not have any input"));
 		}
 	},
-	get_doctype_fields: function() {
+	get_doctype_fields: function () {
 		let fields = [
 			{
 				parent: this.frm.doctype,
@@ -36,7 +36,7 @@ frappe.ui.form.Layout = Class.extend({
 				reqd: 1,
 				hidden: 1,
 				label: __('Name'),
-				get_status: function(field) {
+				get_status: function (field) {
 					if (field.frm && field.frm.is_new()
 						&& field.frm.meta.autoname
 						&& ['prompt', 'name'].includes(field.frm.meta.autoname.toLowerCase())) {
@@ -49,14 +49,14 @@ frappe.ui.form.Layout = Class.extend({
 		fields = fields.concat(frappe.meta.sort_docfields(frappe.meta.docfield_map[this.doctype]));
 		return fields;
 	},
-	show_message: function(html, color) {
+	show_message: function (html, color) {
 		if (this.message_color) {
 			// remove previous color
 			this.message.removeClass(this.message_color);
 		}
 		this.message_color = (color && ['yellow', 'blue'].includes(color)) ? color : 'blue';
-		if(html) {
-			if(html.substr(0, 1)!=='<') {
+		if (html) {
+			if (html.substr(0, 1) !== '<') {
 				// wrap in a block
 				html = '<div>' + html + '</div>';
 			}
@@ -66,7 +66,7 @@ frappe.ui.form.Layout = Class.extend({
 			this.message.empty().addClass('hidden');
 		}
 	},
-	render: function(new_fields) {
+	render: function (new_fields) {
 		var me = this;
 		var fields = new_fields || this.fields;
 
@@ -80,8 +80,8 @@ frappe.ui.form.Layout = Class.extend({
 		if (this.no_opening_section()) {
 			this.make_section();
 		}
-		$.each(fields, function(i, df) {
-			switch(df.fieldtype) {
+		$.each(fields, function (i, df) {
+			switch (df.fieldtype) {
 				case "Fold":
 					me.make_page(df);
 					break;
@@ -98,11 +98,11 @@ frappe.ui.form.Layout = Class.extend({
 
 	},
 
-	no_opening_section: function() {
-		return (this.fields[0] && this.fields[0].fieldtype!="Section Break") || !this.fields.length;
+	no_opening_section: function () {
+		return (this.fields[0] && this.fields[0].fieldtype != "Section Break") || !this.fields.length;
 	},
 
-	setup_dashboard_section: function() {
+	setup_dashboard_section: function () {
 		if (this.no_opening_section()) {
 			this.fields.unshift({fieldtype: 'Section Break'});
 		}
@@ -117,7 +117,7 @@ frappe.ui.form.Layout = Class.extend({
 		});
 	},
 
-	replace_field: function(fieldname, df, render) {
+	replace_field: function (fieldname, df, render) {
 		df.fieldname = fieldname; // change of fieldname is avoided
 		if (this.fields_dict[fieldname] && this.fields_dict[fieldname].df) {
 			const fieldobj = this.init_field(df, render);
@@ -133,14 +133,14 @@ frappe.ui.form.Layout = Class.extend({
 		}
 	},
 
-	make_field: function(df, colspan, render) {
+	make_field: function (df, colspan, render) {
 		!this.section && this.make_section();
 		!this.column && this.make_column();
 
 		const fieldobj = this.init_field(df, render);
 		this.fields_list.push(fieldobj);
 		this.fields_dict[df.fieldname] = fieldobj;
-		if(this.frm) {
+		if (this.frm) {
 			fieldobj.perm = this.frm.perm;
 		}
 
@@ -149,31 +149,32 @@ frappe.ui.form.Layout = Class.extend({
 		fieldobj.section = this.section;
 	},
 
-	init_field: function(df, render = false) {
+	init_field: function (df, render = false) {
 		const fieldobj = frappe.ui.form.make_control({
 			df: df,
 			doctype: this.doctype,
 			parent: this.column.wrapper.get(0),
 			frm: this.frm,
 			render_input: render,
-			doc: this.doc
+			doc: this.doc,
+			layout: this
 		});
 
 		fieldobj.layout = this;
 		return fieldobj;
 	},
 
-	make_page: function(df) {
+	make_page: function (df) { // eslint-disable-line no-unused-vars
 		var me = this,
 			head = $('<div class="form-clickable-section text-center">\
-				<a class="btn-fold h6 text-muted">'+__("Show more details")+'</a>\
+				<a class="btn-fold h6 text-muted">' + __("Show more details") + '</a>\
 			</div>').appendTo(this.wrapper);
 
 		this.page = $('<div class="form-page second-page hide"></div>').appendTo(this.wrapper);
 
-		this.fold_btn = head.find(".btn-fold").on("click", function() {
+		this.fold_btn = head.find(".btn-fold").on("click", function () {
 			var page = $(this).parent().next();
-			if(page.hasClass("hide")) {
+			if (page.hasClass("hide")) {
 				$(this).removeClass("btn-fold").html(__("Hide details"));
 				page.removeClass("hide");
 				frappe.utils.scroll_to($(this), true, 30);
@@ -189,15 +190,15 @@ frappe.ui.form.Layout = Class.extend({
 		this.folded = true;
 	},
 
-	unfold: function() {
+	unfold: function () {
 		this.fold_btn.trigger('click');
 	},
 
-	make_section: function(df) {
+	make_section: function (df) {
 		this.section = new frappe.ui.form.Section(this, df);
 
 		// append to layout fields
-		if(df) {
+		if (df) {
 			this.fields_dict[df.fieldname] = this.section;
 			this.fields_list.push(this.section);
 		}
@@ -205,16 +206,16 @@ frappe.ui.form.Layout = Class.extend({
 		this.column = null;
 	},
 
-	make_column: function(df) {
+	make_column: function (df) {
 		this.column = new frappe.ui.form.Column(this.section, df);
-		if(df && df.fieldname) {
+		if (df && df.fieldname) {
 			this.fields_list.push(this.column);
 		}
 	},
 
-	refresh: function(doc) {
+	refresh: function (doc) {
 		var me = this;
-		if(doc) this.doc = doc;
+		if (doc) this.doc = doc;
 
 		if (this.frm) {
 			this.wrapper.find(".empty-form-alert").remove();
@@ -223,7 +224,7 @@ frappe.ui.form.Layout = Class.extend({
 		// NOTE this might seem redundant at first, but it needs to be executed when frm.refresh_fields is called
 		me.attach_doc_and_docfields(true);
 
-		if(this.frm && this.frm.wrapper) {
+		if (this.frm && this.frm.wrapper) {
 			$(this.frm.wrapper).trigger("refresh-fields");
 		}
 
@@ -234,26 +235,26 @@ frappe.ui.form.Layout = Class.extend({
 		this.refresh_sections();
 
 		// collapse sections
-		if(this.frm) {
+		if (this.frm) {
 			this.refresh_section_collapse();
 		}
 	},
 
-	refresh_sections: function() {
+	refresh_sections: function () {
 		var cnt = 0;
 
 		// hide invisible sections and set alternate background color
-		this.wrapper.find(".form-section:not(.hide-control)").each(function() {
+		this.wrapper.find(".form-section:not(.hide-control)").each(function () {
 			var $this = $(this).removeClass("empty-section")
 				.removeClass("visible-section")
 				.removeClass("shaded-section");
-			if(!$this.find(".frappe-control:not(.hide-control)").length
+			if (!$this.find(".frappe-control:not(.hide-control)").length
 				&& !$this.hasClass('form-dashboard')) {
 				// nothing visible, hide the section
 				$this.addClass("empty-section");
 			} else {
 				$this.addClass("visible-section");
-				if(cnt % 2) {
+				if (cnt % 2) {
 					$this.addClass("shaded-section");
 				}
 				cnt++;
@@ -261,36 +262,36 @@ frappe.ui.form.Layout = Class.extend({
 		});
 	},
 
-	refresh_fields: function(fields) {
+	refresh_fields: function (fields) {
 		let fieldnames = fields.map((field) => {
-			if(field.fieldname) return field.fieldname;
+			if (field.fieldname) return field.fieldname;
 		});
 
 		this.fields_list.map(fieldobj => {
-			if(fieldnames.includes(fieldobj.df.fieldname)) {
+			if (fieldnames.includes(fieldobj.df.fieldname)) {
 				fieldobj.refresh();
-				if(fieldobj.df["default"]) {
+				if (fieldobj.df["default"]) {
 					fieldobj.set_input(fieldobj.df["default"]);
 				}
 			}
 		});
 	},
 
-	add_fields: function(fields) {
+	add_fields: function (fields) {
 		this.render(fields);
 		this.refresh_fields(fields);
 	},
 
-	refresh_section_collapse: function() {
-		if(!this.doc) return;
+	refresh_section_collapse: function () {
+		if (!this.doc) return;
 
-		for(var i=0; i<this.sections.length; i++) {
+		for (var i = 0; i < this.sections.length; i++) {
 			var section = this.sections[i];
 			var df = section.df;
-			if(df && df.collapsible) {
+			if (df && df.collapsible) {
 				var collapse = true;
 
-				if(df.collapsible_depends_on) {
+				if (df.collapsible_depends_on) {
 					collapse = !this.evaluate_depends_on_value(df.collapsible_depends_on);
 				}
 
@@ -298,8 +299,8 @@ frappe.ui.form.Layout = Class.extend({
 					collapse = false;
 				}
 
-				if(df.fieldname === '_form_dashboard') {
-					collapse = localStorage.getItem('collapseFormDashboard')==='yes' ? true : false;
+				if (df.fieldname === '_form_dashboard') {
+					collapse = localStorage.getItem('collapseFormDashboard') === 'yes' ? true : false;
 				}
 
 				section.collapse(collapse);
@@ -307,11 +308,11 @@ frappe.ui.form.Layout = Class.extend({
 		}
 	},
 
-	attach_doc_and_docfields: function(refresh) {
+	attach_doc_and_docfields: function (refresh) {
 		var me = this;
-		for(var i=0, l=this.fields_list.length; i<l; i++) {
+		for (var i = 0, l = this.fields_list.length; i < l; i++) {
 			var fieldobj = this.fields_list[i];
-			if(me.doc) {
+			if (me.doc) {
 				fieldobj.doc = me.doc;
 				fieldobj.doctype = me.doc.doctype;
 				fieldobj.docname = me.doc.name;
@@ -319,7 +320,7 @@ frappe.ui.form.Layout = Class.extend({
 					fieldobj.df.fieldname, me.frm ? me.frm.doc.name : me.doc.name) || fieldobj.df;
 
 				// on form change, permissions can change
-				if(me.frm) {
+				if (me.frm) {
 					fieldobj.perm = me.frm.perm;
 				}
 			}
@@ -327,24 +328,24 @@ frappe.ui.form.Layout = Class.extend({
 		}
 	},
 
-	refresh_section_count: function() {
-		this.wrapper.find(".section-count-label:visible").each(function(i) {
-			$(this).html(i+1);
+	refresh_section_count: function () {
+		this.wrapper.find(".section-count-label:visible").each(function (i) {
+			$(this).html(i + 1);
 		});
 	},
-	setup_tabbing: function() {
+	setup_tabbing: function () {
 		var me = this;
-		this.wrapper.on("keydown", function(ev) {
-			if(ev.which==9) {
+		this.wrapper.on("keydown", function (ev) {
+			if (ev.which == 9) {
 				var current = $(ev.target),
 					doctype = current.attr("data-doctype"),
 					fieldname = current.attr("data-fieldname");
-				if(doctype)
+				if (doctype)
 					return me.handle_tab(doctype, fieldname, ev.shiftKey);
 			}
 		});
 	},
-	handle_tab: function(doctype, fieldname, shift) {
+	handle_tab: function (doctype, fieldname, shift) {
 		var me = this,
 			grid_row = null,
 			prev = null,
@@ -353,25 +354,25 @@ frappe.ui.form.Layout = Class.extend({
 			focused = false;
 
 		// in grid
-		if(doctype != me.doctype) {
+		if (doctype != me.doctype) {
 			grid_row = me.get_open_grid_row();
-			if(!grid_row || !grid_row.layout) {
+			if (!grid_row || !grid_row.layout) {
 				return;
 			}
 			fields = grid_row.layout.fields_list;
 		}
 
-		for(var i=0, len=fields.length; i < len; i++) {
-			if(fields[i].df.fieldname==fieldname) {
-				if(shift) {
-					if(prev) {
+		for (var i = 0, len = fields.length; i < len; i++) {
+			if (fields[i].df.fieldname == fieldname) {
+				if (shift) {
+					if (prev) {
 						this.set_focus(prev);
 					} else {
 						$(this.primary_button).focus();
 					}
 					break;
 				}
-				if(i < len-1) {
+				if (i < len - 1) {
 					focused = me.focus_on_next_field(i, fields);
 				}
 
@@ -379,17 +380,17 @@ frappe.ui.form.Layout = Class.extend({
 					break;
 				}
 			}
-			if(this.is_visible(fields[i]))
+			if (this.is_visible(fields[i]))
 				prev = fields[i];
 		}
 
 		if (!focused) {
 			// last field in this group
-			if(grid_row) {
+			if (grid_row) {
 				// in grid
-				if(grid_row.doc.idx==grid_row.grid.grid_rows.length) {
+				if (grid_row.doc.idx == grid_row.grid.grid_rows.length) {
 					// last row, close it and find next field
-					grid_row.toggle_view(false, function() {
+					grid_row.toggle_view(false, function () {
 						grid_row.grid.frm.layout.handle_tab(grid_row.grid.df.parent, grid_row.grid.df.fieldname);
 					});
 				} else {
@@ -403,14 +404,14 @@ frappe.ui.form.Layout = Class.extend({
 
 		return false;
 	},
-	focus_on_next_field: function(start_idx, fields) {
+	focus_on_next_field: function (start_idx, fields) {
 		// loop to find next eligible fields
-		for(var i= start_idx + 1, len = fields.length; i < len; i++) {
+		for (var i = start_idx + 1, len = fields.length; i < len; i++) {
 			var field = fields[i];
-			if(this.is_visible(field)) {
-				if(field.df.fieldtype==="Table") {
+			if (this.is_visible(field)) {
+				if (field.df.fieldtype === "Table") {
 					// open table grid
-					if(!(field.grid.grid_rows && field.grid.grid_rows.length)) {
+					if (!(field.grid.grid_rows && field.grid.grid_rows.length)) {
 						// empty grid, add a new row
 						field.grid.add_new_row();
 					}
@@ -418,34 +419,34 @@ frappe.ui.form.Layout = Class.extend({
 					field.grid.grid_rows[0].show_form();
 					return true;
 
-				} else if(!in_list(frappe.model.no_value_type, field.df.fieldtype)) {
+				} else if (!in_list(frappe.model.no_value_type, field.df.fieldtype)) {
 					this.set_focus(field);
 					return true;
 				}
 			}
 		}
 	},
-	is_visible: function(field) {
-		return field.disp_status==="Write" && (field.$wrapper && field.$wrapper.is(":visible"));
+	is_visible: function (field) {
+		return field.disp_status === "Write" && (field.$wrapper && field.$wrapper.is(":visible"));
 	},
-	set_focus: function(field) {
+	set_focus: function (field) {
 		// next is table, show the table
-		if(field.df.fieldtype=="Table") {
-			if(!field.grid.grid_rows.length) {
+		if (field.df.fieldtype == "Table") {
+			if (!field.grid.grid_rows.length) {
 				field.grid.add_new_row(1);
 			} else {
 				field.grid.grid_rows[0].toggle_view(true);
 			}
-		} else if(field.editor) {
+		} else if (field.editor) {
 			field.editor.set_focus();
-		} else if(field.$input) {
+		} else if (field.$input) {
 			field.$input.focus();
 		}
 	},
-	get_open_grid_row: function() {
+	get_open_grid_row: function () {
 		return $(".grid-row-open").data("grid_row");
 	},
-	refresh_dependency: function() {
+	refresh_dependency: function () {
 		// Resolve "depends_on" and show / hide accordingly
 		var me = this;
 
@@ -463,7 +464,7 @@ frappe.ui.form.Layout = Class.extend({
 		if (!has_dep) return;
 
 		// show / hide based on values
-		for (var i=me.fields_list.length-1;i>=0;i--) {
+		for (var i = me.fields_list.length - 1; i >= 0; i--) {
 			var f = me.fields_list[i];
 			f.guardian_has_value = true;
 			if (f.df.depends_on) {
@@ -473,12 +474,12 @@ frappe.ui.form.Layout = Class.extend({
 
 				// show / hide
 				if (f.guardian_has_value) {
-					if(f.df.hidden_due_to_dependency) {
+					if (f.df.hidden_due_to_dependency) {
 						f.df.hidden_due_to_dependency = false;
 						f.refresh();
 					}
 				} else {
-					if(!f.df.hidden_due_to_dependency) {
+					if (!f.df.hidden_due_to_dependency) {
 						f.df.hidden_due_to_dependency = true;
 						f.refresh();
 					}
@@ -496,14 +497,14 @@ frappe.ui.form.Layout = Class.extend({
 
 		this.refresh_section_count();
 	},
-	set_dependant_property: function(condition, fieldname, property) {
+	set_dependant_property: function (condition, fieldname, property) {
 		let set_property = this.evaluate_depends_on_value(condition);
 		let value = set_property ? 1 : 0;
 		let form_obj;
 
 		if (this.frm) {
 			form_obj = this.frm;
-		} else if (this.is_dialog) {
+		} else if (this.is_dialog || this.doctype === 'Web Form') {
 			form_obj = this;
 		}
 		if (form_obj) {
@@ -514,7 +515,7 @@ frappe.ui.form.Layout = Class.extend({
 			}
 		}
 	},
-	evaluate_depends_on_value: function(expression) {
+	evaluate_depends_on_value: function (expression) {
 		var out = null;
 		var doc = this.doc;
 
@@ -528,27 +529,27 @@ frappe.ui.form.Layout = Class.extend({
 
 		var parent = this.frm ? this.frm.doc : this.doc || null;
 
-		if(typeof(expression) === 'boolean') {
+		if (typeof (expression) === 'boolean') {
 			out = expression;
 
-		} else if(typeof(expression) === 'function') {
+		} else if (typeof (expression) === 'function') {
 			out = expression(doc);
 
-		} else if(expression.substr(0,5)=='eval:') {
+		} else if (expression.substr(0, 5) == 'eval:') {
 			try {
 				out = eval(expression.substr(5));
-				if(parent && parent.istable && expression.includes('is_submittable')) {
+				if (parent && parent.istable && expression.includes('is_submittable')) {
 					out = true;
 				}
-			} catch(e) {
+			} catch (e) {
 				frappe.throw(__('Invalid "depends_on" expression'));
 			}
 
-		} else if(expression.substr(0,3)=='fn:' && this.frm) {
+		} else if (expression.substr(0, 3) == 'fn:' && this.frm) {
 			out = this.frm.script_manager.trigger(expression.substr(3), this.doctype, this.docname);
 		} else {
 			var value = doc[expression];
-			if($.isArray(value)) {
+			if ($.isArray(value)) {
 				out = !!value.length;
 			} else {
 				out = !!value;
@@ -560,7 +561,7 @@ frappe.ui.form.Layout = Class.extend({
 });
 
 frappe.ui.form.Section = Class.extend({
-	init: function(layout, df) {
+	init: function (layout, df) {
 		var me = this;
 		this.layout = layout;
 		this.df = df || {};
@@ -580,8 +581,8 @@ frappe.ui.form.Section = Class.extend({
 
 		this.refresh();
 	},
-	make: function() {
-		if(!this.layout.page) {
+	make: function () {
+		if (!this.layout.page) {
 			this.layout.page = $('<div class="form-page"></div>').appendTo(this.layout.wrapper);
 		}
 
@@ -589,15 +590,15 @@ frappe.ui.form.Section = Class.extend({
 			.appendTo(this.layout.page);
 		this.layout.sections.push(this);
 
-		if(this.df) {
-			if(this.df.label) {
+		if (this.df) {
+			if (this.df.label) {
 				this.make_head();
 			}
-			if(this.df.description) {
+			if (this.df.description) {
 				$('<div class="col-sm-12 small text-muted form-section-description">' + __(this.df.description) + '</div>')
 					.appendTo(this.wrapper);
 			}
-			if(this.df.cssClass) {
+			if (this.df.cssClass) {
 				this.wrapper.addClass(this.df.cssClass);
 			}
 			if (this.df.hide_border) {
@@ -609,49 +610,49 @@ frappe.ui.form.Section = Class.extend({
 		this.body = $('<div class="section-body">').appendTo(this.wrapper);
 	},
 
-	make_head: function() {
+	make_head: function () {
 		var me = this;
-		if(!this.df.collapsible) {
+		if (!this.df.collapsible) {
 			$('<div class="col-sm-12"><h6 class="form-section-heading uppercase">'
 				+ __(this.df.label) + '</h6></div>')
 				.appendTo(this.wrapper);
 		} else {
 			this.head = $('<div class="section-head"><a class="h6 uppercase">'
-				+__(this.df.label)+'</a><span class="octicon octicon-chevron-down collapse-indicator"></span></div>').appendTo(this.wrapper);
+				+ __(this.df.label) + '</a><span class="octicon octicon-chevron-down collapse-indicator"></span></div>').appendTo(this.wrapper);
 
 			// show / hide based on status
-			this.collapse_link = this.head.on("click", function() {
+			this.collapse_link = this.head.on("click", function () {
 				me.collapse();
 			});
 
 			this.indicator = this.head.find(".collapse-indicator");
 		}
 	},
-	refresh: function() {
-		if(!this.df)
+	refresh: function () {
+		if (!this.df)
 			return;
 
 		// hide if explictly hidden
 		var hide = this.df.hidden || this.df.hidden_due_to_dependency;
 
 		// hide if no perm
-		if(!hide && this.layout && this.layout.frm && !this.layout.frm.get_perm(this.df.permlevel || 0, "read")) {
+		if (!hide && this.layout && this.layout.frm && !this.layout.frm.get_perm(this.df.permlevel || 0, "read")) {
 			hide = true;
 		}
 
 		this.wrapper.toggleClass("hide-control", !!hide);
 	},
-	collapse: function(hide) {
+	collapse: function (hide) {
 		// unknown edge case
 		if (!(this.head && this.body)) {
 			return;
 		}
 
-		if(hide===undefined) {
+		if (hide === undefined) {
 			hide = !this.body.hasClass("hide");
 		}
 
-		if (this.df.fieldname==='_form_dashboard') {
+		if (this.df.fieldname === '_form_dashboard') {
 			localStorage.setItem('collapseFormDashboard', hide ? 'yes' : 'no');
 		}
 
@@ -662,7 +663,7 @@ frappe.ui.form.Section = Class.extend({
 
 		// refresh signature fields
 		this.fields_list.forEach((f) => {
-			if (f.df.fieldtype=='Signature') {
+			if (f.df.fieldtype == 'Signature') {
 				f.refresh();
 			}
 		});
@@ -672,11 +673,11 @@ frappe.ui.form.Section = Class.extend({
 		return this.body.hasClass('hide');
 	},
 
-	has_missing_mandatory: function() {
+	has_missing_mandatory: function () {
 		var missing_mandatory = false;
-		for (var j=0, l=this.fields_list.length; j < l; j++) {
+		for (var j = 0, l = this.fields_list.length; j < l; j++) {
 			var section_df = this.fields_list[j].df;
-			if (section_df.reqd && this.layout.doc[section_df.fieldname]==null) {
+			if (section_df.reqd && this.layout.doc[section_df.fieldname] == null) {
 				missing_mandatory = true;
 				break;
 			}
@@ -686,21 +687,21 @@ frappe.ui.form.Section = Class.extend({
 });
 
 frappe.ui.form.Column = Class.extend({
-	init: function(section, df) {
-		if(!df) df = {};
+	init: function (section, df) {
+		if (!df) df = {};
 
 		this.df = df;
 		this.section = section;
 		this.make();
 		this.resize_all_columns();
 	},
-	make: function() {
+	make: function () {
 		this.wrapper = $('<div class="form-column">\
 			<form>\
 			</form>\
 		</div>').appendTo(this.section.body)
 			.find("form")
-			.on("submit", function() {
+			.on("submit", function () {
 				return false;
 			});
 
@@ -709,7 +710,7 @@ frappe.ui.form.Column = Class.extend({
 				+ '</label>').appendTo(this.wrapper);
 		}
 	},
-	resize_all_columns: function() {
+	resize_all_columns: function () {
 		// distribute all columns equally
 		var colspan = cint(12 / this.section.wrapper.find(".form-column").length);
 
@@ -718,7 +719,7 @@ frappe.ui.form.Column = Class.extend({
 			.addClass("col-sm-" + colspan);
 
 	},
-	refresh: function() {
+	refresh: function () {
 		this.section.refresh();
 	}
 });

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -85,6 +85,7 @@ frappe.ready(function() {
 
 		function setup_fields(form_data) {
 			form_data.web_form.web_form_fields.map(df => {
+				df.is_web_form = true;
 				if (df.fieldtype === "Table") {
 					df.get_data = () => {
 						let data = [];
@@ -99,13 +100,12 @@ frappe.ready(function() {
 						if (field.fieldtype === "Link") {
 							field.only_select = true;
 						}
+						field.is_web_form = true;
 					});
 
 					if (df.fieldtype === "Attach") {
 						df.is_private = true;
 					}
-
-					df.is_web_form = true;
 
 					delete df.parent;
 					delete df.parentfield;

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -96,6 +96,24 @@ def create_doctype(name, fields):
 	}).insert()
 
 @frappe.whitelist()
+def create_child_doctype(name, fields):
+	fields = frappe.parse_json(fields)
+	if frappe.db.exists('DocType', name):
+		return
+	frappe.get_doc({
+		"doctype": "DocType",
+		"module": "Core",
+		"istable": 1,
+		"custom": 1,
+		"fields": fields,
+		"permissions": [{
+			"role": "System Manager",
+			"read": 1
+		}],
+		"name": name
+	}).insert()
+
+@frappe.whitelist()
 def create_contact_records():
 	if frappe.db.get_all('Contact', {'first_name': 'Test Form Contact 1'}):
 		return


### PR DESCRIPTION
Fixed a bug where tables set to read-only still have editable fields in the row form popups.  The grid columns do become read-only, but not the pop-out form.  this is described in the bug report this pull closes.

Added new frappe UI tests.

closes #8781 