### PR TITLE
fix: Bypass validation if force is passed

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -127,7 +127,7 @@ def restore(context, sql_file_path, mariadb_root_username=None, mariadb_root_pas
 	else:
 		decompressed_file_name = sql_file_path
 
-	validate_database_sql(decompressed_file_name, _raise=force)
+	validate_database_sql(decompressed_file_name, _raise=not force)
 	site = get_site(context)
 	frappe.init(site=site)
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -415,21 +415,23 @@ def validate_database_sql(path, _raise=True):
 		path (str): Path of the decompressed SQL file
 		_raise (bool, optional): Raise exception if invalid file. Defaults to True.
 	"""
-	_raise = False
+	to_raise = False
 	error_message = ""
 
 	if not os.path.getsize(path):
 		error_message = f"{path} is an empty file!"
-		_raise = True
+		to_raise = True
 
 	if not _raise:
 		with open(path, "r") as f:
 			for line in f:
 				if 'tabDefaultValue' in line:
 					error_message = "Table `tabDefaultValue` not found in file."
-					_raise = True
+					to_raise = True
 
-	if error_message and _raise:
+	if error_message:
 		import click
 		click.secho(error_message, fg="red")
+
+	if _raise and to_raise:
 		raise frappe.InvalidDatabaseFile


### PR DESCRIPTION
```bash
$ bench --site test_site --force restore ~/frappe-bench/20171108_190013_955977f8_database.sql.gz
```

## Traceback

```
Table `tabDefaultValue` not found in file.
Traceback (most recent call last):
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 99, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 130, in restore
    validate_database_sql(decompressed_file_name, _raise=force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/installer.py", line 435, in validate_database_sql
    raise frappe.InvalidDatabaseFile
frappe.exceptions.InvalidDatabaseFile
The command "bench --site test_site --force restore ~/frappe-bench/20171108_190013_955977f8_database.sql.gz" failed and exited with 1 during .
```
