### PR TITLE
fix: Ace editor fixes

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -31,6 +31,7 @@
    "fieldname": "script",
    "fieldtype": "Code",
    "label": "Script",
+   "options": "Python",
    "reqd": 1
   },
   {
@@ -87,7 +88,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-08-24 16:44:41.060350",
+ "modified": "2020-11-11 12:39:41.391052",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -66,6 +66,7 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 
 		const ace_language_mode = language_map[language] || '';
 		this.editor.session.setMode(ace_language_mode);
+		this.editor.setKeyboardHandler('ace/keyboard/vscode');
 	},
 
 	parse(value) {


### PR DESCRIPTION
- Set VSCode keybindings in ace editor
- Python syntax highlighting in Script field