### PR TITLE
fix(Assignment Rule): allow all Data, Link, Dynamic Link fields to be set in based on field

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -57,7 +57,7 @@ frappe.ui.form.on('Assignment Rule', {
 		frm.set_fields_as_options(
 			'field',
 			doctype,
-			(df) => df.fieldtype == 'Link' && df.options == 'User',
+			() => true,
 			[{ label: 'Owner', value: 'owner' }]
 		);
 		if (doctype) {

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -57,7 +57,8 @@ frappe.ui.form.on('Assignment Rule', {
 		frm.set_fields_as_options(
 			'field',
 			doctype,
-			() => true,
+			(df) => ['Dynamic Link', 'Data'].includes(df.fieldtype)
+				|| (df.fieldtype == 'Link' && df.options == 'User'),
 			[{ label: 'Owner', value: 'owner' }]
 		);
 		if (doctype) {

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -82,7 +82,7 @@ class AssignmentRule(Document):
 		elif self.rule == 'Load Balancing':
 			return self.get_user_load_balancing()
 		elif self.rule == 'Based on Field':
-			return doc.get(self.field)
+			return self.get_user_based_on_field(doc)
 
 	def get_user_round_robin(self):
 		'''
@@ -118,6 +118,11 @@ class AssignmentRule(Document):
 
 		# pick the first user
 		return sorted_counts[0].get('user')
+
+	def get_user_based_on_field(self, doc):
+		val = doc.get(self.field)
+		if frappe.db.exists('User', val):
+			return val
 
 	def safe_eval(self, fieldname, doc):
 		try:


### PR DESCRIPTION
Also allow Dynamic Link and Data fields to be set as the Based on Field for Assignment Rule (previously it was restricted to User link fields).