### PR TITLE
fix: TypeError on saving report with child table

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -61,8 +61,9 @@ class Report(Document):
 	def set_doctype_roles(self):
 		if not self.get('roles') and self.is_standard == 'No':
 			meta = frappe.get_meta(self.ref_doctype)
-			roles = [{'role': d.role} for d in meta.permissions if d.permlevel==0]
-			self.set('roles', roles)
+			if not meta.istable:
+				roles = [{'role': d.role} for d in meta.permissions if d.permlevel==0]
+				self.set('roles', roles)
 
 	def is_permitted(self):
 		"""Returns true if Has Role is not set or the user is allowed."""


### PR DESCRIPTION
On saving a custom report with a child table as a reference doctype, we get the following error. This is because, after insert we try to fetch the roles from the reference doctype. The child table however has not permissions explicitly, therefore it's meta has no permissions property.

This PR adds a check to see if the `ref_doctype` is a child table or not

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/handler.py", line 64, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/__init__.py", line 1064, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/handler.py", line 98, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/desk/form/run_method.py", line 43, in runserverobj
    r = doc.run_method(method)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/model/document.py", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/model/document.py", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/model/document.py", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/model/document.py", line 791, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-10-23/apps/frappe/frappe/core/doctype/report/report.py", line 57, in set_doctype_roles
    roles = [{'role': d.role} for d in meta.permissions if d.permlevel==0]
AttributeError: 'Meta' object has no attribute 'permissions'
```

Frappe Issue: [ISS-20-21-06919](https://frappe.io/desk#Form/Issue/ISS-20-21-06919)