### PR TITLE
fix: Duplicate entry 'db3737307c' for key 'PRIMARY'

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -345,10 +345,6 @@ class BaseDocument(object):
 		except Exception as e:
 			if frappe.db.is_primary_key_violation(e):
 				if self.meta.autoname=="hash":
-					# hash collision? try again
-					frappe.flags.retry_count = (frappe.flags.retry_count or 0) + 1
-					if frappe.flags.retry_count > 5 and not frappe.flags.in_test:
-						raise
 					self.name = None
 					self.db_insert()
 					return


### PR DESCRIPTION
**Issue**

While saving the BOM, getting below error

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/document.py", line 307, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/document.py", line 257, in insert
    d.db_insert()
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/base_document.py", line 344, in db_insert
    ), list(d.values()))
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/database/database.py", line 147, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-13-2020-11-09/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.IntegrityError: (1062, "Duplicate entry '88d4617430' for key 'PRIMARY'")
```

The issue was introduced via https://github.com/frappe/frappe/pull/11439/files#diff-3d6315bcf00ac84a11a4ae14ac283ccdc63a07f03b13b83d675809d1b976b202R338-R340