### PR TITLE
refactor: Fix excel export

### DIFF
--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -27,7 +27,7 @@ class TestReport(unittest.TestCase):
 		columns, data = report.get_data(filters={'user': 'Administrator', 'doctype': 'DocType'})
 		self.assertEqual(columns[0].get('label'), 'Name')
 		self.assertEqual(columns[1].get('label'), 'Module')
-		self.assertTrue('User' in [d[0] for d in data])
+		self.assertTrue('User' in [d.get('name') for d in data])
 
 	def test_report_permissions(self):
 		frappe.set_user('test@example.com')

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import frappe, json, os
 import unittest
-from frappe.desk.query_report import run, save_report, get_report_doc
+from frappe.desk.query_report import run, save_report
 
 test_records = frappe.get_test_records('Report')
 test_dependencies = ['User']

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -32,6 +32,7 @@ class TestReport(unittest.TestCase):
 		self.assertTrue('User' in [d.get('name') for d in data])
 
 	def test_custom_report(self):
+		reset_customization('User')
 		custom_report_name = save_report(
 			'Permitted Documents For User',
 			'Permitted Documents For User Custom',
@@ -55,7 +56,8 @@ class TestReport(unittest.TestCase):
 			}, user=frappe.session.user)
 
 		self.assertListEqual(['email'], [column.get('fieldname') for column in columns])
-		self.assertDictEqual({'name': 'Administrator', 'user_type': 'System User', 'email': 'admin@example.com'}, result[0])
+		admin_dict = frappe.core.utils.find(result, lambda d: d['name'] == 'Administrator')
+		self.assertDictEqual({'name': 'Administrator', 'user_type': 'System User', 'email': 'admin@example.com'}, admin_dict)
 
 	def test_report_with_custom_column(self):
 		reset_customization('User')

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe, json, os
 import unittest
 from frappe.desk.query_report import run, save_report
+from frappe.custom.doctype.customize_form.customize_form import reset_customization
 
 test_records = frappe.get_test_records('Report')
 test_dependencies = ['User']
@@ -57,6 +58,7 @@ class TestReport(unittest.TestCase):
 		self.assertDictEqual({'name': 'Administrator', 'user_type': 'System User', 'email': 'admin@example.com'}, result[0])
 
 	def test_report_with_custom_column(self):
+		reset_customization('User')
 		response = run('Permitted Documents For User',
 			filters={'user': 'Administrator', 'doctype': 'User'},
 			custom_columns=[{
@@ -74,7 +76,8 @@ class TestReport(unittest.TestCase):
 		result = response.get('result')
 		columns = response.get('columns')
 		self.assertListEqual(['name', 'email', 'user_type'], [column.get('fieldname') for column in columns])
-		self.assertDictEqual({'name': 'Administrator', 'user_type': 'System User', 'email': 'admin@example.com'}, result[0])
+		admin_dict = frappe.core.utils.find(result, lambda d: d['name'] == 'Administrator')
+		self.assertDictEqual({'name': 'Administrator', 'user_type': 'System User', 'email': 'admin@example.com'}, admin_dict)
 
 	def test_report_permissions(self):
 		frappe.set_user('test@example.com')

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -49,7 +49,7 @@ class TestReport(unittest.TestCase):
 				'name': 'Email'
 			}]))
 		custom_report = frappe.get_doc('Report', custom_report_name)
-		columns, result = custom_report.run_query_report(
+		columns, result = custom_report.get_data(
 			filters={
 				'user': 'Administrator',
 				'doctype': 'User'

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -413,8 +413,13 @@ class CustomizeForm(Document):
 		if not self.doc_type:
 			return
 
-		frappe.db.sql("""DELETE FROM `tabProperty Setter` WHERE doc_type=%s
-			and `field_name`!='naming_series'
-			and `property`!='options'""", self.doc_type)
-		frappe.clear_cache(doctype=self.doc_type)
+		reset_customization(self.doctype)
 		self.fetch_to_customize()
+
+def reset_customization(doctype):
+	frappe.db.sql("""
+		DELETE FROM `tabProperty Setter` WHERE doc_type=%s
+			and `field_name`!='naming_series'
+			and `property`!='options'
+		""", doctype)
+	frappe.clear_cache(doctype=doctype)

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -413,7 +413,7 @@ class CustomizeForm(Document):
 		if not self.doc_type:
 			return
 
-		reset_customization(self.doctype)
+		reset_customization(self.doc_type)
 		self.fetch_to_customize()
 
 def reset_customization(doctype):

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -60,23 +60,25 @@ def generate_report_result(report, filters=None, user=None, custom_columns=None)
 
 	columns, result, message, chart, report_summary, skip_total_row = ljust_list(res, 6)
 	columns = [get_column_as_dict(col) for col in columns]
+	report_column_names = [col["fieldname"] for col in columns]
 
 	# convert to list of dicts
 	result = normalize_result(result, columns)
 
+	if report.custom_columns:
+		# saved columns (with custom columns / with different column order)
+		columns = json.loads(report.custom_columns)
+
+	# unsaved custom_columns
 	if custom_columns:
 		for custom_column in custom_columns:
 			columns.insert(custom_column['insert_after_index'] + 1, custom_column)
 
-	custom_columns = custom_columns or []
+	# all columns which are not in original report
+	report_custom_columns = [column for column in columns if column["fieldname"] not in report_column_names]
 
-	if isinstance(report.custom_columns, string_types):
-		custom_columns += json.loads(report.custom_columns) or []
-	else:
-		custom_columns += report.custom_columns or []
-
-	if custom_columns:
-		result = add_custom_column_data(custom_columns, result)
+	if report_custom_columns:
+		result = add_custom_column_data(report_custom_columns, result)
 
 	if result:
 		result = get_filtered_data(report.ref_doctype, columns, result, user)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -176,7 +176,6 @@ def get_script(report_name):
 @frappe.whitelist()
 @frappe.read_only()
 def run(report_name, filters=None, user=None, ignore_prepared_report=False, custom_columns=None):
-
 	report = get_report_doc(report_name)
 	if not user:
 		user = frappe.session.user
@@ -211,7 +210,8 @@ def add_custom_column_data(custom_columns, result):
 		key = (column.get('doctype'), column.get('fieldname'))
 		if key in custom_column_data:
 			for row in result:
-				row_reference = row[frappe.scrub(column.get('link_field'))]
+				row_reference = row.get(scrub(column.get('link_field')))
+				if not row_reference: continue
 				row[column.get('fieldname')] = custom_column_data.get(key).get(row_reference)
 
 	return result

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -14,8 +14,7 @@ from frappe.utils import (
 	cstr,
 	get_html_format,
 	get_url_to_form,
-	gzip_decompress,
-	format_duration,
+	gzip_decompress
 )
 from frappe.model.utils import render_include
 from frappe.translate import send_translations
@@ -23,7 +22,6 @@ import frappe.desk.reportview
 from frappe.permissions import get_role_permissions
 from six import string_types, iteritems
 from datetime import timedelta
-from frappe.utils import gzip_decompress
 from frappe.core.utils import ljust_list
 
 def get_report_doc(report_name):
@@ -99,7 +97,7 @@ def generate_report_result(report, filters=None, user=None, custom_columns=None)
 		"columns": columns,
 		"message": message,
 		"chart": chart,
-		"data_to_be_printed": data_to_be_printed,
+		"report_summary": report_summary,
 		"skip_total_row": skip_total_row or 0,
 		"status": None,
 		"execution_time": frappe.cache().hget('report_execution_time', report.name) or 0
@@ -316,10 +314,6 @@ def export_query():
 		columns = get_columns_dict(data.columns)
 
 		from frappe.utils.xlsxutils import make_xlsx
-
-		data["result"] = handle_duration_fieldtype_values(
-			data.get("result"), data.get("columns")
-		)
 		xlsx_data, column_widths = build_xlsx_data(columns, data, visible_idx, include_indentation)
 		xlsx_file = make_xlsx(xlsx_data, "Query Report", column_widths=column_widths)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -210,8 +210,10 @@ def add_custom_column_data(custom_columns, result):
 		key = (column.get('doctype'), column.get('fieldname'))
 		if key in custom_column_data:
 			for row in result:
-				row_reference = row.get(scrub(column.get('link_field')))
-				if not row_reference: continue
+				row_reference = row.get(column.get('link_field'))
+				# possible if the row is empty
+				if not row_reference:
+					continue
 				row[column.get('fieldname')] = custom_column_data.get(key).get(row_reference)
 
 	return result

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -209,7 +209,7 @@ def add_custom_column_data(custom_columns, result):
 		key = (column.get('doctype'), column.get('fieldname'))
 		if key in custom_column_data:
 			for row in result:
-				row_reference = row[column.get('link_field')]
+				row_reference = row[frappe.scrub(column.get('link_field'))]
 				row[column.get('fieldname')] = custom_column_data.get(key).get(row_reference)
 
 	return result

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -336,7 +336,7 @@ def build_xlsx_data(columns, data, visible_idx, include_indentation):
 		if column.get("hidden"):
 			continue
 		result[0].append(column["label"])
-		column_width = column.get('width', 0)
+		column_width = cint(column.get('width', 0))
 		# to convert into scale accepted by openpyxl
 		column_width /= 10
 		column_widths.append(column_width)

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -23,7 +23,11 @@ class TestQueryReport(unittest.TestCase):
 
 		# Create mock data
 		data = frappe._dict()
-		data.columns = ["column_a", "column_b", "column_c"]
+		data.columns = [
+			{"label": "Column A", "fieldname": "column_a"},
+			{"label": "Column B", "fieldname": "column_b", "width": 150},
+			{"label": "Column C", "fieldname": "column_c", "width": 100}
+		]
 		data.result = [
 			[1.0, 3.0, 5.5],
 			{"column_a": 22.1, "column_b": 21.8, "column_c": 30.2},
@@ -35,10 +39,12 @@ class TestQueryReport(unittest.TestCase):
 		visible_idx = [0, 2, 3]
 
 		# Build the result
-		xlsx_data = build_xlsx_data(columns, data, visible_idx, include_indentation=0)
+		xlsx_data, column_widths = build_xlsx_data(columns, data, visible_idx, include_indentation=0)
 
 		self.assertEqual(type(xlsx_data), list)
 		self.assertEqual(len(xlsx_data), 4)  # columns + data
+		# column widths are divided by 10 to match the scale that is supported by openpyxl
+		self.assertListEqual(column_widths, [0, 15, 10])
 
 		for row in xlsx_data:
 			self.assertEqual(type(row), list)

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -9,19 +9,24 @@ import xlrd
 import re
 from openpyxl.styles import Font
 from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
 from six import BytesIO, string_types
 
 ILLEGAL_CHARACTERS_RE = re.compile(r'[\000-\010]|[\013-\014]|[\016-\037]')
 # return xlsx file object
-def make_xlsx(data, sheet_name, wb=None):
-
+def make_xlsx(data, sheet_name, wb=None, column_widths=None):
+	column_widths = column_widths or []
 	if wb is None:
 		wb = openpyxl.Workbook(write_only=True)
 
 	ws = wb.create_sheet(sheet_name, 0)
 
+	for i, column_width in enumerate(column_widths):
+		if column_width:
+			ws.column_dimensions[get_column_letter(i + 1)].width = column_width
+
 	row1 = ws.row_dimensions[1]
-	row1.font = Font(name='Calibri',bold=True)
+	row1.font = Font(name='Calibri', bold=True)
 
 	for row in data:
 		clean_row = []


### PR DESCRIPTION
- The system used to export an empty excel file while trying to export the report with a custom column.

**Before:**
![report-export-fix](https://user-images.githubusercontent.com/13928957/95067209-16a29100-0721-11eb-9695-bc0f3aa18ef6.gif)


**After:**
![report-export-fix-2](https://user-images.githubusercontent.com/13928957/95067222-1bffdb80-0721-11eb-8bca-87083a8884a9.gif)

- Now, column sizes in `.xlsx` file will be set based on column sizes of report columns.


port-of: https://github.com/frappe/frappe/pull/11642