### PR TITLE
fix: display style removed from emails

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -34,7 +34,7 @@ def clean_email_html(html):
 			'margin', 'margin-top', 'margin-bottom', 'margin-left', 'margin-right',
 			'padding', 'padding-top', 'padding-bottom', 'padding-left', 'padding-right',
 			'font-size', 'font-weight', 'font-family', 'text-decoration',
-			'line-height', 'text-align', 'vertical-align'
+			'line-height', 'text-align', 'vertical-align', 'display'
 		],
 		protocols=['cid', 'http', 'https', 'mailto', 'data'],
 		strip=True, strip_comments=True)


### PR DESCRIPTION
Email body is cleaned via `bleach` before saving, we remove some styles from the markup during this process. In case we come across a markup that has `display: none` property, it is removed and the element becomes visible in the email body.

This PR fixes this issue.

Frappe Issue: [ISS-20-21-07002](https://frappe.io/desk#Form/Issue/ISS-20-21-07002)