### PR TITLE
feat: check if auto_repeat field is already present

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -76,17 +76,20 @@ class CustomizeForm(Document):
 
 	def create_auto_repeat_custom_field_if_requried(self, meta):
 		if self.allow_auto_repeat:
-			if not frappe.db.exists('Custom Field', {'fieldname': 'auto_repeat', 'dt': self.doc_type}) and \
-				not frappe.db.exists('DocField', {'fieldname': 'auto_repeat', 'parent': self.name}):
-				insert_after = self.fields[len(self.fields) - 1].fieldname
-				df = dict(
-					fieldname='auto_repeat',
-					label='Auto Repeat',
-					fieldtype='Link',
-					options='Auto Repeat',
-					insert_after=insert_after,
-					read_only=1, no_copy=1, print_hide=1)
-				create_custom_field(self.doc_type, df)
+			all_fields = [df.fieldname for df in meta.fields]
+
+			if "auto_repeat" in all_fields:
+				return
+
+			insert_after = self.fields[len(self.fields) - 1].fieldname
+			create_custom_field(self.doc_type, dict(
+				fieldname='auto_repeat',
+				label='Auto Repeat',
+				fieldtype='Link',
+				options='Auto Repeat',
+				insert_after=insert_after,
+				read_only=1, no_copy=1, print_hide=1
+			))
 
 
 	def get_name_translation(self):

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -75,6 +75,9 @@ class CustomizeForm(Document):
 				self.append(fieldname, d)
 
 	def create_auto_repeat_custom_field_if_required(self, meta):
+		'''
+		Create auto repeat custom field if it's not already present
+		'''
 		if self.allow_auto_repeat:
 			all_fields = [df.fieldname for df in meta.fields]
 

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -39,7 +39,7 @@ class CustomizeForm(Document):
 		translation = self.get_name_translation()
 		self.label = translation.translated_text if translation else ''
 
-		self.create_auto_repeat_custom_field_if_requried(meta)
+		self.create_auto_repeat_custom_field_if_required(meta)
 
 		# NOTE doc (self) is sent to clientside by run_method
 
@@ -74,7 +74,7 @@ class CustomizeForm(Document):
 			for d in meta.get(fieldname):
 				self.append(fieldname, d)
 
-	def create_auto_repeat_custom_field_if_requried(self, meta):
+	def create_auto_repeat_custom_field_if_required(self, meta):
 		if self.allow_auto_repeat:
 			all_fields = [df.fieldname for df in meta.fields]
 


### PR DESCRIPTION
Customize form would break with the following error. 

![image](https://user-images.githubusercontent.com/18097732/99398395-5d7fcb00-290a-11eb-8c6c-396d7db4a2db.png)

This is because we would create the `auto_repeat` field on load of the doctype. The function would only check if the custom field for auto-repeat is created or not. This PR adds a check for the meta as well