### PR TITLE
fix: text editor field type changes in grid row form

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -371,6 +371,7 @@ export default class GridRow {
 
 		// no text editor in grid
 		if (df.fieldtype=='Text Editor') {
+			df = Object.assign({}, df);
 			df.fieldtype = 'Text';
 		}
 


### PR DESCRIPTION
RowGridForm shares fields with the RowGrid. `Text editor` in the grid row is changed to `Text` when rendering. however this when expanded still remains text input.

This PR fixes that by making a copy of the `df` instead of altering the original `df` when rendering the field.

Frappe Issue: [ISS-20-21-07115](https://frappe.io/desk#Form/Issue/ISS-20-21-07115)
