### PR TITLE
fix: `PRIMARY KEY must be NOT NULL` error when install with MySQL 5.7+

### DIFF
--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -233,7 +233,7 @@ CREATE TABLE `tabDocType` (
 
 DROP TABLE IF EXISTS `tabSeries`;
 CREATE TABLE `tabSeries` (
-  `name` varchar(100) DEFAULT NULL,
+  `name` varchar(100),
   `current` int(10) NOT NULL DEFAULT 0,
   PRIMARY KEY(`name`)
 ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED CHARACTER SET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
We meet some trouble when create new site with MySQL 5.7+/8+:

```shell
ERROR 1171 (42000) at line 180: All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
Database not installed, this can due to lack of permission, or that the database name exists.
                        Check your mysql root password, or use --force to reinstall
```

ref: https://mariadb.com/kb/en/mariadb-1017-release-notes/