### PR TITLE
fix: Use modified by or owner to send notification from

### DIFF
--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -207,7 +207,7 @@
    "label": "Value To Be Set"
   },
   {
-   "depends_on": "eval:in_list(['Email', 'SMS'], doc.channel)",
+   "depends_on": "eval:doc.channel !=\"Slack\"",
    "fieldname": "column_break_5",
    "fieldtype": "Section Break",
    "label": "Recipients"
@@ -281,7 +281,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-28 11:04:54.955567",
+ "modified": "2020-11-24 14:25:43.245677",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -181,6 +181,7 @@ def get_context(context):
 			'document_type': doc.doctype,
 			'document_name': doc.name,
 			'subject': subject,
+			'from_user': doc.modified_by or doc.owner,
 			'email_content': frappe.render_template(self.message, context),
 			'attached_file': attachments and json.dumps(attachments[0])
 		}


### PR DESCRIPTION
`from_user` is used to show the image of the user in the dropdown from which user the notification has been triggered.

When creating a system notification from the doc, `from_user` is not set, this PR fixes that by setting the `from_user` to `doc.modified_by` or `doc.owner`.

Steps to replicate
 
1. Create a notification for leave application with system notification going to leave approver
1. Create a leave application from a user and set the leave approver
1. Log into leave approver account and check the notification, it'll show the avatar of the approver (frappe.session.user)

Fixed Notification

<img width="305" alt="Screen Shot 2020-11-24 at 2 29 11 PM" src="https://user-images.githubusercontent.com/18097732/100072203-f5793980-2e61-11eb-84cf-fd85c09139b1.png">

----

Additionally, this PR has a fix, for Notification Type "System Notification" the recipient section was hidden, updating the display depends on condition fixes this.