### PR TITLE
fix: allow other github links in same PR

### DIFF
--- a/.github/helper/documentation.py
+++ b/.github/helper/documentation.py
@@ -21,8 +21,8 @@ def docs_link_exists(body):
 			if word.startswith('http') and uri_validator(word):
 				parsed_url = urlparse(word)
 				if parsed_url.netloc == "github.com":
-					_, org, repo, _type, ref = parsed_url.path.split('/')
-					if org == "frappe" and repo in docs_repos:
+					parts = parsed_url.path.split('/')
+					if len(parts) == 5 and parts[1] == "frappe" and parts[2] in docs_repos:
 						return True
 
 


### PR DESCRIPTION
This fixes a problem with the "documentation required" check.

### Problem

```
> python documentation.py 11000
Exception has occurred: ValueError
not enough values to unpack (expected 5, got 3)
  File "documentation.py", line 24, in docs_link_exists
    _, org, repo, _type, ref = parsed_url.path.split('/')
  File "documentation.py", line 40, in <module>
    if docs_link_exists(body):
```

This happens because #11000 also contains a link to https://github.com/digithinkit/oauth2_client, which is too short to unpack into five values.

### Fix

Check the length before accessing the list elements.

```
> python documentation.py 11000
Documentation Link Found. You're Awesome! 🎉
```