### PR TITLE
fix: Not able to save Domain Settings

### DIFF
--- a/frappe/core/doctype/domain_settings/domain_settings.js
+++ b/frappe/core/doctype/domain_settings/domain_settings.js
@@ -18,6 +18,9 @@ frappe.ui.form.on('Domain Settings', {
 								checked: active_domains.includes(domain)
 							};
 						});
+					},
+					on_change: () => {
+						frm.dirty();
 					}
 				},
 				render_input: true


### PR DESCRIPTION
**Before**: Domain Settings doctype renders a MultiCheck control inside the HTML wrapper. Hence, the document does not get set as dirty if domains are unchecked, thereby, not being able to save.

![domain-settings-before](https://user-images.githubusercontent.com/24353136/100098050-7694f880-2e83-11eb-8cb7-a22957bc36a9.gif)

**After:** Set the form as dirty on change

![domain-settings-after](https://user-images.githubusercontent.com/24353136/100098058-7ac11600-2e83-11eb-9d67-c0ead9d4d96e.gif)

