### PR TITLE
fix: Translate Kanban board title

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -30,7 +30,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		return super.setup_defaults()
 			.then(() => {
 				this.board_name = frappe.get_route()[3];
-				this.page_title = this.board_name;
+				this.page_title = __(this.board_name);
 				this.card_meta = this.get_card_meta();
 
 				this.menu_items.push({


### PR DESCRIPTION
Translate Kanban board title

port-of: https://github.com/frappe/frappe/pull/11985