### PR TITLE
fix: add semicolons to end unicode 

### DIFF
--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -234,11 +234,11 @@ frappe.utils.xss_sanitise = function (string, options) {
 		strategies: ['html', 'js'] // use all strategies.
 	}
 	const HTML_ESCAPE_MAP = {
-		'<': '&lt',
-		'>': '&gt',
-		'"': '&quot',
-		"'": '&#x27',
-		'/': '&#x2F'
+		'<': '&lt;',
+		'>': '&gt;',
+		'"': '&quot;',
+		"'": '&#x27;',
+		'/': '&#x2F;'
 	};
 	const REGEX_SCRIPT     = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi; // used in jQuery 1.7.2 src/ajax.js Line 14
 	options          	   = Object.assign({ }, DEFAULT_OPTIONS, options); // don't deep copy, immutable beauty.


### PR DESCRIPTION
**Issue:**
![image](https://user-images.githubusercontent.com/28212972/100192269-a42b8180-2f17-11eb-8f35-789c89105fd6.png)

**Reason**
Unicode literals are expanded in a greedy fashion

**Solution**
Append ';' at the end


![image](https://user-images.githubusercontent.com/28212972/100192413-e94fb380-2f17-11eb-8f40-bc91df7e1676.png)
