### PR TITLE
fix: clear shared translation cache

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -316,3 +316,4 @@ frappe.patches.v13_0.web_template_set_module #2020-10-05
 frappe.patches.v13_0.remove_custom_link
 execute:frappe.delete_doc("DocType", "Footer Item")
 frappe.patches.v13_0.replace_field_target_with_open_in_new_tab
+execute:frappe.translate.clear_cache


### PR DESCRIPTION
Shared translation cache would earlier contain user translations as well, this was fixed previously, however the shared cache was retained. This PR adds a patch to explicitly clear the shared cache for translation