### PR TITLE
fix: clear shared translation cache

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -273,3 +273,4 @@ frappe.patches.v12_0.email_unsubscribe
 frappe.patches.v12_0.replace_old_data_import
 frappe.patches.v12_0.set_correct_url_in_files
 frappe.patches.v12_0.fix_email_id_formatting
+execute:frappe.translate.clear_cache


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/pull/11994

---

Shared translation cache would earlier contain user translations as well, this was fixed previously, however the shared cache was retained. This PR adds a patch to explicitly clear the shared cache for translation

