### PR TITLE
fix: typerror when creating an SMTP server without port

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -210,7 +210,7 @@ class SMTPServer:
 		try:
 			if self.use_ssl:
 				if not self.port:
-					self.smtp_port = 465
+					self.port = 465
 
 				self._sess = smtplib.SMTP_SSL((self.server or "").encode('utf-8'),
 						cint(self.port) or None)

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -212,8 +212,7 @@ class SMTPServer:
 				if not self.port:
 					self.port = 465
 
-				self._sess = smtplib.SMTP_SSL((self.server or "").encode('utf-8'),
-						cint(self.port) or None)
+				self._sess = smtplib.SMTP_SSL((self.server or ""), cint(self.port))
 			else:
 				if self.use_tls and not self.port:
 					self.port = 587

--- a/frappe/email/test_smtp.py
+++ b/frappe/email/test_smtp.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
+# License: The MIT License
+
+import unittest
+from frappe.email.smtp import SMTPServer
+
+class TestSMTP(unittest.TestCase):
+	def test_smtp_ssl_session(self):
+		for port in [None, 0, 465, "465"]:
+			make_server(port, 1, 0)
+
+	def test_smtp_tls_session(self):
+		for port in [None, 0, 587, "587"]:
+			make_server(port, 0, 1)
+
+
+def make_server(port, ssl, tls):
+	server = SMTPServer(
+		server = "smtp.gmail.com",
+		port = port,
+		use_ssl = ssl,
+		use_tls = tls
+	)
+
+	server.sess


### PR DESCRIPTION
## The Problem

Frappe `SMTPServer` when given `None` or `0` for port value and breaks with the following trace back.

```python
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 1107, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 320, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 930, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 831, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 1116, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 1099, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 825, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 77, in validate
    self.check_smtp()
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 147, in check_smtp
    server.sess
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/email/smtp.py", line 216, in sess
    cint(self.port) or None)
  File "/usr/lib64/python3.6/smtplib.py", line 1031, in __init__
    source_address)
  File "/usr/lib64/python3.6/smtplib.py", line 251, in __init__
    (code, msg) = self.connect(host, port)
  File "/usr/lib64/python3.6/smtplib.py", line 324, in connect
    if not port and (host.find(':') == host.rfind(':')):
TypeError: a bytes-like object is required, not 'str'
```

This can be validated by executing the following in frappe console (P.S. The `encode` function is used in frappe `smtp.py`)

```python
In [1]: import smtplib

In [2]: smtplib.SMTP_SSL(("smtp.gmail.com").encode('utf-8'), 465)
Out[2]: <smtplib.SMTP_SSL at 0x113bb3550>

In [3]: smtplib.SMTP_SSL(("smtp.gmail.com").encode('utf-8'), 0)
TypeError: argument should be integer or bytes-like object, not 'str'

In [4]: smtplib.SMTP_SSL(("smtp.gmail.com").encode('utf-8'), None)
TypeError: argument should be integer or bytes-like object, not 'str'
```

### The Fix

The `TypeError` occurs because smtplib tries to see if server string has a port value **if no port value is given**, the following condition does this

```python
if not port and (host.find(':') == host.rfind(':'))
``` 

Since we encode the server value in the arguments, the `.find` method breaks as follows.

![image](https://user-images.githubusercontent.com/18097732/100210211-bf56bb00-2f30-11eb-88f6-4b9893907e1c.png)

This PR removes the encode function.

There was another mistake in smtp.py which tried setting the default value on the smtp port, the variable to be used was `self.port` however `self.smtp_port` was set and used instead. This PR fixes this as well
