### PR TITLE
fix: clear localstorage if quota exceeds

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -148,7 +148,6 @@ frappe.Application = Class.extend({
 							user: frappe.session.user
 						},
 						callback: function(r) {
-							console.log(r);
 							if(r.message.show_alert){
 								frappe.show_alert({
 									indicator: 'red',

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -103,6 +103,31 @@ $.extend(frappe.model, {
 		return docfield[0];
 	},
 
+	get_from_localstorage: function(doctype) {
+		if (localStorage["_doctype:" + doctype]) {
+			return JSON.parse(localStorage["_doctype:" + doctype]);
+		}
+	},
+
+	set_in_localstorage: function(doctype, docs) {
+		try {
+			localStorage["_doctype:" + doctype] = JSON.stringify(docs);
+		} catch(e) {
+			// if quota is exceeded, clear local storage and set item
+			console.warn("localStorage quota exceeded, clearing doctype cache")
+			frappe.model.clear_local_storage();
+			localStorage["_doctype:" + doctype] = JSON.stringify(docs);
+		}
+	},
+
+	clear_local_storage: function() {
+		for(var key in localStorage) {
+			if (key.startsWith("_doctype:")) {
+				localStorage.removeItem(key);
+			}
+		}
+	},
+
 	with_doctype: function(doctype, callback, async) {
 		if(locals.DocType[doctype]) {
 			callback && callback();
@@ -110,13 +135,15 @@ $.extend(frappe.model, {
 			let cached_timestamp = null;
 			let cached_doc = null;
 
-			if(localStorage["_doctype:" + doctype]) {
-				let cached_docs = JSON.parse(localStorage["_doctype:" + doctype]);
+			let cached_docs = frappe.model.get_from_localstorage(doctype)
+			
+			if (cached_docs) {
 				cached_doc = cached_docs.filter(doc => doc.name === doctype)[0];
 				if(cached_doc) {
 					cached_timestamp = cached_doc.modified;
 				}
 			}
+
 			return frappe.call({
 				method:'frappe.desk.form.load.getdoctype',
 				type: "GET",
@@ -134,7 +161,7 @@ $.extend(frappe.model, {
 					if(r.message=="use_cache") {
 						frappe.model.sync(cached_doc);
 					} else {
-						localStorage["_doctype:" + doctype] = JSON.stringify(r.docs);
+						frappe.model.set_in_localstorage(doctype, r.docs)
 					}
 					frappe.model.init_doctype(doctype);
 


### PR DESCRIPTION
`model.js` caches DocTypes in client `localStorage` for performance and UX. However the localstorage has a quota of only 5MB (in firefox) which may exceed in some cases.

This caching is an essential piece in the SPA routing, if this breaks, the routing will break. The following is the exception thrown by the browser

![2020-11-26 15 40 44](https://user-images.githubusercontent.com/18097732/100337785-d57e7d00-2ffd-11eb-9a63-596e6e9e8653.jpg)

