### PR TITLE
fix: Use html.unescape for Python 3.9 compatibility.

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -10,6 +10,7 @@ import json
 import os
 from bs4 import BeautifulSoup
 from frappe.utils import cint, strip_html_tags
+from frappe.utils.html_utils import unescape_html
 from frappe.model.base_document import get_controller
 from six import text_type
 
@@ -345,11 +346,8 @@ def get_formatted_value(value, field):
 	:return:
 	"""
 
-	from six.moves.html_parser import HTMLParser
-
 	if getattr(field, 'fieldtype', None) in ["Text", "Text Editor"]:
-		h = HTMLParser()
-		value = h.unescape(frappe.safe_decode(value))
+		value = unescape_html(frappe.safe_decode(value))
 		value = (re.subn(r'<[\s]*(script|style).*?</\1>(?s)', '', text_type(value))[0])
 		value = ' '.join(value.split())
 	return field.label + " : " + strip_html_tags(text_type(value))

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -106,9 +106,8 @@ def get_icon_html(icon, small=False):
 		return "<i class='{icon}'></i>".format(icon=icon)
 
 def unescape_html(value):
-	from six.moves.html_parser import HTMLParser
-	h = HTMLParser()
-	return h.unescape(value)
+	from html import unescape
+	return unescape(value)
 
 # adapted from https://raw.githubusercontent.com/html5lib/html5lib-python/4aa79f113e7486c7ec5d15a6e1777bfe546d3259/html5lib/sanitizer.py
 acceptable_elements = [


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

HTMLParser.unescape has been deprecated and removed in favor of html.unescape (Added in `PY3.4` [#ref](https://docs.python.org/3/library/html.html#html.unescape)) in Python 3.9

> Explain the **details** for making this change. What existing problem does the pull request solve?

This PR adds Python 3.9 compatibility