### PR TITLE
fix: changing percent field precision to global default

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -50,7 +50,7 @@ frappe.form.formatters = {
 		return frappe.form.formatters._right(value==null ? "" : cint(value), options)
 	},
 	Percent: function(value, docfield, options) {
-		return frappe.form.formatters._right(flt(value, frappe.defaults.get_default("float_precision")) + "%", options);
+		return frappe.form.formatters._right(flt(value, frappe.defaults.get_default("float_precision") || 3) + "%", options);
 	},
 	Rating: function(value) {
 		return `<span class="rating">

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -50,7 +50,7 @@ frappe.form.formatters = {
 		return frappe.form.formatters._right(value==null ? "" : cint(value), options)
 	},
 	Percent: function(value, docfield, options) {
-		return frappe.form.formatters._right(flt(value, frappe.defaults.get_default("float_precision")) + "%", options)
+		return frappe.form.formatters._right(flt(value, frappe.defaults.get_default("float_precision")) + "%", options);
 	},
 	Rating: function(value) {
 		return `<span class="rating">

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -50,7 +50,14 @@ frappe.form.formatters = {
 		return frappe.form.formatters._right(value==null ? "" : cint(value), options)
 	},
 	Percent: function(value, docfield, options) {
-		var precision = docfield.precision || cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) || 2;
+		const precision = (
+			docfield.precision
+			|| cint(
+				frappe.boot.sysdefaults
+				&& frappe.boot.sysdefaults.float_precision
+			)
+			|| 2
+		);
 		return frappe.form.formatters._right(flt(value, precision) + "%", options);
 	},
 	Rating: function(value) {

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -50,7 +50,7 @@ frappe.form.formatters = {
 		return frappe.form.formatters._right(value==null ? "" : cint(value), options)
 	},
 	Percent: function(value, docfield, options) {
-		return frappe.form.formatters._right(flt(value, 2) + "%", options)
+		return frappe.form.formatters._right(flt(value, frappe.defaults.get_default("float_precision")) + "%", options)
 	},
 	Rating: function(value) {
 		return `<span class="rating">

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -50,7 +50,8 @@ frappe.form.formatters = {
 		return frappe.form.formatters._right(value==null ? "" : cint(value), options)
 	},
 	Percent: function(value, docfield, options) {
-		return frappe.form.formatters._right(flt(value, frappe.defaults.get_default("float_precision") || 3) + "%", options);
+		var precision = docfield.precision || cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) || 2;
+		return frappe.form.formatters._right(flt(value, precision) + "%", options);
 	},
 	Rating: function(value) {
 		return `<span class="rating">


### PR DESCRIPTION
**Issue:**

1. In a Material Request, when the qty of unordered items was very insignificant compared to the qty of ordered items, the document used to reflect wrong status.

![Screenshot 2020-11-27 at 7 27 24 PM](https://user-images.githubusercontent.com/31363128/100458071-2cad4c00-30e9-11eb-8cb2-83554ac9fbac.png)


2. In the above example even though the second item is not ordered, the status was reflecting as Ordered. The **% Ordered** field shows 100%. 

3. This issue was because of rounding. In the database, the proper value of the field was set, the rounding was on the frontend.