### PR TITLE
fix: check if print settings has landscape

### DIFF
--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -89,9 +89,17 @@ frappe.render_template = function(name, data) {
 }
 frappe.render_grid = function(opts) {
 	// build context
-	if(opts.grid) {
+	if (opts.grid) {
 		opts.columns = opts.grid.getColumns();
 		opts.data = opts.grid.getData().getItems();
+	}
+
+	if (
+		opts.print_settings &&
+		opts.print_settings.orientation &&
+		opts.print_settings.orientation.toLowerCase() === "landscape"
+	) {
+		opts.landscape = true;
 	}
 
 	// show landscape view if columns more than 10


### PR DESCRIPTION
Printing a report with print settings set to landscape would have no effect, this is because the print arguments did not match what's expected in `frappe.render_grid` function.

The option would be passed as `orientation: "Landscape"` in the `print_settings` object in `opts`, however, `render_grid` function assumed that `landscape = true` would be provided in the opts object directly.

This PR fixes that.

![image](https://user-images.githubusercontent.com/18097732/100573304-838b6f00-32fd-11eb-9b43-b3509a93ad81.png)


Frappe Issue: [ISS-20-21-07178](https://frappe.io/desk#Form/Issue/ISS-20-21-07178)