### PR TITLE
chore: bump frappe-charts to 1.5.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,9 +2300,9 @@ fragment-cache@^0.2.1:
     map-cache "^0.2.2"
 
 frappe-charts@^1.5.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.5.3.tgz#0dcb86ea774fa7a3e1b79221e958d29701dfff04"
-  integrity sha512-VS5XVxek41ea8mVzetyFF3avNefiwGDcDSDJuHrZyJXgbqiTSXLoqlPFoMqTzuzRm1g+o6TXs+A7wLtVp3Vt0g==
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-1.5.4.tgz#5870f77ac6ffc8ea4dab32adda1d4e5e4fbda64b"
+  integrity sha512-hBr7cRLmsCC5VBj/HwKOCgdwyXnkeAO5CAvOd5H4IYFbk84VD9jOjx9fSaqAE0MygVVbY1nCN+5nb08WThW4Xw==
 
 frappe-datatable@^1.15.3:
   version "1.15.3"


### PR DESCRIPTION
Upgrade to [1.5.4](https://github.com/frappe/charts/releases/tag/1.5.4) with minor fixes

## How to Test
Check reports like
1. Account Receivable & Payable
1. Website Analytics
1. Profit and Loss Statement
