### PR TITLE
feat: allow html in email templates

### DIFF
--- a/frappe/email/doctype/email_template/email_template.json
+++ b/frappe/email/doctype/email_template/email_template.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "Prompt",
@@ -8,6 +9,8 @@
  "engine": "InnoDB",
  "field_order": [
   "subject",
+  "use_html",
+  "response_html",
   "response",
   "owner",
   "section_break_4",
@@ -22,11 +25,12 @@
    "reqd": 1
   },
   {
+   "depends_on": "eval:!doc.use_html",
    "fieldname": "response",
    "fieldtype": "Text Editor",
    "in_list_view": 1,
    "label": "Response",
-   "reqd": 1
+   "mandatory_depends_on": "eval:!doc.use_html"
   },
   {
    "default": "user",
@@ -45,10 +49,24 @@
    "fieldtype": "HTML",
    "label": "Email Reply Help",
    "options": "<h4>Email Reply Example</h4>\n\n<pre>Order Overdue\n\nTransaction {{ name }} has exceeded Due Date. Please take necessary action.\n\nDetails\n\n- Customer: {{ customer }}\n- Amount: {{ grand_total }}\n</pre>\n\n<h4>How to get fieldnames</h4>\n\n<p>The fieldnames you can use in your email template are the fields in the document from which you are sending the email. You can find out the fields of any documents via Setup &gt; Customize Form View and selecting the document type (e.g. Sales Invoice)</p>\n\n<h4>Templating</h4>\n\n<p>Templates are compiled using the Jinja Templating Language. To learn more about Jinja, <a class=\"strong\" href=\"http://jinja.pocoo.org/docs/dev/templates/\">read this documentation.</a></p>\n"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_html",
+   "fieldtype": "Check",
+   "label": "Use HTML"
+  },
+  {
+   "depends_on": "eval:doc.use_html",
+   "fieldname": "response_html",
+   "fieldtype": "Code",
+   "label": "Response ",
+   "options": "HTML"
   }
  ],
  "icon": "fa fa-comment",
- "modified": "2019-10-30 14:15:00.956347",
+ "links": [],
+ "modified": "2020-11-30 14:12:50.321633",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Template",


### PR DESCRIPTION
Jinja templating is allowed in Email Templates, however it is allowed on the text editor. The problem is that the text editor is not aware of jinja and applies it's processing over it, wrapping jinja commands and statements in `<div>`.

Simply printing values is simple and can be done without a problem, however when trying to loop over a table or a list of values, the jinja templating does not work as expected

<img width="931" alt="Screen Shot 2020-11-30 at 2 13 39 PM" src="https://user-images.githubusercontent.com/18097732/100587328-6ca54680-3316-11eb-93f6-4424955dd7a2.png">

This PR allows using raw HTML instead of the text editor

Documentation Link: https://github.com/frappe/erpnext_documentation/pull/205