### PR TITLE
feat: show absolute value in print format

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -802,11 +802,11 @@ class BaseDocument(object):
 		if translated:
 			val = _(val)
 
-		if absolute_value and isinstance(val, (int, float)):
-			val = abs(self.get(fieldname))
-
 		if not doc:
 			doc = getattr(self, "parent_doc", None) or self
+
+		if (absolute_value or doc.get('absolute_value')) and isinstance(val, (int, float)):
+			val = abs(self.get(fieldname))
 
 		return format_value(val, df=df, doc=doc, currency=currency)
 

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -19,6 +19,7 @@ frappe.ui.form.on("Print Format", {
 		}
 		frm.trigger('render_buttons');
 		frm.toggle_display('standard', frappe.boot.developer_mode);
+		frm.trigger('hide_absolute_value_field');
 	},
 	render_buttons: function (frm) {
 		frm.page.clear_inner_toolbar();
@@ -58,5 +59,20 @@ frappe.ui.form.on("Print Format", {
 		frm.set_value('show_section_headings', value);
 		frm.set_value('line_breaks', value);
 		frm.trigger('render_buttons');
+	},
+	doc_type: function (frm) {
+		frm.trigger('hide_absolute_value_field');
+	},
+	hide_absolute_value_field: function (frm) {
+		// TODO: make it work with frm.doc.doc_type
+		// Problem: frm isn't updated in some random cases
+		const doctype = locals[frm.doc.doctype][frm.doc.name];
+		if (doctype) {
+			frappe.model.with_doctype(doctype, () => {
+				const meta = frappe.get_meta(doctype);
+				const has_int_float_currency_field = meta.fields.filter(df => in_list(['Int', 'Float', 'Currency'], df.fieldtype));
+				frm.toggle_display('absolute_value', has_int_float_currency_field.length);
+			});
+		}
 	}
-})
+});

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -200,6 +200,8 @@
   },
   {
    "default": "0",
+   "depends_on": "doc_type",
+   "description": "If checked, negative numberic values of Currency, Quantity or Count would be shown as positive",
    "fieldname": "absolute_value",
    "fieldtype": "Check",
    "label": "Show absolute values"
@@ -209,7 +211,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-11-30 15:26:35.605213",
+ "modified": "2020-12-10 18:58:55.598269",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -22,6 +22,7 @@
   "align_labels_right",
   "show_section_headings",
   "line_breaks",
+  "absolute_value",
   "column_break_11",
   "font",
   "css_section",
@@ -196,13 +197,19 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Print Format Builder"
+  },
+  {
+   "default": "0",
+   "fieldname": "absolute_value",
+   "fieldtype": "Check",
+   "label": "Show absolute values"
   }
  ],
  "icon": "fa fa-print",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-27 18:27:58.307070",
+ "modified": "2020-11-30 15:26:35.605213",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -136,10 +136,9 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="HTML" %}
 		{{ frappe.render_template(df.options, {"doc":doc}) }}
-	{% elif df.fieldtype=="Currency" %}
-		{{ doc.get_formatted(df.fieldname, doc, translated=df.translatable) }}
 	{% else %}
-		{{ doc.get_formatted(df.fieldname, parent_doc or doc, translated=df.translatable) }}
+		{%- set parent = parent_doc or doc -%}
+		{{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) }}
 	{% endif %}
 {%- endmacro %}
 

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -100,6 +100,7 @@ def get_rendered_template(doc, name=None, print_format=None, meta=None,
 		doc.print_section_headings = print_format.show_section_headings
 		doc.print_line_breaks = print_format.line_breaks
 		doc.align_labels_right = print_format.align_labels_right
+		doc.absolute_value = print_format.absolute_value
 
 		def get_template_from_string():
 			return jenv.from_string(get_print_format(doc.doctype,


### PR DESCRIPTION
- Added a checkbox in **Print Format** to show absolute value

<img width="1212" alt="Screenshot 2020-12-10 at 8 05 48 PM" src="https://user-images.githubusercontent.com/25369014/101785752-24123800-3b23-11eb-8df1-47d753f603ba.png">

Docs: https://github.com/frappe/erpnext_documentation/pull/219