### PR TITLE
chore: Add .editorconfig to enforce consistent styling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Root editor config file
+root = true
+
+# Common settings
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# python, js indentation settings
+[{*.py,*.js}]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Github respects .editorconfig settings. Adding indent_size as 4 in
settings makes github indent code to 4 columns.

Tests and docs are not needed as this does not have any production changes, but only styling.

More about editorconfig: https://editorconfig.org/