### PR TITLE
fix: setup record for background color while setting up website theme

### DIFF
--- a/frappe/patches/v13_0/website_theme_custom_scss.py
+++ b/frappe/patches/v13_0/website_theme_custom_scss.py
@@ -2,9 +2,23 @@ import frappe
 
 def execute():
 	frappe.reload_doctype('Website Theme')
+	frappe.reload_doc('website', 'doctype', 'website_theme_ignore_app')
+	frappe.reload_doc('website', 'doctype', 'color')
+
 	for theme in frappe.get_all('Website Theme'):
 		doc = frappe.get_doc('Website Theme', theme.name)
 		if not doc.get('custom_scss') and doc.theme_scss:
 			# move old theme to new theme
 			doc.custom_scss = doc.theme_scss
+
+			if doc.background_color:
+				setup_color_record(doc.background_color)
+
 			doc.save()
+
+def setup_color_record(color):
+	frappe.get_doc({
+		"doctype": "Color",
+		"__newname": color,
+		"color": color,
+	}).save()


### PR DESCRIPTION
```
Executing frappe.patches.v13_0.website_theme_custom_scss in v13conelco.erpnext.com (141b012a3834b611)
#77E65C
Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/utils/bench_helper.py", line 99, in <module>
    main()
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-2020-11-11/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-2020-11-11/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-2020-11-11/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2020-11-11/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2020-11-11/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-2020-11-11/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-2020-11-11/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/commands/site.py", line 287, in migrate
    skip_search_index=skip_search_index
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/patches/v13_0/website_theme_custom_scss.py", line 12, in execute
    doc.save()
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/model/document.py", line 319, in _save
    self._validate_links()
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/model/document.py", line 800, in _validate_links
    frappe.LinkValidationError)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/__init__.py", line 409, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/__init__.py", line 388, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2020-11-11/apps/frappe/frappe/__init__.py", line 342, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.LinkValidationError: Could not find Background Color: #77E65C
```