### PR TITLE
fix(Email): Exception handling in get_owner_email()

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -416,7 +416,7 @@ def get_owner_email(doc):
 	owner = get_parent_doc(doc).owner
 	try:
 		return get_formatted_email(owner)
-	except:
+	except Exception as e:
 		return owner
 
 def get_assignees(doc):

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -414,7 +414,10 @@ def filter_email_list(doc, email_list, exclude, is_cc=False, is_bcc=False):
 
 def get_owner_email(doc):
 	owner = get_parent_doc(doc).owner
-	return get_formatted_email(owner) or owner
+	try:
+		return get_formatted_email(owner)
+	except:
+		return owner
 
 def get_assignees(doc):
 	return [( get_formatted_email(d.owner) or d.owner ) for d in


### PR DESCRIPTION
When the parent doc owner does not have email set, this breaks the email pull operation etc:

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 100, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 821, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 337, in receive
    communication.notify(attachments=attachments, fetched_from_email_account=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/communication.py", line 205, in notify
    fetched_from_email_account)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 126, in notify
    fetched_from_email_account=fetched_from_email_account)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 184, in get_recipients_cc_and_bcc
    cc = get_cc(doc, recipients, fetched_from_email_account=fetched_from_email_account)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 314, in get_cc
    cc.append(get_owner_email(doc))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 417, in get_owner_email
    return get_formatted_email(owner) or owner
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/__init__.py", line 71, in get_formatted_email
    return cstr(make_header(decode_header(formataddr((fullname, mail)))))
  File "/usr/lib64/python3.6/email/utils.py", line 91, in formataddr
    address.encode('ascii')
AttributeError: 'NoneType' object has no attribute 'encode'
```