### PR TITLE
feat: provision to open child table in customize form

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -81,6 +81,11 @@ frappe.ui.form.on("Customize Form", {
 			} else {
 				f._sortable = false;
 			}
+			if (f.fieldtype == "Table") {
+				frm.add_custom_button(f.options, function() {
+					frm.set_value('doc_type', f.options);
+				}, __('Customize Child Table'));
+			}
 		});
 		frm.fields_dict.fields.grid.refresh();
 	},


### PR DESCRIPTION
**Issue -** Till now there is no straightforward way to open the child table in Customize Form rather than typing table name in doctype field.

**Fix-** Added a custom button in Customize Form to open the child table in the Customize Form.

![child-table](https://user-images.githubusercontent.com/20715976/100975855-ac616d80-3564-11eb-90a2-d038abd0f7fb.gif)

> no-docs