### PR TITLE
fix: Multiple y rows in charts

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -15,7 +15,9 @@ frappe.report_utils = {
 
 		if (raw_data.add_total_row) {
 			labels = labels.slice(0, -1);
-			datasets[0].values = datasets[0].values.slice(0, -1);
+			datasets.forEach(dataset => {
+				dataset.values = dataset.values.slice(0, -1);
+			});
 		}
 
 		return {


### PR DESCRIPTION
set chart breaks if 2  Rows are selected in "Y field"
This is because the total row was escaped only in the first selected row
![image](https://user-images.githubusercontent.com/28212972/100985456-03ba0a80-3572-11eb-8071-818822833673.png)
Solution: escaping the total row in each y row