### PR TITLE
fix(newsletter): Render template for HTML content type

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -85,11 +85,11 @@ class Newsletter(WebsiteGenerator):
 			self.db_set("scheduled_to_send", len(self.recipients))
 
 	def get_message(self):
-
+		if self.content_type == "HTML":
+			return frappe.render_template(self.message_html, {"doc": self.as_dict()})
 		return {
 			'Rich Text': self.message,
-			'Markdown': markdown(self.message_md),
-			'HTML': self.message_html
+			'Markdown': markdown(self.message_md)
 		}[self.content_type or 'Rich Text']
 
 	def get_recipients(self):


### PR DESCRIPTION
Ability to write Jinja in Newsletter when the content type is HTML.

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/9355208/101071970-4e17a780-35c3-11eb-8418-0a2a8660cf51.png">
