### PR TITLE
fix: Updated an untranslated field

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar.html
+++ b/frappe/public/js/frappe/list/list_sidebar.html
@@ -10,7 +10,7 @@
 </ul>
 <ul class="list-unstyled sidebar-menu standard-actions">
 	{% if frappe.model.can_get_report(doctype) %}
-	<li class="list-sidebar-label">Views</li>
+	<li class="list-sidebar-label">{{ __("Views") }}</li>
 	<li class="divider visible-sm visible-xs"></li>
 	<li class="list-link">
 		<div class="btn-group">


### PR DESCRIPTION
```
<li class="list-sidebar-label">Views</li>
```
Change to
```
<li class="list-sidebar-label">{{ __("Views") }}</li>
```