### PR TITLE
fix: use frappe.utils.shorten_number

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -269,7 +269,7 @@ export default class NumberCardWidget extends Widget {
 			result: this.number
 		}).then(res => {
 			if (res !== undefined) {
-				this.percentage_stat = shorten_number(res);
+				this.percentage_stat = frappe.utils.shorten_number(res);
 			}
 		});
 	}


### PR DESCRIPTION
Fixes:
<img width="1440" alt="Screenshot 2020-12-04 at 6 32 15 PM" src="https://user-images.githubusercontent.com/19775888/101166915-0e9e9900-365f-11eb-92a5-78ec5fedc0cb.png">
