### PR TITLE
fix: Query report filter

### DIFF
--- a/frappe/core/doctype/report_filter/report_filter.json
+++ b/frappe/core/doctype/report_filter/report_filter.json
@@ -44,7 +44,7 @@
   },
   {
    "fieldname": "options",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Options"
   },
   {
@@ -58,7 +58,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-08-17 16:15:46.937267",
+ "modified": "2020-12-05 19:20:00.503097",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report Filter",

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1112,7 +1112,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	get_filter_values(raise) {
-		const mandatory = this.filters.filter(f => f.df.reqd);
+
+		// check for mandatory property for filters added via UI
+		const mandatory = this.filters.filter(f => (f.df.reqd || f.df.mandatory));
 		const missing_mandatory = mandatory.filter(f => !f.get_value());
 		if (raise && missing_mandatory.length > 0) {
 			let message = __('Please set filters');


### PR DESCRIPTION
- Data was fetched even when mandatory filters were missing
- Changed field type of `options` field from `Data` to `Small Text` so that users can add multiple options for select field 