### PR TITLE
fix: patch to scrub custom report column fieldnames

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -273,3 +273,4 @@ frappe.patches.v12_0.email_unsubscribe
 frappe.patches.v12_0.replace_old_data_import
 frappe.patches.v12_0.set_correct_url_in_files
 frappe.patches.v12_0.fix_email_id_formatting
+frappe.patches.v12_0.scrub_custom_report_column_fieldnames

--- a/frappe/patches/v12_0/scrub_custom_report_column_fieldnames.py
+++ b/frappe/patches/v12_0/scrub_custom_report_column_fieldnames.py
@@ -12,6 +12,6 @@ def execute():
 		columns = frappe.parse_json(report.json)
 		if columns:
 			for col in columns:
-				if isinstance(col, dict):
+				if isinstance(col, dict) and col.get("fieldname"):
 					col['fieldname'] = frappe.scrub(col['fieldname'])
 			frappe.db.set_value('Report', report.name, 'json', frappe.as_json(columns))

--- a/frappe/patches/v12_0/scrub_custom_report_column_fieldnames.py
+++ b/frappe/patches/v12_0/scrub_custom_report_column_fieldnames.py
@@ -1,0 +1,17 @@
+import frappe
+
+def execute():
+	reports = frappe.get_all('Report',
+		fields = ['name', 'json'],
+		filters = {
+			'is_standard': 'No',
+			'report_type': ['!=', 'Report Builder'],
+		})
+
+	for report in reports:
+		columns = frappe.parse_json(report.json)
+		if columns:
+			for col in columns:
+				if isinstance(col, dict):
+					col['fieldname'] = frappe.scrub(col['fieldname'])
+			frappe.db.set_value('Report', report.name, 'json', frappe.as_json(columns))


### PR DESCRIPTION
**Issue:**
Older Custom Reports don't have column fieldnames in sluggified form, while the result keys are in sluggified form, which leads to blank data in the report:
<img width="1200" alt="Screenshot 2020-12-08 at 2 45 51 PM" src="https://user-images.githubusercontent.com/19775888/101463976-1bbfce80-3964-11eb-9fe5-0f1b88bb368e.png">


**Fix:**
Patch that scrubs all column fieldnames in the json of Custom Reports. 