### PR TITLE
WIP: fix(sign up): rate limit query

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -771,7 +771,7 @@ def sign_up(email, full_name, redirect_to):
 			return 0, _("Already Registered")
 	else:
 		if frappe.db.sql("""select count(*) from tabUser where
-			HOUR(TIMEDIFF(CURRENT_TIMESTAMP, TIMESTAMP(modified)))=1""")[0][0] > 300:
+			HOUR(TIMEDIFF(%s, TIMESTAMP(creation)))<1""", now_datetime())[0][0] > 300:
 
 			frappe.respond_as_web_page(_('Temporarily Disabled'),
 				_('Too many users signed up recently, so the registration is disabled. Please try back in an hour'),

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1039,8 +1039,10 @@ def throttle_user_creation():
 	if frappe.flags.in_import:
 		return
 
-	if frappe.db.get_creation_count('User', 60) > frappe.local.conf.get("throttle_user_limit", 60):
-		frappe.throw(_('Throttled'))
+	created = frappe.db.get_creation_count('User', 60)
+	rate_limit = frappe.local.conf.get("throttle_user_limit", 60)
+	if created > rate_limit:
+		frappe.throw(_('Throttled %s / %s' % (created, rate_limit)))
 
 @frappe.whitelist()
 def get_role_profile(role_profile):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -195,7 +195,8 @@ class Database(object):
 	def log_query(self, query, values, debug, explain):
 		# for debugging in tests
 		if frappe.conf.get('allow_tests') and frappe.cache().get_value('flag_print_sql'):
-			print(self.mogrify(query, values))
+			if not query.strip().lower().startswith('select'):
+				print(self.mogrify(query, values))
 
 		# debug
 		if debug:


### PR DESCRIPTION
The sign up rate limiting feature wasn't working as expected, fix the _sign up_ SQL query:
* `CURRENT_TIMESTAMP` should not be used: the time zones between database server and frappe can differ (`now_datetime` is already used [here](https://github.com/frappe/frappe/blob/b08d834363ff2a3e76115879adc0aac297ffec49/frappe/database/database.py#L869)
* count the created users instead of the modified ones
* count the users created during the last hour, not more than one hour ago
* add PostgreSQL support

Test provided.