### PR TITLE
fix: cint seconds before operations

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -369,6 +369,8 @@ def format_duration(seconds, hide_days=False):
 
 	example: converts 12885 to '3h 34m 45s' where 12885 = seconds in float
 	"""
+	
+	seconds = cint(seconds)
 
 	total_duration = {
 		'days': math.floor(seconds / (3600 * 24)),


### PR DESCRIPTION
Type a number say 22 in the duration control directly and save the doc. The save op will break with the a `TypeError` viz. `TypeError: unsupported operand type(s) for /: 'str' and 'int'`

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/document.py", line 337, in _save
    self.run_post_save_methods()
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/document.py", line 980, in run_post_save_methods
    self.save_version()
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/document.py", line 1076, in save_version
    elif version.set_diff(self._doc_before_save, self):
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/core/doctype/version/version.py", line 15, in set_diff
    diff = get_diff(old, new)
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/core/doctype/version/version.py", line 97, in get_diff
    new_value = new.get_formatted(df.fieldname) if new_value else new_value
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/model/base_document.py", line 811, in get_formatted
    return format_value(val, df=df, doc=doc, currency=currency)
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/utils/formatters.py", line 95, in format_value
    return format_duration(value, hide_days)
  File "/home/frappe/benches/bench-version-13-2020-11-09/apps/frappe/frappe/utils/data.py", line 353, in format_duration
    'days': math.floor(seconds / (3600 * 24)),
TypeError: unsupported operand type(s) for /: 'str' and 'int'
```

This PR fixes this

Fixes [ISS-20-21-07603](https://frappe.io/desk#Form/Issue/ISS-20-21-07603)