### PR TITLE
feat(Auto Repeat): Submit on Creation configuration

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.js
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.js
@@ -44,6 +44,20 @@ frappe.ui.form.on('Auto Repeat', {
 
 		// auto repeat schedule
 		frappe.auto_repeat.render_schedule(frm);
+
+		frm.trigger('toggle_submit_on_creation');
+	},
+
+	reference_doctype: function(frm) {
+		frm.trigger('toggle_submit_on_creation');
+	},
+
+	toggle_submit_on_creation: function(frm) {
+		// submit on creation checkbox
+		frappe.model.with_doctype(frm.doc.reference_doctype, () => {
+			let meta = frappe.get_meta(frm.doc.reference_doctype);
+			frm.toggle_display('submit_on_creation', meta.is_submittable);
+		});
 	},
 
 	template: function(frm) {

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.json
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "format:AUT-AR-{#####}",
@@ -12,6 +13,7 @@
   "section_break_3",
   "reference_doctype",
   "reference_document",
+  "submit_on_creation",
   "column_break_5",
   "start_date",
   "end_date",
@@ -186,9 +188,16 @@
    "fieldname": "repeat_on_last_day",
    "fieldtype": "Check",
    "label": "Repeat on Last Day of the Month"
+  },
+  {
+   "default": "0",
+   "fieldname": "submit_on_creation",
+   "fieldtype": "Check",
+   "label": "Submit on Creation"
   }
  ],
- "modified": "2019-07-17 11:30:51.412317",
+ "links": [],
+ "modified": "2020-12-10 10:43:13.449172",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Auto Repeat",

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -21,6 +21,7 @@ class AutoRepeat(Document):
 	def validate(self):
 		self.update_status()
 		self.validate_reference_doctype()
+		self.validate_submit_on_creation()
 		self.validate_dates()
 		self.validate_email_id()
 		self.set_dates()
@@ -59,6 +60,11 @@ class AutoRepeat(Document):
 			return
 		if not frappe.get_meta(self.reference_doctype).allow_auto_repeat:
 			frappe.throw(_("Enable Allow Auto Repeat for the doctype {0} in Customize Form").format(self.reference_doctype))
+
+	def validate_submit_on_creation(self):
+		if self.submit_on_creation and not frappe.get_meta(self.reference_doctype).is_submittable:
+			frappe.throw(_('Cannot enable {0} for a non-submittable doctype').format(
+				frappe.bold('Submit on Creation')))
 
 	def validate_dates(self):
 		if frappe.flags.in_patch:

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -151,7 +151,7 @@ class AutoRepeat(Document):
 		new_doc.insert(ignore_permissions = True)
 
 		if self.submit_on_creation:
-			new_doc.submit(gnore_permissions = True)
+			new_doc.submit()
 
 		return new_doc
 

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -150,6 +150,9 @@ class AutoRepeat(Document):
 		self.update_doc(new_doc, reference_doc)
 		new_doc.insert(ignore_permissions = True)
 
+		if self.submit_on_creation:
+			new_doc.submit(gnore_permissions = True)
+
 		return new_doc
 
 	def update_doc(self, new_doc, reference_doc):
@@ -160,7 +163,7 @@ class AutoRepeat(Document):
 		if new_doc.meta.get_field('auto_repeat'):
 			new_doc.set('auto_repeat', self.name)
 
-		for fieldname in ['naming_series', 'ignore_pricing_rule', 'posting_time', 'select_print_heading', 'remarks', 'owner']:
+		for fieldname in ['naming_series', 'ignore_pricing_rule', 'posting_time', 'select_print_heading', 'user_remark', 'remarks', 'owner']:
 			if new_doc.meta.get_field(fieldname):
 				new_doc.set(fieldname, reference_doc.get(fieldname))
 


### PR DESCRIPTION
When there are multiple documents created via Auto Repeat, it becomes tedious to submit those documents every time. Added a **Submit on Creation** configuration in Auto Repeat to take care of this.

![submit-on-creation](https://user-images.githubusercontent.com/24353136/101729725-bf34ee80-3ade-11eb-9f9a-d9aee848d532.png)

Documentation PR: https://github.com/frappe/erpnext_documentation/pull/218