### PR TITLE
fix: Reload server script via patch

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -21,6 +21,7 @@ execute:frappe.reload_doc('email', 'doctype', 'document_follow')
 execute:frappe.reload_doc('core', 'doctype', 'communication_link') #2019-10-02
 execute:frappe.reload_doc('core', 'doctype', 'has_role')
 execute:frappe.reload_doc('core', 'doctype', 'communication') #2019-10-02
+execute:frappe.reload_doc('core', 'doctype', 'server_script')
 frappe.patches.v11_0.replicate_old_user_permissions
 frappe.patches.v11_0.reload_and_rename_view_log #2019-01-03
 frappe.patches.v7_1.rename_scheduler_log_to_error_log


### PR DESCRIPTION
Issue:
Travis breaks while running patch on erpnext instance

Error:
```
Executing frappe.patches.v11_0.change_email_signature_fieldtype in test_site (test_frappe)
Traceback (most recent call last):
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 99, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 296, in migrate
    skip_search_index=skip_search_index
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v11_0/change_email_signature_fieldtype.py", line 8, in execute
    signatures = frappe.db.get_list('User', {'email_signature': ['!=', '']},['name', 'email_signature'])
  File "/home/travis/frappe-bench/apps/frappe/frappe/database/database.py", line 538, in get_list
    return frappe.get_list(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 1349, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/db_query.py", line 107, in execute
    result = self.build_and_run()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/db_query.py", line 124, in build_and_run
    args = self.prepare_args()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/db_query.py", line 152, in prepare_args
    self.build_conditions()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/db_query.py", line 379, in build_conditions
    match_conditions = self.build_match_conditions()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/db_query.py", line 605, in build_match_conditions
    doctype_conditions = self.get_permission_query_conditions()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/db_query.py", line 695, in get_permission_query_conditions
    permision_script_name = get_server_script_map().get("permission_query").get(self.doctype)
AttributeError: 'NoneType' object has no attribute 'get'

```