### PR TITLE
fix: cache bench apps 

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -348,7 +348,7 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, 
 
 	if as_table and type(msg) in (list, tuple):
 		out.as_table = 1
-	
+
 	if as_list and type(msg) in (list, tuple) and len(msg) > 1:
 		out.as_list = 1
 
@@ -939,7 +939,11 @@ def get_installed_apps(sort=False, frappe_last=False):
 		connect()
 
 	if not local.all_apps:
-		local.all_apps  = get_all_apps(True)
+		local.all_apps = cache().get_value('all_apps', get_all_apps)
+
+		#cache bench apps
+		if not cache().get_value('all_apps'):
+			cache().set_value('all_apps', local.all_apps)
 
 	installed = json.loads(db.get_global("installed_apps") or "[]")
 


### PR DESCRIPTION
```
2020-12-11 07:30:30,051 ERROR scheduler Exception in Enqueue Events for Site *************
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/utils/scheduler.py", line 67, in enqueue_events_for_site
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/utils/scheduler.py", line 85, in enqueue_events
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 1370, in get_all
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 1343, in get_list
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/db_query.py", line 100, in execute
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/db_query.py", line 117, in build_and_run
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/db_query.py", line 144, in prepare_args
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/db_query.py", line 359, in build_conditions
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/db_query.py", line 380, in build_filter_conditions
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/db_query.py", line 388, in prepare_filter_condition
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/boot.py", line 308, in get_additional_filters_from_hooks
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 1093, in get_attr
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 943, in get_installed_apps
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 921, in get_all_apps
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 1061, in get_file_items
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 1083, in read_file
OSError: [Errno 24] Too many open files: b'./apps.txt'

```

## What caused this.

v13 onwards we moved the jobs list to DB. What this entails is that when we enqueue all jobs, a `get_all` function is called. This `get_all` needs to fetch filters from the hooks. To get these hooks, `apps.txt` is opened.

This won't be a problem for most people. But when the scale is that of erpnext.com, the problem shows up. Since all the scheduled jobs for a bench are triggered almost simultaneously, before python can even close the opened file. The OS limit on file open is reached.