### PR TITLE
feat: add alert flag for permission validation

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1000,10 +1000,10 @@ def validate_fields(meta):
 	check_sort_field(meta)
 	check_image_field(meta)
 
-def validate_permissions_for_doctype(doctype, for_remove=False):
+def validate_permissions_for_doctype(doctype, for_remove=False, alert=True):
 	"""Validates if permissions are set correctly."""
 	doctype = frappe.get_doc("DocType", doctype)
-	validate_permissions(doctype, for_remove)
+	validate_permissions(doctype, for_remove, alert=alert)
 
 	# save permissions
 	for perm in doctype.get("permissions"):
@@ -1026,9 +1026,10 @@ def clear_permissions_cache(doctype):
 		""", doctype):
 		frappe.clear_cache(user=user)
 
-def validate_permissions(doctype, for_remove=False):
+def validate_permissions(doctype, for_remove=False, alert=True):
 	permissions = doctype.get("permissions")
-	if not permissions:
+	# Some DocTypes may not have permissions by default, don't show alert for them
+	if not permissions and alert:
 		frappe.msgprint(_('No Permissions Specified'), alert=True, indicator='orange')
 	issingle = issubmittable = isimportable = False
 	if doctype:

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1000,7 +1000,7 @@ def validate_fields(meta):
 	check_sort_field(meta)
 	check_image_field(meta)
 
-def validate_permissions_for_doctype(doctype, for_remove=False, alert=True):
+def validate_permissions_for_doctype(doctype, for_remove=False, alert=False):
 	"""Validates if permissions are set correctly."""
 	doctype = frappe.get_doc("DocType", doctype)
 	validate_permissions(doctype, for_remove, alert=alert)
@@ -1026,7 +1026,7 @@ def clear_permissions_cache(doctype):
 		""", doctype):
 		frappe.clear_cache(user=user)
 
-def validate_permissions(doctype, for_remove=False, alert=True):
+def validate_permissions(doctype, for_remove=False, alert=False):
 	permissions = doctype.get("permissions")
 	# Some DocTypes may not have permissions by default, don't show alert for them
 	if not permissions and alert:

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -90,7 +90,7 @@ def update(doctype, role, permlevel, ptype, value=None):
 	    str: Refresh flag is permission is updated successfully
 	"""
 	frappe.only_for("System Manager")
-	out = update_permission_property(doctype, role, permlevel, ptype, value, alert=False)
+	out = update_permission_property(doctype, role, permlevel, ptype, value)
 	return 'refresh' if out else None
 
 @frappe.whitelist()
@@ -104,7 +104,7 @@ def remove(doctype, role, permlevel):
 	if not frappe.get_all('Custom DocPerm', dict(parent=doctype)):
 		frappe.throw(_('There must be atleast one permission rule.'), title=_('Cannot Remove'))
 
-	validate_permissions_for_doctype(doctype, for_remove=True)
+	validate_permissions_for_doctype(doctype, for_remove=True, alert=True)
 
 @frappe.whitelist()
 def reset(doctype):

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -77,8 +77,20 @@ def add(parent, role, permlevel):
 
 @frappe.whitelist()
 def update(doctype, role, permlevel, ptype, value=None):
+	"""Update role permission params
+	
+	Args:
+	    doctype (str): Name of the DocType to update params for
+	    role (str): Role to be updated for, eg "Website Manager".
+	    permlevel (int): perm level the provided rule applies to
+	    ptype (str): permission type, example "read", "delete", etc.
+	    value (None, optional): value for ptype, None indicates False
+	
+	Returns:
+	    str: Refresh flag is permission is updated successfully
+	"""
 	frappe.only_for("System Manager")
-	out = update_permission_property(doctype, role, permlevel, ptype, value)
+	out = update_permission_property(doctype, role, permlevel, ptype, value, alert=False)
 	return 'refresh' if out else None
 
 @frappe.whitelist()

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -458,7 +458,7 @@ def update_permission_property(doctype, role, permlevel, ptype, value=None, vali
 		update `tabCustom DocPerm`
 		set `{0}`=%s where name=%s""".format(ptype), (value, name))
 	if validate:
-		validate_permissions_for_doctype(doctype, alert=alert)
+		validate_permissions_for_doctype(doctype)
 
 	return out
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -446,7 +446,7 @@ def can_export(doctype, raise_exception=False):
 			raise frappe.PermissionError(_("You are not allowed to export {} doctype").format(doctype))
 		return has_access
 
-def update_permission_property(doctype, role, permlevel, ptype, value=None, validate=True, alert=True):
+def update_permission_property(doctype, role, permlevel, ptype, value=None, validate=True):
 	'''Update a property in Custom Perm'''
 	from frappe.core.doctype.doctype.doctype import validate_permissions_for_doctype
 	out = setup_custom_perms(doctype)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -446,7 +446,7 @@ def can_export(doctype, raise_exception=False):
 			raise frappe.PermissionError(_("You are not allowed to export {} doctype").format(doctype))
 		return has_access
 
-def update_permission_property(doctype, role, permlevel, ptype, value=None, validate=True):
+def update_permission_property(doctype, role, permlevel, ptype, value=None, validate=True, alert=True):
 	'''Update a property in Custom Perm'''
 	from frappe.core.doctype.doctype.doctype import validate_permissions_for_doctype
 	out = setup_custom_perms(doctype)
@@ -458,7 +458,7 @@ def update_permission_property(doctype, role, permlevel, ptype, value=None, vali
 		update `tabCustom DocPerm`
 		set `{0}`=%s where name=%s""".format(ptype), (value, name))
 	if validate:
-		validate_permissions_for_doctype(doctype)
+		validate_permissions_for_doctype(doctype, alert=alert)
 
 	return out
 


### PR DESCRIPTION
In case default permissions are not set, the alert flag will indicate if an alert has to be shown in the UI or not.

## Steps to replicate this Issue

Note: Requires ERPNext

1. Open Role Permission Manager
1. Select "GSTR 3B Report" in doctype
1. Try updating a permission

You'll get an alert saying "No Permissions Specified". 

![image](https://user-images.githubusercontent.com/18097732/101880400-dc3df000-3bb8-11eb-9a31-b7a83229dbae.png)


This is becuase on `permission_manager.update` the `validate_permissions` is called in the `doctype.py`. When it finds no default permissions, it throws the alert.

This is perhaps for anyone creating custom DocTypes or developers creating them. The fix for this issue is adding an alert flag, which cascades down from `update` to `validate_permissions`.

Fixes: [ISS-20-21-07662](https://frappe.io/desk#Form/Issue/ISS-20-21-07662)