### PR TITLE
fix: only in developer mode you can delete doctypes

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -64,7 +64,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 
 			else:
 				doc = frappe.get_doc(doctype, name)
-
+				doc.check_developer_mode()
 				update_flags(doc, flags, ignore_permissions)
 				check_permission_and_not_submitted(doc)
 


### PR DESCRIPTION
related to https://github.com/frappe/frappe/issues/12062 
not allow to delete any doctype in the system only if you activate developer mode .
this apply even if you are logged in with administrator 