### PR TITLE
fix: typo in Print Format Settings

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -66,7 +66,7 @@ frappe.ui.form.on("Print Format", {
 	hide_absolute_value_field: function (frm) {
 		// TODO: make it work with frm.doc.doc_type
 		// Problem: frm isn't updated in some random cases
-		const doctype = locals[frm.doc.doctype][frm.doc.name];
+		const doctype = locals[frm.doc.doctype][frm.doc.name].doc_type;
 		if (doctype) {
 			frappe.model.with_doctype(doctype, () => {
 				const meta = frappe.get_meta(doctype);

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -201,17 +201,17 @@
   {
    "default": "0",
    "depends_on": "doc_type",
-   "description": "If checked, negative numberic values of Currency, Quantity or Count would be shown as positive",
+   "description": "If checked, negative numeric values of Currency, Quantity or Count would be shown as positive",
    "fieldname": "absolute_value",
    "fieldtype": "Check",
-   "label": "Show absolute values"
+   "label": "Show Absolute Values"
   }
  ],
  "icon": "fa fa-print",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-12-10 18:58:55.598269",
+ "modified": "2020-12-14 11:38:49.132061",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",


### PR DESCRIPTION
Changed "numberic" to "numeric"

https://github.com/frappe/erpnext_documentation/pull/219