### PR TITLE
fix: removed keyboard handlers for static modal

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -26,6 +26,8 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				backdrop: 'static',
 				keyboard: false
 			});
+			frappe.ui.keys.off('escape');
+			frappe.ui.keys.off('esc');
 			this.get_close_btn().hide();
 		}
 


### PR DESCRIPTION
Resolves #11926 

- Removed ESC keyboard event handler for static modal.
