### PR TITLE
fix: strip html before checking for null values

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -86,7 +86,7 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			var f = this.fields_dict[key];
 			if (f.get_value) {
 				var v = f.get_value();
-				if (f.df.reqd && is_null(v))
+				if(f.df.reqd && is_null(strip_html(v)))
 					errors.push(__(f.df.label));
 
 				if (f.df.reqd

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -86,7 +86,7 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			var f = this.fields_dict[key];
 			if (f.get_value) {
 				var v = f.get_value();
-				if(f.df.reqd && is_null(strip_html(v)))
+				if (f.df.reqd && is_null(strip_html(v)))
 					errors.push(__(f.df.label));
 
 				if (f.df.reqd


### PR DESCRIPTION
- For Text Editor, Quill appends `<div />` tags in the content and due to which the null value check fails.