### PR TITLE
fix: Improve breadcrumbs markup schema for website

### DIFF
--- a/frappe/templates/includes/breadcrumbs.html
+++ b/frappe/templates/includes/breadcrumbs.html
@@ -6,12 +6,12 @@
 			{% for parent in parents %}
 				<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 					<a itemprop="item" href="{{ url_prefix }}{{ parent.route | abs_url }}" itemprop="url">
-						<span itemprop="name">{{ parent.title or parent.label or parent.name or "" }}</span>
+						<span itemprop="parent">{{ parent.title or parent.label or parent.name or "" }}</span>
 						<meta itemprop="position" content="{{ loop.index }}" />
 					</a>
 				</li>
 			{% endfor %}
-			<li class="breadcrumb-item active" aria-current="page">
+			<li class="breadcrumb-item active" aria-current="page" itemprop="name">
 				{{ title or "" }}
 			</li>
 		</ol>

--- a/frappe/templates/includes/breadcrumbs.html
+++ b/frappe/templates/includes/breadcrumbs.html
@@ -3,16 +3,20 @@
 	<nav aria-label="breadcrumb">
 		<ol class="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 			{%- set parents = parents[-3:] %}
+			{% set count = (parents | length) + 1 %}
 			{% for parent in parents %}
 				<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item">
 					<a itemprop="item" href="{{ url_prefix }}{{ parent.route | abs_url }}" itemprop="url">
-						<span itemprop="parent">{{ parent.title or parent.label or parent.name or "" }}</span>
+						<span itemprop="name">{{ parent.title or parent.label or parent.name or "" }}</span>
 						<meta itemprop="position" content="{{ loop.index }}" />
 					</a>
 				</li>
 			{% endfor %}
-			<li class="breadcrumb-item active" aria-current="page" itemprop="name">
-				{{ title or "" }}
+			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item active" aria-current="page">
+				<span itemprop="item">
+					<span itemprop="name">{{ title }}</span>
+					<meta itemprop="position" content="{{ count }}"/>
+				</span>
 			</li>
 		</ol>
 	</nav>


### PR DESCRIPTION
Update Breadcrumb schema based on the following example

![image](https://user-images.githubusercontent.com/42651287/102860310-96ecae80-4453-11eb-8ec7-15b672a0ede1.png)
