### PR TITLE
fix: document naming rule validation for fields

### DIFF
--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -13,10 +13,11 @@ class DocumentNamingRule(Document):
 		self.validate_fields_in_conditions()
 
 	def validate_fields_in_conditions(self):
-		docfields = [x.fieldname for x in frappe.get_meta(self.document_type).fields]
-		for condition in self.conditions:
-			if condition.field not in docfields:
-				frappe.throw(_("{0} is not a field of doctype {1}").format(frappe.bold(condition.field), frappe.bold(self.document_type)))
+		if self.has_value_changed("document_type"):
+			docfields = [x.fieldname for x in frappe.get_meta(self.document_type).fields]
+			for condition in self.conditions:
+				if condition.field not in docfields:
+					frappe.throw(_("{0} is not a field of doctype {1}").format(frappe.bold(condition.field), frappe.bold(self.document_type)))
 
 	def apply(self, doc):
 		'''

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -13,10 +13,9 @@ class DocumentNamingRule(Document):
 		self.validate_fields_in_conditions()
 
 	def validate_fields_in_conditions(self):
+		docfields = [x.fieldname for x in frappe.get_meta(self.document_type).fields]
 		for condition in self.conditions:
-			docfields = frappe.get_meta(self.document_type).fields
-			matching_field = list(filter(lambda x: x.fieldname == condition.field, docfields))
-			if not len(matching_field):
+			if condition.field not in docfields:
 				frappe.throw(_("{0} is not a field of doctype {1}").format(frappe.bold(condition.field), frappe.bold(self.document_type)))
 
 	def apply(self, doc):

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -6,8 +6,19 @@ from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
 from frappe.utils.data import evaluate_filters
+from frappe import _
 
 class DocumentNamingRule(Document):
+	def validate(self):
+		self.validate_fields_in_conditions()
+
+	def validate_fields_in_conditions(self):
+		for condition in self.conditions:
+			docfields = frappe.get_meta(self.document_type).fields
+			matching_field = list(filter(lambda x: x.fieldname == condition.field, docfields))
+			if not len(matching_field):
+				frappe.throw(_("{0} is not a field of doctype {1}").format(frappe.bold(condition.field), frappe.bold(self.document_type)))
+
 	def apply(self, doc):
 		'''
 		Apply naming rules for the given document. Will set `name` if the rule is matched.


### PR DESCRIPTION
**Issue:**

1. Create a new Document Naming Rule. Select doctype as Item.
2. In the Conditions table select some fields. Save the document.
3. Now change the doctype name to maybe Asset Finance Book.
4. Keep the condition field as it is. Save.
5. No error is thrown even though the doctype does not have this field.

![image](https://user-images.githubusercontent.com/31363128/102583433-b7063000-412a-11eb-9402-f949a6a99011.png)

**Fix:**
1. Validation message appears in this scenario.

![Screenshot 2020-12-18 at 12 16 30 PM](https://user-images.githubusercontent.com/31363128/102583648-1106f580-412b-11eb-80dc-4f7ab00d13ef.png)


