### PR TITLE
fix: Allow images from links in print formats

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -5,7 +5,7 @@
 		<div>{{ frappe.render_template(df.options, {"doc": doc}) or "" }}</div>
 	{%- elif df.fieldtype in ("Text", "Text Editor", "Code", "Long Text") -%}
 		{{ render_text_field(df, doc) }}
-	{%- elif df.fieldtype in ("Image", "Attach Image", "Attach")
+	{%- elif df.fieldtype in ("Image", "Attach Image")
 		and (
 			(guess_mimetype(doc[df.fieldname])[0] or "").startswith("image/")  
 			or doc[df.fieldname].startswith("http")

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -6,7 +6,10 @@
 	{%- elif df.fieldtype in ("Text", "Text Editor", "Code", "Long Text") -%}
 		{{ render_text_field(df, doc) }}
 	{%- elif df.fieldtype in ("Image", "Attach Image", "Attach")
-		and (guess_mimetype(doc[df.fieldname])[0] or "").startswith("image/")  -%}
+		and (
+			(guess_mimetype(doc[df.fieldname])[0] or "").startswith("image/")  
+			or doc[df.fieldname].startswith("http")
+		) -%}
 		{{ render_image(df, doc) }}
 	{%- elif df.fieldtype=="Geolocation" -%}
 		{{ render_geolocation(df, doc) }}
@@ -123,15 +126,14 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
         {% include doc.print_templates[df.fieldname] %}
 	{% elif df.fieldtype=="Check" %}
 		<i class="{{ 'fa fa-check' if doc[df.fieldname] }}"></i>
-	{% elif df.fieldtype=="Image" %}
+	{% elif df.fieldtype in ("Image", "Attach Image") %}
 		<img src="{{ doc[doc.meta.get_field(df.fieldname).options] }}"
 			class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="Signature" %}
 		<img src="{{ doc[df.fieldname] }}" class="signature-img img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
-	{% elif df.fieldtype in ("Attach", "Attach Image") and doc[df.fieldname]
-		and frappe.utils.is_image(doc[df.fieldname]) %}
+	{% elif df.fieldtype == "Attach" and doc[df.fieldname] and frappe.utils.is_image(doc[df.fieldname]) %}
 		<img src="{{ doc[df.fieldname] }}" class="img-responsive"
 			{%- if df.print_width %} style="width: {{ get_width(df) }};"{% endif %}>
 	{% elif df.fieldtype=="HTML" %}


### PR DESCRIPTION
Image when attached as links from sources like Google Drive didn't render on print. This is becuase these links have no extensions, guessing the mime type for these aren't possible just by looking at the name

This PR fixes this

### Broken
<img width="1680" alt="Screen Shot 2020-12-18 at 4 00 28 PM" src="https://user-images.githubusercontent.com/18097732/102604589-67376100-414a-11eb-8773-108c68f88cb8.png">

### Fixed
<img width="1680" alt="Screen Shot 2020-12-18 at 4 00 45 PM" src="https://user-images.githubusercontent.com/18097732/102604599-6a325180-414a-11eb-8bce-6e8ed9ca64ff.png">
