### PR TITLE
fix: do not remove the modules from txt file if developer mode is off

### DIFF
--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -43,7 +43,7 @@ class ModuleDef(Document):
 	def on_trash(self):
 		"""Delete module name from modules.txt"""
 
-		if frappe.flags.in_uninstall or self.custom:
+		if not frappe.conf.get('developer_mode') or frappe.flags.in_uninstall or self.custom:
 			return
 
 		modules = None


### PR DESCRIPTION
If developer mode is not on then do not remove the module name from the modules.txt file