### PR TITLE
fix: don't set Message as mandatory in communication dialog

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -55,38 +55,85 @@ frappe.views.CommunicationComposer = Class.extend({
 	get_fields: function() {
 		let contactList = [];
 		var fields= [
-			{label:__("To"), fieldtype:"MultiSelect", reqd: 0, fieldname:"recipients",options:contactList},
-			{fieldtype: "Section Break", collapsible: 1, label: __("CC, BCC & Email Template")},
-			{label:__("CC"), fieldtype:"MultiSelect", fieldname:"cc",options:contactList},
-			{label:__("BCC"), fieldtype:"MultiSelect", fieldname:"bcc",options:contactList},
-			{label:__("Email Template"), fieldtype:"Link", options:"Email Template",
-				fieldname:"email_template"},
-			{fieldtype: "Section Break"},
-			{label:__("Subject"), fieldtype:"Data", reqd: 1,
-				fieldname:"subject", length:524288},
-			{fieldtype: "Section Break"},
 			{
-				label:__("Message"),
-				fieldtype:"Text Editor",
-				fieldname:"content",
+				label: __("To"),
+				fieldtype: "MultiSelect",
+				reqd: 0,
+				fieldname: "recipients",
+				options: contactList
+			},
+			{
+				fieldtype: "Section Break",
+				collapsible: 1,
+				label: __("CC, BCC & Email Template")
+			},
+			{
+				label: __("CC"),
+				fieldtype: "MultiSelect",
+				fieldname: "cc",
+				options: contactList
+			},
+			{
+				label: __("BCC"),
+				fieldtype: "MultiSelect",
+				fieldname: "bcc",
+				options: contactList
+			},
+			{
+				label: __("Email Template"),
+				fieldtype: "Link",
+				options: "Email Template",
+				fieldname: "email_template"
+			},
+			{ fieldtype: "Section Break" },
+			{
+				label: __("Subject"),
+				fieldtype: "Data",
+				reqd: 1,
+				fieldname: "subject",
+				length: 524288
+			},
+			{ fieldtype: "Section Break" },
+			{
+				label: __("Message"),
+				fieldtype: "Text Editor",
+				fieldname: "content",
 				onchange: frappe.utils.debounce(this.save_as_draft.bind(this), 300)
 			},
-
-			{fieldtype: "Section Break"},
-			{fieldtype: "Column Break"},
-			{label:__("Send me a copy"), fieldtype:"Check",
-				fieldname:"send_me_a_copy", 'default': frappe.boot.user.send_me_a_copy},
-			{label:__("Send Read Receipt"), fieldtype:"Check",
-				fieldname:"send_read_receipt"},
-			{label:__("Attach Document Print"), fieldtype:"Check",
-				fieldname:"attach_document_print"},
-			{label:__("Select Print Format"), fieldtype:"Select",
-				fieldname:"select_print_format"},
-			{label:__("Select Languages"), fieldtype:"Select",
-				fieldname:"language_sel"},
-			{fieldtype: "Column Break"},
-			{label:__("Select Attachments"), fieldtype:"HTML",
-				fieldname:"select_attachments"}
+			{ fieldtype: "Section Break" },
+			{ fieldtype: "Column Break" },
+			{
+				label: __("Send me a copy"),
+				fieldtype: "Check",
+				fieldname: "send_me_a_copy",
+				'default': frappe.boot.user.send_me_a_copy
+			},
+			{
+				label: __("Send Read Receipt"),
+				fieldtype: "Check",
+				fieldname: "send_read_receipt"
+			},
+			{
+				label: __("Attach Document Print"),
+				fieldtype: "Check",
+				fieldname: "attach_document_print"
+			},
+			{
+				label: __("Select Print Format"),
+				fieldtype: "Select",
+				fieldname: "select_print_format"
+			},
+			{
+				label: __("Select Languages"),
+				fieldtype: "Select",
+				fieldname: "language_sel"
+			},
+			{ fieldtype: "Column Break" },
+			{
+				label: __("Select Attachments"),
+				fieldtype: "HTML",
+				fieldname: "select_attachments"
+			}
 		];
 
 		// add from if user has access to multiple email accounts

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -67,7 +67,7 @@ frappe.views.CommunicationComposer = Class.extend({
 			{fieldtype: "Section Break"},
 			{
 				label:__("Message"),
-				fieldtype:"Text Editor", reqd: 1,
+				fieldtype:"Text Editor",
 				fieldname:"content",
 				onchange: frappe.utils.debounce(this.save_as_draft.bind(this), 300)
 			},


### PR DESCRIPTION
Message doesn't need to be mandatory in the communication dialog.