### PR TITLE
fix(patch): Remove Package Publish Tool doctypes

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -317,3 +317,4 @@ frappe.patches.v13_0.web_template_set_module #2020-10-05
 frappe.patches.v13_0.remove_custom_link
 execute:frappe.delete_doc("DocType", "Footer Item")
 frappe.patches.v13_0.replace_field_target_with_open_in_new_tab
+frappe.patches.v13_0.delete_package_publish_tool

--- a/frappe/patches/v13_0/delete_package_publish_tool.py
+++ b/frappe/patches/v13_0/delete_package_publish_tool.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+
+def execute():
+	frappe.delete_doc("DocType", "Package Publish Tool", ignore_missing=True)
+	frappe.delete_doc("DocType", "Package Document Type", ignore_missing=True)
+	frappe.delete_doc("DocType", "Package Publish Target", ignore_missing=True)


### PR DESCRIPTION
Doctypes were not deleted in the PR: https://github.com/frappe/frappe/pull/11863

https://github.com/frappe/frappe/pull/11863#issuecomment-727194601