### PR TITLE
fix: null as default value for rating field

### DIFF
--- a/frappe/public/js/frappe/form/controls/rating.js
+++ b/frappe/public/js/frappe/form/controls/rating.js
@@ -47,7 +47,7 @@ frappe.ui.form.ControlRating  = frappe.ui.form.ControlInt.extend({
 		});
 	},
 	get_value() {
-		return cint(this.value);
+		return cint(this.value, null);
 	},
 	set_formatted_input(value) {
 		let el = $(this.input_area).find('i');


### PR DESCRIPTION
Previously, the value for Rating fields which have not been set would be set as 0. This PR changes this behaviour by setting the default value as `null`. This way if the field is mandatory it will have to be set.





**Note:** This means that we will not allow 0 rating to be set.