### PR TITLE
fix(Event Streaming): row removed in the child table not syncing when it has a dependency field

### DIFF
--- a/frappe/event_streaming/doctype/event_producer/event_producer.py
+++ b/frappe/event_streaming/doctype/event_producer/event_producer.py
@@ -295,7 +295,7 @@ def set_update(update, producer_site):
 		if data.changed:
 			local_doc.update(data.changed)
 		if data.removed:
-			update_row_removed(local_doc, data.removed)
+			local_doc = update_row_removed(local_doc, data.removed)
 		if data.row_changed:
 			update_row_changed(local_doc, data.row_changed)
 		if data.added:
@@ -318,7 +318,17 @@ def update_row_removed(local_doc, removed):
 	for tablename, rownames in iteritems(removed):
 		table = local_doc.get_table_field_doctype(tablename)
 		for row in rownames:
-			frappe.db.delete(table, row)
+			table_rows = local_doc.get(tablename)
+			child_table_row = get_child_table_row(table_rows, row)
+			table_rows.remove(child_table_row)
+			local_doc.set(tablename, table_rows)
+	return local_doc
+
+
+def get_child_table_row(table_rows, row):
+	for entry in table_rows:
+		if entry.get('name') == row:
+			return entry
 
 
 def update_row_changed(local_doc, changed):


### PR DESCRIPTION
**Problem:**

If a child table row is removed on the producer site and it has a dependency field (Link/Dynamic Link) the child table row does not sync since it tries to sync the dependency first. But it should altogether skip doing so if the row is removed.

![event-sync](https://user-images.githubusercontent.com/24353136/102972524-30ce5d00-4521-11eb-90d3-bf3eead4d031.png)

**After fix:**

Update child table rows in the doc instead of doing a direct `frappe.db.delete` operation

![sync](https://user-images.githubusercontent.com/24353136/102972642-62472880-4521-11eb-8ea4-a1d91b6188c0.png)


