### PR TITLE
fix: convert to str before stripping html

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -86,7 +86,7 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			var f = this.fields_dict[key];
 			if (f.get_value) {
 				var v = f.get_value();
-				if (f.df.reqd && is_null(strip_html(v)))
+				if (f.df.reqd && is_null(strip_html(cstr(v))))
 					errors.push(__(f.df.label));
 
 				if (f.df.reqd


### PR DESCRIPTION
Problem: 
`window.strip_html` throws `txt.replace is not a function` if dialog or field group contains a table

Fix:
Convert value to a string before stripping html