### PR TITLE
feat: fetch email account signature in email dialog

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -464,7 +464,6 @@ frappe.views.CommunicationComposer = Class.extend({
 	},
 
 	send_action: function() {
-		debugger;
 		var me = this;
 		var btn = me.dialog.get_primary_btn();
 
@@ -719,4 +718,3 @@ frappe.views.CommunicationComposer = Class.extend({
 		return text.replace(/\n{3,}/g, '\n\n');
 	}
 });
-

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -464,6 +464,7 @@ frappe.views.CommunicationComposer = Class.extend({
 	},
 
 	send_action: function() {
+		debugger;
 		var me = this;
 		var btn = me.dialog.get_primary_btn();
 
@@ -625,9 +626,18 @@ frappe.views.CommunicationComposer = Class.extend({
 		}
 	},
 
-	setup_earlier_reply: function() {
+	get_default_outgoing_email_account_signature: function() {
+		return frappe.db.get_value('Email Account', { 'default_outgoing': 1, 'add_signature': 1 }, 'signature');
+	},
+
+	setup_earlier_reply: async function() {
 		let fields = this.dialog.fields_dict;
 		let signature = frappe.boot.user.email_signature || "";
+
+		if (!signature) {
+			const res = await this.get_default_outgoing_email_account_signature();
+			signature = res.message.signature;
+		}
 
 		if(!frappe.utils.is_html(signature)) {
 			signature = signature.replace(/\n/g, "<br>");


### PR DESCRIPTION
Email Dialog only fetches email signature set in User Settings. This PR checks for outgoing email account signature if the user signature is not found.

> no-docs