### PR TITLE
docs: fix simple typo, transaltion -> translation

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -190,7 +190,7 @@ def get_full_dict(lang):
 	frappe.local.lang_full_dict = load_lang(lang)
 
 	try:
-		# get user specific transaltion data
+		# get user specific translation data
 		user_translations = get_user_translations(lang)
 		frappe.local.lang_full_dict.update(user_translations)
 	except Exception:


### PR DESCRIPTION
There is a small typo in frappe/translate.py.

Should read `translation` rather than `transaltion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md