### PR TITLE
feat: added twitter meta in blog post

### DIFF
--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -95,6 +95,10 @@ class BlogPost(WebsiteGenerator):
 		context.metatags = {
 			"name": self.meta_title,
 			"description": context.description,
+			"twitter:card": "summary",
+			"twitter:title": self.meta_title,
+			"twitter:description": context.description,
+			"twitter:image": self.meta_image
 		}
 
 		#if meta image is not present, then first image inside the blog will be set as the meta image


### PR DESCRIPTION
**Issue-** The Twitter summary card is not generated when we make tweets through API.

**Fix-** Added meta tags in the blog post for Summary Card. ref twitter developer docs - https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary