### PR TITLE
fix: default str for json dumps

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -85,7 +85,7 @@ def enqueue_webhook(doc, webhook):
 
 	for i in range(3):
 		try:
-			r = requests.post(webhook.request_url, data=json.dumps(data), headers=headers, timeout=5)
+			r = requests.post(webhook.request_url, data=json.dumps(data, default=str), headers=headers, timeout=5)
 			r.raise_for_status()
 			frappe.logger().debug({"webhook_success": r.text})
 			break


### PR DESCRIPTION
`json.dumps` in `enqueue_webhook` function would not be able to serialize date objects. Fixed this by defaulting to `str`

> the default should be a function called for objects that can’t otherwise be serialized. 

Fixes: [ISS-20-21-08036](https://frappe.io/app/issue/ISS-20-21-08036)