### PR TITLE
feat: ability to attach photo from webcam

### DIFF
--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -40,7 +40,7 @@ context('FileUploader', () => {
 	it('should accept uploaded files', () => {
 		open_upload_dialog();
 
-		cy.get_open_dialog().find('a:contains("uploaded file")').click();
+		cy.get_open_dialog().find('button:contains("Choose an existing file")').click();
 		cy.get_open_dialog().find('.tree-label:contains("example.json")').first().click();
 		cy.server();
 		cy.route('POST', '/api/method/upload_file').as('upload_file');
@@ -53,7 +53,7 @@ context('FileUploader', () => {
 	it('should accept web links', () => {
 		open_upload_dialog();
 
-		cy.get_open_dialog().find('a:contains("web link")').click();
+		cy.get_open_dialog().find('button:contains("Attach a web link")').click();
 		cy.get_open_dialog().find('.file-web-link input').type('https://github.com', { delay: 100, force: true });
 		cy.server();
 		cy.route('POST', '/api/method/upload_file').as('upload_file');

--- a/frappe/public/js/frappe/file_uploader/WebLink.vue
+++ b/frappe/public/js/frappe/file_uploader/WebLink.vue
@@ -33,4 +33,11 @@ export default {
 .file-web-link .input-group {
 	margin-top: 10px;
 }
+
+@media (max-width: 767px) {
+	.file-web-link input.form-control {
+		margin-bottom: 0;
+	}
+}
+
 </style>

--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -12,16 +12,16 @@
  * // returns "data:image/pngbase64,..."
  */
 frappe._.get_data_uri = element => {
-	const $element = $(element);
-	const width = $element.width();
-	const height = $element.height();
+
+	const width = element.videoWidth;
+	const height = element.videoHeight;
 
 	const $canvas = $('<canvas/>');
 	$canvas[0].width = width;
 	$canvas[0].height = height;
 
 	const context = $canvas[0].getContext('2d');
-	context.drawImage($element[0], 0, 0, width, height);
+	context.drawImage(element, 0, 0, width, height);
 
 	const data_uri = $canvas[0].toDataURL('image/png');
 
@@ -58,10 +58,12 @@ frappe.ui.Capture = class {
 			this.dialog = new frappe.ui.Dialog({
 				title: this.options.title,
 				animate: this.options.animate,
-				action: {
-					secondary: {
-						label: '<b>&times</b>'
-					}
+				secondary_action_label: '<b>&times;</b>',
+				secondary_action: () => {
+					if (stream)
+						stream.getTracks().forEach((track) => {
+							track.stop();
+						});
 				}
 			});
 
@@ -96,7 +98,7 @@ frappe.ui.Capture = class {
 			});
 
 			$e.find('.fc-bs').click(() => {
-				const data_url = frappe._.get_data_uri(video);
+				const data_url = $e.find('.fc-p')[0].src;
 				this.hide();
 
 				if (this.callback) this.callback(data_url);
@@ -138,9 +140,9 @@ frappe.ui.Capture.ERR_MESSAGE = __('Unable to load camera.');
 frappe.ui.Capture.TEMPLATE = `
 <div class="frappe-capture">
 	<div class="panel panel-default">
-		<img class="fc-p img-responsive"/>
-		<div class="fc-s  embed-responsive embed-responsive-16by9">
-			<video class="embed-responsive-item">${frappe.ui.Capture.ERR_MESSAGE}</video>
+		<div class="embed-responsive embed-responsive-16by9">
+			<img class="fc-p embed-responsive-item" style="object-fit: contain; display: none;"/>
+			<video class="fc-s embed-responsive-item">${frappe.ui.Capture.ERR_MESSAGE}</video>
 		</div>
 	</div>
 	<div>
@@ -169,7 +171,7 @@ frappe.ui.Capture.TEMPLATE = `
 				</div>
 				<div class="col-md-6">
 					<div class="pull-right">
-						<button class="btn btn-default fc-bcp">
+						<button class="btn btn-primary fc-bcp">
 							<small>${__('Take Photo')}</small>
 						</button>
 					</div>


### PR DESCRIPTION
### Added Take a Photo to directly attach images from Webcam / Camera.
![Screenshot from 2021-01-04 16-33-10](https://user-images.githubusercontent.com/38958184/103533515-434a7e00-4eb3-11eb-96f1-56b4d39e05a6.png)

**FileUploader.vue**
- Revamped UI for File Uploader.
- Added **Take a Photo** functionality to directly attach image using Webcam / Camera as a PNG image.

![Peek 2021-01-04 16-31](https://user-images.githubusercontent.com/38958184/103533227-bdc6ce00-4eb2-11eb-8cf0-fcddd099d881.gif)
- **Take a Photo** button only appears if site is secure i.e navigator.MediaDevices is available.

![Screenshot from 2021-01-04 17-15-44](https://user-images.githubusercontent.com/38958184/103533525-45acd800-4eb3-11eb-8026-052e73172b57.png)
- Images attached from Webcam / Camera are named as _capture_date_time.png_ e.g. `capture_2021-01-02_07-29-17.png` 
- Dashed border animation on dragging file over upload area.

![Peek 2021-01-04 16-30](https://user-images.githubusercontent.com/38958184/103533223-bbfd0a80-4eb2-11eb-872b-5b213b2fd095.gif)
- **Drag and Drop files** hidden for mobile devices.

![Screenshot from 2021-01-04 17-45-50](https://user-images.githubusercontent.com/38958184/103534392-ca4c2600-4eb4-11eb-8478-c2f131b6d0f4.png)


**capture.js**
- Fixed captured image stretch and resolution.
- Webcam / Camera now stops on Camera close.
- Submitted image is now same as the clicked image, previously a new image was being captured on submit click.
- Retake works as expected.

**Sponsored by:** @aakvatech



