### PR TITLE
fix: Strip HTML only if string is passed, else evaluate like before

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -86,7 +86,10 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			var f = this.fields_dict[key];
 			if (f.get_value) {
 				var v = f.get_value();
-				if (f.df.reqd && is_null(strip_html(v)))
+				if (
+					f.df.reqd &&
+					is_null(typeof v === 'string' ? strip_html(v) : v)
+				)
 					errors.push(__(f.df.label));
 
 				if (f.df.reqd


### PR DESCRIPTION
Bug introduced in https://github.com/frappe/frappe/pull/12088

Fixes https://github.com/frappe/erpnext/issues/24190