### PR TITLE
fix: Strip HTML in get_value only if value is a string

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -86,7 +86,9 @@ frappe.ui.FieldGroup = frappe.ui.form.Layout.extend({
 			var f = this.fields_dict[key];
 			if (f.get_value) {
 				var v = f.get_value();
-				if (f.df.reqd && is_null(strip_html(v)))
+				if (typeof v === "string") strip_html(v);
+
+				if (f.df.reqd && is_null(v))
 					errors.push(__(f.df.label));
 
 				if (f.df.reqd


### PR DESCRIPTION
- After https://github.com/frappe/frappe/pull/12088, `get_value` stripped html of whatever value was retrieved
- This value could be a number or a list as well (MultiCheck)
- In this case:
 ![image](https://user-images.githubusercontent.com/25857446/103640104-71909200-4f75-11eb-9eda-f6a59e00b712.png)


**Fix:**
 - Strip HTML only if string value

Fixes https://github.com/frappe/erpnext/issues/24190