### PR TITLE
perf: revert to using global instead of frappe.cache for 75% reduction in call time

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -27,6 +27,7 @@ __version__ = '13.0.0-dev'
 __title__ = "Frappe Framework"
 
 local = Local()
+controllers = {}
 
 class _dict(dict):
 	"""dict like object that exposes keys as attributes"""

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -72,6 +72,7 @@ def clear_document_cache():
 	frappe.cache().delete_key("document_cache")
 
 def clear_doctype_cache(doctype=None):
+	clear_controller_cache(doctype)
 	cache = frappe.cache()
 
 	if getattr(frappe.local, 'meta_cache') and (doctype in frappe.local.meta_cache):
@@ -103,6 +104,15 @@ def clear_doctype_cache(doctype=None):
 
 	# Clear all document's cache. To clear documents of a specific DocType document_cache should be restructured
 	clear_document_cache()
+
+def clear_controller_cache(doctype=None):
+	if not doctype:
+		del frappe.controllers
+		frappe.controllers = {}
+		return
+	
+	for site_controllers in frappe.controllers.values():
+		site_controllers.pop(doctype, None)
 
 def get_doctype_map(doctype, name, filters=None, order_by=None):
 	cache = frappe.cache()

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import re, copy, os, shutil
 import json
-from frappe.cache_manager import clear_user_cache
+from frappe.cache_manager import clear_user_cache, clear_controller_cache
 
 # imports - third party imports
 import six
@@ -408,13 +408,11 @@ class DocType(Document):
 			if not frappe.flags.in_patch:
 				self.rename_files_and_folders(old, new)
 
-			for site in frappe.utils.get_sites():
-				frappe.cache().delete(f"{site}:doctype_classes", old)
+			clear_controller_cache(old)
 
 	def after_delete(self):
 		if not self.custom:
-			for site in frappe.utils.get_sites():
-				frappe.cache().delete(f"{site}:doctype_classes", self.name)
+			clear_controller_cache(self.name)
 
 	def rename_files_and_folders(self, old, new):
 		# move files

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -26,14 +26,11 @@ max_positive_value = {
 
 DOCTYPES_FOR_DOCTYPE = ('DocType', 'DocField', 'DocPerm', 'DocType Action', 'DocType Link')
 
-_classes = {}
-
 def get_controller(doctype):
 	"""Returns the **class** object of the given DocType.
 	For `custom` type, returns `frappe.model.document.Document`.
 
 	:param doctype: DocType name as string."""
-	global _classes
 
 	def _get_controller():
 		from frappe.model.document import Document
@@ -73,11 +70,11 @@ def get_controller(doctype):
 	if frappe.local.dev_server:
 		return _get_controller()
 	
-	site_classes = _classes.setdefault(frappe.local.site, {})
-	if doctype not in site_classes:
-		site_classes[doctype] = _get_controller()
+	site_controllers = frappe.controllers.setdefault(frappe.local.site, {})
+	if doctype not in site_controllers:
+		site_controllers[doctype] = _get_controller()
 	
-	return site_classes[doctype]
+	return site_controllers[doctype]
 	
 class BaseDocument(object):
 	ignore_in_getter = ("doctype", "_meta", "meta", "_table_fields", "_valid_columns")

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -17,21 +17,21 @@ class TestHooks(unittest.TestCase):
 			hooks.get("doc_events").get("*").get("on_update"))
 
 	def test_override_doctype_class(self):
-		# mock get_hooks
-		original = frappe.get_hooks
-		def get_hooks(hook=None, default=None, app_name=None):
-			if hook == 'override_doctype_class':
-				return {
-					'ToDo': ['frappe.tests.test_hooks.CustomToDo']
-				}
-			return original(hook, default, app_name)
-		frappe.get_hooks = get_hooks
+		from frappe import hooks
+		from frappe.model import base_document
+		
+		# Set hook
+		hooks.override_doctype_class = {
+			'ToDo': ['frappe.tests.test_hooks.CustomToDo']
+		}
+		
+		# Clear cache
+		frappe.cache().delete_value('app_hooks')
+		base_document._classes = {}
 
 		todo = frappe.get_doc(doctype='ToDo', description='asdf')
 		self.assertTrue(isinstance(todo, CustomToDo))
 
-		# restore
-		frappe.get_hooks = original
 
 class CustomToDo(ToDo):
 	pass

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import unittest
 import frappe
 from frappe.desk.doctype.todo.todo import ToDo
+from frappe.cache_manager import clear_controller_cache
 
 class TestHooks(unittest.TestCase):
 	def test_hooks(self):
@@ -18,7 +19,6 @@ class TestHooks(unittest.TestCase):
 
 	def test_override_doctype_class(self):
 		from frappe import hooks
-		from frappe.model import base_document
 		
 		# Set hook
 		hooks.override_doctype_class = {
@@ -27,7 +27,7 @@ class TestHooks(unittest.TestCase):
 		
 		# Clear cache
 		frappe.cache().delete_value('app_hooks')
-		base_document._classes = {}
+		clear_controller_cache('ToDo')
 
 		todo = frappe.get_doc(doctype='ToDo', description='asdf')
 		self.assertTrue(isinstance(todo, CustomToDo))


### PR DESCRIPTION
## Before

### Frappe Recorder

![Screenshot-2021-01-06-131552](https://user-images.githubusercontent.com/16315650/103746397-0c957480-5027-11eb-9839-f19c8bba376e.png)

### Line Profiler

#### First Call

![Screenshot-2021-01-06-135828](https://user-images.githubusercontent.com/16315650/103746659-701fa200-5027-11eb-97b6-75fc286596ec.png)

#### Second Call

![Screenshot-2021-01-06-135841](https://user-images.githubusercontent.com/16315650/103746681-79107380-5027-11eb-9c5b-b6d9efc06be0.png)


## After

### Frappe Recorder

![Screenshot-2021-01-06-134420](https://user-images.githubusercontent.com/16315650/103746353-fc7d9500-5026-11eb-8664-2dd142e0b04c.png)


### Line Profiler

#### First Call

![Screenshot-2021-01-06-135859](https://user-images.githubusercontent.com/16315650/103746848-bd037880-5027-11eb-8f6b-0de3c799c418.png)


#### Second Call

![Screenshot-2021-01-06-135907](https://user-images.githubusercontent.com/16315650/103746867-c2f95980-5027-11eb-8e4b-19cacb10c2e3.png)

---

Tested on: Digital Ocean - Ubuntu (4 vCPUs, 8GB RAM)
Special thanks to: @filtersource