### PR TITLE
fix: strip_html breaks when it gets undefined

### DIFF
--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -108,7 +108,7 @@ window.replace_all = function(s, t1, t2) {
 }
 
 window.strip_html = function(txt) {
-	return txt.replace(/<[^>]*>/g, "");
+	return cstr(txt).replace(/<[^>]*>/g, "");
 }
 
 window.strip = function(s, chars) {


### PR DESCRIPTION
If strip_html sees an undefined it breaks 
![image](https://user-images.githubusercontent.com/28212972/103854402-5b4e1780-50d6-11eb-9d86-52c7fcd6ccda.png)
This PR fixes that by returning "" for undefined input