### PR TITLE
fix: Ensure rollback works with User entity

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -2,7 +2,7 @@
 # MIT License. See license.txt
 from __future__ import unicode_literals
 
-import frappe, unittest
+import frappe, unittest, uuid
 
 from frappe.model.delete_doc import delete_doc
 from frappe.utils.data import today, add_to_date
@@ -234,6 +234,29 @@ class TestUser(unittest.TestCase):
 		self.assertRegex(link, "\/update-password\?key=[A-Za-z0-9]*")
 
 		self.assertRaises(frappe.ValidationError, user.reset_password, False)
+
+	def test_user_rollback(self):
+		""" """
+		frappe.db.commit()
+		frappe.db.begin()
+		user_id = str(uuid.uuid4())
+		email = f'{user_id}@example.com'
+		try:
+			frappe.flags.in_import = True  # disable throttling
+			frappe.get_doc(dict(
+				doctype='User',
+				email=email,
+				first_name=user_id,
+			)).insert()
+		finally:
+			frappe.flags.in_import = False
+
+		# Check user has been added
+		self.assertIsNotNone(frappe.db.get("User", {"email": email}))
+
+		# Check that rollback works
+		frappe.db.rollback()
+		self.assertIsNone(frappe.db.get("User", {"email": email}))
 
 
 def delete_contact(user):

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -42,7 +42,6 @@ def create_notification_settings(user):
 		_doc = frappe.new_doc('Notification Settings')
 		_doc.name = user
 		_doc.insert(ignore_permissions=True)
-		frappe.db.commit()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
The `create_notification_settings` method calls `frappe.db.commit()`. This behavior prevent to use `frappe.db.rollback()` in order to cancel creation of `User` entities.

1. add a dedicated unit test
1. allow to use rollback in order to cancel creation of `User` entities. This commit will be added once the CI has executed the added test: this allows to check that this test fails when the fix is missing.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
