### PR TITLE
fix: add yesterday and tomorrow to timespan; optimise get_timespan_date_range

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -518,7 +518,7 @@ frappe.ui.filter_utils = {
 			['Date', 'Datetime', 'DateRange', 'Select'].includes(df.fieldtype)
 		) {
 			df.fieldtype = 'Select';
-			df.options = this.get_timespan_options(['Last', 'Today', 'This', 'Next']);
+			df.options = this.get_timespan_options(['Last', 'Yesterday', 'Today', 'Tomorrow', 'This', 'Next']);
 		}
 		if (condition === 'is') {
 			df.fieldtype = 'Select';
@@ -533,7 +533,6 @@ frappe.ui.filter_utils = {
 	get_timespan_options(periods) {
 		const period_map = {
 			Last: ['Week', 'Month', 'Quarter', '6 months', 'Year'],
-			Today: null,
 			This: ['Week', 'Month', 'Quarter', 'Year'],
 			Next: ['Week', 'Month', 'Quarter', '6 months', 'Year'],
 		};

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -444,25 +444,29 @@ def get_weekday(datetime=None):
 	return weekdays[datetime.weekday()]
 
 def get_timespan_date_range(timespan):
+	today = nowdate()
 	date_range_map = {
-		"last week": [add_to_date(nowdate(), days=-7), nowdate()],
-		"last month": [add_to_date(nowdate(), months=-1), nowdate()],
-		"last quarter": [add_to_date(nowdate(), months=-3), nowdate()],
-		"last 6 months": [add_to_date(nowdate(), months=-6), nowdate()],
-		"last year": [add_to_date(nowdate(), years=-1), nowdate()],
-		"today": [nowdate(), nowdate()],
-		"this week": [get_first_day_of_week(nowdate(), as_str=True), nowdate()],
-		"this month": [get_first_day(nowdate(), as_str=True), nowdate()],
-		"this quarter": [get_quarter_start(nowdate(), as_str=True), nowdate()],
-		"this year": [get_year_start(nowdate(), as_str=True), nowdate()],
-		"next week": [nowdate(), add_to_date(nowdate(), days=7)],
-		"next month": [nowdate(), add_to_date(nowdate(), months=1)],
-		"next quarter": [nowdate(), add_to_date(nowdate(), months=3)],
-		"next 6 months": [nowdate(), add_to_date(nowdate(), months=6)],
-		"next year": [nowdate(), add_to_date(nowdate(), years=1)],
+		"last week": lambda: (add_to_date(today, days=-7), today),
+		"last month": lambda: (add_to_date(today, months=-1), today),
+		"last quarter": lambda: (add_to_date(today, months=-3), today),
+		"last 6 months": lambda: (add_to_date(today, months=-6), today),
+		"last year": lambda: (add_to_date(today, years=-1), today),
+		"yesterday": lambda: (add_to_date(today, days=-1),) * 2,
+		"today": lambda: (today, today),
+		"tomorrow": lambda: (add_to_date(today, days=1),) * 2,
+		"this week": lambda: (get_first_day_of_week(today, as_str=True), today),
+		"this month": lambda: (get_first_day(today, as_str=True), today),
+		"this quarter": lambda: (get_quarter_start(today, as_str=True), today),
+		"this year": lambda: (get_year_start(today, as_str=True), today),
+		"next week": lambda: (today, add_to_date(today, days=7)),
+		"next month": lambda: (today, add_to_date(today, months=1)),
+		"next quarter": lambda: (today, add_to_date(today, months=3)),
+		"next 6 months": lambda: (today, add_to_date(today, months=6)),
+		"next year": lambda: (today, add_to_date(today, years=1)),
 	}
 
-	return date_range_map.get(timespan)
+	if timespan in date_range_map:
+		return date_range_map[timespan]()
 
 def global_date_format(date, format="long"):
 	"""returns localized date in the form of January 1, 2012"""


### PR DESCRIPTION
- Resolves #12150 by adding options for **Yesterday** and **Tomorrow**
- Modifies `get_timespan_date_range` to only calculate required range instead of all ranges

**Works locally:**

![Screenshot-2021-01-07-212204](https://user-images.githubusercontent.com/16315650/103913760-ece97380-512e-11eb-981c-8a7ade3ed627.png)
