### PR TITLE
feat: allow eval expression in default of docfield

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -190,6 +190,13 @@ $.extend(frappe.model, {
 				if (is_allowed_boot_doc) {
 					return boot_doc;
 				}
+			} else if (df["default"].substr(0,5)=="eval:") {
+				try {
+					return eval(df["default"].substr(5));
+				} catch (e) {
+					// ignore defaults for bad expression
+					return "";
+				}
 			} else if (df.fieldname===meta.title_field) {
 				// ignore defaults for title field
 				return "";


### PR DESCRIPTION
Enable eval expression in default of docfield, similar to depends_on field.