### PR TITLE
fix: Bind input change event for link control

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -49,6 +49,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		this.translate_values = true;
 		this.setup_buttons();
 		this.setup_awesomeplete();
+		this.bind_change_event();
 	},
 	get_options: function() {
 		return this.df.options;

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -93,15 +93,15 @@ frappe.views.TreeView = Class.extend({
 		var me = this;
 		this.opts.onload && this.opts.onload(me);
 	},
-	make_filters: function(){
+	make_filters: function() {
 		var me = this;
 		frappe.treeview_settings.filters = []
 		$.each(this.opts.filters || [], function(i, filter) {
-			if(frappe.route_options && frappe.route_options[filter.fieldname]) {
-				filter.default = frappe.route_options[filter.fieldname]
+			if (frappe.route_options && frappe.route_options[filter.fieldname]) {
+				filter.default = frappe.route_options[filter.fieldname];
 			}
 
-			if(!filter.disable_onchange) {
+			if (!filter.disable_onchange) {
 				filter.change = function() {
 					filter.onchange && filter.onchange();
 					var val = this.get_value();
@@ -113,7 +113,7 @@ frappe.views.TreeView = Class.extend({
 					}
 					me.set_title();
 					me.make_tree();
-				}
+				};
 			}
 
 			me.page.add_field(filter);
@@ -121,7 +121,7 @@ frappe.views.TreeView = Class.extend({
 			if (filter.default) {
 				$("[data-fieldname='"+filter.fieldname+"']").trigger("change");
 			}
-		})
+		});
 	},
 	get_root: function() {
 		var me = this;

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -103,7 +103,7 @@ frappe.views.TreeView = Class.extend({
 
 			if(!filter.disable_onchange) {
 				filter.change = function() {
-					filter.on_change && filter.on_change();
+					filter.onchange && filter.onchange();
 					var val = this.get_value();
 					me.args[filter.fieldname] = val;
 					if (val) {


### PR DESCRIPTION
- Bind input change events for link control. This means any additional change event attached to the input of the link field will also be called.
- Fix a typo in treeview.js. Controls use `onchange` function and not `on_change`.
