### PR TITLE
fix(email): Parse error object before displaying

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -210,7 +210,7 @@ class EmailAccount(Document):
 			elif not in_receive and any(map(lambda t: t in message, auth_error_codes)):
 				self.throw_invalid_credentials_exception()
 			else:
-				frappe.throw(e)
+				frappe.throw(cstr(e))
 
 		except socket.error:
 			if in_receive:


### PR DESCRIPTION
error "object is not json parseable " when the server returns a nonstandard error on validation
![image](https://user-images.githubusercontent.com/28212972/104299571-67c5dc00-54eb-11eb-8415-aec6b1b7c5bc.png)

![image](https://user-images.githubusercontent.com/28212972/104299730-92179980-54eb-11eb-8d42-8af06c206a39.png)

