### PR TITLE
fix: Center align hero title

### DIFF
--- a/frappe/public/scss/page-builder.scss
+++ b/frappe/public/scss/page-builder.scss
@@ -29,11 +29,11 @@
 }
 
 .hero.align-center {
-	h1, .hero-subtitle, .hero-buttons {
+	h1, .hero-title, .hero-subtitle, .hero-buttons {
 		text-align: center;
 	}
 
-	.hero-subtitle {
+	.hero-title, .hero-subtitle {
 		margin-left: auto;
 		margin-right: auto;
 	}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9355208/104351511-7f24b980-552b-11eb-9b80-858ac3ac7632.png)

After:
![image](https://user-images.githubusercontent.com/9355208/104351545-8a77e500-552b-11eb-9437-4fbfbf25126f.png)
