### PR TITLE
fix(desk): Correctly format and render Link fields

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -130,7 +130,7 @@ frappe.form.formatters = {
 		} else if(docfield && doctype) {
 			if (!frappe.model.can_select(doctype) && frappe.model.can_read(doctype)) {
 				return `<a class="grey"
-					#Form/${encodeURIComponent(doctype)}/${encodeURIComponent(original_value)}
+					href="#Form/${encodeURIComponent(doctype)}/${encodeURIComponent(original_value)}"
 					data-doctype="${doctype}"
 					data-name="${original_value}">
 					${__(options && options.label || value)}</a>`;


### PR DESCRIPTION
This seems to be broken after https://github.com/frappe/frappe/pull/12063 https://github.com/saurabh6790/frappe/commit/00cc7df05e53f682a64a53b1479dd3140164a202

**Example:**
![Screenshot from 2021-01-13 15-04-16](https://user-images.githubusercontent.com/8528887/104433978-b2f5f280-55b0-11eb-9a0a-a23e2f9f515a.png)

