### PR TITLE
fix(Auto Email Report): HTML download of auto email report breaks for columns with link field type

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -81,7 +81,7 @@ class AutoEmailReport(Document):
 
 		if self.format == 'HTML':
 			columns, data = make_links(columns, data)
-
+			columns = update_field_types(columns)
 			return self.get_html_table(columns, data)
 
 		elif self.format == 'XLSX':
@@ -236,5 +236,14 @@ def make_links(columns, data):
 			elif col.fieldtype == "Dynamic Link":
 				if col.options and row.get(col.fieldname) and row.get(col.options):
 					row[col.fieldname] = get_link_to_form(row[col.options], row[col.fieldname])
+			elif col.fieldtype == "Currency":
+				row[col.fieldname] = frappe.format_value(row[col.fieldname], col)
 
 	return columns, data
+
+def update_field_types(columns):
+	for col in columns:
+		if col.fieldtype in  ("Link", "Dynamic Link", "Currency")  and col.options != "Currency":
+			col.fieldtype = "Data"
+			col.options = ""
+	return columns


### PR DESCRIPTION
The HTML download of auto email report converts doctype links to HTML links so that they can be hyperlinked.
But they are breaking because the jinja formatter tries to reformat the link but cannot find the link
**eg:** `frappe.exceptions.DoesNotExistError: Company <a href="http://erpnext-local:8004/desk#Form/Company/moha">moha</a> not found`

This PR converts the fieldtype to `Data` so that the formatter does not try to reformat.

**Ways to reproduce:**
- Create an Auto Email Report on a report that has columns with link fieldtype.
- Downloading it as HTML would show a page missing error.