### PR TITLE
fix: Remove whitespace from testimonial text

### DIFF
--- a/frappe/website/web_template/testimonial/testimonial.html
+++ b/frappe/website/web_template/testimonial/testimonial.html
@@ -5,9 +5,7 @@
 	</div>
 	{% endif %}
 	<div class="testimonial-content">
-		<span>“</span>
-		{{ content }}
-		<span>”</span>
+		“{{ content }}”
 	</div>
 	<div class="testimonial-by">
 		{{ name }}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9355208/104702993-cb931380-573c-11eb-9387-b08cee930457.png)

After:
![image](https://user-images.githubusercontent.com/9355208/104703049-dd74b680-573c-11eb-98dc-f729c0dc6f6f.png)
