### PR TITLE
fix: Link Field Validation doesn't use Filter criteria defined for link field

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -456,8 +456,8 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				}
 
 				// check if value exist in the filtered dropdown values 
-				if(this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)){
-					value = ""
+				if (this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
+					value = "";
 				}
 
 				return frappe.call({

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -456,7 +456,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				}
 
 				// check if value exist in the filtered dropdown values 
-				if (this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
+				if (this.$input.cache[doctype] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
 					value = "";
 				}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -455,6 +455,11 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 					fetch = this.frm.fetch_dict[df.fieldname].columns.join(', ');
 				}
 
+				// check if value exist in the filtered dropdown values 
+				if(this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)){
+					value = ""
+				}
+
 				return frappe.call({
 					method:'frappe.desk.form.utils.validate_link',
 					type: "GET",


### PR DESCRIPTION
Issue:

Consider one link field 'Party', if we click on the field we get all the values in the dropdown that exist in that doctype. If we try to type invalid party name field becomes empty.
 
If the link field is filtered (eg. 'Party' , 'party_name', '=', 'Dinesh Supplier'). Now the link field will only show 'Dinesh Supplier' in the dropdown.

But now if we type any existing value from 'Party' doctype in the link field instead of 'Dinesh Supplier' it will still take the value and we can save it.

This PR will fix this issue.