### PR TITLE
fix: Validate reqd report filters

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -97,9 +97,18 @@ frappe.ui.form.on('Auto Email Report', {
 			})
 			report_filters = report_filters_list;
 
-			report_filters.forEach(function(f) {
-				$('<tr><td>' + f.label + '</td><td>'+ frappe.format(filters[f.fieldname], f) +'</td></tr>')
-					.appendTo(table.find('tbody'));
+			const mandatory_css = {
+				"background-color": "#fffdf4",
+				"font-weight": "bold"
+			};
+
+			report_filters.forEach(f => {
+				const css = f.reqd ? mandatory_css : {};
+				const row = $("<tr></tr>").appendTo(table.find("tbody"));
+				$("<td>" + f.label + "</td>").appendTo(row);
+				$("<td>" + frappe.format(filters[f.fieldname], f) +"</td>")
+				.css(css)
+				.appendTo(row);
 			});
 
 			table.on('click', function() {

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -107,8 +107,8 @@ frappe.ui.form.on('Auto Email Report', {
 				const row = $("<tr></tr>").appendTo(table.find("tbody"));
 				$("<td>" + f.label + "</td>").appendTo(row);
 				$("<td>" + frappe.format(filters[f.fieldname], f) +"</td>")
-				.css(css)
-				.appendTo(row);
+					.css(css)
+					.appendTo(row);
 			});
 
 			table.on('click', function() {

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -98,7 +98,7 @@ frappe.ui.form.on('Auto Email Report', {
 			report_filters = report_filters_list;
 
 			const mandatory_css = {
-				"background-color": "#fffdf4",
+				"background-color": "var(--error-bg)",
 				"font-weight": "bold"
 			};
 

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -29,6 +29,7 @@ class AutoEmailReport(Document):
 		self.validate_report_count()
 		self.validate_emails()
 		self.validate_report_format()
+		self.validate_mandatory_fields()
 
 	def validate_emails(self):
 		'''Cleanup list of emails'''
@@ -55,6 +56,21 @@ class AutoEmailReport(Document):
 		if self.format not in valid_report_formats:
 			frappe.throw(_("{0} is not a valid report format. Report format should one of the following {1}")
 				.format(frappe.bold(self.format), frappe.bold(", ".join(valid_report_formats))))
+
+	def validate_mandatory_fields(self):
+		# Check if all Mandatory Report Filters are filled by the User
+		filters = frappe.parse_json(self.filters) if self.filters else {}
+		filter_meta = frappe.parse_json(self.filter_meta) if self.filter_meta else {}
+		throw_list = []
+		for meta in filter_meta:
+			if meta.get("reqd") and not filters.get(meta["fieldname"]):
+				throw_list.append(meta['label'])
+		if throw_list:
+			frappe.throw(
+				title= _('Missing Filters Required'),
+				msg= _('Following Report Filters have missing values:') +
+					'<br><br><ul><li>' + ' <li>'.join(throw_list) + '</ul>',
+			)
 
 	def get_report_content(self):
 		'''Returns file in for the report in given format'''


### PR DESCRIPTION
If an Auto Email Report is created on a report with reqd filters not set there is no feedback but the report is not sent 

Steps to reproduce
1. Create an auto email report which has mandatory filters
2. Do not set the filters
3. Save and Send now
4. Error log is generated

Fix: Add validations for the same

![image](https://user-images.githubusercontent.com/28212972/104940104-4c6d3c00-59d7-11eb-8f20-9044f63eddc1.png)
