### PR TITLE
fix: create error log on outgoing email error

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -81,6 +81,7 @@ def get_outgoing_email_account(raise_exception_not_set=True, append_to=None, sen
 			email_account = get_default_outgoing_email_account(raise_exception_not_set=raise_exception_not_set)
 
 		if not email_account and raise_exception_not_set and cint(frappe.db.get_single_value('System Settings', 'setup_complete')):
+			frappe.log_error("Please setup default Email Account from Setup > Email > Email Account", title="Outgoing Email Error")
 			frappe.throw(_("Please setup default Email Account from Setup > Email > Email Account"),
 				frappe.OutgoingEmailError)
 


### PR DESCRIPTION
If an email is not sent because there was no outgoing email set there is no error log created.
Steps to reproduce the issue
1. Make sure there are no default outgoing emails set
2. Activate document follow
3. Follow some documents
4. wait for the scheduler to schedule the email
5. The email would not be sent but there is no feedback given to the user for the same

now adding an error log