### PR TITLE
fix: Geolocation field with Column Break & Section Break

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -17,7 +17,7 @@ frappe.ui.form.ControlGeolocation = frappe.ui.form.ControlData.extend({
 		this.map_area.prependTo($input_wrapper);
 		this.$wrapper.find('.control-input').addClass("hidden");
 
-		if ($input_wrapper.is(':visible')) {
+		if (this.frm) {
 			this.make_map();
 		} else {
 			$(document).on('frappe.ui.Dialog:shown', () => {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -456,8 +456,8 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				}
 
 				// check if value exist in the filtered dropdown values 
-				if (this.$input.cache[doctype] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
-					value = "";
+				if(this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)){
+					value = ""
 				}
 
 				return frappe.call({

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -456,8 +456,8 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				}
 
 				// check if value exist in the filtered dropdown values 
-				if(this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)){
-					value = ""
+				if (this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
+					value = "";
 				}
 
 				return frappe.call({

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -456,7 +456,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				}
 
 				// check if value exist in the filtered dropdown values 
-				if (this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
+				if (this.$input.cache[doctype] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
 					value = "";
 				}
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -455,11 +455,6 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 					fetch = this.frm.fetch_dict[df.fieldname].columns.join(', ');
 				}
 
-				// check if value exist in the filtered dropdown values 
-				if(this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)){
-					value = ""
-				}
-
 				return frappe.call({
 					method:'frappe.desk.form.utils.validate_link',
 					type: "GET",

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -455,6 +455,11 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 					fetch = this.frm.fetch_dict[df.fieldname].columns.join(', ');
 				}
 
+				// check if value exist in the filtered dropdown values 
+				if(this.$input.cache[doctype][""] && !this.$input.cache[doctype][""].some(d => d.value === value)){
+					value = ""
+				}
+
 				return frappe.call({
 					method:'frappe.desk.form.utils.validate_link',
 					type: "GET",


### PR DESCRIPTION
The geolocation field does not seem to work properly when used with Column Break or with Section Break (collapsible).

Geo Location Field with Collapsible Section Break:
![image](https://user-images.githubusercontent.com/30859809/105068817-59596080-5aa7-11eb-9d87-6d68471de596.png)

Geo Location Field without Collapsible Section Break:
![image](https://user-images.githubusercontent.com/30859809/105068892-66764f80-5aa7-11eb-9067-762ee4518599.png)

fixes #12223