### PR TITLE
fix: Don't evaluate dynamic properties to check if conflicts exist

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -70,6 +70,7 @@ class DocType(Document):
 		validate_series(self)
 		self.validate_document_type()
 		validate_fields(self)
+		self.validate_field_name_conflicts()
 
 		if not self.istable:
 			validate_permissions(self)
@@ -88,6 +89,39 @@ class DocType(Document):
 
 		if self.default_print_format and not self.custom:
 			frappe.throw(_('Standard DocType cannot have default print format, use Customize Form'))
+
+		if frappe.conf.get('developer_mode'):
+			self.owner = 'Administrator'
+			self.modified_by = 'Administrator'
+
+	def validate_field_name_conflicts(self):
+		"""Check if field names dont conflict with controller properties and methods"""
+		from frappe.model.base_document import get_controller
+
+		controller = get_controller(self.name)
+		available_objects = {x for x in dir(controller) if isinstance(x, str)}
+		property_set = {
+			x for x in available_objects if isinstance(getattr(controller, x, None), property)
+		}
+		method_set = {
+			x for x in available_objects if x not in property_set and callable(getattr(controller, x, None))
+		}
+
+		for docfield in self.get("fields") or []:
+			conflict_type = ""
+			field = docfield.fieldname
+			field_label = docfield.label or docfield.fieldname
+
+			if docfield.fieldname in method_set:
+				conflict_type = "controller method"
+			if docfield.fieldname in property_set:
+				conflict_type = "class property"
+
+			if conflict_type:
+				frappe.throw(
+					_("Fieldname '{0}' conflicting with a {1} of the name {2} in {3}")
+						.format(field_label, conflict_type, field, self.name)
+				)
 
 	def after_insert(self):
 		# clear user cache so that on the next reload this doctype is included in boot

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1174,7 +1174,7 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 		else:
 			raise
 
-def check_if_fieldname_conflicts_with_methods(doctype, fieldname):
+def check_if_fieldname_conflicts_with_properties_and_methods(doctype, fieldname):
 	doc = frappe.get_doc({"doctype": doctype})
 	available_objects = [x for x in dir(doc) if isinstance(x, str)]
 	property_list = [

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -70,7 +70,6 @@ class DocType(Document):
 		validate_series(self)
 		self.validate_document_type()
 		validate_fields(self)
-		self.validate_field_name_conflicts()
 
 		if not self.istable:
 			validate_permissions(self)
@@ -84,6 +83,7 @@ class DocType(Document):
 		if not self.is_new():
 			self.before_update = frappe.get_doc('DocType', self.name)
 			self.setup_fields_to_fetch()
+			self.validate_field_name_conflicts()
 
 		check_email_append_to(self)
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -96,6 +96,17 @@ class DocType(Document):
 
 	def validate_field_name_conflicts(self):
 		"""Check if field names dont conflict with controller properties and methods"""
+		core_doctypes = [
+			"Custom DocPerm",
+			"DocPerm",
+			"Custom Field",
+			"Customize Form Field",
+			"DocField",
+		]
+
+		if self.name in core_doctypes:
+			return
+
 		from frappe.model.base_document import get_controller
 
 		controller = get_controller(self.name)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1176,9 +1176,15 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 
 def check_if_fieldname_conflicts_with_methods(doctype, fieldname):
 	doc = frappe.get_doc({"doctype": doctype})
-	method_list = [method for method in dir(doc) if isinstance(method, str) and callable(getattr(doc, method))]
+	available_objects = [x for x in dir(doc) if isinstance(x, str)]
+	property_list = [
+		x for x in available_objects if isinstance(getattr(type(doc), x, None), property)
+	]
+	method_list = [
+		x for x in available_objects if x not in property_list and callable(getattr(doc, x))
+	]
 
-	if fieldname in method_list:
+	if fieldname in method_list + property_list:
 		frappe.throw(_("Fieldname {0} conflicting with meta object").format(fieldname))
 
 def clear_linked_doctype_cache():

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -123,7 +123,7 @@ class DocType(Document):
 		}
 
 		for docfield in self.get("fields") or []:
-			conflict_type = ""
+			conflict_type = None
 			field = docfield.fieldname
 			field_label = docfield.label or docfield.fieldname
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -109,7 +109,11 @@ class DocType(Document):
 
 		from frappe.model.base_document import get_controller
 
-		controller = get_controller(self.name)
+		try:
+			controller = get_controller(self.name)
+		except ImportError:
+			controller = Document
+
 		available_objects = {x for x in dir(controller) if isinstance(x, str)}
 		property_set = {
 			x for x in available_objects if isinstance(getattr(controller, x, None), property)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1223,7 +1223,9 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 		else:
 			raise
 
-def check_if_fieldname_conflicts_with_properties_and_methods(doctype, fieldname):
+def check_fieldname_conflicts(doctype, fieldname):
+	"""Checks if fieldname conflicts with methods or properties"""
+
 	doc = frappe.get_doc({"doctype": doctype})
 	available_objects = [x for x in dir(doc) if isinstance(x, str)]
 	property_list = [

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -64,8 +64,8 @@ class CustomField(Document):
 			self.translatable = 0
 
 		if not self.flags.ignore_validate:
-			from frappe.core.doctype.doctype.doctype import check_if_fieldname_conflicts_with_properties_and_methods
-			check_if_fieldname_conflicts_with_properties_and_methods(self.dt, self.fieldname)
+			from frappe.core.doctype.doctype.doctype import check_fieldname_conflicts
+			check_fieldname_conflicts(self.dt, self.fieldname)
 
 	def on_update(self):
 		frappe.clear_cache(doctype=self.dt)

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -64,8 +64,8 @@ class CustomField(Document):
 			self.translatable = 0
 
 		if not self.flags.ignore_validate:
-			from frappe.core.doctype.doctype.doctype import check_if_fieldname_conflicts_with_methods
-			check_if_fieldname_conflicts_with_methods(self.dt, self.fieldname)
+			from frappe.core.doctype.doctype.doctype import check_if_fieldname_conflicts_with_properties_and_methods
+			check_if_fieldname_conflicts_with_properties_and_methods(self.dt, self.fieldname)
 
 	def on_update(self):
 		frappe.clear_cache(doctype=self.dt)

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -34,8 +34,11 @@ def get_controller(doctype):
 		from frappe.model.document import Document
 		from frappe.utils.nestedset import NestedSet
 
-		module_name, custom = frappe.db.get_value("DocType", doctype, ("module", "custom"), cache=True) \
+		module_name, custom = (
+			frappe.db.get_value("DocType", doctype, ("module", "custom"), cache=True)
+			or frappe.db.get_value("DocType", doctype, ("module", "custom"))
 			or ["Core", False]
+		)
 
 		if custom:
 			if frappe.db.field_exists("DocType", "is_tree"):

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -34,15 +34,9 @@ def get_controller(doctype):
 		from frappe.model.document import Document
 		from frappe.utils.nestedset import NestedSet
 
-		if frappe.flags.in_migrate or frappe.flags.in_install or frappe.flags.in_patch:
-			module_name, custom = ["Core", False]
-		else:
-			# this could be simplified in PY3.8 using walrus operators
-			result = frappe.db.get_value("DocType", doctype, ("module", "custom"), cache=True)
-			if result:
-				module_name, custom = result
-			else:
-				module_name, custom = ["Core", bool(not frappe.db.exists(doctype))]
+		module_name, custom = frappe.db.get_value(
+			"DocType", doctype, ("module", "custom"), cache=True
+		) or ["Core", False]
 
 		if custom:
 			if frappe.db.field_exists("DocType", "is_tree"):


### PR DESCRIPTION
Customizing DocTypes that have class properties defined by Python's `@property` decorators may cause unintended actions in case your properties are dependent on external entities. The `check_if_fieldname_conflicts_with_methods` executed the properties which may seem unnecessary in this case.

### Solution

Don't evaluate properties? Yeah. That's all we're doing...Check if DocType `Site` has property `logs` instead of retrieving the logs to validate the check.

---

### Other Features & Fixes

- Dropped `newsletter..json`
- Added method to validate field names conflicting with controller methods and properties in `DocType.validate`
- Renamed `check_if_fieldname_conflicts_with_methods` to `check_fieldname_conflicts`