### PR TITLE
fix: Insufficient Permission for Leads > Dashboard Chart

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -73,7 +73,7 @@ def has_permission(doc, ptype, user):
 		if doc.report_name in allowed_reports:
 			return True
 	else:
-		allowed_doctypes = [frappe.permissions.get_doctypes_with_read()]
+		allowed_doctypes = frappe.permissions.get_doctypes_with_read()
 		if doc.document_type in allowed_doctypes:
 			return True
 


### PR DESCRIPTION
Issue:

When User with (Sales User, Sales Manager and Sales Master Manager) roles tries to access the Lead Dashboard Chart they get an error "Insufficient Permission for Dashboard Chart <Dashboard Chart Name>"

 
