### PR TITLE
fix: Item qty gets reset to default on adding items using Add Multiple button

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -152,9 +152,13 @@ frappe.ui.form.LinkSelector = Class.extend({
 							d = me.target.add_new_row();
 						},
 						() => frappe.timeout(0.1),
-						() => frappe.model.set_value(d.doctype, d.name, me.fieldname, value),
-						() => frappe.timeout(0.5),
-						() => frappe.model.set_value(d.doctype, d.name, me.qty_fieldname, data.qty),
+						() => {
+							var args = {};
+							args[me.fieldname] = value;
+							args[me.qty_fieldname] = data.qty;
+
+							frappe.model.set_value(d.doctype, d.name, args);
+						},
 						() => frappe.show_alert(__("Added {0} ({1})", [value, data.qty]))
 					]);
 				}

--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -153,11 +153,11 @@ frappe.ui.form.LinkSelector = Class.extend({
 						},
 						() => frappe.timeout(0.1),
 						() => {
-							var args = {};
+							let args = {};
 							args[me.fieldname] = value;
 							args[me.qty_fieldname] = data.qty;
 
-							frappe.model.set_value(d.doctype, d.name, args);
+							return frappe.model.set_value(d.doctype, d.name, args);
 						},
 						() => frappe.show_alert(__("Added {0} ({1})", [value, data.qty]))
 					]);


### PR DESCRIPTION
Issue:
On adding items using _Add Multiple_ button, Qty gets reset to default (1).

This issue can be replicated on _Sales Order_, _Purchase Order_ etc wherever _Add Multiple_ button is. (with Items Table)

![Screen-Recording-2021-01-20-at-7 11 17-PM](https://user-images.githubusercontent.com/60467153/105217025-59c22c00-5b79-11eb-8a33-aefc4d2d4911.gif)

Solution:
Making a single call to set values for Item code & Qty instead of two separate calls solves the issue.

![Screen-Recording-2021-01-20-at-7 44 36-PM](https://user-images.githubusercontent.com/60467153/105217161-85451680-5b79-11eb-88ac-1638ba1da21f.gif)
