### PR TITLE
chore: Add release notes for v12.14.0

### DIFF
--- a/frappe/change_log/v12/v12_14_0.md
+++ b/frappe/change_log/v12/v12_14_0.md
@@ -1,0 +1,16 @@
+## Version 12.14.0 Release Notes
+
+### Fixes & Enhancements
+
+- Fixed sidebar & head style in mobile view for RTL layout ([#11905](https://github.com/frappe/frappe/pull/11905))
+- Fixed list view comment count ([#12159](https://github.com/frappe/frappe/pull/12159))
+- Fixed UX of landscape option in print settings ([#12110](https://github.com/frappe/frappe/pull/12110))
+- Fixed attachment of file in Webform for new document ([#12097](https://github.com/frappe/frappe/pull/12097))
+- Allowed salutations to be renamed ([#12168](https://github.com/frappe/frappe/pull/12168))
+- Fixed date range logic for charts with timespan & interval filter ([#12218](https://github.com/frappe/frappe/pull/12218))
+
+### Features
+
+- Allowed images to be rendered from links in print formats ([#12211](https://github.com/frappe/frappe/pull/12211))
+- Option to show absolute value in print format ([#12020](https://github.com/frappe/frappe/pull/12020)) ([#12162](https://github.com/frappe/frappe/pull/12162))
+- Option to use HTML in email templates ([#12065](https://github.com/frappe/frappe/pull/12065))


### PR DESCRIPTION
<img width="545" alt="Screenshot 2021-01-22 at 2 16 06 PM" src="https://user-images.githubusercontent.com/13928957/105468920-8c753d00-5cbd-11eb-8ca2-2debec0c43b6.png">

