### PR TITLE
fix: user mandatory in change user dialog

### DIFF
--- a/frappe/desk/page/user_profile/user_profile.js
+++ b/frappe/desk/page/user_profile/user_profile.js
@@ -76,6 +76,7 @@ class UserProfile {
 					fieldname: 'user',
 					options: 'User',
 					label: __('User'),
+					reqd: 1
 				}
 			],
 			primary_action_label: __('Go'),


### PR DESCRIPTION
**Issue:**

1. From Settings go to **My Profile** page.
2. Click on the **Change User** button.
3. Don't select a user and click on **Go**.
4. An error will appear.

![Screenshot 2021-01-23 at 7 22 18 PM](https://user-images.githubusercontent.com/31363128/105580145-a9d70380-5db0-11eb-8355-e273935b131f.png)

**Fix:**
1. Made the User field mandatory.