### PR TITLE
fix: Skip translation of gender while creating it

### DIFF
--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -18,14 +18,14 @@ def install():
 
 @frappe.whitelist()
 def update_genders():
-	default_genders = [_("Male"), _("Female"), _("Other"),_("Transgender"), _("Genderqueer"), _("Non-Conforming"),_("Prefer not to say")]
+	default_genders = ["Male", "Female", "Other","Transgender", "Genderqueer", "Non-Conforming","Prefer not to say"]
 	records = [{'doctype': 'Gender', 'gender': d} for d in default_genders]
 	for record in records:
 		frappe.get_doc(record).insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 @frappe.whitelist()
 def update_salutations():
-	default_salutations = [_("Mr"), _("Ms"), _('Mx'), _("Dr"), _("Mrs"), _("Madam"), _("Miss"), _("Master"), _("Prof")]
+	default_salutations = ["Mr", "Ms", 'Mx', "Dr", "Mrs", "Madam", "Miss", "Master", "Prof"]
 	records = [{'doctype': 'Salutation', 'salutation': d} for d in default_salutations]
 	for record in records:
 		doc = frappe.new_doc(record.get("doctype"))

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -230,12 +230,19 @@ def update_oauth_user(user, data, provider):
 
 		save = True
 		user = frappe.new_doc("User")
+
+		gender = (data.get("gender") or "").title()
+
+		if not frappe.db.exists("Gender", gender):
+			doc = frappe.new_doc("Gender", {"gender": gender})
+			doc.insert(ignore_permissions=True)
+
 		user.update({
 			"doctype":"User",
 			"first_name": get_first_name(data),
 			"last_name": get_last_name(data),
 			"email": get_email(data),
-			"gender": (data.get("gender") or "").title(),
+			"gender": gender,
 			"enabled": 1,
 			"new_password": frappe.generate_hash(get_email(data)),
 			"location": data.get("location"),


### PR DESCRIPTION
- Do not translate gender while creating it. 
> The database should store English text of gender and the value should be translated only client-side.

- Validate if gender exists (and create if it does not exist) while updating OAUTH user to avoid login failures.