### PR TITLE
fix: Do not Allow Assignment Rule on Todo

### DIFF
--- a/cypress/integration/table_multiselect.js
+++ b/cypress/integration/table_multiselect.js
@@ -8,7 +8,7 @@ context('Table MultiSelect', () => {
 	it('select value from multiselect dropdown', () => {
 		cy.new_form('Assignment Rule');
 		cy.fill_field('__newname', name);
-		cy.fill_field('document_type', 'ToDo');
+		cy.fill_field('document_type', 'Blog Post');
 		cy.fill_field('assign_condition', 'status=="Open"', 'Code');
 		cy.get('input[data-fieldname="users"]').focus().as('input');
 		cy.get('input[data-fieldname="users"] + ul').should('be.visible');

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.js
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.js
@@ -9,6 +9,16 @@ frappe.ui.form.on('Assignment Rule', {
 		frm.events.rule(frm);
 	},
 
+	setup: function(frm) {
+		frm.set_query("document_type", () => {
+			return {
+				filters: {
+					name: ["!=", "ToDo"]
+				}
+			};
+		});
+	},
+
 	document_type: function(frm) {
 		frm.trigger('set_options');
 	},

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -19,7 +19,7 @@ class AssignmentRule(Document):
 			repeated_days = get_repeated(assignment_days)
 			frappe.throw(_("Assignment Day {0} has been repeated.").format(frappe.bold(repeated_days)))
 		if self.document_type == 'ToDo':
-			frappe.throw('Assignment Rule Not Allowed on Document Type "ToDo"')
+			frappe.throw(_('Assignment Rule is not allowed on {0} document type').format(frappe.bold("ToDo")))
 
 	def on_update(self):
 		clear_assignment_rule_cache(self)

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -18,6 +18,8 @@ class AssignmentRule(Document):
 		if not len(set(assignment_days)) == len(assignment_days):
 			repeated_days = get_repeated(assignment_days)
 			frappe.throw(_("Assignment Day {0} has been repeated.").format(frappe.bold(repeated_days)))
+		if self.document_type == 'ToDo':
+			frappe.throw('Assignment Rule Not Allowed on Document Type "ToDo"')
 
 	def on_update(self):
 		clear_assignment_rule_cache(self)


### PR DESCRIPTION
Frappe uses ToDo to track Assignments

Each Assignment creates a ToDo

If an assignment rule is created on ToDo it forms a loop because each assignment creates a ToDo which triggers another assignment