### PR TITLE
fix: Auto Email Report Bad UI for Email To

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.json
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -147,6 +147,7 @@
      "label": "Email Settings"
     },
     {
+     "description": "For multiple addresses, enter the address on different line. e.g. test@test.com \u23ce test1@test.com",
      "fieldname": "email_to",
      "fieldtype": "Small Text",
      "label": "Email To",

--- a/frappe/email/doctype/auto_email_report/auto_email_report.json
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -201,7 +201,7 @@
      "read_only": 1
     }
    ],
-   "modified": "2019-05-09 22:38:27.570890",
+   "modified": "2021-01-28 15:59:43.151995",
    "modified_by": "Administrator",
    "module": "Email",
    "name": "Auto Email Report",


### PR DESCRIPTION
Issue:

Email To field is a bad UI, how the user is supposed to know to use Enter or Commas while entering addresses? A space between them also causes the problem.

Solution:

Added a description below the 'Email To' field saying 
'For multiple addresses, enter the address on different line. e.g. test@test.com ⏎ test1@test.com'
