### PR TITLE
fix: RTL support for text editor

### DIFF
--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -115,6 +115,9 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 			['bold', 'italic', 'underline'],
 			['blockquote', 'code-block'],
 			['link', 'image'],
+			// Adding Direction tool to give the user the ability to change text direction.
+			[{ 'direction': "rtl" }],
+			[{ 'align': [] }],
 			[{ 'list': 'ordered' }, { 'list': 'bullet' }],
 			['clean']
 		];

--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -111,13 +111,15 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 	},
 
 	get_toolbar_options() {
+		let direction = frappe.utils.is_rtl() ? 'rtl' : 'ltr';
+		let align = frappe.utils.is_rtl() ? 'right' : 'left';
 		return [
 			['bold', 'italic', 'underline'],
 			['blockquote', 'code-block'],
 			['link', 'image'],
 			// Adding Direction tool to give the user the ability to change text direction.
-			[{ 'direction': "rtl" }],
-			[{ 'align': [] }],
+			[{ 'direction': direction }],
+			[{ 'align': align }],
 			[{ 'list': 'ordered' }, { 'list': 'bullet' }],
 			['clean']
 		];

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -76,10 +76,12 @@ const BackgroundStyle = Quill.import('attributors/style/background');
 const ColorStyle = Quill.import('attributors/style/color');
 const FontStyle = Quill.import('attributors/style/font');
 const AlignStyle = Quill.import('attributors/style/align');
+const DirectionStyle = Quill.import('attributors/style/direction');
 Quill.register(BackgroundStyle, true);
 Quill.register(ColorStyle, true);
 Quill.register(FontStyle, true);
 Quill.register(AlignStyle, true);
+Quill.register(DirectionStyle, true);
 
 //Adding fonts in text editor
 const Font = Quill.import('attributors/class/font');

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -1,5 +1,34 @@
 import Quill from 'quill';
 
+// specify the fonts you want
+const fonts = ['Arial', 'Courier', 'Times New Roman', 'Verdana'];
+// generate code friendly names
+function get_font_name(font) {
+	return font.toLowerCase().replace(/\s/g, "-");
+}
+let font_names = fonts.map(font => get_font_name(font));
+// add fonts to style
+let font_styles = "";
+fonts.forEach(function(font) {
+	let font_name = get_font_name(font);
+	font_styles += `
+		.ql-snow .ql-picker.ql-font
+		.ql-picker-label[data-value=${font_name}]::before,
+		.ql-snow .ql-picker.ql-font
+		.ql-picker-item[data-value=${font_name}]::before {
+				content: '${font}';
+				font-family: ${font}, sans-serif;
+		}
+		.ql-font-${font_name} {
+			font-family: ${font}, sans-serif;
+		}
+	`;
+});
+const node = document.createElement('style');
+node.innerHTML = font_styles;
+document.body.appendChild(node);
+
+
 // replace <p> tag with <div>
 const Block = Quill.import('blots/block');
 Block.tagName = 'DIV';
@@ -47,12 +76,15 @@ const BackgroundStyle = Quill.import('attributors/style/background');
 const ColorStyle = Quill.import('attributors/style/color');
 const FontStyle = Quill.import('attributors/style/font');
 const AlignStyle = Quill.import('attributors/style/align');
-const DirectionStyle = Quill.import('attributors/style/direction');
 Quill.register(BackgroundStyle, true);
 Quill.register(ColorStyle, true);
 Quill.register(FontStyle, true);
 Quill.register(AlignStyle, true);
-Quill.register(DirectionStyle, true);
+
+//Adding fonts in text editor
+const Font = Quill.import('attributors/class/font');
+Font.whitelist = font_names;
+Quill.register(Font, true);
 
 frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 	make_wrapper() {
@@ -143,10 +175,14 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 	get_toolbar_options() {
 		return [
 			[{ 'header': [1, 2, 3, false] }],
+			// Adding Font dropdown to give the user the ability to change text font.
+			[{ 'font': font_names }],
 			['bold', 'italic', 'underline'],
 			[{ 'color': [] }, { 'background': [] }],
 			['blockquote', 'code-block'],
 			['link', 'image'],
+			// Adding Direction tool to give the user the ability to change text direction.
+			[{ 'direction': "rtl" }],
 			[{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'list': 'check' }],
 			[{ 'align': [] }],
 			[{ 'indent': '-1'}, { 'indent': '+1' }],

--- a/frappe/public/less/desk.less
+++ b/frappe/public/less/desk.less
@@ -432,6 +432,12 @@ li.user-progress {
 	margin-left: 0px;
 }
 
+.frappe-rtl {
+	.page-body {
+		overflow-x: visible;
+	}
+}
+
 .text-editor {
 	height: 400px;
 	background-color: white;

--- a/frappe/public/less/page.less
+++ b/frappe/public/less/page.less
@@ -27,7 +27,6 @@
 
 @media(min-width: @screen-xs) {
 	.page-body {
-		overflow-x: hidden;
 		min-height: calc(100vh - 40px);
 	}
 }

--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -148,6 +148,6 @@
 	direction: ltr;
 }
 
-.ql-editor ol li.ql-direction-rtl{
-  padding-right: 0;
+.ql-editor ol li.ql-direction-rtl {
+	padding-right: 0;
 }

--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -11,7 +11,6 @@
 .ql-editor {
 	font-family: @font-stack;
 	line-height: 1.6;
-
 	h1, h2, h3, h4, h5 {
 		margin-top: 0.5em;
 		margin-bottom: 0.25em;
@@ -150,4 +149,8 @@
 
 .ql-container {
 	direction: ltr;
+}
+
+.ql-editor ol li.ql-direction-rtl{
+  padding-right: 0;
 }

--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -42,10 +42,6 @@
 	outline: none;
 }
 
-.ql-formats {
-	margin-bottom: 8px;
-}
-
 .ql-bubble .ql-editor {
 	min-height: 100px;
 	max-height: 300px;
@@ -145,6 +141,7 @@
 // RTL alignment
 .ql-formats {
 	text-align: left;
+	margin-bottom: 8px;
 }
 
 .ql-container {

--- a/frappe/public/less/quill.less
+++ b/frappe/public/less/quill.less
@@ -4,13 +4,13 @@
 @import (less) "../js/frappe/form/controls/quill-mention/quill.mention.css";
 
 .ql-toolbar.ql-snow, .ql-container.ql-snow {
-    border-color: @border-color;
-    font-family: inherit;
+	border-color: @border-color;
+	font-family: inherit;
 }
 
 .ql-editor {
-    font-family: @font-stack;
-    line-height: 1.6;
+	font-family: @font-stack;
+	line-height: 1.6;
 
 	h1, h2, h3, h4, h5 {
 		margin-top: 0.5em;
@@ -19,20 +19,20 @@
 }
 
 .ql-toolbar.ql-snow {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-    background-color: @panel-bg;
-    padding-bottom: 0;
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+	background-color: @panel-bg;
+	padding-bottom: 0;
 }
 
 .ql-container.ql-snow {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
 }
 
 .ql-snow .ql-editor {
-    min-height: 400px;
-    max-height: 600px;
+	min-height: 400px;
+	max-height: 600px;
 }
 
 .ql-snow .ql-picker {
@@ -40,87 +40,87 @@
 }
 
 .ql-snow .ql-picker-label {
-    outline: none;
+	outline: none;
 }
 
 .ql-formats {
-    margin-bottom: 8px;
+	margin-bottom: 8px;
 }
 
 .ql-bubble .ql-editor {
-    min-height: 100px;
-    max-height: 300px;
-    border: 1px solid @light-border-color;
-    border-radius: 4px;
+	min-height: 100px;
+	max-height: 300px;
+	border: 1px solid @light-border-color;
+	border-radius: 4px;
 }
 
 .ql-mention-list-container {
-    z-index: 1;
+	z-index: 1;
 }
 
 .ql-mention-list {
-    border-radius: 4px;
+	border-radius: 4px;
 }
 
 .ql-mention-list-item {
-    font-size: @text-small;
-    padding: 10px 12px;
-    height: initial;
-    line-height: initial;
+	font-size: @text-small;
+	padding: 10px 12px;
+	height: initial;
+	line-height: initial;
 
-    &.selected {
-        background-color: @btn-bg;
-    }
+	&.selected {
+		background-color: @btn-bg;
+	}
 }
 
 .ql-editor .mention {
-    height: auto;
-    width: auto;
-    border-radius: 10px;
-    border: 1px solid @light-border-color;
-    padding: 2px 3px;
-    background-color: @btn-bg;
+	height: auto;
+	width: auto;
+	border-radius: 10px;
+	border: 1px solid @light-border-color;
+	padding: 2px 3px;
+	background-color: @btn-bg;
 }
 
 // table
 
 .ql-table {
-    width: 66px;
+	width: 66px;
 
-    .ql-picker-label::before {
-        content: 'Table';
-    }
+	.ql-picker-label::before {
+		content: 'Table';
+	}
 
-    .ql-picker-options {
-        [data-value='insert-table']::before {
-            content: 'Insert Table';
-        }
-        [data-value='insert-row-above']::before {
-            content: 'Insert Row Above';
-        }
-        [data-value='insert-row-below']::before {
-            content: 'Insert Row Below';
-        }
-        [data-value='insert-column-right']::before {
-            content: 'Insert Column Right';
-        }
-        [data-value='insert-column-left']::before {
-            content: 'Insert Column Left';
-        }
-        [data-value='delete-row']::before {
-            content: 'Delete Row';
-        }
-        [data-value='delete-column']::before {
-            content: 'Delete Column';
-        }
-        [data-value='delete-table']::before {
-            content: 'Delete Table';
-        }
-    }
+	.ql-picker-options {
+		[data-value='insert-table']::before {
+			content: 'Insert Table';
+		}
+		[data-value='insert-row-above']::before {
+			content: 'Insert Row Above';
+		}
+		[data-value='insert-row-below']::before {
+			content: 'Insert Row Below';
+		}
+		[data-value='insert-column-right']::before {
+			content: 'Insert Column Right';
+		}
+		[data-value='insert-column-left']::before {
+			content: 'Insert Column Left';
+		}
+		[data-value='delete-row']::before {
+			content: 'Delete Row';
+		}
+		[data-value='delete-column']::before {
+			content: 'Delete Column';
+		}
+		[data-value='delete-table']::before {
+			content: 'Delete Table';
+		}
+	}
 }
 
 .ql-editor td {
-    border: 1px solid @border-color;
+	border: 1px solid @border-color;
 }
 
 .ql-snow .ql-editor blockquote {
@@ -136,8 +136,18 @@
 .ql-editor li[data-list=ordered] {
 	list-style-type: decimal;
 	padding-left: 0;
+	padding-right: 0;
 
 	&::before {
 		content: none;
 	}
+}
+
+// RTL alignment
+.ql-formats {
+	text-align: left;
+}
+
+.ql-container {
+	direction: ltr;
 }


### PR DESCRIPTION
Fixes minor issues in https://github.com/frappe/frappe/pull/11688

- Introduce direction, alignment and font tools to quill editor.
<img width="923" alt="Screenshot 2021-01-27 at 7 31 35 PM" src="https://user-images.githubusercontent.com/19775888/106001715-4f061a80-60d6-11eb-96e5-e33d8cf05655.png">

- Fix overflow issue in comment toolbar:
	
Before:
<img width="1024" alt="Screenshot 2021-01-27 at 7 34 01 PM" src="https://user-images.githubusercontent.com/19775888/106002185-d784bb00-60d6-11eb-9401-705e16410d15.png">


After:
<img width="1103" alt="Screenshot 2021-01-27 at 7 35 10 PM" src="https://user-images.githubusercontent.com/19775888/106002199-db184200-60d6-11eb-8095-a6c914c8c2cd.png">

