### PR TITLE
Fix(list view): escape html properly for fieldname tooltips

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -682,7 +682,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			}
 
 			return `<span class="ellipsis"
-				title="${__(label)}: ${escape(_value)}">
+				title="${__(label)}: ${frappe.utils.escape_html(_value)}">
 				${html}
 			</span>`;
 		};


### PR DESCRIPTION
Fixes https://github.com/frappe/frappe/issues/11938

### Current Behavior
Fields available in listview render with a title attribute, which produces a tooltip on hover (useful for values truncated due to length). The text for this attribute must be properly escaped for safe rendering, but the current method is too aggressive. Under most circumstances, text rendered by escape() is unreadable by humans.

### Fix
This PR replaces the current `escape()` method (intended for URIs) with `frappe.utils.escape_html()`. 