### PR TITLE
fix: Calendar time indicator not accurate based on timezone

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -227,6 +227,7 @@ frappe.views.Calendar = Class.extend({
 			defaultView: defaults.defaultView,
 			weekends: defaults.weekends,
 			nowIndicator: true,
+			now: frappe.datetime.convert_to_system_tz(),
 			events: function(start, end, timezone, callback) {
 				return frappe.call({
 					method: me.get_events_method || "frappe.desk.calendar.get_events",


### PR DESCRIPTION
Issue:

In Calendar, the time indicator was not accurate based on the timezone of the user.


