### PR TITLE
fix: auto login redirect

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -90,7 +90,10 @@ def get_home_page():
 
 		# global
 		if not home_page:
-			home_page = frappe.db.get_value("Website Settings", None, "home_page") or "login"
+			home_page = frappe.db.get_value("Website Settings", None, "home_page")
+
+		if not home_page:
+			home_page = "login" if frappe.session.user == 'Guest' else "me"
 
 		home_page = home_page.strip('/')
 


### PR DESCRIPTION
After a user is logged in, the system tries to find a route/ homepage to redirect the user. If it does not get a route/ homepage it redirects to the login

The priority for searching for route/ homepage is:
1) Route/ homepage defined in the role list
2) Portal Settings
3) Hooks
4) Website settings

(1 being the highest priority)

If none of this is set, it keeps on redirects to login rendering the system unusable

This PR fixes this issue by making me as default if the user is logged in but no homepage is set