### PR TITLE
fix: Don't overwrite source_name if source_name is defined

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -292,7 +292,7 @@ $.extend(frappe.model, {
 			opts.source_name = opts.frm.doc.name;
 
 		// Allow opening a mapped doc without a source document name
-		} else if (!opts.frm) {
+		} else if (!opts.frm && !opts.source_name) {
 			opts.source_name = null;
 		}
 


### PR DESCRIPTION
Simple fix to allow mapping a document when there is no frm available (erpnext Bank Reconciliation page)