### PR TITLE
fix: On Event creation assign to not working

### DIFF
--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -261,7 +261,7 @@ frappe.views.InteractionComposer = class InteractionComposer {
 				args: {
 					doctype: doc.doctype,
 					name: doc.name,
-					assign_to: assignee,
+					assign_to: `["${assignee}"]`,
 				},
 				callback:function(r) {
 					if(!r.exc) {

--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -261,7 +261,7 @@ frappe.views.InteractionComposer = class InteractionComposer {
 				args: {
 					doctype: doc.doctype,
 					name: doc.name,
-					assign_to: `["${assignee}"]`,
+					assign_to: JSON.stringify([assignee]),
 				},
 				callback:function(r) {
 					if(!r.exc) {


### PR DESCRIPTION
Issue:

While creating an Event (with `assign_to` populated ) from the Lead form, an error occurred.
