### PR TITLE
fix: cannot extend a desk page with developer mode off

### DIFF
--- a/frappe/desk/doctype/desk_page/desk_page.js
+++ b/frappe/desk/doctype/desk_page/desk_page.js
@@ -5,7 +5,6 @@ frappe.ui.form.on('Desk Page', {
 	refresh: function(frm) {
 		frm.enable_save();
 		frm.get_field("is_standard").toggle(frappe.boot.developer_mode);
-		frm.get_field("extends_another_page").toggle(frappe.boot.developer_mode);
 		frm.get_field("developer_mode_only").toggle(frappe.boot.developer_mode);
 
 		if (frm.doc.for_user) {


### PR DESCRIPTION
For https://github.com/frappe/frappe/pull/12214
This allows system managers to create a desk page that extends another standard desk page