### PR TITLE
chore: Add release notes for v13-beta-10

### DIFF
--- a/frappe/change_log/v13/v13_0_0-beta_10.md
+++ b/frappe/change_log/v13/v13_0_0-beta_10.md
@@ -1,0 +1,21 @@
+### Version 13.0.0 Beta 10 Release Notes
+
+#### Features and Enhancements
+
+- Option to hide child records for a nested DocType via User Permissions ([12209](https://github.com/frappe/frappe/pull/12209))
+- Added option to grant only `Select` access to document ([12063](https://github.com/frappe/frappe/pull/12063))
+- Introduced map view ([11202](https://github.com/frappe/frappe/pull/11202))
+- Enabled image rendering from links in Print View ([12101](https://github.com/frappe/frappe/pull/12101))
+- Introduced "Yesterday" and "Tomorrow" options for Timespan filter ([12179](https://github.com/frappe/frappe/pull/12179))
+
+#### Fixes
+
+- Fixed HTML download of Auto Email Report that used to break in some cases ([12202](https://github.com/frappe/frappe/pull/12202))
+- Fixed reset customizations functionality ([12152](https://github.com/frappe/frappe/pull/12152))
+- Fixed the rendering of percentage stat in Dashboard Chart ([12090](https://github.com/frappe/frappe/pull/12090))
+- Fixed permission issues in Dashboard Chart ([12243](https://github.com/frappe/frappe/pull/12243))
+- Fixed an issue with grid row index ([12188](https://github.com/frappe/frappe/pull/12188))
+- Fixed an issue where fields used to get reordered after adding new columns ([12058](https://github.com/frappe/frappe/pull/12058))
+- Fixed currency formatting in Print Format ([11897](https://github.com/frappe/frappe/pull/11897))
+- Added a fieldlevel permission check for report data ([12163](https://github.com/frappe/frappe/pull/12163))
+- Fixed an issue with percent precision ([12010](https://github.com/frappe/frappe/pull/12010))


### PR DESCRIPTION
<img width="638" alt="Screenshot 2021-02-01 at 9 28 38 PM" src="https://user-images.githubusercontent.com/13928957/106488734-04bbd980-64da-11eb-8263-1bef92eda4de.png">
