### PR TITLE
fix: reload workspace link in patch

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -327,5 +327,5 @@ execute:frappe.delete_doc_if_exists('Page', 'workspace')
 execute:frappe.delete_doc_if_exists('Page', 'dashboard', force=1)
 frappe.core.doctype.page.patches.drop_unused_pages
 execute:frappe.get_doc('Role', 'Guest').save() # remove desk access
-frappe.patches.v13_0.rename_desk_page_to_workspace
+frappe.patches.v13_0.rename_desk_page_to_workspace # 02.02.2021
 frappe.patches.v13_0.delete_package_publish_tool

--- a/frappe/patches/v13_0/rename_desk_page_to_workspace.py
+++ b/frappe/patches/v13_0/rename_desk_page_to_workspace.py
@@ -17,3 +17,4 @@ def execute():
 		rename_doc('DocType', 'Desk Link', 'Workspace Link', ignore_if_exists=True)
 
 	frappe.reload_doc('desk', 'doctype', 'workspace')
+	frappe.reload_doc('desk', 'doctype', 'workspace_link')


### PR DESCRIPTION
Patch in ERPNext breaking, fixed here to keep all workspace code at one place.
[Traceback](https://github.com/frappe/frappe/pull/12277#issuecomment-771397144)