### PR TITLE
fix(patch): Pass if table is missing

### DIFF
--- a/frappe/desk/utils.py
+++ b/frappe/desk/utils.py
@@ -7,12 +7,13 @@ def validate_route_conflict(doctype, name):
 	'''
 	Raises exception if name clashes with routes from other documents for /app routing
 	'''
-	if frappe.flags.ignore_route_conflict_validation:
-		return
 
 	all_names = []
 	for _doctype in ['Page', 'Workspace', 'DocType']:
-		all_names.extend([slug(d) for d in frappe.get_all(_doctype, pluck='name') if (doctype != _doctype and d != name)])
+		try:
+			all_names.extend([slug(d) for d in frappe.get_all(_doctype, pluck='name') if (doctype != _doctype and d != name)])
+		except frappe.db.TableMissingError:
+			pass
 
 	if slug(name) in all_names:
 		frappe.msgprint(frappe._('Name already taken, please set a new name'))


### PR DESCRIPTION
Skip validation for route_conflict if it raises the table is missing error.

(Will mostly happen for the "Workspace" table since it is a renamed doctype)
