### PR TITLE
fix: Desk Page rename patch

### DIFF
--- a/frappe/patches/v13_0/rename_desk_page_to_workspace.py
+++ b/frappe/patches/v13_0/rename_desk_page_to_workspace.py
@@ -13,8 +13,9 @@ def execute():
 
 	rename_doc('DocType', 'Desk Chart', 'Workspace Chart', ignore_if_exists=True)
 	rename_doc('DocType', 'Desk Shortcut', 'Workspace Shortcut', ignore_if_exists=True)
-	if frappe.db.exists('DocType', 'Desk Link'):
-		rename_doc('DocType', 'Desk Link', 'Workspace Link', ignore_if_exists=True)
+	rename_doc('DocType', 'Desk Link', 'Workspace Link', ignore_if_exists=True)
 
 	frappe.reload_doc('desk', 'doctype', 'workspace')
 	frappe.reload_doc('desk', 'doctype', 'workspace_link')
+	frappe.reload_doc('desk', 'doctype', 'workspace_chart')
+	frappe.reload_doc('desk', 'doctype', 'workspace_shortcut')

--- a/frappe/patches/v13_0/update_icons_in_customized_desk_pages.py
+++ b/frappe/patches/v13_0/update_icons_in_customized_desk_pages.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 import frappe
 
 def execute():
+	if not frappe.db.exists('Desk Page'): return
+
 	pages = frappe.get_all("Desk Page", filters={ "is_standard": False }, fields=["name", "extends", "for_user"])
 	default_icon = {}
 	for page in pages:


### PR DESCRIPTION
Reload child tables of workspace after rename.