### PR TITLE
fix: New currency symbol for Zimbabwe

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2724,11 +2724,11 @@
  },
  "Zimbabwe": {
   "code": "zw",
-  "currency": "ZWD",
-  "currency_fraction": "Thebe",
+  "currency": "ZWL",
+  "currency_fraction": "Cent",
   "currency_fraction_units": 100,
   "currency_name": "Zimbabwe Dollar",
-  "currency_symbol": "P",
+  "currency_symbol": "ZWL$",
   "number_format": "# ###.##",
   "timezones": [
    "Africa/Harare"

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -202,7 +202,7 @@ frappe.patches.v9_1.resave_domain_settings
 frappe.patches.v9_1.revert_domain_settings
 frappe.patches.v9_1.move_feed_to_activity_log
 execute:frappe.delete_doc('Page', 'data-import-tool', ignore_missing=True)
-frappe.patches.v10_0.reload_countries_and_currencies # 20-10-2020
+frappe.patches.v10_0.reload_countries_and_currencies # 2021-02-03
 frappe.patches.v10_0.refactor_social_login_keys
 frappe.patches.v10_0.enable_chat_by_default_within_system_settings
 frappe.patches.v10_0.remove_custom_field_for_disabled_domain


### PR DESCRIPTION
Zimbabwe got a new currency in 2019.

https://de.wikipedia.org/wiki/Simbabwe-Dollar (not available in english, unfortunately)

`develop`: #12308