### PR TITLE
fix(patch): Force reload Workspace doctypes

### DIFF
--- a/frappe/patches/v13_0/rename_desk_page_to_workspace.py
+++ b/frappe/patches/v13_0/rename_desk_page_to_workspace.py
@@ -15,7 +15,7 @@ def execute():
 	rename_doc('DocType', 'Desk Shortcut', 'Workspace Shortcut', ignore_if_exists=True)
 	rename_doc('DocType', 'Desk Link', 'Workspace Link', ignore_if_exists=True)
 
-	frappe.reload_doc('desk', 'doctype', 'workspace')
-	frappe.reload_doc('desk', 'doctype', 'workspace_link')
-	frappe.reload_doc('desk', 'doctype', 'workspace_chart')
-	frappe.reload_doc('desk', 'doctype', 'workspace_shortcut')
+	frappe.reload_doc('desk', 'doctype', 'workspace', force=True)
+	frappe.reload_doc('desk', 'doctype', 'workspace_link', force=True)
+	frappe.reload_doc('desk', 'doctype', 'workspace_chart', force=True)
+	frappe.reload_doc('desk', 'doctype', 'workspace_shortcut', force=True)


### PR DESCRIPTION
Reload after rename doc doesn't actually update the workspace doctypes. Fixing by adding the force flag.