### PR TITLE
fix: Dont cache website rules in development

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -278,6 +278,10 @@ def get_website_rules():
 
 		return rules
 
+	if frappe.local.dev_server:
+		# dont cache in development
+		return _get()
+
 	return frappe.cache().get_value('website_route_rules', _get)
 
 def set_content_type(response, data, path):


### PR DESCRIPTION
Dont cache website rules in development