### PR TITLE
feat: Set default site using FRAPPE_SITE env var

### DIFF
--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -382,3 +382,10 @@ class TestCommands(BaseTestCommands):
 
 		os.remove(test1_path)
 		os.remove(test2_path)
+
+	def test_frappe_site_env(self):
+		os.putenv('FRAPPE_SITE', frappe.local.site)
+		self.execute("bench execute frappe.ping")
+		self.assertEquals(self.returncode, 0)
+		self.assertIn("pong", self.stdout)
+

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -54,6 +54,8 @@ def get_sites(site_arg):
 		return frappe.utils.get_sites()
 	elif site_arg:
 		return [site_arg]
+	elif os.environ.get('FRAPPE_SITE'):
+		return [os.environ.get('FRAPPE_SITE')]
 	elif os.path.exists('currentsite.txt'):
 		with open('currentsite.txt') as f:
 			site = f.read().strip()

--- a/node_utils.js
+++ b/node_utils.js
@@ -27,7 +27,10 @@ function get_conf() {
 	read_config('config.json');
 	read_config('sites/common_site_config.json');
 
-	// detect current site
+	// set default site
+	if (process.env.FRAPPE_SITE) {
+		conf.default_site = process.env.FRAPPE_SITE;
+	}
 	if (fs.existsSync('sites/currentsite.txt')) {
 		conf.default_site = fs.readFileSync('sites/currentsite.txt').toString().trim();
 	}


### PR DESCRIPTION
Default site can now be set using the environment variable FRAPPE_SITE
An attempt to deprecate the use of currentsite.txt

Set the default site for a shell session using the `FRAPPE_SITE` environment variable.

```
~/Projects/benches/frappe-bench
❯ export FRAPPE_SITE=wiki.test

~/Projects/benches/frappe-bench
❯ echo $FRAPPE_SITE
wiki.test

~/Projects/benches/frappe-bench
❯ bench console
Apps in this namespace:
frappe, wiki

In [1]: frappe.local.site
Out[1]: 'wiki.test'
```

- [x] Test
- [x] Docs: https://github.com/frappe/frappe_docs/pull/92