### PR TITLE
fix: letterhead image doesn't show up in pdf

### DIFF
--- a/frappe/printing/doctype/letter_head/letter_head.py
+++ b/frappe/printing/doctype/letter_head/letter_head.py
@@ -20,7 +20,7 @@ class LetterHead(Document):
 	def set_image(self):
 		if self.source=='Image':
 			if self.image and is_image(self.image):
-				self.content = '<img src="{}" style="width: 100%;">'.format(self.image)
+				self.content = '<img src="{}">'.format(self.image)
 				frappe.msgprint(frappe._('Header HTML set from attachment {0}').format(self.image), alert = True)
 			else:
 				frappe.msgprint(frappe._('Please attach an image file to set HTML'), alert = True, indicator = 'orange')


### PR DESCRIPTION
Before:
<img width="1440" alt="Screenshot 2021-02-05 at 11 48 49 AM" src="https://user-images.githubusercontent.com/19775888/106997041-2651e500-67a8-11eb-84f6-c44c4dee730d.png">


After:
<img width="1440" alt="Screenshot 2021-02-05 at 11 50 53 AM" src="https://user-images.githubusercontent.com/19775888/106997174-6ca74400-67a8-11eb-9f38-b18950423ff9.png">
