### PR TITLE
fix: trailing spaces match only when re compile

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -669,8 +669,7 @@ class DocType(Document):
 		flags = {"flags": re.ASCII} if six.PY3 else {}
 
 		# a DocType name should not start or end with an empty space
-		lead_trail_whitespace_re = re.compile("^[ \t\n\r]+|[ \t\n\r]+$", **flags)
-		if lead_trail_whitespace_re.findall(name):
+		if re.search("^[ \t\n\r]+|[ \t\n\r]+$", name, **flags):
 			frappe.throw(_("DocType's name should not start or end with whitespace"), frappe.NameError)
 
 		# a DocType's name should not start with a number or underscore

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -669,7 +669,8 @@ class DocType(Document):
 		flags = {"flags": re.ASCII} if six.PY3 else {}
 
 		# a DocType name should not start or end with an empty space
-		if re.match("^[ \t\n\r]+|[ \t\n\r]+$", name, **flags):
+		lead_trail_whitespace_re = re.compile("^[ \t\n\r]+|[ \t\n\r]+$", **flags)
+		if lead_trail_whitespace_re.findall(name):
 			frappe.throw(_("DocType's name should not start or end with whitespace"), frappe.NameError)
 
 		# a DocType's name should not start with a number or underscore


### PR DESCRIPTION
Issue:
Ia doctype is created with trailing whitespace in name, pymysql error is thrown

Reason:
Trailing whitespaces do not get matched if the regular expression uses match

Solution:
use search instead of match