### PR TITLE
fix: PDF footer overlap with body

### DIFF
--- a/frappe/templates/print_formats/pdf_header_footer.html
+++ b/frappe/templates/print_formats/pdf_header_footer.html
@@ -28,7 +28,7 @@
 
 			.letter-head,
 			.letter-head-footer {
-				margin-top: -15mm !important;
+				margin-top: -14mm !important;
 			}
 
 			/* Dont show explicit links for <a> tags */


### PR DESCRIPTION
When the user use generates a PDF of the invoice with the long body text with footer and header, Some part of the body text is getting hidden because of the footer overlapping on it.

![image](https://user-images.githubusercontent.com/30859809/107476715-6a742980-6b9c-11eb-81f1-e06abfb2d9cc.png)

