### PR TITLE
fix: Miscelleneous fixes

### DIFF
--- a/frappe/public/icons/timeless/symbol-defs.svg
+++ b/frappe/public/icons/timeless/symbol-defs.svg
@@ -677,4 +677,8 @@
 		<path d="M6.04544 17.5001C7.1751 17.5001 8.09087 16.5843 8.09087 15.4546C8.09087 14.325 7.1751 13.4092 6.04544 13.4092C4.91577 13.4092 4 14.325 4 15.4546C4 16.5843 4.91577 17.5001 6.04544 17.5001Z" stroke="var(--icon-stroke)" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 		<path d="M14.2271 6.59087C15.3567 6.59087 16.2725 5.6751 16.2725 4.54544C16.2725 3.41577 15.3567 2.5 14.2271 2.5C13.0974 2.5 12.1816 3.41577 12.1816 4.54544C12.1816 5.6751 13.0974 6.59087 14.2271 6.59087Z" stroke="var(--icon-stroke)" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 	</symbol>
+	<symbol viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" id="icon-arrow-right" stroke-width="1.2">
+		<path d="M10 6.00223L1 5.99973" stroke="var(--icon-stroke)" stroke-linecap="round" stroke-linejoin="round"/>
+		<path d="M7.70015 3.00244L10.7001 6.00244L7.70015 9.00244" stroke="var(--icon-stroke)" stroke-linecap="round" stroke-linejoin="round"/>
+	</symbol>
 </svg>

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -13,13 +13,14 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	make_input: function() {
 		var me = this;
 		// line-height: 1 is for Mozilla 51, shows extra padding otherwise
-		$('<div class="link-field ui-front" style="position: relative; line-height: 1;">\
-			<input type="text" class="input-with-feedback form-control">\
-			<span class="link-btn">\
-				<a class="btn-open no-decoration" title="' + __("Open Link") + '">\
-					<i class="octicon octicon-arrow-right"></i></a>\
-			</span>\
-		</div>').prependTo(this.input_area);
+		$(`<div class="link-field ui-front" style="position: relative; line-height: 1;">
+			<input type="text" class="input-with-feedback form-control">
+			<span class="link-btn">
+				<a class="btn-open no-decoration" title="${__("Open Link")}">
+					${frappe.utils.icon('arrow-right', 'xs')}
+				</a>
+			</span>
+		</div>`).prependTo(this.input_area);
 		this.$input_area = $(this.input_area);
 		this.$input = this.$input_area.find('input');
 		this.$link = this.$input_area.find('.link-btn');

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -12,8 +12,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	trigger_change_on_input_event: false,
 	make_input: function() {
 		var me = this;
-		// line-height: 1 is for Mozilla 51, shows extra padding otherwise
-		$(`<div class="link-field ui-front" style="position: relative; line-height: 1;">
+		$(`<div class="link-field ui-front" style="position: relative;">
 			<input type="text" class="input-with-feedback form-control">
 			<span class="link-btn">
 				<a class="btn-open no-decoration" title="${__("Open Link")}">

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -317,7 +317,7 @@ class FormTimeline extends BaseTimeline {
 			custom_timeline_contents.push({
 				icon: custom_item.icon,
 				icon_size: 'sm',
-				is_card: custom_item.show_card,
+				is_card: custom_item.is_card,
 				creation: custom_item.creation,
 				content: custom_item.content || frappe.render_template(custom_item.template, custom_item.template_data),
 			});

--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -48,8 +48,8 @@ input[type="checkbox"] {
 	}
 
 
-	&.disabled-deselected:before {
-		background: $gray-50;
+	&.disabled-deselected:before, &[disabled]:before {
+		background: var(--disabled-control-bg);
 		border: 0.5px solid var(--gray-300);
 		box-sizing: border-box;
 		box-shadow: inset 0px 1px 7px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
- Update link arrow icon
<img width="517" alt="Screenshot 2021-02-08 at 6 37 02 PM" src="https://user-images.githubusercontent.com/13928957/107224075-f8d19980-6a3c-11eb-9948-f0b36def496f.png">

- Fix typo in timeline
- Set "disabled" style for checkboxes with disabled attribute