### PR TITLE
fix: better way to extract fieldname from key_name

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -402,24 +402,56 @@ class BaseDocument(object):
 				doc.db_update()
 
 	def show_unique_validation_message(self, e):
-		# TODO: Find a better way to extract fieldname
 		if frappe.db.db_type != 'postgres':
 			fieldname = str(e).split("'")[-2]
 			label = None
 
-			# unique_first_fieldname_second_fieldname is the constraint name
-			# created using frappe.db.add_unique
-			if "unique_" in fieldname:
-				fieldname = fieldname.split("_", 1)[1]
+			# MariaDB gives key_name in error. Extracting fieldname from key name
+			try:
+				fieldname = self.get_field_name_by_key_name(fieldname)
+			except IndexError:
+				pass
 
-			df = self.meta.get_field(fieldname)
-			if df:
-				label = df.label
+			label = self.get_label_from_fieldname(fieldname)
 
 			frappe.msgprint(_("{0} must be unique").format(label or fieldname))
 
 		# this is used to preserve traceback
 		raise frappe.UniqueValidationError(self.doctype, self.name, e)
+
+	def get_field_name_by_key_name(self, key_name):
+		"""MariaDB stores a mapping between key_name and column_name.
+		This function returns the column_name associated with the key_name passed
+
+		Args:
+			key_name ([String])
+
+		Returns:
+			[String]: [column_name associated with the String]
+		"""
+		return frappe.db.sql(f"""
+			SHOW
+				INDEX
+			FROM
+				`tab{self.doctype}`
+			WHERE
+				key_name=%s
+			AND
+				Non_unique=0
+			""", key_name)[0][4]
+
+	def get_label_from_fieldname(self, fieldname):
+		"""Returns the associated label for fieldname
+
+		Args:
+			fieldname ([String])
+
+		Returns:
+			[String]: [label associated with the String]
+		"""
+		df = self.meta.get_field(fieldname)
+		if df:
+			return df.label
 
 	def update_modified(self):
 		"""Update modified timestamp"""

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -425,7 +425,7 @@ class BaseDocument(object):
 
 		Args:
 			key_name (str): The name of the database index.
-			
+
 		Raises:
 			IndexError: If the key is not found in the table.
 
@@ -441,7 +441,7 @@ class BaseDocument(object):
 				key_name=%s
 			AND
 				Non_unique=0
-			""", key_name)[0][4]
+			""", key_name, as_dict=True)[0].get("Column_name")
 
 	def get_label_from_fieldname(self, fieldname):
 		"""Returns the associated label for fieldname

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -420,14 +420,17 @@ class BaseDocument(object):
 		raise frappe.UniqueValidationError(self.doctype, self.name, e)
 
 	def get_field_name_by_key_name(self, key_name):
-		"""MariaDB stores a mapping between key_name and column_name.
-		This function returns the column_name associated with the key_name passed
+		"""MariaDB stores a mapping between `key_name` and `column_name`.
+		This function returns the `column_name` associated with the `key_name` passed
 
 		Args:
-			key_name ([String])
+			key_name (str): The name of the database index.
+			
+		Raises:
+			IndexError: If the key is not found in the table.
 
 		Returns:
-			[String]: [column_name associated with the String]
+			str: The column name associated with the key.
 		"""
 		return frappe.db.sql(f"""
 			SHOW
@@ -444,10 +447,10 @@ class BaseDocument(object):
 		"""Returns the associated label for fieldname
 
 		Args:
-			fieldname ([String])
+			fieldname (str): The fieldname in the DocType to use to pull the label.
 
 		Returns:
-			[String]: [label associated with the String]
+			str: The label associated with the fieldname, if found, otherwise `None`.
 		"""
 		df = self.meta.get_field(fieldname)
 		if df:


### PR DESCRIPTION
If a unique constraint is applied on a field that already has a constraint we get the key name instead of Label

![image](https://user-images.githubusercontent.com/28212972/107245687-6ee1fa80-6a55-11eb-9a19-384819c69e60.png)


Steps to reproduce: Apply a unique constraint on a field that already has some other constraint. Try creating records with the same name. eg: apply a unique constraint on the full name in customer doctype

Reason: 
MariaDB gives `key_name` in duplicate key errors instead of `fieldname`

Solution:

1. MariaDB stores the mapping between `fieldname` and `keyname` in `INDEX`
2. Query the `INDEX` table to get the `fieldname`
3. Use the `fieldname` to get the label

- [x] use keys instead of indexes