### PR TITLE
fix: Communication language

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -386,21 +386,18 @@ frappe.views.CommunicationComposer = Class.extend({
 	},
 
 	setup_print_language: function() {
-		var me = this;
 		var doc = this.doc || cur_frm.doc;
 		var fields = this.dialog.fields_dict;
 
 		//Load default print language from doctype
 		this.lang_code = doc.language
 
-		if (this.get_print_format().default_print_language) {
-			var default_print_language_code = this.get_print_format().default_print_language;
-			me.lang_code = default_print_language_code;
-		} else {
-			var default_print_language_code = null;
+		if (!this.lang_code && this.get_print_format().default_print_language) {
+			this.lang_code = this.get_print_format().default_print_language;
 		}
 
 		//On selection of language retrieve language code
+		var me = this;
 		$(fields.language_sel.input).change(function(){
 			me.lang_code = this.value
 		})
@@ -410,10 +407,8 @@ frappe.views.CommunicationComposer = Class.extend({
 			.empty()
 			.add_options(frappe.get_languages());
 
-		if (default_print_language_code) {
-			$(fields.language_sel.input).val(default_print_language_code);
-		} else {
-			$(fields.language_sel.input).val(doc.language);
+		if (this.lang_code) {
+			$(fields.language_sel.input).val(this.lang_code);
 		}
 	},
 
@@ -440,6 +435,7 @@ frappe.views.CommunicationComposer = Class.extend({
 		}
 
 	},
+
 	setup_attach: function() {
 		var fields = this.dialog.fields_dict;
 		var attach = $(fields.select_attachments.wrapper);


### PR DESCRIPTION
- In **Print Format** it's possible to select a "Default Print Language".
- A default should only apply if there is no other value available.
- However, in the communication dialog, the "Default Print Language" overwrites the language of the party / transaction.
- This problem also happens together with #11798 so that it is completely intransparent where the language is coming from.

This PR fixes this. When `doc.language` is available, it will be used. When `doc.language` is not available, the "Default Print Language" will be used. 