### PR TITLE
fix: Fix modal child tables not showing up

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -268,7 +268,7 @@ export default class Grid {
 	}
 
 	refresh(force) {
-		if (this.frm.setting_dependency) return;
+		if (this.frm && this.frm.setting_dependency) return;
 
 		this.data = this.get_data();
 


### PR DESCRIPTION
Modal child tables don't have frm attached to it, hence added check for undefined state.

Closes #12342 ISS-20-21-09425