### PR TITLE
fix: Resource not available error on Purchase Order get items

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -80,13 +80,15 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 			is_whitelisted(frappe.get_attr(query))
 			frappe.response["values"] = frappe.call(query, doctype, txt,
 				searchfield, start, page_length, filters, as_dict=as_dict)
-		except Exception as e:
+		except frappe.exceptions.PermissionError as e:
 			if frappe.local.conf.developer_mode:
 				raise e
 			else:
 				frappe.respond_as_web_page(title='Invalid Method', html='Method not found',
 				indicator_color='red', http_status_code=404)
 			return
+		except Exception as e:
+			raise e
 	elif not query and doctype in standard_queries:
 		# from standard queries
 		search_widget(doctype, txt, standard_queries[doctype][0],


### PR DESCRIPTION
**Steps to Replicate:**

1. Create a new Purchase Order.
2. Select a Supplier who is not a default supplier for any items.
3. Click on the button **Get Items from Open Material Requests** below the supplier field.
4. A pop up opens with an error.

![Screenshot 2021-02-12 at 4 10 02 PM](https://user-images.githubusercontent.com/31363128/107759046-c16d3080-6d4d-11eb-8d68-6ba824ecd969.png)

**Reason:**
1. A validation error is thrown when a supplier who is not a default supplier for any items is selected.
2. The exception for this validation error was not handled properly by search.py. Hence the resource not available error.
