### PR TITLE
fix: Memory limit for watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "node rollup/build.js",
     "production": "FRAPPE_ENV=production node rollup/build.js",
-    "watch": "node rollup/watch.js",
+    "watch": "node --max_old_space_size=1280 rollup/watch.js",
     "snyk-protect": "snyk protect",
     "prepare": "yarn run snyk-protect"
   },


### PR DESCRIPTION
Fix `bench start` crash caused by out-of-memory of `bench watch`
Similar to #11140

> 17:56:46 watch.1          | Rebuilding marketplace.min.js
17:57:13 watch.1          | 
17:57:13 watch.1          | <--- Last few GCs --->
17:57:13 watch.1          | 
17:57:13 watch.1          | [25371:0x3001260]   106133 ms: Mark-sweep 1020.0 (1026.1) -> 1019.2 (1026.1) MB, 1436.9 / 0.0 ms  (average mu = 0.151, current mu = 0.139) allocation failure scavenge might not succeed
17:57:13 watch.1          | 
17:57:13 watch.1          | 
17:57:13 watch.1          | <--- JS stacktrace --->
17:57:13 watch.1          | 
17:57:13 watch.1          | ==== JS stack trace =========================================
17:57:13 watch.1          | 
17:57:13 watch.1          |     0: ExitFrame [pc: 0x13cb4b9]
17:57:13 watch.1          | Security context: 0x19c7c1a408d1 <JSObject>
17:57:13 watch.1          |     1: findVariable [0x70793e41c51] [/home/frappe/erpnextv13/apps/frappe/node_modules/rollup/dist/rollup.js:~4243] [pc=0x126f57fc5396](this=0x200ac9dc9429 <ChildScope map = 0x2c388ba32de9>,0x0de03491d871 <String[18]: transitionEndEvent>)
17:57:13 watch.1          |     2: bind [0x70793e4d071] [/home/frappe/erpnextv13/apps/frappe/node_modules/rollup/dist/rollup.js:~11207] [pc=0x126f57fecb33]...
17:57:13 watch.1          | 
17:57:13 watch.1          | FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
17:57:13 watch.1          |  1: 0xa07f60 node::Abort() [/usr/local/bin/node]
17:57:13 watch.1          |  2: 0xa0836c node::OnFatalError(char const*, char const*) [/usr/local/bin/node]
17:57:13 watch.1          |  3: 0xb80d3e v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/usr/local/bin/node]
17:57:13 watch.1          |  4: 0xb810b9 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/usr/local/bin/node]
17:57:13 watch.1          |  5: 0xd2d815  [/usr/local/bin/node]
17:57:13 watch.1          |  6: 0xd2dea6 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [/usr/local/bin/node]
17:57:13 watch.1          |  7: 0xd3a725 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::GCCallbackFlags) [/usr/local/bin/node]
17:57:13 watch.1          |  8: 0xd3b5d5 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/usr/local/bin/node]
