### PR TITLE
revert: "refactor: mark field as invalid using df"

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -131,14 +131,21 @@ frappe.ui.form.ControlData = frappe.ui.form.ControlInput.extend({
 				// invalid email
 				return '';
 			} else {
-				let email_invalid = false;
+				var invalid_email = false;
 				email_list.forEach(function(email) {
 					if (!validate_email(email)) {
-						email_invalid = true;
+						frappe.msgprint(__("Invalid Email: {0}", [email]));
+						invalid_email = true;
 					}
 				});
-				this.df.invalid = email_invalid;
-				return v;
+
+				if (invalid_email) {
+					// at least 1 invalid email
+					return '';
+				} else {
+					// all good
+					return v;
+				}
 			}
 
 		} else {


### PR DESCRIPTION
This reverts commit 968dbdc05793a4711b0a64785b2e4a420071ee21.

This commit introduces a way to validate email address and highlight form fields however it is not implemented in `base_control.js` yet on v12 branch. This feature/refactor was partially backported to v12 which broke the client side email validation.
