### PR TITLE
fix: Disable trigger_change_on_input_event for few controls

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -1,6 +1,7 @@
 import Awesomplete from 'awesomplete';
 
 frappe.ui.form.ControlAutocomplete = frappe.ui.form.ControlData.extend({
+	trigger_change_on_input_event: false,
 	make_input() {
 		this._super();
 		this.setup_awesomplete();

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -1,4 +1,5 @@
 frappe.ui.form.ControlMultiSelectList = frappe.ui.form.ControlData.extend({
+	trigger_change_on_input_event: false,
 	make_input() {
 		let template  = `
 			<div class="multiselect-list dropdown">


### PR DESCRIPTION
Disable `trigger_change_on_input_event` for Autocomplete & MultiSelectList control to avoid unexpected behaviour.

**Example:**

https://user-images.githubusercontent.com/13928957/107913273-198e7780-6f86-11eb-99fc-b2797e8e10db.mov




