### PR TITLE
fix: Throw early if invalid arguments

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -181,6 +181,9 @@ def make_form_dict(request):
 	else:
 		args = request.form or request.args
 
+	if not isinstance(args, dict):
+		frappe.throw("Invalid request arguments")
+
 	try:
 		frappe.local.form_dict = frappe._dict({ k:v[0] if isinstance(v, (list, tuple)) else v \
 			for k, v in iteritems(args) })

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -26,8 +26,8 @@ from frappe.core.doctype.access_log.access_log import make_access_log
 
 def report_error(status_code):
 	'''Build error. Show traceback in developer mode'''
-	if (cint(frappe.db.get_system_setting('allow_error_traceback'))
-		and (status_code!=404 or frappe.conf.logging)
+	allow_traceback = cint(frappe.db.get_system_setting('allow_error_traceback')) if frappe.db else True
+	if (allow_traceback and (status_code!=404 or frappe.conf.logging)
 		and not frappe.local.flags.disable_traceback):
 		frappe.errprint(frappe.utils.get_traceback())
 


### PR DESCRIPTION
#### Throw early if invalid arguments

When invalid arguments are passed (like a raw string `"test"`) it does not throw the correct error. This change checks the type of the argument after parsing and throws early.

#### Fallback value for allow_traceback when no db 

In case there is no db connection, assume traceback printing.