### PR TITLE
fix: remove trailing quote from formatter html

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1498,7 +1498,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 					const escaped_name = encodeURIComponent(value);
 
-					return `<a class="indicator ${get_color(doc || {})}" href="/app/${frappe.router.slug(df.options)}/${escaped_name}" data-doctype="${doctype}" data-name="${value}">${label}</a>'`;
+					return `<a class="indicator ${get_color(doc || {})}" href="/app/${frappe.router.slug(df.options)}/${escaped_name}" data-doctype="${doctype}" data-name="${value}">${label}</a>`;
 				} else {
 					return '';
 				}


### PR DESCRIPTION
Related issue: FR-ISS-256268

Removed trailing single quote from formatters:

![Screenshot 2021-02-17 at 2 42 23 PM](https://user-images.githubusercontent.com/9079960/108181851-6745e400-712e-11eb-9109-e29376a72601.png)
