### PR TITLE
perf: Ignore notify update in patch execution

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1015,6 +1015,8 @@ class Document(BaseDocument):
 
 	def notify_update(self):
 		"""Publish realtime that the current document is modified"""
+		if frappe.flags.in_patch: return
+
 		frappe.publish_realtime("doc_update", {"modified": self.modified, "doctype": self.doctype, "name": self.name},
 			doctype=self.doctype, docname=self.name, after_commit=True)
 


### PR DESCRIPTION
Don't execute method notify_update while running the patch, this method takes time executing the patch item_reposting_for_incorrect_sl_and_gl

![2021-02-18 13 38 34](https://user-images.githubusercontent.com/8780500/108328333-7c844680-71f2-11eb-877d-e431663cb043.jpg)
