### PR TITLE
fix: border top to bottom

### DIFF
--- a/frappe/public/less/form.less
+++ b/frappe/public/less/form.less
@@ -1002,7 +1002,7 @@ body[data-route^="Form/Communication"] textarea[data-fieldname="subject"] {
 
 .map-columns .form-section {
 	padding: 0 7px 7px;
-	border-top: none;
+	border-bottom: none;
 
 	.clearfix {
 		display: none;


### PR DESCRIPTION
i]In v12 border-bottom is used for horizontal rules between form sections
In data import map columns we want to override the borders


Before:
![image](https://user-images.githubusercontent.com/28212972/108412222-999b3280-724f-11eb-9e22-78945461ac38.png)
Section breaks still visible since the class did not override 

After
![image](https://user-images.githubusercontent.com/28212972/108412250-a7e94e80-724f-11eb-8412-fcb8e0f0f253.png)
