### PR TITLE
fix: Show "New" button in list view after DocType creation

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -53,6 +53,17 @@ frappe.ui.form.on('DocType', {
 		frm.events.autoname(frm);
 	},
 
+	before_save: function(frm) {
+		frappe.flags.reload_bootinfo = frm.is_new();
+	},
+
+	after_save: function(frm) {
+		if (frappe.flags.reload_bootinfo) {
+			frappe.boot.user.can_create.push(frm.doc.name);
+			frappe.flags.reload_bootinfo = false;
+		}
+	},
+
 	autoname(frm) {
 		frm.set_df_property('fields', 'reqd', frm.doc.autoname !== 'Prompt');
 	}

--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -54,13 +54,13 @@ frappe.ui.form.on('DocType', {
 	},
 
 	before_save: function(frm) {
-		frappe.flags.reload_bootinfo = frm.is_new();
+		frappe.flags.update_bootinfo = frm.is_new();
 	},
 
 	after_save: function(frm) {
-		if (frappe.flags.reload_bootinfo) {
+		if (frappe.flags.update_bootinfo) {
 			frappe.boot.user.can_create.push(frm.doc.name);
-			frappe.flags.reload_bootinfo = false;
+			frappe.flags.update_bootinfo = false;
 		}
 	},
 


### PR DESCRIPTION
- Update client bootinfo after new DocType creation
- v12 Port with suggested changes from https://github.com/frappe/frappe/pull/12265

Fixes #10615