### PR TITLE
fix: Data control style

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -95,7 +95,7 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 					if (me.disp_area) {
 						me.set_disp_area(me.value);
 						$(me.disp_area).toggle(true);
-						make_input();
+						if (me.df.options == 'Phone') make_input();
 					}
 				}
 				me.$input && me.$input.prop("disabled", true);

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -95,7 +95,6 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 					if (me.disp_area) {
 						me.set_disp_area(me.value);
 						$(me.disp_area).toggle(true);
-						if (me.df.options == 'Phone') make_input();
 					}
 				}
 				me.$input && me.$input.prop("disabled", true);

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -95,6 +95,7 @@ frappe.ui.form.ControlInput = frappe.ui.form.Control.extend({
 					if (me.disp_area) {
 						me.set_disp_area(me.value);
 						$(me.disp_area).toggle(true);
+						make_input();
 					}
 				}
 				me.$input && me.$input.prop("disabled", true);

--- a/frappe/public/scss/desk/controls.scss
+++ b/frappe/public/scss/desk/controls.scss
@@ -254,7 +254,7 @@ textarea.form-control {
 	overflow-wrap: break-word;
 }
 
-.frappe-control[data-fieldtype="Data"] .control-input {
+.frappe-control[data-fieldtype="Data"] .control-input, .control-value {
 	position: relative;
 }
 


### PR DESCRIPTION
Phone Icon is missing from read_only phone fields.
Before:
![image](https://user-images.githubusercontent.com/30859809/108673657-0c373700-750a-11eb-8533-228368ecae1b.png)

After:
![image](https://user-images.githubusercontent.com/30859809/108673937-7fd94400-750a-11eb-9c48-acd3a8d21f08.png)
