### PR TITLE
fix: Handle legacy doctype in frappe.delete_doc

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -2,25 +2,26 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-import os
-from six import string_types, integer_types
-import shutil
+
+from pymysql.err import ProgrammingError
+from six import integer_types, string_types
 
 import frappe
 import frappe.defaults
 import frappe.model.meta
-from frappe import _
-from frappe import get_module_path
-from frappe.model.dynamic_links import get_dynamic_link_map
+from frappe import _, get_module_path
 from frappe.core.doctype.file.file import remove_all
-from frappe.utils.password import delete_all_passwords_for
-from frappe.model.naming import revert_series_if_last
-from frappe.utils.global_search import delete_for_document
 from frappe.desk.doctype.tag.tag import delete_tags_for_document
 from frappe.exceptions import FileNotFoundError
+from frappe.model.dynamic_links import get_dynamic_link_map
+from frappe.model.naming import revert_series_if_last
+from frappe.utils.global_search import delete_for_document
+from frappe.utils.password import delete_all_passwords_for
+
 
 doctypes_to_skip = ("Communication", "ToDo", "DocShare", "Email Unsubscribe", "Activity Log", "File",
 	"Version", "Document Follow", "Comment" , "View Log", "Tag Link", "Notification Log", "Email Queue")
+
 
 def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reload=False,
 	ignore_permissions=False, flags=None, ignore_on_trash=False, ignore_missing=True):
@@ -371,6 +372,9 @@ def delete_controllers(doctype, module):
 	"""
 	Delete controller code in the doctype folder
 	"""
+	import os
+	import shutil
+
 	module_path = get_module_path(module)
 	dir_path = os.path.join(module_path, 'doctype', frappe.scrub(doctype))
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -2,26 +2,25 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-
-from pymysql.err import ProgrammingError
-from six import integer_types, string_types
+import os
+from six import string_types, integer_types
+import shutil
 
 import frappe
 import frappe.defaults
 import frappe.model.meta
-from frappe import _, get_module_path
-from frappe.core.doctype.file.file import remove_all
-from frappe.desk.doctype.tag.tag import delete_tags_for_document
-from frappe.exceptions import FileNotFoundError
+from frappe import _
+from frappe import get_module_path
 from frappe.model.dynamic_links import get_dynamic_link_map
+from frappe.core.doctype.file.file import remove_all
+from frappe.utils.password import delete_all_passwords_for
 from frappe.model.naming import revert_series_if_last
 from frappe.utils.global_search import delete_for_document
-from frappe.utils.password import delete_all_passwords_for
-
+from frappe.desk.doctype.tag.tag import delete_tags_for_document
+from frappe.exceptions import FileNotFoundError
 
 doctypes_to_skip = ("Communication", "ToDo", "DocShare", "Email Unsubscribe", "Activity Log", "File",
 	"Version", "Document Follow", "Comment" , "View Log", "Tag Link", "Notification Log", "Email Queue")
-
 
 def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reload=False,
 	ignore_permissions=False, flags=None, ignore_on_trash=False, ignore_missing=True):
@@ -364,9 +363,6 @@ def delete_controllers(doctype, module):
 	"""
 	Delete controller code in the doctype folder
 	"""
-	import os
-	import shutil
-
 	module_path = get_module_path(module)
 	dir_path = os.path.join(module_path, 'doctype', frappe.scrub(doctype))
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -69,15 +69,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 				check_permission_and_not_submitted(doc)
 
 				frappe.db.sql("delete from `tabCustom Field` where dt = %s", name)
-
-				try:
-					frappe.db.sql("delete from `tabClient Script` where dt = %s", name)
-				except ProgrammingError:
-					# legacy: renamed Custom Script to CLient Script in v13
-					# the only time this gets executed is in patches that run delete_doc
-					if not frappe.db.exists("Client Script") and frappe.db.exists("Custom Script"):
-						frappe.db.sql("delete from `tabCustom Script` where dt = %s", name)
-
+				frappe.db.sql("delete from `tabClient Script` where dt = %s", name)
 				frappe.db.sql("delete from `tabProperty Setter` where doc_type = %s", name)
 				frappe.db.sql("delete from `tabReport` where ref_doctype=%s", name)
 				frappe.db.sql("delete from `tabCustom DocPerm` where parent=%s", name)

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -68,7 +68,15 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 				check_permission_and_not_submitted(doc)
 
 				frappe.db.sql("delete from `tabCustom Field` where dt = %s", name)
-				frappe.db.sql("delete from `tabClient Script` where dt = %s", name)
+
+				try:
+					frappe.db.sql("delete from `tabClient Script` where dt = %s", name)
+				except ProgrammingError:
+					# legacy: renamed Custom Script to CLient Script in v13
+					# the only time this gets executed is in patches that run delete_doc
+					if not frappe.db.exists("Client Script") and frappe.db.exists("Custom Script"):
+						frappe.db.sql("delete from `tabCustom Script` where dt = %s", name)
+
 				frappe.db.sql("delete from `tabProperty Setter` where doc_type = %s", name)
 				frappe.db.sql("delete from `tabReport` where ref_doctype=%s", name)
 				frappe.db.sql("delete from `tabCustom DocPerm` where parent=%s", name)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -35,6 +35,7 @@ frappe.patches.v11_0.change_email_signature_fieldtype
 execute:frappe.reload_doc('core', 'doctype', 'activity_log')
 execute:frappe.reload_doc('core', 'doctype', 'deleted_document')
 execute:frappe.reload_doc('core', 'doctype', 'domain_settings')
+frappe.patches.v13_0.rename_custom_client_script
 frappe.patches.v8_0.rename_page_role_to_has_role #2017-03-16
 frappe.patches.v7_2.setup_custom_perms #2017-01-19
 frappe.patches.v8_0.set_user_permission_for_page_and_report #2017-03-20


### PR DESCRIPTION
Check if the table Custom Script exists in case a ProgrammingError
comes up on deleting from Client Script and delete from there instead

ref: https://travis-ci.com/github/frappe/erpnext/jobs/484947925

```
Executing frappe.patches.v8_0.rename_page_role_to_has_role #2017-03-16 in test_site (test_frappe)
Traceback (most recent call last):
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.6.3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 101, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/site.py", line 296, in migrate
    skip_search_index=skip_search_index
  File "/home/travis/frappe-bench/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v8_0/rename_page_role_to_has_role.py", line 13, in execute
    remove_doctypes()
  File "/home/travis/frappe-bench/apps/frappe/frappe/patches/v8_0/rename_page_role_to_has_role.py", line 48, in remove_doctypes
    frappe.delete_doc('DocType', doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 862, in delete_doc
    ignore_permissions, flags, ignore_on_trash, ignore_missing)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 71, in delete_doc
    frappe.db.sql("delete from `tabClient Script` where dt = %s", name)
  File "/home/travis/frappe-bench/apps/frappe/frappe/database/database.py", line 147, in sql
    self._cursor.execute(query, values)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/travis/frappe-bench/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1146, "Table 'test_frappe.tabClient Script' doesn't exist")
The command "bench --site test_site migrate" exited with 1.
```