### PR TITLE
fix: error while using data import and importing docs (v12)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1129,10 +1129,10 @@ def make_property_setter(args, ignore_validate=False, validate_fields_for_doctyp
 		ps.validate_fieldtype_change()
 		ps.insert()
 
-def import_doc(path, ignore_links=False, ignore_insert=False, insert=False):
+def import_doc(path):
 	"""Import a file using Data Import."""
 	from frappe.core.doctype.data_import.data_import import import_doc
-	import_doc(path, ignore_links=ignore_links, ignore_insert=ignore_insert, insert=insert)
+	import_doc(path)
 
 def copy_doc(doc, ignore_no_copy=True):
 	""" No_copy fields also get copied."""

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -273,7 +273,7 @@ def import_doc(context, path, force=False):
 		try:
 			frappe.init(site=site)
 			frappe.connect()
-			import_doc(path, overwrite=context.force)
+			import_doc(path)
 		finally:
 			frappe.destroy()
 	if not context.sites:

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -2,16 +2,16 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 import os
-import frappe
-from frappe.model.document import Document
 
-from frappe.core.doctype.data_import.importer import Importer
+import frappe
+from frappe import _
 from frappe.core.doctype.data_import.exporter import Exporter
+from frappe.core.doctype.data_import.importer import Importer
+from frappe.model.document import Document
+from frappe.modules.import_file import import_file_by_path
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.csvutils import validate_google_sheets_url
-from frappe import _
 
 
 class DataImport(Document):
@@ -173,15 +173,7 @@ def import_file(
 ##############
 
 
-def import_doc(
-	path,
-	overwrite=False,
-	ignore_links=False,
-	ignore_insert=False,
-	insert=False,
-	submit=False,
-	pre_process=None,
-):
+def import_doc(path, pre_process=None):
 	if os.path.isdir(path):
 		files = [os.path.join(path, f) for f in os.listdir(path)]
 	else:
@@ -190,30 +182,21 @@ def import_doc(
 	for f in files:
 		if f.endswith(".json"):
 			frappe.flags.mute_emails = True
-			frappe.modules.import_file.import_file_by_path(
-				f, data_import=True, force=True, pre_process=pre_process, reset_permissions=True
+			import_file_by_path(
+				f,
+				data_import=True,
+				force=True,
+				pre_process=pre_process,
+				reset_permissions=True
 			)
 			frappe.flags.mute_emails = False
 			frappe.db.commit()
 		elif f.endswith(".csv"):
-			import_file_by_path(
-				f,
-				ignore_links=ignore_links,
-				overwrite=overwrite,
-				submit=submit,
-				pre_process=pre_process,
-			)
+			validate_csv_import_file(f)
 			frappe.db.commit()
 
 
-def import_file_by_path(
-	path,
-	ignore_links=False,
-	overwrite=False,
-	submit=False,
-	pre_process=None,
-	no_email=True,
-):
+def validate_csv_import_file(path):
 	if path.endswith(".csv"):
 		print()
 		print("This method is deprecated.")

--- a/frappe/core/doctype/data_import_legacy/data_import_legacy.py
+++ b/frappe/core/doctype/data_import_legacy/data_import_legacy.py
@@ -2,20 +2,22 @@
 # Copyright (c) 2017, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
-import frappe, os
-from frappe import _
+import os
+
+import frappe
 import frappe.modules.import_file
-from frappe.model.document import Document
-from frappe.utils.data import format_datetime
+from frappe import _
 from frappe.core.doctype.data_import_legacy.importer import upload
+from frappe.model.document import Document
+from frappe.modules.import_file import import_file_by_path as _import_file_by_path
 from frappe.utils.background_jobs import enqueue
+from frappe.utils.data import format_datetime
 
 
 class DataImportLegacy(Document):
 	def autoname(self):
 		if not self.name:
-			self.name = "Import on " +format_datetime(self.creation)
+			self.name = "Import on " + format_datetime(self.creation)
 
 	def validate(self):
 		if not self.import_file:
@@ -32,6 +34,7 @@ class DataImportLegacy(Document):
 @frappe.whitelist()
 def get_importable_doctypes():
 	return frappe.cache().hget("can_import", frappe.session.user)
+
 
 @frappe.whitelist()
 def import_data(data_import):
@@ -57,7 +60,7 @@ def import_doc(path, overwrite=False, ignore_links=False, ignore_insert=False,
 	for f in files:
 		if f.endswith(".json"):
 			frappe.flags.mute_emails = True
-			frappe.modules.import_file.import_file_by_path(f, data_import=True, force=True, pre_process=pre_process, reset_permissions=True)
+			_import_file_by_path(f, data_import=True, force=True, pre_process=pre_process, reset_permissions=True)
 			frappe.flags.mute_emails = False
 			frappe.db.commit()
 		elif f.endswith(".csv"):
@@ -69,7 +72,7 @@ def import_file_by_path(path, ignore_links=False, overwrite=False, submit=False,
 	from frappe.utils.csvutils import read_csv_content
 	print("Importing " + path)
 	with open(path, "r") as infile:
-		upload(rows = read_csv_content(infile.read()), ignore_links=ignore_links, no_email=no_email, overwrite=overwrite,
+		upload(rows=read_csv_content(infile.read()), ignore_links=ignore_links, no_email=no_email, overwrite=overwrite,
 			submit_after_import=submit, pre_process=pre_process)
 
 

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
-from __future__ import unicode_literals, print_function
+import os
 
-import frappe, os
-from frappe.core.doctype.data_import.data_import import import_doc, export_json
+import frappe
+from frappe.core.doctype.data_import.data_import import export_json, import_doc
+
 
 def sync_fixtures(app=None):
 	"""Import, overwrite fixtures from `[app]/fixtures`"""
@@ -20,14 +21,14 @@ def sync_fixtures(app=None):
 			fixture_files = sorted(os.listdir(frappe.get_app_path(app, "fixtures")))
 			for fname in fixture_files:
 				if fname.endswith(".json") or fname.endswith(".csv"):
-					import_doc(frappe.get_app_path(app, "fixtures", fname),
-						ignore_links=True, overwrite=True)
+					import_doc(frappe.get_app_path(app, "fixtures", fname))
 
 		import_custom_scripts(app)
 
 	frappe.flags.in_fixtures = False
 
 	frappe.db.commit()
+
 
 def import_custom_scripts(app):
 	"""Import custom scripts from `[app]/fixtures/custom_scripts`"""
@@ -44,10 +45,11 @@ def import_custom_scripts(app):
 						custom_script.save()
 					else:
 						frappe.get_doc({
-							"doctype":"Custom Script",
+							"doctype": "Custom Script",
 							"dt": doctype,
 							"script": script
 						}).insert()
+
 
 def export_fixtures(app=None):
 	"""Export fixtures as JSON to `[app]/fixtures`"""


### PR DESCRIPTION
**Problem:**

While importing a document using the Data Import, the following error would show up:

![image](https://user-images.githubusercontent.com/13396535/108704266-c726fb00-7531-11eb-9146-2a058d35816e.png)

I think this might be happening because of the way the `frappe.modules` folder is structured. I'm not 100% sure about the proper fix, so I've atleast changed the function calls to not error out.