### PR TITLE
perf: optimise set_cors_headers

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -152,10 +152,10 @@ def process_response(response):
 
 def set_cors_headers(response):
 	origin = frappe.request.headers.get('Origin')
-	if not origin:
+	allow_cors = frappe.conf.allow_cors
+	if not (origin and allow_cors):
 		return
 
-	allow_cors = frappe.conf.allow_cors
 	if allow_cors != "*":
 		if not isinstance(allow_cors, list):
 			allow_cors = [allow_cors]


### PR DESCRIPTION
Minor optimisation to avoid additional processing if `allow_cors` config doesn't exist.

---
To be backported to versions 12 & 13.