### PR TITLE
fix: Email recipient through reply all

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -358,7 +358,7 @@ class FormTimeline extends BaseTimeline {
 		const args = {
 			doc: this.frm.doc,
 			frm: this.frm,
-			recipients: communication_doc ? communication_doc.sender : this.get_recipient(),
+			recipients: communication_doc && communication_doc.sender != frappe.session.user_email? communication_doc.sender : this.get_recipient(),
 			is_a_reply: Boolean(communication_doc),
 			title: communication_doc ? __('Reply') : null,
 			last_email: communication_doc
@@ -378,7 +378,7 @@ class FormTimeline extends BaseTimeline {
 			const comment_value = frappe.markdown(this.frm.comment_box.get_value());
 			args.txt = strip_html(comment_value) ? comment_value : '';
 		}
-
+		console.log(args)
 		new frappe.views.CommunicationComposer(args);
 	}
 

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -358,11 +358,11 @@ class FormTimeline extends BaseTimeline {
 		const args = {
 			doc: this.frm.doc,
 			frm: this.frm,
-			recipients: communication_doc && communication_doc.sender != frappe.session.user_email? communication_doc.sender : this.get_recipient(),
+			recipients: communication_doc && communication_doc.sender != frappe.session.user_email ? communication_doc.sender : this.get_recipient(),
 			is_a_reply: Boolean(communication_doc),
 			title: communication_doc ? __('Reply') : null,
 			last_email: communication_doc,
-			subject: communication_doc &&  communication_doc.subject
+			subject: communication_doc && communication_doc.subject
 		};
 
 		if (communication_doc && reply_all) {

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -362,7 +362,7 @@ class FormTimeline extends BaseTimeline {
 			is_a_reply: Boolean(communication_doc),
 			title: communication_doc ? __('Reply') : null,
 			last_email: communication_doc,
-			subject: communication_doc ? __("Re: {0}", [communication_doc.subject])  : __("Re: {0}", [this.frm.doc.subject])
+			subject: communication_doc &&  communication_doc.subject
 		};
 
 		if (communication_doc && reply_all) {

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -361,7 +361,8 @@ class FormTimeline extends BaseTimeline {
 			recipients: communication_doc && communication_doc.sender != frappe.session.user_email? communication_doc.sender : this.get_recipient(),
 			is_a_reply: Boolean(communication_doc),
 			title: communication_doc ? __('Reply') : null,
-			last_email: communication_doc
+			last_email: communication_doc,
+			subject: communication_doc ? __("Re: {0}", [communication_doc.subject])  : __("Re: {0}", [this.frm.doc.subject])
 		};
 
 		if (communication_doc && reply_all) {
@@ -378,7 +379,7 @@ class FormTimeline extends BaseTimeline {
 			const comment_value = frappe.markdown(this.frm.comment_box.get_value());
 			args.txt = strip_html(comment_value) ? comment_value : '';
 		}
-		console.log(args)
+
 		new frappe.views.CommunicationComposer(args);
 	}
 

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -721,7 +721,7 @@ frappe.views.CommunicationComposer = Class.extend({
 			signature = res.message.signature;
 		}
 
-		if(!frappe.utils.is_html(signature)) {
+		if(signature && !frappe.utils.is_html(signature)) {
 			signature = signature.replace(/\n/g, "<br>");
 		}
 

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -721,7 +721,7 @@ frappe.views.CommunicationComposer = Class.extend({
 			signature = res.message.signature;
 		}
 
-		if(signature && !frappe.utils.is_html(signature)) {
+		if(!frappe.utils.is_html(signature)) {
 			signature = signature.replace(/\n/g, "<br>");
 		}
 


### PR DESCRIPTION
**Issue:**

1. When sending an email through reply or reply all, the email popup used to pick the sender of the communication as the recipient. But in the case where the user itself was the sender of the communication, it showed the user's email id as the recipient.

![Screenshot 2021-02-23 at 8 01 16 PM](https://user-images.githubusercontent.com/31363128/108858554-4db30980-7612-11eb-9f46-613cc560bfb0.png)

2. Also the subject was picked from the form and not from the communication to which we reply.

**Steps to replicate:**

1. Create a Lead. Send an email through this document.
2. Then click on reply or reply-all to this communication.
3. The email should consider the lead email id as the recipient and not session users.
4. Then send another email but change the subject this time.
5. After sending the email, click on reply or reply-all on this new communication.
6. It should show the subject of this communication and not the previous subject.
