### PR TITLE
fix: Cannot change Entry Form Type

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -76,6 +76,7 @@ frappe.ui.form.on("Customize Form", {
 							frm.trigger("setup_sortable");
 						}
 					}
+					localStorage["customize_doctype"] = frm.doc.doc_type;
 				}
 			});
 		} else {


### PR DESCRIPTION
When we open Customize Form, we select "Enter Form Type" to any doctype. Now if we want to change the "Enter Form Type" then we cannot change it.

![CustomizeForm](https://user-images.githubusercontent.com/30859809/109003742-d347bf80-76cd-11eb-926c-438680beb1fe.gif)
