### PR TITLE
fix: Raise PageDoesNotExistError instead of DoesNotExistError

### DIFF
--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -33,6 +33,9 @@ class PermissionError(Exception):
 class DoesNotExistError(ValidationError):
 	http_status_code = 404
 
+class PageDoesNotExistError(ValidationError):
+	http_status_code = 404
+
 class NameError(Exception):
 	http_status_code = 409
 

--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -48,7 +48,7 @@ def render(path=None, http_status_code=None):
 		else:
 			try:
 				data = render_page_by_language(path)
-			except frappe.DoesNotExistError:
+			except frappe.PageDoesNotExistError:
 				doctype, name = get_doctype_from_path(path)
 				if doctype and name:
 					path = "printview"

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -49,7 +49,7 @@ def get_page_context(path):
 def make_page_context(path):
 	context = resolve_route(path)
 	if not context:
-		raise frappe.DoesNotExistError
+		raise frappe.PageDoesNotExistError
 
 	context.doctype = context.ref_doctype
 


### PR DESCRIPTION
Raise `PageDoesNotExistError` instead of `DoesNotExistError` to avoid it getting mixed up with the "document not found" error.

---
**Previously**, even if there were any documents missing internally while loading a page, `render.py` used to show "Not Found" `404` page even for the valid routes.
<img width="1440" alt="Screenshot 2021-02-25 at 12 33 55 PM" src="https://user-images.githubusercontent.com/13928957/109116019-e4440f80-7765-11eb-9d3b-fb8eb7cd6a21.png">

**Now**, for any internal failure, `render.py` will raise a proper error with `500` status code so that it'll be easier to debug the cause of failure.
<img width="1440" alt="Screenshot 2021-02-25 at 12 38 35 PM" src="https://user-images.githubusercontent.com/13928957/109116347-63394800-7766-11eb-8cab-9c9e3366e317.png">





