### PR TITLE
fix: respect % width while building print formats

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -169,7 +169,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 		{%- if df.print_width.endswith("%") -%}
 			{{ df.print_width }}
 		{%- else -%}
-			{{ (df.print_width|str).replace("px", "") }}px
+			{{ df.print_width.replace("px", "") }}px
 		{%- endif -%}
 	{%- elif df.fieldtype in ("Int", "Check", "Float", "Currency") -%}{{ 80 }}px
 	{%- else -%}{{ 150 }}px{% endif -%}

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -165,7 +165,12 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {%- endmacro %}
 
 {% macro get_width(df) -%}
-	{%- if df.print_width -%}{{ (df.print_width|str).replace("px", "") }}px
+	{%- if df.print_width -%}
+		{%- if df.print_width.endswith("%") -%}
+			{{ df.print_width }}
+		{%- else -%}
+			{{ (df.print_width|str).replace("px", "") }}px
+		{%- endif -%}
 	{%- elif df.fieldtype in ("Int", "Check", "Float", "Currency") -%}{{ 80 }}px
 	{%- else -%}{{ 150 }}px{% endif -%}
 {%- endmacro %}


### PR DESCRIPTION
The print format builder was designed to accept both % and px values for table column widths:

![Screenshot-2021-02-25-153928](https://user-images.githubusercontent.com/16315650/109137929-cdaab200-777f-11eb-9f38-e72b40a0f5b5.png)

But for some reason, the support for % width was never implemented. This PR fixes that.

Also removes unnecessary type-casting.

---

### Values

![Screenshot-2021-02-25-154318](https://user-images.githubusercontent.com/16315650/109138323-41e55580-7780-11eb-9750-074c2731a872.png)

### Before

![Screenshot-2021-02-25-154251](https://user-images.githubusercontent.com/16315650/109138352-49a4fa00-7780-11eb-9170-82d09e33be98.png)

### After

![Screenshot-2021-02-25-154216](https://user-images.githubusercontent.com/16315650/109138377-4f9adb00-7780-11eb-8cb8-0a6d80bfa799.png)
