### PR TITLE
fix: Do not render multiple login blocks

### DIFF
--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -108,7 +108,7 @@
 		{%- endif -%}
 	</section>
 
-
+	{%- if social_login -%}
 	<section class='for-email-login'>
 		<div class="login-content page-card">
 			{{ logo_section() }}
@@ -123,6 +123,7 @@
 		</div>
 		{%- endif -%}
 	</section>
+	{%- endif -%}
 	<section class='for-signup {{ "signup-disabled" if disable_signup else "" }}'>
 		<div class="login-content page-card">
 			{{ logo_section() }}


### PR DESCRIPTION
Previously, we used to render 2 login blocks and hide one of them, but this used to throw following warning message:
<img width="1440" alt="Screenshot 2021-02-25 at 5 12 52 PM" src="https://user-images.githubusercontent.com/13928957/109148779-b45c3280-778c-11eb-8d3c-cadb6a2e9cab.png">



fixes: https://github.com/frappe/frappe/issues/12483

