### PR TITLE
revert: "fix: Memory limit for watch command"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "node rollup/build.js",
     "production": "FRAPPE_ENV=production node rollup/build.js",
-    "watch": "node --max_old_space_size=1280 rollup/watch.js",
+    "watch": "node rollup/watch.js",
     "snyk-protect": "snyk protect",
     "prepare": "yarn run snyk-protect"
   },


### PR DESCRIPTION
Reverts frappe/frappe#12377

Limits devices with higher resources.

Need to opt for a better solution than this. Maybe a simpler [version of this](https://github.com/frappe/frappe/pull/11140).