### PR TITLE
fix: max_old_space_size limit for node processes

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -15,6 +15,7 @@ import frappe
 from frappe.utils.minify import JavascriptMinify
 
 import click
+import psutil
 from six import iteritems, text_type
 from six.moves.urllib.parse import urlparse
 
@@ -245,6 +246,18 @@ def check_yarn():
 	if not find_executable("yarn"):
 		print("Please install yarn using below command and try again.\nnpm install -g yarn")
 
+def get_available_memory_for_usage():
+	try:
+		# 80% of free virtual memory
+		available_memory = (psutil.virtual_memory().free / (1024 * 1024)) * 0.8
+		# 60% of free swap memory
+		available_swap = (psutil.swap_memory().free / (1024 * 1024)) * 0.6
+		available_usage = int(available_memory + available_swap)
+
+	except Exception:
+		available_usage = 0
+
+	return available_usage
 
 def make_asset_dirs(make_copy=False, restore=False):
 	# don't even think of making assets_path absolute - rm -rf ahead.

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -227,7 +227,7 @@ def bundle(no_compress, app=None, make_copy=False, restore=False, verbose=False,
 
 	frappe_app_path = os.path.abspath(os.path.join(app_paths[0], ".."))
 	check_yarn()
-	frappe.commands.popen(command, cwd=frappe_app_path)
+	frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env())
 
 
 def watch(no_compress):
@@ -239,12 +239,18 @@ def watch(no_compress):
 	frappe_app_path = os.path.abspath(os.path.join(app_paths[0], ".."))
 	check_yarn()
 	frappe_app_path = frappe.get_app_path("frappe", "..")
-	frappe.commands.popen("{pacman} run watch".format(pacman=pacman), cwd=frappe_app_path)
+	frappe.commands.popen("{pacman} run watch".format(pacman=pacman),
+		cwd=frappe_app_path, env=get_node_env())
 
 
 def check_yarn():
 	if not find_executable("yarn"):
 		print("Please install yarn using below command and try again.\nnpm install -g yarn")
+
+def get_node_env():
+	# set max_old_space_size based on available memory
+	node_env = dict(NODE_OPTIONS=f"--max_old_space_size={get_available_memory_for_usage()}")
+	return node_env
 
 def get_available_memory_for_usage():
 	try:

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -249,21 +249,20 @@ def check_yarn():
 
 def get_node_env():
 	# set max_old_space_size based on available memory
-	node_env = dict(NODE_OPTIONS=f"--max_old_space_size={get_available_memory_for_usage()}")
+	node_env = dict(NODE_OPTIONS=f"--max_old_space_size={get_safe_max_old_space_size()}")
 	return node_env
 
-def get_available_memory_for_usage():
+def get_safe_max_old_space_size():
+	safe_max_old_space_size = 0
 	try:
-		# 80% of free virtual memory
-		available_memory = (psutil.virtual_memory().free / (1024 * 1024)) * 0.8
-		# 60% of free swap memory
-		available_swap = (psutil.swap_memory().free / (1024 * 1024)) * 0.6
-		available_usage = int(available_memory + available_swap)
-
+		total_memory = psutil.virtual_memory().total / (1024 * 1024)
+		# reference for the safe limit assumption
+		# https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
+		safe_max_old_space_size = int(total_memory * 0.75)
 	except Exception:
-		available_usage = 0
+		pass
 
-	return available_usage
+	return safe_max_old_space_size
 
 def make_asset_dirs(make_copy=False, restore=False):
 	# don't even think of making assets_path absolute - rm -rf ahead.

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -248,8 +248,9 @@ def check_yarn():
 		print("Please install yarn using below command and try again.\nnpm install -g yarn")
 
 def get_node_env():
-	# set max_old_space_size based on available memory
-	node_env = dict(NODE_OPTIONS=f"--max_old_space_size={get_safe_max_old_space_size()}")
+	node_env = {
+		"NODE_OPTIONS": f"--max_old_space_size={get_safe_max_old_space_size()}"
+	}
 	return node_env
 
 def get_safe_max_old_space_size():
@@ -258,7 +259,8 @@ def get_safe_max_old_space_size():
 		total_memory = psutil.virtual_memory().total / (1024 * 1024)
 		# reference for the safe limit assumption
 		# https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
-		safe_max_old_space_size = int(total_memory * 0.75)
+		# set minimum value 1GB
+		safe_max_old_space_size = max(1024, int(total_memory * 0.75))
 	except Exception:
 		pass
 

--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -11,6 +11,7 @@ import frappe.utils
 import subprocess # nosec
 from functools import wraps
 from six import StringIO
+from os import environ
 
 click.disable_unicode_literals_warning = True
 
@@ -58,6 +59,8 @@ def popen(command, *args, **kwargs):
 	shell = kwargs.get('shell', True)
 	raise_err = kwargs.get('raise_err')
 	env = kwargs.get('env')
+	if env:
+		env = dict(environ, **env)
 
 	proc = subprocess.Popen(command,
 		stdout = None if output else subprocess.PIPE,

--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -63,11 +63,11 @@ def popen(command, *args, **kwargs):
 		env = dict(environ, **env)
 
 	proc = subprocess.Popen(command,
-		stdout = None if output else subprocess.PIPE,
-		stderr = None if output else subprocess.PIPE,
-		shell = shell,
-		cwd = cwd,
-		env = env
+		stdout=None if output else subprocess.PIPE,
+		stderr=None if output else subprocess.PIPE,
+		shell=shell,
+		cwd=cwd,
+		env=env
 	)
 
 	return_ = proc.wait()

--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -53,16 +53,18 @@ def get_site(context, raise_err=True):
 		return None
 
 def popen(command, *args, **kwargs):
-	output    = kwargs.get('output', True)
-	cwd       = kwargs.get('cwd')
-	shell     = kwargs.get('shell', True)
+	output = kwargs.get('output', True)
+	cwd = kwargs.get('cwd')
+	shell = kwargs.get('shell', True)
 	raise_err = kwargs.get('raise_err')
+	env = kwargs.get('env')
 
 	proc = subprocess.Popen(command,
 		stdout = None if output else subprocess.PIPE,
 		stderr = None if output else subprocess.PIPE,
-		shell  = shell,
-		cwd    = cwd
+		shell = shell,
+		cwd = cwd,
+		env = env
 	)
 
 	return_ = proc.wait()

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ passlib==1.7.3
 pdfkit==0.6.1
 Pillow>=8.0.0
 premailer==3.6.1
+psutil==5.7.2
 psycopg2-binary==2.8.4
 pyasn1==0.4.8
 PyJWT==1.7.1


### PR DESCRIPTION
A simpler version of https://github.com/frappe/frappe/pull/11140

Aimed to fix the issue mentioned in https://github.com/frappe/frappe/pull/11140#issuecomment-778678166

> reference for the safe limit assumption
> https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
> set minimum value 1GB to avoid build failures in smaller devices.