### PR TITLE
fix: console crash due upstream issue in ipython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ gunicorn==19.10.0
 html2text==2016.9.19
 html5lib==1.0.1
 ipython==7.14.0
+jedi==0.17.2  # not directly required. Pinned to fix upstream issue with ipython.
 Jinja2==2.11.3
 ldap3==2.7
 markdown2==2.4.0


### PR DESCRIPTION
Console randomly crashes due to upstream issue in ipython. Temporary solution is to pin jedi to one version lower.

Reference: https://github.com/ipython/ipython/issues/12740#issuecomment-751273584
