### PR TITLE
fix: Notification fixes for a modified user

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -8,7 +8,7 @@ from frappe.utils import cint, flt, has_gravatar, escape_html, format_datetime, 
 from frappe import throw, msgprint, _
 from frappe.utils.password import update_password as _update_password
 from frappe.desk.notifications import clear_notifications
-from frappe.desk.doctype.notification_settings.notification_settings import create_notification_settings, enable_disable_notifications
+from frappe.desk.doctype.notification_settings.notification_settings import create_notification_settings, toggle_notifications
 from frappe.utils.user import get_system_managers
 from bs4 import BeautifulSoup
 import frappe.permissions
@@ -121,15 +121,14 @@ class User(Document):
 		if not cint(self.enabled):
 			self.a_system_manager_should_exist()
 			# disable notifications if the user has been disabled
-			enable_disable_notifications(self.name, enabled=False)
+			toggle_notifications(self.name, enable=False)
+		else:
+			# enable notifications if the user has been enabled
+			toggle_notifications(self.name, enable=True)
 
 		# clear sessions if disabled
 		if not cint(self.enabled) and getattr(frappe.local, "login_manager", None):
 			frappe.local.login_manager.logout(user=self.name)
-
-		# enable notifications if the user has been enabled
-		if cint(self.enabled):
-			enable_disable_notifications(self.name, enabled=True)
 
 	def add_system_manager_role(self):
 		# if adding system manager, do nothing

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -120,15 +120,13 @@ class User(Document):
 
 		if not cint(self.enabled):
 			self.a_system_manager_should_exist()
-			# disable notifications if the user has been disabled
-			toggle_notifications(self.name, enable=False)
-		else:
-			# enable notifications if the user has been enabled
-			toggle_notifications(self.name, enable=True)
 
 		# clear sessions if disabled
 		if not cint(self.enabled) and getattr(frappe.local, "login_manager", None):
 			frappe.local.login_manager.logout(user=self.name)
+
+		# toggle notifications based on the user's status
+		toggle_notifications(self.name, enable=cint(self.enabled))
 
 	def add_system_manager_role(self):
 		# if adding system manager, do nothing

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -42,7 +42,8 @@ def create_notification_settings(user):
 		frappe.db.commit()
 
 def enable_disable_notifications(user, enabled):
-	frappe.set_value("Notification Settings", user, 'enabled', enabled)
+	if frappe.db.exists("Notification Settings", user):
+		frappe.set_value("Notification Settings", user, 'enabled', enabled)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -41,6 +41,9 @@ def create_notification_settings(user):
 		_doc.insert(ignore_permissions=True)
 		frappe.db.commit()
 
+def enable_disable_notifications(user, enabled):
+	frappe.set_value("Notification Settings", user, 'enabled', enabled)
+
 
 @frappe.whitelist()
 def get_subscribed_documents():

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -43,7 +43,7 @@ def create_notification_settings(user):
 
 def enable_disable_notifications(user, enabled):
 	if frappe.db.exists("Notification Settings", user):
-		frappe.set_value("Notification Settings", user, 'enabled', enabled)
+		frappe.db.set_value("Notification Settings", user, 'enabled', enabled)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -41,9 +41,10 @@ def create_notification_settings(user):
 		_doc.insert(ignore_permissions=True)
 		frappe.db.commit()
 
-def enable_disable_notifications(user, enabled):
+
+def toggle_notifications(user, enable=False):
 	if frappe.db.exists("Notification Settings", user):
-		frappe.db.set_value("Notification Settings", user, 'enabled', enabled)
+		frappe.db.set_value("Notification Settings", user, 'enabled', enable)
 
 
 @frappe.whitelist()

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -318,7 +318,10 @@ def send_summary(timespan):
 
 	from_date = getdate(from_date)
 	to_date = getdate()
-	all_users = [user.email for user in get_enabled_system_users()]
+
+	# select only those users that have energy point email notifications enabled
+	all_users = [user.email for user in get_enabled_system_users() if
+		is_email_notifications_enabled_for_type(user.name, 'Energy Point')]
 
 	frappe.sendmail(
 			subject='{} energy points summary'.format(timespan),


### PR DESCRIPTION
Changes made:
- disables/enables notification settings for a user when the user is disabled/enabled
- deletes the Notification Settings doc for a user when the user is deleted
- added check to sending Energy Point Summary emails to check if user has notifications enabled for energy points