### PR TITLE
fix: Set valid status for Scheduled Job Type

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -71,7 +71,7 @@ class ScheduledJobType(Document):
 	def execute(self):
 		self.scheduler_log = None
 		try:
-			self.log_status('Started')
+			self.log_status('Start')
 			if self.server_script:
 				script_name = frappe.db.get_value("Server Script", self.server_script)
 				if script_name:


### PR DESCRIPTION
Change in [this PR](https://github.com/frappe/frappe/pull/12428) was causing issue because "Started" is not a valid status for Scheduled Job Type.