### PR TITLE
fix: Patch - Remove Twilio doctypes from DB

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -331,3 +331,4 @@ execute:frappe.get_doc('Role', 'Guest').save() # remove desk access
 frappe.patches.v13_0.rename_desk_page_to_workspace # 02.02.2021
 frappe.patches.v13_0.delete_package_publish_tool
 frappe.patches.v13_0.rename_list_view_setting_to_list_view_settings
+frappe.patches.v13_0.remove_twilio_settings

--- a/frappe/patches/v13_0/remove_twilio_settings.py
+++ b/frappe/patches/v13_0/remove_twilio_settings.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+import frappe
+
+
+def execute():
+	"""Add missing Twilio patch.
+
+	While making Twilio as a standaone app, we missed to delete Twilio records from DB through migration. Adding the missing patch.
+	"""
+	frappe.delete_doc_if_exists('DocType', 'Twilio Number Group')
+	if twilio_settings_doctype_in_integrations():
+		frappe.delete_doc_if_exists('DocType', 'Twilio Settings')
+		frappe.db.sql("delete from `tabSingles` where `doctype`=%s", 'Twilio Settings')
+
+def twilio_settings_doctype_in_integrations() -> bool:
+	"""Check Twilio Settings doctype exists in integrations module or not.
+	"""
+	return frappe.db.exists("DocType", {'name': 'Twilio Settings', 'module': 'Integrations'})


### PR DESCRIPTION
We missed to add migration while moving Twilio code from Frappe to standalone app. Added migration that removes Twilio doctype's from DB.

Closes #ISS-20-21-09964

**Issues raised because of missing migration**
1. `Twilio Settings` are searchable through Awesome bar, but fails to opens the page once selected
2. Unable to install new apps in the system incase of Twilio settings configured.

With this migration above issues will be resolved.