### PR TITLE
fix(UI): Miscellaneous fixes

### DIFF
--- a/frappe/public/icons/timeless/icon-right-arrow.svg
+++ b/frappe/public/icons/timeless/icon-right-arrow.svg
@@ -1,3 +1,0 @@
-<svg width="6" height="8" viewBox="0 0 6 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M1.25 7.5L4.75 4L1.25 0.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/frappe/public/scss/common/buttons.scss
+++ b/frappe/public/scss/common/buttons.scss
@@ -78,8 +78,9 @@
 
 .btn.btn-primary {
 	background-color: var(--primary-color);
+	color: var(--white);
 	white-space: nowrap;
-	--icon-stroke: white;
+	--icon-stroke: currentColor;
 	--icon-fill-bg: var(--primary-color);
 }
 

--- a/frappe/public/scss/desk/breadcrumb.scss
+++ b/frappe/public/scss/desk/breadcrumb.scss
@@ -12,7 +12,7 @@
 		font-size: var(--text-md);
 		margin-right: 10px;
 		&:before {
-			content: url('/assets/frappe/icons/timeless/icon-right-arrow.svg');
+			content: var(--right-arrow-svg);
 			display: inline-block;
 			margin-right: 10px;
 		}

--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -50,6 +50,7 @@ $input-height: 28px !default;
 
 	// input
 	--input-height: #{$input-height};
+	--input-disabled-bg: var(--gray-200);
 
 	// timeline
 	--timeline-item-icon-size: 34px;
@@ -60,4 +61,6 @@ $input-height: 28px !default;
 
 	// skeleton
 	--skeleton-bg: var(--gray-100);
+
+	--right-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1.25 7.5L4.75 4L1.25 0.5' stroke='%231F272E' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 }

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -142,4 +142,6 @@
 
 	// skeleton
 	--skeleton-bg: var(--gray-800);
+
+	--right-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1.25 7.5L4.75 4L1.25 0.5' stroke='white' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 }

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -72,6 +72,9 @@
 	--highlight-color: var(--gray-700);
 	--yellow-highlight-color: var(--yellow-700);
 
+	// input
+	--input-disabled-bg: none;
+
 	.frappe-card {
 		.btn-default {
 			background-color: var(--bg-color);

--- a/frappe/public/scss/desk/variables.scss
+++ b/frappe/public/scss/desk/variables.scss
@@ -60,7 +60,7 @@ $link-color: var(--text-color);
 // input
 $input-bg: var(--control-bg);
 $input-placeholder-color: var(--gray-500);
-$input-disabled-bg: var(--gray-200);
+$input-disabled-bg: var(--input-disabled-bg);
 $input-color: var(--text-color);
 $input-box-shadow: none;
 $input-focus-border-color: var(--gray-500);
@@ -135,9 +135,9 @@ $grid-breakpoints: (
   2xl: 1440px
 ) !default;
 
-@import 'dark';
 @import 'typography';
 @import '~bootstrap/scss/functions';
 @import '~bootstrap/scss/variables';
 @import "~bootstrap/scss/mixins";
 @import 'css_variables';
+@import 'dark';

--- a/frappe/public/scss/desk/variables.scss
+++ b/frappe/public/scss/desk/variables.scss
@@ -65,6 +65,7 @@ $input-color: var(--text-color);
 $input-box-shadow: none;
 $input-focus-border-color: var(--gray-500);
 $input-border-radius: var(--border-radius);
+$input-btn-focus-width: 2px;
 
 // dropdown
 $dropdown-color: var(--text-color);


### PR DESCRIPTION
- Fixed breadcrumb arrow color in Dark mode
	**Before:**
	<img width="350" alt="Screenshot 2021-03-02 at 3 40 51 PM" src="https://user-images.githubusercontent.com/13928957/109633205-da5b4b80-7b6d-11eb-9d23-5f43ee650686.png">

	**Now:**
	<img width="350" alt="Screenshot 2021-03-02 at 3 36 09 PM" src="https://user-images.githubusercontent.com/13928957/109633232-e1825980-7b6d-11eb-8775-1e0777cc53cf.png">

---

- Reduced button focus outline width

	**Before:**
	<img width="345" alt="Screenshot 2021-03-02 at 2 28 51 PM" src="https://user-images.githubusercontent.com/13928957/109624114-d6c2c700-7b63-11eb-8c58-2bcfda78b7e4.png">
	**Now:**
	<img width="335" alt="Screenshot 2021-03-02 at 2 29 10 PM" src="https://user-images.githubusercontent.com/13928957/109624089-cf032280-7b63-11eb-8399-e8b57ce63351.png">
---

- Fixed disabled input style in a child table (for dark mode)
	**Before:**	
	<img width="948" alt="Screenshot 2021-03-02 at 3 47 45 PM" src="https://user-images.githubusercontent.com/13928957/109633913-a9c7e180-7b6e-11eb-925b-99fdf0f1a39e.png">

	**Now:**
	<img width="1023" alt="Screenshot 2021-03-02 at 3 46 47 PM" src="https://user-images.githubusercontent.com/13928957/109633804-8c931300-7b6e-11eb-8dc9-dab0c58dde95.png">
	Fixes: https://github.com/frappe/frappe/issues/12449
