### PR TITLE
feat: Lazy import functionality added

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -18,9 +18,14 @@ import os, sys, importlib, inspect, json
 from past.builtins import cmp
 import click
 
-# public
+# Local application imports
 from .exceptions import *
 from .utils.jinja import (get_jenv, get_template, render_template, get_email_from_template, get_jloader)
+from .utils.lazy_loader import lazy_import
+
+# Lazy imports
+faker = lazy_import('faker')
+
 
 # Harmless for Python 3
 # For Python 2 set default encoding to utf-8
@@ -1749,15 +1754,13 @@ def parse_json(val):
 	return parse_json(val)
 
 def mock(type, size=1, locale='en'):
-	from faker import Faker
-
 	results = []
-	faker = Faker(locale)
-	if not type in dir(faker):
+	fake = faker.Faker(locale)
+	if type not in dir(fake):
 		raise ValueError('Not a valid mock type.')
 	else:
 		for i in range(size):
-			data = getattr(faker, type)()
+			data = getattr(fake, type)()
 			results.append(data)
 
 	from frappe.chat.util import squashify

--- a/frappe/utils/lazy_loader.py
+++ b/frappe/utils/lazy_loader.py
@@ -1,0 +1,38 @@
+import importlib.util
+import sys
+
+def lazy_import(name, package=None):
+	"""Import a module lazily.
+
+	The module is loaded when modules's attribute is accessed for the first time.
+	This works with both absolute and relative imports.
+	$ cat mod.py
+	print("I am loading..")
+	$ python -i lazy_loader.py
+	>>> mod = lazy_import("mod") # Module is not loaded
+	>>> mod.__str__() # module is loaded on accessing attribute
+	I am loading..
+	"<module 'mod' from '/Users/leela/Work/ERPNext/frappe/frappe/utils/mod.py'>"
+	>>>
+
+	Code based on https://github.com/python/cpython/blob/master/Doc/library/importlib.rst#implementing-lazy-imports.
+	"""
+	# Return if the module already loaded
+	if name in sys.modules:
+		return sys.modules[name]
+
+	# Find the spec if not loaded
+	spec = importlib.util.find_spec(name, package)
+	if not spec:
+		raise ImportError(f'Module {name} Not found.')
+
+	# Check for compatibility
+	if not hasattr(spec.loader, 'exec_module'):
+		raise ImportError('Not Supported')
+
+	loader = importlib.util.LazyLoader(spec.loader)
+	spec.loader = loader
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[name] = module
+	loader.exec_module(module)
+	return module

--- a/frappe/utils/lazy_loader.py
+++ b/frappe/utils/lazy_loader.py
@@ -7,12 +7,12 @@ def lazy_import(name, package=None):
 	The module is loaded when modules's attribute is accessed for the first time.
 	This works with both absolute and relative imports.
 	$ cat mod.py
-	print("I am loading..")
+	print("Loading mod.py")
 	$ python -i lazy_loader.py
 	>>> mod = lazy_import("mod") # Module is not loaded
 	>>> mod.__str__() # module is loaded on accessing attribute
-	I am loading..
-	"<module 'mod' from '/Users/leela/Work/ERPNext/frappe/frappe/utils/mod.py'>"
+	Loading mod.py
+	"<module 'mod' from '.../frappe/utils/mod.py'>"
 	>>>
 
 	Code based on https://github.com/python/cpython/blob/master/Doc/library/importlib.rst#implementing-lazy-imports.
@@ -25,10 +25,6 @@ def lazy_import(name, package=None):
 	spec = importlib.util.find_spec(name, package)
 	if not spec:
 		raise ImportError(f'Module {name} Not found.')
-
-	# Check for compatibility
-	if not hasattr(spec.loader, 'exec_module'):
-		raise ImportError('Not Supported')
 
 	loader = importlib.util.LazyLoader(spec.loader)
 	spec.loader = loader


### PR DESCRIPTION
Lazy imports are helpful to make applications little faster by reducing startup time through loading the module when module attributes are accessed instead of loading the module at time of import.

We currently do that by adding imports within function but that comes with disadvantages like:
1. import duplication, we end up having same import in multiple functions in the same file.
2. We miss import errors unless and until the function is executed incase of missing packages.

With this PR, we can remove function level imports and also import errors get captured while doing lazy imports.


