### PR TITLE
fix: show link based on READ ignoring select perm

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -131,7 +131,7 @@ frappe.form.formatters = {
 			return repl('<a onclick="%(onclick)s">%(value)s</a>',
 				{onclick: docfield.link_onclick.replace(/"/g, '&quot;'), value:value});
 		} else if(docfield && doctype) {
-			if (!frappe.model.can_select(doctype) && frappe.model.can_read(doctype)) {
+			if (frappe.model.can_read(doctype)) {
 				return `<a
 					href="/app/${encodeURIComponent(frappe.router.slug(doctype))}/${encodeURIComponent(original_value)}"
 					data-doctype="${doctype}"


### PR DESCRIPTION
If user has select + read perm both they should be able to see the link. Currently it is "if not select AND read" which seems to be flawed.