### PR TITLE
chore: add semgrep linting

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,13 @@
+name: Semgrep
+
+on:
+  pull_request: {}
+
+jobs:
+  semgrep:
+    name: Frappe Linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,29 @@
+#Reference: https://semgrep.dev/docs/writing-rules/rule-syntax/
+
+rules:
+- id: eval
+  patterns:
+  - pattern-not: eval("...")
+  - pattern: eval(...)
+  message: |
+    Detected the use of eval(). eval() can be dangerous if used to evaluate
+    dynamic content. Avoid it or use safe_eval().
+  languages:
+  - python
+  severity: ERROR
+
+# translations
+- id: frappe-translation-syntax-python
+  pattern-either:
+  - pattern: _(f"...")  # f-strings not allowed
+  - pattern: _("..." + "...")  # concatenation not allowed
+  - pattern: _("")  # empty string is meaningless
+  - pattern: _("..." % ...)  # Only positional formatters are allowed.
+  - pattern: _("...".format(...))  # format should not be used before translating
+  - pattern: _("...") + ... + _("...")  # don't split strings
+  message: |
+    Incorrect use of translation function detected.
+    Please refer: https://frappeframework.com/docs/user/en/translations
+  languages:
+  - python
+  severity: ERROR


### PR DESCRIPTION
At present we use multiple linting tools for maintaining code quality, some even completely written from scratch. This PR introduces a way to define custom linting rules that are very similar to language grammar itself. We want to add more such linting to improve code quality checks. However this means writing more and more REGEXes or custom tooling like Flake8 plugins that use AST. Both are very specific to language and take a lot of time. 

## What is SemGrep (semantic grep)?
Semgrep is tool which uses tree-sitter to create AST for languages and then "grep" for patterns which themselves are defined in syntax that is very similar to original syntax. As it doesn't rely on text itself it can avoid lots of edge cases which regex can't. Also it's dead simple to write in comparison, if something can't be meaningfully expressed with patterns than we can still fall back on regex.

E.g. 

`_(f"...")` is rule for catching F-strings inside translation function. (`...` is similar to `.*` in regex.)

As demonstration I have translated several rules specified in our translation guidelines to semgrep rules syntax.

## Ideas for more rules:
1. Catching string formatting inside whitelisted functions - to check for SQLi vulnerabilities. 
2. Frappe specific code style / process enforcement. 
3. More security focused rules, catching use of deprecated functionalities.  

## How to test
Locally:
- Install semgrep `pip install semgrep` or `brew install semgrep` (mac)
- Create a local branch from develop. `git checkout -b semgrep_test`
- Pull this PR into your local branch. `git pull https://github.com/ankush/frappe.git semgrep_linting`
- run `semgrep` in root directory. It will pickup `.semgrep.yml` as config file and scan entire codebase for specified rules.

in CI:
- Once merged, semgrep will run against each PR. It's diff aware so only changed files are scanned.
- Time: ~20 seconds to pull docker. Scans ~10-40K lines per second. So scanning time is almost negligible.