### PR TITLE
refactor: Rate limiting decorator for endpoints

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1170,3 +1170,10 @@ def generate_keys(user):
 def switch_theme(theme):
 	if theme in ["Dark", "Light"]:
 		frappe.db.set_value("User", frappe.session.user, "desk_theme", theme)
+
+@frappe.whitelist(allow_guest=True)
+@rate_limit(key='user', limit=2, seconds = 60*60)
+def test_ratelimit(user):
+	"""This endpoint is used by testcases to check the ratelimit is functioning as expected.
+	"""
+	return

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -6,6 +6,9 @@ from __future__ import unicode_literals, print_function
 from bs4 import BeautifulSoup
 
 import frappe
+import frappe.share
+import frappe.defaults
+import frappe.permissions
 from frappe.model.document import Document
 from frappe.utils import cint, flt, has_gravatar, escape_html, format_datetime, now_datetime, get_formatted_email, today
 from frappe import throw, msgprint, _
@@ -1170,10 +1173,3 @@ def generate_keys(user):
 def switch_theme(theme):
 	if theme in ["Dark", "Light"]:
 		frappe.db.set_value("User", frappe.session.user, "desk_theme", theme)
-
-@frappe.whitelist(allow_guest=True)
-@rate_limit(key='user', limit=2, seconds = 60*60)
-def test_ratelimit(user):
-	"""This endpoint is used by testcases to check the ratelimit is functioning as expected.
-	"""
-	return

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -2,21 +2,21 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals, print_function
+
+from bs4 import BeautifulSoup
+
 import frappe
 from frappe.model.document import Document
 from frappe.utils import cint, flt, has_gravatar, escape_html, format_datetime, now_datetime, get_formatted_email, today
 from frappe import throw, msgprint, _
-from frappe.utils.password import update_password as _update_password, check_password
+from frappe.utils.password import update_password as _update_password, check_password, get_password_reset_limit
 from frappe.desk.notifications import clear_notifications
 from frappe.desk.doctype.notification_settings.notification_settings import create_notification_settings, toggle_notifications
 from frappe.utils.user import get_system_managers
-from bs4 import BeautifulSoup
-import frappe.permissions
-import frappe.share
-import frappe.defaults
 from frappe.website.utils import is_signup_enabled
-from frappe.utils.background_jobs import enqueue
 from frappe.rate_limiter import rate_limit
+from frappe.utils.background_jobs import enqueue
+
 
 STANDARD_USERS = ("Guest", "Administrator")
 
@@ -838,7 +838,7 @@ def sign_up(email, full_name, redirect_to):
 			return 2, _("Please ask your administrator to verify your sign-up")
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(key='user', limit=3, seconds = 24*60*60, methods=['POST'])
+@rate_limit(key='user', limit=get_password_reset_limit, seconds = 24*60*60, methods=['POST'])
 def reset_password(user):
 	if user=="Administrator":
 		return 'not allowed'

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -207,8 +207,7 @@ scheduler_events = {
 		"frappe.deferred_insert.save_to_db",
 		"frappe.desk.form.document_follow.send_hourly_updates",
 		"frappe.integrations.doctype.google_calendar.google_calendar.sync",
-		"frappe.email.doctype.newsletter.newsletter.send_scheduled_email",
-		"frappe.utils.password.delete_password_reset_cache"
+		"frappe.email.doctype.newsletter.newsletter.send_scheduled_email"
 	],
 	"daily": [
 		"frappe.email.queue.set_expiry_for_email_queue",

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -5,10 +5,14 @@
 from __future__ import unicode_literals
 
 from datetime import datetime
+from functools import wraps
+from typing import Union
+
+from werkzeug.wrappers import Response
+
 import frappe
 from frappe import _
 from frappe.utils import cint
-from werkzeug.wrappers import Response
 
 
 def apply():
@@ -79,3 +83,40 @@ class RateLimiter:
 	def respond(self):
 		if self.rejected:
 			return Response(_("Too Many Requests"), status=429)
+
+def rate_limit(key: str, limit: int = 5, seconds: int= 24*60*60, methods: Union[str, list]='ALL'):
+	"""Decorator to rate limit an endpoint.
+
+	This will limit Number of requests per endpoint to `limit` within `seconds`.
+	Uses redis cache to track request counts.
+
+	:param key: Key is used to identify the requests uniqueness
+	:param limit: Maximum number of requests to allow with in window time
+	:param seconds: window time to allow requests
+	:param methods: Limit the validation for these methods.
+		`ALL` is a wildcard that applies rate limit on all methods.
+	:type methods: string or list or tuple
+
+	:returns: a decorator function that limit the number of requests per endpoint
+	"""
+	def ratelimit_decorator(fun):
+		@wraps(fun)
+		def wrapper(*args, **kwargs):
+			# Do not apply rate limits if method is not opted to check
+			if methods != 'ALL' and frappe.request.method.upper() not in methods:
+				return frappe.call(fun, **frappe.form_dict)
+
+			identity = frappe.form_dict[key]
+			cache_key = f"rl:{frappe.form_dict.cmd}:{identity}"
+
+			value = frappe.cache().get_value(cache_key, expires=True) or 0
+			if not value:
+				frappe.cache().set_value(cache_key, 0, expires_in_sec=seconds)
+
+			value = frappe.cache().incrby(cache_key, 1)
+			if value > limit:
+				frappe.throw(_("You hit the rate limit because of too many requests. Please try after sometime."))
+
+			return frappe.call(fun, **frappe.form_dict)
+		return wrapper
+	return ratelimit_decorator

--- a/frappe/tests/test_rate_limiter.py
+++ b/frappe/tests/test_rate_limiter.py
@@ -13,8 +13,6 @@ import frappe
 import frappe.rate_limiter
 from frappe.rate_limiter import RateLimiter
 from frappe.utils import cint
-from frappe.frappeclient import FrappeClient
-from frappe.utils.data import get_url
 
 
 class TestRateLimiter(unittest.TestCase):
@@ -118,23 +116,3 @@ class TestRateLimiter(unittest.TestCase):
 		self.assertEqual(limiter.duration, cint(frappe.cache().get(limiter.key)))
 
 		frappe.cache().delete(limiter.key)
-
-	def test_rate_limit_decorator(self):
-		"""Check that rate limit decorator raises 417 when limit is crossed.
-		"""
-		url = get_url()
-		data={'cmd': 'frappe.core.doctype.user.user.test_ratelimit', 'user': 'test@test.com'}
-
-		# Clear rate limit tracker to start fresh
-		key = f"rl:{data['cmd']}:{data['user']}"
-		frappe.cache().delete(key)
-
-		c = FrappeClient(url)
-		res1 = c.session.post(url, data=data, verify=c.verify, headers=c.headers)
-		res2 = c.session.post(url, data=data, verify=c.verify, headers=c.headers)
-		res3 = c.session.post(url, data=data, verify=c.verify, headers=c.headers)
-
-		self.assertEqual(res1.status_code, 200)
-		self.assertEqual(res2.status_code, 200)
-		self.assertEqual(res3.status_code, 417)
-

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -90,14 +90,6 @@ def delete_login_failed_cache(user):
 	frappe.cache().hdel('login_failed_count', user)
 	frappe.cache().hdel('locked_account_time', user)
 
-
-def delete_password_reset_cache(user=None):
-	if user:
-		frappe.cache().hdel('password_reset_link_count', user)
-	else:
-		frappe.cache().delete_key('password_reset_link_count')
-
-
 def update_password(user, pwd, doctype='User', fieldname='password', logout_all_sessions=False):
 	'''
 		Update the password for the User
@@ -179,3 +171,6 @@ def get_encryption_key():
 		frappe.local.conf.encryption_key = encryption_key
 
 	return frappe.local.conf.encryption_key
+
+def get_password_reset_limit():
+	return frappe.db.get_single_value("System Settings", "password_reset_limit") or 0


### PR DESCRIPTION
We currently have a rate limit functionality on reset password endpoint but that can not be extended if we wanted to have the rate limiter  on any other endpoint. Added a rate limit decorator, that can be used on top of any endpoint.

Changed reset password functionality to use rate limit decorator. Here is how the error looks like when the rate limit is crossed.
![forgot_password_ratelimit](https://user-images.githubusercontent.com/36557/109938724-5f716c80-7cf6-11eb-9c16-70badd5217b5.png)
