### PR TITLE
fix: dashboard edit and show buttons not working

### DIFF
--- a/frappe/public/js/frappe/views/pageview.js
+++ b/frappe/public/js/frappe/views/pageview.js
@@ -73,7 +73,6 @@ frappe.views.Page = class Page {
 				return;
 			}
 			this.wrapper = frappe.container.add_page(this.name);
-			this.wrapper.label = this.pagedoc.title || this.pagedoc.name;
 			this.wrapper.page_name = this.pagedoc.name;
 
 			// set content, script and style


### PR DESCRIPTION
### Issue
The buttons to **Edit** a dashboard from it's view or **Show** a dashboard from it's form aren't currently working.

### Fix
`this.wrapper.label` is already being set when calling `frappe.container.add_page` on the previous line. When this label was being overwritten, it accidentally matched the label for the Dashboard form view. Consequently, the call to `frappe.container.change_to` returned prematurely.

**Alternate solution:** compare `route_str` instead of `label` when returning in `frappe.container.change_to`

---

**Before**

![edit dashboard before](https://user-images.githubusercontent.com/16315650/110082271-221ee480-7db3-11eb-88a6-083877b07046.gif)


**After**

![edit dashboard after](https://user-images.githubusercontent.com/16315650/110082295-2814c580-7db3-11eb-9365-1028740c99f2.gif)
