### PR TITLE
fix(router): navigating forward not working for routes in frappe.re_route

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -101,6 +101,7 @@ frappe.router = {
 		let sub_path = this.get_sub_path();
 		if (this.re_route(sub_path)) return;
 
+		this.current_sub_path = sub_path;
 		this.current_route = this.parse();
 		this.set_history(sub_path);
 		this.render();
@@ -223,14 +224,14 @@ frappe.router = {
 			// it doesn't allow us to go back to the one prior to "new-doctype-1"
 			// Hence if this check is true, instead of changing location hash,
 			// we just do a back to go to the doc previous to the "new-doctype-1"
-			var re_route_val = this.get_sub_path(frappe.re_route[sub_path]);
-			if (decodeURIComponent(re_route_val) !== decodeURIComponent(sub_path)) {
+			const re_route_val = this.get_sub_path(frappe.re_route[sub_path]);
+			if (re_route_val === this.current_sub_path) {
 				window.history.back();
-				return true;
 			} else {
 				frappe.set_route(re_route_val);
-				return true;
 			}
+
+			return true;
 		}
 	},
 


### PR DESCRIPTION
## Issue

For any route added to `frappe.re_route`, navigating back works, but navigating forward doesn't.

## Changes Made

- store the current `sub_path` as `frappe.router.current_sub_path`
- compare `re_route_val` with `current_sub_path` (last page before clicking back/forward button), as earlier comparison with `sub_path` always failed. This is how it is currently being done in `v13`.
- remove unnecessary calls to `decodeURIComponent`, since the values being compared are already decoded when `get_sub_path` is called.
- commonify `return true` in `frappe.router.re_route`

## Example

Renaming documents has been taken as an example as `frappe.re_route` gets updated during this action.

### Before

![re_route before](https://user-images.githubusercontent.com/16315650/110102642-0cb5b480-7dcb-11eb-9737-f40f650f77e4.gif)

### After

![re_route after](https://user-images.githubusercontent.com/16315650/110102657-12ab9580-7dcb-11eb-9d86-678ca899cfb6.gif)
