### PR TITLE
fix: allow navigating back from dashboard view

### DIFF
--- a/frappe/core/page/dashboard_view/dashboard_view.js
+++ b/frappe/core/page/dashboard_view/dashboard_view.js
@@ -36,17 +36,17 @@ class Dashboard {
 		} else {
 			// last opened
 			if (frappe.last_dashboard) {
-				frappe.set_route('dashboard-view', frappe.last_dashboard);
+				frappe.set_re_route('dashboard-view', frappe.last_dashboard);
 			} else {
 				// default dashboard
 				frappe.db.get_list('Dashboard', {filters: {is_default: 1}}).then(data => {
 					if (data && data.length) {
-						frappe.set_route('dashboard-view', data[0].name);
+						frappe.set_re_route('dashboard-view', data[0].name);
 					} else {
 						// no default, get the latest one
 						frappe.db.get_list('Dashboard', {limit: 1}).then(data => {
 							if (data && data.length) {
-								frappe.set_route('dashboard-view', data[0].name);
+								frappe.set_re_route('dashboard-view', data[0].name);
 							} else {
 								// create a new dashboard!
 								frappe.new_doc('Dashboard');


### PR DESCRIPTION
Requires #12529

### Issue
Navigating back from `dashboard-view` page wasn't working.

### Fix
Using `set_re_route` instead of `set_route` to navigate to specific dashboard.

Note:
`set_re_route` creates a permanent redirect. If the logic to redirect to a specific dashboard needs to run every time the `dashboard-view` page is opened, a function that does a temporary JS redirect must be implemented in `frappe.router`.

---
**Before**

![Peek 2021-03-05 12-54](https://user-images.githubusercontent.com/38958184/110102533-e98b0500-7dca-11eb-99b9-e72077beb857.gif)

**After**

![Peek 2021-03-05 15-57](https://user-images.githubusercontent.com/38958184/110103147-9bc2cc80-7dcb-11eb-9d06-1e29f5ea9997.gif)
