### PR TITLE
fix: Document rename

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -621,6 +621,7 @@ $.extend(frappe.model, {
 							r.message || args.new_name]);
 						if(locals[doctype] && locals[doctype][docname])
 							delete locals[doctype][docname];
+						this.frm.reload_doc();
 						d.hide();
 						if(callback)
 							callback(r.message);


### PR DESCRIPTION
### Issue

Old Doc Not Found after renaming doc from the Menu.

### Fix

Reloading Doc after rename.

---

**Before**

![Peek 2021-03-05 18-08](https://user-images.githubusercontent.com/38958184/110117764-53ada500-7ddf-11eb-8046-1e206f80c641.gif)

**After**

![Peek 2021-03-05 18-31](https://user-images.githubusercontent.com/38958184/110118958-206c1580-7de1-11eb-945d-b8db3bce2226.gif)

