### PR TITLE
feat: allow query/custom reports to save custom data in the json field

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -37,7 +37,10 @@ def run_background(prepared_report):
 			custom_report_doc = report
 			reference_report = custom_report_doc.reference_report
 			report = frappe.get_doc("Report", reference_report)
-			report.custom_columns = custom_report_doc.json
+			if custom_report_doc.json:
+				data = json.loads(custom_report_doc.json)
+				if data:
+					report.custom_columns = data["columns"]
 
 		result = generate_report_result(
 			report=report,

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -36,7 +36,10 @@ def get_report_doc(report_name):
 		reference_report = custom_report_doc.reference_report
 		doc = frappe.get_doc("Report", reference_report)
 		doc.custom_report = report_name
-		doc.custom_columns = custom_report_doc.json
+		if custom_report_doc.json:
+			data = json.loads(custom_report_doc.json)
+			if data:
+				doc.custom_columns = data["columns"]
 		doc.is_custom_report = True
 
 	if not doc.is_permitted():
@@ -83,7 +86,7 @@ def generate_report_result(report, filters=None, user=None, custom_columns=None)
 
 	if report.custom_columns:
 		# saved columns (with custom columns / with different column order)
-		columns = json.loads(report.custom_columns)
+		columns = report.custom_columns
 
 	# unsaved custom_columns
 	if custom_columns:
@@ -524,9 +527,12 @@ def save_report(reference_report, report_name, columns):
 			"report_type": "Custom Report",
 		},
 	)
+
 	if docname:
 		report = frappe.get_doc("Report", docname)
-		report.update({"json": columns})
+		existing_jd = json.loads(report.json)
+		existing_jd["columns"] = json.loads(columns)
+		report.update({"json": json.dumps(existing_jd, separators=(',', ':'))})
 		report.save()
 		frappe.msgprint(_("Report updated successfully"))
 
@@ -536,7 +542,7 @@ def save_report(reference_report, report_name, columns):
 			{
 				"doctype": "Report",
 				"report_name": report_name,
-				"json": columns,
+				"json": f'{{"columns":{columns}}}',
 				"ref_doctype": report_doc.ref_doctype,
 				"is_standard": "No",
 				"report_type": "Custom Report",

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -334,3 +334,4 @@ frappe.patches.v13_0.delete_package_publish_tool
 frappe.patches.v13_0.rename_list_view_setting_to_list_view_settings
 frappe.patches.v13_0.remove_twilio_settings
 frappe.patches.v12_0.rename_uploaded_files_with_proper_name
+frappe.patches.v13_0.queryreport_columns

--- a/frappe/patches/v13_0/queryreport_columns.py
+++ b/frappe/patches/v13_0/queryreport_columns.py
@@ -2,7 +2,8 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-import frappe, json
+import frappe
+import json
 
 def execute():
 	"""Convert Query Report json to support other content"""

--- a/frappe/patches/v13_0/queryreport_columns.py
+++ b/frappe/patches/v13_0/queryreport_columns.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import frappe, json
+
+def execute():
+	"""Convert Query Report json to support other content"""
+	records = frappe.get_all('Report',
+		filters={
+			"json": ["!=", ""]
+		},
+		fields=["name", "json"]
+	)
+	for record in records:
+		jstr = record["json"]
+		data = json.loads(jstr)
+		if isinstance(data, list):
+			# double escape braces
+			jstr = f'{{"columns":{jstr}}}'
+			frappe.db.update('Report', record["name"], "json", jstr)


### PR DESCRIPTION
This change allows other customizations to a custom report to be saved rather than just adding/reordering columns.
It changes the JSON content to a dictionary containing a `columns` key with the columns list rather than solely the `columns` array

After:
![Screen Shot 2021-03-06 at 09 33 44](https://user-images.githubusercontent.com/64409021/110202296-80a19c80-7e5f-11eb-8766-aa1962d09efc.png)

> no-docs