### PR TITLE
fix: Section collapse in modal

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -289,7 +289,7 @@ frappe.ui.form.Layout = Class.extend({
 	},
 
 	refresh_section_collapse: function () {
-		if (!this.doc) return;
+		if (!(this.sections && this.sections.length)) return;
 
 		for (var i = 0; i < this.sections.length; i++) {
 			var section = this.sections[i];

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -52,6 +52,8 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		// make fields (if any)
 		super.make();
 
+		this.refresh_section_collapse();
+
 		// show footer
 		this.action = this.action || { primary: { }, secondary: { } };
 		if (this.primary_action || (this.action.primary && this.action.primary.onsubmit)) {


### PR DESCRIPTION
'collapsible': true was not working for the section in the modal

<img width="275" alt="Screenshot 2021-03-07 at 11 59 44 AM" src="https://user-images.githubusercontent.com/8780500/110231276-b2d4fc00-7f3c-11eb-82d6-d385fed4e36c.png">
