### PR TITLE
fix: include quill theme in website css

### DIFF
--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -1,4 +1,6 @@
 @import '~quill/dist/quill.core';
+@import '~quill/dist/quill.snow.css';
+@import '~quill/dist/quill.bubble.css';
 @import 'variables';
 @import '~bootstrap/scss/bootstrap';
 @import "../common/mixins";


### PR DESCRIPTION
Theme css are used by text editor in website view, without it the text editor doesn't render properly. (refer to linked issue for more context)

closes #12535

Before:
![image](https://user-images.githubusercontent.com/9079960/110320601-93ba9500-8036-11eb-9dfb-b4d614e36506.png)


After:
![image](https://user-images.githubusercontent.com/9079960/110320609-961cef00-8036-11eb-9795-3fc752a17829.png)

