### PR TITLE
fix: routing issues in recorder

### DIFF
--- a/frappe/core/page/recorder/recorder.js
+++ b/frappe/core/page/recorder/recorder.js
@@ -22,6 +22,7 @@ class Recorder {
 	}
 
 	show() {
-
+		if (!this.view || this.view.$route.name == "recorder-detail") return;
+		this.view.$router.replace({name: "recorder-detail"});
 	}
 }

--- a/frappe/public/js/frappe/recorder/RecorderRoot.vue
+++ b/frappe/public/js/frappe/recorder/RecorderRoot.vue
@@ -7,8 +7,11 @@
 <script>
 export default {
 	name: "RecorderRoot",
-	created() {
-		this.$router.push({name: 'recorder-detail'});
-	},
+	watch: {
+		$route() {
+			frappe.router.current_route = frappe.router.parse();
+			frappe.breadcrumbs.update();
+		}
+	}
 };
 </script>

--- a/frappe/public/js/frappe/recorder/RequestDetail.vue
+++ b/frappe/public/js/frappe/recorder/RequestDetail.vue
@@ -284,7 +284,7 @@ export default {
 		frappe.breadcrumbs.add({
 			type: 'Custom',
 			label: __('Recorder'),
-			route: '#recorder'
+			route: '/app/recorder'
 		});
 		frappe.call({
 			method: "frappe.recorder.get",

--- a/frappe/public/js/frappe/recorder/recorder.js
+++ b/frappe/public/js/frappe/recorder/recorder.js
@@ -18,6 +18,12 @@ const routes = [
 		path: '/request/:id',
 		component: RequestDetail,
 	},
+	{
+		path: '/',
+		redirect: {
+			name: "recorder-detail"
+		}
+	}
 ];
 
 const router = new VueRouter({
@@ -26,11 +32,11 @@ const router = new VueRouter({
 	routes: routes,
 });
 
-new Vue({
+frappe.recorder.view = new Vue({
 	el: ".recorder-container",
 	router: router,
 	data: {
-		page: cur_page.page.page
+		page: frappe.pages["recorder"].page
 	},
 	template: "<recorder-root/>",
 	components: {


### PR DESCRIPTION
## Issue 1: Recorder would not load the list of recorded requests randomly

### Screenshots

#### Before

![Screenshot-2021-03-10-170430](https://user-images.githubusercontent.com/16315650/110624068-ba5a0680-81c3-11eb-9d76-3ce53732aac8.png)

#### After

![recorder redirect after](https://user-images.githubusercontent.com/16315650/110624088-c2b24180-81c3-11eb-9eec-313b193b09da.gif)

### Changes made

- Added a redirect for `/` to `/detail` in VueRouter
- Removed redundant code in `created` method of `RecorderRoot.vue`
- Use `frappe.pages` instead of `cur_page` when initialising Vue.

## Issue 2: Recorder breadcrumb not working

### Screenshots

#### Before

![recorder breadcrumb before](https://user-images.githubusercontent.com/16315650/110625132-0d808900-81c5-11eb-9e60-3ef5881b3dac.gif)

#### After

![recorder breadcrumb after](https://user-images.githubusercontent.com/16315650/110625150-14a79700-81c5-11eb-824b-0f4ba26af3cb.gif)

### Changes made

- Change breadcrumb route to confirm with v2-style routing
- Store Vue object as `frappe.recorder.view`
- Breadcrumb triggered `page.show`, which did nothing previously. Changed it to set the current path to the list of recorded requests without affecting browser history (using VueRouter's `replace` method)
- Added a watcher to Vue's `$route` object. When this changes, `frappe.router.current_route` gets updated. This is useful as it is used by `frappe.breadcrumbs` to decide whether / not to show breadcrumbs. Also called `frappe.breadcrumbs.update` here so as to remove the `Recorder` breadcumb when navigating from individual request to request list view.
