### PR TITLE
fix: Document rename

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -381,7 +381,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 			method: method,
 			args: {
 				doctype: this.frm.doctype,
-				name: this.frm.doc.name,
+				name: this.frm.docname,
 				items: items
 			},
 			callback: function(r) {
@@ -681,7 +681,7 @@ class Section {
 		this.set_icon(hide);
 
 		// save state for next reload ('' is falsy)
-		localStorage.setItem(this.df.css_class + '-closed', hide ? '1' : '');	
+		localStorage.setItem(this.df.css_class + '-closed', hide ? '1' : '');
 	}
 
 	set_icon(hide) {

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -621,7 +621,6 @@ $.extend(frappe.model, {
 							r.message || args.new_name]);
 						if(locals[doctype] && locals[doctype][docname])
 							delete locals[doctype][docname];
-						this.frm.reload_doc();
 						d.hide();
 						if(callback)
 							callback(r.message);


### PR DESCRIPTION
Reverts #12532 because - 
- It caused another issue instead of solving the original one (`frappe.model` object does not have `frm` property).
- `reload_doc` wasn't required, setting `doc.name` as the new name would have sufficed.

---

A new working fix has been implemented. Since `frm.doc.name` points to the older name when `frm.refresh_header` is called, using `frm.docname` instead in `dashboard.refresh()`.

**Alternate solution:** Set `frm.doc.name` as well when setting `frm.docname` during `frm.rename_notify()`.