### PR TITLE
fix: Build priority on computers with low resources

### DIFF
--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -62,11 +62,24 @@ def popen(command, *args, **kwargs):
 	if env:
 		env = dict(environ, **env)
 
+	def set_low_prio():
+		import psutil
+		if psutil.LINUX:
+			psutil.Process().nice(19)
+			psutil.Process().ionice(psutil.IOPRIO_CLASS_IDLE)
+		elif psutil.WINDOWS:
+			psutil.Process().nice(psutil.IDLE_PRIORITY_CLASS)
+			psutil.Process().ionice(psutil.IOPRIO_VERYLOW)
+		else:
+			psutil.Process().nice(19)
+			# ionice not supported
+
 	proc = subprocess.Popen(command,
 		stdout=None if output else subprocess.PIPE,
 		stderr=None if output else subprocess.PIPE,
 		shell=shell,
 		cwd=cwd,
+		preexec_fn=set_low_prio,
 		env=env
 	)
 


### PR DESCRIPTION
fixes: frappe/bench#1135

This causes node/yarn process to be executed with low cpu and io priority. Rather than slow the build down on constrained and busy computers, it actually speeds it up, makes the computer usable and reduces deadlocking with swapping

Also recommend changing the supervisor.conf to set different priorities too. See the issue linked above