### PR TITLE
Chore: use semgrep cli instead of docker image

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,13 +1,22 @@
 name: Semgrep
 
 on:
-  pull_request: {}
-
+  pull_request:
+    branches:
+      - develop
 jobs:
   semgrep:
     name: Frappe Linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: returntocorp/semgrep-action@v1
-
+    - uses: actions/checkout@v2
+    - name: Setup python3
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Run semgrep
+      run: |
+        python -m pip install -q semgrep
+        git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF -q
+        files=$(git diff --name-only --diff-filter=d $GITHUB_BASE_REF)
+        if [ -f .semgrep.yml ]; then semgrep --config=.semgrep.yml --quiet --error $files; fi


### PR DESCRIPTION
CLI is more flexible at present. Until github action catches up, switch to CLI version.

This also fixes failure from forks which don't contain semgrep config yet.
