### PR TITLE
test: encoding @ since we encode each url

### DIFF
--- a/cypress/integration/table_multiselect.js
+++ b/cypress/integration/table_multiselect.js
@@ -45,6 +45,6 @@ context('Table MultiSelect', () => {
 		cy.get(`.list-subject:contains("table multiselect")`).last().find('a').click();
 		cy.get('.frappe-control[data-fieldname="users"] .form-control .tb-selected-value').as('existing_value');
 		cy.get('@existing_value').find('.btn-link-to-form').click();
-		cy.location('pathname').should('contain', '/user/test@erpnext.com');
+		cy.location('pathname').should('contain', '/user/test%40erpnext.com');
 	});
 });


### PR DESCRIPTION
`Table multiselect Test` test fails because it expects unencoded `@` but now we encode all url's  

![image](https://user-images.githubusercontent.com/28212972/110809147-a6d59b00-82aa-11eb-8643-c317e112b5b2.png)
