### PR TITLE
fix: Redirect Web Form user directly to success URL, if no amount is due

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -212,6 +212,11 @@ def get_context(context):
 			amount = self.amount
 			if self.amount_based_on_field:
 				amount = doc.get(self.amount_field)
+				
+			from decimal import Decimal
+			if amount is None or Decimal(amount) <= 0:
+				return frappe.utils.get_url(self.success_url or self.route)
+
 			payment_details = {
 				"amount": amount,
 				"title": title,


### PR DESCRIPTION
If there is no amount due when using WebForms which accept payments, redirect the user directly to the success URL. This is useful for free items.