### PR TITLE
fix: Remove unused parameter

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -483,7 +483,6 @@ def console(context):
 @click.option('--doctype', help="For DocType")
 @click.option('--doctype-list-path', help="Path to .txt file for list of doctypes. Example erpnext/tests/server/agriculture.txt")
 @click.option('--test', multiple=True, help="Specific test")
-@click.option('--driver', help="For Travis")
 @click.option('--ui-tests', is_flag=True, default=False, help="Run UI Tests")
 @click.option('--module', help="Run tests in a module")
 @click.option('--profile', is_flag=True, default=False)
@@ -493,9 +492,9 @@ def console(context):
 @click.option('--junit-xml-output', help="Destination file path for junit xml report")
 @click.option('--failfast', is_flag=True, default=False)
 @pass_context
-def run_tests(context, app=None, module=None, doctype=None, test=(),
-	driver=None, profile=False, coverage=False, junit_xml_output=False, ui_tests = False,
-	doctype_list_path=None, skip_test_records=False, skip_before_tests=False, failfast=False):
+def run_tests(context, app=None, module=None, doctype=None, test=(), profile=False,
+		coverage=False, junit_xml_output=False, ui_tests = False, doctype_list_path=None,
+		skip_test_records=False, skip_before_tests=False, failfast=False):
 
 	"Run tests"
 	import frappe.test_runner
@@ -535,8 +534,8 @@ def run_tests(context, app=None, module=None, doctype=None, test=(),
 		cov.start()
 
 	ret = frappe.test_runner.main(app, module, doctype, context.verbose, tests=tests,
-								force=context.force, profile=profile, junit_xml_output=junit_xml_output,
-								ui_tests=ui_tests, doctype_list_path=doctype_list_path, failfast=failfast)
+		force=context.force, profile=profile, junit_xml_output=junit_xml_output,
+		ui_tests=ui_tests, doctype_list_path=doctype_list_path, failfast=failfast)
 
 	if coverage:
 		cov.stop()


### PR DESCRIPTION
- Remove unused parameter from `run-tests` command