### PR TITLE
fix: Remove the starting new line from send email popup body

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -775,8 +775,8 @@ frappe.views.CommunicationComposer = Class.extend({
 
 			let communication_date = last_email.communication_date || last_email.creation;
 			content = `
-				<div><br></div>
 				${reply}
+				<div><br></div>
 				${frappe.separator_element || ''}
 				<p>${__("On {0}, {1} wrote:", [frappe.datetime.global_date_format(communication_date) , last_email.sender])}</p>
 				<blockquote>
@@ -784,7 +784,7 @@ frappe.views.CommunicationComposer = Class.extend({
 				</blockquote>
 			`;
 		} else {
-			content = "<div><br></div>" + reply;
+			content = reply;
 		}
 		fields.content.set_value(content);
 	},


### PR DESCRIPTION
New line is needed at start of the email body only when sending a reply to
existing emails but not in any other cases.

Before (There is an empty line before the salutation):
![email_quotation](https://user-images.githubusercontent.com/36557/111121311-7d5e8d00-8592-11eb-8b3c-da52c4851f34.png)

After removing empty line:
![K19xCALKa2](https://user-images.githubusercontent.com/36557/111121368-8fd8c680-8592-11eb-9da9-17eca0d7863d.gif)
