### PR TITLE
ci: update badge in README and add push event trigger

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,8 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-  workflow_dispatch:
+on: [pull_request, workflow_dispatch, push]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 </div>
 
 <div align="center">
-    <a href="https://travis-ci.com/frappe/frappe">
-        <img src="https://travis-ci.com/frappe/frappe.svg?branch=develop">
+    <a href="https://github.com/frappe/frappe/actions/workflows/ci-tests.yml">
+        <img src="https://github.com/frappe/frappe/actions/workflows/ci-tests.yml/badge.svg?branch=develop">
     </a>
     <a href='https://frappeframework.com/docs'>
         <img src='https://img.shields.io/badge/docs-📖-7575FF.svg?style=flat-square'/>


### PR DESCRIPTION
The new badge looks like this: 

<img src="https://github.com/frappe/frappe/actions/workflows/ci-tests.yml/badge.svg?branch=develop">

---
The `push` trigger is needed to:
- update badge
- run the CI on manual commits

The badge also gets updated on the `workflow_dispatch` trigger (manual), but not the `pull_request` trigger (because it may not get merged).
