### PR TITLE
test: reduce chance of failure by stricter comparison

### DIFF
--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -19,7 +19,7 @@ class TestDB(unittest.TestCase):
 		self.assertEqual(frappe.db.get_value("User", {"name": ["=", "Administrator"]}), "Administrator")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["like", "Admin%"]}), "Administrator")
 		self.assertNotEquals(frappe.db.get_value("User", {"name": ["!=", "Guest"]}), "Guest")
-		self.assertEqual(frappe.db.get_value("User", {"name": ["<", "B"]}), "Administrator")
+		self.assertEqual(frappe.db.get_value("User", {"name": ["<", "Adn"]}), "Administrator")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<=", "Administrator"]}), "Administrator")
 
 		self.assertEqual(frappe.db.sql("""SELECT name FROM `tabUser` WHERE name > 's' ORDER BY MODIFIED DESC""")[0][0],


### PR DESCRIPTION
The test changed in this code used to fail randomly ([example](https://github.com/frappe/frappe/runs/2124414803#step:15:110)). Fixed by doing a stricter comparison.