### PR TITLE
fix: Support calling get_context without a param

### DIFF
--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -50,8 +50,12 @@ def update_controller_context(context, controller):
 				context[prop] = getattr(module, prop)
 
 		if hasattr(module, "get_context"):
+			import inspect
 			try:
-				ret = module.get_context(context)
+				if inspect.getargspec(module.get_context).args:
+					ret = module.get_context(context)
+				else:
+					ret = module.get_context()
 				if ret:
 					context.update(ret)
 			except (frappe.PermissionError, frappe.DoesNotExistError, frappe.Redirect):


### PR DESCRIPTION
For web pages in `www` folder, you can write a python file to update context to render a page.

For e.g.,

**www/test.html**
```
<div>Hello {{ message }}</div>
```

**www/test.py**
```py
def get_context(context): <-- you need to pass context variable here
  return {
    'message': 'world'
  }
```

If you are not directly working with the context variable, you are still required to pass it because of the way `frappe` calls the `get_context` method.

Not anymore. Now this will work.

**www/test.py**
```py
def get_context(): <-- it's gone
  return {
    'message': 'world'
  }
```

That's it.