### PR TITLE
revert: "fix: include space and tab in special characters to match to encode url"

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -335,7 +335,10 @@ frappe.router = {
 				return null;
 			} else {
 				a = String(a);
-				a = encodeURIComponent(a);
+				if (a && a.match(/[%'"]/)) {
+					// if special chars, then encode
+					a = encodeURIComponent(a);
+				}
 				return a;
 			}
 		}).join('/');


### PR DESCRIPTION
Reverts frappe/frappe#12464

URLs with "#" are breaking. We can handle spaces as suggested in https://github.com/frappe/frappe/pull/12464#discussion_r582797402 in a later PR.