### PR TITLE
fix: validate link field in the backend with filters

### DIFF
--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -24,14 +24,21 @@ def validate_link():
 	import frappe
 	import frappe.utils
 
-	value, options, fetch = frappe.form_dict.get('value'), frappe.form_dict.get('options'), frappe.form_dict.get('fetch')
+	value, options, fetch, filters = frappe.form_dict.get('value'), frappe.form_dict.get('options'), frappe.form_dict.get('fetch'), frappe.form_dict.get('filters')
 
 	# no options, don't validate
 	if not options or options=='null' or options=='undefined':
 		frappe.response['message'] = 'Ok'
 		return
 
-	valid_value = frappe.db.get_all(options, filters=dict(name=value), as_list=1, limit=1)
+	filters = json.loads(filters) if filters else dict()
+
+	if isinstance(filters, dict):
+		filters = dict(name=value, **filters)
+	if isinstance(filters, list):
+		filters.append(["name", "=", value])
+
+	valid_value = frappe.db.get_all(options, filters, as_list=1, limit=1)
 
 	if valid_value:
 		valid_value = valid_value[0][0]

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -13,23 +13,23 @@ from six import string_types
 
 @frappe.whitelist()
 def remove_attach():
-	"""remove attachment"""
-	fid = frappe.form_dict.get('fid')
-	file_name = frappe.form_dict.get('file_name')
-	frappe.delete_doc('File', fid)
+    """remove attachment"""
+    fid = frappe.form_dict.get('fid')
+    file_name = frappe.form_dict.get('file_name')
+    frappe.delete_doc('File', fid)
 
 @frappe.whitelist()
 def validate_link():
-	"""validate link when updated by user"""
-	import frappe
-	import frappe.utils
+    """validate link when updated by user"""
+    import frappe
+    import frappe.utils
 
     value, options, fetch, filters = frappe.form_dict.get('value'), frappe.form_dict.get('options'), frappe.form_dict.get('fetch'), frappe.form_dict.get('filters')
 
-	# no options, don't validate
-	if not options or options=='null' or options=='undefined':
-		frappe.response['message'] = 'Ok'
-		return
+    # no options, don't validate
+    if not options or options=='null' or options=='undefined':
+        frappe.response['message'] = 'Ok'
+        return
 
     filters = json.loads(filters) if filters else dict()
 
@@ -40,91 +40,91 @@ def validate_link():
 
     valid_value = frappe.db.get_all(options, filters, as_list=1, limit=1)
 
-	if valid_value:
-		valid_value = valid_value[0][0]
+    if valid_value:
+        valid_value = valid_value[0][0]
 
-		# get fetch values
-		if fetch:
-			# escape with "`"
-			fetch = ", ".join(("`{0}`".format(f.strip()) for f in fetch.split(",")))
-			fetch_value = None
-			try:
-				fetch_value = frappe.db.sql("select %s from `tab%s` where name=%s"
-					% (fetch, options, '%s'), (value,))[0]
-			except Exception as e:
-				error_message = str(e).split("Unknown column '")
-				fieldname = None if len(error_message)<=1 else error_message[1].split("'")[0]
-				frappe.msgprint(_("Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script").format(fieldname))
-				frappe.errprint(frappe.get_traceback())
+        # get fetch values
+        if fetch:
+            # escape with "`"
+            fetch = ", ".join(("`{0}`".format(f.strip()) for f in fetch.split(",")))
+            fetch_value = None
+            try:
+                fetch_value = frappe.db.sql("select %s from `tab%s` where name=%s"
+                    % (fetch, options, '%s'), (value,))[0]
+            except Exception as e:
+                error_message = str(e).split("Unknown column '")
+                fieldname = None if len(error_message)<=1 else error_message[1].split("'")[0]
+                frappe.msgprint(_("Wrong fieldname <b>{0}</b> in add_fetch configuration of custom script").format(fieldname))
+                frappe.errprint(frappe.get_traceback())
 
-			if fetch_value:
-				frappe.response['fetch_values'] = [frappe.utils.parse_val(c) for c in fetch_value]
+            if fetch_value:
+                frappe.response['fetch_values'] = [frappe.utils.parse_val(c) for c in fetch_value]
 
-		frappe.response['valid_value'] = valid_value
-		frappe.response['message'] = 'Ok'
+        frappe.response['valid_value'] = valid_value
+        frappe.response['message'] = 'Ok'
 
 @frappe.whitelist()
 def add_comment(reference_doctype, reference_name, content, comment_email):
-	"""allow any logged user to post a comment"""
-	doc = frappe.get_doc(dict(
-		doctype = 'Comment',
-		reference_doctype = reference_doctype,
-		reference_name = reference_name,
-		comment_email = comment_email,
-		comment_type = 'Comment'
-	))
-	doc.content = extract_images_from_html(doc, content)
-	doc.insert(ignore_permissions = True)
+    """allow any logged user to post a comment"""
+    doc = frappe.get_doc(dict(
+        doctype = 'Comment',
+        reference_doctype = reference_doctype,
+        reference_name = reference_name,
+        comment_email = comment_email,
+        comment_type = 'Comment'
+    ))
+    doc.content = extract_images_from_html(doc, content)
+    doc.insert(ignore_permissions = True)
 
-	follow_document(doc.reference_doctype, doc.reference_name, frappe.session.user)
-	return doc.as_dict()
+    follow_document(doc.reference_doctype, doc.reference_name, frappe.session.user)
+    return doc.as_dict()
 
 @frappe.whitelist()
 def update_comment(name, content):
-	"""allow only owner to update comment"""
-	doc = frappe.get_doc('Comment', name)
+    """allow only owner to update comment"""
+    doc = frappe.get_doc('Comment', name)
 
-	if frappe.session.user not in ['Administrator', doc.owner]:
-		frappe.throw(_('Comment can only be edited by the owner'), frappe.PermissionError)
+    if frappe.session.user not in ['Administrator', doc.owner]:
+        frappe.throw(_('Comment can only be edited by the owner'), frappe.PermissionError)
 
-	doc.content = content
-	doc.save(ignore_permissions=True)
+    doc.content = content
+    doc.save(ignore_permissions=True)
 
 @frappe.whitelist()
 def get_next(doctype, value, prev, filters=None, sort_order='desc', sort_field='modified'):
 
-	prev = int(prev)
-	if not filters: filters = []
-	if isinstance(filters, string_types):
-		filters = json.loads(filters)
+    prev = int(prev)
+    if not filters: filters = []
+    if isinstance(filters, string_types):
+        filters = json.loads(filters)
 
-	# # condition based on sort order
-	condition = ">" if sort_order.lower() == "asc" else "<"
+    # # condition based on sort order
+    condition = ">" if sort_order.lower() == "asc" else "<"
 
-	# switch the condition
-	if prev:
-		sort_order = "asc" if sort_order.lower() == "desc" else "desc"
-		condition = "<" if condition == ">" else ">"
+    # switch the condition
+    if prev:
+        sort_order = "asc" if sort_order.lower() == "desc" else "desc"
+        condition = "<" if condition == ">" else ">"
 
-	# # add condition for next or prev item
-	filters.append([doctype, sort_field, condition, frappe.get_value(doctype, value, sort_field)])
+    # # add condition for next or prev item
+    filters.append([doctype, sort_field, condition, frappe.get_value(doctype, value, sort_field)])
 
-	res = frappe.get_list(doctype,
-		fields = ["name"],
-		filters = filters,
-		order_by = "`tab{0}`.{1}".format(doctype, sort_field) + " " + sort_order,
-		limit_start=0, limit_page_length=1, as_list=True)
+    res = frappe.get_list(doctype,
+        fields = ["name"],
+        filters = filters,
+        order_by = "`tab{0}`.{1}".format(doctype, sort_field) + " " + sort_order,
+        limit_start=0, limit_page_length=1, as_list=True)
 
-	if not res:
-		frappe.msgprint(_("No further records"))
-		return None
-	else:
-		return res[0][0]
+    if not res:
+        frappe.msgprint(_("No further records"))
+        return None
+    else:
+        return res[0][0]
 
 def get_pdf_link(doctype, docname, print_format='Standard', no_letterhead=0):
-	return '/api/method/frappe.utils.print_format.download_pdf?doctype={doctype}&name={docname}&format={print_format}&no_letterhead={no_letterhead}'.format(
-		doctype = doctype,
-		docname = docname,
-		print_format = print_format,
-		no_letterhead = no_letterhead
-	)
+    return '/api/method/frappe.utils.print_format.download_pdf?doctype={doctype}&name={docname}&format={print_format}&no_letterhead={no_letterhead}'.format(
+        doctype = doctype,
+        docname = docname,
+        print_format = print_format,
+        no_letterhead = no_letterhead
+    )

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -15,7 +15,6 @@ from six import string_types
 def remove_attach():
     """remove attachment"""
     fid = frappe.form_dict.get('fid')
-    file_name = frappe.form_dict.get('file_name')
     frappe.delete_doc('File', fid)
 
 @frappe.whitelist()
@@ -94,7 +93,7 @@ def update_comment(name, content):
 def get_next(doctype, value, prev, filters=None, sort_order='desc', sort_field='modified'):
 
     prev = int(prev)
-    if not filters: filters = []
+    filters = filters or filters
     if isinstance(filters, string_types):
         filters = json.loads(filters)
 

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -24,21 +24,21 @@ def validate_link():
 	import frappe
 	import frappe.utils
 
-	value, options, fetch, filters = frappe.form_dict.get('value'), frappe.form_dict.get('options'), frappe.form_dict.get('fetch'), frappe.form_dict.get('filters')
+    value, options, fetch, filters = frappe.form_dict.get('value'), frappe.form_dict.get('options'), frappe.form_dict.get('fetch'), frappe.form_dict.get('filters')
 
 	# no options, don't validate
 	if not options or options=='null' or options=='undefined':
 		frappe.response['message'] = 'Ok'
 		return
 
-	filters = json.loads(filters) if filters else dict()
+    filters = json.loads(filters) if filters else dict()
 
-	if isinstance(filters, dict):
-		filters = dict(name=value, **filters)
-	if isinstance(filters, list):
-		filters.append(["name", "=", value])
+    if isinstance(filters, dict):
+        filters = dict(name=value, **filters)
+    if isinstance(filters, list):
+        filters.append(["name", "=", value])
 
-	valid_value = frappe.db.get_all(options, filters, as_list=1, limit=1)
+    valid_value = frappe.db.get_all(options, filters, as_list=1, limit=1)
 
 	if valid_value:
 		valid_value = valid_value[0][0]

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -430,43 +430,41 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			this.docname, value);
 	},
 	validate_link_and_fetch: function(df, doctype, docname, value) {
+		if(!value) { return; }
 		var me = this;
 
-		if(value) {
-			return new Promise((resolve) => {
-				var fetch = '';
+		return new Promise((resolve) => {
+			var fetch = '';
+			var args = {}
 
-				if(this.frm && this.frm.fetch_dict[df.fieldname]) {
-					fetch = this.frm.fetch_dict[df.fieldname].columns.join(', ');
-				}
+			this.set_custom_query(args);
 
-				// check if value exist in the filtered dropdown values 
-				if (this.$input.cache[doctype] && !this.$input.cache[doctype][""].some(d => d.value === value)) {
-					value = "";
-				}
+			if(this.frm && this.frm.fetch_dict[df.fieldname]) {
+				fetch = this.frm.fetch_dict[df.fieldname].columns.join(', ');
+			}
 
-				return frappe.call({
-					method:'frappe.desk.form.utils.validate_link',
-					type: "GET",
-					args: {
-						'value': value,
-						'options': doctype,
-						'fetch': fetch
-					},
-					no_spinner: true,
-					callback: function(r) {
-						if(r.message=='Ok') {
-							if(r.fetch_values && docname) {
-								me.set_fetch_values(df, docname, r.fetch_values);
-							}
-							resolve(r.valid_value);
-						} else {
-							resolve("");
+			return frappe.call({
+				method:'frappe.desk.form.utils.validate_link',
+				type: "GET",
+				args: {
+					'value': value,
+					'options': doctype,
+					'fetch': fetch,
+					'filters': args.filters
+				},
+				no_spinner: true,
+				callback: function(r) {
+					if(r.message=='Ok') {
+						if(r.fetch_values && docname) {
+							me.set_fetch_values(df, docname, r.fetch_values);
 						}
+						resolve(r.valid_value);
+					} else {
+						resolve("");
 					}
-				});
+				}
 			});
-		}
+		});
 	},
 	set_fetch_values: function(df, docname, fetch_values) {
 		var fl = this.frm.fetch_dict[df.fieldname].fields;

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -25,14 +25,14 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		this.set_input_attributes();
 		this.$input.on("focus", function() {
 			setTimeout(function() {
-				if(me.$input.val() && me.get_options()) {
+				if (me.$input.val() && me.get_options()) {
 					let doctype = me.get_options();
 					let name = me.$input.val();
 					me.$link.toggle(true);
 					me.$link_open.attr('href', frappe.utils.get_form_link(doctype, name));
 				}
 
-				if(!me.$input.val()) {
+				if (!me.$input.val()) {
 					me.$input.val("").trigger("input");
 				}
 			}, 500);
@@ -63,13 +63,13 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		}
 	},
 	setup_buttons: function() {
-		if(this.only_input && !this.with_link_btn) {
+		if (this.only_input && !this.with_link_btn) {
 			this.$input_area.find(".link-btn").remove();
 		}
 	},
 	open_advanced_search: function() {
 		var doctype = this.get_options();
-		if(!doctype) return;
+		if (!doctype) return;
 		new frappe.ui.form.LinkSelector({
 			doctype: doctype,
 			target: this,
@@ -81,10 +81,10 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		var doctype = this.get_options();
 		var me = this;
 
-		if(!doctype) return;
+		if (!doctype) return;
 
 		// set values to fill in the new document
-		if(this.df.get_route_options_for_new_doc) {
+		if (this.df.get_route_options_for_new_doc) {
 			frappe.route_options = this.df.get_route_options_for_new_doc(this);
 		} else {
 			frappe.route_options = {};
@@ -124,11 +124,13 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			},
 			item: function (item) {
 				var d = this.get_item(item.value);
-				if(!d.label) {	d.label = d.value; }
+				if (!d.label) {
+					d.label = d.value;
+				}
 
 				var _label = (me.translate_values) ? __(d.label) : d.label;
 				var html = d.html || "<strong>" + _label + "</strong>";
-				if(d.description && d.value!==d.description) {
+				if (d.description && d.value!==d.description) {
 					html += '<br><span class="small">' + __(d.description) + '</span>';
 				}
 				return $('<li></li>')
@@ -144,7 +146,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 
 		this.$input.on("input", frappe.utils.debounce(function(e) {
 			var doctype = me.get_options();
-			if(!doctype) return;
+			if (!doctype) return;
 			if (!me.$input.cache[doctype]) {
 				me.$input.cache[doctype] = {};
 			}
@@ -166,11 +168,11 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 
 			frappe.call({
 				type: "POST",
-				method:'frappe.desk.search.search_link',
+				method: 'frappe.desk.search.search_link',
 				no_spinner: true,
 				args: args,
 				callback: function(r) {
-					if(!me.$input.is(":focus")) {
+					if (!me.$input.is(":focus")) {
 						return;
 					}
 					r.results = me.merge_duplicates(r.results);
@@ -187,8 +189,8 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 						}
 					}
 
-					if(!me.df.only_select) {
-						if(frappe.model.can_create(doctype)) {
+					if (!me.df.only_select) {
+						if (frappe.model.can_create(doctype)) {
 							// new item
 							r.results.push({
 								label: "<span class='text-primary link-option'>"
@@ -220,12 +222,12 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		}, 500));
 
 		this.$input.on("blur", function() {
-			if(me.selected) {
+			if (me.selected) {
 				me.selected = false;
 				return;
 			}
 			var value = me.get_input_value();
-			if(value!==me.last_value) {
+			if (value!==me.last_value) {
 				me.parse_validate_and_set_in_model(value);
 			}
 		});
@@ -249,13 +251,13 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 
 			// prevent selection on tab
 			var TABKEY = 9;
-			if(e.keyCode === TABKEY) {
+			if (e.keyCode === TABKEY) {
 				e.preventDefault();
 				me.awesomplete.close();
 				return false;
 			}
 
-			if(item.action) {
+			if (item.action) {
 				item.value = "";
 				item.action.apply(me);
 			}
@@ -264,7 +266,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			// then add this value
 			// to defaults so you do not need to set it again
 			// unless it is changed.
-			if(me.df.remember_last_selected_value) {
+			if (me.df.remember_last_selected_value) {
 				frappe.boot.user.last_selected_values[me.df.options] = item.value;
 			}
 
@@ -273,7 +275,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 
 		this.$input.on("awesomplete-selectcomplete", function(e) {
 			var o = e.originalEvent;
-			if(o.text.value.indexOf("__link_option") !== -1) {
+			if (o.text.value.indexOf("__link_option") !== -1) {
 				me.$input.val("");
 			}
 		});
@@ -354,20 +356,20 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	set_custom_query: function(args) {
 		var set_nulls = function(obj) {
 			$.each(obj, function(key, value) {
-				if(value!==undefined) {
+				if (value!==undefined) {
 					obj[key] = value;
 				}
 			});
 			return obj;
 		};
-		if(this.get_query || this.df.get_query) {
+		if (this.get_query || this.df.get_query) {
 			var get_query = this.get_query || this.df.get_query;
-			if($.isPlainObject(get_query)) {
+			if ($.isPlainObject(get_query)) {
 				var filters = null;
-				if(get_query.filters) {
+				if (get_query.filters) {
 					// passed as {'filters': {'key':'value'}}
 					filters = get_query.filters;
-				} else if(get_query.query) {
+				} else if (get_query.query) {
 
 					// passed as {'query': 'path.to.method'}
 					args.query = get_query;
@@ -386,23 +388,23 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 					// add "filters" for standard query (search.py)
 					args.filters = filters;
 				}
-			} else if(typeof(get_query)==="string") {
+			} else if (typeof (get_query)==="string") {
 				args.query = get_query;
 			} else {
 				// get_query by function
 				var q = (get_query)(this.frm && this.frm.doc || this.doc, this.doctype, this.docname);
 
-				if (typeof(q)==="string") {
+				if (typeof (q)==="string") {
 					// returns a string
 					args.query = q;
-				} else if($.isPlainObject(q)) {
+				} else if ($.isPlainObject(q)) {
 					// returns a plain object with filters
-					if(q.filters) {
+					if (q.filters) {
 						set_nulls(q.filters);
 					}
 
 					// turn off value translation
-					if(q.translate_values !== undefined) {
+					if (q.translate_values !== undefined) {
 						this.translate_values = q.translate_values;
 					}
 
@@ -414,15 +416,15 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				}
 			}
 		}
-		if(this.df.filters) {
+		if (this.df.filters) {
 			set_nulls(this.df.filters);
-			if(!args.filters) args.filters = {};
+			if (!args.filters) args.filters = {};
 			$.extend(args.filters, this.df.filters);
 		}
 	},
 	validate: function(value) {
 		// validate the value just entered
-		if(this.df.options=="[Select]" || this.df.ignore_link_validation) {
+		if (this.df.options=="[Select]" || this.df.ignore_link_validation) {
 			return value;
 		}
 
@@ -430,21 +432,21 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			this.docname, value);
 	},
 	validate_link_and_fetch: function(df, doctype, docname, value) {
-		if(!value) { return; }
+		if (!value) return;
 		var me = this;
 
 		return new Promise((resolve) => {
 			var fetch = '';
-			var args = {}
+			var args = {};
 
 			this.set_custom_query(args);
 
-			if(this.frm && this.frm.fetch_dict[df.fieldname]) {
+			if (this.frm && this.frm.fetch_dict[df.fieldname]) {
 				fetch = this.frm.fetch_dict[df.fieldname].columns.join(', ');
 			}
 
 			return frappe.call({
-				method:'frappe.desk.form.utils.validate_link',
+				method: 'frappe.desk.form.utils.validate_link',
 				type: "GET",
 				args: {
 					'value': value,
@@ -454,8 +456,8 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 				},
 				no_spinner: true,
 				callback: function(r) {
-					if(r.message=='Ok') {
-						if(r.fetch_values && docname) {
+					if (r.message=='Ok') {
+						if (r.fetch_values && docname) {
 							me.set_fetch_values(df, docname, r.fetch_values);
 						}
 						resolve(r.valid_value);
@@ -468,13 +470,13 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	},
 	set_fetch_values: function(df, docname, fetch_values) {
 		var fl = this.frm.fetch_dict[df.fieldname].fields;
-		for(var i=0; i < fl.length; i++) {
+		for (var i=0; i < fl.length; i++) {
 			frappe.model.set_value(df.parent, docname, fl[i], fetch_values[i], df.fieldtype);
 		}
 	}
 });
 
-if(Awesomplete) {
+if (Awesomplete) {
 	Awesomplete.prototype.get_item = function(value) {
 		return this._list.find(function(item) {
 			return item.value === value;


### PR DESCRIPTION
The issue #12627 is caused by the following:

Currently the **Link Field** clears it's value if the value is not found in the js cache, `$input.cache[doctype][""]`, but It doesn't take into account the cache of search terms `$input.cache[doctype][term]`, and additional values shown by the  **Link Selector** when you click the "More button" (which are not saved in the cache).

This was implemented in version 12.16.0 in order to fix previous issues (#9944 and  #7235). Those issues describe that you can input a value of the same doctype even if it doesn't appear as an option due to the filters and it won't validate those filters on the backed letting you keep the value.

This PR solves this issue by sending the filters to the backend and validating against them, as suggested by @SaiFi0102 back in 2019 ([see comment](https://github.com/frappe/frappe/issues/7235#issuecomment-486092621))

