### PR TITLE
fix: Webform user getting error while adding items in child table

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -256,13 +256,13 @@ $.extend(frappe.model, {
 	},
 
 	can_select: function(doctype) {
-		if(frappe.boot.user) {
+		if (frappe.boot.user) {
 			return frappe.boot.user.can_select.indexOf(doctype)!==-1;
 		}
 	},
 
 	can_read: function(doctype) {
-		if(frappe.boot.user) {
+		if (frappe.boot.user) {
 			return frappe.boot.user.can_read.indexOf(doctype)!==-1;
 		}
 	},

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -256,11 +256,15 @@ $.extend(frappe.model, {
 	},
 
 	can_select: function(doctype) {
-		return frappe.boot.user.can_select.indexOf(doctype)!==-1;
+		if(frappe.boot.user) {
+			return frappe.boot.user.can_select.indexOf(doctype)!==-1;
+		}
 	},
 
 	can_read: function(doctype) {
-		return frappe.boot.user.can_read.indexOf(doctype)!==-1;
+		if(frappe.boot.user) {
+			return frappe.boot.user.can_read.indexOf(doctype)!==-1;
+		}
 	},
 
 	can_write: function(doctype) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -834,7 +834,7 @@ Object.assign(frappe.utils, {
 	get_form_link: function(doctype, name, html = false, display_text = null) {
 		display_text = display_text || name;
 		name = encodeURIComponent(name);
-		const route = `/app/${encodeURIComponent(frappe.router.slug(doctype))}/${name}`;
+		const route = `/app/${encodeURIComponent(doctype.toLowerCase().replace(/ /g, '-'))}/${name}`;
 		if (html) {
 			return `<a href="${route}">${display_text}</a>`;
 		}


### PR DESCRIPTION
On web form, `frappe.boot.user` is undefined hence, `can_select` and `can_read` do not work.
Also, `frappe.router.slug(doctype)` is also not accessible so using code directly without calling it.