### PR TITLE
fix: include space and tab in special characters to match to encode url

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -335,7 +335,7 @@ frappe.router = {
 				return null;
 			} else {
 				a = String(a);
-				if (a && a.match(/[%'"]/)) {
+				if (a && a.match(/[%'"\s\t]/)) {
 					// if special chars, then encode
 					a = encodeURIComponent(a);
 				}


### PR DESCRIPTION
Implements original fix in https://github.com/frappe/frappe/pull/12464:

If a docname contains a trailing space or a tab, the routing breaks:

<img width="1089" alt="Screenshot 2021-02-23 at 1 51 03 PM" src="https://user-images.githubusercontent.com/19775888/108817627-322e0b80-75de-11eb-95f8-a3cab5a283b5.png">

