### PR TITLE
fix: Auth failing

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -536,9 +536,15 @@ class User(Document):
 		"""Find the user by credentials.
 		"""
 		login_with_mobile = cint(frappe.db.get_value("System Settings", "System Settings", "allow_login_using_mobile_number"))
-		filter = {"mobile_no": user_name} if login_with_mobile else {"name": user_name}
 
-		user = frappe.db.get_value("User", filters=filter, fieldname=['name', 'enabled'], as_dict=True) or {}
+		user = None
+		if login_with_mobile:
+			filter = {"mobile_no": user_name}
+			user = frappe.db.get_value("User", filters=filter, fieldname=['name', 'enabled'], as_dict=True)
+		if not user:
+			filter = {"name": user_name}
+			user = frappe.db.get_value("User", filters=filter, fieldname=['name', 'enabled'], as_dict=True)
+
 		if not user:
 			return
 

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -4,7 +4,24 @@ from __future__ import unicode_literals
 
 import time
 import unittest
+
+import frappe
 from frappe.auth import LoginAttemptTracker
+from frappe.frappeclient import FrappeClient
+
+
+class TestAuth(unittest.TestCase):
+	def test_admin_login(self):
+		# Make sure that authentication works when allow_login_using_mobile_number is set to 0
+		frappe.db.set_value("System Settings", "System Settings", "allow_login_using_mobile_number", 0)
+		frappe.db.commit()
+		FrappeClient(frappe.get_site_config().host_name, "Administrator", "admin", verify=False)
+
+		# Make sure that authentication works when allow_login_using_mobile_number is set to 1
+		frappe.db.set_value("System Settings", "System Settings", "allow_login_using_mobile_number", 1)
+		frappe.db.commit()
+		FrappeClient(frappe.get_site_config().host_name, "Administrator", "admin", verify=False)
+
 
 class TestLoginAttemptTracker(unittest.TestCase):
 	def test_account_lock(self):


### PR DESCRIPTION
**ISSUE:** Login is failing when allow_login_using_mobile_number is set

When system setting named `allow_login_using_mobile_number` is set, we are doing auth validation With respect to mobile_no with the assumption that all logins use mobile number  as username though that is not really the case.

Ideally we should match auth credential with mobile number if `allow_login_using_mobile_number` is set and if there is no match found then should match with the username to find the user. This is the fix applied.

Related issue is @ https://github.com/frappe/erpnext/issues/24967

Fixes: https://github.com/frappe/frappe/issues/12643
