### PR TITLE
fix: Remove 'ignore_user_type' from user filter

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -874,6 +874,7 @@ def user_query(doctype, txt, searchfield, start, page_len, filters):
 	user_type_condition = "and user_type = 'System User'"
 	if filters and filters.get('ignore_user_type'):
 		user_type_condition = ''
+		filters.pop('ignore_user_type')
 
 	txt = "%{}%".format(txt)
 	return frappe.db.sql("""SELECT `name`, CONCAT_WS(' ', first_name, middle_name, last_name)


### PR DESCRIPTION
**Fixes:**
<img width="1440" alt="Screenshot 2021-03-23 at 9 54 56 AM" src="https://user-images.githubusercontent.com/13928957/112092588-d4c9b200-8bbd-11eb-9bd7-f7ffbfc1f832.png">

**Note:** this happened while querying the user list in Employee master.

This issue got introduced after: https://github.com/frappe/frappe/pull/12615
