### PR TITLE
fix(Workspace): Make scrolling separate for sidebar and main content

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -733,3 +733,18 @@ body {
 		height: 200px;
 	}
 }
+
+[data-page-route="Workspaces"] {
+	@media (min-width: map-get($grid-breakpoints, "lg")) {
+		.layout-main {
+			height: calc(100vh - var(--navbar-height) - var(--page-head-height) - 5px);
+			.layout-side-section, .layout-main-section-wrapper {
+				height: 100%;
+				overflow-y: scroll;
+			}
+			.desk-sidebar {
+				margin-bottom: var(--margin-2xl);
+			}
+		}
+	}
+}

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -485,6 +485,19 @@ body {
 				}
 			}
 		}
+
+		@media (max-width: map-get($grid-breakpoints, "sm")) {
+			.widget-body {
+				flex-direction: column;
+				.onboarding-steps-wrapper {
+					min-width: none;
+				}
+				.onboarding-step-preview {
+					padding-left: 0;
+					padding-top: var(--padding-lg);
+				}
+			}
+		}
 	}
 
 	&.shortcut-widget-box {


### PR DESCRIPTION
- **Issue:** Content used to scroll with the sidebar which was creating a bad experience while interacting with the main content of the workpace.
	**Before:**
![workspace_scrolling_issue](https://user-images.githubusercontent.com/13928957/112121395-39e4ce00-8be5-11eb-9763-85659709ca1e.gif)
	**After:**
![workspace_scrolling_issue_fix](https://user-images.githubusercontent.com/13928957/112121406-3c472800-8be5-11eb-8f40-05aa864a8d2f.gif)

- Content overflow in mobile view
	**Before:**	
	<img width="200" alt="Screenshot 2021-03-23 at 2 38 43 PM" src="https://user-images.githubusercontent.com/13928957/112121791-a52ea000-8be5-11eb-9190-5dff79467b26.png">
	**After:**
	<img width="200" alt="Screenshot 2021-03-23 at 2 39 15 PM" src="https://user-images.githubusercontent.com/13928957/112121822-ae1f7180-8be5-11eb-9f01-4132c6e566e5.png">




