### PR TITLE
fix(Workspace): Remove forced scrollbar

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -753,7 +753,7 @@ body {
 			height: calc(100vh - var(--navbar-height) - var(--page-head-height) - 5px);
 			.layout-side-section, .layout-main-section-wrapper {
 				height: 100%;
-				overflow-y: scroll;
+				overflow-y: auto;
 			}
 			.desk-sidebar {
 				margin-bottom: var(--margin-2xl);


### PR DESCRIPTION
Removes a forced scroll-bar from workspace page, which was introduced in https://github.com/frappe/frappe/pull/12650

Such issues seem to arise because of the fact that most of the Frappe team uses MacOS

**Before**
![Screenshot_2021-03-24 Website(1)](https://user-images.githubusercontent.com/8528887/112266289-ccdf4000-8c99-11eb-9f8c-aa30879f7a7d.png)
![Screenshot_2021-03-24 Build(1)](https://user-images.githubusercontent.com/8528887/112266307-cf419a00-8c99-11eb-9928-0525223a45a9.png)
**After**
![Screenshot_2021-03-24 Website](https://user-images.githubusercontent.com/8528887/112266320-d10b5d80-8c99-11eb-9525-a89adafa8292.png)
![Screenshot_2021-03-24 Build](https://user-images.githubusercontent.com/8528887/112266315-cfda3080-8c99-11eb-995a-e561424632c9.png)
