### PR TITLE
test: sort folders and files before running tests for consistency

### DIFF
--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -222,7 +222,7 @@ class TestUserPermission(unittest.TestCase):
 
 		# User default Doctype value is ToDo via Session Defaults
 		frappe.set_user("user_default_test@example.com")
-		set_session_default_values({"doctype": "ToDo"})
+		set_session_default_values({"doc": "ToDo"})
 
 		new_doc = frappe.new_doc("Doc A")
 

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -18,6 +18,7 @@ class TestUserPermission(unittest.TestCase):
 				'nested_doc_user@example.com')""")
 		frappe.delete_doc_if_exists("DocType", "Person")
 		frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabPerson`")
+		frappe.delete_doc_if_exists("DocType", "Doc A")
 		frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabDoc A`")
 
 	def test_default_user_permission_validation(self):

--- a/frappe/core/doctype/version/test_version.py
+++ b/frappe/core/doctype/version/test_version.py
@@ -9,6 +9,7 @@ from frappe.core.doctype.version.version import get_diff
 
 class TestVersion(unittest.TestCase):
 	def test_get_diff(self):
+		frappe.set_user('Administrator')
 		test_records = make_test_objects('Event', reset = True)
 		old_doc = frappe.get_doc("Event", test_records[0])
 		new_doc = copy.deepcopy(old_doc)

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -121,8 +121,10 @@ def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False, failfa
 				if dontwalk in folders:
 					folders.remove(dontwalk)
 
+			# for predictability
 			folders.sort()
 			files.sort()
+
 			# print path
 			for filename in files:
 				if filename.startswith("test_") and filename.endswith(".py")\

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -117,10 +117,11 @@ def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False, failfa
 	test_suite = unittest.TestSuite()
 	for app in apps:
 		for path, folders, files in os.walk(frappe.get_pymodule_path(app)):
-			for dontwalk in ('locals', '.git', 'public'):
+			for dontwalk in ('locals', '.git', 'public', '__pycache__'):
 				if dontwalk in folders:
 					folders.remove(dontwalk)
 
+			folders.sort()
 			# print path
 			for filename in files:
 				filename = cstr(filename)

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -125,7 +125,6 @@ def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False, failfa
 			files.sort()
 			# print path
 			for filename in files:
-				filename = cstr(filename)
 				if filename.startswith("test_") and filename.endswith(".py")\
 					and filename != 'test_runner.py':
 					# print filename[:-3]

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -122,6 +122,7 @@ def run_all_tests(app=None, verbose=False, profile=False, ui_tests=False, failfa
 					folders.remove(dontwalk)
 
 			folders.sort()
+			files.sort()
 			# print path
 			for filename in files:
 				filename = cstr(filename)

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -12,7 +12,7 @@ from frappe.frappeclient import FrappeClient, AuthError
 class TestAuth(unittest.TestCase):
 	def __init__(self, *args, **kwargs):
 		super(TestAuth, self).__init__(*args, **kwargs)
-		self.test_user_email = 'test@test.com'
+		self.test_user_email = 'test_auth@test.com'
 		self.test_user_name = 'test_user'
 		self.test_user_mobile = '+911234567890'
 		self.test_user_password = 'pwd_012'

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -13,7 +13,7 @@ class TestAuth(unittest.TestCase):
 	def __init__(self, *args, **kwargs):
 		super(TestAuth, self).__init__(*args, **kwargs)
 		self.test_user_email = 'test_auth@test.com'
-		self.test_user_name = 'test_user'
+		self.test_user_name = 'test_auth_user'
 		self.test_user_mobile = '+911234567890'
 		self.test_user_password = 'pwd_012'
 


### PR DESCRIPTION
### Issue
- `os.walk` gives the list of folders in an arbitrary order, which causes dependent tests to fail if the order doesn't remain consistent.

### Fix
- Sort `folders` and `files` before adding tests.