### PR TITLE
fix: System Notification fix

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -61,7 +61,7 @@ def make_notification_logs(doc, users):
 	from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 
 	for user in users:
-		if frappe.db.exists('User', {"name": user, "enabled": 1}):
+		if frappe.db.exists('User', {"email": user, "enabled": 1}):
 			if is_notifications_enabled(user):
 				if doc.type == 'Energy Point' and not is_energy_point_enabled():
 					return


### PR DESCRIPTION
Check if user exists using email instead of name, since name for the admin user is "Administrator", not the email.