### PR TITLE
fix: filters in share url not working

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -361,7 +361,7 @@ frappe.router = {
 		// return clean sub_path from hash or url
 		// supports both v1 and v2 routing
 		if (!route) {
-			route = window.location.hash || window.location.pathname;
+			route = window.location.hash || (window.location.pathname + window.location.search);
 		}
 
 		return this.strip_prefix(route);
@@ -386,8 +386,6 @@ frappe.router = {
 	set_route_options_from_url(route) {
 		// set query parameters as frappe.route_options
 		var last_part = route[route.length - 1];
-		// add routing v2 compatability
-		if (!last_part.includes("?")) last_part = route[route.length - 1] + window.location.search
 		if (last_part.indexOf("?") < last_part.indexOf("=")) {
 			// has ? followed by =
 			let parts = last_part.split("?");

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -387,7 +387,7 @@ frappe.router = {
 		// set query parameters as frappe.route_options
 		var last_part = route[route.length - 1];
 		// add routing v2 compatability
-		if (!last_part.includes("?")) last_part = route[route.length - 1] + window.location.search
+		if (!last_part.includes("?")) last_part = route[route.length - 1] + window.location.search;
 		if (last_part.indexOf("?") < last_part.indexOf("=")) {
 			// has ? followed by =
 			let parts = last_part.split("?");

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -386,6 +386,8 @@ frappe.router = {
 	set_route_options_from_url(route) {
 		// set query parameters as frappe.route_options
 		var last_part = route[route.length - 1];
+		// add routing v2 compatability
+		if (!last_part.includes("?")) last_part = route[route.length - 1] + window.location.search
 		if (last_part.indexOf("?") < last_part.indexOf("=")) {
 			// has ? followed by =
 			let parts = last_part.split("?");


### PR DESCRIPTION
Filling the filters in listview depends on the values in the query 
`http://v13-dev-new:8010/app/item?item_group=Drug`


In routing v1 has contained the query part and the logic depended on the way the route is processed from hash.

In routingv2 hash is undefined hence the filters are never available to the list view.

This PR adds a fallback to make sure the query string reaches the listview 