### PR TITLE
fix: Only allow user's attachments to show in attachments tree

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -945,12 +945,22 @@ def get_files_in_folder(folder, start=0, page_length=20):
 	start = cint(start)
 	page_length = cint(page_length)
 
-	files = frappe.db.get_all('File',
+	attachment_folder = frappe.db.get_value('File',
+		'Home/Attachments',
+		['name', 'file_name', 'file_url', 'is_folder', 'modified'],
+		as_dict=1
+	)
+
+	files = frappe.db.get_list('File',
 		{ 'folder': folder },
 		['name', 'file_name', 'file_url', 'is_folder', 'modified'],
 		start=start,
 		page_length=page_length + 1
 	)
+
+	if folder == 'Home' and attachment_folder not in files:
+		files.insert(0, attachment_folder)
+
 	return {
 		'files': files[:page_length],
 		'has_more': len(files) > page_length

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -404,7 +404,24 @@ class TestAttachment(unittest.TestCase):
 class TestAttachmentsAccess(unittest.TestCase):
 
 	def test_attachments_access(self):
+
+		frappe.set_user('test4@example.com')
 		self.attached_to_doctype, self.attached_to_docname = make_test_doc()
+
+		frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'test_user.txt',
+			"attached_to_doctype": self.attached_to_doctype,
+			"attached_to_name": self.attached_to_docname,
+			"content": 'Testing User'
+		}).insert()
+
+		frappe.get_doc({
+			"doctype": "File",
+			"file_name": "test_user_home.txt",
+			"content": 'User Home',
+		}).insert()
+
 		frappe.set_user('test@example.com')
 
 		frappe.get_doc({
@@ -421,23 +438,6 @@ class TestAttachmentsAccess(unittest.TestCase):
 			"content": 'System Manager Home',
 		}).insert()
 
-		frappe.set_user('test4@example.com')
-
-		frappe.get_doc({
-			"doctype": "File",
-			"file_name": 'test_user.txt',
-			"attached_to_doctype": self.attached_to_doctype,
-			"attached_to_name": self.attached_to_docname,
-			"content": 'Testing User'
-		}).insert()
-
-		frappe.get_doc({
-			"doctype": "File",
-			"file_name": "test_user_home.txt",
-			"content": 'User Home',
-		}).insert()
-		
-		frappe.set_user('test@example.com')
 		system_manager_files = [file.file_name for file in get_files_in_folder('Home')['files']]
 		system_manager_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
 

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -405,9 +405,9 @@ class TestAttachmentsAccess(unittest.TestCase):
 
 	def test_attachments_access(self):
 		self.attached_to_doctype, self.attached_to_docname = make_test_doc()
-		frappe.set_user('testperm@example.com')
+		frappe.set_user('test@example.com')
 
-		_file1 = frappe.get_doc({
+		frappe.get_doc({
 			"doctype": "File",
 			"file_name": 'test_system_manager.txt',
 			"attached_to_doctype": self.attached_to_doctype,
@@ -415,7 +415,7 @@ class TestAttachmentsAccess(unittest.TestCase):
 			"content": 'Testing System Manager'
 		}).insert()
 
-		_file2 = frappe.get_doc({
+		frappe.get_doc({
 			"doctype": "File",
 			"file_name": "test_sm_home.txt",
 			"content": 'System Manager Home',
@@ -423,7 +423,7 @@ class TestAttachmentsAccess(unittest.TestCase):
 
 		frappe.set_user('test4@example.com')
 
-		_file3 = frappe.get_doc({
+		frappe.get_doc({
 			"doctype": "File",
 			"file_name": 'test_user.txt',
 			"attached_to_doctype": self.attached_to_doctype,
@@ -431,13 +431,13 @@ class TestAttachmentsAccess(unittest.TestCase):
 			"content": 'Testing User'
 		}).insert()
 
-		_file4 = frappe.get_doc({
+		frappe.get_doc({
 			"doctype": "File",
 			"file_name": "test_user_home.txt",
 			"content": 'User Home',
 		}).insert()
 		
-		frappe.set_user('testperm@example.com')
+		frappe.set_user('test@example.com')
 		system_manager_files = [file.file_name for file in get_files_in_folder('Home')['files']]
 		system_manager_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
 

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -8,7 +8,7 @@ import frappe
 import os
 import unittest
 from frappe import _
-from frappe.core.doctype.file.file import move_file
+from frappe.core.doctype.file.file import move_file, get_files_in_folder
 from frappe.utils import get_files_path
 # test_records = frappe.get_test_records('File')
 
@@ -399,3 +399,61 @@ class TestAttachment(unittest.TestCase):
 		})
 
 		self.assertTrue(exists)
+
+
+class TestAttachmentsAccess(unittest.TestCase):
+
+	def test_attachments_access(self):
+		self.attached_to_doctype, self.attached_to_docname = make_test_doc()
+		frappe.set_user('testperm@example.com')
+
+		_file1 = frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'test_system_manager.txt',
+			"attached_to_doctype": self.attached_to_doctype,
+			"attached_to_name": self.attached_to_docname,
+			"content": 'Testing System Manager'
+		}).insert()
+
+		_file2 = frappe.get_doc({
+			"doctype": "File",
+			"file_name": "test_sm_home.txt",
+			"content": 'System Manager Home',
+		}).insert()
+
+		frappe.set_user('test4@example.com')
+
+		_file3 = frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'test_user.txt',
+			"attached_to_doctype": self.attached_to_doctype,
+			"attached_to_name": self.attached_to_docname,
+			"content": 'Testing User'
+		}).insert()
+
+		_file4 = frappe.get_doc({
+			"doctype": "File",
+			"file_name": "test_user_home.txt",
+			"content": 'User Home',
+		}).insert()
+		
+		frappe.set_user('testperm@example.com')
+		system_manager_files = [file.file_name for file in get_files_in_folder('Home')['files']]
+		system_manager_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
+
+		frappe.set_user('test4@example.com')
+		user_files = [file.file_name for file in get_files_in_folder('Home')['files']]
+		user_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
+
+		self.assertIn('test_sm_home.txt', system_manager_files)
+		self.assertNotIn('test_sm_home.txt', user_files)
+		self.assertIn('test_user_home.txt', system_manager_files)
+		self.assertIn('test_user_home.txt', user_files)
+
+		self.assertIn('test_system_manager.txt', system_manager_attachments_files)
+		self.assertNotIn('test_system_manager.txt', user_attachments_files)
+		self.assertIn('test_user.txt', system_manager_attachments_files)
+		self.assertIn('test_user.txt', user_attachments_files)
+
+		frappe.set_user('Administrator')
+		frappe.db.rollback()


### PR DESCRIPTION
When attaching a file on any document from the uploaded file option any user with limited access can see all the attachments
for which they should not have access.
![image](https://user-images.githubusercontent.com/30859809/112966178-9ad15080-9167-11eb-89a4-52ac8f67774d.png)


After Fix: User can only see attachments that they added.
![image](https://user-images.githubusercontent.com/30859809/112966295-b9374c00-9167-11eb-94f9-586dc42f7417.png)
 