### PR TITLE
fix: global get_conf() fails to return site config

### DIFF
--- a/frappe/utils/connections.py
+++ b/frappe/utils/connections.py
@@ -3,7 +3,6 @@ import socket
 from six.moves.urllib.parse import urlparse
 from frappe import get_conf
 
-config = get_conf()
 REDIS_KEYS = ('redis_cache', 'redis_queue', 'redis_socketio')
 
 
@@ -21,6 +20,7 @@ def is_open(ip, port, timeout=10):
 
 
 def check_database():
+	config = get_conf()
 	db_type = config.get("db_type", "mariadb")
 	db_host = config.get("db_host", "localhost")
 	db_port = config.get("db_port", 3306 if db_type == "mariadb" else 5342)
@@ -28,6 +28,7 @@ def check_database():
 
 
 def check_redis(redis_services=None):
+	config = get_conf()
 	services = redis_services or REDIS_KEYS
 	status = {}
 	for conn in services:


### PR DESCRIPTION

Global get_conf() fails to return site_config, due to which migration fails for Postgres. 
