### PR TITLE
fix: enable fetch from for Check fieldtype

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -184,7 +184,7 @@ frappe.ui.form.ScriptManager = Class.extend({
 		}
 
 		function setup_add_fetch(df) {
-			if((['Data', 'Read Only', 'Text', 'Small Text', 'Currency',
+			if ((['Data', 'Read Only', 'Text', 'Small Text', 'Currency', 'Check',
 				'Text Editor', 'Code', 'Link', 'Float', 'Int', 'Date', 'Select'].includes(df.fieldtype) || df.read_only==1)
 				&& df.fetch_from && df.fetch_from.indexOf(".")!=-1) {
 				var parts = df.fetch_from.split(".");


### PR DESCRIPTION
Previously fetch_from didn't work for Check type fields.
Added Check fieldtype in `setup_add_fetch`.

