### PR TITLE
refactor: Code cleanup and attempt tracker for 2FA

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -215,9 +215,7 @@ class LoginManager:
 		if not (user and pwd):
 			self.fail(_('Incomplete login details'), user=user)
 
-		# Ignore password check if tmp_id is set, 2FA takes care of authentication.
-		validate_password = not bool(frappe.form_dict.get('tmp_id'))
-		user = User.find_by_credentials(user, pwd, validate_password=validate_password)
+		user = User.find_by_credentials(user, pwd)
 
 		if not user:
 			self.fail('Invalid login credentials')

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -396,7 +396,7 @@ def validate_ip_address(user):
 
 	frappe.throw(_("Access not allowed from this IP Address"), frappe.AuthenticationError)
 
-def get_login_attempt_tracker(user_name: str, raise_locked_exception: bool=True):
+def get_login_attempt_tracker(user_name: str, raise_locked_exception: bool = True):
 	"""Get login attempt tracker instance.
 
 	:param user_name: Name of the loggedin user

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -220,28 +220,20 @@ class LoginManager:
 		if not user:
 			self.fail('Invalid login credentials')
 
-		sys_settings = frappe.get_doc("System Settings")
-		track_login_attempts = (sys_settings.allow_consecutive_login_attempts >0)
-
-		tracker_kwargs = {}
-		if track_login_attempts:
-			tracker_kwargs['lock_interval'] = sys_settings.allow_login_after_fail
-			tracker_kwargs['max_consecutive_login_attempts'] = sys_settings.allow_consecutive_login_attempts
-
-		tracker = LoginAttemptTracker(user.name, **tracker_kwargs)
-
-		if track_login_attempts and not tracker.is_user_allowed():
-			frappe.throw(_("Your account has been locked and will resume after {0} seconds")
-				.format(sys_settings.allow_login_after_fail), frappe.SecurityException)
+		# Current login flow uses cached credentials for authentication while checking OTP.
+		# Incase of OTP check, tracker for auth needs to be disabled(If not, it can remove tracker history as it is going to succeed anyway)
+		# Tracker is activated for 2FA incase of OTP.
+		ignore_tracker = should_run_2fa(user.name) and ('otp' in frappe.form_dict)
+		tracker = None if ignore_tracker else get_login_attempt_tracker(user.name)
 
 		if not user.is_authenticated:
-			tracker.add_failure_attempt()
+			tracker and tracker.add_failure_attempt()
 			self.fail('Invalid login credentials', user=user.name)
 		elif not (user.name == 'Administrator' or user.enabled):
-			tracker.add_failure_attempt()
+			tracker and tracker.add_failure_attempt()
 			self.fail('User disabled or missing', user=user.name)
 		else:
-			tracker.add_success_attempt()
+			tracker and tracker.add_success_attempt()
 		self.user = user.name
 
 	def force_user_to_reset_password(self):
@@ -403,6 +395,27 @@ def validate_ip_address(user):
 			return
 
 	frappe.throw(_("Access not allowed from this IP Address"), frappe.AuthenticationError)
+
+def get_login_attempt_tracker(user_name: str, raise_locked_exception: bool=True):
+	"""Get login attempt tracker instance.
+
+	:param user_name: Name of the loggedin user
+	:param raise_locked_exception: If set, raises an exception incase of user not allowed to login
+	"""
+	sys_settings = frappe.get_doc("System Settings")
+	track_login_attempts = (sys_settings.allow_consecutive_login_attempts >0)
+	tracker_kwargs = {}
+
+	if track_login_attempts:
+		tracker_kwargs['lock_interval'] = sys_settings.allow_login_after_fail
+		tracker_kwargs['max_consecutive_login_attempts'] = sys_settings.allow_consecutive_login_attempts
+
+	tracker = LoginAttemptTracker(user_name, **tracker_kwargs)
+
+	if raise_locked_exception and track_login_attempts and not tracker.is_user_allowed():
+		frappe.throw(_("Your account has been locked and will resume after {0} seconds")
+			.format(sys_settings.allow_login_after_fail), frappe.SecurityException)
+	return tracker
 
 
 class LoginAttemptTracker(object):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -558,7 +558,7 @@ class User(Document):
 		user['is_authenticated'] = True
 		if validate_password:
 			try:
-				check_password(user['name'], password)
+				check_password(user['name'], password, delete_tracker_cache=False)
 			except frappe.AuthenticationError:
 				user['is_authenticated'] = False
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -296,8 +296,7 @@ class Session:
 			expiry = get_expiry_in_seconds(session_data.get("session_expiry"))
 
 			if self.time_diff > expiry:
-				print('deleting...')
-				self.delete_session()
+				self._delete_session()
 				data = None
 
 		return data and data.data
@@ -316,12 +315,12 @@ class Session:
 			data = frappe._dict(eval(rec and rec[0][1] or '{}'))
 			data.user = rec[0][0]
 		else:
-			self.delete_session()
+			self._delete_session()
 			data = None
 
 		return data
 
-	def delete_session(self):
+	def _delete_session(self):
 		delete_session(self.sid, reason="Session Expired")
 
 	def start_as_guest(self):

--- a/frappe/tests/__init__.py
+++ b/frappe/tests/__init__.py
@@ -1,0 +1,9 @@
+import frappe
+
+def update_system_settings(args):
+	doc = frappe.get_doc('System Settings')
+	doc.update(args)
+	doc.save()
+
+def get_system_setting(key):
+	return frappe.db.get_single_value("System Settings", key)

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -118,6 +118,7 @@ def get_verification_method():
 
 def confirm_otp_token(login_manager, otp=None, tmp_id=None):
 	'''Confirm otp matches.'''
+	from frappe.auth import get_login_attempt_tracker
 	if not otp:
 		otp = frappe.form_dict.get('otp')
 	if not otp:
@@ -130,12 +131,17 @@ def confirm_otp_token(login_manager, otp=None, tmp_id=None):
 	otp_secret = frappe.cache().get(tmp_id + '_otp_secret')
 	if not otp_secret:
 		raise ExpiredLoginException(_('Login session expired, refresh page to retry'))
+
+	tracker = get_login_attempt_tracker(login_manager.user)
+
 	hotp = pyotp.HOTP(otp_secret)
 	if hotp_token:
 		if hotp.verify(otp, int(hotp_token)):
 			frappe.cache().delete(tmp_id + '_token')
+			tracker.add_success_attempt()
 			return True
 		else:
+			tracker.add_failure_attempt()
 			login_manager.fail(_('Incorrect Verification code'), login_manager.user)
 
 	totp = pyotp.TOTP(otp_secret)
@@ -144,8 +150,10 @@ def confirm_otp_token(login_manager, otp=None, tmp_id=None):
 		if not frappe.db.get_default(login_manager.user + '_otplogin'):
 			frappe.db.set_default(login_manager.user + '_otplogin', 1)
 			delete_qrimage(login_manager.user)
+		tracker.add_success_attempt()
 		return True
 	else:
+		tracker.add_failure_attempt()
 		login_manager.fail(_('Incorrect Verification code'), login_manager.user)
 
 

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -65,7 +65,7 @@ def set_encrypted_password(doctype, name, pwd, fieldname='password'):
 		raise e
 
 
-def check_password(user, pwd, doctype='User', fieldname='password'):
+def check_password(user, pwd, doctype='User', fieldname='password', delete_tracker_cache=True):
 	'''Checks if user and password are correct, else raises frappe.AuthenticationError'''
 
 	auth = frappe.db.sql("""select `name`, `password` from `__Auth`
@@ -77,7 +77,11 @@ def check_password(user, pwd, doctype='User', fieldname='password'):
 
 	# lettercase agnostic
 	user = auth[0].name
-	delete_login_failed_cache(user)
+
+	# TODO: This need to be deleted after checking side effects of it.
+	# We have a `LoginAttemptTracker` that can take care of tracking related cache.
+	if delete_tracker_cache:
+		delete_login_failed_cache(user)
 
 	if not passlibctx.needs_update(auth[0].password):
 		update_password(user, pwd, doctype, fieldname)


### PR DESCRIPTION
1. Using `delete_session` name for a function and also as a method name is confusing. Cleaned that up.
2. Making authentication check mandatory even incase of 2FA.
3. Added LoginTracker to track OTP attempts done by user.