### PR TITLE
fix: first column padding in datatable

### DIFF
--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -123,6 +123,10 @@
 		font-feature-settings: "tnum";
 	}
 
+	.dt-cell__content--header-0, .dt-cell__content--col-0 {
+		padding: 0.5rem;
+	}
+
 	.dt-scrollable--highlight-all {
 		.dt-cell__content {
 			background: var(--dt-selection-highlight-color);


### PR DESCRIPTION
Increase padding to remove the dot next to the checkbox due to `text-overflow: ellipsis`

<img width="1117" alt="Screenshot 2021-03-31 at 11 38 50 AM" src="https://user-images.githubusercontent.com/19775888/113098134-b4c96c80-9215-11eb-856a-27c4c23b7813.png">
