### PR TITLE
fix: get `frappe.client.get_value()` to work when `as_dict` is false

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -21,7 +21,7 @@ Requests via FrappeClient are also handled here.
 
 @frappe.whitelist()
 def get_list(doctype, fields=None, filters=None, order_by=None,
-	limit_start=None, limit_page_length=20, parent=None):
+	limit_start=None, limit_page_length=20, parent=None, debug=False, as_dict=True):
 	'''Returns a list of records by filters, fields, ordering and limit
 
 	:param doctype: DocType of the data to be queried
@@ -40,10 +40,11 @@ def get_list(doctype, fields=None, filters=None, order_by=None,
 		order_by=order_by,
 		limit_start=limit_start,
 		limit_page_length=limit_page_length,
+		debug=debug,
+		as_list=not as_dict
 	)
 
 	validate_args(args)
-
 	return frappe.get_list(**args)
 
 @frappe.whitelist()
@@ -103,14 +104,15 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 	if frappe.get_meta(doctype).issingle:
 		value = frappe.db.get_values_from_single(fields, filters, doctype, as_dict=as_dict, debug=debug)
 	else:
-		value = get_list(doctype, filters=filters, fields=fields, limit_page_length=1)
+		value = get_list(doctype, filters=filters, fields=fields, debug=debug, limit_page_length=1, as_dict=as_dict)
 
 	if as_dict:
-		value = value[0] if value else {}
-	else:
-		value = value[0][fieldname]
+		return value[0] if value else {}
 
-	return value
+	if not value:
+		return
+
+	return value[0] if len(fields) > 1 else value[0][0]
 
 @frappe.whitelist()
 def get_single_value(doctype, field):


### PR DESCRIPTION
- `get_list` now has two additional params `debug` and `as_dict`.
- `debug` was accidentally removed from line 106 in #12713 and has been added back.
- `frappe.client.get_value()` is fixed and works when `as_dict` is false.