### PR TITLE
fix: Invalid method should not throw 404 error

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -54,12 +54,7 @@ def execute_cmd(cmd, from_async=False):
 	try:
 		method = get_attr(cmd)
 	except Exception as e:
-		if frappe.local.conf.developer_mode:
-			raise e
-		else:
-			frappe.respond_as_web_page(title=_('Invalid Method'), html=_('Method not found'),
-				indicator_color='red', http_status_code=500)
-		return
+		frappe.throw(_('Invalid Method'))
 
 	if from_async:
 		method = method.queue

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -57,8 +57,8 @@ def execute_cmd(cmd, from_async=False):
 		if frappe.local.conf.developer_mode:
 			raise e
 		else:
-			frappe.respond_as_web_page(title='Invalid Method', html='Method not found',
-			indicator_color='red', http_status_code=404)
+			frappe.respond_as_web_page(title=_('Invalid Method'), html=_('Method not found'),
+				indicator_color='red', http_status_code=500)
 		return
 
 	if from_async:


### PR DESCRIPTION
- Invalid method should not throw a 404 error because any invalid method call will result in redirection to the login page via https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/request.js#L134
