### PR TITLE
fix: change z-index even when list is empty

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -251,7 +251,6 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 		head ? $row.addClass('list-item--head')
 			: $row = $(`<div class="list-item-container" data-item-name="${result.name}"></div>`).append($row);
 
-		$(".modal-dialog .list-item--head").css("z-index", 0);
 		return $row;
 	}
 
@@ -264,6 +263,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 			this.empty_list();
 		}
 		more_btn.hide();
+		$(".modal-dialog .list-item--head").css("z-index", 0);
 
 		if (results.length === 0) return;
 		if (more) more_btn.show();


### PR DESCRIPTION
fix for list item header overlapping company dropdown 
![image](https://user-images.githubusercontent.com/28212972/113144610-0dffc300-924b-11eb-977c-aabe947fb0aa.png)
