### PR TITLE
fix: Return correct value from `frappe.db.count`

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -100,17 +100,11 @@ frappe.db = {
 
 		const fields = [];
 
-		return frappe.call({
-			type: 'GET',
-			method: 'frappe.desk.reportview.get_count',
-			args: {
-				doctype,
-				filters,
-				fields,
-				distinct,
-			}
-		}).then(r => {
-			return r.message.values;
+		return frappe.xcall('frappe.desk.reportview.get_count', {
+			doctype,
+			filters,
+			fields,
+			distinct,
 		});
 	},
 	get_link_options(doctype, txt = '', filters={}) {


### PR DESCRIPTION
Client-side `frappe.db.count` stopped working after https://github.com/frappe/frappe/pull/12713

This PR fixes that.
