### PR TITLE
fix: Chart style in Dark Mode

### DIFF
--- a/frappe/public/build.json
+++ b/frappe/public/build.json
@@ -79,9 +79,9 @@
 		"public/less/controls.less",
 		"public/less/chat.less",
 		"public/css/fonts/inter/inter.css",
-		"public/scss/desk.scss",
 		"node_modules/frappe-charts/dist/frappe-charts.min.css",
-		"node_modules/plyr/dist/plyr.css"
+		"node_modules/plyr/dist/plyr.css",
+		"public/scss/desk.scss"
 	],
 	"css/frappe-rtl.css": [
 		"public/css/bootstrap-rtl.css",

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -114,19 +114,21 @@
 	// --criticism-bg: var(--red-600);
 
 	// Frappe Charts Colors
-	--charts-label-color: var(--gray-300);
-	--charts-axis-line-color: var(--gray-500);
+	.chart-container {
+		--charts-label-color: var(--gray-300);
+		--charts-axis-line-color: var(--gray-500);
 
-	--charts-stroke-width: 5px;
-	--charts-dataset-circle-stroke: #ffffff;
-	--charts-dataset-circle-stroke-width: var(--charts-stroke-width);
+		--charts-stroke-width: 5px;
+		--charts-dataset-circle-stroke: #ffffff;
+		--charts-dataset-circle-stroke-width: var(--charts-stroke-width);
 
-	--charts-tooltip-title: var(--charts-label-color);
-	--charts-tooltip-label: var(--charts-label-color);
-	--charts-tooltip-value: white;
-	--charts-tooltip-bg: var(--gray-900);
+		--charts-tooltip-title: var(--charts-label-color);
+		--charts-tooltip-label: var(--charts-label-color);
+		--charts-tooltip-value: white;
+		--charts-tooltip-bg: var(--gray-900);
 
-	--charts-legend-label: var(--charts-label-color);
+		--charts-legend-label: var(--charts-label-color);
+	}
 
 	// find better fix
 	.heatmap-chart {


### PR DESCRIPTION
**Before**
<img width="1076" alt="Screenshot 2021-03-31 at 11 40 08 PM" src="https://user-images.githubusercontent.com/13928957/113190862-7619cd80-927a-11eb-9398-9d43057b07cc.png">


**After**
<img width="1084" alt="Screenshot 2021-03-31 at 11 38 03 PM" src="https://user-images.githubusercontent.com/13928957/113190718-48348900-927a-11eb-93a1-dcd7f27eac65.png">
