### PR TITLE
fix: Webform checkout

### DIFF
--- a/frappe/templates/pages/integrations/stripe_checkout.py
+++ b/frappe/templates/pages/integrations/stripe_checkout.py
@@ -26,7 +26,7 @@ def get_context(context):
 
 		context['amount'] = fmt_money(amount=context['amount'], currency=context['currency'])
 
-		if frappe.get_meta(context.reference_doctype).has_field('is_a_subscription') and frappe.db.get_value(context.reference_doctype, context.reference_docname, "is_a_subscription"):
+		if is_a_subscription(context.reference_doctype, context.reference_docname):
 			payment_plan = frappe.db.get_value(context.reference_doctype, context.reference_docname, "payment_plan")
 			recurrence = frappe.db.get_value("Payment Plan", payment_plan, "recurrence")
 
@@ -60,7 +60,7 @@ def make_payment(stripe_token_id, data, reference_doctype=None, reference_docnam
 
 	gateway_controller = get_gateway_controller(reference_doctype,reference_docname)
 
-	if frappe.get_meta(reference_doctype).has_field('is_a_subscription') and frappe.db.get_value(reference_doctype, reference_docname, 'is_a_subscription'):
+	if is_a_subscription(reference_doctype, reference_docname):
 		reference = frappe.get_doc(reference_doctype, reference_docname)
 		data =  reference.create_subscription("stripe", gateway_controller, data)
 	else:
@@ -68,3 +68,8 @@ def make_payment(stripe_token_id, data, reference_doctype=None, reference_docnam
 
 	frappe.db.commit()
 	return data
+
+def is_a_subscription(reference_doctype, reference_docname):
+	if not frappe.get_meta(reference_doctype).has_field('is_a_subscription'):
+		return False
+	return frappe.db.get_value(reference_doctype, reference_docname, "is_a_subscription")

--- a/frappe/templates/pages/integrations/stripe_checkout.py
+++ b/frappe/templates/pages/integrations/stripe_checkout.py
@@ -26,7 +26,7 @@ def get_context(context):
 
 		context['amount'] = fmt_money(amount=context['amount'], currency=context['currency'])
 
-		if frappe.db.get_value(context.reference_doctype, context.reference_docname, "is_a_subscription"):
+		if frappe.get_meta(context.reference_doctype).has_field('is_a_subscription') and frappe.db.get_value(context.reference_doctype, context.reference_docname, "is_a_subscription"):
 			payment_plan = frappe.db.get_value(context.reference_doctype, context.reference_docname, "payment_plan")
 			recurrence = frappe.db.get_value("Payment Plan", payment_plan, "recurrence")
 
@@ -60,7 +60,7 @@ def make_payment(stripe_token_id, data, reference_doctype=None, reference_docnam
 
 	gateway_controller = get_gateway_controller(reference_doctype,reference_docname)
 
-	if frappe.db.get_value(reference_doctype, reference_docname, 'is_a_subscription'):
+	if frappe.get_meta(reference_doctype).has_field('is_a_subscription') and frappe.db.get_value(reference_doctype, reference_docname, 'is_a_subscription'):
 		reference = frappe.get_doc(reference_doctype, reference_docname)
 		data =  reference.create_subscription("stripe", gateway_controller, data)
 	else:

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -220,7 +220,7 @@ def get_context(context):
 				"title": title,
 				"description": title,
 				"reference_doctype": "Web Form",
-				"reference_docname": webform.name,
+				"reference_docname": self.name,
 				"payer_email": frappe.session.user,
 				"payer_name": frappe.utils.get_fullname(frappe.session.user),
 				"order_id": doc.name,

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -463,7 +463,7 @@ def accept(web_form, data, docname=None, for_payment=False):
 	frappe.flags.web_form_doc = doc
 
 	if for_payment:
-		return web_form.get_payment_gateway_url(doc, web_form)
+		return web_form.get_payment_gateway_url(doc)
 	else:
 		return doc
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -207,7 +207,7 @@ def get_context(context):
 				context.comment_list = get_comment_list(context.doc.doctype,
 					context.doc.name)
 
-	def get_payment_gateway_url(self, doc):
+	def get_payment_gateway_url(self, doc, webform):
 		if self.accept_payment:
 			controller = get_payment_gateway_controller(self.payment_gateway)
 
@@ -219,8 +219,8 @@ def get_context(context):
 				"amount": amount,
 				"title": title,
 				"description": title,
-				"reference_doctype": doc.doctype,
-				"reference_docname": doc.name,
+				"reference_doctype": "Web Form",
+				"reference_docname": webform.name,
 				"payer_email": frappe.session.user,
 				"payer_name": frappe.utils.get_fullname(frappe.session.user),
 				"order_id": doc.name,
@@ -463,7 +463,7 @@ def accept(web_form, data, docname=None, for_payment=False):
 	frappe.flags.web_form_doc = doc
 
 	if for_payment:
-		return web_form.get_payment_gateway_url(doc)
+		return web_form.get_payment_gateway_url(doc, web_form)
 	else:
 		return doc
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -207,7 +207,7 @@ def get_context(context):
 				context.comment_list = get_comment_list(context.doc.doctype,
 					context.doc.name)
 
-	def get_payment_gateway_url(self, doc, webform):
+	def get_payment_gateway_url(self, doc):
 		if self.accept_payment:
 			controller = get_payment_gateway_controller(self.payment_gateway)
 


### PR DESCRIPTION
We store the payment gateway details in Webform but we are passing the reference doctype.
The reference doctype does not have the gateway stuff so this error is thrown 
![image](https://user-images.githubusercontent.com/28212972/113252743-d728bc00-92e1-11eb-92b2-76250eb709e0.png)

To test please use the keys [here](https://stripe.com/docs/keys)

Steps to reproduce test

1. Create a web form based on any doctype
2. fill in the payment gateway details using the test keys 
3. go to webform
4. fill in the details
5. Click Save
6. On the checkout page put the card number as `4242 4242 4242 4242` valid expiry and any test cvv
7. Make sure that the email(in the text box as well as url) is valid
8. click pay you should see this screen

![image](https://user-images.githubusercontent.com/28212972/113253147-7b126780-92e2-11eb-8054-e50e103cac76.png)


for other reference implementation check payment request in erpnext
