### PR TITLE
fix: only focus on first input if form is new

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -451,7 +451,7 @@ frappe.ui.form.Form = class FrappeForm {
 						return this.script_manager.trigger("onload_post_render");
 					}
 				},
-				() => this.focus_on_first_input(),
+				() => this.is_new() && this.focus_on_first_input(),
 				() => this.run_after_load_hook(),
 				() => this.dashboard.after_refresh()
 			]);


### PR DESCRIPTION
Focusing on the first input scrolls to the top of the form, this is only necessary for new forms.