### PR TITLE
fix: create `_get_children` for passing `ignore_permissions` when needed

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -36,20 +36,27 @@ def get_all_nodes(doctype, label, parent, tree_method, **filters):
 	return out
 
 @frappe.whitelist()
-def get_children(doctype, parent='', **filters):
+def get_children(doctype, parent=''):
+	return _get_children(doctype, parent)
+
+def _get_children(doctype, parent='', ignore_permissions=False):
 	parent_field = 'parent_' + doctype.lower().replace(' ', '_')
-	filters=[['ifnull(`{0}`,"")'.format(parent_field), '=', parent],
+	filters = [['ifnull(`{0}`,"")'.format(parent_field), '=', parent],
 		['docstatus', '<' ,'2']]
 
-	doctype_meta = frappe.get_meta(doctype)
-	data = frappe.get_list(doctype, fields=[
-		'name as value',
-		'{0} as title'.format(doctype_meta.get('title_field') or 'name'),
-		'is_group as expandable'],
-		filters=filters,
-		order_by='name')
+	meta = frappe.get_meta(doctype)
 
-	return data
+	return frappe.get_list(
+		doctype,
+		fields=[
+			'name as value',
+			'{0} as title'.format(meta.get('title_field') or 'name'),
+			'is_group as expandable'
+		],
+		filters=filters,
+		order_by='name',
+		ignore_permissions=ignore_permissions
+	)
 
 @frappe.whitelist()
 def add_node():


### PR DESCRIPTION
Also removes unused parameter `filters`