### PR TITLE
fix: Emit doc close event on doc change

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -162,6 +162,9 @@ frappe.socketio = {
 		if (!frappe.socketio.last_doc
 			|| (frappe.socketio.last_doc[0] != doctype || frappe.socketio.last_doc[1] != docname)) {
 			frappe.socketio.socket.emit('doc_open', doctype, docname);
+
+			frappe.socketio.last_doc &&
+				frappe.socketio.doc_close(frappe.socketio.last_doc[0], frappe.socketio.last_doc[1]);
 		}
 		frappe.socketio.last_doc = [doctype, docname];
 	},


### PR DESCRIPTION
Fixes issue where a user was still shown as viewing on a form, even after switching to another doc.