### PR TITLE
fix: revert to reportview.get API till get_count is fixed

### DIFF
--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -100,7 +100,7 @@ frappe.db = {
 
 		const fields = [];
 
-		return frappe.xcall('frappe.desk.reportview.get_count', {
+		return frappe.xcall('frappe.desk.reportview.get', {
 			doctype,
 			filters,
 			fields,


### PR DESCRIPTION
Unable to use query documents using child table filters as get_count is failing with join queries. Reverting back to `get` API method till `get_count` is fixed.. 

Here is the issue:
![IMAGE 2021-04-01 18:42:01](https://user-images.githubusercontent.com/36557/113298915-f3e0e600-9319-11eb-8156-a9d67cd4767c.jpg)
