### PR TITLE
fix: get_count API endpoint

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -31,7 +31,9 @@ def get_list():
 @frappe.read_only()
 def get_count():
 	args = get_form_params()
-	args.fields = ['{distinct}count(name) as total_count'.format(distinct = 'distinct ' if args.distinct=='true' else '')]
+
+	distinct = 'distinct ' if args.distinct=='true' else ''
+	args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
 	return execute(**args)[0].get('total_count')
 
 def execute(doctype, *args, **kwargs):


### PR DESCRIPTION
Unable to query documents using child table filters as get_count is failing with join queries. Got fixed here..

Here is what happening before:

![113298915-f3e0e600-9319-11eb-8156-a9d67cd4767c](https://user-images.githubusercontent.com/36557/113303291-8e432880-931e-11eb-9811-edc83591175c.jpg)
