### PR TITLE
fix: use reload_doc instead of reload_doctype

### DIFF
--- a/frappe/patches/v13_0/rename_list_view_setting_to_list_view_settings.py
+++ b/frappe/patches/v13_0/rename_list_view_setting_to_list_view_settings.py
@@ -8,7 +8,7 @@ import frappe
 def execute():
 	if frappe.db.table_exists('List View Setting'):
 		if not frappe.db.table_exists('List View Settings'):
-			frappe.reload_doctype("List View Settings")
+			frappe.reload_doc("desk", "doctype", "List View Settings")
 
 		existing_list_view_settings = frappe.get_all('List View Settings', as_list=True)
 		for list_view_setting in frappe.get_all('List View Setting', fields = ['disable_count', 'disable_sidebar_stats', 'disable_auto_refresh', 'name']):


### PR DESCRIPTION
reload_doctype uses `tabDocType` before executing reload_doc which fails since `List View Setting` does not exist in tabDoctype