### PR TITLE
fix: Reload website_theme_ignore_app before Website Theme

### DIFF
--- a/frappe/patches/v13_0/website_theme_custom_scss.py
+++ b/frappe/patches/v13_0/website_theme_custom_scss.py
@@ -1,9 +1,9 @@
 import frappe
 
 def execute():
-	frappe.reload_doctype('Website Theme')
 	frappe.reload_doc('website', 'doctype', 'website_theme_ignore_app')
 	frappe.reload_doc('website', 'doctype', 'color')
+	frappe.reload_doctype('Website Theme')
 
 	for theme in frappe.get_all('Website Theme'):
 		doc = frappe.get_doc('Website Theme', theme.name)


### PR DESCRIPTION
should avoid:

```
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/init.py”, line 27, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py”, line 297, in migrate
migrate(
File “/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py”, line 67, in migrate
frappe.modules.patch_handler.run_all(skip_failing)
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 41, in run_all
run_patch(patch)
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 30, in run_patch
if not run_single(patchmodule = patch):
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 71, in run_single
return execute_patch(patchmodule, method, methodargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 91, in execute_patch
frappe.get_attr(patchmodule.split()[0] + “.execute”)()
File “/home/frappe/frappe-bench/apps/frappe/frappe/patches/v13_0/website_theme_custom_scss.py”, line 17, in execu
te
doc.save()
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 284, in save
return self._save(*args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 319, in _save
self.run_before_save_methods()
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 949, in run_before_save_methods
self.run_method(“validate”)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 847, in run_method
out = Document.hook(fn)(self, *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 1136, in composer
return composed(self, method, *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 1119, in runner
add_to_return_value(self, fn(self, *args, **kwargs))
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 841, in
fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/website/doctype/website_theme/website_theme.py”, line 14, in v
alidate
self.generate_bootstrap_theme()
File “/home/frappe/frappe-bench/apps/frappe/frappe/website/doctype/website_theme/website_theme.py”, line 69, in g
enerate_bootstrap_theme
self.theme_scss = content = get_scss(self)
File “/home/frappe/frappe-bench/apps/frappe/frappe/website/doctype/website_theme/website_theme.py”, line 145, in
get_scss
apps_to_ignore = tuple((d.app + ‘/’) for d in website_theme.ignored_apps)
AttributeError: ‘WebsiteTheme’ object has no attribute ‘ignored_apps’
```
