### PR TITLE
fix: change package name to `frappe-framework`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frappe",
+  "name": "frappe-framework",
   "scripts": {
     "build": "node rollup/build.js",
     "production": "FRAPPE_ENV=production node rollup/build.js",


### PR DESCRIPTION
The package name `frappe` refers to another published package on NPM:
https://www.npmjs.com/package/frappe

This also causes incorrect dependents to be shown, for example:
![Screenshot-2021-04-02-160901](https://user-images.githubusercontent.com/16315650/113408914-dd946200-93cd-11eb-95f7-84041cd2a956.png)
