### PR TITLE
fix: Check if doctype is virtual doctype before getting value

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -455,9 +455,9 @@ class Database(object):
 					elif (not ignore) and frappe.db.is_table_missing(e):
 						# table not found, look in singles
 						out = self.get_values_from_single(fields, filters, doctype, as_dict, debug, update)
-						if not out:
+						if not out and frappe.get_meta(doctype).get('is_virtual'):
 							# check for virtual doctype
-							out = self.get_values_from_virtual_doctype(fields, filters, doctype, as_dict, debug, update)
+							out = self.get_value_from_virtual_doctype(fields, filters, doctype, as_dict, debug, update)
 
 					else:
 						raise
@@ -511,9 +511,9 @@ class Database(object):
 			else:
 				return r and [[i[1] for i in r]] or []
 
-	def get_values_from_virtual_doctype(self, fields, filters, doctype, as_dict=False, debug=False, update=None):
-		"""Reture single values from virtual doctype."""
-		return frappe.get_doc(doctype).get_value(fields, filters, as_dict=False, debug=False, update=None)
+	def get_value_from_virtual_doctype(self, fields, filters, doctype, as_dict=False, debug=False, update=None):
+		"""Return a single value from virtual doctype."""
+		return frappe.get_doc(doctype).get_value(fields, filters, as_dict=as_dict, debug=debug, update=update)
 
 	def get_singles_dict(self, doctype, debug = False):
 		"""Get Single DocType as dict.


### PR DESCRIPTION
Check if doctype is virtual doctype before getting value avoid recursive call like
https://github.com/frappe/erpnext/pull/25006/checks?check_run_id=2252328630