### PR TITLE
fix: Check if df.options exists before setting docfields

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -455,9 +455,6 @@ class Database(object):
 					elif (not ignore) and frappe.db.is_table_missing(e):
 						# table not found, look in singles
 						out = self.get_values_from_single(fields, filters, doctype, as_dict, debug, update)
-						if not out and frappe.get_meta(doctype).get('is_virtual'):
-							# check for virtual doctype
-							out = self.get_value_from_virtual_doctype(fields, filters, doctype, as_dict, debug, update)
 
 					else:
 						raise
@@ -511,9 +508,6 @@ class Database(object):
 			else:
 				return r and [[i[1] for i in r]] or []
 
-	def get_value_from_virtual_doctype(self, fields, filters, doctype, as_dict=False, debug=False, update=None):
-		"""Return a single value from virtual doctype."""
-		return frappe.get_doc(doctype).get_value(fields, filters, as_dict=as_dict, debug=debug, update=update)
 
 	def get_singles_dict(self, doctype, debug = False):
 		"""Get Single DocType as dict.

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -5,7 +5,7 @@ export default class GridRow {
 		this.on_grid_fields_dict = {};
 		this.on_grid_fields = [];
 		$.extend(this, opts);
-		if (this.doc) {
+		if (this.doc && this.parent_df.options) {
 			this.docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
 		}
 		this.columns = {};
@@ -255,6 +255,7 @@ export default class GridRow {
 		this.grid.visible_columns.forEach((col, ci) => {
 			// to get update df for the row
 			let df = this.docfields.find(field => field.fieldname === col[0].fieldname);
+
 			let colsize = col[1];
 			let txt = this.doc ?
 				frappe.format(this.doc[df.fieldname], df, null, this.doc) :


### PR DESCRIPTION
- Check if `df.options` exists before setting docfields
fixes: https://github.com/frappe/frappe/issues/12793
fixes: https://github.com/frappe/frappe/issues/12788
- Remove code causing circular calls.
fixes: https://github.com/frappe/frappe/pull/12121#issuecomment-812412853