### PR TITLE
chore: Bump version to v13.0.1

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -33,7 +33,7 @@ if PY2:
 	reload(sys)
 	sys.setdefaultencoding("utf-8")
 
-__version__ = '13.0.0'
+__version__ = '13.0.1'
 
 __title__ = "Frappe Framework"
 

--- a/frappe/patches/v13_0/website_theme_custom_scss.py
+++ b/frappe/patches/v13_0/website_theme_custom_scss.py
@@ -1,9 +1,9 @@
 import frappe
 
 def execute():
-	frappe.reload_doctype('Website Theme')
 	frappe.reload_doc('website', 'doctype', 'website_theme_ignore_app')
 	frappe.reload_doc('website', 'doctype', 'color')
+	frappe.reload_doctype('Website Theme')
 
 	for theme in frappe.get_all('Website Theme'):
 		doc = frappe.get_doc('Website Theme', theme.name)

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -151,19 +151,23 @@ function get_version_comment(version_doc, text) {
 		let version_comment = "";
 		let unlinked_content = "";
 
-		Array.from($(text)).forEach(element => {
-			if ($(element).is('a')) {
-				version_comment += unlinked_content ? frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content) : "";
-				unlinked_content = "";
-				version_comment += element.outerHTML;
-			} else {
-				unlinked_content += element.outerHTML || element.textContent;
+		try {
+			Array.from($(text)).forEach(element => {
+				if ($(element).is('a')) {
+					version_comment += unlinked_content ? frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content) : "";
+					unlinked_content = "";
+					version_comment += element.outerHTML;
+				} else {
+					unlinked_content += element.outerHTML || element.textContent;
+				}
+			});
+			if (unlinked_content) {
+				version_comment += frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content);
 			}
-		});
-		if (unlinked_content) {
-			version_comment += frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content);
+			return version_comment;
+		} catch (e) {
+			// pass
 		}
-		return version_comment;
 	}
 	return frappe.utils.get_form_link('Version', version_doc.name, true, text);
 }

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -5,7 +5,7 @@ export default class GridRow {
 		this.on_grid_fields_dict = {};
 		this.on_grid_fields = [];
 		$.extend(this, opts);
-		if (this.doc) {
+		if (this.doc && this.parent_df.options) {
 			this.docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
 		}
 		this.columns = {};
@@ -255,6 +255,7 @@ export default class GridRow {
 		this.grid.visible_columns.forEach((col, ci) => {
 			// to get update df for the row
 			let df = this.docfields.find(field => field.fieldname === col[0].fieldname);
+
 			let colsize = col[1];
 			let txt = this.doc ?
 				frappe.format(this.doc[df.fieldname], df, null, this.doc) :


### PR DESCRIPTION
- fix: Reload website_theme_ignore_app before Website Theme (https://github.com/frappe/frappe/pull/12795)
- fix: Check if df.options exists before setting docfields (https://github.com/frappe/frappe/pull/12797)
- fix: Handle exception while building version comment (https://github.com/frappe/frappe/pull/12802)