### PR TITLE
fix: Handle exception while building version comment

### DIFF
--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -151,19 +151,23 @@ function get_version_comment(version_doc, text) {
 		let version_comment = "";
 		let unlinked_content = "";
 
-		Array.from($(text)).forEach(element => {
-			if ($(element).is('a')) {
-				version_comment += unlinked_content ? frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content) : "";
-				unlinked_content = "";
-				version_comment += element.outerHTML;
-			} else {
-				unlinked_content += element.outerHTML || element.textContent;
+		try {
+			Array.from($(text)).forEach(element => {
+				if ($(element).is('a')) {
+					version_comment += unlinked_content ? frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content) : "";
+					unlinked_content = "";
+					version_comment += element.outerHTML;
+				} else {
+					unlinked_content += element.outerHTML || element.textContent;
+				}
+			});
+			if (unlinked_content) {
+				version_comment += frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content);
 			}
-		});
-		if (unlinked_content) {
-			version_comment += frappe.utils.get_form_link('Version', version_doc.name, true, unlinked_content);
+			return version_comment;
+		} catch (e) {
+			// pass
 		}
-		return version_comment;
 	}
 	return frappe.utils.get_form_link('Version', version_doc.name, true, text);
 }


### PR DESCRIPTION
Fixes the following issue while loading the form:
<img width="1440" alt="Screenshot 2021-04-05 at 11 40 56 AM" src="https://user-images.githubusercontent.com/13928957/113543337-cc349b00-9603-11eb-8816-0dce9f51cf87.png">

Error in console.
```
Error: Syntax error, unrecognized expression: added <a href='example.com' target='_blank'>example.com</a>
    at Function.fa.error (jquery.min.js:2)
    at fa.tokenize (jquery.min.js:2)
    at fa.select (jquery.min.js:2)
    at Function.fa [as find] (jquery.min.js:2)
    at n.fn.init.find (jquery.min.js:2)
    at new n.fn.init (jquery.min.js:2)
    at n (jquery.min.js:2)
    at get_version_comment (version_timeline_content_builder.js:154)
    at get_version_timeline_content (version_timeline_content_builder.js:9)
    at form_timeline.js:240
```

