### PR TITLE
fix: reverting of series with a variable

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -157,10 +157,10 @@ def update_naming_series(doc):
 	if doc.meta.autoname:
 		if doc.meta.autoname.startswith("naming_series:") \
 			and getattr(doc, "naming_series", None):
-			revert_series_if_last(doc.naming_series, doc.name)
+			revert_series_if_last(doc.naming_series, doc.name, doc)
 
 		elif doc.meta.autoname.split(":")[0] not in ("Prompt", "field", "hash"):
-			revert_series_if_last(doc.meta.autoname, doc.name)
+			revert_series_if_last(doc.meta.autoname, doc.name, doc)
 
 def delete_from_table(doctype, name, ignore_doctypes, doc):
 	if doctype!="DocType" and doctype==name:

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -198,7 +198,7 @@ def getseries(key, digits):
 	return ('%0'+str(digits)+'d') % current
 
 
-def revert_series_if_last(key, name, doc):
+def revert_series_if_last(key, name, doc=None):
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -198,7 +198,7 @@ def getseries(key, digits):
 	return ('%0'+str(digits)+'d') % current
 
 
-def revert_series_if_last(key, name):
+def revert_series_if_last(key, name, doc):
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:
@@ -207,7 +207,7 @@ def revert_series_if_last(key, name):
 		prefix = key
 
 	if '.' in prefix:
-		prefix = parse_naming_series(prefix.split('.'))
+		prefix = parse_naming_series(prefix.split('.'), doc=doc)
 
 	count = cint(name.replace(prefix, ""))
 	current = frappe.db.sql("SELECT `current` FROM `tabSeries` WHERE `name`=%s FOR UPDATE", (prefix,))

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -244,7 +244,7 @@ class TestDocument(unittest.TestCase):
 			prefix = parse_naming_series(prefix)
 			old_current = frappe.db.get_value('Series', prefix, "current", order_by="name")
 
-			revert_series_if_last(series, name, doc)
+			revert_series_if_last(series, name)
 			new_current = cint(frappe.db.get_value('Series', prefix, "current", order_by="name"))
 
 			self.assertEqual(cint(old_current) - 1, new_current)

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -244,7 +244,7 @@ class TestDocument(unittest.TestCase):
 			prefix = parse_naming_series(prefix)
 			old_current = frappe.db.get_value('Series', prefix, "current", order_by="name")
 
-			revert_series_if_last(series, name)
+			revert_series_if_last(series, name, doc)
 			new_current = cint(frappe.db.get_value('Series', prefix, "current", order_by="name"))
 
 			self.assertEqual(cint(old_current) - 1, new_current)


### PR DESCRIPTION
Consider a naming series : `INV-21-.category.-.####`
Here, `category` comes from invoice document & can have values such as B2B, B2C etc.

While creating a new invoice, the name is set as **INV-21-B2B-0001**

Now, on cancelling this document, when `revert_series_if_last` gets called, it tries to parse the naming series `INV-21-.category.-.####`. 

While parsing this, since no `doc` is passed to `parse_naming_series` the `category` field is not substituted which results in `prefix` being `INV-21-category`

With such a prefix, line 213 tries to find the `current` index for incorrect series. Hence, the reverting/decrement of the series is skipped. 

Fix: passed reference `doc` while reverting the series on `delete_doc`