### PR TITLE
fix: added 'ps' to the right-to-left languages list

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -938,7 +938,7 @@ Object.assign(frappe.utils, {
 		});
 	},
 	is_rtl(lang=null) {
-		return ["ar", "he", "fa"].includes(lang || frappe.boot.lang);
+		return ["ar", "he", "fa", "ps"].includes(lang || frappe.boot.lang);
 	},
 	bind_actions_with_object($el, object) {
 		// remove previously bound event

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -48,7 +48,7 @@ def get_context(context):
 		"css": get_print_style(frappe.form_dict.style, print_format),
 		"comment": frappe.session.user,
 		"title": doc.get(meta.title_field) if meta.title_field else doc.name,
-		"has_rtl": True if frappe.local.lang in ["ar", "he", "fa"] else False
+		"has_rtl": True if frappe.local.lang in ["ar", "he", "fa", "ps"] else False
 	}
 
 def get_print_format_doc(print_format_name, meta):


### PR DESCRIPTION
fix: added ps to the right-to-left languages list
Pashto (ps) writing is based on Arabic script, so it is a right to left language.  Therefore, added the "ps" to the rtl languages list in the following line of code.
is_rtl(lang=null) {
		return ["ar", "he", "fa", "ps"].includes(lang || frappe.boot.lang);
}

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
