### PR TITLE
fix(Email): checks for `this.frm` before removing item from localforage

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -603,7 +603,7 @@ frappe.views.CommunicationComposer = Class.extend({
 	},
 
 	delete_saved_draft() {
-		if (this.dialog) {
+		if (this.dialog && this.frm) {
 			localforage.removeItem(this.frm.doctype + this.frm.docname).catch(e => {
 				if (e) {
 					// silently fail


### PR DESCRIPTION
- Resolves [Issue](https://discuss.erpnext.com/t/email-dialog-error-customisation-version-13/73733) in `delete_saved_draft()`:

```
Uncaught TypeError: Cannot read property 'doctype' of undefined
    at init.delete_saved_draft (communication.js:607)
    at Dialog.primary_action (communication.js:23)
    at HTMLButtonElement.<anonymous> (dialog.js:149)
    at HTMLButtonElement.dispatch (jquery.min.js:3)
    at HTMLButtonElement.r.handle (jquery.min.js:3)
```