### PR TITLE
fix: check authorization before changing report status

### DIFF
--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -25,7 +25,7 @@ frappe.ui.form.on('Report', {
 			}
 		}, "fa fa-table");
 
-		if (doc.is_standard === "Yes") {
+		if (doc.is_standard === "Yes" && frm.perm[0].write) {
 			frm.add_custom_button(doc.disabled ? __("Enable Report") : __("Disable Report"), function() {
 				frm.call('toggle_disable', {
 					disable: doc.disabled ? 0 : 1

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -307,6 +307,9 @@ class Report(Document):
 
 	@frappe.whitelist()
 	def toggle_disable(self, disable):
+		if not self.has_permission('write'):
+			frappe.throw(_("You are not allowed to edit the report."))
+
 		self.db_set("disabled", cint(disable))
 
 @frappe.whitelist()

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -201,3 +201,27 @@ result = [
 
 		# check values
 		self.assertTrue('System User' in [d.get('type') for d in data[1]])
+
+	def test_toggle_disabled(self):
+		"""Make sure that authorization is respected.
+		"""
+		# Assuming that there will be reports in the system.
+		reports = frappe.get_all(doctype='Report', limit=1)
+		report_name = reports[0]['name']
+		doc = frappe.get_doc('Report', report_name)
+		status = doc.disabled
+
+		# User has write permission on reports and should pass through
+		frappe.set_user('test@example.com')
+		doc.toggle_disable(not status)
+		doc.reload()
+		self.assertNotEqual(status, doc.disabled)
+
+		# User has no write permission on reports, permission error is expected.
+		frappe.set_user('test1@example.com')
+		doc = frappe.get_doc('Report', report_name)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			doc.toggle_disable(1)
+
+		# Set user back to administrator
+		frappe.set_user('Administrator')


### PR DESCRIPTION
Currently we do not authorize the request before updating status of a report and also we provide `Disable Report` Button.
Added permission check at frontend and backend.

**With Permissions**
![Screenshot 2021-04-08 at 3 05 47 PM](https://user-images.githubusercontent.com/36557/114004403-3fe0dd00-987c-11eb-8062-663bbacfb6a4.png)

**Without permissions**

![Screenshot 2021-04-08 at 3 09 28 PM](https://user-images.githubusercontent.com/36557/114004640-7d456a80-987c-11eb-8341-73412d1a1cb9.png)

