### PR TITLE
fix: Only allow user's attachments to show in attachments tree (bp #1…

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -947,10 +947,18 @@ def validate_filename(filename):
 
 @frappe.whitelist()
 def get_files_in_folder(folder):
-	return frappe.db.get_all('File',
+	attachment_folder = frappe.db.get_value('File',
+		'Home/Attachments',
+		['name', 'file_name', 'file_url', 'is_folder', 'modified'],
+		as_dict=1
+	)
+	files = frappe.db.get_list('File',
 		{ 'folder': folder },
 		['name', 'file_name', 'file_url', 'is_folder', 'modified']
 	)
+	if folder == 'Home' and attachment_folder not in files:
+		files.insert(0, attachment_folder)
+	return files
 
 def update_existing_file_docs(doc):
 	# Update is private and file url of all file docs that point to the same file

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -8,7 +8,7 @@ import frappe
 import os
 import unittest
 from frappe import _
-from frappe.core.doctype.file.file import move_file
+from frappe.core.doctype.file.file import move_file, get_files_in_folder
 from frappe.utils import get_files_path
 # test_records = frappe.get_test_records('File')
 
@@ -390,3 +390,61 @@ class TestFile(unittest.TestCase):
 		file1.reload()
 		file1.file_url = '/private/files/parent_dir2.txt'
 		file1.save()
+
+
+class TestAttachmentsAccess(unittest.TestCase):
+
+	def test_attachments_access(self):
+
+		frappe.set_user('test4@example.com')
+		self.attached_to_doctype, self.attached_to_docname = make_test_doc()
+
+		frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'test_user.txt',
+			"attached_to_doctype": self.attached_to_doctype,
+			"attached_to_name": self.attached_to_docname,
+			"content": 'Testing User'
+		}).insert()
+
+		frappe.get_doc({
+			"doctype": "File",
+			"file_name": "test_user_home.txt",
+			"content": 'User Home',
+		}).insert()
+
+		frappe.set_user('test@example.com')
+
+		frappe.get_doc({
+			"doctype": "File",
+			"file_name": 'test_system_manager.txt',
+			"attached_to_doctype": self.attached_to_doctype,
+			"attached_to_name": self.attached_to_docname,
+			"content": 'Testing System Manager'
+		}).insert()
+
+		frappe.get_doc({
+			"doctype": "File",
+			"file_name": "test_sm_home.txt",
+			"content": 'System Manager Home',
+		}).insert()
+
+		system_manager_files = [file.file_name for file in get_files_in_folder('Home')['files']]
+		system_manager_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
+
+		frappe.set_user('test4@example.com')
+		user_files = [file.file_name for file in get_files_in_folder('Home')['files']]
+		user_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
+
+		self.assertIn('test_sm_home.txt', system_manager_files)
+		self.assertNotIn('test_sm_home.txt', user_files)
+		self.assertIn('test_user_home.txt', system_manager_files)
+		self.assertIn('test_user_home.txt', user_files)
+
+		self.assertIn('test_system_manager.txt', system_manager_attachments_files)
+		self.assertNotIn('test_system_manager.txt', user_attachments_files)
+		self.assertIn('test_user.txt', system_manager_attachments_files)
+		self.assertIn('test_user.txt', user_attachments_files)
+
+		frappe.set_user('Administrator')
+		frappe.db.rollback()

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -429,12 +429,12 @@ class TestAttachmentsAccess(unittest.TestCase):
 			"content": 'System Manager Home',
 		}).insert()
 
-		system_manager_files = [file.file_name for file in get_files_in_folder('Home')['files']]
-		system_manager_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
+		system_manager_files = [file.file_name for file in get_files_in_folder('Home')]
+		system_manager_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')]
 
 		frappe.set_user('test4@example.com')
-		user_files = [file.file_name for file in get_files_in_folder('Home')['files']]
-		user_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')['files']]
+		user_files = [file.file_name for file in get_files_in_folder('Home')]
+		user_attachments_files = [file.file_name for file in get_files_in_folder('Home/Attachments')]
 
 		self.assertIn('test_sm_home.txt', system_manager_files)
 		self.assertNotIn('test_sm_home.txt', user_files)

--- a/frappe/core/doctype/user/test_records.json
+++ b/frappe/core/doctype/user/test_records.json
@@ -40,6 +40,13 @@
  },
  {
   "doctype": "User",
+  "email": "test4@example.com",
+  "first_name": "_Test4",
+  "new_password": "Eastern_43A1W",
+  "enabled": 1
+ },
+ {
+  "doctype": "User",
   "email": "testperm@example.com",
   "first_name": "_Test Perm",
   "new_password": "Eastern_43A1W",


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/pull/12722

When attaching a file on any document from the uploaded file option any user with limited access can see all the attachments
for which they should not have access.
![image](https://user-images.githubusercontent.com/30859809/112966178-9ad15080-9167-11eb-89a4-52ac8f67774d.png)


After Fix: User can only see attachments that they added.
![image](https://user-images.githubusercontent.com/30859809/112966295-b9374c00-9167-11eb-94f9-586dc42f7417.png)
 