### PR TITLE
chore: static analysis hack for globals

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -15,6 +15,7 @@ from __future__ import unicode_literals, print_function
 from six import iteritems, binary_type, text_type, string_types, PY2
 from werkzeug.local import Local, release_local
 import os, sys, importlib, inspect, json
+import typing
 from past.builtins import cmp
 import click
 
@@ -132,6 +133,14 @@ debug_log = local("debug_log")
 message_log = local("message_log")
 
 lang = local("lang")
+
+# This if block is never executed when running the code. It is only used for
+# telling static code analyzer where to find dynamically defined attributes.
+if typing.TYPE_CHECKING:
+	from frappe.database.mariadb.database import MariaDBDatabase
+	from frappe.database.postgres.database import PostgresDatabase
+	db: typing.Union[MariaDBDatabase, PostgresDatabase]
+# end: static analysis hack
 
 def init(site, sites_path=None, new_site=False):
 	"""Initialize frappe for the current site. Reset thread locals `frappe.local`"""


### PR DESCRIPTION
Since `frappe.db` is dynamically defined static code analyzers can't understand what it is.  `typing.TYPE_CHECKING` can be used to instructs static code analyzers what to do with such globals. 

Reference: https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING

Outcome: Depending on your editor/config now `frappe.db.*` should auto-complete, jump to the definition and give docstrings on hover etc. 

Note: 
- this is NOT py2 compatible.
- Comment at end of if-block is intentional. This is to avoid accidentally leaking some code outside of if block.
- I've only added `frappe.db` for now, more can be added if required.

https://user-images.githubusercontent.com/9079960/114210217-21aed600-997d-11eb-8291-872dce37feef.mov

