### PR TITLE
fix: user type patch

### DIFF
--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -121,8 +121,10 @@ class UserType(Document):
 			self.prepare_select_perm_doctypes(doc, user_doctypes, select_doctypes)
 
 			for child_table in doc.get_table_fields():
-				child_doc = frappe.get_meta(child_table.options)
-				self.prepare_select_perm_doctypes(child_doc, user_doctypes, select_doctypes)
+				if frappe.db.table_exists(child_table.options):
+					child_doc = frappe.get_meta(child_table.options)
+					if not child_doc.istable:
+						self.prepare_select_perm_doctypes(child_doc, user_doctypes, select_doctypes)
 
 		if select_doctypes:
 			select_doctypes = set(select_doctypes)


### PR DESCRIPTION
```
Success: Done in 0.027s
  File "/opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 101, in <module>
    main()
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/runner/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/runner/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 27, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/site.py", line 300, in migrate
    skip_search_index=skip_search_index
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/patches/v13_0/make_non_standard_user_type.py", line 8, in execute
    add_non_standard_user_types()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/install.py", line 182, in add_non_standard_user_types
    create_user_type(user_type, data)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/install.py", line 227, in create_user_type
    doc.save(ignore_permissions=True)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 284, in save
    return self._save(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 306, in _save
    self.insert()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 237, in insert
    self.run_before_save_methods()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 960, in run_before_save_methods
    self.run_method("validate")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 858, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1147, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1130, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 852, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/user_type/user_type.py", line 17, in validate
    self.add_select_perm_doctypes()
  File "/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/user_type/user_type.py", line 124, in add_select_perm_doctypes
    child_doc = frappe.get_meta(child_table.options)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 872, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/meta.py", line 37, in get_meta
    meta = Meta(doctype)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/meta.py", line 83, in __init__
    super(Meta, self).__init__("DocType", doctype)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 112, in __init__
    self.load_from_db()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/meta.py", line 88, in load_from_db
    super(Meta, self).load_from_db()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 155, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 423, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 402, in msgprint
    _raise_exception()
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 356, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType Salary Detail not found
```