### PR TITLE
fix(Auto Email Report): None type error for empty lines

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -252,7 +252,7 @@ def make_links(columns, data):
 			elif col.fieldtype == "Dynamic Link":
 				if col.options and row.get(col.fieldname) and row.get(col.options):
 					row[col.fieldname] = get_link_to_form(row[col.options], row[col.fieldname])
-			elif col.fieldtype == "Currency":
+			elif col.fieldtype == "Currency" and row.get(col.fieldname):
 				row[col.fieldname] = frappe.format_value(row[col.fieldname], col)
 
 	return columns, data


### PR DESCRIPTION
If an auto email report is based on a report that has empty lines it breaks when trying to access the values

Steps to reproduce:
1. Create an auto email report that has empty lines(eg: accounts receivable report, turn on group by customer)
2. Try sending the report

Solution
add a check for empty currency like we had for link types

before:
![image](https://user-images.githubusercontent.com/28212972/114391262-e565ba80-9bb4-11eb-9586-f9866b7f89bc.png)

After:
![image](https://user-images.githubusercontent.com/28212972/114391475-28c02900-9bb5-11eb-868d-8d8096dea00a.png)
