### PR TITLE
fix: Include dropped and renamed tables in touched tables list

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -985,7 +985,7 @@ class Database(object):
 	def log_touched_tables(self, query, values=None):
 		if values:
 			query = frappe.safe_decode(self._cursor.mogrify(query, values))
-		if query.strip().lower().split()[0] in ('insert', 'delete', 'update', 'alter'):
+		if query.strip().lower().split()[0] in ('insert', 'delete', 'update', 'alter', 'drop', 'rename'):
 			# single_word_regex is designed to match following patterns
 			# `tabXxx`, tabXxx and "tabXxx"
 


### PR DESCRIPTION
Touched tables list can be used to selectively restore changed tables from a backup after migration failure.

Consider tables that are dropped or renamed as touched in this context.

Reference: https://github.com/frappe/frappe/pull/7333