### PR TITLE
fix(minor): dynamically changing grid properties

### DIFF
--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.js
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.js
@@ -15,8 +15,9 @@ frappe.ui.form.on('Document Naming Rule', {
 					}).map((d) => {
 						return {label: `${d.label} (${d.fieldname})`, value: d.fieldname};
 					});
-				frappe.meta.get_docfield('Document Naming Rule Condition', 'field', frm.doc.name).options = fieldnames;
-				frm.refresh_field('conditions');
+				frm.fields_dict.conditions.grid.update_docfield_property(
+					'field', 'options', fieldnames
+				);
 			});
 		}
 	}

--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -85,14 +85,11 @@ frappe.notification = {
 			}
 
 			// set email recipient options
-			frappe.meta.get_docfield(
-				'Notification Recipient',
+			frm.fields_dict.recipients.grid.update_docfield_property(
 				'receiver_by_document_field',
-				// set first option as blank to allow notification not to be defaulted to the owner
-				frm.doc.name
-			).options = [''].concat(["owner"]).concat(receiver_fields);
-
-			frm.fields_dict.recipients.grid.refresh();
+				'options',
+				[''].concat(["owner"]).concat(receiver_fields)
+			);
 		});
 	},
 	setup_example_message: function(frm) {

--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -25,7 +25,9 @@ frappe.webhook = {
 					}
 				}
 
-				frappe.meta.get_docfield("Webhook Data", "fieldname", frm.doc.name).options = [""].concat(fields);
+				frm.fields_dict.webhook_data.grid.update_docfield_property(
+					'fieldname', 'options', [""].concat(fields)
+				);
 			});
 		}
 	},

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -34,7 +34,6 @@ frappe.ui.form.Form = class FrappeForm {
 		this.grids = [];
 		this.cscript = new frappe.ui.form.Controller({ frm: this });
 		this.events = {};
-		this.pformat = {};
 		this.fetch_dict = {};
 		this.parent = parent;
 		this.doctype_layout = frappe.get_doc('DocType Layout', doctype_layout_name);
@@ -1142,10 +1141,6 @@ frappe.ui.form.Form = class FrappeForm {
 	//Remove specific custom button by button Label
 	remove_custom_button(label, group) {
 		this.page.remove_inner_button(label, group);
-	}
-
-	set_print_heading(txt) {
-		this.pformat[this.docname] = txt;
 	}
 
 	scroll_to_element() {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -901,4 +901,21 @@ export default class Grid {
 		// hide all custom buttons
 		this.grid_buttons.find('.btn-custom').addClass('hidden');
 	}
+
+	update_docfield_property(fieldname, property, value) {
+		// update the docfield of each row
+		for (let row of this.grid_rows) {
+			let docfield = row.docfields.find(d => d.fieldname === fieldname);
+			if (docfield) {
+				docfield[property] = value;
+			} else {
+				throw `field ${fieldname} not found`;
+			}
+		}
+
+		// update the parent too (for new rows)
+		this.docfields.find(d => d.fieldname === fieldname)[property] = value;
+
+		this.refresh();
+	}
 }

--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -20,7 +20,10 @@ frappe.web_form = {
 							return null;
 						}
 					});
-					frappe.meta.get_docfield("Web Form Field", "fieldname", frm.doc.name).options = [""].concat(fields);
+
+					frm.fields_dict.web_form_fields.grid.update_docfield_property(
+						'fieldname', 'options', fields
+					);
 					frappe.meta.get_docfield("Web Form", "amount_field", frm.doc.name).options = [""].concat(currency_fields);
 					frm.refresh_field("amount_field");
 					resolve();

--- a/frappe/website/doctype/web_page/web_page.json
+++ b/frappe/website/doctype/web_page/web_page.json
@@ -86,14 +86,14 @@
    "width": "50%"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "published",
    "fieldtype": "Check",
    "in_standard_filter": 1,
    "label": "Published"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "show_title",
    "fieldtype": "Check",
    "label": "Show Title"
@@ -114,7 +114,7 @@
    "label": "Content"
   },
   {
-   "default": "Rich Text",
+   "default": "Page Builder",
    "fieldname": "content_type",
    "fieldtype": "Select",
    "label": "Content Type",
@@ -259,7 +259,7 @@
    "options": "Web Page Block"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "full_width",
    "fieldtype": "Check",
    "label": "Full Width"
@@ -314,7 +314,7 @@
  "is_published_field": "published",
  "links": [],
  "max_attachments": 20,
- "modified": "2020-09-21 16:32:53.568573",
+ "modified": "2021-04-13 10:23:28.681197",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Page",

--- a/frappe/website/doctype/website_settings/website_settings.js
+++ b/frappe/website/doctype/website_settings/website_settings.js
@@ -30,8 +30,7 @@ frappe.ui.form.on('Website Settings', {
 	},
 
 	set_parent_label_options: function(frm) {
-		frappe.meta.get_docfield("Top Bar Item", "parent_label", frm.docname).options =
-			frm.events.get_parent_options(frm, "top_bar_items");
+		frm.fields_dict.top_bar_items.grid.update_docfield_property('parent_label', 'options', frm.events.get_parent_options(frm, "top_bar_items"));
 
 		if ($(frm.fields_dict.top_bar_items.grid.wrapper).find(".grid-row-open")) {
 			frm.fields_dict.top_bar_items.grid.refresh();
@@ -39,8 +38,7 @@ frappe.ui.form.on('Website Settings', {
 	},
 
 	set_parent_label_options_footer: function(frm) {
-		frappe.meta.get_docfield("Top Bar Item", "parent_label", frm.docname).options =
-			frm.events.get_parent_options(frm, "footer_items");
+		frm.fields_dict.footer_items.grid.update_docfield_property('parent_label', 'options', frm.events.get_parent_options(frm, "top_bar_items"));
 
 		if ($(frm.fields_dict.footer_items.grid.wrapper).find(".grid-row-open")) {
 			frm.fields_dict.footer_items.grid.refresh();

--- a/frappe/website/doctype/website_settings/website_settings.js
+++ b/frappe/website/doctype/website_settings/website_settings.js
@@ -30,7 +30,9 @@ frappe.ui.form.on('Website Settings', {
 	},
 
 	set_parent_label_options: function(frm) {
-		frm.fields_dict.top_bar_items.grid.update_docfield_property('parent_label', 'options', frm.events.get_parent_options(frm, "top_bar_items"));
+		frm.fields_dict.top_bar_items.grid.update_docfield_property(
+			'parent_label', 'options', frm.events.get_parent_options(frm, "top_bar_items")
+		);
 
 		if ($(frm.fields_dict.top_bar_items.grid.wrapper).find(".grid-row-open")) {
 			frm.fields_dict.top_bar_items.grid.refresh();
@@ -38,7 +40,9 @@ frappe.ui.form.on('Website Settings', {
 	},
 
 	set_parent_label_options_footer: function(frm) {
-		frm.fields_dict.footer_items.grid.update_docfield_property('parent_label', 'options', frm.events.get_parent_options(frm, "top_bar_items"));
+		frm.fields_dict.footer_items.grid.update_docfield_property(
+			'parent_label', 'options', frm.events.get_parent_options(frm, "top_bar_items")
+		);
 
 		if ($(frm.fields_dict.footer_items.grid.wrapper).find(".grid-row-open")) {
 			frm.fields_dict.footer_items.grid.refresh();

--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -142,6 +142,7 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "top_bar_items",
    "fieldname": "top_bar",
    "fieldtype": "Section Break",
    "label": "Navbar"
@@ -160,6 +161,7 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "banner_html",
    "fieldname": "banner",
    "fieldtype": "Section Break",
    "label": "Banner"
@@ -173,6 +175,7 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "footer_items",
    "fieldname": "footer",
    "fieldtype": "Section Break",
    "label": "Footer"
@@ -415,7 +418,7 @@
  "issingle": 1,
  "links": [],
  "max_attachments": 10,
- "modified": "2020-09-28 18:47:18.506700",
+ "modified": "2021-04-13 10:22:51.888788",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -44,7 +44,9 @@ frappe.ui.form.on("Workflow", {
 			const get_field_method = 'frappe.workflow.doctype.workflow.workflow.get_fieldnames_for';
 			frappe.xcall(get_field_method, { doctype: doc.document_type })
 				.then(resp => {
-					frappe.meta.get_docfield("Workflow Document State", "update_field", frm.doc.name).options = [""].concat(resp);
+					frm.fields_dict.states.grid.update_docfield_property(
+						'update_field', options, [""].concat(resp)
+					);
 				})
 		}
 	},

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -45,7 +45,7 @@ frappe.ui.form.on("Workflow", {
 			frappe.xcall(get_field_method, { doctype: doc.document_type })
 				.then(resp => {
 					frm.fields_dict.states.grid.update_docfield_property(
-						'update_field', options, [""].concat(resp)
+						'update_field', 'options', [""].concat(resp)
 					);
 				})
 		}


### PR DESCRIPTION
Dynamically changing properties of grid fields was broken because of the new design where every row has its own field object. This fix adds a new method on the `Grid` object, `update_docfield_property(field, property, value)` that will update all the rows and also the master copy, so that new rows get the correct field property.

This is used in several places like Web Form, Workflow etc. etc.

Related fix: https://github.com/frappe/erpnext/pull/25310