### PR TITLE
fix: travis patch while creating limited access user type

### DIFF
--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -108,7 +108,7 @@ class UserType(Document):
 			frappe.db.set_value('Custom DocPerm', docperm, values)
 
 	def add_select_perm_doctypes(self):
-		if not frappe.flags.in_patch and not frappe.conf.developer_mode:
+		if frappe.flags.ignore_select_perm:
 			return
 
 		self.select_doctypes = []
@@ -121,9 +121,8 @@ class UserType(Document):
 			self.prepare_select_perm_doctypes(doc, user_doctypes, select_doctypes)
 
 			for child_table in doc.get_table_fields():
-				if (frappe.db.table_exists(child_table.options)
-					and not frappe.get_cached_value('DocType', child_table.options, 'istable')):
-					child_doc = frappe.get_meta(child_table.options)
+				child_doc = frappe.get_meta(child_table.options)
+				if not child_doc.istable:
 					self.prepare_select_perm_doctypes(child_doc, user_doctypes, select_doctypes)
 
 		if select_doctypes:


### PR DESCRIPTION
**Issue**

```
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/patches/v13_0/make_non_standard_user_type.py", line 8, in execute
    add_non_standard_user_types()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/install.py", line 182, in add_non_standard_user_types
    create_user_type(user_type, data)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/install.py", line 227, in create_user_type
    doc.save(ignore_permissions=True)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 284, in save
    return self._save(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 306, in _save
    self.insert()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 237, in insert
    self.run_before_save_methods()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 960, in run_before_save_methods
    self.run_method("validate")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 858, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1147, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1130, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 852, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/user_type/user_type.py", line 17, in validate
    self.add_select_perm_doctypes()
  File "/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/user_type/user_type.py", line 125, in add_select_perm_doctypes
    and not frappe.get_cached_value('DocType', child_table.options, 'istable')):
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 813, in get_cached_value
    doc = get_cached_doc(doctype, name)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 798, in get_cached_doc
    doc = get_doc(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 841, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 74, in get_doc
    return controller(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 112, in __init__
    self.load_from_db()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 155, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 423, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 402, in msgprint
    _raise_exception()
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 356, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType Salary Slip Timesheet not found
```